### PR TITLE
fix(affaires): titres cliquables vers la fiche depuis la fiche politicien

### DIFF
--- a/src/components/politicians/AffairCard.tsx
+++ b/src/components/politicians/AffairCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { formatDate, stripMarkdown } from "@/lib/utils";
 import {
@@ -45,7 +46,15 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
                   ).getFullYear()}
                 </Badge>
               )}
-              <h3 className="font-semibold text-lg">{affair.title}</h3>
+              <h3 className="font-semibold text-lg">
+                <Link
+                  href={`/affaires/${affair.slug || affair.id}`}
+                  className="hover:underline focus-visible:underline"
+                  prefetch={false}
+                >
+                  {affair.title}
+                </Link>
+              </h3>
             </div>
           </div>
           <Badge

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -233,7 +233,15 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                                 ).getFullYear()}
                               </Badge>
                             )}
-                            <h3 className="font-semibold text-lg">{affair.title}</h3>
+                            <h3 className="font-semibold text-lg">
+                              <Link
+                                href={`/affaires/${affair.slug || affair.id}`}
+                                className="hover:underline focus-visible:underline"
+                                prefetch={false}
+                              >
+                                {affair.title}
+                              </Link>
+                            </h3>
                           </div>
                         </div>
                         <div className="flex items-center gap-2 self-start">

--- a/src/components/politicians/__tests__/AffairCard.test.tsx
+++ b/src/components/politicians/__tests__/AffairCard.test.tsx
@@ -5,6 +5,7 @@ import { AffairCard } from "@/components/politicians/AffairCard";
 function makeAffair(overrides: Record<string, unknown> = {}) {
   return {
     id: "a1",
+    slug: "affaire-de-test",
     title: "Affaire de test",
     description: "Description factuelle des faits.",
     status: "RELAXE",
@@ -84,5 +85,21 @@ describe("AffairCard — issues favorables dominantes (RGPD art. 10)", () => {
       />
     );
     expect(container.querySelector('[role="note"]')).toBeNull();
+  });
+});
+
+describe("AffairCard — navigation vers la fiche de l'affaire", () => {
+  it("le titre renvoie vers /affaires/<slug>", () => {
+    const { container } = render(<AffairCard affair={makeAffair()} variant="critique" />);
+    const link = container.querySelector('a[href="/affaires/affaire-de-test"]');
+    expect(link).toBeTruthy();
+    expect(link?.textContent).toContain("Affaire de test");
+  });
+
+  it("retombe sur l'id quand le slug est absent", () => {
+    const { container } = render(
+      <AffairCard affair={makeAffair({ slug: null })} variant="other" />
+    );
+    expect(container.querySelector('a[href="/affaires/a1"]')).toBeTruthy();
   });
 });

--- a/src/components/politicians/__tests__/AffairsSection.test.tsx
+++ b/src/components/politicians/__tests__/AffairsSection.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { AffairsSection } from "@/components/politicians/AffairsSection";
+
+function makeAffair(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "v1",
+    slug: "affaire-victime",
+    title: "Affaire de test",
+    description: "Faits factuels.",
+    status: "CONDAMNATION_DEFINITIVE",
+    category: "VIOLENCE",
+    involvement: "VICTIM",
+    factsDate: null,
+    startDate: null,
+    verdictDate: new Date("2024-01-15"),
+    createdAt: new Date("2024-01-01"),
+    appeal: false,
+    court: null,
+    chamber: null,
+    caseNumber: null,
+    partyAtTime: null,
+    events: [],
+    sources: [],
+    linkedAffair: null,
+    linkedBy: [],
+    prisonMonths: null,
+    prisonSuspended: null,
+    fineAmount: null,
+    ineligibilityMonths: null,
+    communityService: null,
+    otherSentence: null,
+    sentence: null,
+    ...overrides,
+  };
+}
+
+describe("AffairsSection — liens vers les fiches d'affaires", () => {
+  it("une affaire en cause directe renvoie vers sa fiche", () => {
+    const { container } = render(
+      <AffairsSection
+        affairs={[makeAffair({ id: "d1", slug: "affaire-directe", involvement: "DIRECT" })]}
+        civility="M"
+      />
+    );
+    expect(container.querySelector('a[href="/affaires/affaire-directe"]')).toBeTruthy();
+  });
+
+  it("une affaire où le politicien est victime renvoie vers sa fiche", () => {
+    const { container } = render(<AffairsSection affairs={[makeAffair()]} civility="M" />);
+    expect(container.querySelector('a[href="/affaires/affaire-victime"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problème
Sur l'onglet « Affaires » d'une fiche politicien, les affaires n'étaient pas cliquables : le titre était un simple `<h3>`. Seules les affaires en « Mentions » pointaient vers `/affaires/<slug>`.

## Correctif
Le titre des affaires en cause directe (`AffairCard`) et des affaires « Victime » (`AffairsSection`) devient un lien vers la fiche de l'affaire. Le lien est porté par le titre (et non la carte entière) pour éviter d'imbriquer des ancres dans les liens de sources.

## Tests
`AffairCard.test.tsx` et `AffairsSection.test.tsx` : le titre pointe vers `/affaires/<slug>`, avec repli sur l'id si le slug manque. 30 tests verts sur `src/components/politicians`.