### PR TITLE
feat(groupes): distinguer la concordance des votes finaux

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1051,6 +1051,7 @@ model ParliamentaryGroupStats {
   legislature             Int
   cohesionPct             Float
   governmentAlignmentPct  Float
+  finalVoteAlignmentPct   Float              @default(0)
   averageParticipationPct Float
   computedAt              DateTime           @default(now())
   updatedAt               DateTime           @updatedAt

--- a/src/app/parlement/groupes/[slug]/page.tsx
+++ b/src/app/parlement/groupes/[slug]/page.tsx
@@ -8,7 +8,10 @@ import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import { getGroupeDetail, getGroupKeyVotes } from "@/lib/data/groupes";
 import { VoteCard } from "@/components/votes";
 import { CHAMBER_SHORT_LABELS } from "@/config/labels";
-import { Users, TrendingUp, Target, Activity } from "lucide-react";
+import { GLOSSARY } from "@/config/glossary";
+import { GOVERNMENT_GROUP_CODE, SENATE_GOVERNMENT_GROUP_CODE } from "@/config/scrutin-importance";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
+import { Users, TrendingUp, Target, Activity, FileCheck2 } from "lucide-react";
 import { ParliamentaryGroupJsonLd } from "@/components/seo/JsonLd";
 
 export const revalidate = 3600;
@@ -39,6 +42,10 @@ export default async function GroupeDetailPage({ params }: PageProps) {
   const stats = group.stats[0];
 
   const chamberLabel = group.chamber === "AN" ? "Assemblée nationale" : "Sénat";
+  const referenceGroupCode =
+    group.chamber === "AN" ? GOVERNMENT_GROUP_CODE : SENATE_GOVERNMENT_GROUP_CODE;
+  const concordanceVotesTooltip = `${GLOSSARY.concordanceVotesGroupes} Groupe de référence pour cette chambre : ${referenceGroupCode}.`;
+  const concordanceTextesTooltip = `${GLOSSARY.concordanceTextesLoi} Groupe de référence pour cette chambre : ${referenceGroupCode}.`;
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -85,24 +92,43 @@ export default async function GroupeDetailPage({ params }: PageProps) {
 
       {/* Stats row */}
       {stats && (
-        <div className="grid grid-cols-3 gap-4 mb-8">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
           <Card>
             <CardContent className="p-4 text-center">
-              <TrendingUp className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+              <TrendingUp
+                className="h-5 w-5 mx-auto mb-1 text-muted-foreground"
+                aria-hidden="true"
+              />
               <p className="text-2xl font-bold">{Math.round(stats.cohesionPct)}%</p>
               <p className="text-xs text-muted-foreground">Cohésion</p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="p-4 text-center">
-              <Target className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+              <Target className="h-5 w-5 mx-auto mb-1 text-muted-foreground" aria-hidden="true" />
               <p className="text-2xl font-bold">{Math.round(stats.governmentAlignmentPct)}%</p>
-              <p className="text-xs text-muted-foreground">Alignement gouvernemental</p>
+              <div className="flex items-center justify-center gap-1">
+                <p className="text-xs text-muted-foreground">Concordance des votes</p>
+                <InfoTooltip text={concordanceVotesTooltip} side="bottom" />
+              </div>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="p-4 text-center">
-              <Activity className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+              <FileCheck2
+                className="h-5 w-5 mx-auto mb-1 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <p className="text-2xl font-bold">{Math.round(stats.finalVoteAlignmentPct)}%</p>
+              <div className="flex items-center justify-center gap-1">
+                <p className="text-xs text-muted-foreground">Concordance sur les textes de loi</p>
+                <InfoTooltip text={concordanceTextesTooltip} side="bottom" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <Activity className="h-5 w-5 mx-auto mb-1 text-muted-foreground" aria-hidden="true" />
               <p className="text-2xl font-bold">{Math.round(stats.averageParticipationPct)}%</p>
               <p className="text-xs text-muted-foreground">Participation</p>
             </CardContent>

--- a/src/components/groupes/GroupCard.tsx
+++ b/src/components/groupes/GroupCard.tsx
@@ -56,7 +56,7 @@ export function GroupCard({ group }: GroupCardProps) {
                 <p className="text-lg font-bold">
                   {Math.round(group.stats.governmentAlignmentPct)}%
                 </p>
-                <p className="text-xs text-muted-foreground">Alignement</p>
+                <p className="text-xs text-muted-foreground">Concordance</p>
               </div>
               <div>
                 <p className="text-lg font-bold">

--- a/src/components/ui/info-tooltip.tsx
+++ b/src/components/ui/info-tooltip.tsx
@@ -54,6 +54,7 @@ export function InfoTooltip({
             className
           )}
           aria-label={`Aide : ${term || "information"}`}
+          title={`Aide : ${term || "information"}`}
         >
           <Info className={iconSize} aria-hidden="true" />
         </button>

--- a/src/config/glossary.ts
+++ b/src/config/glossary.ts
@@ -44,6 +44,10 @@ export const PARLIAMENTARY_TERMS = {
     "Les représentants sont élus par des grands électeurs, eux-mêmes élus (ex : sénatoriales).",
   concordance:
     "Pourcentage de votes identiques entre deux parlementaires sur les scrutins auxquels ils ont tous les deux participé.",
+  concordanceVotesGroupes:
+    "Pourcentage de scrutins où la position majoritaire du groupe correspond à celle du groupe de référence de sa chambre. Tous les types de scrutins sont inclus. Le groupe de référence sert d'indicateur de la position gouvernementale, sans constituer une position officielle du gouvernement.",
+  concordanceTextesLoi:
+    "Pourcentage de votes finaux sur les projets et propositions de loi où la position majoritaire du groupe correspond à celle du groupe de référence de sa chambre. Les amendements, les votes par article et les motions sont exclus. Le groupe de référence sert d'indicateur de la position gouvernementale, sans constituer une position officielle du gouvernement.",
 } as const;
 
 // ============================================

--- a/src/lib/data/groupes.ts
+++ b/src/lib/data/groupes.ts
@@ -80,6 +80,7 @@ export interface GroupListingItem {
   stats: {
     cohesionPct: number;
     governmentAlignmentPct: number;
+    finalVoteAlignmentPct: number;
     averageParticipationPct: number;
   } | null;
 }
@@ -134,6 +135,7 @@ export async function getGroupesListing(
       ? {
           cohesionPct: g.stats[0].cohesionPct,
           governmentAlignmentPct: g.stats[0].governmentAlignmentPct,
+          finalVoteAlignmentPct: g.stats[0].finalVoteAlignmentPct,
           averageParticipationPct: g.stats[0].averageParticipationPct,
         }
       : null,

--- a/src/services/sync/__tests__/compute-group-stats.test.ts
+++ b/src/services/sync/__tests__/compute-group-stats.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({ db: {} }));
 
-import { computeAverageCohesion, computeGovernmentAlignment } from "../compute-group-stats";
+import {
+  computeAlignmentRates,
+  computeAverageCohesion,
+  computeGovernmentAlignment,
+} from "../compute-group-stats";
 
 describe("computeAverageCohesion", () => {
   it("averages cohesion across all group positions", () => {
@@ -42,5 +46,27 @@ describe("computeGovernmentAlignment", () => {
       govGroupPositions: [],
     });
     expect(result).toBe(0);
+  });
+});
+
+describe("computeAlignmentRates", () => {
+  it("separates all scrutin types from final votes", () => {
+    const result = computeAlignmentRates({
+      groupPositions: [
+        { scrutinId: "final-1", position: "POUR", scrutin: { type: "FINAL" } },
+        { scrutinId: "final-2", position: "CONTRE", scrutin: { type: "FINAL" } },
+        { scrutinId: "amendement-1", position: "POUR", scrutin: { type: "AMENDEMENT" } },
+        { scrutinId: "amendement-2", position: "POUR", scrutin: { type: "AMENDEMENT" } },
+      ],
+      govGroupPositions: [
+        { scrutinId: "final-1", position: "POUR", scrutin: { type: "FINAL" } },
+        { scrutinId: "final-2", position: "POUR", scrutin: { type: "FINAL" } },
+        { scrutinId: "amendement-1", position: "POUR", scrutin: { type: "AMENDEMENT" } },
+        { scrutinId: "amendement-2", position: "POUR", scrutin: { type: "AMENDEMENT" } },
+      ],
+    });
+
+    expect(result.governmentAlignmentPct).toBe(75);
+    expect(result.finalVoteAlignmentPct).toBe(50);
   });
 });

--- a/src/services/sync/compute-group-stats.ts
+++ b/src/services/sync/compute-group-stats.ts
@@ -5,7 +5,7 @@ import {
   CURRENT_LEGISLATURE,
   CURRENT_SENATE_SESSION,
 } from "@/config/scrutin-importance";
-import type { Chamber } from "@/generated/prisma";
+import type { Chamber, ScrutinType } from "@/generated/prisma";
 
 export function computeAverageCohesion(positions: Array<{ cohesionPct: number }>): number {
   if (positions.length === 0) return 0;
@@ -32,6 +32,39 @@ export function computeGovernmentAlignment(params: {
   }
 
   return total > 0 ? Math.round((matching / total) * 1000) / 10 : 0;
+}
+
+interface TypedAlignmentPosition {
+  scrutinId: string;
+  position: string;
+  scrutin: { type: ScrutinType | null };
+}
+
+export function computeAlignmentRates(params: {
+  groupPositions: TypedAlignmentPosition[];
+  govGroupPositions: TypedAlignmentPosition[];
+}): {
+  governmentAlignmentPct: number;
+  finalVoteAlignmentPct: number;
+} {
+  const { groupPositions, govGroupPositions } = params;
+  const finalGroupPositions = groupPositions.filter(
+    (position) => position.scrutin.type === "FINAL"
+  );
+  const finalGovGroupPositions = govGroupPositions.filter(
+    (position) => position.scrutin.type === "FINAL"
+  );
+
+  return {
+    governmentAlignmentPct: computeGovernmentAlignment({
+      groupPositions,
+      govGroupPositions,
+    }),
+    finalVoteAlignmentPct: computeGovernmentAlignment({
+      groupPositions: finalGroupPositions,
+      govGroupPositions: finalGovGroupPositions,
+    }),
+  };
 }
 
 interface ChamberConfig {
@@ -69,18 +102,27 @@ async function computeForChamber(config: ChamberConfig): Promise<number> {
   const govPositions = govGroup
     ? await db.scrutinGroupPosition.findMany({
         where: { groupId: govGroup.id },
-        select: { scrutinId: true, position: true },
+        select: {
+          scrutinId: true,
+          position: true,
+          scrutin: { select: { type: true } },
+        },
       })
     : [];
 
   for (const group of groups) {
     const positions = await db.scrutinGroupPosition.findMany({
       where: { groupId: group.id },
-      select: { scrutinId: true, position: true, cohesionPct: true },
+      select: {
+        scrutinId: true,
+        position: true,
+        cohesionPct: true,
+        scrutin: { select: { type: true } },
+      },
     });
 
     const cohesionPct = computeAverageCohesion(positions);
-    const governmentAlignmentPct = computeGovernmentAlignment({
+    const { governmentAlignmentPct, finalVoteAlignmentPct } = computeAlignmentRates({
       groupPositions: positions,
       govGroupPositions: govPositions,
     });
@@ -122,11 +164,13 @@ async function computeForChamber(config: ChamberConfig): Promise<number> {
         legislature: config.statsLegislature,
         cohesionPct,
         governmentAlignmentPct,
+        finalVoteAlignmentPct,
         averageParticipationPct,
       },
       update: {
         cohesionPct,
         governmentAlignmentPct,
+        finalVoteAlignmentPct,
         averageParticipationPct,
       },
     });


### PR DESCRIPTION
## Résumé

- renomme l'indicateur actuel en « Concordance des votes »
- ajoute « Concordance sur les textes de loi », calculée uniquement sur les scrutins `FINAL`
- adapte le groupe de référence à la chambre, EPR à l'Assemblée nationale et RDPI au Sénat
- ajoute les info-bulles, les définitions de glossaire et le champ de statistiques associé
- couvre la différence entre tous les scrutins et les votes finaux par un test unitaire

## Pourquoi

L'indicateur existant était présenté comme un alignement gouvernemental alors qu'il compare les groupes parlementaires à un groupe de référence. Il ne précisait pas non plus que son périmètre incluait les amendements, les articles et les votes intermédiaires.

Cette modification conserve le calcul historique et ajoute un indicateur distinct pour la position politique exprimée lors de l'adoption finale des textes.

Closes #451

## Impact

Les fiches de groupes affichent maintenant deux mesures complémentaires et transparentes. La carte compacte des listes conserve une seule valeur afin de ne pas modifier son tri.

## Validation

- `npm run test:run`, 1 868 tests réussis et 117 ignorés
- `npm run typecheck`
- `npm run lint`
- validation Prisma réussie
- compilation Next.js et contrôle TypeScript réussis localement, la collecte finale des pages nécessite une `DATABASE_URL` non disponible dans l'environnement local
