### PR TITLE
feat: extract parliamentaryGroupId into MandateParliamentary (#275)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -286,7 +286,7 @@ model Mandate {
   europeanGroupId   String?
 
   // National parliamentary group (for deputies & senators)
-  parliamentaryGroup   ParliamentaryGroup? @relation(fields: [parliamentaryGroupId], references: [id])
+  parliamentaryGroup   ParliamentaryGroup? @relation("LegacyMandateGroup", fields: [parliamentaryGroupId], references: [id])
   parliamentaryGroupId String?
 
   // Data origin tracking
@@ -306,6 +306,9 @@ model Mandate {
 
   // Government mandate extension (1:1)
   governmentData MandateGovernment?
+
+  // Parliamentary mandate extension (1:1)
+  parliamentaryData MandateParliamentary?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -349,6 +352,19 @@ model MandateGovernment {
   governmentName String   // "Gouvernement Borne", etc.
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+}
+
+// Parliamentary mandate extension - 1:1 with Mandate for parliamentary group membership
+model MandateParliamentary {
+  id                   String             @id @default(cuid())
+  mandate              Mandate            @relation(fields: [mandateId], references: [id], onDelete: Cascade)
+  mandateId            String             @unique
+  parliamentaryGroup   ParliamentaryGroup @relation(fields: [parliamentaryGroupId], references: [id])
+  parliamentaryGroupId String
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
+
+  @@index([parliamentaryGroupId])
 }
 
 // European Parliament political groups
@@ -400,7 +416,8 @@ model ParliamentaryGroup {
   defaultPartyId String?
 
   // Relations
-  mandates Mandate[]
+  legacyMandates Mandate[]              @relation("LegacyMandateGroup")
+  mandates       MandateParliamentary[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/scripts/migrate-parliamentary-data.ts
+++ b/scripts/migrate-parliamentary-data.ts
@@ -1,0 +1,48 @@
+/**
+ * One-shot migration: copy Mandate.parliamentaryGroupId to MandateParliamentary rows.
+ * Safe to re-run (skips mandates that already have parliamentaryData).
+ *
+ * Usage: npx dotenv -e .env -- npx tsx scripts/migrate-parliamentary-data.ts
+ * Dry run: DRY_RUN=1 npx dotenv -e .env -- npx tsx scripts/migrate-parliamentary-data.ts
+ */
+import { db } from "@/lib/db";
+
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+async function main() {
+  console.log(`MandateParliamentary migration ${DRY_RUN ? "(DRY RUN)" : ""}`);
+
+  // Use raw SQL since old field may be removed from Prisma schema in future
+  const mandates = await db.$queryRaw<{ id: string; parliamentaryGroupId: string }[]>`
+    SELECT m.id, m."parliamentaryGroupId"
+    FROM "Mandate" m
+    LEFT JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+    WHERE m."parliamentaryGroupId" IS NOT NULL AND mp.id IS NULL
+  `;
+
+  console.log(`Found ${mandates.length} mandates to migrate`);
+
+  if (DRY_RUN || mandates.length === 0) {
+    await db.$disconnect();
+    return;
+  }
+
+  let created = 0;
+  for (const m of mandates) {
+    await db.mandateParliamentary.create({
+      data: {
+        mandateId: m.id,
+        parliamentaryGroupId: m.parliamentaryGroupId,
+      },
+    });
+    created++;
+  }
+
+  console.log(`Created ${created} MandateParliamentary records`);
+  await db.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/compare/search-index/route.ts
+++ b/src/app/api/compare/search-index/route.ts
@@ -30,7 +30,12 @@ async function getSearchIndex() {
         },
         mandates: {
           where: { isCurrent: true },
-          select: { type: true, parliamentaryGroupId: true },
+          select: {
+            type: true,
+            parliamentaryData: {
+              select: { parliamentaryGroupId: true },
+            },
+          },
           orderBy: { startDate: "desc" },
           take: 1,
         },
@@ -58,7 +63,7 @@ async function getSearchIndex() {
     }),
     db.parliamentaryGroup.findMany({
       where: {
-        legacyMandates: { some: { isCurrent: true } },
+        mandates: { some: { mandate: { isCurrent: true } } },
       },
       select: {
         id: true,
@@ -67,7 +72,7 @@ async function getSearchIndex() {
         shortName: true,
         color: true,
         chamber: true,
-        _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
+        _count: { select: { mandates: { where: { mandate: { isCurrent: true } } } } },
       },
       orderBy: { name: "asc" },
     }),
@@ -81,7 +86,7 @@ async function getSearchIndex() {
     partyShortName: p.currentParty?.shortName ?? null,
     partyColor: p.currentParty?.color ?? null,
     mandateType: p.mandates[0]?.type ?? null,
-    parliamentaryGroupId: p.mandates[0]?.parliamentaryGroupId ?? null,
+    parliamentaryGroupId: p.mandates[0]?.parliamentaryData?.parliamentaryGroupId ?? null,
   }));
 
   // Map parties to a flat shape, sorted by member count desc then name asc
@@ -104,7 +109,7 @@ async function getSearchIndex() {
     shortName: g.shortName,
     color: g.color,
     chamber: g.chamber,
-    memberCount: g._count.legacyMandates,
+    memberCount: g._count.mandates,
   }));
 
   return { politicians: politicianIndex, parties: partyIndex, groups: groupIndex };

--- a/src/app/api/compare/search-index/route.ts
+++ b/src/app/api/compare/search-index/route.ts
@@ -58,7 +58,7 @@ async function getSearchIndex() {
     }),
     db.parliamentaryGroup.findMany({
       where: {
-        mandates: { some: { isCurrent: true } },
+        legacyMandates: { some: { isCurrent: true } },
       },
       select: {
         id: true,
@@ -67,7 +67,7 @@ async function getSearchIndex() {
         shortName: true,
         color: true,
         chamber: true,
-        _count: { select: { mandates: { where: { isCurrent: true } } } },
+        _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
       },
       orderBy: { name: "asc" },
     }),
@@ -104,7 +104,7 @@ async function getSearchIndex() {
     shortName: g.shortName,
     color: g.color,
     chamber: g.chamber,
-    memberCount: g._count.mandates,
+    memberCount: g._count.legacyMandates,
   }));
 
   return { politicians: politicianIndex, parties: partyIndex, groups: groupIndex };

