### PR TITLE
Aligner le libellé « concordance » sur /statistiques (#470)

### DIFF
--- a/src/components/stats/GroupDynamics.tsx
+++ b/src/components/stats/GroupDynamics.tsx
@@ -25,7 +25,7 @@ function AlignmentSpectrum({
   return (
     <div
       role="img"
-      aria-label={`Alignement gouvernemental - ${chamberLabel}`}
+      aria-label={`Concordance des votes - ${chamberLabel}`}
       aria-describedby={descId}
     >
       {/* Zone labels */}
@@ -56,8 +56,8 @@ function AlignmentSpectrum({
               prefetch={false}
               className="absolute -translate-x-1/2 transition-transform hover:scale-110 hover:z-10"
               style={{ left: `${leftPct}%`, top: `${topPx}px` }}
-              title={`${g.groupName}: ${g.governmentAlignmentPct.toFixed(0)}% d'alignement`}
-              aria-label={`${g.groupName}: ${g.governmentAlignmentPct.toFixed(0)}% d'alignement gouvernemental`}
+              title={`${g.groupName}: ${g.governmentAlignmentPct.toFixed(0)}% de concordance`}
+              aria-label={`${g.groupName}: ${g.governmentAlignmentPct.toFixed(0)}% de concordance des votes`}
             >
               <div
                 className="px-1.5 py-0.5 rounded-full text-[11px] font-bold leading-tight whitespace-nowrap shadow-sm border border-background/50"
@@ -82,11 +82,11 @@ function AlignmentSpectrum({
 
       {/* Screen reader table */}
       <table className="sr-only" id={descId}>
-        <caption>Alignement gouvernemental par groupe - {chamberLabel}</caption>
+        <caption>Concordance des votes par groupe - {chamberLabel}</caption>
         <thead>
           <tr>
             <th>Groupe</th>
-            <th>Alignement</th>
+            <th>Concordance</th>
             <th>Cohésion</th>
             <th>Participation</th>
           </tr>
@@ -141,7 +141,7 @@ function MetricsList({
             </Link>
             <span
               className={`tabular-nums shrink-0 ${alignmentColor(g.governmentAlignmentPct)}`}
-              title="Alignement gouvernemental"
+              title="Concordance des votes"
             >
               {g.governmentAlignmentPct.toFixed(0)}%
             </span>


### PR DESCRIPTION
## Contexte

La PR #452 a renommé « alignement gouvernemental » en « concordance » sur la fiche groupe et la carte de listing. Sur `/statistiques`, le composant `GroupDynamics` affichait encore l'ancien libellé pour la même mesure (`governmentAlignmentPct`), donc le terme jugé trompeur par #451 restait visible à un endroit.

## Changement

Un seul fichier, `src/components/stats/GroupDynamics.tsx`. Toutes les occurrences visibles et accessibles passent à « concordance » :

- `aria-label` du spectre
- `caption` et en-tête `<th>` de la table lecteur d'écran
- `title` et `aria-label` des badges de groupe
- `title` de la colonne dans la liste

Le vocabulaire suit les composants déjà en place : « Concordance des votes » en version longue, « Concordance » pour la colonne compacte. Les identifiants code restent en anglais.

## Hors périmètre

La refonte du spectre « Opposition / Coalition » et l'ajout de la mesure « textes de loi » sur `/statistiques`, comme précisé dans l'issue.

Refs #470
