### PR TITLE
Refonte fiche politique (PR A) : tableau de bord, sources, a11y

### DIFF
--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -6,22 +6,15 @@ import { db } from "@/lib/db";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatDate, formatCompactCurrency } from "@/lib/utils";
-import {
-  MANDATE_TYPE_LABELS,
-  PARTY_ROLE_LABELS,
-  feminizePartyRole,
-  DATA_SOURCE_LABELS,
-} from "@/config/labels";
+import { MANDATE_TYPE_LABELS, PARTY_ROLE_LABELS, feminizePartyRole } from "@/config/labels";
 import { ensureContrast } from "@/lib/contrast";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
-import { MandateTimeline } from "@/components/politicians/MandateTimeline";
-import { InteractiveTimeline } from "@/components/politicians/InteractiveTimeline";
 import { PersonJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { DeclarationCard } from "@/components/declarations/DeclarationCard";
 import { MarkdownText } from "@/components/ui/markdown";
 import type { DeclarationDetails } from "@/types/hatvp";
-import { Scale, FileText, Mail, Globe, Facebook } from "lucide-react";
+import { FileText, Mail, Globe, Facebook } from "lucide-react";
 import { StatusBadge } from "@/components/legislation";
 import { BetaDisclaimer } from "@/components/BetaDisclaimer";
 import { ProfileTabs } from "@/components/politicians/ProfileTabs";
@@ -40,7 +33,12 @@ import { FollowButton } from "@/components/politicians/FollowButton";
 import { CopyableId } from "@/components/politicians/CopyableId";
 import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
-import { isJudiciallyValidated, getJudicialMaturity } from "@/config/judicial-maturity";
+import { computeJudicialCounts } from "@/lib/politicians/judicial-counts";
+import { buildPoliticianSignals } from "@/lib/politicians/signals";
+import { buildSourceLinks } from "@/lib/politicians/external-sources";
+import { PoliticianSignals } from "@/components/politicians/PoliticianSignals";
+import { PresumptionNotice } from "@/components/politicians/PresumptionNotice";
+import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag
 
@@ -179,7 +177,6 @@ export default async function PoliticianPage({ params }: PageProps) {
     notFound();
   }
 
-  const hasMandates = politician.mandates.length > 0;
   const currentMandate = politician.mandates.find((m) => m.isCurrent);
   const currentGroup = (
     currentMandate as typeof currentMandate & {
@@ -206,42 +203,13 @@ export default async function PoliticianPage({ params }: PageProps) {
       : null,
   ]);
 
-  // Split affairs by involvement for sidebar stats and timeline
+  // directAffairs still feeds the Carrière timeline.
   const directAffairs = politician.affairs.filter((a) => a.involvement === "DIRECT");
 
-  // Tab badge: only judicially-validated affairs (Tier 1 + 2, DIRECT/INDIRECT)
-  const validatedAffairsCount = politician.affairs.filter((a) => {
-    if (
-      a.involvement === "VICTIM" ||
-      a.involvement === "PLAINTIFF" ||
-      a.involvement === "MENTIONED_ONLY"
-    )
-      return false;
-    return isJudiciallyValidated(a.status);
-  }).length;
-
-  // Sidebar: condamnation and en cours counts for DIRECT + INDIRECT
-  const directAndIndirect = politician.affairs.filter(
-    (a) => a.involvement === "DIRECT" || a.involvement === "INDIRECT"
-  );
-  const condamnationsCount = directAndIndirect.filter(
-    (a) => getJudicialMaturity(a.status) === "CONDAMNATION"
-  ).length;
-  // Tier 2 strict : les enquêtes préliminaires ne comptent pas comme
-  // procédure validée par un juge (RGPD art. 10, invariant I4)
-  const proceduresEnCoursCount = directAndIndirect.filter(
-    (a) => getJudicialMaturity(a.status) === "PROCEDURE_VALIDEE"
-  ).length;
-
-  // Encart: only condamnations (Tier 1)
-  const encartAffairs = directAffairs.filter(
-    (a) => getJudicialMaturity(a.status) === "CONDAMNATION"
-  );
-  const mentionAffairs = politician.affairs.filter(
-    (a) => a.involvement === "INDIRECT" || a.involvement === "MENTIONED_ONLY"
-  );
-  const victimAffairs = politician.affairs.filter(
-    (a) => a.involvement === "VICTIM" || a.involvement === "PLAINTIFF"
+  // Judicial counters: "mis en cause" = DIRECT only (no double count with
+  // mentions; enquêtes préliminaires excluded, RGPD art. 10 invariant).
+  const judicial = computeJudicialCounts(
+    politician.affairs.map((a) => ({ involvement: a.involvement, status: a.status }))
   );
 
   // Extract companies where politician is a board member for JSON-LD
@@ -252,6 +220,37 @@ export default async function PoliticianPage({ params }: PageProps) {
       .filter((p) => p.isBoardMember)
       .map((p) => ({ name: p.company }))
       .slice(0, 10) ?? [];
+
+  // Dashboard signals + verification sources (single source of truth, passed
+  // to both PoliticianSignals and the two responsive PoliticianSummary mounts).
+  const portfolioValue = detailsForLD?.totalPortfolioValue ?? null;
+  const signals = buildPoliticianSignals({
+    slug: politician.slug,
+    mandatesCount: politician.mandates.length,
+    votesTotal: voteData ? voteData.stats.total : null,
+    hasVotesTab: Boolean((voteData && voteData.stats.total > 0) || parliamentaryCard),
+    hasFactchecksTab: politician.factCheckMentions.length > 0,
+    factchecksCount: politician.factCheckMentions.length,
+    dossiersCount: politician.dossierAuthors.length,
+    declarationsCount: politician.declarations.length,
+    portfolioValue,
+    patrimoineHref: `/politiques/${politician.slug}#declarations`, // PR B: ?tab=patrimoine
+    judicial,
+  });
+  const sourceLinks = buildSourceLinks(
+    politician.externalIds.map((e) => ({ source: e.source, url: e.url }))
+  );
+  const osEntry = politician.externalIds.find((e) => e.source === "OPENSANCTIONS");
+  const osMeta = (osEntry?.metadata ?? null) as { datasets?: string[] } | null;
+  const registres = [
+    ...new Set(
+      (osMeta?.datasets ?? [])
+        .map((d) => OS_DATASET_LABELS[d])
+        .filter((l): l is string => l != null)
+    ),
+  ];
+  const lastUpdated = formatDate(politician.updatedAt);
+  const relationsHref = `/politiques/${politician.slug}/relations`;
 
   return (
     <>
@@ -442,24 +441,30 @@ export default async function PoliticianPage({ params }: PageProps) {
           </div>
         </div>
 
+        {/* Summary before the tabbed body on mobile (DOM order matches reading order). */}
+        <div className="lg:hidden mb-8">
+          <PoliticianSummary
+            signals={signals}
+            sources={sourceLinks}
+            registres={registres}
+            relationsHref={relationsHref}
+            lastUpdated={lastUpdated}
+          />
+        </div>
+
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Main content */}
           <div className="lg:col-span-2">
             <ProfileTabs
-              affairsCount={validatedAffairsCount}
+              affairsCount={judicial.badgeCount}
               profileContent={
                 <div className="space-y-8">
-                  {/* Interactive Timeline - Desktop only */}
-                  {(hasMandates || directAffairs.length > 0) && (
-                    <div className="hidden lg:block">
-                      <InteractiveTimeline
-                        mandates={politician.mandates}
-                        affairs={directAffairs}
-                        birthDate={politician.birthDate}
-                        deathDate={politician.deathDate}
-                      />
-                    </div>
-                  )}
+                  {/* Dashboard: clickable signals + computed presumption note */}
+                  <PoliticianSignals signals={signals} />
+                  <PresumptionNotice
+                    proceduresEnCours={judicial.proceduresEnCours}
+                    condamnationsNonDefinitives={judicial.condamnationsNonDefinitives}
+                  />
 
                   {/* Biography */}
                   {politician.biography && (
@@ -484,68 +489,6 @@ export default async function PoliticianPage({ params }: PageProps) {
                               ` — ${formatDate(politician.biographyGeneratedAt)}`}
                           </span>
                         </div>
-                      </CardContent>
-                    </Card>
-                  )}
-
-                  {/* Affairs summary card — only shows condemnations (Etabli + Prononce) */}
-                  {encartAffairs.length > 0 && (
-                    <Link
-                      href={`/politiques/${politician.slug}?tab=affaires`}
-                      prefetch={false}
-                      scroll={false}
-                      className="block"
-                    >
-                      <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-950/20 hover:bg-amber-50 dark:hover:bg-amber-950/30 transition-colors cursor-pointer group">
-                        <CardContent className="py-4 flex items-center gap-4">
-                          <div className="flex items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/50 text-amber-600 dark:text-amber-400 size-10 shrink-0">
-                            <Scale className="size-5" />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="font-medium text-sm">
-                              {`${encartAffairs.length} condamnation${encartAffairs.length > 1 ? "s" : ""}`}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {encartAffairs
-                                .slice(0, 2)
-                                .map((a) => a.title)
-                                .join(", ")}
-                              {encartAffairs.length > 2 && "..."}
-                            </p>
-                          </div>
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            className="size-5 text-muted-foreground group-hover:text-foreground transition-colors shrink-0"
-                            aria-hidden="true"
-                          >
-                            <path
-                              fillRule="evenodd"
-                              d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                              clipRule="evenodd"
-                            />
-                          </svg>
-                        </CardContent>
-                      </Card>
-                    </Link>
-                  )}
-
-                  {/* Career / Mandates */}
-                  {hasMandates && (
-                    <Card id="parcours">
-                      <CardHeader>
-                        <h2 className="leading-none font-semibold">Parcours politique</h2>
-                        <p className="text-xs text-muted-foreground mt-1">
-                          Liste des mandats nationaux et européens connus. Les mandats locaux
-                          (maire, conseiller, etc.) peuvent ne pas être listés.
-                        </p>
-                      </CardHeader>
-                      <CardContent>
-                        <MandateTimeline
-                          mandates={politician.mandates}
-                          civility={politician.civility}
-                        />
                       </CardContent>
                     </Card>
                   )}
@@ -687,122 +630,16 @@ export default async function PoliticianPage({ params }: PageProps) {
             />
           </div>
 
-          {/* Sidebar */}
-          <div className="space-y-6">
-            {/* Quick stats */}
-            <Card>
-              <CardHeader>
-                <h2 className="leading-none font-semibold text-lg">En bref</h2>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Mandats</span>
-                  <span className="font-semibold">{politician.mandates.length}</span>
-                </div>
-                {voteData && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Votes</span>
-                    <span className="font-semibold">{voteData.stats.total}</span>
-                  </div>
-                )}
-                {condamnationsCount > 0 && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Condamnations</span>
-                    <span className="font-semibold text-red-600 dark:text-red-400">
-                      {condamnationsCount}
-                    </span>
-                  </div>
-                )}
-                {proceduresEnCoursCount > 0 && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Procédures validées en cours</span>
-                    <span className="font-semibold">{proceduresEnCoursCount}</span>
-                  </div>
-                )}
-                {mentionAffairs.length > 0 && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Mentions</span>
-                    <span className="font-semibold text-gray-500">{mentionAffairs.length}</span>
-                  </div>
-                )}
-                {victimAffairs.length > 0 && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Victime</span>
-                    <span className="font-semibold text-primary">{victimAffairs.length}</span>
-                  </div>
-                )}
-                {politician.dossierAuthors.length > 0 && (
-                  <div className="flex justify-between">
-                    <Link
-                      href={`/politiques/${politician.slug}#dossiers`}
-                      className="text-muted-foreground hover:underline"
-                    >
-                      Propositions de loi
-                    </Link>
-                    <span className="font-semibold">{politician.dossierAuthors.length}</span>
-                  </div>
-                )}
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Déclarations HATVP</span>
-                  <span className="font-semibold">{politician.declarations.length}</span>
-                </div>
-                {/* Relations link */}
-                <div className="pt-3 border-t">
-                  <Link
-                    href={`/politiques/${politician.slug}/relations`}
-                    className="flex items-center gap-2 text-sm text-primary hover:underline"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      className="w-4 h-4"
-                    >
-                      <path d="M10 9a3 3 0 100-6 3 3 0 000 6zM6 8a2 2 0 11-4 0 2 2 0 014 0zM1.49 15.326a.78.78 0 01-.358-.442 3 3 0 014.308-3.516 6.484 6.484 0 00-1.905 3.959c-.023.222-.014.442.025.654a4.97 4.97 0 01-2.07-.655zM16.44 15.98a4.97 4.97 0 002.07-.654.78.78 0 00.357-.442 3 3 0 00-4.308-3.517 6.484 6.484 0 011.907 3.96 2.32 2.32 0 01-.026.654zM18 8a2 2 0 11-4 0 2 2 0 014 0zM5.304 16.19a.844.844 0 01-.277-.71 5 5 0 019.947 0 .843.843 0 01-.277.71A6.975 6.975 0 0110 18a6.974 6.974 0 01-4.696-1.81z" />
-                    </svg>
-                    Voir les relations
-                  </Link>
-                </div>
-              </CardContent>
-            </Card>
-
+          {/* Sidebar (desktop): same summary component, hidden on mobile where it renders above the tabs. */}
+          <div className="hidden lg:block space-y-6">
+            <PoliticianSummary
+              signals={signals}
+              sources={sourceLinks}
+              registres={registres}
+              relationsHref={relationsHref}
+              lastUpdated={lastUpdated}
+            />
             <BetaDisclaimer variant="profile" />
-
-            {/* External links + data source */}
-            <Card className="bg-muted">
-              <CardContent className="pt-6">
-                {politician.externalIds.filter((e) => e.url).length > 0 && (
-                  <div className="mb-4">
-                    <p className="text-xs font-medium text-muted-foreground mb-2">Liens externes</p>
-                    <div className="flex flex-wrap gap-x-3 gap-y-1">
-                      {politician.externalIds
-                        .filter((e) => e.url)
-                        .map((ext) => (
-                          <a
-                            key={ext.source}
-                            href={ext.url!}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-xs text-primary hover:underline"
-                          >
-                            {DATA_SOURCE_LABELS[ext.source]} ↗
-                          </a>
-                        ))}
-                    </div>
-                    <OpenSanctionsDatasets externalIds={politician.externalIds} />
-                  </div>
-                )}
-                <p className="text-xs text-muted-foreground">
-                  Dernière mise à jour : {formatDate(politician.updatedAt)}
-                </p>
-                <Link
-                  href="/methodologie"
-                  className="text-xs text-primary hover:underline mt-2 inline-block"
-                >
-                  Voir notre méthodologie
-                </Link>
-              </CardContent>
-            </Card>
           </div>
         </div>
 
@@ -851,24 +688,3 @@ const OS_DATASET_LABELS: Record<string, string> = {
   ann_pep_positions: "PEPs",
   everypolitician: "EveryPolitician",
 };
-
-function OpenSanctionsDatasets({
-  externalIds,
-}: {
-  externalIds: Array<{ source: string; metadata: unknown }>;
-}) {
-  const osEntry = externalIds.find((e) => e.source === "OPENSANCTIONS");
-  if (!osEntry) return null;
-
-  const meta = osEntry.metadata as { datasets?: string[] } | null;
-  const datasets = meta?.datasets ?? [];
-  const labels = [
-    ...new Set(datasets.map((d) => OS_DATASET_LABELS[d]).filter((l): l is string => l != null)),
-  ];
-
-  if (labels.length === 0) return null;
-
-  return (
-    <p className="text-[10px] text-muted-foreground mt-1.5">Registres : {labels.join(", ")}</p>
-  );
-}

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -335,7 +335,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                   }}
                   title={currentGroup.name}
                 >
