### PR TITLE
Refonte fiche politique (PR B) : onglet Patrimoine & intérêts, cadrage DIA/DSP

### DIFF
--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -116,7 +116,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const parts: string[] = [];
     if (details.totalPortfolioValue && details.totalPortfolioValue > 0) {
       parts.push(
-        `${formatCompactCurrency(details.totalPortfolioValue)} de participations financières`
+        `${formatCompactCurrency(details.totalPortfolioValue)} de participations financières déclarées`
       );
     }
     if (details.totalCompanies > 0) {
@@ -235,7 +235,7 @@ export default async function PoliticianPage({ params }: PageProps) {
     dossiersCount: politician.dossierAuthors.length,
     declarationsCount: politician.declarations.length,
     portfolioValue,
-    patrimoineHref: `/politiques/${politician.slug}#declarations`, // PR B: ?tab=patrimoine
+    patrimoineHref: `/politiques/${politician.slug}?tab=patrimoine`,
     judicial,
   });
   const sourceLinks = buildSourceLinks(
@@ -536,55 +536,6 @@ export default async function PoliticianPage({ params }: PageProps) {
                       </CardContent>
                     </Card>
                   )}
-
-                  {/* HATVP Declarations */}
-                  {politician.declarations.length > 0 ? (
-                    <DeclarationCard
-                      id="declarations"
-                      declarations={politician.declarations.map((d) => ({
-                        id: d.id,
-                        type: d.type,
-                        year: d.year,
-                        hatvpUrl: d.hatvpUrl,
-                        pdfUrl: d.pdfUrl,
-                        details: d.details as DeclarationDetails | null,
-                      }))}
-                      politicianHatvpUrl={
-                        politician.externalIds.find((e) => e.source === "HATVP")?.url ?? null
-                      }
-                    />
-                  ) : isActiveParliamentarian ? (
-                    <Card id="declarations">
-                      <CardHeader>
-                        <h2 className="text-lg font-semibold">
-                          Déclarations d&apos;intérêts et d&apos;activités
-                        </h2>
-                      </CardHeader>
-                      <CardContent>
-                        <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-                          <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">
-                            Aucune déclaration publiée
-                          </p>
-                          <p className="text-sm text-amber-700 dark:text-amber-300 leading-relaxed">
-                            Tout député et sénateur est tenu de déposer une déclaration
-                            d&apos;intérêts et d&apos;activités dans les 2 mois suivant son élection
-                            (loi n°2013-907 du 11 octobre 2013). Le non-dépôt est passible de 3 ans
-                            d&apos;emprisonnement, 45 000 € d&apos;amende et 10 ans
-                            d&apos;inéligibilité. Seules les déclarations publiées par la HATVP sont
-                            affichées ici.
-                          </p>
-                          <a
-                            href="https://www.hatvp.fr/consulter-les-declarations/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-block mt-3 text-sm text-amber-700 dark:text-amber-300 underline hover:text-amber-900 dark:hover:text-amber-100"
-                          >
-                            Consulter le site de la HATVP →
-                          </a>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ) : null}
                 </div>
               }
               factchecksContent={
@@ -642,6 +593,52 @@ export default async function PoliticianPage({ params }: PageProps) {
                     isChamberPresident={isChamberPresident}
                     themeDistribution={voteData?.themeDistribution}
                   />
+                ) : null
+              }
+              patrimoineContent={
+                politician.declarations.length > 0 ? (
+                  <DeclarationCard
+                    id="declarations"
+                    declarations={politician.declarations.map((d) => ({
+                      id: d.id,
+                      type: d.type,
+                      year: d.year,
+                      hatvpUrl: d.hatvpUrl,
+                      pdfUrl: d.pdfUrl,
+                      details: d.details as DeclarationDetails | null,
+                    }))}
+                  />
+                ) : isActiveParliamentarian ? (
+                  <Card id="declarations">
+                    <CardHeader>
+                      <h2 className="text-lg font-semibold">
+                        Déclarations d&apos;intérêts et d&apos;activités
+                      </h2>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+                        <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">
+                          Aucune déclaration publiée
+                        </p>
+                        <p className="text-sm text-amber-700 dark:text-amber-300 leading-relaxed">
+                          Tout député et sénateur est tenu de déposer une déclaration
+                          d&apos;intérêts et d&apos;activités dans les 2 mois suivant son élection
+                          (loi n°2013-907 du 11 octobre 2013). Le non-dépôt est passible de 3 ans
+                          d&apos;emprisonnement, 45 000 € d&apos;amende et 10 ans
+                          d&apos;inéligibilité. Seules les déclarations publiées par la HATVP sont
+                          affichées ici.
+                        </p>
+                        <a
+                          href="https://www.hatvp.fr/consulter-les-declarations/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-block mt-3 text-sm text-amber-700 dark:text-amber-300 underline hover:text-amber-900 dark:hover:text-amber-100"
+                        >
+                          Consulter le site de la HATVP →
+                        </a>
+                      </div>
+                    </CardContent>
+                  </Card>
                 ) : null
               }
               affairsContent={

--- a/src/components/declarations/DeclarationCard.tsx
+++ b/src/components/declarations/DeclarationCard.tsx
@@ -2,8 +2,9 @@ import type { DeclarationDetails } from "@/types/hatvp";
 import { HorizontalBars } from "@/components/stats/HorizontalBars";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Info } from "lucide-react";
 import { DeclarationMetrics } from "./DeclarationMetrics";