--- a/src/app/api/compare/suggestions/route.ts
+++ b/src/app/api/compare/suggestions/route.ts
@@ -270,14 +270,14 @@ async function getPartySuggestions() {
 async function getGroupSuggestions() {
   try {
     const groups = await db.parliamentaryGroup.findMany({
-      where: { mandates: { some: { isCurrent: true } } },
+      where: { legacyMandates: { some: { isCurrent: true } } },
       select: {
         id: true,
         code: true,
         name: true,
         shortName: true,
         politicalPosition: true,
-        _count: { select: { mandates: { where: { isCurrent: true } } } },
+        _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
       },
       orderBy: { name: "asc" },
       take: 30,
@@ -300,7 +300,7 @@ async function getGroupSuggestions() {
           a.politicalPosition as PoliticalPosition | null,
           b.politicalPosition as PoliticalPosition | null
         );
-        const score = distance * 100 + a._count.mandates + b._count.mandates;
+        const score = distance * 100 + a._count.legacyMandates + b._count.legacyMandates;
         candidates.push({
           leftSlug: a.id,
           leftName: a.shortName || a.code,

--- a/src/app/api/compare/suggestions/route.ts
+++ b/src/app/api/compare/suggestions/route.ts
@@ -270,14 +270,14 @@ async function getPartySuggestions() {
 async function getGroupSuggestions() {
   try {
     const groups = await db.parliamentaryGroup.findMany({
-      where: { legacyMandates: { some: { isCurrent: true } } },
+      where: { mandates: { some: { mandate: { isCurrent: true } } } },
       select: {
         id: true,
         code: true,
         name: true,
         shortName: true,
         politicalPosition: true,
-        _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
+        _count: { select: { mandates: { where: { mandate: { isCurrent: true } } } } },
       },
       orderBy: { name: "asc" },
       take: 30,
@@ -300,7 +300,7 @@ async function getGroupSuggestions() {
           a.politicalPosition as PoliticalPosition | null,
           b.politicalPosition as PoliticalPosition | null
         );
-        const score = distance * 100 + a._count.legacyMandates + b._count.legacyMandates;
+        const score = distance * 100 + a._count.mandates + b._count.mandates;
         candidates.push({
           leftSlug: a.id,
           leftName: a.shortName || a.code,

--- a/src/app/api/politiques/[slug]/route.ts
+++ b/src/app/api/politiques/[slug]/route.ts
@@ -69,7 +69,9 @@ export const GET = withPublicRoute(async (request, context) => {
         : null,
       mandates: politician.mandates.map((m) => {
         const mandate = m as typeof m & {
-          parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+          parliamentaryData?: {
+            parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+          } | null;
         };
         return {
           id: mandate.id,
@@ -80,11 +82,11 @@ export const GET = withPublicRoute(async (request, context) => {
           startDate: mandate.startDate,
           endDate: mandate.endDate,
           isCurrent: mandate.isCurrent,
-          parliamentaryGroup: mandate.parliamentaryGroup
+          parliamentaryGroup: mandate.parliamentaryData?.parliamentaryGroup
             ? {
-                code: mandate.parliamentaryGroup.code,
-                name: mandate.parliamentaryGroup.name,
-                color: mandate.parliamentaryGroup.color,
+                code: mandate.parliamentaryData.parliamentaryGroup.code,
+                name: mandate.parliamentaryData.parliamentaryGroup.name,
+                color: mandate.parliamentaryData.parliamentaryGroup.color,
               }
             : null,
         };

--- a/src/app/assemblee/[slug]/page.tsx
+++ b/src/app/assemblee/[slug]/page.tsx
@@ -56,13 +56,17 @@ const includeOptions = {
           mandates: {
             where: {
               type: { in: ["DEPUTE", "SENATEUR"] as MandateType[] },
-              parliamentaryGroupId: { not: null },
+              parliamentaryData: { isNot: null },
             },
             orderBy: { startDate: "desc" as const },
             take: 1,
             select: {
-              parliamentaryGroup: {
-                select: { code: true, name: true, shortName: true, color: true },
+              parliamentaryData: {
+                select: {
+                  parliamentaryGroup: {
+                    select: { code: true, name: true, shortName: true, color: true },
+                  },
+                },
               },
             },
           },

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -152,9 +152,11 @@ export default async function PoliticianPage({ params }: PageProps) {
   const currentMandate = politician.mandates.find((m) => m.isCurrent);
   const currentGroup = (
     currentMandate as typeof currentMandate & {
-      parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+      parliamentaryData?: {
+        parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+      } | null;
     }
-  )?.parliamentaryGroup;
+  )?.parliamentaryData?.parliamentaryGroup;
   const isActiveParliamentarian = politician.mandates.some(
     (m) => m.isCurrent && (m.type === "DEPUTE" || m.type === "SENATEUR")
   );

--- a/src/app/votes/[slug]/page.tsx
+++ b/src/app/votes/[slug]/page.tsx
@@ -47,10 +47,14 @@ const getScrutinWithRedirect = cache(async function getScrutinWithRedirect(slugO
           include: {
             currentParty: true,
             mandates: {
-              where: { isCurrent: true, parliamentaryGroupId: { not: null } },
+              where: { isCurrent: true, parliamentaryData: { isNot: null } },
               take: 1,
               select: {
-                parliamentaryGroup: { select: { code: true, name: true } },
+                parliamentaryData: {
+                  select: {
+                    parliamentaryGroup: { select: { code: true, name: true } },
+                  },
+                },
               },
             },
           },
@@ -439,7 +443,9 @@ export default async function ScrutinPage({ params }: PageProps) {
                             <div className="flex-1 min-w-0">
                               <p className="text-sm font-medium">{vote.politician.fullName}</p>
                               {(() => {
-                                const group = vote.politician.mandates[0]?.parliamentaryGroup;
+                                const group =
+                                  vote.politician.mandates[0]?.parliamentaryData
+                                    ?.parliamentaryGroup;
                                 if (group) {
                                   return (
                                     <p className="text-xs text-muted-foreground" title={group.name}>

--- a/src/components/compare/categories/DeputesComparison.tsx
+++ b/src/components/compare/categories/DeputesComparison.tsx
@@ -115,7 +115,7 @@ export function DeputesComparison({ left, right }: Props) {
 }
 
 function DeputeInfoCard({ data }: { data: PoliticianComparisonData }) {
-  const group = data.currentMandate.parliamentaryGroup;
+  const group = data.currentMandate.parliamentaryData?.parliamentaryGroup;
 
   return (
     <div className="bg-muted rounded-lg p-4">

--- a/src/components/compare/categories/SenateursComparison.tsx
+++ b/src/components/compare/categories/SenateursComparison.tsx
@@ -115,7 +115,7 @@ export function SenateursComparison({ left, right }: Props) {
 }
 
 function SenateurInfoCard({ data }: { data: PoliticianComparisonData }) {
-  const group = data.currentMandate.parliamentaryGroup;
+  const group = data.currentMandate.parliamentaryData?.parliamentaryGroup;
 
   return (
     <div className="bg-muted rounded-lg p-4">

--- a/src/components/legislation/DossierAuthors.tsx
+++ b/src/components/legislation/DossierAuthors.tsx
@@ -16,11 +16,13 @@ interface DossierAuthor {
     civility: string | null;
     currentParty: { shortName: string; color: string | null } | null;
     mandates?: {
-      parliamentaryGroup: {
-        code: string;
-        name: string;
-        shortName: string | null;
-        color: string | null;
+      parliamentaryData: {
+        parliamentaryGroup: {
+          code: string;
+          name: string;
+          shortName: string | null;
+          color: string | null;
+        } | null;
       } | null;
     }[];
   };
@@ -41,7 +43,7 @@ function AuthorEntry({
   const party = author.politician.currentParty;
   const partyColor = party?.color ? ensureContrast(party.color) : undefined;
   const chamberLabel = author.chamber ? CHAMBER_LABELS[author.chamber] : null;
-  const group = author.politician.mandates?.[0]?.parliamentaryGroup;
+  const group = author.politician.mandates?.[0]?.parliamentaryData?.parliamentaryGroup;
   const groupColor = group?.color ? ensureContrast(group.color) : undefined;
 
   return (

--- a/src/components/politicians/MandateTimeline.tsx
+++ b/src/components/politicians/MandateTimeline.tsx
@@ -23,7 +23,9 @@ function getCommuneElectionUrl(mandate: {
 }
 
 interface MandateWithGroup extends SerializedMandate {
-  parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+  parliamentaryData?: {
+    parliamentaryGroup?: { code: string; name: string; color: string | null } | null;
+  } | null;
 }
 
 interface MandateTimelineProps {
@@ -169,6 +171,7 @@ export function MandateTimeline({ mandates, civility }: MandateTimelineProps) {
               const titleIsDescriptive =
                 mandate.title && mandate.title !== typeLabel && !displayRole;
               const heading = displayRole || (titleIsDescriptive ? mandate.title : typeLabel);
+              const group = mandate.parliamentaryData?.parliamentaryGroup;
               return (
                 <div key={mandate.id} className="relative pl-6 pb-3 border-l-2 border-primary">
                   <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-primary border-2 border-background" />
@@ -178,15 +181,15 @@ export function MandateTimeline({ mandates, civility }: MandateTimelineProps) {
                         <p className="font-semibold text-lg">{heading}</p>
                         <div className="flex flex-wrap items-center gap-1.5 mt-1">
                           {displayRole && <Badge variant="outline">{typeLabel}</Badge>}
-                          {mandate.parliamentaryGroup && (
+                          {group && (
                             <Badge
                               variant="outline"
                               style={{
-                                borderColor: mandate.parliamentaryGroup.color || undefined,
-                                color: mandate.parliamentaryGroup.color || undefined,
+                                borderColor: group.color || undefined,
+                                color: group.color || undefined,
                               }}
                             >
-                              {mandate.parliamentaryGroup.code}
+                              {group.code}
                             </Badge>
                           )}
                         </div>
@@ -272,6 +275,7 @@ export function MandateTimeline({ mandates, civility }: MandateTimelineProps) {
                                   `${(MANDATE_TYPE_LABELS[type] || "").toLowerCase()} français`
                                   ? mandate.title
                                   : mandate.institution || mandate.constituency || null;
+                              const group = mandate.parliamentaryData?.parliamentaryGroup;
                               return (
                                 <div
                                   key={mandate.id}
@@ -283,17 +287,17 @@ export function MandateTimeline({ mandates, civility }: MandateTimelineProps) {
                                   </span>
                                   <span>·</span>
                                   <span>
-                                    {mandate.parliamentaryGroup && (
+                                    {group && (
                                       <span
                                         className="font-medium"
                                         style={{
-                                          color: mandate.parliamentaryGroup.color || undefined,
+                                          color: group.color || undefined,
                                         }}
                                       >
-                                        {mandate.parliamentaryGroup.code}
+                                        {group.code}
                                       </span>
                                     )}
-                                    {mandate.parliamentaryGroup && " · "}
+                                    {group && " · "}
                                     {detail
                                       ? `${detail} · ${formatDuration(mandate.startDate, mandate.endDate)}`
                                       : formatDuration(mandate.startDate, mandate.endDate)}

--- a/src/lib/data/compare.ts
+++ b/src/lib/data/compare.ts
@@ -202,7 +202,7 @@ async function getGroupPreview(idOrCode: string): Promise<ComparePreview | null>
       shortName: true,
       color: true,
       chamber: true,
-      _count: { select: { mandates: { where: { isCurrent: true } } } },
+      _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
     },
   });
 
@@ -646,7 +646,7 @@ async function getGroupForComparison(idOrCode: string) {
         select: { name: true, shortName: true, color: true, slug: true },
       },
       _count: {
-        select: { mandates: { where: { isCurrent: true } } },
+        select: { legacyMandates: { where: { isCurrent: true } } },
       },
     },
   });
@@ -759,7 +759,7 @@ async function getGroupForComparison(idOrCode: string) {
   return {
     group: {
       ...group,
-      memberCount: group._count.mandates,
+      memberCount: group._count.legacyMandates,
     },
     stats: {
       avgParticipation,

--- a/src/lib/data/compare.ts
+++ b/src/lib/data/compare.ts
@@ -202,7 +202,7 @@ async function getGroupPreview(idOrCode: string): Promise<ComparePreview | null>
       shortName: true,
       color: true,
       chamber: true,
-      _count: { select: { legacyMandates: { where: { isCurrent: true } } } },
+      _count: { select: { mandates: { where: { mandate: { isCurrent: true } } } } },
     },
   });
 
@@ -654,7 +654,7 @@ async function getGroupForComparison(idOrCode: string) {
         select: { name: true, shortName: true, color: true, slug: true },
       },
       _count: {
-        select: { legacyMandates: { where: { isCurrent: true } } },
+        select: { mandates: { where: { mandate: { isCurrent: true } } } },
       },
     },
   });
@@ -767,7 +767,7 @@ async function getGroupForComparison(idOrCode: string) {
   return {
     group: {
       ...group,
-      memberCount: group._count.legacyMandates,
+      memberCount: group._count.mandates,
     },
     stats: {
       avgParticipation,

--- a/src/lib/data/compare.ts
+++ b/src/lib/data/compare.ts
@@ -270,8 +270,12 @@ const POLITICIAN_COMPARISON_SELECT = {
       governmentData: {
         select: { governmentName: true },
       },
-      parliamentaryGroup: {
-        select: { name: true, shortName: true, color: true },
+      parliamentaryData: {
+        select: {
+          parliamentaryGroup: {
+            select: { name: true, shortName: true, color: true },
+          },
+        },
       },
     },
   },
@@ -402,8 +406,12 @@ async function getMinistreForComparison(slug: string) {
           },
           constituency: true,
           departmentCode: true,
-          parliamentaryGroup: {
-            select: { name: true, shortName: true, color: true },
+          parliamentaryData: {
+            select: {
+              parliamentaryGroup: {
+                select: { name: true, shortName: true, color: true },
+              },
+            },
           },
         },
       },
@@ -655,7 +663,7 @@ async function getGroupForComparison(idOrCode: string) {
 
   // Get member votes through current mandates
   const memberMandates = await db.mandate.findMany({
-    where: { parliamentaryGroupId: group.id, isCurrent: true },
+    where: { parliamentaryData: { parliamentaryGroupId: group.id }, isCurrent: true },
     select: {
       politician: {
         select: {
@@ -727,7 +735,7 @@ async function getGroupForComparison(idOrCode: string) {
       politician: {
         mandates: {
           some: {
-            parliamentaryGroupId: group.id,
+            parliamentaryData: { parliamentaryGroupId: group.id },
             isCurrent: true,
           },
         },
@@ -744,7 +752,7 @@ async function getGroupForComparison(idOrCode: string) {
       politician: {
         mandates: {
           some: {
-            parliamentaryGroupId: group.id,
+            parliamentaryData: { parliamentaryGroupId: group.id },
             isCurrent: true,
           },
         },

--- a/src/lib/data/hemicycle.ts
+++ b/src/lib/data/hemicycle.ts
@@ -40,7 +40,7 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
   const groups = await db.parliamentaryGroup.findMany({
     where: {
       chamber: "AN",
-      legacyMandates: { some: { isCurrent: true, type: "DEPUTE" } },
+      mandates: { some: { mandate: { isCurrent: true, type: "DEPUTE" } } },
     },
     select: {
       code: true,
@@ -48,23 +48,27 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
       shortName: true,
       color: true,
       politicalPosition: true,
-      legacyMandates: {
-        where: { isCurrent: true, type: "DEPUTE" },
+      mandates: {
+        where: { mandate: { isCurrent: true, type: "DEPUTE" } },
         take: 1000,
         select: {
-          politician: {
+          mandate: {
             select: {
-              id: true,
-              slug: true,
-              firstName: true,
-              lastName: true,
-              photoUrl: true,
-              affairs: {
-                where: {
-                  publicationStatus: "PUBLISHED",
-                  involvement: "DIRECT",
+              politician: {
+                select: {
+                  id: true,
+                  slug: true,
+                  firstName: true,
+                  lastName: true,
+                  photoUrl: true,
+                  affairs: {
+                    where: {
+                      publicationStatus: "PUBLISHED",
+                      involvement: "DIRECT",
+                    },
+                    select: { status: true },
+                  },
                 },
-                select: { status: true },
               },
             },
           },
@@ -86,7 +90,7 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
       shortName: g.shortName,
       color: g.color || "#AAAAAA",
       politicalPosition: g.politicalPosition,
-      deputies: g.legacyMandates.map((m) => {
+      deputies: g.mandates.map(({ mandate: m }) => {
         const affairs = m.politician.affairs;
         let maxCertainty: CertaintyLevel | null = null;
         let activeCount = 0;

--- a/src/lib/data/hemicycle.ts
+++ b/src/lib/data/hemicycle.ts
@@ -40,7 +40,7 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
   const groups = await db.parliamentaryGroup.findMany({
     where: {
       chamber: "AN",
-      mandates: { some: { isCurrent: true, type: "DEPUTE" } },
+      legacyMandates: { some: { isCurrent: true, type: "DEPUTE" } },
     },
     select: {
       code: true,
@@ -48,7 +48,7 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
       shortName: true,
       color: true,
       politicalPosition: true,
-      mandates: {
+      legacyMandates: {
         where: { isCurrent: true, type: "DEPUTE" },
         take: 1000,
         select: {
@@ -86,7 +86,7 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
       shortName: g.shortName,
       color: g.color || "#AAAAAA",
       politicalPosition: g.politicalPosition,
-      deputies: g.mandates.map((m) => {
+      deputies: g.legacyMandates.map((m) => {
         const affairs = m.politician.affairs;
         let maxCertainty: CertaintyLevel | null = null;
         let activeCount = 0;

--- a/src/lib/data/politicians.ts
+++ b/src/lib/data/politicians.ts
@@ -14,8 +14,12 @@ export const getPolitician = cache(async function getPolitician(slug: string) {
       mandates: {
         orderBy: { startDate: "desc" },
         include: {
-          parliamentaryGroup: {
-            select: { code: true, name: true, color: true },
+          parliamentaryData: {
+            select: {
+              parliamentaryGroup: {
+                select: { code: true, name: true, color: true },
+              },
+            },
           },
         },
       },

--- a/src/lib/social/generators.ts
+++ b/src/lib/social/generators.ts
@@ -93,9 +93,15 @@ async function divisiveVotes(recent: RecentlyPosted): Promise<TweetDraft[]> {
           politician: {
             select: {
               mandates: {
-                where: { isCurrent: true, parliamentaryGroupId: { not: null } },
+                where: { isCurrent: true, parliamentaryData: { isNot: null } },
                 take: 1,
-                select: { parliamentaryGroup: { select: { name: true, code: true } } },
+                select: {
+                  parliamentaryData: {
+                    select: {
+                      parliamentaryGroup: { select: { name: true, code: true } },
+                    },
+                  },
+                },
               },
             },
           },
@@ -118,7 +124,7 @@ async function divisiveVotes(recent: RecentlyPosted): Promise<TweetDraft[]> {
     >();
     for (const v of s.votes) {
       if (v.position === "ABSENT" || v.position === "NON_VOTANT") continue;
-      const group = v.politician.mandates[0]?.parliamentaryGroup;
+      const group = v.politician.mandates[0]?.parliamentaryData?.parliamentaryGroup;
       const code = group?.code || "NI";
       const name = group?.name || "Non-inscrits";
       const entry = groupVotes.get(code) || {

--- a/src/services/politicians/index.ts
+++ b/src/services/politicians/index.ts
@@ -79,8 +79,12 @@ export async function getPoliticianBySlug(slug: string): Promise<PoliticianFull 
       mandates: {
         orderBy: { startDate: "desc" },
         include: {
-          parliamentaryGroup: {
-            select: { code: true, name: true, color: true },
+          parliamentaryData: {
+            select: {
+              parliamentaryGroup: {
+                select: { code: true, name: true, color: true },
+              },
+            },
           },
         },
       },

--- a/src/services/sync/compute-stats.ts
+++ b/src/services/sync/compute-stats.ts
@@ -180,7 +180,8 @@ async function computePoliticianParticipation(verbose = false): Promise<Politici
         )
     ) vote_sub
     LEFT JOIN "Party" p ON p.id = pol."currentPartyId"
-    LEFT JOIN "ParliamentaryGroup" pg ON pg.id = m."parliamentaryGroupId"
+    LEFT JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+    LEFT JOIN "ParliamentaryGroup" pg ON pg.id = mp."parliamentaryGroupId"
     WHERE pol."publicationStatus" = 'PUBLISHED'
       AND me.eligible > 0
   `;

--- a/src/services/sync/deputes.ts
+++ b/src/services/sync/deputes.ts
@@ -205,7 +205,6 @@ async function syncDeputy(
       sourceUrl: `https://www.assemblee-nationale.fr/dyn/deputes/${dep.id}`,
       officialUrl: `https://www.assemblee-nationale.fr/dyn/deputes/${dep.id}`,
       externalId: `${dep.id}-leg${dep.legislature}`,
-      parliamentaryGroupId: groupId,
     };
 
     if (existing) {
@@ -229,7 +228,17 @@ async function syncDeputy(
       if (existingMandate) {
         await db.mandate.update({
           where: { id: existingMandate.id },
-          data: mandateData,
+          data: {
+            ...mandateData,
+            parliamentaryData: groupId
+              ? {
+                  upsert: {
+                    create: { parliamentaryGroupId: groupId },
+                    update: { parliamentaryGroupId: groupId },
+                  },
+                }
+              : undefined,
+          },
         });
       } else {
         // Mark old mandates as not current
@@ -239,7 +248,11 @@ async function syncDeputy(
         });
 
         await db.mandate.create({
-          data: { ...mandateData, politicianId: existing.id },
+          data: {
+            ...mandateData,
+            politicianId: existing.id,
+            parliamentaryData: groupId ? { create: { parliamentaryGroupId: groupId } } : undefined,
+          },
         });
       }
 
@@ -250,7 +263,12 @@ async function syncDeputy(
         data: {
           ...politicianData,
           mandates: {
-            create: mandateData,
+            create: {
+              ...mandateData,
+              parliamentaryData: groupId
+                ? { create: { parliamentaryGroupId: groupId } }
+                : undefined,
+            },
           },
         },
       });

--- a/src/services/sync/senateurs.ts
+++ b/src/services/sync/senateurs.ts
@@ -257,7 +257,6 @@ async function syncSenator(
         ? `https://www.senat.fr${sen.url}`
         : `https://www.senat.fr/senateur/${sen.matricule}/`,
       externalId: `senat-${sen.matricule}`,
-      parliamentaryGroupId: groupId,
     };
 
     if (existing) {
@@ -299,11 +298,25 @@ async function syncSenator(
         }
         await db.mandate.update({
           where: { id: existingMandate.id },
-          data: updateData,
+          data: {
+            ...updateData,
+            parliamentaryData: groupId
+              ? {
+                  upsert: {
+                    create: { parliamentaryGroupId: groupId },
+                    update: { parliamentaryGroupId: groupId },
+                  },
+                }
+              : undefined,
+          },
         });
       } else {
         await db.mandate.create({
-          data: { ...mandateData, politicianId: existing.id },
+          data: {
+            ...mandateData,
+            politicianId: existing.id,
+            parliamentaryData: groupId ? { create: { parliamentaryGroupId: groupId } } : undefined,
+          },
         });
       }
 
@@ -313,7 +326,14 @@ async function syncSenator(
       const newPolitician = await db.politician.create({
         data: {
           ...politicianData,
-          mandates: { create: mandateData },
+          mandates: {
+            create: {
+              ...mandateData,
+              parliamentaryData: groupId
+                ? { create: { parliamentaryGroupId: groupId } }
+                : undefined,
+            },
+          },
         },
       });
 


### PR DESCRIPTION
## Summary

- Add `MandateParliamentary` 1:1 association model (same pattern as `MandateLocal`/`MandateGovernment`)
- Migrate all sync writes (deputes, senateurs) to write to new table
- Migrate all reads (~17 files: data layer, pages, components, API routes, raw SQL) to read through `parliamentaryData`
- Include one-shot migration script for existing data

## Notes

- Old `Mandate.parliamentaryGroupId` column kept temporarily with `@relation("LegacyMandateGroup")` disambiguation
- Column drop (Task 10) happens AFTER this deploys successfully
- Migration script: `npx dotenv -e .env -- npx tsx scripts/migrate-parliamentary-data.ts`

## Test plan

- [x] `npm run typecheck` passes
- [x] All 756 tests pass
- [ ] Run migration script after merge
- [ ] Verify Vercel deploy succeeds
- [ ] Then drop old column (Task 10)