### PR TITLE
perf(amendments): cron durable (ingestion incrémentale) + fallback seconde délibération + watchdog

### DIFF
--- a/scripts/backfill-amendments-ingest.ts
+++ b/scripts/backfill-amendments-ingest.ts
@@ -1,6 +1,10 @@
 /**
  * User-accord-gated catch-up: full re-ingest of the AN amendments feed.
  *
+ * This is the manual resync tool, so it defaults to `mode: "full"` (parse every
+ * entry, re-baseline the per-dossier signatures). Pass `--full` to be explicit;
+ * omit it and it still runs full. The daily cron uses the incremental path.
+ *
  * Default = dryRun (download + parse + memory/duration report, NO DB writes).
  * `--apply` performs the real ingest (writes Amendment rows to whatever DB
  * DATABASE_URL points at — in this project that is PROD). Idempotent: the
@@ -11,17 +15,31 @@ import { syncAmendmentsAN } from "@/services/sync/amendments-an";
 import { db } from "@/lib/db";
 
 const APPLY = process.argv.includes("--apply");
+// Manual resync defaults to a full re-ingest. `--full` forces it (and is the
+// default); `--incremental` opts into the cron's diff path for manual checks.
+const MODE: "full" | "incremental" = process.argv.includes("--incremental")
+  ? "incremental"
+  : "full";
 
 (async () => {
   const before = await db.amendment.count();
-  console.log(`[ingest] mode=${APPLY ? "APPLY (writes prod)" : "dry-run (no writes)"}`);
+  console.log(
+    `[ingest] mode=${APPLY ? "APPLY (writes prod)" : "dry-run (no writes)"} ingest=${MODE}`
+  );
   console.log(`[ingest] Amendment rows before: ${before}`);
 
-  const stats = await syncAmendmentsAN({ legislature: 17, force: true, dryRun: !APPLY });
+  const stats = await syncAmendmentsAN({
+    legislature: 17,
+    mode: MODE,
+    force: true,
+    dryRun: !APPLY,
+  });
 
   console.log(
     "[ingest] stats " +
       JSON.stringify({
+        dossiersInspected: stats.dossiersInspected,
+        dossiersChanged: stats.dossiersChanged,
         seen: stats.amendmentsSeen,
         created: stats.amendmentsCreated,
         updated: stats.amendmentsUpdated,

--- a/scripts/backfill-approve-high.ts
+++ b/scripts/backfill-approve-high.ts
@@ -1,0 +1,42 @@
+/**
+ * User-accord-gated: auto-approve the HIGH, non-fallback DRAFT titles that pass
+ * the existing eligibility guard. MEDIUM/LOW/fallback/ambiguous are never forced
+ * (autoApproveBatchEligible filters confidence:HIGH + generationSource != FALLBACK
+ * and the guard skips anything with blockers). minAgeHours:0 because quality was
+ * reviewed on the sample. Prints stats + the approved scrutinIds (for revalidation)
+ * + the DRAFT/NEEDS_REVIEW leftovers.
+ */
+import { autoApproveBatchEligible } from "@/services/scrutin-policy-title/approval";
+import { db } from "@/lib/db";
+
+(async () => {
+  const startedAt = new Date();
+  const stats = await autoApproveBatchEligible({ minAgeHours: 0, limit: 2000 });
+  console.log("[approve] stats " + JSON.stringify(stats));
+
+  const approved = await db.scrutin.findMany({
+    where: { policyTitle: { is: { status: "APPROVED", updatedAt: { gte: startedAt } } } },
+    select: { id: true, slug: true },
+  });
+  console.log(`[approve] approved this run: ${approved.length}`);
+  console.log("[approve] approvedIds=" + JSON.stringify(approved.map((a) => a.id)));
+
+  const leftover = await db.scrutinPolicyTitle.groupBy({
+    by: ["status", "confidence"],
+    where: { status: { in: ["DRAFT", "NEEDS_REVIEW"] } },
+    _count: { _all: true },
+  });
+  console.log(
+    "[approve] remaining DRAFT/NEEDS_REVIEW by status/confidence:",
+    JSON.stringify(leftover.map((l) => ({ s: l.status, c: l.confidence, n: l._count._all })))
+  );
+  await db.$disconnect();
+})().catch(async (e) => {
+  console.error("[approve] FAILED:", e);
+  try {
+    await db.$disconnect();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/scripts/backfill-generate-policy-titles.ts
+++ b/scripts/backfill-generate-policy-titles.ts
@@ -1,0 +1,101 @@
+/**
+ * User-accord-gated: generate the remaining policy-title backlog with Mistral.
+ *
+ * Resumable + idempotent: generateScrutinPolicyTitles() selects linked + untitled
+ * scrutins newest-first, so re-running continues where a prior (possibly killed)
+ * run stopped. Loops in bounded batches until the backlog is drained.
+ *
+ * Cost guard: reads the process-wide Mistral token meter after each batch,
+ * projects the full-backlog cost at a conservative blended rate, and STOPS if the
+ * projection exceeds HARD_STOP_EUR (default 15). Real token counts are logged so
+ * cost can be recomputed with the exact Mistral tariff.
+ *
+ * Writes DRAFT rows only (never approves). Approval is a separate, HIGH-only step.
+ */
+import { generateScrutinPolicyTitles } from "@/services/sync/generate-scrutin-policy-titles";
+import { getMistralTokensUsed, resetMistralTokensUsed } from "@/lib/api/mistral";
+import { db } from "@/lib/db";
+
+const BATCH = Number(process.env.GEN_BATCH ?? "40");
+const EUR_PER_1M = Number(process.env.MISTRAL_EUR_PER_1M ?? "3"); // conservative blended large-latest
+const HARD_STOP_EUR = Number(process.env.GEN_HARD_STOP_EUR ?? "15");
+const MAX_BATCHES = Number(process.env.GEN_MAX_BATCHES ?? "60"); // safety cap
+
+const backlogWhere = {
+  legislature: 17,
+  chamber: "AN" as const,
+  amendmentLinks: { some: {} },
+  policyTitle: { is: null },
+};
+
+(async () => {
+  if (!process.env.MISTRAL_API_KEY) {
+    console.log("NO_MISTRAL_KEY");
+    await db.$disconnect();
+    process.exit(2);
+  }
+  resetMistralTokensUsed();
+  const backlogStart = await db.scrutin.count({ where: backlogWhere });
+  console.log(
+    `[gen] backlog=${backlogStart} batch=${BATCH} rate=${EUR_PER_1M}EUR/1M hardStop=${HARD_STOP_EUR}EUR`
+  );
+
+  let produced = 0;
+  let generated = 0;
+  let fallbacks = 0;
+  const errors: Array<{ scrutinId: string; error: string }> = [];
+
+  for (let b = 1; b <= MAX_BATCHES; b++) {
+    const stats = await generateScrutinPolicyTitles({ limit: BATCH });
+    const batchProduced = stats.generated + stats.fallbacks;
+    produced += batchProduced;
+    generated += stats.generated;
+    fallbacks += stats.fallbacks;
+    errors.push(...stats.errors);
+
+    const tokens = getMistralTokensUsed();
+    const eur = (tokens / 1_000_000) * EUR_PER_1M;
+    const projectedEur = produced > 0 ? (eur / produced) * backlogStart : eur;
+    console.log(
+      `[gen] batch ${b}: generated=${stats.generated} fallbacks=${stats.fallbacks} errors=${stats.errors.length} | cumul produced=${produced}/${backlogStart} tokens=${tokens} eur=${eur.toFixed(2)} projected=${projectedEur.toFixed(2)}`
+    );
+
+    if (projectedEur > HARD_STOP_EUR) {
+      console.log(
+        `[gen] STOP: projected cost ${projectedEur.toFixed(2)}EUR exceeds hard stop ${HARD_STOP_EUR}EUR. Halting for review.`
+      );
+      break;
+    }
+    if (batchProduced === 0) {
+      console.log("[gen] backlog drained (0 produced this batch).");
+      break;
+    }
+  }
+
+  const tokens = getMistralTokensUsed();
+  const backlogEnd = await db.scrutin.count({ where: backlogWhere });
+  console.log(
+    "[gen] DONE " +
+      JSON.stringify({
+        producedTitles: produced,
+        generated,
+        fallbacks,
+        errorCount: errors.length,
+        backlogStart,
+        backlogEnd,
+        tokensUsed: tokens,
+        estEUR: Number(((tokens / 1_000_000) * EUR_PER_1M).toFixed(2)),
+        rateEURper1M: EUR_PER_1M,
+      })
+  );
+  if (errors.length) console.log("[gen] first errors:", JSON.stringify(errors.slice(0, 10)));
+  await db.$disconnect();
+})().catch(async (e) => {
+  console.error("[gen] FAILED:", e);
+  try {
+    await db.$disconnect();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/scripts/backfill-scrutin-amendment-links.ts
+++ b/scripts/backfill-scrutin-amendment-links.ts
@@ -27,6 +27,7 @@
 import { db } from "@/lib/db";
 import { linkScrutinsToAmendments } from "@/services/sync/link-scrutins-to-amendments";
 import { evaluateLinkLoopStep } from "@/services/sync/link-scrutins-to-amendments/backfill-loop";
+import { linkableUnlinkedVoteWhere } from "@/lib/monitoring/amendment-link-query";
 
 const OUT_OF_SCOPE_TYPES = ["ARTICLE", "MOTION", "FINAL", "AUTRE"] as const;
 
@@ -79,8 +80,11 @@ async function classifyRecentUnlinked(
   };
 
   const [linkableCount, outOfScopeGroups, amendementNoDossierCount] = await Promise.all([
+    // Excludes confirmed-unresolvable votes (shared with the freshness monitor
+    // and the sync-daily guard) so the loop does not report "stuck" forever over
+    // a known-unresolvable vote.
     db.scrutin.count({
-      where: { ...recentUnlinkedWhere, type: "AMENDEMENT", dossierLegislatifId: { not: null } },
+      where: linkableUnlinkedVoteWhere({ legislature, votingDate: { gte: sinceDate } }),
     }),
     db.scrutin.groupBy({
       by: ["type"],
@@ -124,13 +128,7 @@ function printReport(report: ClassificationReport): void {
 /** Fetches the still-unlinked linkable candidates for the stuck-backlog error report. */
 async function fetchLinkableCandidates(legislature: number, sinceDate: Date, take = 50) {
   return db.scrutin.findMany({
-    where: {
-      legislature,
-      votingDate: { gte: sinceDate },
-      amendmentLinks: { none: {} },
-      type: "AMENDEMENT",
-      dossierLegislatifId: { not: null },
-    },
+    where: linkableUnlinkedVoteWhere({ legislature, votingDate: { gte: sinceDate } }),
     select: {
       externalId: true,
       title: true,

--- a/scripts/check-amendment-link-freshness.ts
+++ b/scripts/check-amendment-link-freshness.ts
@@ -16,7 +16,11 @@
  */
 import { appendFileSync } from "node:fs";
 import { db } from "@/lib/db";
-import { isLinkingStalled } from "@/lib/monitoring/amendment-link-freshness";
+import {
+  isLinkingStalled,
+  partitionUnlinkedVotes,
+} from "@/lib/monitoring/amendment-link-freshness";
+import { AMENDMENT_LINK_UNRESOLVABLE_IDS } from "@/config/amendment-link-unresolvable";
 
 const MAX_LAG_HOURS = Number(process.env.LINK_FRESHNESS_MAX_LAG_HOURS ?? "48");
 const LEGISLATURE = Number(process.env.LINK_FRESHNESS_LEGISLATURE ?? "17");
@@ -41,7 +45,8 @@ async function main(): Promise<void> {
   const [
     latestLinkedVote,
     latestAmendableVote,
-    recentLinkableUnlinked,
+    windowUnlinked,
+    confirmedUnlinked,
     amendmentCount,
     lastAmendment,
   ] = await Promise.all([
@@ -58,8 +63,11 @@ async function main(): Promise<void> {
     // Only AMENDEMENT votes with a dossier are ever eligible for a link/title —
     // ARTICLE/MOTION/FINAL/AUTRE votes are out of scope and must not count
     // toward the stall signal. Old enough that linking SHOULD have happened,
-    // yet hasn't.
-    db.scrutin.count({
+    // yet hasn't. No config exclusion in the query: partitionUnlinkedVotes
+    // splits this window population into blocking vs confirmed-unresolvable,
+    // which is equivalent to `externalId NOT IN (unresolvable keys)` for the
+    // blocking count while also yielding the confirmed list for the detail.
+    db.scrutin.findMany({
       where: {
         legislature: LEGISLATURE,
         chamber: "AN",
@@ -68,10 +76,35 @@ async function main(): Promise<void> {
         votingDate: { gte: windowStart, lte: lagCutoff },
         amendmentLinks: { none: {} },
       },
+      select: { externalId: true },
+    }),
+    // Confirmed-unresolvable votes still unlinked at ANY age (no lower window
+    // bound): so an explicitly-classified vote is never silently hidden just
+    // because it aged out of the recent window.
+    db.scrutin.findMany({
+      where: {
+        legislature: LEGISLATURE,
+        chamber: "AN",
+        type: "AMENDEMENT",
+        dossierLegislatifId: { not: null },
+        votingDate: { lte: lagCutoff },
+        amendmentLinks: { none: {} },
+        externalId: { in: [...AMENDMENT_LINK_UNRESOLVABLE_IDS] },
+      },
+      orderBy: { votingDate: "desc" },
+      select: { externalId: true, votingDate: true },
     }),
     db.amendment.count(),
     db.amendment.findFirst({ orderBy: { createdAt: "desc" }, select: { createdAt: true } }),
   ]);
+
+  // MAIN (blocking) signal excludes the confirmed-unresolvable set by explicit
+  // id only — never by age.
+  const { blocking, confirmedUnresolvable: confirmedInWindow } = partitionUnlinkedVotes(
+    windowUnlinked.map((s) => s.externalId),
+    AMENDMENT_LINK_UNRESOLVABLE_IDS
+  );
+  const recentLinkableUnlinked = blocking.length;
 
   const lagHours =
     latestAmendableVote && latestLinkedVote
@@ -87,12 +120,17 @@ async function main(): Promise<void> {
 
   const iso = (d: Date | null | undefined) => d?.toISOString() ?? "n/a";
   const day = (d: Date | null | undefined) => d?.toISOString().slice(0, 10) ?? "n/a";
+  const confirmedList =
+    confirmedUnlinked.length > 0
+      ? ` [${confirmedUnlinked.map((s) => s.externalId).join(", ")}]`
+      : "";
   const detail = [
     `Amendment linking freshness (legislature ${LEGISLATURE}, threshold ${MAX_LAG_HOURS}h)`,
     `- newest amendable vote (type AMENDEMENT): ${day(latestAmendableVote?.votingDate)} ${latestAmendableVote?.externalId ?? ""}`.trim(),
     `- newest vote that HAS a link:            ${day(latestLinkedVote?.votingDate)}`,
     `- linked frontier lag: ${(lagHours / 24).toFixed(1)} days`,
-    `- linkable votes (AMENDEMENT + dossier) >${MAX_LAG_HOURS}h old still unlinked (last ${RECENT_WINDOW_DAYS}d): ${recentLinkableUnlinked}`,
+    `- linkable votes (AMENDEMENT + dossier) >${MAX_LAG_HOURS}h old still unlinked (last ${RECENT_WINDOW_DAYS}d): ${windowUnlinked.length} = ${recentLinkableUnlinked} unresolved-not-yet-classified (BLOCKING) + ${confirmedInWindow.length} confirmed-unresolvable`,
+    `- confirmed-unresolvable, still unlinked (explicit config, NON-BLOCKING): ${confirmedUnlinked.length}${confirmedList}`,
     `- Amendment corpus: ${amendmentCount} rows, newest ingested ${iso(lastAmendment?.createdAt)}`,
     `- verdict: ${stalled ? "STALLED" : "ok"}`,
   ].join("\n");

--- a/src/config/amendment-link-unresolvable.ts
+++ b/src/config/amendment-link-unresolvable.ts
@@ -1,0 +1,21 @@
+/**
+ * Scrutins confirmed unresolvable to an amendment link after investigation,
+ * keyed by scrutin externalId -> human-readable reason.
+ *
+ * Purpose: the amendment-linking watchdog must not stay STALLED for days over a
+ * KNOWN, explicitly-classified unresolvable vote, yet it must never silently
+ * hide an unlinked vote merely because it is old. So exclusion from the blocking
+ * stall signal is by EXPLICIT entry here only, never by age.
+ *
+ * Start EMPTY: the délibération-aware resolver fallback (see
+ * link-scrutins-to-amendments/resolve.ts) links the previously-stuck
+ * seconde-délibération votes. Add an entry ONLY when a vote is genuinely
+ * unresolvable (documented reason), so the watchdog stops treating it as a live
+ * stall while still surfacing it in the non-blocking detail.
+ */
+export const AMENDMENT_LINK_UNRESOLVABLE: Record<string, string> = {};
+
+/** Keys of AMENDMENT_LINK_UNRESOLVABLE, for fast membership lookups. */
+export const AMENDMENT_LINK_UNRESOLVABLE_IDS: ReadonlySet<string> = new Set(
+  Object.keys(AMENDMENT_LINK_UNRESOLVABLE)
+);

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -3,6 +3,7 @@ import { POLICY_TITLE_CRON } from "@/config/policy-titles";
 import { syncMetadata } from "@/lib/sync/sync-metadata";
 import { revalidateTags } from "@/lib/cache";
 import { isIngestionAnomaly } from "@/lib/monitoring/amendment-link-freshness";
+import { linkableUnlinkedVoteWhere } from "@/lib/monitoring/amendment-link-query";
 
 interface DailyStep {
   name: string;
@@ -111,15 +112,14 @@ const DAILY_STEPS: DailyStep[] = [
       // normal, but a fully-processed feed that ingests nothing while linkable
       // recent votes remain unlinked means the pipeline is failing silently.
       const { db } = await import("@/lib/db");
+      // Same shared where-fragment as the freshness monitor and the backfill
+      // loop: confirmed-unresolvable votes are excluded from the blocking count.
       const recentLinkableUnlinked = await db.scrutin.count({
-        where: {
+        where: linkableUnlinkedVoteWhere({
           legislature: 17,
           chamber: "AN",
-          type: "AMENDEMENT",
-          dossierLegislatifId: { not: null },
           votingDate: { gte: new Date(Date.now() - 14 * 24 * 3_600_000) },
-          amendmentLinks: { none: {} },
-        },
+        }),
       });
       const anomaly = isIngestionAnomaly({
         notModified: stats.notModified ?? false,

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -102,6 +102,7 @@ const DAILY_STEPS: DailyStep[] = [
     run: async () => {
       const { syncAmendmentsAN } = await import("@/services/sync/amendments-an");
       const stats = await syncAmendmentsAN({
+        mode: "incremental",
         force: false,
         safetyCap: POLICY_TITLE_CRON.amendmentsSafetyCap,
       });
@@ -137,6 +138,8 @@ const DAILY_STEPS: DailyStep[] = [
         itemCount: stats.amendmentsCreated,
         durationS: stats.durationMs / 1000,
         extra: {
+          dossiersInspected: stats.dossiersInspected,
+          dossiersChanged: stats.dossiersChanged,
           seen: stats.amendmentsSeen,
           created: stats.amendmentsCreated,
           updated: stats.amendmentsUpdated,

--- a/src/lib/api/mistral.ts
+++ b/src/lib/api/mistral.ts
@@ -65,7 +65,20 @@ export async function callMistral(
     throw new Error(`Mistral API error ${response.status}: ${errorText}`);
   }
 
-  return response.json();
+  const json = (await response.json()) as MistralResponse;
+  if (json.usage?.total_tokens) _mistralTokensUsed += json.usage.total_tokens;
+  return json;
+}
+
+// Process-wide token meter. callMistral adds each response's total_tokens here so
+// long batch jobs (e.g. the policy-title generation backfill) can track real cost
+// and enforce a budget ceiling without threading usage through every caller.
+let _mistralTokensUsed = 0;
+export function getMistralTokensUsed(): number {
+  return _mistralTokensUsed;
+}
+export function resetMistralTokensUsed(): void {
+  _mistralTokensUsed = 0;
 }
 
 export function extractMistralText(response: MistralResponse): string {

--- a/src/lib/monitoring/__tests__/amendment-link-freshness.test.ts
+++ b/src/lib/monitoring/__tests__/amendment-link-freshness.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { isLinkingStalled, isIngestionAnomaly } from "@/lib/monitoring/amendment-link-freshness";
+import {
+  isLinkingStalled,
+  isIngestionAnomaly,
+  partitionUnlinkedVotes,
+} from "@/lib/monitoring/amendment-link-freshness";
+import { linkableUnlinkedVoteWhere } from "@/lib/monitoring/amendment-link-query";
+
+const MAX_LAG = 48;
+const ABS = 20;
+const stalledFromCount = (count: number) =>
+  isLinkingStalled({
+    lagHours: 240,
+    recentLinkableUnlinked: count,
+    maxLagHours: MAX_LAG,
+    absoluteUnlinkedThreshold: ABS,
+  });
 
 describe("isLinkingStalled", () => {
   it("lag beyond threshold + linkable unlinked votes remain -> stalled", () => {
@@ -76,5 +91,60 @@ describe("isIngestionAnomaly", () => {
     expect(
       isIngestionAnomaly({ notModified: false, created: 0, updated: 0, recentLinkableUnlinked: 0 })
     ).toBe(false);
+  });
+});
+
+describe("partitionUnlinkedVotes — confirmed-unresolvable exclusion", () => {
+  it("a vote in the confirmed-unresolvable set does NOT feed the blocking count (-> not stalled)", () => {
+    const set = new Set(["VTANR5L17V0001"]);
+    const { blocking, confirmedUnresolvable } = partitionUnlinkedVotes(["VTANR5L17V0001"], set);
+    expect(blocking).toEqual([]);
+    expect(confirmedUnresolvable).toEqual(["VTANR5L17V0001"]);
+    expect(stalledFromCount(blocking.length)).toBe(false);
+  });
+
+  it("an unclassified unlinked vote DOES feed the blocking count (-> stalled)", () => {
+    const set = new Set(["VTANR5L17V0001"]);
+    const { blocking } = partitionUnlinkedVotes(["VTANR5L17V0001", "VTANR5L17V9999"], set);
+    expect(blocking).toEqual(["VTANR5L17V9999"]);
+    expect(stalledFromCount(blocking.length)).toBe(true);
+  });
+
+  it("a NEW unresolved vote appearing next to a classified one re-trips the signal", () => {
+    // Start: the only unlinked vote is classified -> not stalled.
+    const set = new Set(["VTANR5L17V0001"]);
+    expect(stalledFromCount(partitionUnlinkedVotes(["VTANR5L17V0001"], set).blocking.length)).toBe(
+      false
+    );
+    // A brand-new unlinked vote appears; it is NOT in the config -> stalled again.
+    const after = partitionUnlinkedVotes(["VTANR5L17V0001", "VTANR5L17V0002"], set);
+    expect(after.blocking).toEqual(["VTANR5L17V0002"]);
+    expect(stalledFromCount(after.blocking.length)).toBe(true);
+  });
+
+  it("exclusion is by id only, never by age: order/age of ids is irrelevant", () => {
+    const set = new Set<string>();
+    const { blocking, confirmedUnresolvable } = partitionUnlinkedVotes(["A", "B", "C"], set);
+    expect(blocking).toEqual(["A", "B", "C"]);
+    expect(confirmedUnresolvable).toEqual([]);
+  });
+});
+
+describe("linkableUnlinkedVoteWhere — shared where-fragment", () => {
+  it("excludes the confirmed-unresolvable ids via externalId NOT IN", () => {
+    const where = linkableUnlinkedVoteWhere({
+      legislature: 17,
+      chamber: "AN",
+      unresolvableIds: ["VTANR5L17V0001"],
+    });
+    expect(where.externalId).toEqual({ notIn: ["VTANR5L17V0001"] });
+    expect(where.type).toBe("AMENDEMENT");
+    expect(where.dossierLegislatifId).toEqual({ not: null });
+    expect(where.amendmentLinks).toEqual({ none: {} });
+  });
+
+  it("adds no exclusion when the set is empty (unclassified votes stay in scope)", () => {
+    const where = linkableUnlinkedVoteWhere({ legislature: 17, unresolvableIds: [] });
+    expect(where.externalId).toBeUndefined();
   });
 });

--- a/src/lib/monitoring/amendment-link-freshness.ts
+++ b/src/lib/monitoring/amendment-link-freshness.ts
@@ -32,6 +32,26 @@ export function isLinkingStalled(i: LinkStallInput): boolean {
   );
 }
 
+/**
+ * Splits the past-window linkable-unlinked votes into the BLOCKING population
+ * (fed to isLinkingStalled) and the CONFIRMED-UNRESOLVABLE ones (surfaced in the
+ * detail, non-blocking). Exclusion is by explicit id membership only — never by
+ * age — so a brand-new unlinked vote always lands in `blocking` and keeps
+ * feeding the stall signal until it is either linked or explicitly classified.
+ */
+export function partitionUnlinkedVotes(
+  linkableUnlinkedExternalIds: string[],
+  unresolvableIds: ReadonlySet<string>
+): { blocking: string[]; confirmedUnresolvable: string[] } {
+  const blocking: string[] = [];
+  const confirmedUnresolvable: string[] = [];
+  for (const id of linkableUnlinkedExternalIds) {
+    if (unresolvableIds.has(id)) confirmedUnresolvable.push(id);
+    else blocking.push(id);
+  }
+  return { blocking, confirmedUnresolvable };
+}
+
 export interface IngestionAnomalyInput {
   /** Feed returned 304 / unchanged. */
   notModified: boolean;

--- a/src/lib/monitoring/amendment-link-query.ts
+++ b/src/lib/monitoring/amendment-link-query.ts
@@ -1,0 +1,30 @@
+import type { Prisma } from "@/generated/prisma";
+import { AMENDMENT_LINK_UNRESOLVABLE_IDS } from "@/config/amendment-link-unresolvable";
+
+/**
+ * Shared WHERE fragment for "a linkable AMENDEMENT vote still unlinked". Reused
+ * by the freshness monitor, the sync-daily anomaly guard and the backfill loop
+ * so the three agree on what counts toward the BLOCKING stall signal.
+ *
+ * Confirmed-unresolvable votes (explicit config) are excluded via `externalId
+ * NOT IN (...)`. Nothing is excluded by age — the window bounds are the caller's
+ * own scan scope, not a way to hide an unlinked vote.
+ */
+export function linkableUnlinkedVoteWhere(opts: {
+  legislature: number;
+  chamber?: "AN" | "SENAT";
+  votingDate?: { gte?: Date; lte?: Date };
+  /** Defaults to the confirmed-unresolvable config; injectable for tests. */
+  unresolvableIds?: readonly string[];
+}): Prisma.ScrutinWhereInput {
+  const ids = opts.unresolvableIds ?? [...AMENDMENT_LINK_UNRESOLVABLE_IDS];
+  return {
+    legislature: opts.legislature,
+    ...(opts.chamber ? { chamber: opts.chamber } : {}),
+    type: "AMENDEMENT",
+    dossierLegislatifId: { not: null },
+    amendmentLinks: { none: {} },
+    ...(opts.votingDate ? { votingDate: opts.votingDate } : {}),
+    ...(ids.length ? { externalId: { notIn: [...ids] } } : {}),
+  };
+}

--- a/src/services/sync/__tests__/amendments-an/dossier-index.test.ts
+++ b/src/services/sync/__tests__/amendments-an/dossier-index.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import yazl from "yazl";
+import {
+  readDossierSignatures,
+  scanCentralDirectory,
+} from "@/services/sync/amendments-an/dossier-index";
+
+/** Writes a ZIP from [entryPath, content] pairs, added in the given order. */
+async function buildZip(dir: string, name: string, entries: [string, string][]): Promise<string> {
+  const zp = path.join(dir, name);
+  const zf = new yazl.ZipFile();
+  for (const [entryPath, content] of entries) zf.addBuffer(Buffer.from(content), entryPath);
+  zf.end();
+  await new Promise<void>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    zf.outputStream.on("data", (c) => chunks.push(c as Buffer));
+    zf.outputStream.on("end", () => {
+      writeFileSync(zp, Buffer.concat(chunks));
+      resolve();
+    });
+    zf.outputStream.on("error", reject);
+  });
+  return zp;
+}
+
+describe("readDossierSignatures", () => {
+  let tmp: string;
+
+  const setup = () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "dossier-sig-"));
+    return tmp;
+  };
+  const teardown = () => rmSync(tmp, { recursive: true, force: true });
+
+  const DA = "DLR5L17N54083";
+  const DB = "DLR5L17N54084";
+  const ENTRIES: [string, string][] = [
+    [`json/${DA}/PIONANR5L17B1432/a1.json`, '{"amendement":{"uid":"A1"}}'],
+    [`json/${DA}/PIONANR5L17B1432/a2.json`, '{"amendement":{"uid":"A2"}}'],
+    [`json/${DB}/PIONANR5L17B1500/b1.json`, '{"amendement":{"uid":"B1"}}'],
+  ];
+
+  it("produces identical signatures for identical content across two ZIPs", async () => {
+    const dir = setup();
+    try {
+      const z1 = await buildZip(dir, "one.zip", ENTRIES);
+      const z2 = await buildZip(dir, "two.zip", ENTRIES);
+      const s1 = await readDossierSignatures(z1);
+      const s2 = await readDossierSignatures(z2);
+      expect([...s1.keys()].sort()).toEqual([DA, DB]);
+      expect(s1.get(DA)).toBe(s2.get(DA));
+      expect(s1.get(DB)).toBe(s2.get(DB));
+    } finally {
+      teardown();
+    }
+  });
+
+  it("changes only the affected dossier's signature when one entry's content changes", async () => {
+    const dir = setup();
+    try {
+      const baseline = await readDossierSignatures(await buildZip(dir, "base.zip", ENTRIES));
+      const mutated: [string, string][] = [
+        [`json/${DA}/PIONANR5L17B1432/a1.json`, '{"amendement":{"uid":"A1","v":2}}'], // changed
+        [`json/${DA}/PIONANR5L17B1432/a2.json`, '{"amendement":{"uid":"A2"}}'],
+        [`json/${DB}/PIONANR5L17B1500/b1.json`, '{"amendement":{"uid":"B1"}}'],
+      ];
+      const after = await readDossierSignatures(await buildZip(dir, "mut.zip", mutated));
+      expect(after.get(DA)).not.toBe(baseline.get(DA));
+      expect(after.get(DB)).toBe(baseline.get(DB)); // untouched dossier stable
+    } finally {
+      teardown();
+    }
+  });
+
+  it("is independent of ZIP entry order (shuffled entries -> same signatures)", async () => {
+    const dir = setup();
+    try {
+      const ordered = await readDossierSignatures(await buildZip(dir, "ord.zip", ENTRIES));
+      const shuffled: [string, string][] = [ENTRIES[2]!, ENTRIES[0]!, ENTRIES[1]!];
+      const scrambled = await readDossierSignatures(await buildZip(dir, "shuf.zip", shuffled));
+      expect(scrambled.get(DA)).toBe(ordered.get(DA));
+      expect(scrambled.get(DB)).toBe(ordered.get(DB));
+    } finally {
+      teardown();
+    }
+  });
+
+  it("ignores non-.json entries and entries with no dossier ref", async () => {
+    const dir = setup();
+    try {
+      const mixed: [string, string][] = [
+        [`json/${DA}/PIONANR5L17B1432/a1.json`, '{"amendement":{"uid":"A1"}}'],
+        [`json/${DA}/PIONANR5L17B1432/readme.txt`, "not json"],
+        ["json/no-dossier/x.json", "{}"], // no DLR segment -> no dossier ref
+      ];
+      const sigs = await readDossierSignatures(await buildZip(dir, "mixed.zip", mixed));
+      expect([...sigs.keys()]).toEqual([DA]);
+    } finally {
+      teardown();
+    }
+  });
+
+  it("scanCentralDirectory counts every .json entry (safety-cap basis)", async () => {
+    const dir = setup();
+    try {
+      const withNoise: [string, string][] = [
+        ...ENTRIES,
+        [`json/${DA}/PIONANR5L17B1432/note.txt`, "skip me"], // not .json -> not counted
+      ];
+      const scan = await scanCentralDirectory(await buildZip(dir, "count.zip", withNoise));
+      expect(scan.entriesInspected).toBe(3);
+      expect(scan.signatures.size).toBe(2);
+    } finally {
+      teardown();
+    }
+  });
+});

--- a/src/services/sync/__tests__/amendments-an/incremental-ingest.test.ts
+++ b/src/services/sync/__tests__/amendments-an/incremental-ingest.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import yazl from "yazl";
+
+// DB-backed: run via `npm run test:db:477 -- <this file>`. Skipped (and the file
+// stays loadable) when DATABASE_URL is unset — db-touching modules are imported
+// dynamically in beforeAll, exactly like writer.test.ts.
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+let db: typeof import("@/lib/db").db;
+let syncAmendmentsAN: typeof import("@/services/sync/amendments-an").syncAmendmentsAN;
+let syncMetadata: typeof import("@/lib/sync").syncMetadata;
+let dossierSignatureKey: typeof import("@/services/sync/amendments-an/signature-store").dossierSignatureKey;
+let loadStoredDossierSignatures: typeof import("@/services/sync/amendments-an/signature-store").loadStoredDossierSignatures;
+
+/** Valid amendment JSON in the AN feed shape. externalId = uid. */
+function amendmentJson(uid: string, numero: string, dispositif: string): string {
+  return JSON.stringify({
+    amendement: {
+      uid,
+      identification: { numeroLong: numero },
+      texteLegislatifRef: "PIONANR5L17B1432",
+      corps: { contenuAuteur: { dispositif, exposeSommaire: `<p>expose ${uid}</p>` } },
+      cycleDeVie: { sort: "En construction" },
+      amendementParentRef: { "@xsi:nil": "true" },
+      discussionIdentique: { "@xsi:nil": "true" },
+      pointeurFragmentTexte: { division: { articleDesignation: "Article 1" } },
+      signataires: { auteur: { typeAuteur: "Député" }, libelle: "M. Test" },
+      legislature: "17",
+    },
+  });
+}
+
+let tmpDir: string;
+
+/** Writes a ZIP from [entryPath, content] pairs. */
+async function buildZip(name: string, entries: [string, string][]): Promise<string> {
+  const zp = path.join(tmpDir, name);
+  const zf = new yazl.ZipFile();
+  for (const [entryPath, content] of entries) zf.addBuffer(Buffer.from(content), entryPath);
+  zf.end();
+  await new Promise<void>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    zf.outputStream.on("data", (c) => chunks.push(c as Buffer));
+    zf.outputStream.on("end", () => {
+      writeFileSync(zp, Buffer.concat(chunks));
+      resolve();
+    });
+    zf.outputStream.on("error", reject);
+  });
+  return zp;
+}
+
+const entryPath = (dlr: string, uid: string) => `json/${dlr}/PIONANR5L17B1432/${uid}.json`;
+
+describeIfDb("syncAmendmentsAN incremental ingestion", () => {
+  const USED_LEGISLATURES = [91, 92, 93, 95, 96, 97];
+
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ syncAmendmentsAN } = await import("@/services/sync/amendments-an"));
+    ({ syncMetadata } = await import("@/lib/sync"));
+    ({ dossierSignatureKey, loadStoredDossierSignatures } =
+      await import("@/services/sync/amendments-an/signature-store"));
+
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "incremental-ingest-"));
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: "TEST_INC_" } } });
+    for (const leg of USED_LEGISLATURES) await syncMetadata.reset(dossierSignatureKey(leg));
+  });
+
+  afterAll(async () => {
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: "TEST_INC_" } } });
+    for (const leg of USED_LEGISLATURES) await syncMetadata.reset(dossierSignatureKey(leg));
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("[1] identical ZIP on the second run: 0 dossiers changed, 0 writes", async () => {
+    const leg = 91;
+    const dlr = "DLR5L17N91001";
+    const entries: [string, string][] = [
+      [entryPath(dlr, "TEST_INC_T1_a1"), amendmentJson("TEST_INC_T1_a1", "1", "<p>d1</p>")],
+      [entryPath(dlr, "TEST_INC_T1_a2"), amendmentJson("TEST_INC_T1_a2", "2", "<p>d2</p>")],
+    ];
+    const zip = await buildZip("t1.zip", entries);
+
+    const r1 = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    expect(r1.amendmentsCreated).toBe(2);
+    expect(r1.dossiersChanged).toBe(1);
+
+    const r2 = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    expect(r2.dossiersInspected).toBe(1);
+    expect(r2.dossiersChanged).toBe(0);
+    expect(r2.amendmentsCreated).toBe(0);
+    expect(r2.amendmentsUpdated).toBe(0);
+  });
+
+  it("[2] new dossier added: only the new dossier is parsed and its rows created", async () => {
+    const leg = 92;
+    const d1 = "DLR5L17N92001";
+    const d2 = "DLR5L17N92002";
+    const base: [string, string][] = [
+      [entryPath(d1, "TEST_INC_T2_a1"), amendmentJson("TEST_INC_T2_a1", "1", "<p>d1a1</p>")],
+      [entryPath(d1, "TEST_INC_T2_a2"), amendmentJson("TEST_INC_T2_a2", "2", "<p>d1a2</p>")],
+    ];
+    await syncAmendmentsAN({
+      zipPath: await buildZip("t2-base.zip", base),
+      legislature: leg,
+      mode: "incremental",
+    });
+
+    const withNew: [string, string][] = [
+      ...base,
+      [entryPath(d2, "TEST_INC_T2_b1"), amendmentJson("TEST_INC_T2_b1", "3", "<p>d2b1</p>")],
+    ];
+    const r = await syncAmendmentsAN({
+      zipPath: await buildZip("t2-new.zip", withNew),
+      legislature: leg,
+      mode: "incremental",
+    });
+
+    expect(r.dossiersInspected).toBe(2);
+    expect(r.dossiersChanged).toBe(1); // only D2
+    expect(r.amendmentsSeen).toBe(1); // only D2's entry was decompressed (D1 skipped)
+    expect(r.amendmentsCreated).toBe(1);
+    const created = await db.amendment.findUnique({ where: { externalId: "TEST_INC_T2_b1" } });
+    expect(created).not.toBeNull();
+  });
+
+  it("[3] existing dossier changed (one entry's content differs): reparsed and updated", async () => {
+    const leg = 93;
+    const dlr = "DLR5L17N93001";
+    const base: [string, string][] = [
+      [entryPath(dlr, "TEST_INC_T3_a1"), amendmentJson("TEST_INC_T3_a1", "1", "<p>original</p>")],
+      [entryPath(dlr, "TEST_INC_T3_a2"), amendmentJson("TEST_INC_T3_a2", "2", "<p>stable</p>")],
+    ];
+    await syncAmendmentsAN({
+      zipPath: await buildZip("t3-base.zip", base),
+      legislature: leg,
+      mode: "incremental",
+    });
+
+    const changed: [string, string][] = [
+      [entryPath(dlr, "TEST_INC_T3_a1"), amendmentJson("TEST_INC_T3_a1", "1", "<p>REWRITTEN</p>")],
+      [entryPath(dlr, "TEST_INC_T3_a2"), amendmentJson("TEST_INC_T3_a2", "2", "<p>stable</p>")],
+    ];
+    const r = await syncAmendmentsAN({
+      zipPath: await buildZip("t3-changed.zip", changed),
+      legislature: leg,
+      mode: "incremental",
+    });
+
+    expect(r.dossiersChanged).toBe(1);
+    expect(r.amendmentsSeen).toBe(2); // whole dossier reparsed
+    expect(r.amendmentsSubstanceChanged).toBe(1);
+    const a1 = await db.amendment.findUnique({ where: { externalId: "TEST_INC_T3_a1" } });
+    expect(a1?.content).toBe("<p>REWRITTEN</p>");
+  });
+
+  it("[5] resume after interruption: sigs not persisted on throw; reprocessed idempotently", async () => {
+    const leg = 95;
+    const dlr = "DLR5L17N95001";
+    const entries: [string, string][] = [
+      [entryPath(dlr, "TEST_INC_T5_a1"), amendmentJson("TEST_INC_T5_a1", "1", "<p>x1</p>")],
+      [entryPath(dlr, "TEST_INC_T5_a2"), amendmentJson("TEST_INC_T5_a2", "2", "<p>x2</p>")],
+    ];
+    const zip = await buildZip("t5.zip", entries);
+
+    // First successful run: rows written + signatures persisted.
+    const r1 = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    expect(r1.amendmentsCreated).toBe(2);
+    const countAfter1 = await db.amendment.count({
+      where: { externalId: { startsWith: "TEST_INC_T5_" } },
+    });
+
+    // Simulate an interrupted run: the on-success signature write (the last DB op)
+    // never happened. Rows remain; the stored baseline is back to empty.
+    await syncMetadata.reset(dossierSignatureKey(leg));
+
+    // Next run reprocesses the same dossier (sigs empty) WITHOUT duplicating rows.
+    const r2 = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    expect(r2.dossiersChanged).toBe(1);
+    expect(r2.amendmentsCreated).toBe(0);
+    expect(r2.amendmentsUnchanged).toBe(2);
+    const countAfter2 = await db.amendment.count({
+      where: { externalId: { startsWith: "TEST_INC_T5_" } },
+    });
+    expect(countAfter2).toBe(countAfter1);
+
+    // A genuine throw leaves the stored signatures untouched (cap fires before
+    // the signature write), so a resume still sees work to do.
+    await syncMetadata.reset(dossierSignatureKey(leg));
+    await expect(
+      syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental", safetyCap: 1 })
+    ).rejects.toThrow(/safety cap/i);
+    expect(await loadStoredDossierSignatures(leg)).toEqual({});
+  });
+
+  it("[6] full resync processes every dossier regardless of stored signatures", async () => {
+    const leg = 96;
+    const d1 = "DLR5L17N96001";
+    const d2 = "DLR5L17N96002";
+    const entries: [string, string][] = [
+      [entryPath(d1, "TEST_INC_T6_a1"), amendmentJson("TEST_INC_T6_a1", "1", "<p>a1</p>")],
+      [entryPath(d1, "TEST_INC_T6_a2"), amendmentJson("TEST_INC_T6_a2", "2", "<p>a2</p>")],
+      [entryPath(d2, "TEST_INC_T6_b1"), amendmentJson("TEST_INC_T6_b1", "3", "<p>b1</p>")],
+    ];
+    const zip = await buildZip("t6.zip", entries);
+
+    // Baseline via incremental so signatures match the feed.
+    await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+
+    // Full mode ignores the matching signatures and still walks every dossier.
+    const r = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "full" });
+    expect(r.dossiersInspected).toBe(2);
+    expect(r.dossiersChanged).toBe(2); // all, despite unchanged signatures
+    expect(r.amendmentsSeen).toBe(3); // every entry processed
+    expect(r.amendmentsUnchanged).toBe(3); // idempotent: no dup writes
+  });
+
+  it("[7] no new content: fast path decompresses nothing", async () => {
+    const leg = 97;
+    const dlr = "DLR5L17N97001";
+    const entries: [string, string][] = [
+      [entryPath(dlr, "TEST_INC_T7_a1"), amendmentJson("TEST_INC_T7_a1", "1", "<p>c1</p>")],
+    ];
+    const zip = await buildZip("t7.zip", entries);
+
+    await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    const r = await syncAmendmentsAN({ zipPath: zip, legislature: leg, mode: "incremental" });
+    expect(r.dossiersChanged).toBe(0);
+    expect(r.amendmentsSeen).toBe(0); // no entry decompressed
+    expect(r.amendmentsCreated).toBe(0);
+    expect(r.amendmentsUpdated).toBe(0);
+  });
+});

--- a/src/services/sync/__tests__/link-scrutins-to-amendments/parse-title.test.ts
+++ b/src/services/sync/__tests__/link-scrutins-to-amendments/parse-title.test.ts
@@ -79,6 +79,29 @@ describe("parseScrutinTitle", () => {
     expect(t.warnings.some((w) => w.code === "SUB_WITHOUT_PARENT")).toBe(true);
   });
 
+  it("reads 'seconde délibération' as deliberation 2", () => {
+    const t = parseScrutinTitle(
+      "l'amendement n° 1 du Gouvernement de rétablissement de l'article 11 (supprimé) (seconde délibération)"
+    );
+    expect(t.deliberation).toBe(2);
+    expect(t.principalNumbers).toEqual(["1"]);
+  });
+
+  it("reads 'première délibération' as deliberation 1", () => {
+    const t = parseScrutinTitle("l'amendement n° 42 du Gouvernement (première délibération)");
+    expect(t.deliberation).toBe(1);
+  });
+
+  it("leaves deliberation null when the title does not mention one", () => {
+    const t = parseScrutinTitle("l'amendement n° 1234 de M. Dupont");
+    expect(t.deliberation).toBeNull();
+  });
+
+  it("detects the délibération accent-insensitively", () => {
+    const t = parseScrutinTitle("l'amendement n° 1 du Gouvernement (seconde deliberation)");
+    expect(t.deliberation).toBe(2);
+  });
+
   it("is deterministic across repeated calls (no shared regex lastIndex bug)", () => {
     const title = "le sous-amendement n° 2368 de M. Potier à l'amendement n° 2058 du Gouvernement";
     const a = parseScrutinTitle(title);

--- a/src/services/sync/__tests__/link-scrutins-to-amendments/resolve.test.ts
+++ b/src/services/sync/__tests__/link-scrutins-to-amendments/resolve.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import type { ParsedTitle } from "@/services/sync/link-scrutins-to-amendments/types";
+import { parseScrutinTitle } from "@/services/sync/link-scrutins-to-amendments/parse-title";
 
 const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 
@@ -15,6 +16,7 @@ const parsedPotier: ParsedTitle = {
   parentAmendmentNumber: "2058",
   hasIdentique: true,
   identiqueNumbers: [],
+  deliberation: null,
   warnings: [],
   confidence: 0.85,
 };
@@ -330,5 +332,244 @@ describeIfDb("dedupeLinks (pure)", () => {
     expect(out).toHaveLength(2);
     expect(out.find((l) => l.amendmentId === "a1")!.role).toBe("PRINCIPAL");
     expect(out.find((l) => l.amendmentId === "a2")!.role).toBe("SUB_AMENDMENT");
+  });
+});
+
+/**
+ * Délibération-aware fallback for the ambiguous same-number case: on a dossier
+ * where numbers 1 and 2 exist in BOTH première (D1) and seconde (D2)
+ * délibération, a plain (dossier, number) match is ambiguous and fails closed.
+ * The fallback disambiguates using the délibération cited in the title and the
+ * D1/D2 marker in the amendment uid. Mirrors the V8428 / V8429 shape (no
+ * externalId hardcoded — the marker is generic).
+ */
+describeIfDb("resolveLinks — délibération-aware fallback", () => {
+  const DLR_EXT = "TEST_DELIB_DLR";
+  const AMEND_PFX = "TEST_DELIB_A_";
+  const SCRUTIN_PFX = "TEST_DELIB_S_";
+
+  // externalIds carry the P0D1N / P0D2N marker the resolver reads.
+  const GOV1_D1 = `${AMEND_PFX}gov1_P0D1N`;
+  const GOV1_D2 = `${AMEND_PFX}gov1_P0D2N`;
+  const GOULET2_D1 = `${AMEND_PFX}goulet2_P0D1N`;
+  const GOULET2_D2 = `${AMEND_PFX}goulet2_P0D2N`;
+  const N8A_D1 = `${AMEND_PFX}n8a_P0D1N`;
+  const N8B_D1 = `${AMEND_PFX}n8b_P0D1N`;
+  const N9A_D2 = `${AMEND_PFX}n9a_P0D2N`;
+  const N9B_D2 = `${AMEND_PFX}n9b_P0D2N`;
+
+  let dossierId: string;
+  let idByExt: Map<string, string>;
+
+  async function makeScrutin(suffix: string, title: string) {
+    return db.scrutin.create({
+      data: {
+        externalId: `${SCRUTIN_PFX}${suffix}`,
+        title,
+        votingDate: new Date("2026-05-22T10:00:00Z"),
+        legislature: 17,
+        chamber: "AN",
+        votesFor: 1,
+        votesAgainst: 0,
+        votesAbstain: 0,
+        result: "ADOPTED",
+        dossierLegislatifId: dossierId,
+      },
+    });
+  }
+
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ resolveLinks } = await import("@/services/sync/link-scrutins-to-amendments/resolve"));
+
+    await db.scrutinAmendment.deleteMany({
+      where: { scrutin: { externalId: { startsWith: SCRUTIN_PFX } } },
+    });
+    await db.scrutin.deleteMany({ where: { externalId: { startsWith: SCRUTIN_PFX } } });
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: AMEND_PFX } } });
+    await db.legislativeDossier.deleteMany({ where: { externalId: DLR_EXT } });
+
+    const dossier = await db.legislativeDossier.create({
+      data: {
+        externalId: DLR_EXT,
+        slug: "test-delib-dossier",
+        title: "Test délibération dossier",
+        status: "EN_COURS",
+      },
+    });
+    dossierId = dossier.id;
+
+    await db.amendment.createMany({
+      data: [
+        // number 1 in D1 and D2, both Government (mirror V8429's target)
+        {
+          externalId: GOV1_D1,
+          number: "1",
+          dossierId,
+          status: "ADOPTE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Gouvernement",
+          authorName: "Gouvernement",
+        },
+        {
+          externalId: GOV1_D2,
+          number: "1",
+          dossierId,
+          status: "ADOPTE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Gouvernement",
+          authorName: "Gouvernement",
+        },
+        // number 2 in D1 and D2, both by Mme Perrine Goulet (mirror V8428's target)
+        {
+          externalId: GOULET2_D1,
+          number: "2",
+          dossierId,
+          status: "ADOPTE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "Mme Perrine Goulet",
+        },
+        {
+          externalId: GOULET2_D2,
+          number: "2",
+          dossierId,
+          status: "ADOPTE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "Mme Perrine Goulet",
+        },
+        // number 8 only in D1 (twice) — a seconde-délib vote for it must refuse
+        {
+          externalId: N8A_D1,
+          number: "8",
+          dossierId,
+          status: "DEPOSE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "M. A",
+        },
+        {
+          externalId: N8B_D1,
+          number: "8",
+          dossierId,
+          status: "DEPOSE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "M. B",
+        },
+        // number 9 twice in D2 — still ambiguous after délibération filter
+        {
+          externalId: N9A_D2,
+          number: "9",
+          dossierId,
+          status: "DEPOSE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "M. C",
+        },
+        {
+          externalId: N9B_D2,
+          number: "9",
+          dossierId,
+          status: "DEPOSE",
+          legislature: 17,
+          chamber: "AN",
+          authorType: "Individuel",
+          authorName: "M. D",
+        },
+      ],
+    });
+
+    const rows = await db.amendment.findMany({
+      where: { externalId: { startsWith: AMEND_PFX } },
+      select: { id: true, externalId: true },
+    });
+    idByExt = new Map(rows.map((r) => [r.externalId, r.id]));
+  });
+
+  afterAll(async () => {
+    await db.scrutinAmendment.deleteMany({
+      where: { scrutin: { externalId: { startsWith: SCRUTIN_PFX } } },
+    });
+    await db.scrutin.deleteMany({ where: { externalId: { startsWith: SCRUTIN_PFX } } });
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: AMEND_PFX } } });
+    await db.legislativeDossier.deleteMany({ where: { externalId: DLR_EXT } });
+  });
+
+  it("POSITIVE: a seconde-délibération Government principal resolves to the D2 amendment (V8429 shape)", async () => {
+    const title =
+      "l'amendement n° 1 du Gouvernement de rétablissement de l'article 11 (supprimé) (seconde délibération)";
+    const scrutin = await makeScrutin("gov", title);
+    const res = await resolveLinks(scrutin, parseScrutinTitle(title));
+
+    expect(res.scope).toBe("dossier");
+    const principal = res.links.filter((l) => l.role === "PRINCIPAL");
+    expect(principal).toHaveLength(1);
+    expect(principal[0]!.amendmentId).toBe(idByExt.get(GOV1_D2));
+    expect(principal[0]!.parserWarnings.some((w) => w.code === "DELIBERATION_DISAMBIGUATED")).toBe(
+      true
+    );
+    expect(res.warnings.some((w) => w.code === "AMBIGUOUS_CANDIDATES")).toBe(false);
+  });
+
+  it("POSITIVE: a seconde-délibération sous-amendement resolves sub + Government parent to their D2 amendments (V8428 shape)", async () => {
+    const title =
+      "le sous-amendement n° 2 de Mme Perrine Goulet à l'amendement n° 1 du Gouvernement de rétablissement de l'article 11 (supprimé) (seconde délibération)";
+    const scrutin = await makeScrutin("sub", title);
+    const res = await resolveLinks(scrutin, parseScrutinTitle(title));
+
+    expect(res.scope).toBe("dossier");
+    const sub = res.links.find((l) => l.role === "SUB_AMENDMENT");
+    const parent = res.links.find((l) => l.role === "PARENT_AMENDMENT");
+    expect(sub?.amendmentId).toBe(idByExt.get(GOULET2_D2));
+    expect(parent?.amendmentId).toBe(idByExt.get(GOV1_D2));
+    expect(res.warnings.some((w) => w.code === "AMBIGUOUS_CANDIDATES")).toBe(false);
+  });
+
+  it("NEGATIVE (a): ambiguous same-number candidates with NO délibération in the title still refuse", async () => {
+    const title = "l'amendement n° 1 du Gouvernement de rétablissement de l'article 11 (supprimé)";
+    const scrutin = await makeScrutin("nodelib", title);
+    const parsed = parseScrutinTitle(title);
+    expect(parsed.deliberation).toBeNull();
+
+    const res = await resolveLinks(scrutin, parsed);
+    expect(res.warnings.some((w) => w.code === "AMBIGUOUS_CANDIDATES")).toBe(true);
+    expect(res.links.filter((l) => l.role === "PRINCIPAL")).toHaveLength(0);
+  });
+
+  it("NEGATIVE (b): a seconde-délibération vote whose D2 candidate is absent refuses (no D1 fallback)", async () => {
+    const title = "l'amendement n° 8 (seconde délibération)";
+    const scrutin = await makeScrutin("d2absent", title);
+    const res = await resolveLinks(scrutin, parseScrutinTitle(title));
+
+    expect(res.warnings.some((w) => w.code === "AMBIGUOUS_CANDIDATES")).toBe(true);
+    expect(res.links.filter((l) => l.role === "PRINCIPAL")).toHaveLength(0);
+  });
+
+  it("NEGATIVE (c): two D2 candidates sharing the number stay ambiguous and refuse", async () => {
+    const title = "l'amendement n° 9 (seconde délibération)";
+    const scrutin = await makeScrutin("twoD2", title);
+    const res = await resolveLinks(scrutin, parseScrutinTitle(title));
+
+    expect(res.warnings.some((w) => w.code === "AMBIGUOUS_CANDIDATES")).toBe(true);
+    expect(res.links.filter((l) => l.role === "PRINCIPAL")).toHaveLength(0);
+  });
+});
+
+describeIfDb("amendmentDeliberation (pure)", () => {
+  it("reads D1 / D2 from the uid marker and null when absent", async () => {
+    const { amendmentDeliberation } =
+      await import("@/services/sync/link-scrutins-to-amendments/resolve");
+    expect(amendmentDeliberation("AMANR5L17PO838901B3018P0D2N000002")).toBe(2);
+    expect(amendmentDeliberation("AMANR5L17PO838901B3018P0D1N000001")).toBe(1);
+    expect(amendmentDeliberation("AMANR5L17PO838901B3018N000001")).toBeNull();
   });
 });

