### PR TITLE
test(db): harnais Postgres jetable pour les tests d'intégration DB (#477)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+# Disposable PostgreSQL for the #477 DB integration tests ONLY.
+# NEVER for production or shared data. Torn down with `down -v` by scripts/test-db-477.sh.
+name: poligraph-test-477
+services:
+  db-test:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: poligraph_test
+      POSTGRES_PASSWORD: poligraph_test
+      POSTGRES_DB: poligraph_test
+    ports:
+      - "55432:5432"
+    volumes:
+      - pgdata_test:/var/lib/postgresql/data
+      - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U poligraph_test -d poligraph_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+volumes:
+  pgdata_test:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
+    "test:db:477": "bash scripts/test-db-477.sh",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",

--- a/scripts/test-db-477.sh
+++ b/scripts/test-db-477.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Disposable Docker Postgres harness for the #477 DB integration tests.
+#
+# SAFETY: never uses .env / .env.prod / Supabase / any shared DB. It injects its
+# own DATABASE_URL + DIRECT_URL pointing at a local throwaway container, forces
+# DATABASE_SSL=false, and sets DOTENV_CONFIG_PATH=/dev/null so the Prisma CLI
+# (prisma.config.ts runs `import "dotenv/config"`) cannot read the real .env.
+# The container + volume are always destroyed on exit, including on failure.
+set -euo pipefail
+
+COMPOSE=(docker compose -f docker-compose.test.yml)
+PORT=55432
+TEST_DB_URL="postgresql://poligraph_test:poligraph_test@localhost:${PORT}/poligraph_test?sslmode=disable"
+
+# --- self-contained env; .env is never used to target the DB ---
+export DATABASE_URL="$TEST_DB_URL"
+export DIRECT_URL="$TEST_DB_URL"        # prisma.config.ts prefers DIRECT_URL for migrations
+export DATABASE_SSL=false
+export NODE_ENV=test
+export DOTENV_CONFIG_PATH=/dev/null     # neutralize prisma.config.ts's dotenv/config
+
+# --- refuse to run against anything that is not the local disposable DB ---
+for v in DATABASE_URL DIRECT_URL; do
+  val="${!v}"
+  case "$val" in
+    *"localhost:${PORT}/poligraph_test"*) : ;;
+    *) echo "REFUSING: $v is not the local test DB: $val" >&2; exit 1 ;;
+  esac
+  case "$val" in
+    *supabase*|*pooler*|*amazonaws*|*neon*) echo "REFUSING: $v looks remote/prod: $val" >&2; exit 1 ;;
+  esac
+done
+
+cleanup() {
+  echo "[test:db:477] teardown: destroying container + volume (down -v)"
+  "${COMPOSE[@]}" down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "[test:db:477] DATABASE_URL=$DATABASE_URL"
+echo "[test:db:477] DATABASE_SSL=$DATABASE_SSL  DOTENV_CONFIG_PATH=$DOTENV_CONFIG_PATH"
+"${COMPOSE[@]}" up -d
+
+echo "[test:db:477] waiting for postgres..."
+for i in $(seq 1 60); do
+  if "${COMPOSE[@]}" exec -T db-test pg_isready -U poligraph_test -d poligraph_test >/dev/null 2>&1; then
+    echo "[test:db:477] ready (${i}s)"; break
+  fi
+  [ "$i" -eq 60 ] && { echo "[test:db:477] not ready after 60s" >&2; exit 1; }
+  sleep 1
+done
+
+echo "[test:db:477] prisma generate"
+npx prisma generate
+
+echo "[test:db:477] prisma db push (schema -> disposable DB)"
+npx prisma db push --url "$DATABASE_URL" --accept-data-loss
+
+echo "[test:db:477] creating poligraphId sequences (publicId generator backing)"
+npx tsx scripts/create-public-id-sequences.ts
+
+echo "[test:db:477] running the two #477 integration test files"
+npx vitest run \
+  src/services/sync/reconcile-scrutin-dossier/__tests__/remediate.integration.test.ts \
+  src/services/scrutin-policy-title/__tests__/force-regen-fields.integration.test.ts

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -20,12 +20,17 @@ function buildExtendedClient() {
 
   // Create a connection pool (SSL required by Supabase, rejectUnauthorized: false for pooler certs)
   // Serverless-friendly: small pool per lambda, but enough to handle parallel queries within a request
+  //
+  // SSL: on by default (production/staging on Supabase are unchanged). Set
+  // DATABASE_SSL=false ONLY for a local, non-TLS Postgres such as the disposable
+  // Docker test database. The variable must be the exact string "false" to disable.
+  const useSsl = process.env.DATABASE_SSL !== "false";
   const pool = new Pool({
     connectionString,
     max: 2, // Serverless: each Vercel lambda gets its own pool — keep low to avoid exhausting Supabase pooler
     idleTimeoutMillis: 10_000,
     connectionTimeoutMillis: 15_000,
-    ssl: { rejectUnauthorized: false },
+    ssl: useSsl ? { rejectUnauthorized: false } : false,
     allowExitOnIdle: true, // Release idle connections faster in serverless
     statement_timeout: 30_000, // Kill queries after 30s to prevent pool starvation
   });


### PR DESCRIPTION
## Pourquoi

Les tests d'intégration DB de #477 (`describeIfDb`) ne tournent que si un `DATABASE_URL` réel est injecté. En local/CI on ne veut JAMAIS pointer vers Supabase prod ni une base partagée. Cette PR fournit un harnais Postgres **jetable** pour lancer ces tests en toute sûreté, et la seule ligne de code prod nécessaire (`DATABASE_SSL`).

C'est l'outillage qui exécute la porte pré-merge de #480 (les 2 fichiers `describeIfDb`), gardé **séparé** de #480 comme demandé.

## Contenu (4 fichiers)

- **`src/lib/db.ts`** (seule ligne de prod) : SSL désormais conditionnel. `ssl: useSsl ? { rejectUnauthorized: false } : false` avec `useSsl = process.env.DATABASE_SSL !== "false"`. **Défaut prod inchangé** (variable non définie → SSL activé). `DATABASE_SSL=false` sert uniquement à un Postgres local non-TLS.
- **`docker-compose.test.yml`** (nouveau) : `pgvector/pgvector:pg16`, base/user/pass `poligraph_test`, port non-standard `55432`, volume nommé `pgdata_test` jetable, init des extensions.
- **`scripts/test-db-477.sh`** (nouveau) : le harnais — up → attente readiness → `prisma generate` → `prisma db push --url` explicite → séquences `poligraph_*_seq` + extensions → lance UNIQUEMENT les 2 fichiers `describeIfDb` → **teardown `down -v` systématique via trap EXIT (même en échec)**.
- **`package.json`** : `+ "test:db:477": "bash scripts/test-db-477.sh"`.

## Sûreté (aucune base prod/partagée touchée)

Le script exporte son propre `DATABASE_URL`/`DIRECT_URL` (local uniquement), met `DOTENV_CONFIG_PATH=/dev/null` (empêche `prisma.config.ts` de lire `.env`), force `DATABASE_SSL=false`, passe `--url` explicite à `prisma db push`, et **refuse de tourner** si l'URL n'est pas la base de test locale ou ressemble à une base distante. Le volume Docker est détruit sur EXIT, y compris en cas d'échec.

## Résultat vérifié

`npm run test:db:477` → **2 fichiers, 13 tests passants** (`remediate.integration.test.ts` 10 + `force-regen-fields.integration.test.ts` 3), volume détruit. Aucune connexion prod/pooler/supabase (grep du log = 0 correspondance) — seul `localhost:55432` contacté.

## Notes

- Le script cible les fichiers de test de #477 : `npm run test:db:477` devient pleinement utilisable une fois **#480** mergée (ses 2 fichiers de test doivent exister). Cette PR reste mergeable indépendamment (le script n'est pas exécuté en CI).
- Prisma 7 : `db push` n'accepte plus `--skip-generate` → on passe `--url` explicite (aussi une garde de sûreté plus forte).

Refs #477