+import { DeclarationHistory } from "./DeclarationHistory";
 
 interface DeclarationCardProps {
   id?: string;
@@ -15,7 +16,6 @@ interface DeclarationCardProps {
     pdfUrl: string | null;
     details: DeclarationDetails | null;
   }>;
-  politicianHatvpUrl: string | null;
 }
 
 function CollapsibleSection({
@@ -84,13 +84,36 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
       </CardHeader>
 
       <CardContent className="space-y-6">
+        {/* Editorial integrity: declarative, not audited; DIA is not DSP. */}
+        <div className="flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-xs leading-relaxed text-blue-900 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-100">
+          <Info className="mt-0.5 size-4 shrink-0" aria-hidden={true} />
+          <div>
+            <strong>Données déclaratives, non auditées.</strong> Ces montants sont déclarés par
+            l&apos;élu(e) et publiés par la Haute Autorité pour la transparence de la vie publique
+            (HATVP). Poligraph les met en forme sans les vérifier ni les estimer.
+            <details className="mt-1.5">
+              <summary className="cursor-pointer font-medium text-primary">
+                Intérêts (DIA) n&apos;est pas patrimoine (DSP)
+              </summary>
+              <p className="mt-1 text-muted-foreground">
+                Pour les parlementaires, seule la déclaration d&apos;intérêts et d&apos;activités
+                (DIA) est consultable en ligne : elle liste les activités, revenus et
+                participations. La déclaration de patrimoine (DSP), qui détaille les biens
+                immobiliers, comptes et épargne, n&apos;est consultable qu&apos;en préfecture. Les
+                montants affichés ici ne représentent donc pas une fortune nette.
+              </p>
+            </details>
+          </div>
+        </div>
+
         {/* Key metrics */}
         {details && (
           <DeclarationMetrics
             totalPortfolioValue={details.totalPortfolioValue}
             totalCompanies={details.totalCompanies}
             latestAnnualIncome={details.latestAnnualIncome}
-            totalDirectorships={details.totalDirectorships}
+            electoralMandatesCount={details.electoralMandates.length}
+            directorshipsCount={details.directorships.length}
           />
         )}
 
@@ -218,6 +241,13 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
             ))}
           </CollapsibleSection>
         )}
+
+        {/* DIA history (chronological, null-aware, no variation) */}
+        <DeclarationHistory
+          declarations={declarations
+            .filter((d) => d.type === "INTERETS")
+            .map((d) => ({ id: d.id, year: d.year, details: d.details }))}
+        />
 
         {/* All declaration links */}
         <div className="flex flex-wrap gap-2 pt-4 border-t">