--- a/src/services/sync/amendments-an.ts
+++ b/src/services/sync/amendments-an.ts
@@ -14,6 +14,11 @@ import {
   resolveIdenticalGroups,
 } from "./amendments-an/writer";
 import { loadFeedState, saveFeedState } from "./amendments-an/feed-state";
+import { scanCentralDirectory } from "./amendments-an/dossier-index";
+import {
+  loadStoredDossierSignatures,
+  saveStoredDossierSignatures,
+} from "./amendments-an/signature-store";
 import { markPolicyTitlesForSubstanceDrift } from "./mark-policy-titles-substance-drift";
 import type {
   NormalizedAmendment,
@@ -25,6 +30,8 @@ import type {
 
 function emptyStats(warnings: SyncWarning[]): SyncAmendmentsANStats {
   return {
+    dossiersInspected: 0,
+    dossiersChanged: 0,
     amendmentsSeen: 0,
     amendmentsCreated: 0,
     amendmentsUpdated: 0,
@@ -54,6 +61,7 @@ export async function syncAmendmentsAN(
   const started = Date.now();
   const legislature = opts.legislature ?? 17;
   const batchSize = opts.batchSize ?? 500;
+  const mode = opts.mode ?? "incremental";
   const warnings: SyncWarning[] = [];
   const stats = emptyStats(warnings);
 
@@ -98,6 +106,40 @@ export async function syncAmendmentsAN(
     }
   }
 
+  // --- Central-directory diff (cheap: reads metadata only, no decompression) ---
+  // Signature each dossier from the ZIP central directory, then decide which to
+  // parse. The fail-loud safety cap is enforced here against the TOTAL number of
+  // entries seen during the scan — never a silent truncation.
+  const scan = await scanCentralDirectory(zipPath!);
+  const current = scan.signatures;
+  stats.dossiersInspected = current.size;
+
+  if (opts.safetyCap !== undefined && scan.entriesInspected > opts.safetyCap) {
+    throw new Error(
+      `[amendments] corpus exceeds safety cap (${opts.safetyCap} entries): refusing to ` +
+        `truncate silently. Raise POLICY_TITLE_AMENDMENTS_SAFETY_CAP or investigate feed growth.`
+    );
+  }
+
+  // Full mode parses every entry and re-baselines the signatures. Incremental
+  // mode diffs against the last successful run and parses only new/changed
+  // dossiers, skipping the rest before any decompression via `entryFilter`.
+  let entryFilter: ((entryPath: string) => boolean) | undefined;
+  if (mode === "full") {
+    stats.dossiersChanged = current.size;
+  } else {
+    const stored = opts.dryRun ? {} : await loadStoredDossierSignatures(legislature);
+    const changed = new Set<string>();
+    for (const [ref, sig] of current) {
+      if (stored[ref] !== sig) changed.add(ref);
+    }
+    stats.dossiersChanged = changed.size;
+    entryFilter = (entryPath: string): boolean => {
+      const ref = dossierRefFromEntryPath(entryPath);
+      return ref !== null && changed.has(ref);
+    };
+  }
+
   // Light projection only: the resolve passes below read just these three
   // fields, so we never retain the heavy content/summary HTML for the whole
   // ~123k-entry pass. `batch` still holds full rows but is flushed every
@@ -134,14 +176,12 @@ export async function syncAmendmentsAN(
   };
 
   try {
-    for await (const entry of iterateZipJsonEntries(zipPath!, { limit: opts.limit, onWarning })) {
+    for await (const entry of iterateZipJsonEntries(zipPath!, {
+      limit: opts.limit,
+      onWarning,
+      entryFilter,
+    })) {
       stats.amendmentsSeen++;
-      if (opts.safetyCap !== undefined && stats.amendmentsSeen > opts.safetyCap) {
-        throw new Error(
-          `[amendments] corpus exceeds safety cap (${opts.safetyCap} entries): refusing to ` +
-            `truncate silently. Raise POLICY_TITLE_AMENDMENTS_SAFETY_CAP or investigate feed growth.`
-        );
-      }
       const dossierRefFromPath = dossierRefFromEntryPath(entry.entryPath);
       const texteRefFromPath = texteRefFromEntryPath(entry.entryPath);
       const n = normalizeAmendment(entry.json, {
@@ -195,6 +235,13 @@ export async function syncAmendmentsAN(
         lastSuccessfulSyncAt: new Date().toISOString(),
       });
     }
+
+    // Re-baseline the per-dossier signatures on success (both modes). Writing
+    // only here — after the resolve passes — means an interrupted run leaves the
+    // stored baseline untouched, so the next run reprocesses the same dossiers.
+    if (!opts.dryRun) {
+      await saveStoredDossierSignatures(legislature, current);
+    }
   } finally {
     if (tmpDir && !usingProvidedZip && existsSync(tmpDir)) {
       rmSync(tmpDir, { recursive: true, force: true });
@@ -205,7 +252,9 @@ export async function syncAmendmentsAN(
   stats.writeMs = writeMs;
   stats.peakRssMb = Math.round(peakRss / 1048576);
   stats.durationMs = Date.now() - started;
-  console.info("[amendments] full pass", {
+  console.info(`[amendments] ${mode} pass`, {
+    dossiersInspected: stats.dossiersInspected,
+    dossiersChanged: stats.dossiersChanged,
     seen: stats.amendmentsSeen,
     created: stats.amendmentsCreated,
     updated: stats.amendmentsUpdated,

--- a/src/services/sync/amendments-an/dossier-index.ts
+++ b/src/services/sync/amendments-an/dossier-index.ts
@@ -1,0 +1,78 @@
+import crypto from "node:crypto";
+import yauzl from "yauzl";
+import { dossierRefFromEntryPath } from "./zip-iterator";
+
+export interface CentralDirectoryScan {
+  /** sha1-hex content signature per dossier ref (order-independent). */
+  signatures: Map<string, string>;
+  /** Total `.json` entries enumerated (used for the fail-loud safety cap). */
+  entriesInspected: number;
+}
+
+/**
+ * Reads ONLY the ZIP central directory (no decompression) and derives a
+ * deterministic content signature per dossier ref.
+ *
+ * yauzl parses the whole central directory at open time; enumerating entries
+ * with `readEntry()` (and never calling `openReadStream`) exposes each entry's
+ * `fileName`, `crc32` and `uncompressedSize` without inflating any bytes. This
+ * stays cheap even on the ~283 MB / ~123k-entry AN feed.
+ *
+ * Per dossier we collect `fileName:crc32:uncompressedSize` for each of its
+ * `.json` entries, sort them (so ZIP entry order does not matter), join and
+ * sha1-hash. crc32 and uncompressedSize are both functions of the uncompressed
+ * content, so two runs of the same feed produce identical signatures and any
+ * changed entry changes exactly its dossier's signature.
+ */
+export async function scanCentralDirectory(zipPath: string): Promise<CentralDirectoryScan> {
+  const perDossier = new Map<string, string[]>();
+  let entriesInspected = 0;
+
+  const zipfile = await new Promise<yauzl.ZipFile>((resolve, reject) => {
+    yauzl.open(zipPath, { lazyEntries: true, autoClose: false }, (err, zf) => {
+      if (err || !zf) return reject(err ?? new Error("yauzl: no zipfile"));
+      resolve(zf);
+    });
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onEntry = (entry: yauzl.Entry) => {
+        const name = entry.fileName;
+        // Skip directory records; only .json entries carry amendment content.
+        if (!name.endsWith("/") && name.endsWith(".json")) {
+          entriesInspected++;
+          const ref = dossierRefFromEntryPath(name);
+          if (ref) {
+            const parts = perDossier.get(ref) ?? [];
+            parts.push(`${name}:${entry.crc32}:${entry.uncompressedSize}`);
+            perDossier.set(ref, parts);
+          }
+        }
+        zipfile.readEntry();
+      };
+      zipfile.on("entry", onEntry);
+      zipfile.on("end", () => resolve());
+      zipfile.on("error", reject);
+      zipfile.readEntry();
+    });
+  } finally {
+    zipfile.close();
+  }
+
+  const signatures = new Map<string, string>();
+  for (const [ref, parts] of perDossier) {
+    parts.sort();
+    signatures.set(ref, crypto.createHash("sha1").update(parts.join("\n")).digest("hex"));
+  }
+  return { signatures, entriesInspected };
+}
+
+/**
+ * Public API: per-dossier content signatures from the ZIP central directory.
+ * Thin wrapper over {@link scanCentralDirectory} for callers that only need the
+ * signature map (the incremental diff and its tests).
+ */
+export async function readDossierSignatures(zipPath: string): Promise<Map<string, string>> {
+  return (await scanCentralDirectory(zipPath)).signatures;
+}

--- a/src/services/sync/amendments-an/signature-store.ts
+++ b/src/services/sync/amendments-an/signature-store.ts
@@ -1,0 +1,36 @@
+import { syncMetadata } from "@/lib/sync";
+
+/**
+ * Per-dossier signatures from the last SUCCESSFUL amendment ingestion, persisted
+ * so the next run can diff the ZIP against it and parse only changed dossiers.
+ *
+ * Stored as a dedicated SyncMetadata row (no schema migration): the
+ * `Record<dossierRef, sha1>` lives in the `extra` JSON bag. A few thousand short
+ * hashes is ~200 KB of JSON, acceptable for a single row.
+ */
+export const dossierSignatureKey = (legislature: number) => `amendments-dossier-sig:${legislature}`;
+
+/** Read the stored signatures. Returns an empty record when none persisted yet. */
+export async function loadStoredDossierSignatures(
+  legislature: number
+): Promise<Record<string, string>> {
+  const state = await syncMetadata.get(dossierSignatureKey(legislature));
+  const extra = state?.extra;
+  if (!extra || typeof extra !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [ref, sig] of Object.entries(extra as Record<string, unknown>)) {
+    if (typeof sig === "string") out[ref] = sig;
+  }
+  return out;
+}
+
+/** Persist the current signatures as the new baseline (call only on success). */
+export async function saveStoredDossierSignatures(
+  legislature: number,
+  signatures: Map<string, string>
+): Promise<void> {
+  await syncMetadata.set(dossierSignatureKey(legislature), {
+    itemCount: signatures.size,
+    extra: Object.fromEntries(signatures),
+  });
+}

--- a/src/services/sync/amendments-an/types.ts
+++ b/src/services/sync/amendments-an/types.ts
@@ -31,6 +31,13 @@ export type AmendmentResolveRef = Pick<
 
 export interface SyncAmendmentsANOptions {
   legislature?: number; // default 17
+  /**
+   * "incremental" (default): diff the ZIP central directory against the last
+   * successful run's per-dossier signatures and parse/write only new or changed
+   * dossiers. "full": parse/write every entry (manual resync) and re-baseline
+   * the stored signatures.
+   */
+  mode?: "incremental" | "full";
   dryRun?: boolean; // parse + report, no DB writes
   limit?: number; // debug/sample only: truncates silently — not for production runs
   safetyCap?: number; // hard ceiling: throw (do NOT truncate) if entries exceed this
@@ -61,6 +68,8 @@ export interface PolicyTitleSubstanceDriftResult {
 export interface SyncAmendmentsANStats {
   notModified?: boolean; // true when feed-state returned 304 and the run short-circuited
   downloadedBytes?: number; // bytes written to disk this run (0 when notModified or zipPath used)
+  dossiersInspected?: number; // distinct dossiers found in the ZIP central directory
+  dossiersChanged?: number; // dossiers whose signature differed (parsed this run); == inspected in full mode
   amendmentsSeen: number;
   amendmentsCreated: number;
   amendmentsUpdated: number; // amendmentsSubstanceChanged + amendmentsMetadataOnly

--- a/src/services/sync/amendments-an/zip-iterator.ts
+++ b/src/services/sync/amendments-an/zip-iterator.ts
@@ -14,6 +14,12 @@ export interface IterateOptions {
   limit?: number;
   /** Called for entries that cannot be parsed; the iterator never silently drops data. */
   onWarning?: (w: ZipEntryWarning) => void;
+  /**
+   * Pure predicate evaluated on the entry path BEFORE any decompression. When it
+   * returns false the entry is skipped without inflating its bytes — this is what
+   * lets the incremental ingest avoid parsing unchanged dossiers.
+   */
+  entryFilter?: (entryPath: string) => boolean;
 }
 
 /**
@@ -68,6 +74,8 @@ export async function* iterateZipJsonEntries(
 
       if (entry === null) break;
       if (entry.fileName.endsWith("/") || !entry.fileName.endsWith(".json")) continue;
+      // Skip filtered entries before opening a read stream: no decompression cost.
+      if (opts.entryFilter && !opts.entryFilter(entry.fileName)) continue;
 
       const buf = await new Promise<Buffer>((resolve, reject) => {
         zipfile.openReadStream(entry, (err, stream) => {

--- a/src/services/sync/link-scrutins-to-amendments/parse-title.ts
+++ b/src/services/sync/link-scrutins-to-amendments/parse-title.ts
@@ -30,6 +30,19 @@ const PRINCIPAL_RE = new RegExp(
 const IDENTIQUE_RE = /amendements?\s+identiques?|identique\s+suivant/i;
 const ENUMERATED_RE = new RegExp(String.raw`(${NUMBER_RE})\s+et\s+(?:n°?\s*)?(${NUMBER_RE})`, "i");
 
+/**
+ * Detects the délibération cited in the title. Accent-insensitive: diacritics
+ * are stripped first so "seconde délibération" and "seconde deliberation" both
+ * match. An unspecified title is an ordinary première-délibération vote (null).
+ */
+const DIACRITICS_RE = new RegExp("[\\u0300-\\u036f]", "g");
+function detectDeliberation(title: string): 1 | 2 | null {
+  const norm = title.normalize("NFD").replace(DIACRITICS_RE, "");
+  if (/seconde\s+deliberation/i.test(norm)) return 2;
+  if (/premiere\s+deliberation/i.test(norm)) return 1;
+  return null;
+}
+
 export function parseScrutinTitle(title: string): ParsedTitle {
   const warnings: ParserWarning[] = [];
   let confidence = 1.0;
@@ -91,6 +104,7 @@ export function parseScrutinTitle(title: string): ParsedTitle {
     parentAmendmentNumber,
     hasIdentique,
     identiqueNumbers,
+    deliberation: detectDeliberation(title),
     warnings,
     confidence: Math.max(0, confidence),
   };

--- a/src/services/sync/link-scrutins-to-amendments/resolve.ts
+++ b/src/services/sync/link-scrutins-to-amendments/resolve.ts
@@ -10,6 +10,57 @@ export interface ScrutinForLink {
   dossierLegislatifId: string | null;
 }
 
+/**
+ * Reads the délibération an amendment belongs to from its AN uid. The uid
+ * carries a `P0D1N`/`P0D2N` marker: D1 = première délibération, D2 = seconde.
+ * Returns null when no such marker is present (fail closed — the caller then
+ * cannot disambiguate on this candidate).
+ */
+export function amendmentDeliberation(externalId: string): 1 | 2 | null {
+  const m = /P0D([12])N/.exec(externalId);
+  if (!m) return null;
+  return m[1] === "2" ? 2 : 1;
+}
+
+/** True when the amendment is authored by the Government. */
+function isGovernmentAuthor(a: { authorType: string | null; authorName: string | null }): boolean {
+  return a.authorType?.toLowerCase() === "gouvernement" || /gouvernement/i.test(a.authorName ?? "");
+}
+
+/**
+ * Whether the title attributes THIS specific amendment number to the Government
+ * (e.g. "l'amendement n° 1 du Gouvernement"). Scoped to the number so a
+ * sous-amendement by a named MP citing a Government parent (e.g. "le
+ * sous-amendement n° 2 de Mme X à l'amendement n° 1 du Gouvernement") only
+ * flags number 1, never number 2.
+ */
+function titleAttributesNumberToGovernment(title: string, number: string): boolean {
+  const escaped = number.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`n[°o]\\s*${escaped}\\s+du\\s+gouvernement`, "i").test(title);
+}
+
+/**
+ * Deterministic tie-break for a (dossier, number) match that returned more than
+ * one candidate. Keeps only candidates in the cited délibération; when the title
+ * attributes the number to the Government, additionally requires the candidate
+ * be Government-authored. Returns the single survivor or null (0 or >1 left).
+ * Never guesses — a null keeps the resolver's fail-closed AMBIGUOUS behaviour.
+ */
+function disambiguateByDeliberation<
+  T extends {
+    id: string;
+    externalId: string;
+    authorType: string | null;
+    authorName: string | null;
+  },
+>(candidates: T[], deliberation: 1 | 2, requireGovernment: boolean): T | null {
+  const inDeliberation = candidates.filter(
+    (c) => amendmentDeliberation(c.externalId) === deliberation
+  );
+  const kept = requireGovernment ? inDeliberation.filter(isGovernmentAuthor) : inDeliberation;
+  return kept.length === 1 ? kept[0]! : null;
+}
+
 export async function resolveLinks(
   scrutin: ScrutinForLink,
   parsed: ParsedTitle
@@ -47,7 +98,15 @@ export async function resolveLinks(
   const candidates = allNumbers.length
     ? await db.amendment.findMany({
         where: { dossierId: scrutin.dossierLegislatifId, number: { in: allNumbers } },
-        select: { id: true, number: true, identicalGroupKey: true, texteRef: true },
+        select: {
+          id: true,
+          number: true,
+          identicalGroupKey: true,
+          texteRef: true,
+          externalId: true,
+          authorType: true,
+          authorName: true,
+        },
       })
     : [];
   const byNumber = new Map<string, typeof candidates>();
@@ -63,7 +122,15 @@ export async function resolveLinks(
   for (const n of unmatched) {
     const variants = await db.amendment.findMany({
       where: { dossierId: scrutin.dossierLegislatifId, number: { startsWith: `${n} (` } },
-      select: { id: true, number: true, identicalGroupKey: true, texteRef: true },
+      select: {
+        id: true,
+        number: true,
+        identicalGroupKey: true,
+        texteRef: true,
+        externalId: true,
+        authorType: true,
+        authorName: true,
+      },
     });
     if (variants.length > 0) variantsByNumber.set(n, variants);
   }
@@ -83,6 +150,29 @@ export async function resolveLinks(
       continue;
     }
     if (exact.length > 1) {
+      // Ambiguous (dossier, number) match. Only resolvable when the title names
+      // a délibération: same-number amendments in D1 vs D2 are then separated by
+      // their uid marker. Everything else stays fail-closed AMBIGUOUS.
+      if (parsed.deliberation != null) {
+        const requireGovernment =
+          parsed.deliberation === 2 && titleAttributesNumberToGovernment(scrutin.title, number);
+        const picked = disambiguateByDeliberation(exact, parsed.deliberation, requireGovernment);
+        if (picked) {
+          links.push({
+            scrutinId: scrutin.id,
+            amendmentId: picked.id,
+            role,
+            parserConfidence: Math.max(PARSER_FLOOR, confidence - 0.1),
+            parserWarnings: [
+              {
+                code: "DELIBERATION_DISAMBIGUATED",
+                message: `n° ${number} (${role}) resolved to délibération ${parsed.deliberation} candidate ${picked.externalId}${requireGovernment ? " (Government-authored, per title)" : ""}`,
+              },
+            ],
+          });
+          continue;
+        }
+      }
       warnings.push({
         code: "AMBIGUOUS_CANDIDATES",
         message: `Amendment n° ${number} (${role}) has ${exact.length} exact candidates in dossier scope: ${exact.map((c) => c.id).join(", ")}.`,

--- a/src/services/sync/link-scrutins-to-amendments/types.ts
+++ b/src/services/sync/link-scrutins-to-amendments/types.ts
@@ -7,6 +7,15 @@ export interface ParsedTitle {
   parentAmendmentNumber: string | null;
   hasIdentique: boolean;
   identiqueNumbers: string[];
+  /**
+   * Délibération the vote belongs to, read from the title:
+   *   2   -> "seconde délibération"
+   *   1   -> "première délibération"
+   *   null -> unspecified (an ordinary première-délibération vote)
+   * Used to disambiguate a (dossier, number) match when the same amendment
+   * number exists in both the first and the second délibération.
+   */
+  deliberation: 1 | 2 | null;
   warnings: ParserWarning[];
   confidence: number;
 }


### PR DESCRIPTION
Suite du correctif d'ingestion (#489) : rend le cron quotidien durable, robuste aux amendements de seconde délibération, et fiabilise le watchdog. Accompagne le rattrapage de génération des titres (opéré hors PR, voir plus bas).

## B. Cron quotidien durable (ingestion incrémentale par répertoire central)

Le step quotidien re-parsait tout le ZIP (~123k entrées) chaque jour de changement (~45 min mesuré contre prod, bien au-delà du timeout Inngest de 270 s). Désormais :

- `dossier-index.ts` lit le **répertoire central** du ZIP (yauzl, sans décompression) et calcule une signature `crc32:taille` par dossier.
- `syncAmendmentsAN` mode `incremental` (défaut cron) : diffe les signatures vs le dernier run réussi (stockées dans `SyncMetadata`), ne décompresse/écrit que les dossiers nouveaux ou modifiés. Mode `full` conservé pour un resync manuel (`backfill-amendments-ingest.ts --full`).
- Signatures ne dépendent pas de `createdAt` (contenu réel via crc), détectent les dossiers existants modifiés, idempotent (signatures écrites seulement en cas de succès → reprise après interruption), plafond de sécurité fail-loud sur le scan.
- **Mesure (ZIP réel 283 Mo, base jetable locale)** : run 1 (tout) 134 s ; run 2 (feed identique) **25,8 s / 316 Mo**, bien sous 270 s. Un jour sans changement court-circuite en 304 avant même le scan.

## C. Amendements de seconde délibération (fallback déterministe)

Deux scrutins récents (rétablissement art. 11, protection de l'enfance) ne se liaient pas : n° 1/2 existent en 1re ET 2de délibération sur le même dossier, donc l'appariement dossier+numéro était ambigu et refusait (fail-closed). La délibération est encodée dans l'`uid` (`P0D1N` / `P0D2N`). Le fallback : lit « seconde délibération » dans le titre, désambiguïse les candidats par le marqueur D1/D2, vérifie dossier+numéro+délibération (+ auteur Gouvernement quand le titre le précise), lie si unique sinon refuse. Généralisable, borné, testé (positifs + refus). Un `unresolvable` explicite (config, vide) reste possible pour de vrais cas insolubles.

## D. Watchdog fiabilisé

Le signal bloquant porte sur les scrutins réellement liables en excluant un ensemble explicite de cas confirmés insolubles (jamais masqués par l'âge). Une ligne non bloquante distincte remonte les insolubles confirmés et les non-classés ; les trois points d'appel (watchdog, garde in-sync, backfill) partagent le même fragment.

## A. Rattrapage (opéré, hors code de cette PR)

Effectué contre la prod avec l'outillage gardé (scripts `backfill-*`, dry-run par défaut) : corpus amendements complété (123 224), 476 scrutins récents liés + les 2 de seconde délibération via le fallback, 819 titres générés (Mistral, coût réel documenté dans le rapport), auto-approbation HIGH-only, MEDIUM/LOW/NEEDS_REVIEW laissés en DRAFT. Détails chiffrés dans le rapport de session.

## Tests

Suite complète verte, `tsc` 0 erreur. Ajouts : signatures + ingestion incrémentale (8 scénarios : inchangé / nouveau dossier / dossier modifié / ordre non chronologique / reprise / full resync / aucun contenu / plafond), fallback délibération (positifs + refus), exclusion watchdog. Tests DB via le harness Docker jetable.

**Ne pas merger sans CI verte.** Le merge déclenche l'auto-déploiement Vercel.
