### PR TITLE
fix(sync): fiabiliser le daily sync + alerte backlog presse

### DIFF
--- a/.github/workflows/sync-daily.yml
+++ b/.github/workflows/sync-daily.yml
@@ -23,6 +23,12 @@ env:
   JUDILIBRE_CLIENT_ID: ${{ secrets.JUDILIBRE_CLIENT_ID }}
   JUDILIBRE_CLIENT_SECRET: ${{ secrets.JUDILIBRE_CLIENT_SECRET }}
   JUDILIBRE_API_KEY: ${{ secrets.JUDILIBRE_API_KEY }}
+  # Press backlog notifier (scripts/notify-press-backlog.ts)
+  MAILJET_API_KEY: ${{ secrets.MAILJET_API_KEY }}
+  MAILJET_SECRET_KEY: ${{ secrets.MAILJET_SECRET_KEY }}
+  MAILJET_SENDER_EMAIL: ${{ secrets.MAILJET_SENDER_EMAIL }}
+  MAILJET_SENDER_NAME: ${{ secrets.MAILJET_SENDER_NAME }}
+  PRESS_BACKLOG_NOTIFY_EMAIL: ${{ secrets.PRESS_BACKLOG_NOTIFY_EMAIL }}
 
 jobs:
   daily-sync:

