### PR TITLE
fix(municipales): masquer la section maires manquants sur /cumul

### DIFF
--- a/src/app/elections/municipales-2026/cumul/page.tsx
+++ b/src/app/elections/municipales-2026/cumul/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from "next";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
-import { getCumulCandidates, getMissingMaires } from "@/lib/data/municipales";
+import { getCumulCandidates } from "@/lib/data/municipales";
 import { CumulTable } from "@/components/elections/municipales/CumulTable";
-import { MissingMairesTable } from "@/components/elections/municipales/MissingMairesTable";
 
 export const revalidate = 300;
 
@@ -27,9 +26,7 @@ const MANDATE_STATS_LABELS: Record<string, string> = {
 };
 
 export default async function CumulPage() {
-  // Sequential queries to respect DB pool limit of 2
   const candidates = await getCumulCandidates();
-  const missingMaires = await getMissingMaires();
 
   // Compute stats by mandate type
   const statsByType = new Map<string, number>();
@@ -111,28 +108,6 @@ export default async function CumulPage() {
           <CumulTable candidates={candidates} />
         </section>
       )}
-
-      {/* Missing mayors */}
-      <section className="py-8 border-t">
-        <h2 className="text-2xl font-bold mb-2">Qui manque à l&apos;appel ?</h2>
-        <p className="text-muted-foreground mb-6">
-          Ces maires en exercice ne se représentent pas (ou n&apos;ont pas encore déclaré leur
-          candidature).
-        </p>
-        {missingMaires.length > 0 ? (
-          <>
-            <p className="text-sm text-muted-foreground mb-4">
-              {missingMaires.length} maire{missingMaires.length > 1 ? "s" : ""} absent
-              {missingMaires.length > 1 ? "s" : ""} des listes
-            </p>
-            <MissingMairesTable maires={missingMaires} />
-          </>
-        ) : (
-          <p className="text-muted-foreground text-center py-8">
-            Tous les maires en exercice se représentent.
-          </p>
-        )}
-      </section>
     </div>
   );
 }

--- a/src/lib/data/municipales.ts
+++ b/src/lib/data/municipales.ts
@@ -535,6 +535,9 @@ export const getCumulCandidates = cache(async function getCumulCandidates() {
   );
 });
 
+// Currently unused: the "Qui manque à l'appel ?" section on /cumul was hidden
+// because candidacy-politician linking is still sparse (nearly every maire shows
+// as "missing"). Kept for when linking is fuller; re-add the section to restore.
 export const getMissingMaires = cache(async function getMissingMaires() {
   "use cache";
   cacheTag("elections-municipales-2026");


### PR DESCRIPTION
## Problème

Suite à #472, `/elections/municipales-2026/cumul` est passée en ISR. Le déploiement Vercel échoue : la page prérendue fait 51 Mo, au-delà de la limite ISR de 19 Mo (`FALLBACK_BODY_TOO_LARGE`).

Cause : la section « Qui manque à l'appel ? » rend `getMissingMaires`, soit **34 592 maires sur 34 808** (seuls ~216 maires sont liés à une candidature municipales-2026). En `force-dynamic`, cette liste était diffusée par requête sans plafond ; en ISR, elle est prérendue en un seul fichier statique.

## Changement

- Masquage de la section « Qui manque à l'appel ? » sur `/cumul`. Avec 216/34 808 maires liés, la liste est un artefact de complétude des données (quasi tous les maires apparaissent « absents »), pas un signal exploitable.
- `getMissingMaires` et `MissingMairesTable` sont conservés (non appelés) pour réactiver la section quand le liage candidature-politicien sera plus complet.
- La table de cumul (452 candidatures) reste inchangée : c'est la vraie valeur de la page.

## Vérification

- `tsc --noEmit` : OK
- `eslint` (fichiers touchés) : OK
- `npm run build` : OK. `/cumul` reste `○` (ISR, 5m) ; le HTML prérendu passe de **51 Mo à 3,9 Mo**, sous la limite Vercel.
- `municipales-snapshots.test.ts` : 5/5.

Refs #465
