### PR TITLE
Paliers mensuels : échelle d'impact + CTA unique (au lieu d'une fausse grille)

### DIFF
--- a/src/components/donation/DonationTiers.test.tsx
+++ b/src/components/donation/DonationTiers.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { DonationDialogProvider } from "./DonationDialogProvider";
 import { DonationTiers } from "./DonationTiers";
-import { DONATION_PREFILL_MODE, MONTHLY_TIERS } from "@/config/donation";
+import { MONTHLY_TIERS } from "@/config/donation";
 
 function renderTiers() {
   return render(
@@ -17,6 +18,7 @@ describe("DonationTiers", () => {
     renderTiers();
     expect(screen.getByText("Recommandé")).toBeInTheDocument();
   });
+
   it("affiche tous les montants mensuels", () => {
     renderTiers();
     for (const t of MONTHLY_TIERS) {
@@ -24,13 +26,17 @@ describe("DonationTiers", () => {
       expect(screen.getByText(new RegExp(`(?<!\\d)${t.monthlyEuros}€`))).toBeInTheDocument();
     }
   });
-  it("en mode unsupported, aucun bouton ne prétend présélectionner un montant", () => {
+
+  it("n'affiche aucun bouton prétendant présélectionner un montant", () => {
     renderTiers();
-    if (DONATION_PREFILL_MODE === "unsupported") {
-      expect(screen.queryByRole("button", { name: /soutenir 10 € par mois/i })).toBeNull();
-      expect(
-        screen.getAllByRole("button", { name: /choisir mon montant/i }).length
-      ).toBeGreaterThan(0);
-    }
+    expect(screen.queryByRole("button", { name: /soutenir \d+ € par mois/i })).toBeNull();
+  });
+
+  it("un unique CTA « Je soutiens » ouvre le formulaire sécurisé", async () => {
+    renderTiers();
+    const ctas = screen.getAllByRole("button", { name: /je soutiens/i });
+    expect(ctas).toHaveLength(1);
+    await userEvent.click(ctas[0]!);
+    expect(screen.getByTitle(/formulaire de don helloasso/i)).toBeInTheDocument();
   });
 });

--- a/src/components/donation/DonationTiers.tsx
+++ b/src/components/donation/DonationTiers.tsx
@@ -1,52 +1,52 @@
 "use client";
 
-import { DONATION_PREFILL_MODE, MONTHLY_TIERS } from "@/config/donation";
+import { MONTHLY_TIERS } from "@/config/donation";
 import { cn } from "@/lib/utils";
 import { useDonationDialog } from "./DonationDialogProvider";
 
+// Monthly amounts are an impact scale, not a control surface: HelloAsso cannot
+// pre-select an amount for a recurring donation, so a single CTA opens the form
+// where the donor picks amount and frequency. Avoids a misleading pricing-grid.
 export function DonationTiers() {
   const { open } = useDonationDialog();
-  const prefill = DONATION_PREFILL_MODE === "verified";
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-      {MONTHLY_TIERS.map((tier) => (
-        <div
-          key={tier.monthlyEuros}
-          className={cn(
-            "relative flex flex-col gap-2 rounded-xl border bg-card p-4",
-            tier.recommended && "border-2 border-brand"
-          )}
-        >
-          {tier.recommended && (
-            <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-brand px-2 py-0.5 font-display text-[0.62rem] font-bold uppercase tracking-wide text-brand-foreground">
-              Recommandé
-            </span>
-          )}
-          <div className="font-display text-2xl font-extrabold">
-            {tier.monthlyEuros}€
-            <span className="text-sm font-semibold text-muted-foreground">/mois</span>
-          </div>
-          <p className="flex-1 text-sm text-muted-foreground">{tier.impactLabel}</p>
-          <button
-            type="button"
-            onClick={() => open("monthly")}
-            aria-label={
-              prefill
-                ? `Soutenir ${tier.monthlyEuros} € par mois`
-                : "Choisir mon montant sur le formulaire sécurisé"
-            }
+    <div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+        {MONTHLY_TIERS.map((tier) => (
+          <div
+            key={tier.monthlyEuros}
             className={cn(
-              "rounded-full px-4 py-2 font-display text-sm font-semibold",
-              tier.recommended
-                ? "bg-brand text-brand-foreground"
-                : "border bg-muted text-foreground hover:bg-accent"
+              "relative flex flex-col gap-2 rounded-xl border bg-card p-4",
+              tier.recommended && "border-2 border-brand"
             )}
           >
-            {prefill ? "Je soutiens" : "Choisir mon montant"}
-          </button>
-        </div>
-      ))}
+            {tier.recommended && (
+              <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-brand px-2 py-0.5 font-display text-[0.62rem] font-bold uppercase tracking-wide text-brand-foreground">
+                Recommandé
+              </span>
+            )}
+            <div className="font-display text-2xl font-extrabold">
+              {tier.monthlyEuros}€
+              <span className="text-sm font-semibold text-muted-foreground">/mois</span>
+            </div>
+            <p className="text-sm text-muted-foreground">{tier.impactLabel}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 flex flex-col items-center gap-2 text-center">
+        <button
+          type="button"
+          onClick={() => open("monthly")}
+          className="rounded-full bg-brand px-8 py-3 font-display text-base font-semibold text-brand-foreground hover:opacity-90"
+        >
+          Je soutiens
+        </button>
+        <p className="text-xs text-muted-foreground">
+          Vous choisissez le montant et la fréquence dans le formulaire sécurisé.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Pourquoi

Vérifié dans la doc HelloAsso : le mensuel récurrent **ne peut pas** être pré-rempli par un montant (ni via l'iframe, ni via le Checkout API, qui ne gère que le ponctuel et les échéances fixes, par redirection). Les 5 cartes avec un bouton par palier ressemblaient donc à une grille tarifaire cliquable qui, en réalité, ouvrait toutes le même formulaire.

## Changement

- Les paliers deviennent une **échelle d'impact** informative (montant + ce que ça permet, 10€ « Recommandé »), **sans bouton par carte**.
- **Un seul CTA « Je soutiens »** ouvre le formulaire HelloAsso, où le donateur choisit montant et fréquence.
- Suppression de la dépendance à `DONATION_PREFILL_MODE` dans ce composant (inutile pour le mensuel).
- Tests mis à jour (échelle informative, CTA unique qui ouvre le formulaire).

## Côté admin HelloAsso (toi)

Régler les montants suggérés (5/10/15/20/50) + l'option mensuelle dans le formulaire, pour que l'iframe embarquée soit elle-même un bon sélecteur de montant.

Suite de #466.