### PR TITLE
Votes expliqués : showcase, teaser, vue dédiée et fraîcheur du cache

### DIFF
--- a/scripts/test-db-477.sh
+++ b/scripts/test-db-477.sh
@@ -59,7 +59,12 @@ npx prisma db push --url "$DATABASE_URL" --accept-data-loss
 echo "[test:db:477] creating poligraphId sequences (publicId generator backing)"
 npx tsx scripts/create-public-id-sequences.ts
 
-echo "[test:db:477] running the two #477 integration test files"
-npx vitest run \
-  src/services/sync/reconcile-scrutin-dossier/__tests__/remediate.integration.test.ts \
-  src/services/scrutin-policy-title/__tests__/force-regen-fields.integration.test.ts
+if [ "$#" -gt 0 ]; then
+  echo "[test:db:477] running requested test files: $*"
+  npx vitest run "$@"
+else
+  echo "[test:db:477] running the two #477 integration test files"
+  npx vitest run \
+    src/services/sync/reconcile-scrutin-dossier/__tests__/remediate.integration.test.ts \
+    src/services/scrutin-policy-title/__tests__/force-regen-fields.integration.test.ts
+fi

--- a/src/app/admin/policy-titles/__tests__/actions.test.ts
+++ b/src/app/admin/policy-titles/__tests__/actions.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/lib/auth", () => ({
 // can assert public revalidation (Plan 6).
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  updateTag: vi.fn(),
 }));
 
 // Mock ONLY generateScrutinPolicyTitle; keep buildInputHashInput real (actions

--- a/src/app/admin/policy-titles/__tests__/batch-actions.test.ts
+++ b/src/app/admin/policy-titles/__tests__/batch-actions.test.ts
@@ -12,6 +12,8 @@ vi.mock("@/lib/auth", () => ({
 // revalidatePath throws outside a Next request context; no-op it under vitest.
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
+  revalidateTag: () => {},
+  updateTag: () => {},
 }));
 
 // Mock ONLY generateScrutinPolicyTitle; keep buildInputHashInput real (actions

--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -20,7 +20,8 @@ import {
   type ApprovalContext,
 } from "@/services/scrutin-policy-title/approval";
 import { queryQueue, type QueueFilters } from "@/app/admin/policy-titles/_data/queue-query";
-import { revalidatePublicForScrutin } from "@/lib/votes/revalidate-public";
+import { revalidatePublicPathsForScrutin } from "@/lib/votes/revalidate-public";
+import { updateTags } from "@/lib/cache";
 import { ApproveBlockedError } from "@/app/admin/policy-titles/errors";
 import type { Prisma, ScrutinPolicyTitle } from "@/generated/prisma";
 
