### PR TITLE
feat(votes): endpoint admin de revalidation groupee des votes approuves (#477)

### DIFF
--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -20,7 +20,7 @@ import {
   type ApprovalContext,
 } from "@/services/scrutin-policy-title/approval";
 import { queryQueue, type QueueFilters } from "@/app/admin/policy-titles/_data/queue-query";
-import { themeToSlug } from "@/lib/theme-utils";
+import { revalidatePublicForScrutin } from "@/lib/votes/revalidate-public";
 import { ApproveBlockedError } from "@/app/admin/policy-titles/errors";
 import type { Prisma, ScrutinPolicyTitle } from "@/generated/prisma";
 
@@ -42,27 +42,6 @@ async function assertAuthenticated(): Promise<void> {
 function revalidate(scrutinId: string): void {
   revalidatePath("/admin/policy-titles");
   revalidatePath(`/admin/policy-titles/${scrutinId}`);
-}
-
-/**
- * Plan 6 V1 (path-based): revalidate the public surfaces a title appears on after
- * a status/title change, so an approval becomes visible and a reject/regenerate
- * hides it. Covers vote detail + list + theme + (when spotlight-eligible) home.
- * Politician vote tabs intentionally refresh on their own ISR interval (V1).
- */
-async function revalidatePublicForScrutin(scrutinId: string): Promise<void> {
-  const scrutin = await db.scrutin.findUnique({
-    where: { id: scrutinId },
-    select: { slug: true, theme: true, importance: { select: { isKeyVote: true } } },
-  });
-  if (!scrutin) return;
-  if (scrutin.slug) revalidatePath(`/parlement/votes/${scrutin.slug}`);
-  revalidatePath("/parlement/votes");
-  if (scrutin.theme) revalidatePath(`/parlement/votes/themes/${themeToSlug(scrutin.theme)}`);
-  if (scrutin.importance?.isKeyVote) {
-    revalidatePath("/");
-    revalidatePath("/parlement");
-  }
 }
 
 /**

--- a/src/app/api/admin/votes/revalidate/__tests__/partition.test.ts
+++ b/src/app/api/admin/votes/revalidate/__tests__/partition.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { partitionRevalidatable } from "../partition";
+
+describe("partitionRevalidatable", () => {
+  it("puts a found APPROVED row in toRevalidate", () => {
+    const result = partitionRevalidatable(["sc-1"], [{ id: "sc-1", status: "APPROVED" }]);
+    expect(result.toRevalidate).toEqual(["sc-1"]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("skips a found row with a non-APPROVED status as not_approved", () => {
+    for (const status of ["DRAFT", "NEEDS_REVIEW", "STALE", "REJECTED"]) {
+      const result = partitionRevalidatable(["sc-1"], [{ id: "sc-1", status }]);
+      expect(result.toRevalidate).toEqual([]);
+      expect(result.skipped).toEqual([{ id: "sc-1", reason: "not_approved" }]);
+    }
+  });
+
+  it("skips a null status (no policy title yet) as not_approved", () => {
+    const result = partitionRevalidatable(["sc-1"], [{ id: "sc-1", status: null }]);
+    expect(result.toRevalidate).toEqual([]);
+    expect(result.skipped).toEqual([{ id: "sc-1", reason: "not_approved" }]);
+  });
+
+  it("skips an id missing from rows as not_found", () => {
+    const result = partitionRevalidatable(["sc-missing"], []);
+    expect(result.toRevalidate).toEqual([]);
+    expect(result.skipped).toEqual([{ id: "sc-missing", reason: "not_found" }]);
+  });
+
+  it("handles a mixed set of ids", () => {
+    const result = partitionRevalidatable(
+      ["sc-approved", "sc-draft", "sc-missing"],
+      [
+        { id: "sc-approved", status: "APPROVED" },
+        { id: "sc-draft", status: "DRAFT" },
+      ]
+    );
+    expect(result.toRevalidate).toEqual(["sc-approved"]);
+    expect(result.skipped).toEqual([
+      { id: "sc-draft", reason: "not_approved" },
+      { id: "sc-missing", reason: "not_found" },
+    ]);
+  });
+});

--- a/src/app/api/admin/votes/revalidate/partition.ts
+++ b/src/app/api/admin/votes/revalidate/partition.ts
@@ -1,0 +1,38 @@
+/** One row per requested scrutinId, as loaded by the batch query: null status
+ *  means either the row was not found or it has no policy title yet. */
+export interface RevalidatableRow {
+  id: string;
+  status: string | null;
+}
+
+export interface PartitionResult {
+  toRevalidate: string[];
+  skipped: Array<{ id: string; reason: "not_found" | "not_approved" }>;
+}
+
+/**
+ * Pure partition: decides which requested ids are safe to revalidate. An id
+ * missing from `rows` was not found in the database; an id present but whose
+ * status is not APPROVED must never be revalidated (that would make an
+ * unapproved title visible). No DB access here, so this is unit-testable
+ * without a database.
+ */
+export function partitionRevalidatable(ids: string[], rows: RevalidatableRow[]): PartitionResult {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+
+  const toRevalidate: string[] = [];
+  const skipped: PartitionResult["skipped"] = [];
+
+  for (const id of ids) {
+    const row = byId.get(id);
+    if (!row) {
+      skipped.push({ id, reason: "not_found" });
+    } else if (row.status !== "APPROVED") {
+      skipped.push({ id, reason: "not_approved" });
+    } else {
+      toRevalidate.push(id);
+    }
+  }
+
+  return { toRevalidate, skipped };
+}

--- a/src/app/api/admin/votes/revalidate/route.ts
+++ b/src/app/api/admin/votes/revalidate/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation } from "@/lib/security/validate";
+import { revalidateVotesSchema } from "@/lib/security/schemas";
+import { db } from "@/lib/db";
+import { revalidatePublicForScrutin } from "@/lib/votes/revalidate-public";
+import { partitionRevalidatable } from "./partition";
+
+/**
+ * POST /api/admin/votes/revalidate
+ *
+ * Bulk-revalidate the public vote pages for a set of scrutins after their
+ * policy titles were approved out-of-band (daily auto-approve cron, or a
+ * cloud SQL routine), neither of which triggers Next.js revalidation on
+ * their own. Only scrutins whose policy title is APPROVED are revalidated;
+ * everything else is reported back as skipped. Capped at 200 ids per call
+ * (see revalidateVotesSchema) since each id can trigger several
+ * revalidatePath calls inline in the request.
+ * Body: { scrutinIds: string[] }
+ */
+export const POST = withAdminAuth(
+  withValidation(revalidateVotesSchema, async (_request, _context, body) => {
+    const rows = await db.scrutin.findMany({
+      where: { id: { in: body.scrutinIds } },
+      select: { id: true, policyTitle: { select: { status: true } } },
+    });
+
+    const { toRevalidate, skipped } = partitionRevalidatable(
+      body.scrutinIds,
+      rows.map((row) => ({ id: row.id, status: row.policyTitle?.status ?? null }))
+    );
+
+    for (const scrutinId of toRevalidate) {
+      await revalidatePublicForScrutin(scrutinId);
+    }
+
+    await db.auditLog.create({
+      data: {
+        action: "INVALIDATE",
+        entityType: "Scrutin",
+        entityId: `${toRevalidate.length} scrutins`,
+        changes: { revalidated: toRevalidate.length, skipped: skipped.length },
+      },
+    });
+
+    return NextResponse.json({ revalidated: toRevalidate, skipped });
+  })
+);

--- a/src/app/api/admin/votes/revalidate/route.ts
+++ b/src/app/api/admin/votes/revalidate/route.ts
@@ -20,13 +20,15 @@ import { partitionRevalidatable } from "./partition";
  */
 export const POST = withAdminAuth(
   withValidation(revalidateVotesSchema, async (_request, _context, body) => {
+    const ids = Array.from(new Set(body.scrutinIds));
+
     const rows = await db.scrutin.findMany({
-      where: { id: { in: body.scrutinIds } },
+      where: { id: { in: ids } },
       select: { id: true, policyTitle: { select: { status: true } } },
     });
 
     const { toRevalidate, skipped } = partitionRevalidatable(
-      body.scrutinIds,
+      ids,
       rows.map((row) => ({ id: row.id, status: row.policyTitle?.status ?? null }))
     );
 
@@ -39,7 +41,7 @@ export const POST = withAdminAuth(
         action: "INVALIDATE",
         entityType: "Scrutin",
         entityId: `${toRevalidate.length} scrutins`,
-        changes: { revalidated: toRevalidate.length, skipped: skipped.length },
+        changes: { revalidated: toRevalidate, skipped },
       },
     });
 

--- a/src/lib/security/schemas/__tests__/admin.test.ts
+++ b/src/lib/security/schemas/__tests__/admin.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { revalidateVotesSchema } from "../admin";
+
+describe("revalidateVotesSchema", () => {
+  it("rejects an empty scrutinIds array", () => {
+    const r = revalidateVotesSchema.safeParse({ scrutinIds: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects more than 200 scrutinIds", () => {
+    const scrutinIds = Array.from({ length: 201 }, (_, i) => `sc-${i}`);
+    const r = revalidateVotesSchema.safeParse({ scrutinIds });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a valid list of scrutinIds", () => {
+    const r = revalidateVotesSchema.safeParse({ scrutinIds: ["sc-1", "sc-2", "sc-3"] });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts exactly 200 scrutinIds (cap boundary)", () => {
+    const scrutinIds = Array.from({ length: 200 }, (_, i) => `sc-${i}`);
+    const r = revalidateVotesSchema.safeParse({ scrutinIds });
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/lib/security/schemas/__tests__/admin.test.ts
+++ b/src/lib/security/schemas/__tests__/admin.test.ts
@@ -7,6 +7,11 @@ describe("revalidateVotesSchema", () => {
     expect(r.success).toBe(false);
   });
 
+  it("rejects a scrutinIds array containing an empty string", () => {
+    const r = revalidateVotesSchema.safeParse({ scrutinIds: [""] });
+    expect(r.success).toBe(false);
+  });
+
   it("rejects more than 200 scrutinIds", () => {
     const scrutinIds = Array.from({ length: 201 }, (_, i) => `sc-${i}`);
     const r = revalidateVotesSchema.safeParse({ scrutinIds });

--- a/src/lib/security/schemas/admin.ts
+++ b/src/lib/security/schemas/admin.ts
@@ -16,6 +16,12 @@ export const revalidateCacheSchema = z.union([
   z.object({ tags: z.array(z.enum(VALID_CACHE_TAGS)).min(1) }),
 ]);
 
+// Cap at 200: this endpoint revalidates paths inline in the request, so an
+// unbounded batch would mean an unbounded number of revalidatePath calls.
+export const revalidateVotesSchema = z.object({
+  scrutinIds: z.array(z.string().min(1)).min(1).max(200),
+});
+
 export const createSyncSchema = z.object({
   script: z.string().min(1).max(200),
 });

--- a/src/lib/security/schemas/index.ts
+++ b/src/lib/security/schemas/index.ts
@@ -17,6 +17,7 @@ export { updateDossierSchema } from "./dossier";
 export { createFeatureFlagSchema, updateFeatureFlagSchema } from "./feature-flag";
 export {
   revalidateCacheSchema,
+  revalidateVotesSchema,
   createSyncSchema,
   resolveIdentitySchema,
   deleteRejectionsSchema,

--- a/src/lib/votes/revalidate-public.ts
+++ b/src/lib/votes/revalidate-public.ts
@@ -1,0 +1,24 @@
+import { revalidatePath } from "next/cache";
+import { db } from "@/lib/db";
+import { themeToSlug } from "@/lib/theme-utils";
+
+/**
+ * Plan 6 V1 (path-based): revalidate the public surfaces a title appears on after
+ * a status/title change, so an approval becomes visible and a reject/regenerate
+ * hides it. Covers vote detail + list + theme + (when spotlight-eligible) home.
+ * Politician vote tabs intentionally refresh on their own ISR interval (V1).
+ */
+export async function revalidatePublicForScrutin(scrutinId: string): Promise<void> {
+  const scrutin = await db.scrutin.findUnique({
+    where: { id: scrutinId },
+    select: { slug: true, theme: true, importance: { select: { isKeyVote: true } } },
+  });
+  if (!scrutin) return;
+  if (scrutin.slug) revalidatePath(`/parlement/votes/${scrutin.slug}`);
+  revalidatePath("/parlement/votes");
+  if (scrutin.theme) revalidatePath(`/parlement/votes/themes/${themeToSlug(scrutin.theme)}`);
+  if (scrutin.importance?.isKeyVote) {
+    revalidatePath("/");
+    revalidatePath("/parlement");
+  }
+}


### PR DESCRIPTION
## Pourquoi

Suivi du correctif #477 (PR #480). La page vote `/parlement/votes/[slug]` a un backstop ISR de 24h ; la revalidation à la demande n'est déclenchée que par le chemin server-action (`/moderate-titles`, UI admin). L'**auto-approbation quotidienne** et la **routine cloud** (SQL direct) n'entraînent **aucune** revalidation, donc un titre approuvé par ces chemins peut mettre jusqu'à 24h à apparaître sur les pages de détail.

Cet endpoint donne un moyen explicite de faire apparaître promptement un lot de titres approuvés hors chemin applicatif (notamment après le backfill #477 et la routine cloud).

## Ce que fait cette PR

- **`POST /api/admin/votes/revalidate`** : protégé (`withAdminAuth`), validé (`withValidation`), **plafonné à 200 IDs** par appel (`min 1`, `max 200` via Zod).
- Corps : `{ scrutinIds: string[] }`. Pour chaque scrutin dont le titre public est **exactement `APPROVED`**, revalide ses surfaces publiques ; les autres sont renvoyés dans `skipped` avec la raison (`not_found` / `not_approved`). **Ne revalide jamais** un scrutin non trouvé ou non approuvé.
- Réponse : `{ revalidated: string[], skipped: { id, reason }[] }`. Écrit une entrée `auditLog`.
- **DRY** : la logique de revalidation publique (`revalidatePublicForScrutin`) est extraite de `admin/policy-titles/actions.ts` vers un module partagé `src/lib/votes/revalidate-public.ts`, réutilisé par l'action admin existante ET par ce nouvel endpoint. Comportement de l'action admin inchangé.
- Suit exactement le patron de `src/app/api/admin/cache/revalidate/route.ts`.

## Tests

- Unitaires purs : schéma (rejette `[]` et 201 IDs, accepte une liste valide) + `partitionRevalidatable` (APPROVED -> revalidé ; DRAFT/NEEDS_REVIEW/STALE -> `not_approved` ; ID absent -> `not_found` ; jeu mixte). 9/9 verts.
- Suite complète verte, `tsc` + eslint propres.

## Usage rollout

Après une approbation en lot hors UI (backfill #477, routine cloud, auto-approbation), appeler cet endpoint avec les IDs approuvés pour les publier sans attendre le backstop 24h.

**À merger avant la publication automatisée du Stage 3 de #477** (pour que l'auto-approbation et la routine cloud disposent d'un chemin de revalidation).

Refs #477 (pas de fermeture auto : #477 se ferme manuellement après vérification en production).
