### PR TITLE
feat: extract europeanGroupId into MandateEuropean (#276)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -282,7 +282,7 @@ model Mandate {
 
   // European Parliament specific (for MEPs)
   europeanGroupCode String? // Legacy: group code as text, will be migrated
-  europeanGroup     EuropeanGroup? @relation(fields: [europeanGroupId], references: [id])
+  europeanGroup     EuropeanGroup? @relation("LegacyEuropeanGroup", fields: [europeanGroupId], references: [id])
   europeanGroupId   String?
 
 
@@ -306,6 +306,9 @@ model Mandate {
 
   // Parliamentary mandate extension (1:1)
   parliamentaryData MandateParliamentary?
+
+  // European Parliament mandate extension (1:1)
+  europeanData MandateEuropean?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -363,6 +366,20 @@ model MandateParliamentary {
   @@index([parliamentaryGroupId])
 }
 
+// European Parliament mandate extension - 1:1 with Mandate for European Parliament group membership
+model MandateEuropean {
+  id                String        @id @default(cuid())
+  mandate           Mandate       @relation(fields: [mandateId], references: [id], onDelete: Cascade)
+  mandateId         String        @unique
+  europeanGroup     EuropeanGroup @relation(fields: [europeanGroupId], references: [id])
+  europeanGroupId   String
+  europeanGroupCode String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  @@index([europeanGroupId])
+}
+
 // European Parliament political groups
 model EuropeanGroup {
   id        String  @id @default(cuid())
@@ -382,7 +399,8 @@ model EuropeanGroup {
   legislature Int? // EP term number (e.g., 10 for 2024-2029)
 
   // Relations
-  mandates Mandate[]
+  legacyMandates Mandate[]         @relation("LegacyEuropeanGroup")
+  mandates       MandateEuropean[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/scripts/migrate-european-data.ts
+++ b/scripts/migrate-european-data.ts
@@ -1,0 +1,50 @@
+/**
+ * One-shot migration: copy Mandate.europeanGroupId/Code to MandateEuropean rows.
+ * Safe to re-run (skips mandates that already have europeanData).
+ *
+ * Usage: npx dotenv -e .env -- npx tsx scripts/migrate-european-data.ts
+ * Dry run: DRY_RUN=1 npx dotenv -e .env -- npx tsx scripts/migrate-european-data.ts
+ */
+import { db } from "@/lib/db";
+
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+async function main() {
+  console.log(`MandateEuropean migration ${DRY_RUN ? "(DRY RUN)" : ""}`);
+
+  const mandates = await db.$queryRaw<
+    { id: string; europeanGroupId: string; europeanGroupCode: string | null }[]
+  >`
+    SELECT m.id, m."europeanGroupId", m."europeanGroupCode"
+    FROM "Mandate" m
+    LEFT JOIN "MandateEuropean" me ON me."mandateId" = m.id
+    WHERE m."europeanGroupId" IS NOT NULL AND me.id IS NULL
+  `;
+
+  console.log(`Found ${mandates.length} mandates to migrate`);
+
+  if (DRY_RUN || mandates.length === 0) {
+    await db.$disconnect();
+    return;
+  }
+
+  let created = 0;
+  for (const m of mandates) {
+    await db.mandateEuropean.create({
+      data: {
+        mandateId: m.id,
+        europeanGroupId: m.europeanGroupId,
+        europeanGroupCode: m.europeanGroupCode,
+      },
+    });
+    created++;
+  }
+
+  console.log(`Created ${created} MandateEuropean records`);
+  await db.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/sync/europarl.ts
+++ b/src/services/sync/europarl.ts
@@ -230,11 +230,17 @@ async function syncMEP(
       await db.mandate.update({
         where: { id: existingMandate.id },
         data: {
-          europeanGroupCode,
-          europeanGroupId: europeanGroupId || undefined,
           externalId: europarlId,
           sourceUrl: `https://www.europarl.europa.eu/meps/fr/${europarlId}`,
           officialUrl: `https://www.europarl.europa.eu/meps/fr/${europarlId}`,
+          europeanData: europeanGroupId
+            ? {
+                upsert: {
+                  create: { europeanGroupId, europeanGroupCode },
+                  update: { europeanGroupId, europeanGroupCode },
+                },
+              }
+            : undefined,
         },
       });
       mandateResult = "updated";
@@ -250,14 +256,15 @@ async function syncMEP(
           title: mandateTitle,
           institution: mandateInstitution,
           constituency,
-          europeanGroupCode,
-          europeanGroupId: europeanGroupId || undefined,
           startDate,
           isCurrent: true,
           source: DataSource.PARLEMENT_EUROPEEN,
           externalId: europarlId,
           sourceUrl: `https://www.europarl.europa.eu/meps/fr/${europarlId}`,
           officialUrl: `https://www.europarl.europa.eu/meps/fr/${europarlId}`,
+          europeanData: europeanGroupId
+            ? { create: { europeanGroupId, europeanGroupCode } }
+            : undefined,
         },
       });
       mandateResult = "created";
@@ -343,7 +350,9 @@ export async function getEuroparlStats() {
       isCurrent: true,
     },
     include: {
-      europeanGroup: true,
+      europeanData: {
+        include: { europeanGroup: true },
+      },
     },
   });
 
@@ -353,7 +362,7 @@ export async function getEuroparlStats() {
     { code: string; name: string; color: string | null; count: number }
   >();
   for (const mandate of mandatesWithGroups) {
-    const group = mandate.europeanGroup;
+    const group = mandate.europeanData?.europeanGroup;
     const key = group?.id || "unknown";
     const existing = groupCounts.get(key);
     if (existing) {


### PR DESCRIPTION
## Summary

- Add `MandateEuropean` 1:1 association model (same pattern as `MandateLocal`/`MandateGovernment`/`MandateParliamentary`)
- Migrate europarl sync writes and reads to new table
- Include one-shot migration script for existing data

## Notes

- Old `Mandate.europeanGroupId`/`europeanGroupCode` columns kept temporarily
- Column drop happens AFTER this deploys successfully
- Migration script: `npx dotenv -e .env -- npx tsx scripts/migrate-european-data.ts`
- DB table already created via `db:push` before merge

## Test plan

- [x] `npm run typecheck` passes
- [x] All 756 tests pass
- [ ] Run migration script after merge
- [ ] Verify Vercel deploy succeeds
- [ ] Then drop old columns