--- a/src/components/declarations/DeclarationHistory.tsx
+++ b/src/components/declarations/DeclarationHistory.tsx
@@ -1,0 +1,59 @@
+import type { DeclarationDetails } from "@/types/hatvp";
+
+export type HistoryDeclaration = { id: string; year: number; details: DeclarationDetails | null };
+
+type StateKind = "value" | "none" | "unknown" | "unavailable";
+
+// Formats a REAL number of declared participations, including "0 €" for a
+// genuine zero. Deliberately NOT formatCompactCurrency (which maps 0 -> "—").
+function formatEuro(value: number): string {
+  return `${new Intl.NumberFormat("fr-FR").format(value)} €`;
+}
+
+// The model distinguishes "no usable evaluation" (totalPortfolioValue === null)
+// from a real zero sum. We never say "non déclaré" when the model can't tell.
+export function declarationHistoryState(details: DeclarationDetails | null): {
+  kind: StateKind;
+  text: string;
+} {
+  if (!details) return { kind: "unavailable", text: "Donnée indisponible" };
+  const parts = details.financialParticipations ?? [];
+  if (parts.length === 0) return { kind: "none", text: "Aucune participation financière déclarée" };
+  if (details.totalPortfolioValue === null)
+    return { kind: "unknown", text: "Montant non renseigné" };
+  return { kind: "value", text: formatEuro(details.totalPortfolioValue) };
+}
+
+export function DeclarationHistory({ declarations }: { declarations: HistoryDeclaration[] }) {
+  if (declarations.length === 0) return null;
+  const rows = [...declarations].sort((a, b) => b.year - a.year);
+  return (
+    <div>
+      <h3 className="font-display text-sm font-semibold mb-3">
+        Historique des participations financières déclarées
+      </h3>
+      <ul className="divide-y">
+        {rows.map((d) => {
+          const state = declarationHistoryState(d.details);
+          return (
+            <li key={d.id} className="flex items-center justify-between gap-3 py-2 text-sm">
+              <span className="flex items-center gap-2">
+                <span className="font-mono text-muted-foreground">{d.year}</span>
+                <span className="rounded border px-1.5 py-0.5 text-xs text-muted-foreground">
+                  DIA
+                </span>
+              </span>
+              <span
+                className={
+                  state.kind === "value" ? "font-display font-semibold" : "text-muted-foreground"
+                }
+              >
+                {state.text}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/declarations/DeclarationMetrics.tsx
+++ b/src/components/declarations/DeclarationMetrics.tsx
@@ -6,7 +6,8 @@ interface DeclarationMetricsProps {
   totalPortfolioValue: number | null;
   totalCompanies: number;
   latestAnnualIncome: number | null;
-  totalDirectorships: number;
+  electoralMandatesCount: number;
+  directorshipsCount: number;
 }
 
 const HATVP_DI_URL =
@@ -16,27 +17,30 @@ export function DeclarationMetrics({
   totalPortfolioValue,
   totalCompanies,
   latestAnnualIncome,
-  totalDirectorships,
+  electoralMandatesCount,
+  directorshipsCount,
 }: DeclarationMetricsProps) {
   const metrics: { value: string; label: string; term: GlossaryKey }[] = [
     {
       value: formatCompactCurrency(totalPortfolioValue),
-      label: "Portefeuille total",
+      label: "Participations financières déclarées",
       term: "portefeuilleTotal",
     },
     {
       value: String(totalCompanies),
-      label: "Participations",
+      label: "Sociétés déclarées",
       term: "participationsHatvp",
     },
     {
       value: formatCompactCurrency(latestAnnualIncome),
-      label: "Revenus annuels",
+      label: "Revenus annuels déclarés",
       term: "revenusAnnuels",
     },
     {
-      value: String(totalDirectorships),
-      label: "Mandats & directions",
+      // Count elective mandates AND directorships (the old "totalDirectorships"
+      // counted directorships only, contradicting the label).
+      value: String(electoralMandatesCount + directorshipsCount),
+      label: "Mandats et fonctions de direction",
       term: "mandatsDirections",
     },
   ];

--- a/src/components/declarations/__tests__/DeclarationHistory.test.tsx
+++ b/src/components/declarations/__tests__/DeclarationHistory.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  DeclarationHistory,
+  declarationHistoryState,
+} from "@/components/declarations/DeclarationHistory";
+import type { DeclarationDetails } from "@/types/hatvp";
+
+const details = (over: Partial<DeclarationDetails>): DeclarationDetails => ({
+  financialParticipations: [],
+  professionalActivities: [],
+  electoralMandates: [],
+  directorships: [],
+  spouseActivity: null,
+  collaborators: [],
+  totalPortfolioValue: null,
+  totalCompanies: 0,
+  latestAnnualIncome: null,
+  totalDirectorships: 0,
+  ...over,
+});
+
+const part = (evaluation: number | null) => ({
+  company: "X",
+  evaluation,
+  shares: null,
+  capitalPercent: null,
+  dividends: null,
+  isBoardMember: false,
+});
+
+describe("declarationHistoryState", () => {
+  it("no parsed details => unavailable", () => {
+    expect(declarationHistoryState(null).kind).toBe("unavailable");
+    expect(declarationHistoryState(null).text).toBe("Donnée indisponible");
+  });
+  it("DIA with no participation => none", () => {
+    const s = declarationHistoryState(details({ financialParticipations: [] }));
+    expect(s.kind).toBe("none");
+    expect(s.text).toBe("Aucune participation financière déclarée");
+  });
+  it("participations but no usable evaluation => unknown", () => {
+    const s = declarationHistoryState(
+      details({ financialParticipations: [part(null)], totalPortfolioValue: null })
+    );
+    expect(s.kind).toBe("unknown");
+    expect(s.text).toBe("Montant non renseigné");
+  });
+  it("real zero sum shows 0 €, not a dash", () => {
+    const s = declarationHistoryState(
+      details({ financialParticipations: [part(0)], totalPortfolioValue: 0 })
+    );
+    expect(s.kind).toBe("value");
+    expect(s.text).toBe("0 €");
+  });
+  it("real value shows the amount", () => {
+    const s = declarationHistoryState(
+      details({ financialParticipations: [part(617000)], totalPortfolioValue: 617000 })
+    );
+    expect(s.kind).toBe("value");
+    expect(s.text).toContain("617");
+  });
+});
+
+describe("DeclarationHistory", () => {
+  it("lists DIA rows newest first with 'DIA' label", () => {
+    render(
+      <DeclarationHistory
+        declarations={[
+          {
+            id: "a",
+            year: 2022,
+            details: details({
+              financialParticipations: [part(438000)],
+              totalPortfolioValue: 438000,
+            }),
+          },
+          {
+            id: "b",
+            year: 2024,
+            details: details({
+              financialParticipations: [part(617000)],
+              totalPortfolioValue: 617000,
+            }),
+          },
+        ]}
+      />
+    );
+    expect(screen.getAllByText("DIA")).toHaveLength(2);
+    const years = screen.getAllByText(/202[24]/).map((n) => n.textContent);
+    expect(years[0]).toContain("2024");
+  });
+
+  it("renders nothing when there are no declarations", () => {
+    const { container } = render(<DeclarationHistory declarations={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/declarations/__tests__/DeclarationMetrics.test.tsx
+++ b/src/components/declarations/__tests__/DeclarationMetrics.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { DeclarationMetrics } from "@/components/declarations/DeclarationMetrics";
+import type { ComponentProps } from "react";
+
+// DeclarationMetrics renders InfoTooltip (Radix Tooltip), which needs a provider.
+function renderMetrics(props: ComponentProps<typeof DeclarationMetrics>) {
+  return render(
+    <TooltipProvider>
+      <DeclarationMetrics {...props} />
+    </TooltipProvider>
+  );
+}
+
+describe("DeclarationMetrics", () => {
+  it("renames the portfolio tile and never calls it a total portfolio", () => {
+    renderMetrics({
+      totalPortfolioValue: 617000,
+      totalCompanies: 1,
+      latestAnnualIncome: 124000,
+      electoralMandatesCount: 1,
+      directorshipsCount: 1,
+    });
+    expect(screen.getByText("Participations financières déclarées")).toBeInTheDocument();
+    expect(screen.queryByText("Portefeuille total")).toBeNull();
+  });
+
+  it("counts mandats + directions, not directorships alone", () => {
+    renderMetrics({
+      totalPortfolioValue: null,
+      totalCompanies: 0,
+      latestAnnualIncome: null,
+      electoralMandatesCount: 2,
+      directorshipsCount: 1,
+    });
+    const tile = screen
+      .getByText("Mandats et fonctions de direction")
+      .closest("div")?.parentElement;
+    expect(tile).toHaveTextContent("3");
+  });
+});

--- a/src/components/politicians/ProfileTabs.test.tsx
+++ b/src/components/politicians/ProfileTabs.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { ProfileTabs } from "./ProfileTabs";
 
 // Radix Tabs activates triggers on mousedown (left primary button), not click.
@@ -32,7 +33,13 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/politiques/eric-coquerel",
 }));
 
-function renderTabs(initialSearch: string) {
+function renderTabs(initialSearch: string, opts: { patrimoine?: ReactNode } = {}) {
+  const patrimoine =
+    "patrimoine" in opts ? (
+      opts.patrimoine
+    ) : (
+      <div data-testid="content-patrimoine">patrimoine-content</div>
+    );
   searchParamsRef.current = new URLSearchParams(initialSearch);
   window.history.replaceState(null, "", `/politiques/eric-coquerel?${initialSearch}`);
   return render(
@@ -40,6 +47,7 @@ function renderTabs(initialSearch: string) {
       profileContent={<div data-testid="content-profil">profil-content</div>}
       careerContent={<div data-testid="content-carriere">carriere-content</div>}
       votesContent={<div data-testid="content-votes">votes-content</div>}
+      patrimoineContent={patrimoine}
       factchecksContent={<div data-testid="content-factchecks">factchecks-content</div>}
       affairsContent={<div data-testid="content-affaires">affaires-content</div>}
     />
@@ -87,6 +95,21 @@ describe("ProfileTabs", () => {
 
     clickTab(/profil/i);
 
+    expect(window.location.search).toBe("");
+    expect(routerReplace).not.toHaveBeenCalled();
+  });
+
+  it("selects the patrimoine tab from ?tab=patrimoine when available", () => {
+    renderTabs("tab=patrimoine");
+    expect(screen.getByRole("tab", { name: /patrimoine/i })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+  });
+
+  it("falls back to Profil and clears the query when patrimoine is unavailable", () => {
+    renderTabs("tab=patrimoine", { patrimoine: null });
+    expect(screen.getByRole("tab", { name: /profil/i })).toHaveAttribute("aria-selected", "true");
     expect(window.location.search).toBe("");
     expect(routerReplace).not.toHaveBeenCalled();
   });

--- a/src/components/politicians/ProfileTabs.tsx
+++ b/src/components/politicians/ProfileTabs.tsx
@@ -4,9 +4,9 @@ import { useSearchParams } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import type { ReactNode } from "react";
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { User, Briefcase, Vote, FileCheck, Scale } from "lucide-react";
+import { User, Briefcase, Vote, Wallet, FileCheck, Scale } from "lucide-react";
 
-const VALID_TABS = ["profil", "carriere", "votes", "factchecks", "affaires"] as const;
+const VALID_TABS = ["profil", "carriere", "votes", "patrimoine", "factchecks", "affaires"] as const;
 type TabValue = (typeof VALID_TABS)[number];
 const DEFAULT_TAB: TabValue = "profil";
 
@@ -14,6 +14,7 @@ interface ProfileTabsProps {
   profileContent: ReactNode;
   careerContent: ReactNode;
   votesContent: ReactNode | null;
+  patrimoineContent: ReactNode | null;
   factchecksContent: ReactNode | null;
   affairsContent: ReactNode;
   affairsCount?: number;
@@ -23,6 +24,7 @@ function ProfileTabsInner({
   profileContent,
   careerContent,
   votesContent,
+  patrimoineContent,
   factchecksContent,
   affairsContent,
   affairsCount,
@@ -33,10 +35,11 @@ function ProfileTabsInner({
     () =>
       VALID_TABS.filter((t) => {
         if (t === "votes" && !votesContent) return false;
+        if (t === "patrimoine" && !patrimoineContent) return false;
         if (t === "factchecks" && !factchecksContent) return false;
         return true;
       }),
-    [votesContent, factchecksContent]
+    [votesContent, patrimoineContent, factchecksContent]
   );
 
   const tabFromUrl = useMemo<TabValue>(() => {
@@ -51,6 +54,19 @@ function ProfileTabsInner({
   useEffect(() => {
     setTab(tabFromUrl);
   }, [tabFromUrl]);
+
+  // If the URL names a tab that isn't available (e.g. ?tab=patrimoine on a
+  // profile without declarations), drop ?tab so the URL matches the fallback
+  // tab instead of lying.
+  useEffect(() => {
+    const raw = searchParams.get("tab");
+    if (raw && !availableTabs.includes(raw as TabValue)) {
+      const params = new URLSearchParams(window.location.search);
+      params.delete("tab");
+      const qs = params.toString();
+      window.history.replaceState(null, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+    }
+  }, [searchParams, availableTabs]);
 
   function onTabChange(value: string) {
     const next = value as TabValue;
@@ -82,6 +98,12 @@ function ProfileTabsInner({
             Votes
           </TabsTrigger>
         )}
+        {patrimoineContent && (
+          <TabsTrigger value="patrimoine">
+            <Wallet className="size-4" />
+            Patrimoine
+          </TabsTrigger>
+        )}
         {factchecksContent && (
           <TabsTrigger value="factchecks">
             <FileCheck className="size-4" />
@@ -101,6 +123,7 @@ function ProfileTabsInner({
       <TabsContent value="profil">{profileContent}</TabsContent>
       <TabsContent value="carriere">{careerContent}</TabsContent>
       {votesContent && <TabsContent value="votes">{votesContent}</TabsContent>}
+      {patrimoineContent && <TabsContent value="patrimoine">{patrimoineContent}</TabsContent>}
       {factchecksContent && <TabsContent value="factchecks">{factchecksContent}</TabsContent>}
       <TabsContent value="affaires">{affairsContent}</TabsContent>
     </Tabs>


### PR DESCRIPTION
Partie 2 (et dernière) de la refonte de la fiche `/politiques/[slug]` (issue #493). Construite sur PR A (#500, mergée).

## Ce que fait cette PR

- **Nouvel onglet « Patrimoine & intérêts »** : `DeclarationCard` sort du Profil pour vivre dans son onglet dédié. Visibilité conditionnelle (déclarations présentes, ou parlementaire actif pour l'état vide « obligation légale »). Repli propre : `?tab=patrimoine` sur un profil sans déclaration retombe sur Profil et nettoie la query.
- **Cadrage éditorial honnête** : bandeau « Données déclaratives, non auditées » (déclaré par l'élu, publié par la HATVP, mis en forme sans vérification) et disclosure « Intérêts (DIA) n'est pas patrimoine (DSP) » (seule la DIA est en ligne, la DSP est en préfecture, ce n'est pas une fortune nette).
- **Métriques renommées et corrigées** : « Portefeuille total » devient « Participations financières déclarées » ; « Participations » devient « Sociétés déclarées » ; « Mandats & directions » devient « Mandats et fonctions de direction » et compte désormais mandats électifs **plus** directions (l'ancien compteur ne comptait que les directions).
- **Chronologie sans calcul de variation** (`DeclarationHistory`) : « Historique des participations financières déclarées », une entrée par DIA, avec quatre états distincts (pas de déclaration ; aucune participation déclarée ; montant non renseigné ; montant, y compris 0 € réel). Pas de pourcentage, jamais présenté comme un enrichissement. Le modèle distingue `null` (aucune évaluation exploitable) d'un 0 réel ; `formatCompactCurrency` (qui confond les deux en « — ») n'est volontairement pas utilisé ici.
- **SEO** : `generateMetadata` parle de « participations financières déclarées » (jamais patrimoine, fortune nette ou portefeuille global) ; clause omise quand le montant est indisponible.

## Tests

- `DeclarationHistory` / `declarationHistoryState` : les quatre états, `0 €` réel distinct de « Montant non renseigné », tri décroissant (7 tests).
- `DeclarationMetrics` : libellé renommé, compte mandats + directions (2 tests).
- `ProfileTabs` : onglet `patrimoine` sélectionné via `?tab=patrimoine` ; repli + nettoyage de query quand indisponible.
- `tsc --noEmit` : 0 erreur ; `eslint` : clean ; 63 tests verts au total (PR A + PR B).

Refs #493
