### PR TITLE
Exiger une corroboration hors-nom pour lier une affaire

### DIFF
--- a/src/lib/affair-matching/__tests__/combiner.test.ts
+++ b/src/lib/affair-matching/__tests__/combiner.test.ts
@@ -21,7 +21,14 @@ describe("AffairCombiner", () => {
 
   it("returns SAME when top candidate clears SAME_THRESHOLD and gap >= MIN_GAP", () => {
     const result = combiner.judge([
-      scored("winner", [5.2, 3.0, 2.0]), // total 10.2
+      {
+        candidateId: "winner",
+        signals: [
+          signal(5.2, "name-quality"),
+          signal(3.0, "jurisdiction"),
+          signal(2.0, "role-context"),
+        ],
+      }, // total 10.2, corroborated
       scored("runnerup", [2.0]), // total 2.0, gap 8.2
     ]);
     expect(result.judgment).toBe("SAME");
@@ -32,15 +39,15 @@ describe("AffairCombiner", () => {
 
   it("returns UNDECIDED when top clears SAME but gap is below MIN_GAP", () => {
     const result = combiner.judge([
-      scored("c1", [5.2, 1.0]), // total 6.2
-      scored("c2", [5.2, 0.5]), // total 5.7, gap 0.5
+      { candidateId: "c1", signals: [signal(5.2, "name-quality"), signal(1.0, "role-context")] }, // 6.2, corroborated
+      { candidateId: "c2", signals: [signal(5.2, "name-quality"), signal(0.5, "role-context")] }, // 5.7, gap 0.5
     ]);
     expect(result.judgment).toBe("UNDECIDED");
   });
 
   it("returns UNDECIDED when top is between FLOOR and SAME_THRESHOLD", () => {
     const result = combiner.judge([
-      scored("c1", [4.0]), // between FLOOR (3.0) and SAME_THRESHOLD (5.0)
+      { candidateId: "c1", signals: [signal(4.0, "role-context")] }, // between FLOOR and SAME, corroborated
     ]);
     expect(result.judgment).toBe("UNDECIDED");
   });
@@ -71,5 +78,60 @@ describe("AffairCombiner", () => {
     expect(result.topCandidateId).toBe("high");
     expect(result.topCandidates.map((c) => c.candidateId)).toEqual(["high", "mid", "low"]);
     expect(result.topCandidates).toHaveLength(3);
+  });
+});
+
+describe("AffairCombiner — name-only gate", () => {
+  it("downgrades a name-only match to NO_MATCH even above SAME_THRESHOLD", () => {
+    const result = combiner.judge([
+      // Exact name (5.2) + first name (1.5) = 6.7, but nothing ties this person
+      // to the affair: an incidental mention.
+      {
+        candidateId: "mention",
+        signals: [signal(5.2, "name-quality"), signal(1.5, "first-name")],
+      },
+    ]);
+    expect(result.judgment).toBe("NO_MATCH");
+    // Candidate is preserved for inspection, not discarded.
+    expect(result.topCandidateId).toBe("mention");
+    expect(result.topScore).toBeCloseTo(6.7);
+  });
+
+  it("keeps SAME when a corroborating signal supports the name match", () => {
+    const result = combiner.judge([
+      { candidateId: "real", signals: [signal(5.2, "name-quality"), signal(4.0, "role-context")] },
+      { candidateId: "other", signals: [signal(1.0, "name-quality")] },
+    ]);
+    expect(result.judgment).toBe("SAME");
+    expect(result.topCandidateId).toBe("real");
+  });
+
+  it("treats external-id alone as corroboration (deterministic match)", () => {
+    const result = combiner.judge([
+      { candidateId: "ecli", signals: [signal(10.0, "external-id")] },
+    ]);
+    expect(result.judgment).toBe("SAME");
+  });
+
+  it("does not treat context-plausibility (French anchor) as corroboration", () => {
+    const result = combiner.judge([
+      {
+        candidateId: "x",
+        signals: [signal(5.2, "name-quality"), signal(1.0, "context-plausibility")],
+      },
+    ]);
+    expect(result.judgment).toBe("NO_MATCH");
+  });
+
+  it("does not count a negative corroborating signal (role mismatch)", () => {
+    const result = combiner.judge([
+      // Name matches (5.2) but role context contradicts (-2): net 3.2, above FLOOR
+      // yet the only non-name signal is negative -> no corroboration.
+      {
+        candidateId: "wrong",
+        signals: [signal(5.2, "name-quality"), signal(-2.0, "role-context")],
+      },
+    ]);
+    expect(result.judgment).toBe("NO_MATCH");
   });
 });

--- a/src/lib/affair-matching/__tests__/resolver.test.ts
+++ b/src/lib/affair-matching/__tests__/resolver.test.ts
@@ -82,7 +82,31 @@ describe("scoreAffairAgainstCandidates", () => {
     expect(decision.judgment).toBe("NO_MATCH");
   });
 
-  it("returns UNDECIDED when two candidates have close scores", () => {
+  it("returns UNDECIDED when two corroborated candidates have close scores", () => {
+    const input: AffairScoringInput = {
+      text: "Le maire de Lyon Jean Dupont aurait reçu des fonds non déclarés selon l'enquête.",
+      metadata: { source: SourceType.PRESSE },
+    };
+
+    const lyonMayor = {
+      type: "MAIRE",
+      roleLabel: "Maire",
+      location: "Lyon",
+      startDate: new Date("2014-01-01"),
+      endDate: null,
+    };
+    const candidates: AffairCandidateRecord[] = [
+      politician({ id: "pol1", mandates: [lyonMayor] }),
+      politician({ id: "pol2", mandates: [lyonMayor] }),
+    ];
+
+    const decision = scoreAffairAgainstCandidates(input, candidates);
+    expect(decision.judgment).toBe("UNDECIDED");
+  });
+
+  it("returns NO_MATCH for a name-only mention with no corroboration", () => {
+    // Two homonyms, nothing ties either to the affair (no mandate, party, or
+    // jurisdiction). Name alone must not reach the SAME/UNDECIDED queues.
     const input: AffairScoringInput = {
       text: "Jean Dupont aurait reçu des fonds non déclarés selon l'enquête.",
       metadata: { source: SourceType.PRESSE },
@@ -94,6 +118,6 @@ describe("scoreAffairAgainstCandidates", () => {
     ];
 
     const decision = scoreAffairAgainstCandidates(input, candidates);
-    expect(decision.judgment).toBe("UNDECIDED");
+    expect(decision.judgment).toBe("NO_MATCH");
   });
 });

--- a/src/lib/affair-matching/combiner.ts
+++ b/src/lib/affair-matching/combiner.ts
@@ -3,6 +3,28 @@ import { FLOOR_SCORE, SAME_THRESHOLD, MIN_GAP } from "./signals/constants";
 
 export type AffairJudgment = "SAME" | "UNDECIDED" | "NO_MATCH";
 
+/**
+ * Signals that tie a *specific* candidate to the *specific* affair, beyond the
+ * name itself. A name match alone (even NAME_FULL_EXACT at 5.2, which clears
+ * SAME_THRESHOLD on its own) must not reach SAME/UNDECIDED without at least one
+ * of these firing positive. Otherwise incidental mentions ("X a réagi à
+ * l'affaire Y", "selon le maire X…") flood the SAME/UNDECIDED review queues.
+ *
+ * `name-quality` and `first-name` are identity-only; `context-plausibility` is
+ * a global French/foreign anchor, not a per-candidate tie. None corroborate.
+ */
+const CORROBORATING_SIGNAL_IDS = new Set([
+  "external-id",
+  "jurisdiction",
+  "party-context",
+  "role-context",
+  "temporal-mandate",
+]);
+
+function hasCorroboration(signals: AffairSignalResult[]): boolean {
+  return signals.some((s) => CORROBORATING_SIGNAL_IDS.has(s.signalId) && s.logLikelihoodRatio > 0);
+}
+
 export interface CandidateSignals {
   candidateId: string;
   signals: AffairSignalResult[];
@@ -59,6 +81,20 @@ export class AffairCombiner {
         judgment: "NO_MATCH",
         topCandidateId: top?.candidateId ?? null,
         topScore: top?.totalScore ?? 0,
+        gap,
+        topCandidates,
+      };
+    }
+
+    // Name-only gate: a candidate can only enter the SAME/UNDECIDED review
+    // queues if a non-name signal ties it to this affair. Without corroboration
+    // it is an incidental mention — keep the candidate for inspection but push
+    // it out of the review queues as NO_MATCH.
+    if (!hasCorroboration(top.signals)) {
+      return {
+        judgment: "NO_MATCH",
+        topCandidateId: top.candidateId,
+        topScore: top.totalScore,
         gap,
         topCandidates,
       };


### PR DESCRIPTION
## Problème

Le combineur `affair-matching` juge par simple somme de log-vraisemblances,
avec `SAME_THRESHOLD = 5.0`. Or un nom exact seul vaut déjà `NAME_FULL_EXACT = 5.2` :
une mention incidente (« X a réagi à l'affaire Y », « selon le maire X… »)
franchissait le seuil et générait une ligne `SAME`/`UNDECIDED` à modérer. Sur
le backlog actuel, ~446 lignes `SAME` sont des mentions « nom seul ».

## Correctif

Un candidat ne peut entrer dans les files `SAME`/`UNDECIDED` que si un signal
**hors-nom** le relie à cette affaire précise : `role-context`, `jurisdiction`,
`temporal-mandate`, `party-context` ou `external-id` positif. Sinon → `NO_MATCH`
(le candidat reste consultable via `topCandidates`, il n'est pas perdu).

`name-quality` et `first-name` sont purement identitaires ; `context-plausibility`
est un ancrage FR/étranger global : aucun ne corrobore à lui seul.

Effet : tarit à la source les mentions incidentes dans les files de revue. Ne
retraite pas le backlog déjà persisté (nettoyage séparé).

## Tests

`npx vitest run src/lib/affair-matching` → 81 passants (combineur 6→11).
Cas couverts : downgrade nom-seul même au-dessus du seuil, `external-id` seul
suffit, `context-plausibility` ne corrobore pas, signal négatif non compté,
et un test d'intégration resolver nom-seul → `NO_MATCH`.
