### PR TITLE
perf(municipales): cacher /cumul, sortir le fallback parité du rendu

### DIFF
--- a/src/__tests__/lib/data/municipales-snapshots.test.ts
+++ b/src/__tests__/lib/data/municipales-snapshots.test.ts
@@ -70,47 +70,24 @@ describe("municipales snapshot fallback", () => {
     expect(queryRawMock).not.toHaveBeenCalled(); // didn't fall back to live
   });
 
-  it("getParityOutliers falls back to live SQL when snapshot is missing", async () => {
+  it("getParityOutliers returns empty without a live scan when snapshot missing", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
-    // Single-pass query: one $queryRaw returns both buckets, tagged by `bucket`.
-    queryRawMock.mockResolvedValueOnce([
-      {
-        bucket: "best",
-        listName: "Live A",
-        communeId: "x",
-        communeName: "X",
-        departmentCode: "01",
-        femaleRate: 0.5,
-        candidateCount: 30,
-      },
-      {
-        bucket: "worst",
-        listName: "Live B",
-        communeId: "y",
-        communeName: "Y",
-        departmentCode: "02",
-        femaleRate: 0.0,
-        candidateCount: 30,
-      },
-    ]);
 
     const result = await getParityOutliers();
 
-    expect(result.best[0]?.listName).toBe("Live A");
-    expect(result.worst[0]?.listName).toBe("Live B");
-    expect(queryRawMock).toHaveBeenCalledTimes(1); // single-pass live fallback
+    // No live fallback in the request path (perf: avoids scanning ~1.28M rows).
+    // The daily sync recomputes the snapshot.
+    expect(result).toEqual({ best: [], worst: [] });
+    expect(queryRawMock).not.toHaveBeenCalled();
   });
 
-  it("getParityBySize falls back to live when snapshot missing", async () => {
+  it("getParityBySize returns empty without a live scan when snapshot missing", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
-    queryRawMock.mockResolvedValueOnce([
-      { bracket: "< 1 000 hab.", femaleCount: 5, totalCount: 10 },
-    ]);
 
     const result = await getParityBySize();
 
-    expect(result).toHaveLength(1);
-    expect(result[0]?.femaleRate).toBe(0.5);
+    expect(result).toEqual([]);
+    expect(queryRawMock).not.toHaveBeenCalled();
   });
 
   it("getDepartmentPartyData falls back to live when snapshot missing", async () => {
@@ -124,16 +101,6 @@ describe("municipales snapshot fallback", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.dominantParty).toBe("EELV");
-  });
-
-  it("getParityOutliers returns empty fallback when snapshot missing AND election not found", async () => {
-    findUniqueMock.mockResolvedValueOnce(null);
-    electionFindUniqueMock.mockResolvedValueOnce(null);
-
-    const result = await getParityOutliers();
-
-    expect(result).toEqual({ best: [], worst: [] });
-    expect(queryRawMock).not.toHaveBeenCalled();
   });
 
   it("getDepartmentPartyData returns empty array when snapshot missing AND election not found", async () => {

--- a/src/app/elections/municipales-2026/cumul/page.tsx
+++ b/src/app/elections/municipales-2026/cumul/page.tsx
@@ -5,7 +5,7 @@ import { getCumulCandidates, getMissingMaires } from "@/lib/data/municipales";
 import { CumulTable } from "@/components/elections/municipales/CumulTable";
 import { MissingMairesTable } from "@/components/elections/municipales/MissingMairesTable";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Cumul des mandats — Municipales 2026 | Poligraph",

--- a/src/lib/data/municipales.ts
+++ b/src/lib/data/municipales.ts
@@ -11,11 +11,7 @@ import {
   DeptPartyDataSchema,
   parseSnapshot,
 } from "@/types/stats-snapshots";
-import {
-  computeParityOutliersLive,
-  computeParityBySizeLive,
-  computeDepartmentPartyDataLive,
-} from "@/services/sync/compute-municipales-snapshots";
+import { computeDepartmentPartyDataLive } from "@/services/sync/compute-municipales-snapshots";
 
 // ============================================
 // Incumbent maire helper
@@ -462,12 +458,12 @@ export const getParityBySize = cache(async function getParityBySize() {
     return parseSnapshot(ParityBySizeSchema, snapshot.data);
   }
 
-  const election = await db.election.findUnique({
-    where: { slug: "municipales-2026" },
-    select: { id: true },
-  });
-  if (!election) return [];
-  return computeParityBySizeLive(election.id);
+  // Snapshot missing (cold start / failed sync): return empty rather than
+  // scanning ~1.28M Candidacy rows in the request path. The daily sync step
+  // compute-municipales-snapshots recomputes it.
+  // eslint-disable-next-line no-console -- deliberate ops signal (missing snapshot)
+  console.warn("[municipales] parityBySize snapshot missing — returning empty");
+  return [];
 });
 
 export const getCumulCandidates = cache(async function getCumulCandidates() {
@@ -540,6 +536,10 @@ export const getCumulCandidates = cache(async function getCumulCandidates() {
 });
 
 export const getMissingMaires = cache(async function getMissingMaires() {
+  "use cache";
+  cacheTag("elections-municipales-2026");
+  cacheLife("synced");
+
   const election = await db.election.findUnique({
     where: { slug: "municipales-2026" },
     select: { id: true },
@@ -585,12 +585,12 @@ export const getParityOutliers = cache(async function getParityOutliers() {
     return parseSnapshot(ParityOutliersSchema, snapshot.data);
   }
 
-  const election = await db.election.findUnique({
-    where: { slug: "municipales-2026" },
-    select: { id: true },
-  });
-  if (!election) return { best: [], worst: [] };
-  return computeParityOutliersLive(election.id);
+  // Snapshot missing (cold start / failed sync): return empty rather than
+  // scanning ~1.28M Candidacy rows in the request path. The daily sync step
+  // compute-municipales-snapshots recomputes it.
+  // eslint-disable-next-line no-console -- deliberate ops signal (missing snapshot)
+  console.warn("[municipales] parityOutliers snapshot missing — returning empty");
+  return { best: [], worst: [] };
 });
 
 // ============================================


### PR DESCRIPTION
## Problème

Les pages `/elections/municipales-2026/cumul` et `/parite` sont lentes à charger.

- **Cumul** : la route est en `force-dynamic`, donc jamais mise en cache, et `getMissingMaires` n'a que le `cache()` de React (portée requête). Son `NOT EXISTS` corrélé sur ~1,28M candidatures tourne à chaque chargement.
- **Parité** : rapide tant que les snapshots existent (c'est le cas actuellement), mais en cas de snapshot manquant (cold start, sync en échec), les getters retombaient sur un scan live de ~1,28M lignes dans le rendu de la requête.

## Changements

- **Cumul** : `force-dynamic` remplacé par `revalidate = 300` (aligné sur parité). `getMissingMaires` mis en cache (`"use cache"` + `cacheTag("elections-municipales-2026")` + `cacheLife("synced")`), même tag que `getCumulCandidates` pour une invalidation conjointe par la sync quotidienne.
- **Parité** : suppression du fallback live du chemin web. En l'absence de snapshot, les getters renvoient vide et loguent un avertissement ; la sync quotidienne (`compute-municipales-snapshots`) recalcule le snapshot. Les computers live restent exportés (toujours utilisés par la sync).
- **Tests** : les deux tests de fallback parité vérifient désormais l'absence de scan live sur snapshot manquant.

Index composite `(politicianId, electionId)` volontairement non ajouté : la mise en cache retire le coût par requête, gain négligeable au regard du risque de créer un index en prod.

## Vérification

- `tsc --noEmit` : OK
- `eslint` (fichiers touchés) : OK
- `npm run build` : OK. La route `/cumul` passe de `ƒ` (Dynamic) à `○` (ISR, revalidate 5m), comme parité.
- `municipales-snapshots.test.ts` : 5/5.

Refs #465