--- a/scripts/notify-press-backlog.ts
+++ b/scripts/notify-press-backlog.ts
@@ -1,0 +1,84 @@
+/**
+ * Press backlog notifier (daily sync step).
+ *
+ * Counts press articles still awaiting AI analysis (aiAnalyzedAt = null). When the
+ * backlog crosses a threshold, emails a catch-up nudge so the analysis can be
+ * replayed manually from a Claude Code CLI session (`/analyse-presse`) without
+ * spending API credits. De-duplicated to at most once per ~day via syncMetadata.
+ *
+ * Non-blocking in the orchestrator (allowFailure): a mail hiccup must never fail
+ * the whole daily sync.
+ *
+ * Usage:
+ *   npx tsx scripts/notify-press-backlog.ts
+ *   npx tsx scripts/notify-press-backlog.ts --dry-run   # count only, no email
+ */
+
+import "dotenv/config";
+import { db } from "../src/lib/db";
+import { syncMetadata } from "../src/lib/sync/sync-metadata";
+import { sendTransactional } from "../src/lib/email/mailjet";
+import {
+  PRESS_BACKLOG_THRESHOLD_DEFAULT,
+  buildPressBacklogEmail,
+  shouldNotifyPressBacklog,
+} from "../src/lib/email/press-backlog";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const NOTIFY_KEY = "press-backlog-notify";
+// At most one nudge per ~day (the sync runs 3x/day).
+const NOTIFY_MIN_INTERVAL_MS = 20 * 60 * 60 * 1000;
+// Only recent articles matter: the pipeline prioritizes fresh news, so a fresh
+// backlog means it fell behind. The deep all-time backlog (~13k old Tier-2
+// articles) is a separate drain project (#338) and would otherwise page daily.
+const BACKLOG_WINDOW_DAYS = 3;
+
+function getThreshold(): number {
+  const raw = Number(process.env.PRESS_BACKLOG_THRESHOLD);
+  return Number.isFinite(raw) && raw > 0 ? raw : PRESS_BACKLOG_THRESHOLD_DEFAULT;
+}
+
+async function main() {
+  const threshold = getThreshold();
+  const recipient = process.env.PRESS_BACKLOG_NOTIFY_EMAIL || "lamine@poligraph.fr";
+
+  const cutoff = new Date(Date.now() - BACKLOG_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const backlog = await db.pressArticle.count({
+    where: { aiAnalyzedAt: null, publishedAt: { gte: cutoff } },
+  });
+  console.log(
+    `Press backlog (last ${BACKLOG_WINDOW_DAYS}d): ${backlog} unanalyzed article(s) (threshold ${threshold})`
+  );
+
+  if (!shouldNotifyPressBacklog(backlog, threshold)) {
+    console.log("Backlog under threshold, no notification.");
+    return;
+  }
+
+  if (DRY_RUN) {
+    console.log(`[dry-run] Would email ${recipient} about ${backlog} article(s).`);
+    return;
+  }
+
+  if (!process.env.MAILJET_API_KEY || !process.env.MAILJET_SECRET_KEY) {
+    console.warn("MAILJET_API_KEY / MAILJET_SECRET_KEY not set, skipping notification.");
+    return;
+  }
+
+  // De-duplicate: skip if we already notified within the last ~day.
+  if (!(await syncMetadata.shouldSync(NOTIFY_KEY, NOTIFY_MIN_INTERVAL_MS))) {
+    console.log("Already notified recently, skipping.");
+    return;
+  }
+
+  const { subject, html, text } = buildPressBacklogEmail(backlog, BACKLOG_WINDOW_DAYS);
+  await sendTransactional({ to: recipient, subject, html, text });
+  await syncMetadata.markCompleted(NOTIFY_KEY, { itemCount: backlog });
+  console.log(`Notification sent to ${recipient}.`);
+}
+
+main().catch((err) => {
+  console.error("Press backlog notification failed:", err);
+  process.exit(1);
+});

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -23,6 +23,12 @@ const BASE_URL =
     : "http://localhost:3000";
 const CRON_SECRET = process.env.CRON_SECRET;
 
+// Pause between retry attempts so a still-ongoing transient blip (e.g. a
+// Supabase connection drop) has time to clear instead of the retry hitting it
+// back-to-back.
+const RETRY_BACKOFF_MS = 20 * 1000;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 interface SyncStep {
   name: string;
   command: string;
@@ -116,13 +122,23 @@ const steps: SyncStep[] = [
   {
     name: "Compute participation stats",
     command: `npx tsx scripts/compute-stats.ts${dryRunFlag}`,
-    // Blocking step killed once by a transient Supabase connection drop (#442);
-    // the very next run succeeded without any change. One retry absorbs the blip.
-    retries: 1,
+    // Blocking step recurrently killed by transient Supabase connection drops
+    // (#442). One retry (6587772) was not enough on 2026-07-16: both back-to-back
+    // attempts hit the same ongoing drop. Two retries + the RETRY_BACKOFF_MS pause
+    // between attempts give the blip time to clear.
+    retries: 2,
   },
   {
     name: "IndexNow",
     command: `npx tsx scripts/submit-indexnow.ts`,
+  },
+  {
+    // Non-blocking: emails a catch-up nudge when press articles pile up
+    // unanalyzed (dry credits, upstream slowness, volume). The manual
+    // /analyse-presse skill drains the backlog without spending API credits.
+    name: "Notification backlog presse",
+    command: `npx tsx scripts/notify-press-backlog.ts${dryRunFlag}`,
+    allowFailure: true,
   },
   ...(CRON_SECRET
     ? [
@@ -194,6 +210,10 @@ async function main() {
             `  skipping retry: attempt ran ${(attemptDuration / 1000).toFixed(0)}s (not a transient blip)`
           );
           break;
+        }
+        if (attempt < maxAttempts) {
+          console.error(`  ↻ backing off ${(RETRY_BACKOFF_MS / 1000).toFixed(0)}s before retry`);
+          await sleep(RETRY_BACKOFF_MS);
         }
       }
     }

--- a/scripts/sync-press-analysis.ts
+++ b/scripts/sync-press-analysis.ts
@@ -17,7 +17,11 @@
 
 import "dotenv/config";
 import { createCLI, type SyncHandler, type SyncResult } from "../src/lib/sync";
-import { syncPressAnalysis, getPressAnalysisStats } from "../src/services/sync/press-analysis";
+import {
+  syncPressAnalysis,
+  getPressAnalysisStats,
+  isPressAnalysisSuccessful,
+} from "../src/services/sync/press-analysis";
 
 const handler: SyncHandler = {
   name: "Poligraph - Analyse IA Presse (affaires judiciaires)",
@@ -109,7 +113,7 @@ Environment:
     });
 
     return {
-      success: stats.analysisErrors === 0,
+      success: isPressAnalysisSuccessful(stats),
       duration: 0,
       stats: {
         articlesProcessed: stats.articlesProcessed,
@@ -121,6 +125,7 @@ Environment:
         scrapeErrors: stats.scrapeErrors,
         analysisErrors: stats.analysisErrors,
         sensitiveWarnings: stats.sensitiveWarnings,
+        quotaStopped: stats.quotaStopped ? 1 : 0,
       },
       errors: [],
     };

--- a/src/lib/api/article-scraper.ts
+++ b/src/lib/api/article-scraper.ts
@@ -63,8 +63,12 @@ export class ArticleScraper {
   constructor() {
     this.httpClient = new HTTPClient({
       rateLimitMs: SCRAPE_RATE_LIMIT_MS,
-      timeout: 30_000,
-      retries: 2,
+      // Tight budget on purpose: press analysis has an RSS title+description
+      // fallback for every scrapable source, so a slow/hanging fetch should
+      // fail fast rather than burn the daily-sync 10 min per-step timeout.
+      // Worst case per slow source drops from 30s×3 to 12s×2.
+      timeout: 12_000,
+      retries: 1,
       headers: {
         Accept: "text/html,application/xhtml+xml",
       },

--- a/src/lib/email/press-backlog.test.ts
+++ b/src/lib/email/press-backlog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRESS_BACKLOG_THRESHOLD_DEFAULT,
+  buildPressBacklogEmail,
+  shouldNotifyPressBacklog,
+} from "./press-backlog";
+
+describe("shouldNotifyPressBacklog", () => {
+  it("notifies at or above the threshold", () => {
+    expect(shouldNotifyPressBacklog(30, 30)).toBe(true);
+    expect(shouldNotifyPressBacklog(45, 30)).toBe(true);
+  });
+
+  it("stays quiet below the threshold", () => {
+    expect(shouldNotifyPressBacklog(29, 30)).toBe(false);
+    expect(shouldNotifyPressBacklog(0, 30)).toBe(false);
+  });
+
+  it("has a sane default threshold", () => {
+    expect(PRESS_BACKLOG_THRESHOLD_DEFAULT).toBe(30);
+  });
+});
+
+describe("buildPressBacklogEmail", () => {
+  it("mentions the backlog count and the catch-up command", () => {
+    const email = buildPressBacklogEmail(42, 3);
+    expect(email.subject).toContain("42");
+    expect(email.text).toContain("42");
+    expect(email.text).toContain("sync:press-analysis");
+    expect(email.html).toContain("sync:press-analysis");
+    expect(email.text).toContain("3 derniers jours");
+  });
+
+  it("keeps French accents and avoids em/en dashes in user-facing copy", () => {
+    const email = buildPressBacklogEmail(42, 3);
+    expect(email.subject).toMatch(/[éèàêôçûî]/);
+    for (const part of [email.subject, email.text, email.html]) {
+      expect(part).not.toContain("—");
+      expect(part).not.toContain("–");
+    }
+  });
+});

--- a/src/lib/email/press-backlog.ts
+++ b/src/lib/email/press-backlog.ts
@@ -1,0 +1,52 @@
+/**
+ * Content and threshold logic for the "press backlog to analyze" notification.
+ *
+ * Kept free of any Mailjet / DB import so it can be unit-tested in isolation and
+ * reused by the daily-sync notifier step (scripts/notify-press-backlog.ts).
+ */
+
+/** Default number of unanalyzed articles above which we email a catch-up nudge. */
+export const PRESS_BACKLOG_THRESHOLD_DEFAULT = 30;
+
+/** Whether the current backlog warrants a catch-up email. */
+export function shouldNotifyPressBacklog(backlog: number, threshold: number): boolean {
+  return backlog >= threshold;
+}
+
+/** Build the transactional email body for a press-analysis backlog nudge. */
+export function buildPressBacklogEmail(
+  backlog: number,
+  windowDays: number
+): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const subject = `Poligraph : ${backlog} articles de presse récents à analyser`;
+
+  const catchUpCommand = "npm run sync:press-analysis -- --limit=100";
+
+  const text = [
+    `${backlog} articles de presse publiés ces ${windowDays} derniers jours`,
+    `attendent une analyse.`,
+    ``,
+    `L'analyse automatique du daily sync a décroché (crédit API, lenteur upstream`,
+    `ou volume d'articles).`,
+    ``,
+    `Pour rattraper quand tu veux, ouvre une session Claude Code CLI et lance :`,
+    ``,
+    `    ${catchUpCommand}`,
+  ].join("\n");
+
+  const html = `<!-- press backlog nudge -->
+<div style="font-family: system-ui, sans-serif; font-size: 15px; line-height: 1.5; color: #1a1a1a;">
+  <p><strong>${backlog} articles de presse</strong> publiés ces ${windowDays} derniers
+  jours attendent une analyse.</p>
+  <p>L'analyse automatique du daily sync a décroché (crédit API, lenteur upstream
+  ou volume d'articles).</p>
+  <p>Pour rattraper quand tu veux, ouvre une session Claude Code CLI et lance :</p>
+  <p><code style="background:#f2f2f2;padding:4px 8px;border-radius:4px;">${catchUpCommand}</code></p>
+</div>`;
+
+  return { subject, html, text };
+}

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { isPressAnalysisSuccessful } from "./press-analysis";
+
+describe("isPressAnalysisSuccessful", () => {
+  it("succeeds on a normal run (all articles analyzed)", () => {
+    expect(
+      isPressAnalysisSuccessful({
+        articlesProcessed: 100,
+        articlesAnalyzed: 100,
+        quotaStopped: false,
+      })
+    ).toBe(true);
+  });
+
+  it("tolerates isolated per-article errors (analyzed > 0)", () => {
+    // 07-16 11:29 regression: 100 processed, 1 analysis error → must not fail the run.
+    expect(
+      isPressAnalysisSuccessful({
+        articlesProcessed: 100,
+        articlesAnalyzed: 99,
+        quotaStopped: false,
+      })
+    ).toBe(true);
+  });
+
+  it("succeeds on an empty run (nothing to analyze)", () => {
+    expect(
+      isPressAnalysisSuccessful({
+        articlesProcessed: 0,
+        articlesAnalyzed: 0,
+        quotaStopped: false,
+      })
+    ).toBe(true);
+  });
+
+  it("succeeds when analysis stopped early on a quota/credit blip (backlog handled by email)", () => {
+    expect(
+      isPressAnalysisSuccessful({
+        articlesProcessed: 12,
+        articlesAnalyzed: 0,
+        quotaStopped: true,
+      })
+    ).toBe(true);
+  });
+
+  it("fails when articles were queued but none analyzed for a non-quota reason (real breakage)", () => {
+    expect(
+      isPressAnalysisSuccessful({
+        articlesProcessed: 100,
+        articlesAnalyzed: 0,
+        quotaStopped: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -52,6 +52,28 @@ export interface PressAnalysisStats {
   scrapeErrors: number;
   analysisErrors: number;
   sensitiveWarnings: number;
+  /**
+   * True when analysis stopped early because the AI provider throttled us
+   * (quota / rate limit / payment required). Distinguishes an expected
+   * cost/credit stop (leaves a backlog for the manual catch-up) from a real
+   * code/infra breakage.
+   */
+  quotaStopped: boolean;
+}
+
+/**
+ * Whether a press-analysis run should count as successful for the daily sync.
+ *
+ * A run only fails when it had articles to analyze but got none through for a
+ * non-quota reason (e.g. DB down, a code bug) — that is a real breakage worth
+ * paging. Isolated per-article errors (analyzed > 0) and an early quota/credit
+ * stop are tolerated: the leftover backlog is drained via the email notifier
+ * plus the manual `/analyse-presse` catch-up.
+ */
+export function isPressAnalysisSuccessful(
+  stats: Pick<PressAnalysisStats, "articlesProcessed" | "articlesAnalyzed" | "quotaStopped">
+): boolean {
+  return !(stats.articlesProcessed > 0 && stats.articlesAnalyzed === 0 && !stats.quotaStopped);
 }
 
 // ============================================
@@ -91,6 +113,7 @@ export async function syncPressAnalysis(
     scrapeErrors: 0,
     analysisErrors: 0,
     sensitiveWarnings: 0,
+    quotaStopped: false,
   };
 
   // Check sync interval
@@ -370,6 +393,7 @@ export async function syncPressAnalysis(
       }
 
       if (isQuotaError) {
+        stats.quotaStopped = true;
         console.error(`\n✗ API quota/rate limit error, stopping early: ${errorMsg}`);
         break;
       }


### PR DESCRIPTION
## Contexte

Le workflow `sync-daily.yml` avait des échecs intermittents (16-07 x2, 17-07). Diagnostic sur les 15 derniers runs : 3 échecs, 2 étapes bloquantes, tous liés à des aléas upstream transitoires.

| Run (UTC)   | Étape bloquante             | Erreur                                  | Durée                   |
| ----------- | --------------------------- | --------------------------------------- | ----------------------- |
| 17-07 11:27 | Analyse presse IA           | `spawnSync /bin/sh ETIMEDOUT`           | 600s (= timeout 10 min) |
| 16-07 11:29 | Analyse presse IA           | `Command failed` (exit 1)               | 418s                    |
| 16-07 19:30 | Compute participation stats | `Connection terminated unexpectedly` x2 | 297s                    |

## Cause racine

1. **Presse, gate trop stricte** (16-07 11:29) : le handler renvoyait `success: analysisErrors === 0`. Une seule erreur d'analyse sur 100 articles (déjà gérée, article marqué, boucle qui continue) faisait sortir en code 1 et virait tout le sync au rouge, alors que les 17 erreurs de scraping étaient tolérées. Le run avait pourtant fini son travail (100 analysés, 1 affaire créée).
2. **Presse, timeout** (17-07 11:27) : scraping + analyse de 100 articles en séquentiel, avec des sources qui pendouillent jusqu'à 30s x3 chacune. Un jour lent, l'étape dépasse les 10 min du `execSync` qui tue l'enfant.
3. **Compute-stats** (16-07 19:30) : drop de connexion Supabase (classe #442). Le retry unique (6587772) ne suffisait pas : les 2 tentatives dos-à-dos, sans backoff, ont tapé le même blip.

À noter : l'issue auto `#445` (06-07) est restée ouverte, donc le job `notify` (qui dédoublonne par label) n'a pas re-créé d'issue pour 16/17-07. Les échecs sont passés sous le radar.

## Correctifs

- **Gate presse tolérante** : échec seulement si des articles étaient à traiter mais aucun n'a été analysé pour une raison non-quota (vrai bug). Les erreurs isolées et les arrêts quota/crédit sont tolérés. Fonction pure testée.
- **Budget scraper** : timeout 30s -> 12s, retries 2 -> 1. Le fallback RSS couvre déjà les scrapes ratés, donc le pire cas par source lente passe de 90s à 24s et l'étape repasse sous le timeout. Blast radius nul (scraper utilisé uniquement par la presse).
- **Compute-stats** : retries 1 -> 2 + backoff de 20s entre tentatives, pour laisser le blip Supabase se dissiper.
- **Alerte backlog presse** : nouveau step non-bloquant `notify-press-backlog.ts`. Si le nombre d'articles récents (3 derniers jours) non analysés dépasse 30, un email part vers `PRESS_BACKLOG_NOTIFY_EMAIL` (défaut `lamine@poligraph.fr`) via Mailjet, dédoublonné à 1x/jour. Fenêtre récente volontaire : le backlog ancien (~13k, issue #338) ferait sonner tous les jours. Calibré le 19-07 : 3j ≈ 1 article en normal, 7j ≈ 239 (longue traîne Tier-2).

## À configurer

Secrets GitHub pour le step d'alerte (sinon le step log un warning et passe, non-bloquant) :
`MAILJET_API_KEY`, `MAILJET_SECRET_KEY`, `MAILJET_SENDER_EMAIL`, `MAILJET_SENDER_NAME`, `PRESS_BACKLOG_NOTIFY_EMAIL`.

## Suivi

- Skill `/analyse-presse` (rattrapage API-free où Claude Code fait la détection sans coût API) : PR follow-up dédiée, car il faut extraire la logique post-analyse partagée du pipeline (revue séparée du refactor).
- Backlog presse ancien (~13k articles) : reste couvert par #338.
- Nettoyer l'issue stale #445.

## Tests

`npm run typecheck`, `npm run test:run` (nouvelles suites presse + email), prettier et eslint : verts. Dry-run du notifier vérifié en local (1 article sur 3j, sous le seuil, pas d'email).