@@ -87,7 +88,10 @@ export async function editScrutinPolicyTitle(
 
   revalidate(scrutinId);
   // An edit to an APPROVED row changes what the public sees.
-  if (row.status === "APPROVED") await revalidatePublicForScrutin(scrutinId);
+  if (row.status === "APPROVED") {
+    await revalidatePublicPathsForScrutin(scrutinId);
+    updateTags(["votes"]);
+  }
 }
 
 /**
@@ -119,7 +123,8 @@ export async function approveScrutinPolicyTitle(scrutinId: string): Promise<void
 
   await persistApproval(ctx, { actor: ACTOR });
   revalidate(scrutinId);
-  await revalidatePublicForScrutin(scrutinId);
+  await revalidatePublicPathsForScrutin(scrutinId);
+  updateTags(["votes"]);
 }
 
 /**
@@ -157,7 +162,8 @@ export async function approveWithOverrideScrutinPolicyTitle(
 
   await persistApproval(ctx, { actor: ACTOR, approvalOverride: { reason: trimmed, actor: ACTOR } });
   revalidate(scrutinId);
-  await revalidatePublicForScrutin(scrutinId);
+  await revalidatePublicPathsForScrutin(scrutinId);
+  updateTags(["votes"]);
 }
 
 /**
@@ -224,7 +230,10 @@ export async function rejectScrutinPolicyTitle(scrutinId: string, reason: string
 
   revalidate(scrutinId);
   // A reject can hide a previously-approved title.
-  if (row.status === "APPROVED") await revalidatePublicForScrutin(scrutinId);
+  if (row.status === "APPROVED") {
+    await revalidatePublicPathsForScrutin(scrutinId);
+    updateTags(["votes"]);
+  }
 }
 
 /**
@@ -274,7 +283,10 @@ export async function regenerateScrutinPolicyTitle(scrutinId: string): Promise<v
   }
 
   revalidate(scrutinId);
-  if (wasApproved) await revalidatePublicForScrutin(scrutinId);
+  if (wasApproved) {
+    await revalidatePublicPathsForScrutin(scrutinId);
+    updateTags(["votes"]);
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -327,7 +339,8 @@ export async function batchApprove(scrutinIds: string[]): Promise<BatchApproveRe
   for (const ctx of contexts) {
     await persistApproval(ctx, { actor: ACTOR });
     revalidate(ctx.scrutin.id);
-    await revalidatePublicForScrutin(ctx.scrutin.id);
+    await revalidatePublicPathsForScrutin(ctx.scrutin.id);
+    updateTags(["votes"]);
   }
 
   return { approved: contexts.length, failures: [] };

--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -340,6 +340,8 @@ export async function batchApprove(scrutinIds: string[]): Promise<BatchApproveRe
     await persistApproval(ctx, { actor: ACTOR });
     revalidate(ctx.scrutin.id);
     await revalidatePublicPathsForScrutin(ctx.scrutin.id);
+  }
+  if (contexts.length > 0) {
     updateTags(["votes"]);
   }
 

--- a/src/app/api/admin/votes/revalidate/route.ts
+++ b/src/app/api/admin/votes/revalidate/route.ts
@@ -3,7 +3,8 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation } from "@/lib/security/validate";
 import { revalidateVotesSchema } from "@/lib/security/schemas";
 import { db } from "@/lib/db";
-import { revalidatePublicForScrutin } from "@/lib/votes/revalidate-public";
+import { revalidatePublicPathsForScrutin } from "@/lib/votes/revalidate-public";
+import { revalidateTags } from "@/lib/cache";
 import { partitionRevalidatable } from "./partition";
 
 /**
@@ -33,8 +34,9 @@ export const POST = withAdminAuth(
     );
 
     for (const scrutinId of toRevalidate) {
-      await revalidatePublicForScrutin(scrutinId);
+      await revalidatePublicPathsForScrutin(scrutinId);
     }
+    if (toRevalidate.length > 0) revalidateTags(["votes"], "max");
 
     await db.auditLog.create({
       data: {

--- a/src/app/parlement/votes/__tests__/explained-seo.test.ts
+++ b/src/app/parlement/votes/__tests__/explained-seo.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+
+// page.tsx's default export renders <ScrutinsListing>, whose data-layer import
+// chain (src/lib/data/scrutins.ts -> src/lib/db.ts) constructs a real Prisma
+// client at module load, throwing when DATABASE_URL is unset. generateMetadata
+// itself never touches the database, so stub db here to import the module
+// safely with no DB available (e.g. in CI).
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { generateMetadata } from "@/app/parlement/votes/page";
+
+describe("votes page metadata — explained view", () => {
+  it("bare filter=expliques is indexable with its own canonical + title", async () => {
+    const m = await generateMetadata({
+      searchParams: Promise.resolve({ filter: "expliques" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(m.title).toBe("Votes expliqués");
+    expect(m.alternates?.canonical).toBe("/parlement/votes?filter=expliques");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m.robots as any)?.index).not.toBe(false);
+  });
+  it("faceted explained view is noindex", async () => {
+    const m = await generateMetadata({
+      searchParams: Promise.resolve({ filter: "expliques", chamber: "AN" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m.robots as any)?.index).toBe(false);
+  });
+});

--- a/src/app/parlement/votes/page.tsx
+++ b/src/app/parlement/votes/page.tsx
@@ -15,6 +15,7 @@ interface PageProps {
     theme?: string;
     type?: string;
     search?: string;
+    filter?: string;
   }>;
 }
 
@@ -30,7 +31,19 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
 
   // Lot 3a: de-index utility-filtered/paginated variants (noindex,follow); the
   // bare /parlement/votes stays indexable. GSC: these facet URLs get 0 clicks.
-  const noindex = hasActiveListingFilter(params, VOTES_LISTING_FILTER_KEYS);
+  // Task 9: the bare ?filter=expliques view is its own indexable surface (own
+  // title/canonical); any other param alongside it still falls back to noindex.
+  const isBareExplainedView =
+    params.filter === "expliques" &&
+    !params.page &&
+    !params.type &&
+    !params.theme &&
+    !params.legislature &&
+    !params.chamber &&
+    !params.result &&
+    !params.search;
+
+  const noindex = !isBareExplainedView && hasActiveListingFilter(params, VOTES_LISTING_FILTER_KEYS);
 
   const chamberTitle =
     params.chamber === "AN"
@@ -39,11 +52,16 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
         ? "Votes du Sénat"
         : "Votes parlementaires";
   return {
-    title: chamberTitle,
-    description:
-      "Suivez les votes de l'Assemblée nationale et du Sénat. Consultez les scrutins et découvrez comment votent vos représentants.",
+    title: isBareExplainedView ? "Votes expliqués" : chamberTitle,
+    description: isBareExplainedView
+      ? "Les votes de l'Assemblée nationale et du Sénat traduits en titres clairs et vérifiés."
+      : "Suivez les votes de l'Assemblée nationale et du Sénat. Consultez les scrutins et découvrez comment votent vos représentants.",
     ...listingRobotsMetadata(noindex),
-    alternates: { canonical: `/parlement/votes${qs ? `?${qs}` : ""}` },
+    alternates: {
+      canonical: isBareExplainedView
+        ? "/parlement/votes?filter=expliques"
+        : `/parlement/votes${qs ? `?${qs}` : ""}`,
+    },
   };
 }
 

--- a/src/app/parlement/votes/page.tsx
+++ b/src/app/parlement/votes/page.tsx
@@ -34,14 +34,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   // Task 9: the bare ?filter=expliques view is its own indexable surface (own
   // title/canonical); any other param alongside it still falls back to noindex.
   const isBareExplainedView =
-    params.filter === "expliques" &&
-    !params.page &&
-    !params.type &&
-    !params.theme &&
-    !params.legislature &&
-    !params.chamber &&
-    !params.result &&
-    !params.search;
+    params.filter === "expliques" && !hasActiveListingFilter(params, VOTES_LISTING_FILTER_KEYS);
 
   const noindex = !isBareExplainedView && hasActiveListingFilter(params, VOTES_LISTING_FILTER_KEYS);
 

--- a/src/components/parlement/ExplainedVotesModule.tsx
+++ b/src/components/parlement/ExplainedVotesModule.tsx
@@ -1,0 +1,49 @@
+import { getExplainedShowcase } from "@/lib/data/scrutins";
+import { VoteCard } from "@/components/votes";
+import { EXPLAINED_LISTING_SHOWCASE_COUNT } from "@/config/votes";
+
+interface ExplainedVotesModuleProps {
+  count?: number;
+  maxPerDossier?: number;
+}
+
+export async function ExplainedVotesModule({
+  count = EXPLAINED_LISTING_SHOWCASE_COUNT,
+  maxPerDossier = 2,
+}: ExplainedVotesModuleProps) {
+  const votes = await getExplainedShowcase({ count, maxPerDossier });
+  if (votes.length === 0) return null;
+
+  return (
+    <section className="mb-8" aria-labelledby="votes-expliques-heading">
+      <h2 id="votes-expliques-heading" className="text-lg font-semibold mb-1">
+        Votes expliqués
+      </h2>
+      <p className="text-sm text-muted-foreground mb-3">
+        Des votes récents traduits en langage clair.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {votes.map((s) => (
+          <VoteCard
+            key={s.id}
+            id={s.id}
+            externalId={s.externalId}
+            slug={s.slug}
+            title={s.title}
+            votingDate={s.votingDate}
+            legislature={s.legislature}
+            chamber={s.chamber}
+            votesFor={s.votesFor}
+            votesAgainst={s.votesAgainst}
+            votesAbstain={s.votesAbstain}
+            result={s.result}
+            theme={s.theme}
+            type={s.type}
+            dossier={s.dossierLegislatif}
+            policy={s.policyTitle}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/parlement/ExplainedVotesTeaser.tsx
+++ b/src/components/parlement/ExplainedVotesTeaser.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { getExplainedShowcase } from "@/lib/data/scrutins";
+import { VoteCard } from "@/components/votes";
+
+interface ExplainedVotesTeaserProps {
+  excludeScrutinIds: string[];
+}
+
+/**
+ * Hub teaser for "Votes expliqués": 3 compact cards, deduped against the
+ * key-votes ids already shown above it on the same page. Falls back to an
+ * unfiltered pick if excluding key votes leaves fewer than 3 candidates.
+ */
+export async function ExplainedVotesTeaser({ excludeScrutinIds }: ExplainedVotesTeaserProps) {
+  let votes = await getExplainedShowcase({ count: 3, maxPerDossier: 1, excludeScrutinIds });
+  if (votes.length < 3) {
+    votes = await getExplainedShowcase({ count: 3, maxPerDossier: 1 });
+  }
+  if (votes.length === 0) return null;
+
+  return (
+    <section className="mb-8" aria-labelledby="votes-expliques-teaser-heading">
+      <div className="flex items-center justify-between mb-3">
+        <h2 id="votes-expliques-teaser-heading" className="text-lg font-semibold">
+          Votes expliqués
+        </h2>
+        <Link
+          href="/parlement/votes?filter=expliques"
+          className="text-sm text-primary hover:underline"
+        >
+          Voir tous les votes expliqués →
+        </Link>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {votes.map((s) => (
+          <VoteCard
+            key={s.id}
+            id={s.id}
+            externalId={s.externalId}
+            slug={s.slug}
+            title={s.title}
+            votingDate={s.votingDate}
+            legislature={s.legislature}
+            chamber={s.chamber}
+            votesFor={s.votesFor}
+            votesAgainst={s.votesAgainst}
+            votesAbstain={s.votesAbstain}
+            result={s.result}
+            theme={s.theme}
+            type={s.type}
+            dossier={s.dossierLegislatif}
+            policy={s.policyTitle}
+            compact
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/parlement/ParlementHub.tsx
+++ b/src/components/parlement/ParlementHub.tsx
@@ -4,6 +4,9 @@ import { KeyVoteCard } from "@/components/votes/KeyVoteCard";
 import { DossierCard } from "@/components/legislation";
 import { CompositionHemicycle } from "./CompositionHemicycle";
 import { ParlementEntryCards } from "./ParlementEntryCards";
+// Direct import (not the barrel) to avoid a self-referential cycle: the
+// parlement barrel also re-exports ParlementHub.
+import { ExplainedVotesTeaser } from "./ExplainedVotesTeaser";
 import { FAQJsonLd } from "@/components/seo/JsonLd";
 import { getFeatureValue } from "@/lib/feature-flags";
 import {
@@ -85,6 +88,10 @@ export async function ParlementHub() {
 
   const anGroups = allGroups.filter((g) => g.chamber === "AN" && g.seatCount > 0);
   const senatGroups = allGroups.filter((g) => g.chamber === "SENAT" && g.seatCount > 0);
+
+  const keyVoteIds = [keyVotes.hero?.id, ...keyVotes.grid.map((s) => s.id)].filter(
+    Boolean
+  ) as string[];
 
   return (
     <div className="container mx-auto px-4">
@@ -261,6 +268,9 @@ export async function ParlementHub() {
           </Link>
         </div>
       </section>
+
+      {/* Votes expliqués: teaser deduped against the key votes shown above */}
+      <ExplainedVotesTeaser excludeScrutinIds={keyVoteIds} />
 
       {/* Aujourd'hui au Parlement */}
       <section className="mb-8">

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -3,6 +3,7 @@ import { SimplePagination } from "@/components/ui/SimplePagination";
 import { VoteCard, ScrutinTypeTabs } from "@/components/votes";
 import { VotesSearchInput } from "@/components/votes/VotesSearchInput";
 import { ThemeGrid } from "@/components/votes/ThemeGrid";
+import { ExplainedVotesModule } from "./ExplainedVotesModule";
 
 import {
   VOTING_RESULT_LABELS,
@@ -57,6 +58,7 @@ interface ScrutinsListingProps {
     theme?: string;
     type?: string;
     search?: string;
+    filter?: string;
   };
 }
 
@@ -69,13 +71,25 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
   const theme = (params.theme || undefined) as ThemeCategory | undefined;
   const search = params.search || undefined;
   const typeTab = params.type || "votes"; // default to "votes" (non-amendments)
+  const filter = params.filter;
+  const explainedOnly = filter === "expliques";
 
   // Resolve type/excludeType from tab param
   const typeFilter = TYPE_TAB_MAP[typeTab] ?? {};
 
   const [{ scrutins, total, totalPages, stats }, legislatures, chambers, themeCounts, typeCounts] =
     await Promise.all([
-      getScrutins({ page, limit, result, legislature, chamber, theme, search, ...typeFilter }),
+      getScrutins({
+        page,
+        limit,
+        result,
+        legislature,
+        chamber,
+        theme,
+        search,
+        explainedOnly,
+        ...typeFilter,
+      }),
       getLegislatures(),
       getChambers(),
       getThemeCounts(),
@@ -96,6 +110,7 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
     if (chamber) current.set("chamber", chamber);
     if (theme) current.set("theme", theme);
     if (typeTab && typeTab !== "votes") current.set("type", typeTab);
+    if (filter) current.set("filter", filter);
 
     for (const [key, value] of Object.entries(newParams)) {
       if (value) {
@@ -148,16 +163,34 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
     },
   ];
 
-  // Dynamic title based on chamber
-  const pageTitle = chamber
-    ? `Votes ${chamber === "AN" ? "de l'Assemblée nationale" : "du Sénat"}`
-    : "Votes parlementaires";
+  // Dynamic title based on chamber (or the explained-votes filter, which takes priority)
+  const pageTitle = explainedOnly
+    ? "Votes expliqués"
+    : chamber
+      ? `Votes ${chamber === "AN" ? "de l'Assemblée nationale" : "du Sénat"}`
+      : "Votes parlementaires";
+  const pageSubtitle = explainedOnly
+    ? "Les votes de l'Assemblée nationale et du Sénat traduits en titres clairs."
+    : "Scrutins publics en séance - résultats, thèmes et positions des groupes";
 
   // Adoption rate for results summary
   const adoptedPct = total > 0 && stats.ADOPTED ? Math.round((stats.ADOPTED / total) * 100) : 0;
 
   // Active non-chamber/non-type filters for display
   const hasActiveFilters = !!(result || legislature || theme || search);
+
+  // Showcase renders only on the default, unfiltered "votes" view (not paginated,
+  // not the explained-only listing) so it doesn't duplicate results the user
+  // already filtered for.
+  const showShowcase =
+    !explainedOnly &&
+    !search &&
+    !result &&
+    !legislature &&
+    !chamber &&
+    !theme &&
+    page === 1 &&
+    typeTab === "votes";
 
   return (
     <>
@@ -174,9 +207,7 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
             <h1 className="text-3xl font-display font-extrabold tracking-tight mb-1">
               {pageTitle}
             </h1>
-            <p className="text-muted-foreground text-sm">
-              Scrutins publics en séance - résultats, thèmes et positions des groupes
-            </p>
+            <p className="text-muted-foreground text-sm">{pageSubtitle}</p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <Link
@@ -315,6 +346,8 @@ export async function ScrutinsListing({ searchParams: params }: ScrutinsListingP
             </Link>
           )}
         </div>
+
+        {showShowcase && <ExplainedVotesModule />}
 
         {/* List */}
         {scrutins.length > 0 ? (

--- a/src/components/parlement/__tests__/explained-module.test.tsx
+++ b/src/components/parlement/__tests__/explained-module.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/data/scrutins", () => ({ getExplainedShowcase: vi.fn().mockResolvedValue([]) }));
+
+import { ExplainedVotesModule } from "@/components/parlement/ExplainedVotesModule";
+
+describe("ExplainedVotesModule", () => {
+  it("renders nothing when the pool is empty", async () => {
+    const ui = await ExplainedVotesModule({});
+    expect(ui).toBeNull();
+  });
+});

--- a/src/components/parlement/__tests__/explained-teaser.test.tsx
+++ b/src/components/parlement/__tests__/explained-teaser.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/data/scrutins", () => ({ getExplainedShowcase: vi.fn().mockResolvedValue([]) }));
+
+import { ExplainedVotesTeaser } from "@/components/parlement/ExplainedVotesTeaser";
+
+describe("ExplainedVotesTeaser", () => {
+  it("renders nothing when the pool is empty", async () => {
+    const ui = await ExplainedVotesTeaser({ excludeScrutinIds: [] });
+    expect(ui).toBeNull();
+  });
+});

--- a/src/components/parlement/index.ts
+++ b/src/components/parlement/index.ts
@@ -1,3 +1,4 @@
 export { ParlementHub } from "./ParlementHub";
 export { ScrutinsListing } from "./ScrutinsListing";
 export { ParlementSearch } from "./ParlementSearch";
+export { ExplainedVotesModule } from "./ExplainedVotesModule";

--- a/src/components/parlement/index.ts
+++ b/src/components/parlement/index.ts
@@ -2,3 +2,4 @@ export { ParlementHub } from "./ParlementHub";
 export { ScrutinsListing } from "./ScrutinsListing";
 export { ParlementSearch } from "./ParlementSearch";
 export { ExplainedVotesModule } from "./ExplainedVotesModule";
+export { ExplainedVotesTeaser } from "./ExplainedVotesTeaser";

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -39,6 +39,7 @@ interface VoteCardProps {
   /** Plan 6: the joined policy-title row. When APPROVED + valid, the card shows
    *  the policy title + "Titre explicatif" badge; otherwise the official title. */
   policy?: PolicyForView | null;
+  compact?: boolean;
 }
 
 function extractScrutinNumber(externalId: string): string | null {
@@ -67,6 +68,7 @@ export function VoteCard({
   type,
   dossier,
   policy,
+  compact = false,
 }: VoteCardProps) {
   // Use slug for URL if available, fallback to id
   const href = `/parlement/votes/${slug || id}`;
@@ -137,10 +139,12 @@ export function VoteCard({
                 <Calendar className="h-3 w-3" />
                 {formatDate(new Date(votingDate))}
               </span>
-              <span className="flex items-center gap-1">
-                <Users className="h-3 w-3" />
-                {total} votants
-              </span>
+              {!compact && (
+                <span className="flex items-center gap-1">
+                  <Users className="h-3 w-3" />
+                  {total} votants
+                </span>
+              )}
               <span className="text-muted-foreground/60">{legislature}e législature</span>
             </div>
             {dossier?.slug && (
@@ -170,31 +174,35 @@ export function VoteCard({
           </div>
         </div>
 
-        {/* Vote bar */}
-        <div className="space-y-1">
-          <div className="flex h-2 rounded-full overflow-hidden bg-gray-100">
-            <div
-              className="bg-green-500 transition-all"
-              style={{ width: `${forPercent}%` }}
-              title={`Pour: ${votesFor}`}
-            />
-            <div
-              className="bg-red-500 transition-all"
-              style={{ width: `${againstPercent}%` }}
-              title={`Contre: ${votesAgainst}`}
-            />
-            <div
-              className="bg-yellow-500 transition-all"
-              style={{ width: `${abstainPercent}%` }}
-              title={`Abstention: ${votesAbstain}`}
-            />
-          </div>
-          <div className="flex justify-between text-xs text-muted-foreground">
-            <span className="text-green-600">Pour: {votesFor}</span>
-            <span className="text-red-600">Contre: {votesAgainst}</span>
-            <span className="text-yellow-600">Abstention: {votesAbstain}</span>
-          </div>
-        </div>
+        {!compact && (
+          <>
+            {/* Vote bar */}
+            <div className="space-y-1">
+              <div className="flex h-2 rounded-full overflow-hidden bg-gray-100">
+                <div
+                  className="bg-green-500 transition-all"
+                  style={{ width: `${forPercent}%` }}
+                  title={`Pour: ${votesFor}`}
+                />
+                <div
+                  className="bg-red-500 transition-all"
+                  style={{ width: `${againstPercent}%` }}
+                  title={`Contre: ${votesAgainst}`}
+                />
+                <div
+                  className="bg-yellow-500 transition-all"
+                  style={{ width: `${abstainPercent}%` }}
+                  title={`Abstention: ${votesAbstain}`}
+                />
+              </div>
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span className="text-green-600">Pour: {votesFor}</span>
+                <span className="text-red-600">Contre: {votesAgainst}</span>
+                <span className="text-yellow-600">Abstention: {votesAbstain}</span>
+              </div>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/votes/__tests__/vote-card-compact.test.tsx
+++ b/src/components/votes/__tests__/vote-card-compact.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { VoteCard } from "@/components/votes/VoteCard";
+
+const props = {
+  id: "1",
+  externalId: "VTANR5L17V1",
+  slug: "s",
+  title: "Titre officiel",
+  votingDate: new Date("2026-06-27"),
+  legislature: 17,
+  chamber: "AN" as const,
+  votesFor: 100,
+  votesAgainst: 20,
+  votesAbstain: 5,
+  result: "ADOPTED" as const,
+};
+
+describe("VoteCard compact", () => {
+  it("omits the votants count in compact mode", () => {
+    const { queryByText } = render(<VoteCard {...props} compact />);
+    expect(queryByText(/votants/)).toBeNull();
+  });
+  it("keeps it in full mode", () => {
+    const { queryByText } = render(<VoteCard {...props} />);
+    expect(queryByText(/votants/)).not.toBeNull();
+  });
+});

--- a/src/config/votes.ts
+++ b/src/config/votes.ts
@@ -1,0 +1,1 @@
+export const EXPLAINED_LISTING_SHOWCASE_COUNT = 8;

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -1,6 +1,7 @@
 import { inngest } from "../client";
 import { POLICY_TITLE_CRON } from "@/config/policy-titles";
 import { syncMetadata } from "@/lib/sync/sync-metadata";
+import { revalidateTags } from "@/lib/cache";
 
 interface DailyStep {
   name: string;
@@ -193,6 +194,7 @@ const DAILY_STEPS: DailyStep[] = [
           byReason: stats.byReason,
         },
       });
+      if (stats.approved > 0) revalidateTags(["votes"], "max");
       console.info("[sync-daily] approve-policy-titles", stats);
       return stats;
     },

--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateTag = vi.fn();
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+  revalidatePath: vi.fn(),
+  updateTag: (t: string) => updateTag(t),
+}));
+
+import { updateTags } from "@/lib/cache";
+
+describe("updateTags", () => {
+  beforeEach(() => updateTag.mockClear());
+  it("calls updateTag once per tag, with no profile arg", () => {
+    updateTags(["votes", "dossiers"]);
+    expect(updateTag).toHaveBeenCalledTimes(2);
+    expect(updateTag).toHaveBeenNthCalledWith(1, "votes");
+    expect(updateTag).toHaveBeenNthCalledWith(2, "dossiers");
+  });
+});

--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -4,7 +4,7 @@ const updateTag = vi.fn();
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
   revalidatePath: vi.fn(),
-  updateTag: (t: string) => updateTag(t),
+  updateTag: (...args: unknown[]) => updateTag(...args),
 }));
 
 import { updateTags } from "@/lib/cache";

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,4 +1,4 @@
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag, updateTag } from "next/cache";
 
 // ─── Cache tiers for API responses ────────────────────────────────
 
@@ -168,4 +168,10 @@ export function revalidateTags(tags: string[], profile: string = DEFAULT_PROFILE
   for (const tag of tags) {
     revalidateTag(tag, profile);
   }
+}
+
+/** Immediate, read-your-write tag refresh. Server-Action context only.
+ *  updateTag takes ONLY a tag (no cacheLife profile), unlike revalidateTag. */
+export function updateTags(tags: string[]): void {
+  for (const tag of tags) updateTag(tag);
 }

--- a/src/lib/data/__tests__/_seed-explained.ts
+++ b/src/lib/data/__tests__/_seed-explained.ts
@@ -1,0 +1,83 @@
+import type { PolicyTitleConfidence } from "@/generated/prisma";
+
+// Shared fixtures for the getExplainedShowcase integration tests.
+//
+// Explicit ids (not cuid-generated) so tests can assert on them directly.
+// - Dossiers A, B, C
+// - dA1, dA2: dossier A, HIGH confidence, importance score 10, today
+// - dB1: dossier B, HIGH confidence, importance score 5, today
+// - low1: dossier C, LOW confidence, importance score 100 (proves LOW is
+//   excluded from the showcase regardless of how high its score is)
+const DOSSIER_IDS = ["A", "B", "C"] as const;
+const SCRUTIN_FIXTURES: Array<{
+  id: string;
+  dossierId: (typeof DOSSIER_IDS)[number];
+  confidence: PolicyTitleConfidence;
+  score: number;
+}> = [
+  { id: "dA1", dossierId: "A", confidence: "HIGH", score: 10 },
+  { id: "dA2", dossierId: "A", confidence: "HIGH", score: 10 },
+  { id: "dB1", dossierId: "B", confidence: "HIGH", score: 5 },
+  { id: "low1", dossierId: "C", confidence: "LOW", score: 100 },
+];
+const SCRUTIN_IDS = SCRUTIN_FIXTURES.map((s) => s.id);
+
+/**
+ * Seeds the fixtures above (idempotent: deletes any existing rows with these
+ * explicit ids first, children before parents, so re-running never throws on
+ * an FK conflict).
+ */
+export async function seedExplainedFixtures(db: typeof import("@/lib/db").db): Promise<void> {
+  await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
+  await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
+  await db.scrutin.deleteMany({ where: { id: { in: SCRUTIN_IDS } } });
+  await db.legislativeDossier.deleteMany({ where: { id: { in: [...DOSSIER_IDS] } } });
+
+  await db.legislativeDossier.createMany({
+    data: DOSSIER_IDS.map((id) => ({
+      id,
+      externalId: `TEST_EXPL_DLR_${id}`,
+      title: `Dossier test ${id}`,
+      status: "EN_COURS",
+    })),
+  });
+
+  const today = new Date();
+
+  for (const s of SCRUTIN_FIXTURES) {
+    await db.scrutin.create({
+      data: {
+        id: s.id,
+        externalId: `TEST_EXPL_${s.id}`,
+        title: `Scrutin test ${s.id}`,
+        votingDate: today,
+        legislature: 17,
+        chamber: "AN",
+        votesFor: 100,
+        votesAgainst: 50,
+        votesAbstain: 5,
+        result: "ADOPTED",
+        dossierLegislatifId: s.dossierId,
+        policyTitle: {
+          create: {
+            officialTitleSnapshot: `Snapshot ${s.id}`,
+            inputHash: "0".repeat(64),
+            policyTitle: `Titre politique ${s.id}`,
+            proceduralLabel: "Scrutin solennel",
+            confidence: s.confidence,
+            qualitySignals: {},
+            generationSource: "LLM",
+            status: "APPROVED",
+          },
+        },
+        importance: {
+          create: {
+            score: s.score,
+            isKeyVote: false,
+            signals: {},
+          },
+        },
+      },
+    });
+  }
+}

--- a/src/lib/data/__tests__/_seed-explained.ts
+++ b/src/lib/data/__tests__/_seed-explained.ts
@@ -25,11 +25,29 @@ const SCRUTIN_FIXTURES: Array<{
 const SCRUTIN_IDS = SCRUTIN_FIXTURES.map((s) => s.id);
 
 /**
+ * Allowlist guard: only the disposable local harness DB may be touched by
+ * these fixtures. A denylist would silently miss any future non-matching
+ * remote host, so we require the URL to look like the local harness instead
+ * of merely not looking like a known remote provider.
+ */
+function assertLocalTestDb(): void {
+  const url = process.env.DATABASE_URL ?? "";
+  if (!/@(localhost|127\.0\.0\.1)[:/]/.test(url)) {
+    throw new Error(
+      "Explained fixtures refuse to run: DATABASE_URL is not a local test DB. " +
+        "Run explained integration tests only via the disposable harness (npm run test:db:477)."
+    );
+  }
+}
+
+/**
  * Deletes the shared fixtures above, children before parents, using the same
  * explicit id sets the seed uses. Exported so integration tests can call it
  * from an afterAll and leave no residue behind, even against a real DB.
  */
 export async function cleanupExplainedFixtures(db: typeof import("@/lib/db").db): Promise<void> {
+  assertLocalTestDb();
+
   await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
   await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
   await db.scrutin.deleteMany({ where: { id: { in: SCRUTIN_IDS } } });
@@ -42,13 +60,7 @@ export async function cleanupExplainedFixtures(db: typeof import("@/lib/db").db)
  * an FK conflict).
  */
 export async function seedExplainedFixtures(db: typeof import("@/lib/db").db): Promise<void> {
-  const dbUrl = process.env.DATABASE_URL ?? "";
-  if (/supabase|pooler|amazonaws|neon/i.test(dbUrl)) {
-    throw new Error(
-      "seedExplainedFixtures refuses to run against a remote/prod-looking DATABASE_URL. " +
-        "Run explained integration tests only via the disposable local harness (npm run test:db:477)."
-    );
-  }
+  assertLocalTestDb();
 
   await cleanupExplainedFixtures(db);
 

--- a/src/lib/data/__tests__/_seed-explained.ts
+++ b/src/lib/data/__tests__/_seed-explained.ts
@@ -1,11 +1,12 @@
-import type { PolicyTitleConfidence } from "@/generated/prisma";
+import type { PolicyTitleConfidence, ScrutinType } from "@/generated/prisma";
 
-// Shared fixtures for the getExplainedShowcase integration tests.
+// Shared fixtures for the getExplainedShowcase / getScrutins integration tests.
 //
 // Explicit ids (not cuid-generated) so tests can assert on them directly.
 // - Dossiers A, B, C
 // - dA1, dA2: dossier A, HIGH confidence, importance score 10, today
-// - dB1: dossier B, HIGH confidence, importance score 5, today
+// - dB1: dossier B, HIGH confidence, importance score 5, today, type AMENDEMENT
+//   (lets explainedOnly tests prove excludeType gets overridden)
 // - low1: dossier C, LOW confidence, importance score 100 (proves LOW is
 //   excluded from the showcase regardless of how high its score is)
 const DOSSIER_IDS = ["A", "B", "C"] as const;
@@ -14,10 +15,11 @@ const SCRUTIN_FIXTURES: Array<{
   dossierId: (typeof DOSSIER_IDS)[number];
   confidence: PolicyTitleConfidence;
   score: number;
+  type?: ScrutinType;
 }> = [
   { id: "dA1", dossierId: "A", confidence: "HIGH", score: 10 },
   { id: "dA2", dossierId: "A", confidence: "HIGH", score: 10 },
-  { id: "dB1", dossierId: "B", confidence: "HIGH", score: 5 },
+  { id: "dB1", dossierId: "B", confidence: "HIGH", score: 5, type: "AMENDEMENT" },
   { id: "low1", dossierId: "C", confidence: "LOW", score: 100 },
 ];
 const SCRUTIN_IDS = SCRUTIN_FIXTURES.map((s) => s.id);
@@ -58,6 +60,7 @@ export async function seedExplainedFixtures(db: typeof import("@/lib/db").db): P
         votesAbstain: 5,
         result: "ADOPTED",
         dossierLegislatifId: s.dossierId,
+        ...(s.type && { type: s.type }),
         policyTitle: {
           create: {
             officialTitleSnapshot: `Snapshot ${s.id}`,

--- a/src/lib/data/__tests__/_seed-explained.ts
+++ b/src/lib/data/__tests__/_seed-explained.ts
@@ -25,15 +25,32 @@ const SCRUTIN_FIXTURES: Array<{
 const SCRUTIN_IDS = SCRUTIN_FIXTURES.map((s) => s.id);
 
 /**
+ * Deletes the shared fixtures above, children before parents, using the same
+ * explicit id sets the seed uses. Exported so integration tests can call it
+ * from an afterAll and leave no residue behind, even against a real DB.
+ */
+export async function cleanupExplainedFixtures(db: typeof import("@/lib/db").db): Promise<void> {
+  await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
+  await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
+  await db.scrutin.deleteMany({ where: { id: { in: SCRUTIN_IDS } } });
+  await db.legislativeDossier.deleteMany({ where: { id: { in: [...DOSSIER_IDS] } } });
+}
+
+/**
  * Seeds the fixtures above (idempotent: deletes any existing rows with these
  * explicit ids first, children before parents, so re-running never throws on
  * an FK conflict).
  */
 export async function seedExplainedFixtures(db: typeof import("@/lib/db").db): Promise<void> {
-  await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
-  await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: SCRUTIN_IDS } } });
-  await db.scrutin.deleteMany({ where: { id: { in: SCRUTIN_IDS } } });
-  await db.legislativeDossier.deleteMany({ where: { id: { in: [...DOSSIER_IDS] } } });
+  const dbUrl = process.env.DATABASE_URL ?? "";
+  if (/supabase|pooler|amazonaws|neon/i.test(dbUrl)) {
+    throw new Error(
+      "seedExplainedFixtures refuses to run against a remote/prod-looking DATABASE_URL. " +
+        "Run explained integration tests only via the disposable local harness (npm run test:db:477)."
+    );
+  }
+
+  await cleanupExplainedFixtures(db);
 
   await db.legislativeDossier.createMany({
     data: DOSSIER_IDS.map((id) => ({

--- a/src/lib/data/__tests__/explained-only.integration.test.ts
+++ b/src/lib/data/__tests__/explained-only.integration.test.ts
@@ -1,0 +1,43 @@
+import { vi } from "vitest";
+
+// getScrutins routes through the "use cache" getScrutinsFiltered path when
+// there is no search term: cacheTag()/cacheLife() throw outside a real
+// Next.js cache-components runtime, so mock them here as the other
+// data-function tests in this directory do (e.g. explained-showcase).
+vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
+
+import { describe, it, expect, beforeAll } from "vitest";
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+// Dynamic imports (deferred to beforeAll, inside describeIfDb): both @/lib/db
+// and @/lib/data/scrutins transitively construct the Prisma client at import
+// time, which throws when DATABASE_URL is unset. Static imports would make
+// this suite fail instead of skip when run without a database.
+let db: typeof import("@/lib/db").db;
+let getScrutins: typeof import("@/lib/data/scrutins").getScrutins;
+let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
+
+describeIfDb("getScrutins explainedOnly", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ getScrutins } = await import("@/lib/data/scrutins"));
+    ({ seedExplainedFixtures } = await import("./_seed-explained"));
+    await seedExplainedFixtures(db);
+  });
+
+  it("returns only APPROVED titles, overrides excludeType for amendments, includes LOW", async () => {
+    // excludeType: "AMENDEMENT" is passed on purpose: if explainedOnly
+    // amendments still come back, that proves explainedOnly overrode the
+    // exclusion rather than the test merely never exercising it.
+    const { scrutins } = await getScrutins({
+      page: 1,
+      limit: 50,
+      explainedOnly: true,
+      excludeType: "AMENDEMENT",
+    });
+    expect(scrutins.every((s) => s.policyTitle?.status === "APPROVED")).toBe(true);
+    expect(scrutins.some((s) => s.type === "AMENDEMENT")).toBe(true); // override proven
+    expect(scrutins.map((s) => s.id)).toContain("low1"); // LOW present in full corpus
+  });
+});

--- a/src/lib/data/__tests__/explained-only.integration.test.ts
+++ b/src/lib/data/__tests__/explained-only.integration.test.ts
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 // data-function tests in this directory do (e.g. explained-showcase).
 vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 
@@ -17,13 +17,18 @@ const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 let db: typeof import("@/lib/db").db;
 let getScrutins: typeof import("@/lib/data/scrutins").getScrutins;
 let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
+let cleanupExplainedFixtures: typeof import("./_seed-explained").cleanupExplainedFixtures;
 
 describeIfDb("getScrutins explainedOnly", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ getScrutins } = await import("@/lib/data/scrutins"));
-    ({ seedExplainedFixtures } = await import("./_seed-explained"));
+    ({ seedExplainedFixtures, cleanupExplainedFixtures } = await import("./_seed-explained"));
     await seedExplainedFixtures(db);
+  });
+
+  afterAll(async () => {
+    await cleanupExplainedFixtures(db);
   });
 
   it("returns only APPROVED titles, overrides excludeType for amendments, includes LOW", async () => {

--- a/src/lib/data/__tests__/explained-showcase.integration.test.ts
+++ b/src/lib/data/__tests__/explained-showcase.integration.test.ts
@@ -5,7 +5,7 @@ import { vi } from "vitest";
 // other data-function tests in this directory do (e.g. condamnations.test.ts).
 vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 
@@ -16,12 +16,13 @@ const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 let db: typeof import("@/lib/db").db;
 let getExplainedShowcase: typeof import("@/lib/data/scrutins").getExplainedShowcase;
 let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
+let cleanupExplainedFixtures: typeof import("./_seed-explained").cleanupExplainedFixtures;
 
 describeIfDb("getExplainedShowcase", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
-    ({ seedExplainedFixtures } = await import("./_seed-explained"));
+    ({ seedExplainedFixtures, cleanupExplainedFixtures } = await import("./_seed-explained"));
     await seedExplainedFixtures(db);
   });
 
@@ -50,6 +51,7 @@ describeIfDb("getExplainedShowcase — all-time fallback", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
+    ({ cleanupExplainedFixtures } = await import("./_seed-explained"));
 
     // Idempotent: delete-first by these explicit ids, children before parents.
     await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
@@ -118,6 +120,14 @@ describeIfDb("getExplainedShowcase — all-time fallback", () => {
         },
       });
     }
+  });
+
+  afterAll(async () => {
+    await cleanupExplainedFixtures(db);
+    await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
+    await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
+    await db.scrutin.deleteMany({ where: { id: { in: FB_SCRUTIN_IDS } } });
+    await db.legislativeDossier.deleteMany({ where: { id: { in: [...FB_DOSSIER_IDS] } } });
   });
 
   it("widens to all-time when the 365-day window's diversified output is short", async () => {

--- a/src/lib/data/__tests__/explained-showcase.integration.test.ts
+++ b/src/lib/data/__tests__/explained-showcase.integration.test.ts
@@ -39,3 +39,100 @@ describeIfDb("getExplainedShowcase", () => {
     expect(out.filter((s) => s.dossierLegislatifId === "A").length).toBe(1);
   });
 });
+
+// Own fixtures (FB_* ids/dossiers, isolated via excludeScrutinIds) proving the
+// all-time fallback fires when the widest (365-day) window's DIVERSIFIED
+// output is short of `count` — even though the raw fetched row count is not.
+describeIfDb("getExplainedShowcase — all-time fallback", () => {
+  const FB_DOSSIER_IDS = ["FB_X", "FB_Y", "FB_Z"] as const;
+  const FB_SCRUTIN_IDS = ["FB_x1", "FB_x2", "FB_x3", "FB_y1", "FB_z1"];
+
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
+
+    // Idempotent: delete-first by these explicit ids, children before parents.
+    await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
+    await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
+    await db.scrutin.deleteMany({ where: { id: { in: FB_SCRUTIN_IDS } } });
+    await db.legislativeDossier.deleteMany({ where: { id: { in: [...FB_DOSSIER_IDS] } } });
+
+    await db.legislativeDossier.createMany({
+      data: FB_DOSSIER_IDS.map((id) => ({
+        id,
+        externalId: `TEST_EXPL_DLR_${id}`,
+        title: `Dossier test ${id}`,
+        status: "EN_COURS",
+      })),
+    });
+
+    const today = new Date();
+    const old = new Date();
+    old.setDate(old.getDate() - 400);
+
+    const fixtures: Array<{
+      id: string;
+      dossierId: (typeof FB_DOSSIER_IDS)[number];
+      votingDate: Date;
+    }> = [
+      { id: "FB_x1", dossierId: "FB_X", votingDate: today },
+      { id: "FB_x2", dossierId: "FB_X", votingDate: today },
+      { id: "FB_x3", dossierId: "FB_X", votingDate: today },
+      { id: "FB_y1", dossierId: "FB_Y", votingDate: old },
+      { id: "FB_z1", dossierId: "FB_Z", votingDate: old },
+    ];
+
+    for (const f of fixtures) {
+      await db.scrutin.create({
+        data: {
+          id: f.id,
+          externalId: `TEST_EXPL_${f.id}`,
+          title: `Scrutin test ${f.id}`,
+          votingDate: f.votingDate,
+          legislature: 17,
+          chamber: "AN",
+          votesFor: 100,
+          votesAgainst: 50,
+          votesAbstain: 5,
+          result: "ADOPTED",
+          dossierLegislatifId: f.dossierId,
+          policyTitle: {
+            create: {
+              officialTitleSnapshot: `Snapshot ${f.id}`,
+              inputHash: "0".repeat(64),
+              policyTitle: `Titre politique ${f.id}`,
+              proceduralLabel: "Scrutin solennel",
+              confidence: "HIGH",
+              qualitySignals: {},
+              generationSource: "LLM",
+              status: "APPROVED",
+            },
+          },
+          importance: {
+            create: {
+              score: 10,
+              isKeyVote: false,
+              signals: {},
+            },
+          },
+        },
+      });
+    }
+  });
+
+  it("widens to all-time when the 365-day window's diversified output is short", async () => {
+    // Only 3 FB_X rows fall inside the 365-day window; maxPerDossier:1
+    // diversifies them down to 1 — short of count:3. FB_Y/FB_Z sit ~400 days
+    // back, outside every adaptive window, so they can only appear via the
+    // bounded all-time fallback. Exclude the shared standard fixtures so only
+    // FB_* rows compete.
+    const out = await getExplainedShowcase({
+      count: 3,
+      maxPerDossier: 1,
+      excludeScrutinIds: ["dA1", "dA2", "dB1", "low1"],
+    });
+    expect(out.length).toBe(3);
+    const ids = out.map((s) => s.id);
+    expect(ids.some((id) => id === "FB_y1" || id === "FB_z1")).toBe(true);
+  });
+});

--- a/src/lib/data/__tests__/explained-showcase.integration.test.ts
+++ b/src/lib/data/__tests__/explained-showcase.integration.test.ts
@@ -1,0 +1,41 @@
+import { vi } from "vitest";
+
+// getExplainedShowcase is a "use cache" function: cacheTag()/cacheLife() throw
+// outside a real Next.js cache-components runtime, so mock them here as the
+// other data-function tests in this directory do (e.g. condamnations.test.ts).
+vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
+
+import { describe, it, expect, beforeAll } from "vitest";
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+// Dynamic imports (deferred to beforeAll, inside describeIfDb): both @/lib/db
+// and @/lib/data/scrutins transitively construct the Prisma client at import
+// time, which throws when DATABASE_URL is unset. Static imports would make
+// this suite fail instead of skip when run without a database.
+let db: typeof import("@/lib/db").db;
+let getExplainedShowcase: typeof import("@/lib/data/scrutins").getExplainedShowcase;
+let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
+
+describeIfDb("getExplainedShowcase", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
+    ({ seedExplainedFixtures } = await import("./_seed-explained"));
+    await seedExplainedFixtures(db);
+  });
+
+  it("excludes LOW, caps per dossier, honors count", async () => {
+    const out = await getExplainedShowcase({ count: 8, maxPerDossier: 2 });
+    const ids = out.map((s) => s.id);
+    expect(ids).not.toContain("low1"); // LOW excluded from showcase
+    expect(out.length).toBeLessThanOrEqual(8);
+    const fromA = out.filter((s) => s.dossierLegislatifId === "A").length;
+    expect(fromA).toBeLessThanOrEqual(2); // per-dossier cap
+  });
+
+  it("respects maxPerDossier: 1", async () => {
+    const out = await getExplainedShowcase({ count: 8, maxPerDossier: 1 });
+    expect(out.filter((s) => s.dossierLegislatifId === "A").length).toBe(1);
+  });
+});

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -192,8 +192,20 @@ async function queryScrutins(params: {
   type?: ScrutinType;
   excludeType?: ScrutinType;
   search?: string;
+  explainedOnly?: boolean;
 }) {
-  const { page, limit, result, legislature, chamber, theme, type, excludeType, search } = params;
+  const {
+    page,
+    limit,
+    result,
+    legislature,
+    chamber,
+    theme,
+    type,
+    excludeType,
+    search,
+    explainedOnly,
+  } = params;
   const skip = (page - 1) * limit;
 
   const where = {
@@ -202,7 +214,12 @@ async function queryScrutins(params: {
     ...(chamber && { chamber }),
     ...(theme && { theme }),
     ...(type && { type }),
-    ...(excludeType && { type: { not: excludeType } }),
+    // explainedOnly includes amendments: requested `type` still applies, but
+    // `excludeType` (e.g. hiding amendments by default) is ignored.
+    ...(!explainedOnly && excludeType && { type: { not: excludeType } }),
+    ...(explainedOnly && {
+      policyTitle: { is: { status: "APPROVED" as const, policyTitle: { not: null } } },
+    }),
     ...(search && {
       OR: [
         { title: { contains: search, mode: "insensitive" as const } },
@@ -213,6 +230,21 @@ async function queryScrutins(params: {
             title: { contains: search, mode: "insensitive" as const },
           },
         },
+        ...(explainedOnly
+          ? [
+              {
+                policyTitle: {
+                  is: {
+                    status: "APPROVED" as const,
+                    OR: [
+                      { policyTitle: { contains: search, mode: "insensitive" as const } },
+                      { policySubtitle: { contains: search, mode: "insensitive" as const } },
+                    ],
+                  },
+                },
+              },
+            ]
+          : []),
       ],
     }),
   };
@@ -260,6 +292,7 @@ async function getScrutinsFiltered(params: {
   theme?: ThemeCategory;
   type?: ScrutinType;
   excludeType?: ScrutinType;
+  explainedOnly?: boolean;
 }) {
   "use cache";
   cacheTag("votes");
@@ -278,6 +311,7 @@ export async function getScrutins(params: {
   type?: ScrutinType;
   excludeType?: ScrutinType;
   search?: string;
+  explainedOnly?: boolean;
 }) {
   if (params.search) {
     return queryScrutins(params);

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -1,8 +1,9 @@
 import { cacheTag, cacheLife } from "next/cache";
 import { db } from "@/lib/db";
-import type { Chamber, VotingResult, ThemeCategory, ScrutinType } from "@/generated/prisma";
+import type { Chamber, VotingResult, ThemeCategory, ScrutinType, Prisma } from "@/generated/prisma";
 import { KEY_VOTES_HUB_WINDOW_DAYS, KEY_VOTES_GRID_COUNT } from "@/config/scrutin-importance";
 import type { PolicyForView } from "@/lib/votes/to-public-title-view";
+import { scoreExplainedVote, diversify } from "@/lib/votes/explained-scoring";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -526,4 +527,108 @@ export async function getKeyVotes(): Promise<{
   }));
 
   return { hero: mapped[0] ?? null, grid: mapped.slice(1) };
+}
+
+// ---------------------------------------------------------------------------
+// Votes expliqués showcase
+// ---------------------------------------------------------------------------
+
+const EXPLAINED_WINDOWS_DAYS = [90, 180, 365] as const;
+const ALL_TIME_FALLBACK_POOL_SIZE = 200;
+
+const EXPLAINED_SELECT = {
+  ...DAILY_SELECT,
+  dossierLegislatifId: true, // scalar FK — scoring/diversify read s.dossierLegislatifId
+  dossierLegislatif: { select: { title: true, slug: true } },
+  importance: { select: { score: true, isKeyVote: true } },
+  // Override DAILY_SELECT's policyTitle to add `confidence` (needed for scoring),
+  // keeping the other fields so VoteCard behaves identically.
+  policyTitle: {
+    select: {
+      status: true,
+      policyTitle: true,
+      policySubtitle: true,
+      officialSourceUrl: true,
+      proceduralLabel: true,
+      confidence: true,
+    },
+  },
+} satisfies Prisma.ScrutinSelect;
+
+type ExplainedRow = Prisma.ScrutinGetPayload<{ select: typeof EXPLAINED_SELECT }>;
+
+const EXPLAINED_BASE_WHERE = {
+  policyTitle: {
+    is: {
+      status: "APPROVED" as const,
+      policyTitle: { not: null },
+      confidence: { in: ["HIGH", "MEDIUM"] as const },
+    },
+  },
+} satisfies Prisma.ScrutinWhereInput;
+
+function toExplainedCandidate(s: ExplainedRow) {
+  return {
+    id: s.id,
+    policyTitle: s.policyTitle!.policyTitle as string,
+    votingDate: s.votingDate,
+    dossierLegislatifId: s.dossierLegislatifId ?? null,
+    confidence: s.policyTitle!.confidence!,
+    importance: s.importance,
+    _row: s,
+  };
+}
+
+/**
+ * Curated "Votes expliqués" showcase: best APPROVED HIGH/MEDIUM policy titles,
+ * ranked by scoreExplainedVote and de-duplicated by diversify. Uses an adaptive
+ * window (90/180/365 days, widening only if needed) and falls back to a
+ * bounded all-time pool when recent windows can't fill `count`.
+ */
+export async function getExplainedShowcase(opts: {
+  count: number;
+  maxPerDossier: number;
+  excludeScrutinIds?: string[];
+}) {
+  "use cache";
+  cacheTag("votes", "votes-explained");
+  cacheLife("synced");
+
+  // 1. one 365-day query, newest first
+  const windowStart = new Date();
+  windowStart.setDate(windowStart.getDate() - 365);
+  let rows = await db.scrutin.findMany({
+    where: { ...EXPLAINED_BASE_WHERE, votingDate: { gte: windowStart } },
+    orderBy: { votingDate: "desc" },
+    select: EXPLAINED_SELECT,
+    take: 400,
+  });
+
+  const now = new Date();
+  const pick = (pool: ExplainedRow[]) => {
+    const cands = pool
+      .map(toExplainedCandidate)
+      .sort((a, b) => scoreExplainedVote(b, now) - scoreExplainedVote(a, now));
+    return diversify(cands, opts).map((c) => c._row);
+  };
+
+  // 2. progressively wider in-memory sub-windows
+  for (const days of EXPLAINED_WINDOWS_DAYS) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const sub = rows.filter((r) => r.votingDate >= cutoff);
+    const out = pick(sub);
+    if (out.length >= opts.count) return out.slice(0, opts.count);
+  }
+
+  // 3. bounded all-time fallback
+  if (rows.length < opts.count) {
+    rows = await db.scrutin.findMany({
+      where: EXPLAINED_BASE_WHERE,
+      orderBy: { votingDate: "desc" },
+      select: EXPLAINED_SELECT,
+      take: ALL_TIME_FALLBACK_POOL_SIZE,
+    });
+  }
+  return pick(rows).slice(0, opts.count);
 }

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -573,7 +573,7 @@ function toExplainedCandidate(s: ExplainedRow) {
     policyTitle: s.policyTitle!.policyTitle as string,
     votingDate: s.votingDate,
     dossierLegislatifId: s.dossierLegislatifId ?? null,
-    confidence: s.policyTitle!.confidence!,
+    confidence: s.policyTitle!.confidence,
     importance: s.importance,
     _row: s,
   };
@@ -613,16 +613,19 @@ export async function getExplainedShowcase(opts: {
   };
 
   // 2. progressively wider in-memory sub-windows
+  let diversified: ExplainedRow[] = [];
   for (const days of EXPLAINED_WINDOWS_DAYS) {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - days);
     const sub = rows.filter((r) => r.votingDate >= cutoff);
-    const out = pick(sub);
-    if (out.length >= opts.count) return out.slice(0, opts.count);
+    diversified = pick(sub);
+    if (diversified.length >= opts.count) return diversified.slice(0, opts.count);
   }
 
-  // 3. bounded all-time fallback
-  if (rows.length < opts.count) {
+  // 3. bounded all-time fallback — gate on the last window's diversified
+  // output, not the raw row count (rows.length stays ~400 regardless of
+  // whether diversify() shrank the result below opts.count).
+  if (diversified.length < opts.count) {
     rows = await db.scrutin.findMany({
       where: EXPLAINED_BASE_WHERE,
       orderBy: { votingDate: "desc" },

--- a/src/lib/votes/__tests__/explained-scoring.test.ts
+++ b/src/lib/votes/__tests__/explained-scoring.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  scoreExplainedVote,
+  isNearDuplicate,
+  diversify,
+  type ExplainedCandidate,
+} from "@/lib/votes/explained-scoring";
+
+const NOW = new Date("2026-07-22T00:00:00Z");
+const base = (o: Partial<ExplainedCandidate>): ExplainedCandidate => ({
+  id: "x",
+  policyTitle: "Titre",
+  votingDate: NOW,
+  dossierLegislatifId: "d1",
+  confidence: "HIGH",
+  importance: { score: 10, isKeyVote: false },
+  ...o,
+});
+
+describe("scoreExplainedVote", () => {
+  it("ranks key votes above non-key at equal base", () => {
+    const key = scoreExplainedVote(base({ importance: { score: 10, isKeyVote: true } }), NOW);
+    const nonKey = scoreExplainedVote(base({ importance: { score: 10, isKeyVote: false } }), NOW);
+    expect(key).toBeGreaterThan(nonKey);
+  });
+  it("ranks HIGH above MEDIUM at equal base", () => {
+    expect(scoreExplainedVote(base({ confidence: "HIGH" }), NOW)).toBeGreaterThan(
+      scoreExplainedVote(base({ confidence: "MEDIUM" }), NOW)
+    );
+  });
+  it("ranks newer above older at equal base", () => {
+    const old = base({ votingDate: new Date("2025-01-01T00:00:00Z") });
+    expect(scoreExplainedVote(base({}), NOW)).toBeGreaterThan(scoreExplainedVote(old, NOW));
+  });
+  it("treats missing importance as base 0", () => {
+    expect(scoreExplainedVote(base({ importance: null }), NOW)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("isNearDuplicate", () => {
+  it("flags same dossier + same day + similar title", () => {
+    const a = base({ id: "a", policyTitle: "Supprimer l'article 5 du budget" });
+    const b = base({ id: "b", policyTitle: "Supprimer l article 5 du budget" });
+    expect(isNearDuplicate(a, b)).toBe(true);
+  });
+  it("never groups null dossiers", () => {
+    const a = base({ id: "a", dossierLegislatifId: null });
+    const b = base({ id: "b", dossierLegislatifId: null });
+    expect(isNearDuplicate(a, b)).toBe(false);
+  });
+  it("does not flag different days", () => {
+    const a = base({ id: "a" });
+    const b = base({ id: "b", votingDate: new Date("2026-07-20T00:00:00Z") });
+    expect(isNearDuplicate(a, b)).toBe(false);
+  });
+});
+
+describe("diversify", () => {
+  it("caps per dossier and honors count", () => {
+    const sorted = [
+      base({ id: "1", dossierLegislatifId: "d1", policyTitle: "A" }),
+      base({ id: "2", dossierLegislatifId: "d1", policyTitle: "B" }),
+      base({ id: "3", dossierLegislatifId: "d1", policyTitle: "C" }),
+      base({ id: "4", dossierLegislatifId: "d2", policyTitle: "D" }),
+    ];
+    const out = diversify(sorted, { count: 3, maxPerDossier: 2 });
+    expect(out.map((c) => c.id)).toEqual(["1", "2", "4"]);
+  });
+  it("excludes excludeScrutinIds", () => {
+    const sorted = [base({ id: "1" }), base({ id: "2", dossierLegislatifId: "d2" })];
+    expect(
+      diversify(sorted, { count: 5, maxPerDossier: 5, excludeScrutinIds: ["1"] }).map((c) => c.id)
+    ).toEqual(["2"]);
+  });
+});

--- a/src/lib/votes/__tests__/revalidate-public.test.ts
+++ b/src/lib/votes/__tests__/revalidate-public.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
 
 const revalidatePath = vi.fn();
+const revalidateTag = vi.fn();
+const updateTag = vi.fn();
 // Wrapped in an arrow function (not the bare shorthand) so the factory doesn't
 // dereference `revalidatePath` at hoist time, which throws a TDZ error since
 // vi.mock factories run before local const declarations are initialized.
 vi.mock("next/cache", () => ({
   revalidatePath: (...args: unknown[]) => revalidatePath(...args),
-  revalidateTag: vi.fn(),
-  updateTag: vi.fn(),
+  revalidateTag: (...args: unknown[]) => revalidateTag(...args),
+  updateTag: (...args: unknown[]) => updateTag(...args),
 }));
 vi.mock("@/lib/db", () => ({
   db: {
@@ -26,5 +28,7 @@ describe("revalidatePublicPathsForScrutin", () => {
     await revalidatePublicPathsForScrutin("id1");
     expect(revalidatePath).toHaveBeenCalledWith("/parlement/votes/s");
     expect(revalidatePath).toHaveBeenCalledWith("/parlement/votes");
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(updateTag).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/votes/__tests__/revalidate-public.test.ts
+++ b/src/lib/votes/__tests__/revalidate-public.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+
+const revalidatePath = vi.fn();
+// Wrapped in an arrow function (not the bare shorthand) so the factory doesn't
+// dereference `revalidatePath` at hoist time, which throws a TDZ error since
+// vi.mock factories run before local const declarations are initialized.
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => revalidatePath(...args),
+  revalidateTag: vi.fn(),
+  updateTag: vi.fn(),
+}));
+vi.mock("@/lib/db", () => ({
+  db: {
+    scrutin: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ slug: "s", theme: "SANTE", importance: { isKeyVote: false } }),
+    },
+  },
+}));
+
+import { revalidatePublicPathsForScrutin } from "@/lib/votes/revalidate-public";
+
+describe("revalidatePublicPathsForScrutin", () => {
+  it("revalidates detail + list + theme paths, never the votes tag", async () => {
+    await revalidatePublicPathsForScrutin("id1");
+    expect(revalidatePath).toHaveBeenCalledWith("/parlement/votes/s");
+    expect(revalidatePath).toHaveBeenCalledWith("/parlement/votes");
+  });
+});

--- a/src/lib/votes/explained-scoring.ts
+++ b/src/lib/votes/explained-scoring.ts
@@ -1,0 +1,78 @@
+export const EXPLAINED_TITLE_SIMILARITY_THRESHOLD = 0.8;
+
+const KEY_VOTE_BOOST = 50;
+const HIGH_CONFIDENCE_BOOST = 15;
+const RECENCY_MAX = 30; // points at day 0
+const RECENCY_HALFLIFE_DAYS = 120;
+
+export interface ExplainedCandidate {
+  id: string;
+  policyTitle: string;
+  votingDate: Date;
+  dossierLegislatifId: string | null;
+  confidence: "HIGH" | "MEDIUM" | "LOW";
+  importance: { score: number; isKeyVote: boolean } | null;
+}
+
+export function scoreExplainedVote(c: ExplainedCandidate, now: Date): number {
+  const base = c.importance?.score ?? 0;
+  const keyBoost = c.importance?.isKeyVote ? KEY_VOTE_BOOST : 0;
+  const confBoost = c.confidence === "HIGH" ? HIGH_CONFIDENCE_BOOST : 0;
+  const ageDays = Math.max(0, (now.getTime() - c.votingDate.getTime()) / 86_400_000);
+  const recency = RECENCY_MAX * Math.pow(0.5, ageDays / RECENCY_HALFLIFE_DAYS);
+  return base + keyBoost + confBoost + recency;
+}
+
+export function normalizeTitle(t: string): string {
+  return t
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+export function titleSimilarity(a: string, b: string): number {
+  const ta = new Set(a.split(" ").filter(Boolean));
+  const tb = new Set(b.split(" ").filter(Boolean));
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let inter = 0;
+  for (const w of ta) if (tb.has(w)) inter++;
+  return inter / new Set([...ta, ...tb]).size; // Jaccard
+}
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+  return a.toISOString().slice(0, 10) === b.toISOString().slice(0, 10);
+}
+
+export function isNearDuplicate(a: ExplainedCandidate, b: ExplainedCandidate): boolean {
+  if (!a.dossierLegislatifId || !b.dossierLegislatifId) return false;
+  if (a.dossierLegislatifId !== b.dossierLegislatifId) return false;
+  if (!isSameCalendarDay(a.votingDate, b.votingDate)) return false;
+  return (
+    titleSimilarity(normalizeTitle(a.policyTitle), normalizeTitle(b.policyTitle)) >=
+    EXPLAINED_TITLE_SIMILARITY_THRESHOLD
+  );
+}
+
+export function diversify<T extends ExplainedCandidate>(
+  sorted: T[],
+  opts: { count: number; maxPerDossier: number; excludeScrutinIds?: string[] }
+): T[] {
+  const excluded = new Set(opts.excludeScrutinIds ?? []);
+  const perDossier = new Map<string, number>();
+  const picked: T[] = [];
+  for (const c of sorted) {
+    if (picked.length >= opts.count) break;
+    if (excluded.has(c.id)) continue;
+    if (c.dossierLegislatifId) {
+      const n = perDossier.get(c.dossierLegislatifId) ?? 0;
+      if (n >= opts.maxPerDossier) continue;
+    }
+    if (picked.some((p) => isNearDuplicate(p, c))) continue;
+    picked.push(c);
+    if (c.dossierLegislatifId)
+      perDossier.set(c.dossierLegislatifId, (perDossier.get(c.dossierLegislatifId) ?? 0) + 1);
+  }
+  return picked;
+}

--- a/src/lib/votes/revalidate-public.ts
+++ b/src/lib/votes/revalidate-public.ts
@@ -7,8 +7,10 @@ import { themeToSlug } from "@/lib/theme-utils";
  * a status/title change, so an approval becomes visible and a reject/regenerate
  * hides it. Covers vote detail + list + theme + (when spotlight-eligible) home.
  * Politician vote tabs intentionally refresh on their own ISR interval (V1).
+ * Paths only — callers are responsible for their own votes tag invalidation
+ * (updateTags for manual Server Actions, revalidateTags for automated batches).
  */
-export async function revalidatePublicForScrutin(scrutinId: string): Promise<void> {
+export async function revalidatePublicPathsForScrutin(scrutinId: string): Promise<void> {
   const scrutin = await db.scrutin.findUnique({
     where: { id: scrutinId },
     select: { slug: true, theme: true, importance: { select: { isKeyVote: true } } },


### PR DESCRIPTION
Closes #476

## Objectif

Rendre les 2645 titres de votes déjà validés (policyTitle APPROVED) visibles comme une vraie surface de découverte, et corriger l'écart de fraîcheur du cache qui retardait l'apparition des validations.

## Surfaces ajoutées

- **Showcase** en tête de `/parlement/votes` : une sélection de votes récents traduits en langage clair (8 cartes, diversifiées par dossier).
- **Teaser** sur le hub `/parlement` : 3 votes expliqués, dédoublonnés des votes clés déjà mis en avant.
- **Vue dédiée** `/parlement/votes?filter=expliques` : le corpus complet des votes expliqués (toutes confiances, amendements inclus), avec recherche sur le titre pédagogique.
- **Variante `compact`** de `VoteCard` pour le teaser.
- **SEO** : la vue nue `?filter=expliques` est indexable avec son propre titre et canonical ; les variantes à facettes restent en noindex.

## Fraîcheur du cache

Les fonctions de données `use cache` sont taggées `"votes"`, mais seule la revalidation de chemins était déclenchée à l'approbation, donc une validation pouvait rester invisible jusqu'à 24h. Ce PR :

- sépare l'invalidation : `updateTags(["votes"])` (immédiat, contexte Server Action) sur les actions manuelles ; `revalidateTags(["votes"], "max")` une fois par lot sur la route admin de revalidation groupée et le cron quotidien.
- réduit `revalidatePublicPathsForScrutin` aux seuls chemins.

## Architecture

- Module pur `src/lib/votes/explained-scoring.ts` (score, similarité, dédup, diversité), sans DB ni React, testé unitairement.
- `getExplainedShowcase` : fenêtre adaptative 90/180/365 jours puis repli borné toutes périodes ; exclut les titres LOW.
- Branche `explainedOnly` sur la requête de listing (titres APPROVED, LOW et amendements inclus).

## Tests

- Suite unitaire complète : 2004 passés / 134 skippés.
- Tests d'intégration DB (`describeIfDb`) validés via le harness Docker jetable `npm run test:db:477` : tous verts.
- Les fixtures d'intégration refusent désormais toute base non locale (allowlist localhost) et nettoient derrière elles (`afterAll`).

## À noter

- `isSameCalendarDay` (dédup du showcase) compare le jour en UTC, conformément au plan. Un passage en heure de Paris serait un peu plus juste pour les scrutins de nuit à l'Assemblée (impact purement visuel, borné par le cap par dossier) : à trancher.