-                  Groupe parlementaire : {currentGroup.code}
+                  Groupe : {currentGroup.name} ({currentGroup.code})
                 </Badge>
               )}
               {politician.partyHistory
@@ -358,7 +358,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                     href={`mailto:${politician.contactEmail}`}
                     aria-label={`Envoyer un email à ${politician.fullName}`}
                     title="Email"
-                    className="inline-flex items-center justify-center h-9 w-9 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
+                    className="inline-flex items-center justify-center h-11 w-11 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
                   >
                     <Mail className="h-4 w-4" />
                   </a>
@@ -374,7 +374,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                     rel="noopener noreferrer"
                     aria-label={`Profil X de ${politician.fullName}`}
                     title="X (Twitter)"
-                    className="inline-flex items-center justify-center h-9 w-9 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
+                    className="inline-flex items-center justify-center h-11 w-11 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
                   >
                     <svg
                       className="h-4 w-4"
@@ -397,7 +397,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                     rel="noopener noreferrer"
                     aria-label={`Page Facebook de ${politician.fullName}`}
                     title="Facebook"
-                    className="inline-flex items-center justify-center h-9 w-9 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
+                    className="inline-flex items-center justify-center h-11 w-11 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
                   >
                     <Facebook className="h-4 w-4" />
                   </a>
@@ -413,7 +413,7 @@ export default async function PoliticianPage({ params }: PageProps) {
                     rel="noopener noreferrer"
                     aria-label={`Site web de ${politician.fullName}`}
                     title="Site web"
-                    className="inline-flex items-center justify-center h-9 w-9 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
+                    className="inline-flex items-center justify-center h-11 w-11 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors"
                   >
                     <Globe className="h-4 w-4" />
                   </a>

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { formatDate, formatCompactCurrency } from "@/lib/utils";
 import { MANDATE_TYPE_LABELS, PARTY_ROLE_LABELS, feminizePartyRole } from "@/config/labels";
 import { ensureContrast } from "@/lib/contrast";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
+import { MandateTimeline } from "@/components/politicians/MandateTimeline";
 import { PersonJsonLd } from "@/components/seo/JsonLd";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { DeclarationCard } from "@/components/declarations/DeclarationCard";
@@ -595,13 +596,32 @@ export default async function PoliticianPage({ params }: PageProps) {
                 ) : null
               }
               careerContent={
-                <CareerTimeline
-                  mandates={politician.mandates}
-                  partyHistory={politician.partyHistory}
-                  affairs={directAffairs}
-                  birthDate={politician.birthDate}
-                  deathDate={politician.deathDate}
-                />
+                <div className="space-y-8">
+                  <CareerTimeline
+                    mandates={politician.mandates}
+                    partyHistory={politician.partyHistory}
+                    affairs={directAffairs}
+                    birthDate={politician.birthDate}
+                    deathDate={politician.deathDate}
+                  />
+                  {politician.mandates.length > 0 && (
+                    <Card>
+                      <CardHeader>
+                        <h2 className="leading-none font-semibold">Mandats</h2>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Liste des mandats nationaux et européens connus. Les mandats locaux
+                          (maire, conseiller, etc.) peuvent ne pas être listés.
+                        </p>
+                      </CardHeader>
+                      <CardContent>
+                        <MandateTimeline
+                          mandates={politician.mandates}
+                          civility={politician.civility}
+                        />
+                      </CardContent>
+                    </Card>
+                  )}
+                </div>
               }
               votesContent={
                 (voteData && voteData.stats.total > 0) || parliamentaryCard ? (

--- a/src/components/declarations/DeclarationCard.tsx
+++ b/src/components/declarations/DeclarationCard.tsx
@@ -55,7 +55,7 @@ const DECLARATION_LABEL: Record<string, string> = {
   INTERETS: "Intérêts",
 };
 
-export function DeclarationCard({ id, declarations, politicianHatvpUrl }: DeclarationCardProps) {
+export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
   if (declarations.length === 0) return null;
 
   // Find the latest DIA that has parsed details
@@ -80,21 +80,7 @@ export function DeclarationCard({ id, declarations, politicianHatvpUrl }: Declar
   return (
     <Card id={id}>
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">
-            Déclarations d&apos;intérêts et d&apos;activités
-          </h2>
-          {politicianHatvpUrl && (
-            <a
-              href={politicianHatvpUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-muted-foreground hover:underline"
-            >
-              Source : HATVP ↗
-            </a>
-          )}
-        </div>
+        <h2 className="text-lg font-semibold">Déclarations d&apos;intérêts et d&apos;activités</h2>
       </CardHeader>
 
       <CardContent className="space-y-6">

--- a/src/components/politicians/PoliticianSignals.tsx
+++ b/src/components/politicians/PoliticianSignals.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import {
+  Vote,
+  Landmark,
+  Scale,
+  Gavel,
+  Shield,
+  Users,
+  FileCheck,
+  Wallet,
+  FileText,
+} from "lucide-react";
+import type { Signal, SignalIconKey, SignalTone } from "@/lib/politicians/signals";
+
+const ICONS: Record<
+  SignalIconKey,
+  React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>
+> = {
+  vote: Vote,
+  mandate: Landmark,
+  scale: Scale,
+  gavel: Gavel,
+  shield: Shield,
+  users: Users,
+  filecheck: FileCheck,
+  wallet: Wallet,
+  filetext: FileText,
+};
+
+const TONE: Record<SignalTone, string> = {
+  danger: "text-red-600 dark:text-red-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  neutral: "text-foreground",
+};
+
+// Dashboard cards: only the "primary" signals. Meaning is carried by icon +
+// label + value; tone is a visual reinforcement only.
+export function PoliticianSignals({ signals }: { signals: Signal[] }) {
+  const cards = signals.filter((s) => s.primary);
+  if (cards.length === 0) return null;
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {cards.map((s) => {
+        const Icon = ICONS[s.iconKey];
+        return (
+          <Link
+            key={s.key}
+            href={s.href}
+            prefetch={false}
+            scroll={false}
+            className="flex min-h-11 flex-col justify-between rounded-lg border bg-card p-3 transition-colors hover:bg-muted/50"
+          >
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Icon className={`size-4 ${TONE[s.tone]}`} aria-hidden={true} />
+              {s.label}
+            </span>
+            <span className={`mt-1 font-display text-xl font-extrabold ${TONE[s.tone]}`}>
+              {s.value}{" "}
+              <span aria-hidden className="text-xs text-primary">
+                →
+              </span>
+            </span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/politicians/PoliticianSummary.tsx
+++ b/src/components/politicians/PoliticianSummary.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+import {
+  Vote,
+  Landmark,
+  Scale,
+  Gavel,
+  Shield,
+  Users,
+  FileCheck,
+  Wallet,
+  FileText,
+  ExternalLink,
+} from "lucide-react";
+import type { Signal, SignalIconKey, SignalTone } from "@/lib/politicians/signals";
+import type { SourceLink } from "@/lib/politicians/external-sources";
+
+const ICONS: Record<
+  SignalIconKey,
+  React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>
+> = {
+  vote: Vote,
+  mandate: Landmark,
+  scale: Scale,
+  gavel: Gavel,
+  shield: Shield,
+  users: Users,
+  filecheck: FileCheck,
+  wallet: Wallet,
+  filetext: FileText,
+};
+const TONE: Record<SignalTone, string> = {
+  danger: "text-red-600 dark:text-red-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  neutral: "text-foreground",
+};
+
+// Compact summary rendered at two responsive locations (mobile before the
+// tabs, desktop in the right column). MUST NOT emit any fixed HTML id, since
+// it is mounted twice; a fixed id would duplicate identifiers in the DOM.
+export function PoliticianSummary({
+  signals,
+  sources,
+  relationsHref,
+  lastUpdated,
+}: {
+  signals: Signal[];
+  sources: SourceLink[];
+  relationsHref: string;
+  lastUpdated: string;
+}) {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border p-4">
+        <h2 className="mb-3 font-semibold">En bref</h2>
+        <ul className="space-y-2 text-sm">
+          {signals.map((s) => {
+            const Icon = ICONS[s.iconKey];
+            return (
+              <li key={s.key}>
+                <Link
+                  href={s.href}
+                  prefetch={false}
+                  scroll={false}
+                  className="flex items-center justify-between gap-2 py-1 text-foreground hover:underline"
+                >
+                  <span className="flex items-center gap-1.5">
+                    <Icon className={`size-4 ${TONE[s.tone]}`} aria-hidden={true} />
+                    {s.label}
+                  </span>
+                  <span className={`font-semibold ${TONE[s.tone]}`}>{s.value} ›</span>
+                </Link>
+              </li>
+            );
+          })}
+          <li className="border-t pt-2">
+            <Link
+              href={relationsHref}
+              className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              <Users className="size-4" aria-hidden={true} />
+              Voir les relations
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <h2 className="mb-3 font-semibold">Sources &amp; vérifier</h2>
+        <ul className="space-y-2">
+          {sources.map((src) => (
+            <li key={`${src.source}-${src.url}`}>
+              <a
+                href={src.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted/50"
+              >
+                <span>{src.label}</span>
+                <ExternalLink className="size-3.5 text-muted-foreground" aria-hidden={true} />
+                <span className="sr-only"> (ouvre un nouvel onglet)</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Dernière mise à jour : {lastUpdated} ·{" "}
+          <Link href="/methodologie" className="text-primary hover:underline">
+            Méthodologie
+          </Link>
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/politicians/PoliticianSummary.tsx
+++ b/src/components/politicians/PoliticianSummary.tsx
@@ -40,11 +40,13 @@ const TONE: Record<SignalTone, string> = {
 export function PoliticianSummary({
   signals,
   sources,
+  registres = [],
   relationsHref,
   lastUpdated,
 }: {
   signals: Signal[];
   sources: SourceLink[];
+  registres?: string[];
   relationsHref: string;
   lastUpdated: string;
 }) {
@@ -102,6 +104,9 @@ export function PoliticianSummary({
             </li>
           ))}
         </ul>
+        {registres.length > 0 && (
+          <p className="mt-2 text-xs text-muted-foreground">Registres : {registres.join(", ")}</p>
+        )}
         <p className="mt-3 text-xs text-muted-foreground">
           Dernière mise à jour : {lastUpdated} ·{" "}
           <Link href="/methodologie" className="text-primary hover:underline">

--- a/src/components/politicians/PresumptionNotice.tsx
+++ b/src/components/politicians/PresumptionNotice.tsx
@@ -1,0 +1,19 @@
+import { Info } from "lucide-react";
+import { buildPresumptionNote } from "@/lib/politicians/presumption";
+
+export function PresumptionNotice({
+  proceduresEnCours,
+  condamnationsNonDefinitives,
+}: {
+  proceduresEnCours: number;
+  condamnationsNonDefinitives: number;
+}) {
+  const note = buildPresumptionNote({ proceduresEnCours, condamnationsNonDefinitives });
+  if (!note) return null;
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+      <Info className="mt-0.5 size-4 shrink-0" aria-hidden={true} />
+      <p>{note}</p>
+    </div>
+  );
+}

--- a/src/components/politicians/ProfileTabs.tsx
+++ b/src/components/politicians/ProfileTabs.tsx
@@ -74,7 +74,7 @@ function ProfileTabsInner({
         </TabsTrigger>
         <TabsTrigger value="carriere">
           <Briefcase className="size-4" />
-          Carriere
+          Carrière
         </TabsTrigger>
         {votesContent && (
           <TabsTrigger value="votes">

--- a/src/components/politicians/__tests__/PoliticianSignals.test.tsx
+++ b/src/components/politicians/__tests__/PoliticianSignals.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PoliticianSignals } from "@/components/politicians/PoliticianSignals";
+import type { Signal } from "@/lib/politicians/signals";
+
+const signal = (over: Partial<Signal>): Signal => ({
+  key: "mandats",
+  iconKey: "mandate",
+  label: "Mandats",
+  value: "8",
+  href: "/politiques/x?tab=carriere",
+  tone: "neutral",
+  primary: true,
+  ...over,
+});
+
+describe("PoliticianSignals", () => {
+  it("renders primary signals as links with label + value", () => {
+    render(<PoliticianSignals signals={[signal({})]} />);
+    const link = screen.getByRole("link", { name: /Mandats/ });
+    expect(link).toHaveAttribute("href", "/politiques/x?tab=carriere");
+    expect(link).toHaveTextContent("8");
+  });
+
+  it("does not render non-primary signals as cards", () => {
+    render(
+      <PoliticianSignals
+        signals={[signal({ key: "mentionne", label: "Mentionné / secondaire", primary: false })]}
+      />
+    );
+    expect(screen.queryByRole("link", { name: /Mentionné/ })).toBeNull();
+  });
+});

--- a/src/components/politicians/__tests__/PoliticianSummary.test.tsx
+++ b/src/components/politicians/__tests__/PoliticianSummary.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
+import type { Signal } from "@/lib/politicians/signals";
+import type { SourceLink } from "@/lib/politicians/external-sources";
+
+const signals: Signal[] = [
+  {
+    key: "mandats",
+    iconKey: "mandate",
+    label: "Mandats",
+    value: "8",
+    href: "/politiques/x?tab=carriere",
+    tone: "neutral",
+    primary: true,
+  },
+];
+const sources: SourceLink[] = [{ source: "HATVP", label: "HATVP", url: "https://www.hatvp.fr/x" }];
+
+describe("PoliticianSummary", () => {
+  it("renders every signal as a link and the sources with a new-tab hint", () => {
+    render(
+      <PoliticianSummary
+        signals={signals}
+        sources={sources}
+        relationsHref="/politiques/x/relations"
+        lastUpdated="19 juil. 2026"
+      />
+    );
+    expect(screen.getByRole("link", { name: /Mandats/ })).toBeInTheDocument();
+    const hatvp = screen.getByRole("link", { name: /HATVP.*ouvre un nouvel onglet/i });
+    expect(hatvp).toHaveAttribute("target", "_blank");
+    expect(hatvp).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("generates no fixed HTML id (mounted twice)", () => {
+    const { container } = render(
+      <PoliticianSummary
+        signals={signals}
+        sources={sources}
+        relationsHref="/politiques/x/relations"
+        lastUpdated="19 juil. 2026"
+      />
+    );
+    expect(container.querySelectorAll("[id]").length).toBe(0);
+  });
+});

--- a/src/components/politicians/__tests__/PresumptionNotice.test.tsx
+++ b/src/components/politicians/__tests__/PresumptionNotice.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PresumptionNotice } from "@/components/politicians/PresumptionNotice";
+
+describe("PresumptionNotice", () => {
+  it("renders nothing when not applicable", () => {
+    const { container } = render(
+      <PresumptionNotice proceduresEnCours={0} condamnationsNonDefinitives={0} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the localized note when applicable", () => {
+    render(<PresumptionNotice proceduresEnCours={2} condamnationsNonDefinitives={0} />);
+    expect(screen.getByText(/Présomption d'innocence\./)).toBeInTheDocument();
+    expect(screen.getByText(/2 procédures en cours/)).toBeInTheDocument();
+  });
+});

--- a/src/lib/politicians/__tests__/external-sources.test.ts
+++ b/src/lib/politicians/__tests__/external-sources.test.ts
@@ -9,7 +9,7 @@ describe("buildSourceLinks", () => {
       { source: "MANUAL", url: null },
     ]);
     expect(links.map((l) => l.source)).toEqual(["HATVP", "WIKIDATA"]);
-    expect(links[0].label).toBe("HATVP");
+    expect(links[0]!.label).toBe("HATVP");
   });
 
   it("dedupes only strictly identical (source, normalized url)", () => {

--- a/src/lib/politicians/__tests__/external-sources.test.ts
+++ b/src/lib/politicians/__tests__/external-sources.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildSourceLinks } from "@/lib/politicians/external-sources";
+
+describe("buildSourceLinks", () => {
+  it("drops entries without url and orders by source priority", () => {
+    const links = buildSourceLinks([
+      { source: "WIKIDATA", url: "https://www.wikidata.org/wiki/Q1" },
+      { source: "HATVP", url: "https://www.hatvp.fr/fiche/x" },
+      { source: "MANUAL", url: null },
+    ]);
+    expect(links.map((l) => l.source)).toEqual(["HATVP", "WIKIDATA"]);
+    expect(links[0].label).toBe("HATVP");
+  });
+
+  it("dedupes only strictly identical (source, normalized url)", () => {
+    const links = buildSourceLinks([
+      { source: "HATVP", url: "https://www.hatvp.fr/fiche/x/" },
+      { source: "HATVP", url: "https://www.hatvp.fr/fiche/x?utm_source=a" },
+    ]);
+    expect(links).toHaveLength(1);
+  });
+
+  it("keeps multiple distinct urls for the same source", () => {
+    const links = buildSourceLinks([
+      { source: "ASSEMBLEE_NATIONALE", url: "https://www.assemblee-nationale.fr/dyn/17/a" },
+      { source: "ASSEMBLEE_NATIONALE", url: "https://www.assemblee-nationale.fr/dyn/16/a" },
+    ]);
+    expect(links).toHaveLength(2);
+  });
+});

--- a/src/lib/politicians/__tests__/judicial-counts.test.ts
+++ b/src/lib/politicians/__tests__/judicial-counts.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { computeJudicialCounts } from "@/lib/politicians/judicial-counts";
+import type { AffairInput } from "@/lib/politicians/judicial-counts";
+
+const a = (
+  involvement: AffairInput["involvement"],
+  status: AffairInput["status"]
+): AffairInput => ({ involvement, status });
+
+describe("computeJudicialCounts", () => {
+  it("separates definitive from non-definitive convictions (DIRECT only)", () => {
+    const counts = computeJudicialCounts([
+      a("DIRECT", "CONDAMNATION_DEFINITIVE"),
+      a("DIRECT", "CONDAMNATION_PREMIERE_INSTANCE"),
+      a("DIRECT", "APPEL_EN_COURS"),
+    ]);
+    expect(counts.condamnationsDefinitives).toBe(1);
+    expect(counts.condamnationsNonDefinitives).toBe(2);
+    expect(counts.proceduresEnCours).toBe(0);
+  });
+
+  it("counts PROCEDURE_VALIDEE as procedures but excludes ENQUETE_PRELIMINAIRE (RGPD)", () => {
+    const counts = computeJudicialCounts([
+      a("DIRECT", "MISE_EN_EXAMEN"),
+      a("DIRECT", "INSTRUCTION"),
+      a("DIRECT", "RENVOI_TRIBUNAL"),
+      a("DIRECT", "PROCES_EN_COURS"),
+      a("DIRECT", "ENQUETE_PRELIMINAIRE"),
+    ]);
+    expect(counts.proceduresEnCours).toBe(4);
+    expect(counts.condamnationsDefinitives).toBe(0);
+    expect(counts.condamnationsNonDefinitives).toBe(0);
+  });
+
+  it("does NOT double-count INDIRECT: it is a mention, never a conviction/procedure", () => {
+    const counts = computeJudicialCounts([
+      a("INDIRECT", "CONDAMNATION_DEFINITIVE"),
+      a("INDIRECT", "MISE_EN_EXAMEN"),
+      a("MENTIONED_ONLY", "PROCES_EN_COURS"),
+    ]);
+    expect(counts.condamnationsDefinitives).toBe(0);
+    expect(counts.proceduresEnCours).toBe(0);
+    expect(counts.mentionneOuSecondaire).toBe(3);
+  });
+
+  it("groups victim and plaintiff", () => {
+    const counts = computeJudicialCounts([
+      a("VICTIM", "PROCES_EN_COURS"),
+      a("PLAINTIFF", "INSTRUCTION"),
+    ]);
+    expect(counts.victimeOuPlaignant).toBe(2);
+    expect(counts.mentionneOuSecondaire).toBe(0);
+  });
+
+  it("badgeCount = DIRECT judicially-validated (Tier 1+2), excludes enquete/victim/mention", () => {
+    const counts = computeJudicialCounts([
+      a("DIRECT", "CONDAMNATION_DEFINITIVE"),
+      a("DIRECT", "MISE_EN_EXAMEN"),
+      a("DIRECT", "ENQUETE_PRELIMINAIRE"),
+      a("INDIRECT", "CONDAMNATION_DEFINITIVE"),
+      a("VICTIM", "PROCES_EN_COURS"),
+    ]);
+    expect(counts.badgeCount).toBe(2);
+  });
+});

--- a/src/lib/politicians/__tests__/presumption.test.ts
+++ b/src/lib/politicians/__tests__/presumption.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { buildPresumptionNote } from "@/lib/politicians/presumption";
+
+describe("buildPresumptionNote", () => {
+  it("returns null when nothing needs presumption", () => {
+    expect(
+      buildPresumptionNote({ proceduresEnCours: 0, condamnationsNonDefinitives: 0 })
+    ).toBeNull();
+  });
+
+  it("procedures only, singular", () => {
+    const note = buildPresumptionNote({ proceduresEnCours: 1, condamnationsNonDefinitives: 0 })!;
+    expect(note).toContain("Présomption d'innocence.");
+    expect(note).toContain("1 procédure en cours");
+    expect(note).not.toContain("condamnation non");
+    expect(note).toContain("Cette situation ne constitue pas une condamnation définitive");
+  });
+
+  it("non-definitive convictions only, plural", () => {
+    const note = buildPresumptionNote({ proceduresEnCours: 0, condamnationsNonDefinitives: 2 })!;
+    expect(note).toContain("2 condamnations non définitives");
+    expect(note).not.toContain("procédure");
+    expect(note).toContain("Ces situations ne constituent pas des condamnations définitives");
+  });
+
+  it("combined never states a global absence of conviction", () => {
+    const note = buildPresumptionNote({ proceduresEnCours: 3, condamnationsNonDefinitives: 1 })!;
+    expect(note).toContain("3 procédures en cours");
+    expect(note).toContain("1 condamnation non définitive");
+    expect(note).not.toContain("aucune condamnation");
+    expect(note).toContain("pour les faits concernés");
+  });
+});

--- a/src/lib/politicians/__tests__/signals.test.ts
+++ b/src/lib/politicians/__tests__/signals.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { buildPoliticianSignals } from "@/lib/politicians/signals";
+import type { SignalsInput } from "@/lib/politicians/signals";
+
+const base: SignalsInput = {
+  slug: "camille-renard",
+  mandatesCount: 8,
+  votesTotal: 830,
+  hasVotesTab: true,
+  hasFactchecksTab: false,
+  factchecksCount: 0,
+  dossiersCount: 0,
+  declarationsCount: 3,
+  portfolioValue: 617000,
+  patrimoineHref: "#declarations",
+  judicial: {
+    condamnationsDefinitives: 1,
+    condamnationsNonDefinitives: 0,
+    proceduresEnCours: 2,
+    victimeOuPlaignant: 0,
+    mentionneOuSecondaire: 0,
+    badgeCount: 3,
+  },
+};
+
+describe("buildPoliticianSignals", () => {
+  it("omits votes when there is no votes tab", () => {
+    const signals = buildPoliticianSignals({ ...base, hasVotesTab: false, votesTotal: null });
+    expect(signals.find((s) => s.key === "votes")).toBeUndefined();
+  });
+
+  it("omits a judicial signal when its count is 0", () => {
+    const signals = buildPoliticianSignals({
+      ...base,
+      judicial: { ...base.judicial, condamnationsDefinitives: 0 },
+    });
+    expect(signals.find((s) => s.key === "condamnations-definitives")).toBeUndefined();
+  });
+
+  it("routes each signal to its destination", () => {
+    const signals = buildPoliticianSignals(base);
+    const byKey = Object.fromEntries(signals.map((s) => [s.key, s]));
+    expect(byKey["mandats"].href).toBe("/politiques/camille-renard?tab=carriere");
+    expect(byKey["condamnations-definitives"].href).toBe("/politiques/camille-renard?tab=affaires");
+    expect(byKey["patrimoine"].href).toBe("#declarations");
+    expect(byKey["condamnations-definitives"].tone).toBe("danger");
+  });
+
+  it("carries a textual value and never relies on tone alone", () => {
+    const signals = buildPoliticianSignals(base);
+    for (const s of signals) {
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(s.value.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/politicians/__tests__/signals.test.ts
+++ b/src/lib/politicians/__tests__/signals.test.ts
@@ -40,10 +40,12 @@ describe("buildPoliticianSignals", () => {
   it("routes each signal to its destination", () => {
     const signals = buildPoliticianSignals(base);
     const byKey = Object.fromEntries(signals.map((s) => [s.key, s]));
-    expect(byKey["mandats"].href).toBe("/politiques/camille-renard?tab=carriere");
-    expect(byKey["condamnations-definitives"].href).toBe("/politiques/camille-renard?tab=affaires");
-    expect(byKey["patrimoine"].href).toBe("#declarations");
-    expect(byKey["condamnations-definitives"].tone).toBe("danger");
+    expect(byKey["mandats"]!.href).toBe("/politiques/camille-renard?tab=carriere");
+    expect(byKey["condamnations-definitives"]!.href).toBe(
+      "/politiques/camille-renard?tab=affaires"
+    );
+    expect(byKey["patrimoine"]!.href).toBe("#declarations");
+    expect(byKey["condamnations-definitives"]!.tone).toBe("danger");
   });
 
   it("carries a textual value and never relies on tone alone", () => {

--- a/src/lib/politicians/external-sources.ts
+++ b/src/lib/politicians/external-sources.ts
@@ -1,4 +1,4 @@
-import type { DataSource } from "@prisma/client";
+import type { DataSource } from "@/generated/prisma";
 import { DATA_SOURCE_LABELS } from "@/config/labels";
 
 export type ExternalIdInput = { source: DataSource; url: string | null };

--- a/src/lib/politicians/external-sources.ts
+++ b/src/lib/politicians/external-sources.ts
@@ -1,0 +1,54 @@
+import type { DataSource } from "@prisma/client";
+import { DATA_SOURCE_LABELS } from "@/config/labels";
+
+export type ExternalIdInput = { source: DataSource; url: string | null };
+export type SourceLink = { source: DataSource; label: string; url: string };
+
+// Verification links shown in "Sources & vérifier", most trustworthy first.
+const SOURCE_PRIORITY: DataSource[] = [
+  "HATVP",
+  "ASSEMBLEE_NATIONALE",
+  "SENAT",
+  "PARLEMENT_EUROPEEN",
+  "WIKIDATA",
+  "NOSDEPUTES",
+  "OPENSANCTIONS",
+  "WIKIPEDIA",
+  "GOUVERNEMENT",
+  "RNE",
+];
+
+function normalizeUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.hostname = u.hostname.toLowerCase();
+    u.hash = "";
+    for (const key of [...u.searchParams.keys()]) {
+      if (key.toLowerCase().startsWith("utm_")) u.searchParams.delete(key);
+    }
+    let out = u.toString();
+    if (out.endsWith("/")) out = out.slice(0, -1);
+    return out;
+  } catch {
+    return url.trim().replace(/\/$/, "");
+  }
+}
+
+// Dedupe ONLY strictly identical (source, normalized URL) pairs. Distinct URLs
+// for the same source (e.g. several legislatures) are all kept.
+export function buildSourceLinks(externalIds: ExternalIdInput[]): SourceLink[] {
+  const seen = new Set<string>();
+  const links: SourceLink[] = [];
+  for (const e of externalIds) {
+    if (!e.url) continue;
+    const key = `${e.source} ${normalizeUrl(e.url)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({ source: e.source, label: DATA_SOURCE_LABELS[e.source], url: e.url });
+  }
+  const rank = (s: DataSource) => {
+    const i = SOURCE_PRIORITY.indexOf(s);
+    return i === -1 ? SOURCE_PRIORITY.length : i;
+  };
+  return links.sort((a, b) => rank(a.source) - rank(b.source));
+}

--- a/src/lib/politicians/judicial-counts.ts
+++ b/src/lib/politicians/judicial-counts.ts
@@ -1,0 +1,40 @@
+import type { AffairStatus, Involvement } from "@prisma/client";
+import { getJudicialMaturity, isJudiciallyValidated } from "@/config/judicial-maturity";
+
+export type AffairInput = { involvement: Involvement; status: AffairStatus };
+
+export type JudicialCounts = {
+  condamnationsDefinitives: number;
+  condamnationsNonDefinitives: number;
+  proceduresEnCours: number;
+  victimeOuPlaignant: number;
+  mentionneOuSecondaire: number;
+  /** DIRECT + judicially validated (Tier 1+2). Feeds the Affaires tab badge. */
+  badgeCount: number;
+};
+
+const NON_DEFINITIVE: ReadonlySet<AffairStatus> = new Set<AffairStatus>([
+  "CONDAMNATION_PREMIERE_INSTANCE",
+  "APPEL_EN_COURS",
+]);
+
+// "Mis en cause" scope for judicial counters: DIRECT only. This removes the
+// prior double-count (INDIRECT was counted both as conviction/procedure and as
+// a mention) and never labels a witness/secondary as convicted. Enquêtes
+// préliminaires are excluded from all counters (RGPD art. 10 invariant).
+export function computeJudicialCounts(affairs: AffairInput[]): JudicialCounts {
+  const direct = affairs.filter((x) => x.involvement === "DIRECT");
+  return {
+    condamnationsDefinitives: direct.filter((x) => x.status === "CONDAMNATION_DEFINITIVE").length,
+    condamnationsNonDefinitives: direct.filter((x) => NON_DEFINITIVE.has(x.status)).length,
+    proceduresEnCours: direct.filter((x) => getJudicialMaturity(x.status) === "PROCEDURE_VALIDEE")
+      .length,
+    victimeOuPlaignant: affairs.filter(
+      (x) => x.involvement === "VICTIM" || x.involvement === "PLAINTIFF"
+    ).length,
+    mentionneOuSecondaire: affairs.filter(
+      (x) => x.involvement === "INDIRECT" || x.involvement === "MENTIONED_ONLY"
+    ).length,
+    badgeCount: direct.filter((x) => isJudiciallyValidated(x.status)).length,
+  };
+}

--- a/src/lib/politicians/judicial-counts.ts
+++ b/src/lib/politicians/judicial-counts.ts
@@ -1,4 +1,4 @@
-import type { AffairStatus, Involvement } from "@prisma/client";
+import type { AffairStatus, Involvement } from "@/generated/prisma";
 import { getJudicialMaturity, isJudiciallyValidated } from "@/config/judicial-maturity";
 
 export type AffairInput = { involvement: Involvement; status: AffairStatus };

--- a/src/lib/politicians/presumption.ts
+++ b/src/lib/politicians/presumption.ts
@@ -1,0 +1,22 @@
+// Builds a presumption-of-innocence note strictly from counts, localized to
+// the concerned facts. Never asserts a global absence of conviction (the
+// person may have a definitive conviction on another affair).
+export function buildPresumptionNote(input: {
+  proceduresEnCours: number;
+  condamnationsNonDefinitives: number;
+}): string | null {
+  const { proceduresEnCours: n, condamnationsNonDefinitives: m } = input;
+  if (n <= 0 && m <= 0) return null;
+
+  const parts: string[] = [];
+  if (n > 0) parts.push(`${n} procédure${n > 1 ? "s" : ""} en cours`);
+  if (m > 0) parts.push(`${m} condamnation${m > 1 ? "s" : ""} non définitive${m > 1 ? "s" : ""}`);
+
+  const total = n + m;
+  const closing =
+    total === 1
+      ? "Cette situation ne constitue pas une condamnation définitive pour les faits concernés."
+      : "Ces situations ne constituent pas des condamnations définitives pour les faits concernés.";
+
+  return `Présomption d'innocence. Cette fiche recense ${parts.join(" et ")}. ${closing}`;
+}

--- a/src/lib/politicians/signals.ts
+++ b/src/lib/politicians/signals.ts
@@ -1,0 +1,165 @@
+import type { JudicialCounts } from "./judicial-counts";
+
+export type SignalIconKey =
+  | "vote"
+  | "mandate"
+  | "scale"
+  | "gavel"
+  | "shield"
+  | "users"
+  | "filecheck"
+  | "wallet"
+  | "filetext";
+export type SignalTone = "neutral" | "danger" | "warning";
+export type Signal = {
+  key: string;
+  iconKey: SignalIconKey;
+  label: string;
+  value: string;
+  href: string;
+  tone: SignalTone;
+  primary: boolean;
+};
+
+export type SignalsInput = {
+  slug: string;
+  mandatesCount: number;
+  votesTotal: number | null;
+  hasVotesTab: boolean;
+  hasFactchecksTab: boolean;
+  factchecksCount: number;
+  dossiersCount: number;
+  declarationsCount: number;
+  portfolioValue: number | null;
+  patrimoineHref: string;
+  judicial: JudicialCounts;
+};
+
+function tab(slug: string, t: string): string {
+  return `/politiques/${slug}?tab=${t}`;
+}
+
+// Compact currency for the signal value only (0 stays "0 €"; null handled by caller).
+function money(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)} M€`;
+  if (v >= 1_000) return `${Math.round(v / 1_000)} k€`;
+  return `${v} €`;
+}
+
+export function buildPoliticianSignals(input: SignalsInput): Signal[] {
+  const s: Signal[] = [];
+  const { slug, judicial: j } = input;
+
+  if (input.hasVotesTab && input.votesTotal != null) {
+    s.push({
+      key: "votes",
+      iconKey: "vote",
+      label: "Votes enregistrés",
+      value: String(input.votesTotal),
+      href: tab(slug, "votes"),
+      tone: "neutral",
+      primary: true,
+    });
+  }
+  if (input.mandatesCount > 0) {
+    s.push({
+      key: "mandats",
+      iconKey: "mandate",
+      label: "Mandats",
+      value: String(input.mandatesCount),
+      href: tab(slug, "carriere"),
+      tone: "neutral",
+      primary: true,
+    });
+  }
+  if (j.condamnationsDefinitives > 0) {
+    s.push({
+      key: "condamnations-definitives",
+      iconKey: "scale",
+      label: "Condamnations définitives",
+      value: String(j.condamnationsDefinitives),
+      href: tab(slug, "affaires"),
+      tone: "danger",
+      primary: true,
+    });
+  }
+  if (j.condamnationsNonDefinitives > 0) {
+    s.push({
+      key: "condamnations-non-definitives",
+      iconKey: "scale",
+      label: "Condamnations non définitives",
+      value: String(j.condamnationsNonDefinitives),
+      href: tab(slug, "affaires"),
+      tone: "warning",
+      primary: false,
+    });
+  }
+  if (j.proceduresEnCours > 0) {
+    s.push({
+      key: "procedures",
+      iconKey: "gavel",
+      label: "Procédures en cours",
+      value: String(j.proceduresEnCours),
+      href: tab(slug, "affaires"),
+      tone: "warning",
+      primary: false,
+    });
+  }
+  if (j.victimeOuPlaignant > 0) {
+    s.push({
+      key: "victime",
+      iconKey: "shield",
+      label: "Victime / plaignant",
+      value: String(j.victimeOuPlaignant),
+      href: tab(slug, "affaires"),
+      tone: "neutral",
+      primary: false,
+    });
+  }
+  if (j.mentionneOuSecondaire > 0) {
+    s.push({
+      key: "mentionne",
+      iconKey: "users",
+      label: "Mentionné / secondaire",
+      value: String(j.mentionneOuSecondaire),
+      href: tab(slug, "affaires"),
+      tone: "neutral",
+      primary: false,
+    });
+  }
+  if (input.hasFactchecksTab && input.factchecksCount > 0) {
+    s.push({
+      key: "factchecks",
+      iconKey: "filecheck",
+      label: "Fact-checks",
+      value: String(input.factchecksCount),
+      href: tab(slug, "factchecks"),
+      tone: "neutral",
+      primary: false,
+    });
+  }
+  if (input.declarationsCount > 0) {
+    const hasValue = input.portfolioValue != null && input.portfolioValue > 0;
+    s.push({
+      key: "patrimoine",
+      iconKey: "wallet",
+      label: hasValue ? "Participations déclarées" : "Déclarations HATVP",
+      value: hasValue ? money(input.portfolioValue as number) : String(input.declarationsCount),
+      href: input.patrimoineHref,
+      tone: "neutral",
+      primary: true,
+    });
+  }
+  if (input.dossiersCount > 0) {
+    s.push({
+      key: "dossiers",
+      iconKey: "filetext",
+      label: "Propositions de loi",
+      value: String(input.dossiersCount),
+      href: `/politiques/${slug}#dossiers`,
+      tone: "neutral",
+      primary: false,
+    });
+  }
+  return s;
+}


### PR DESCRIPTION
Partie 1 de la refonte de la fiche `/politiques/[slug]` (issue #493). Spec et plan validés en amont, découpage en 2 PR plus 2 issues de suivi (#498, #499).

## Ce que fait cette PR

- **Profil = tableau de bord** : signaux cliquables (icône + libellé + valeur, jamais la couleur seule) renvoyant chacun à son onglet, via un helper pur unique `buildPoliticianSignals` (une seule source de vérité, plus deux résumés concurrents).
- **Fin de la duplication** : retrait des frises et de la liste de mandats du Profil. La chronologie vit dans l'onglet Carrière, complétée par une liste lisible des mandats (la frise seule n'était pas pratique en desktop).
- **Sémantique judiciaire corrigée** : condamnations définitives et non définitives séparées ; fin du double comptage des affaires INDIRECT (désormais « Mentionné / secondaire », plus comptées comme condamnation) ; enquêtes préliminaires exclues des compteurs (RGPD art. 10). Badge Affaires = affaires DIRECT publiables et judiciairement validées, avec un nom accessible.
- **Note de présomption d'innocence** calculée depuis `AFFAIR_STATUS_NEEDS_PRESUMPTION`, localisée aux faits concernés (jamais d'affirmation globale « aucune condamnation »).
- **Bloc « Sources & vérifier » promu** : section titrée à taille normale, doublon HATVP supprimé, déduplication limitée aux couples (source, URL normalisée), mention accessible « ouvre un nouvel onglet », ligne « Registres » OpenSanctions conservée.
- **Accessibilité** : cibles de contact à 44 px, groupe parlementaire nommé en entier, accent « Carrière ».
- **Responsive** : le résumé apparaît avant les onglets sur mobile via deux instances du même `PoliticianSummary` (`lg:hidden` / `hidden lg:block`), ce qui garde l'ordre clavier cohérent (pas de réordonnancement CSS trompeur).

## Hors périmètre (suite)

- **PR B** : onglet « Patrimoine & intérêts », cadrage DIA/DSP, renommage des métriques, chronologie des DIA (`DeclarationHistory`), mise à jour SEO de `generateMetadata`.
- **#498** : comparaison statistique des participations financières déclarées (médiane différée).
- **#499** : postes comme entités (browse par mandat/siège).

## Tests

- Fonctions pures : `judicial-counts`, `presumption`, `external-sources`, `signals` (16 tests).
- Composants : `PoliticianSignals`, `PresumptionNotice`, `PoliticianSummary` (6 tests).
- `tsc --noEmit` : 0 erreur ; `eslint` : clean. Rendu vérifié sur profils réels avec et sans condamnation.

Refs #493
