### PR TITLE
Fiabiliser le tableau des condamnations par parti

### DIFF
--- a/src/components/affairs/CondamnationsStatsTable.tsx
+++ b/src/components/affairs/CondamnationsStatsTable.tsx
@@ -1,6 +1,14 @@
 import Link from "next/link";
 import type { CondamnationsPartyStats } from "@/lib/data/condamnations";
 
+/**
+ * En dessous de ce nombre d'élus suivis, un taux de condamnation n'est pas
+ * statistiquement significatif (un parti à 1 élu condamné afficherait 100 %).
+ * On affiche alors « n.s. » plutôt qu'un pourcentage trompeur. Seuil d'affichage,
+ * sans impact sur les données renvoyées par la requête.
+ */
+export const MIN_SUIVIS_FOR_RATE = 10;
+
 function formatPct(v: number): string {
   return `${(v * 100).toFixed(1)}%`;
 }
@@ -13,63 +21,85 @@ export function CondamnationsStatsTable({
   currentMandat?: string;
 }) {
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-sm" aria-describedby="stats-caption">
-        <caption id="stats-caption" className="sr-only">
-          Nombre et taux de responsables politiques condamnés définitivement par parti
-          {currentMandat ? `, filtré sur le mandat ${currentMandat}` : ""}.
-        </caption>
-        <thead>
-          <tr className="border-b-2 border-border">
-            <th scope="col" className="text-left py-3 px-2 font-semibold">
-              Parti
-            </th>
-            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
-              Élus suivis
-            </th>
-            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
-              Condamnés définitifs
-            </th>
-            <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
-              Taux
-            </th>
-            <th scope="col" className="text-left py-3 px-2 font-semibold">
-              Détails
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => {
-            return (
-              <tr key={r.partyId} className="border-b border-border hover:bg-muted/30">
-                <th scope="row" className="text-left py-3 px-2 font-medium">
-                  <Link
-                    href={`/partis/${r.partySlug}`}
-                    className="hover:underline"
-                    prefetch={false}
-                  >
-                    {r.partyName}
-                    <span className="text-muted-foreground ml-1">({r.partyShortName})</span>
-                  </Link>
-                </th>
-                <td className="text-right py-3 px-2 tabular-nums">{r.nSuivis}</td>
-                <td className="text-right py-3 px-2 tabular-nums">{r.nCondamnesDefinitifs}</td>
-                <td className="text-right py-3 px-2 tabular-nums">{formatPct(r.tauxDefinitif)}</td>
-                <td className="py-3 px-2">
-                  <Link
-                    href={`/affaires/condamnations?parti=${r.partySlug}&certainty=etabli${currentMandat ? `&mandat=${currentMandat}` : ""}`}
-                    className="text-primary hover:underline"
-                    prefetch={false}
-                    aria-label={`Voir les condamnations définitives — ${r.partyName}`}
-                  >
-                    Voir <span aria-hidden="true">→</span>
-                  </Link>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+    <div>
+      <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        <span className="font-semibold text-foreground">Comment lire ce tableau.</span> «&nbsp;Élus
+        suivis&nbsp;» désigne les responsables du parti présents dans notre base avec un mandat
+        concerné, pas le nombre de sièges. Un parti à l{"'"}effectif plus large compte mécaniquement
+        plus de condamnés en valeur absolue&nbsp;; le taux ramène ce nombre à l{"'"}effectif. Ni l
+        {"'"}un ni l{"'"}autre ne suffit seul, et un taux calculé sur moins de {MIN_SUIVIS_FOR_RATE}{" "}
+        élus suivis n{"'"}est pas jugé significatif («&nbsp;n.s.&nbsp;»).
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm" aria-describedby="stats-caption">
+          <caption id="stats-caption" className="sr-only">
+            Nombre et taux de responsables politiques condamnés définitivement par parti
+            {currentMandat ? `, filtré sur le mandat ${currentMandat}` : ""}.
+          </caption>
+          <thead>
+            <tr className="border-b-2 border-border">
+              <th scope="col" className="text-left py-3 px-2 font-semibold">
+                Parti
+              </th>
+              <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+                Élus suivis
+              </th>
+              <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+                Condamnés définitifs
+              </th>
+              <th scope="col" className="text-right py-3 px-2 font-semibold tabular-nums">
+                Taux
+              </th>
+              <th scope="col" className="text-left py-3 px-2 font-semibold">
+                Détails
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              return (
+                <tr key={r.partyId} className="border-b border-border hover:bg-muted/30">
+                  <th scope="row" className="text-left py-3 px-2 font-medium">
+                    <Link
+                      href={`/partis/${r.partySlug}`}
+                      className="hover:underline"
+                      prefetch={false}
+                    >
+                      {r.partyName}
+                      <span className="text-muted-foreground ml-1">({r.partyShortName})</span>
+                    </Link>
+                  </th>
+                  <td className="text-right py-3 px-2 tabular-nums">{r.nSuivis}</td>
+                  <td className="text-right py-3 px-2 tabular-nums">{r.nCondamnesDefinitifs}</td>
+                  <td className="text-right py-3 px-2 tabular-nums">
+                    {r.nSuivis >= MIN_SUIVIS_FOR_RATE ? (
+                      formatPct(r.tauxDefinitif)
+                    ) : (
+                      <span
+                        className="text-muted-foreground"
+                        title="Effectif trop faible pour un taux significatif"
+                      >
+                        n.s.
+                        <span className="sr-only"> (non significatif, effectif trop faible)</span>
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-3 px-2">
+                    <Link
+                      href={`/affaires/condamnations?parti=${r.partySlug}&certainty=etabli${currentMandat ? `&mandat=${currentMandat}` : ""}`}
+                      className="text-primary hover:underline"
+                      prefetch={false}
+                      aria-label={`Voir les condamnations définitives — ${r.partyName}`}
+                    >
+                      Voir <span aria-hidden="true">→</span>
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
       <p className="text-xs text-muted-foreground mt-3">
         Parti affiché si au moins 3 élus suivis ou 1 condamnation définitive. Le taux dépend aussi
         de la visibilité médiatique, pas uniquement de la criminalité réelle.

--- a/src/components/affairs/CondamnationsStatsTable.tsx
+++ b/src/components/affairs/CondamnationsStatsTable.tsx
@@ -2,12 +2,11 @@ import Link from "next/link";
 import type { CondamnationsPartyStats } from "@/lib/data/condamnations";
 
 /**
- * En dessous de ce nombre d'élus suivis, un taux de condamnation n'est pas
- * statistiquement significatif (un parti à 1 élu condamné afficherait 100 %).
- * On affiche alors « n.s. » plutôt qu'un pourcentage trompeur. Seuil d'affichage,
- * sans impact sur les données renvoyées par la requête.
+ * Nombre minimal d'élus suivis pour afficher un taux de condamnation. En dessous,
+ * le taux n'est pas significatif (un parti à 1 élu condamné afficherait 100 %) et
+ * on montre « n.s. ». Seuil d'affichage, sans impact sur les données de la requête.
  */
-export const MIN_SUIVIS_FOR_RATE = 10;
+export const SEUIL_SUIVIS_TAUX = 10;
 
 function formatPct(v: number): string {
   return `${(v * 100).toFixed(1)}%`;
@@ -27,7 +26,7 @@ export function CondamnationsStatsTable({
         suivis&nbsp;» désigne les responsables du parti présents dans notre base avec un mandat
         concerné, pas le nombre de sièges. Un parti à l{"'"}effectif plus large compte mécaniquement
         plus de condamnés en valeur absolue&nbsp;; le taux ramène ce nombre à l{"'"}effectif. Ni l
-        {"'"}un ni l{"'"}autre ne suffit seul, et un taux calculé sur moins de {MIN_SUIVIS_FOR_RATE}{" "}
+        {"'"}un ni l{"'"}autre ne suffit seul, et un taux calculé sur moins de {SEUIL_SUIVIS_TAUX}{" "}
         élus suivis n{"'"}est pas jugé significatif («&nbsp;n.s.&nbsp;»).
       </div>
       <div className="overflow-x-auto">
@@ -72,7 +71,7 @@ export function CondamnationsStatsTable({
                   <td className="text-right py-3 px-2 tabular-nums">{r.nSuivis}</td>
                   <td className="text-right py-3 px-2 tabular-nums">{r.nCondamnesDefinitifs}</td>
                   <td className="text-right py-3 px-2 tabular-nums">
-                    {r.nSuivis >= MIN_SUIVIS_FOR_RATE ? (
+                    {r.nSuivis >= SEUIL_SUIVIS_TAUX ? (
                       formatPct(r.tauxDefinitif)
                     ) : (
                       <span

--- a/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
+++ b/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
-import { CondamnationsStatsTable } from "@/components/affairs/CondamnationsStatsTable";
+import {
+  CondamnationsStatsTable,
+  MIN_SUIVIS_FOR_RATE,
+} from "@/components/affairs/CondamnationsStatsTable";
 import type { CondamnationsPartyStats } from "@/lib/data/condamnations";
 
 const rows: CondamnationsPartyStats[] = [
@@ -24,13 +27,35 @@ const rows: CondamnationsPartyStats[] = [
     nCondamnesPrononces: 1,
     tauxDefinitif: 1 / 5,
   },
+  {
+    partyId: "3",
+    partySlug: "parti-au-seuil",
+    partyShortName: "SEU",
+    partyName: "Parti au seuil",
+    nSuivis: MIN_SUIVIS_FOR_RATE,
+    nCondamnesDefinitifs: 1,
+    nCondamnesPrononces: 0,
+    tauxDefinitif: 1 / MIN_SUIVIS_FOR_RATE,
+  },
 ];
 
 describe("CondamnationsStatsTable", () => {
-  it("affiche le taux en texte pour chaque parti", () => {
+  it("affiche le taux quand l'effectif atteint le seuil", () => {
     render(<CondamnationsStatsTable rows={rows} />);
-    expect(screen.getByText("1.6%")).toBeInTheDocument();
-    expect(screen.getByText("20.0%")).toBeInTheDocument();
+    expect(screen.getByText("1.6%")).toBeInTheDocument(); // LR, 309 suivis
+    expect(screen.getByText("10.0%")).toBeInTheDocument(); // seuil, 10 suivis
+  });
+
+  it("masque le taux (n.s.) sous le seuil d'effectif", () => {
+    render(<CondamnationsStatsTable rows={rows} />);
+    // PRG (5 suivis) ne doit pas afficher son taux brut trompeur de 20%
+    expect(screen.queryByText("20.0%")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Effectif trop faible pour un taux significatif")).toBeInTheDocument();
+  });
+
+  it("explique comment lire le tableau (brut vs taux)", () => {
+    render(<CondamnationsStatsTable rows={rows} />);
+    expect(screen.getByText(/Comment lire ce tableau/)).toBeInTheDocument();
   });
 
   it("n'affiche plus de jauge SVG (régression jauge trompeuse)", () => {
@@ -55,7 +80,6 @@ describe("CondamnationsStatsTable", () => {
     const table = screen.getByRole("table");
     expect(within(table).getByRole("columnheader", { name: "Taux" })).toBeInTheDocument();
     expect(within(table).getByRole("columnheader", { name: "Élus suivis" })).toBeInTheDocument();
-    // Le parti est un en-tête de ligne (scope="row")
     expect(within(table).getByRole("rowheader", { name: /Les Républicains/ })).toBeInTheDocument();
   });
 });

--- a/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
+++ b/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import {
   CondamnationsStatsTable,
-  MIN_SUIVIS_FOR_RATE,
+  SEUIL_SUIVIS_TAUX,
 } from "@/components/affairs/CondamnationsStatsTable";
 import type { CondamnationsPartyStats } from "@/lib/data/condamnations";
 
@@ -32,10 +32,10 @@ const rows: CondamnationsPartyStats[] = [
     partySlug: "parti-au-seuil",
     partyShortName: "SEU",
     partyName: "Parti au seuil",
-    nSuivis: MIN_SUIVIS_FOR_RATE,
+    nSuivis: SEUIL_SUIVIS_TAUX,
     nCondamnesDefinitifs: 1,
     nCondamnesPrononces: 0,
-    tauxDefinitif: 1 / MIN_SUIVIS_FOR_RATE,
+    tauxDefinitif: 1 / SEUIL_SUIVIS_TAUX,
   },
 ];
 

--- a/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
+++ b/src/components/affairs/__tests__/CondamnationsStatsTable.test.tsx
@@ -27,11 +27,12 @@ const rows: CondamnationsPartyStats[] = [
     nCondamnesPrononces: 1,
     tauxDefinitif: 1 / 5,
   },
+  // Effectif exactement au seuil : le taux doit s'afficher (comparaison >=).
   {
     partyId: "3",
-    partySlug: "parti-au-seuil",
-    partyShortName: "SEU",
-    partyName: "Parti au seuil",
+    partySlug: "parti-fictif",
+    partyShortName: "PF",
+    partyName: "Parti fictif",
     nSuivis: SEUIL_SUIVIS_TAUX,
     nCondamnesDefinitifs: 1,
     nCondamnesPrononces: 0,


### PR DESCRIPTION
## Contexte
Le tableau « taux de condamnation par parti » pouvait se lire comme un classement trompeur : tri par nombre brut (les groupes les plus nombreux ressortent en tête) et taux affiché même sur de très faibles effectifs (un parti avec un seul élu condamné affichait 100 %).

## Changements
- Taux affiché « n.s. » (non significatif) sous 10 élus suivis, pour ne plus exposer un pourcentage calculé sur un effectif dérisoire.
- Encart « comment lire ce tableau » : définition d'« élus suivis » (et non un nombre de sièges), et rappel que le nombre brut favorise les gros groupes alors que le taux ramène à l'effectif.
- Aucun changement de données ni de requête : seuil purement d'affichage.

## Tests
Tests unitaires du composant mis à jour (seuil d'affichage, encart, régressions a11y). Typecheck et lint OK.