### PR TITLE
Lisibilité du détail HATVP déplié : micro-séries, participations, badges (#503)

### DIFF
--- a/src/components/declarations/AnnualRevenueSeries.tsx
+++ b/src/components/declarations/AnnualRevenueSeries.tsx
@@ -1,0 +1,57 @@
+import type { AnnualRevenue } from "@/types/hatvp";
+import {
+  sortRevenuesAsc,
+  sumRevenues,
+  coveredPeriod,
+  formatEuroExact,
+} from "@/lib/declarations/hatvp-display";
+
+// Decorative vertical micro-bars (aria-hidden) + a visible year:amount list
+// (the accessible source of truth, no hover). Heights are normalized WITHIN
+// this series only — never imply cross-line comparability.
+export function AnnualRevenueSeries({ revenues }: { revenues: AnnualRevenue[] }) {
+  const sorted = sortRevenuesAsc(revenues);
+  if (sorted.length === 0) return null;
+  const max = Math.max(...sorted.map((r) => r.amount), 1);
+  const total = sumRevenues(sorted);
+  const period = coveredPeriod(sorted);
+  return (
+    <div className="mt-2">
+      <div className="flex items-end gap-1 h-12" aria-hidden={true}>
+        {sorted.map((r) => (
+          <div key={r.year} className="flex flex-1 flex-col items-center justify-end">
+            <div
+              className="w-full max-w-[28px] rounded-t bg-primary/70"
+              style={{ height: `${Math.round((r.amount / max) * 100)}%` }}
+            />
+            <span className="mt-1 text-[10px] text-muted-foreground">
+              {String(r.year).slice(2)}
+            </span>
+          </div>
+        ))}
+      </div>
+      <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
+        {sorted.map((r) => (
+          <li key={r.year}>
+            <span className="font-medium text-foreground">{r.year}</span> :{" "}
+            {formatEuroExact(r.amount)}
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 text-sm">
+        <span className="font-semibold">Total déclaré sur la période</span>
+        {period && (
+          <span className="text-muted-foreground">
+            {" "}
+            ({period.from} → {period.to})
+          </span>
+        )}{" "}
+        : <span className="font-semibold tabular-nums">{formatEuroExact(total)}</span>
+      </div>
+      <p className="mt-1 text-[11px] text-muted-foreground">
+        Somme des années présentes dans la déclaration ; les hauteurs ne sont comparables qu&apos;au
+        sein de cette ligne.
+      </p>
+    </div>
+  );
+}

--- a/src/components/declarations/DeclarationCard.tsx
+++ b/src/components/declarations/DeclarationCard.tsx
@@ -1,10 +1,17 @@
 import type { DeclarationDetails } from "@/types/hatvp";
-import { HorizontalBars } from "@/components/stats/HorizontalBars";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ChevronRight, Info } from "lucide-react";
 import { DeclarationMetrics } from "./DeclarationMetrics";
 import { DeclarationHistory } from "./DeclarationHistory";
+import { AnnualRevenueSeries } from "./AnnualRevenueSeries";
+import { FinancialParticipations } from "./FinancialParticipations";
+import {
+  displayHatvpText,
+  isEmptyPlaceholder,
+  formatEuroExact,
+} from "@/lib/declarations/hatvp-display";
+import { groupDeclarationLinks, type DeclarationLink } from "@/lib/declarations/declaration-links";
 
 interface DeclarationCardProps {
   id?: string;
@@ -44,38 +51,55 @@ function CollapsibleSection({
   );
 }
 
-function cleanCompanyName(name: string): string {
-  return name.includes("[Données non publiées]") ? "Société (nom non publié)" : name;
+// Sum of every declared annual amount across the items of a section.
+function sectionTotal(items: Array<{ annualRevenues: { amount: number }[] }>): number {
+  return items.reduce((sum, it) => sum + it.annualRevenues.reduce((a, r) => a + r.amount, 0), 0);
 }
 
-const DECLARATION_LABEL: Record<string, string> = {
-  PATRIMOINE_DEBUT_MANDAT: "Patrimoine (début mandat)",
-  PATRIMOINE_FIN_MANDAT: "Patrimoine (fin mandat)",
-  PATRIMOINE_MODIFICATION: "Patrimoine (modification)",
-  INTERETS: "Intérêts",
-};
+function SectionTotal({ items }: { items: Array<{ annualRevenues: { amount: number }[] }> }) {
+  return (
+    <p className="pt-2 mt-1 border-t text-sm">
+      <span className="font-semibold">Total des montants déclarés dans cette section</span> :{" "}
+      <span className="font-semibold tabular-nums">{formatEuroExact(sectionTotal(items))}</span>
+    </p>
+  );
+}
+
+function DeclarationLinkGroup({ title, links }: { title: string; links: DeclarationLink[] }) {
+  if (links.length === 0) return null;
+  return (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground mb-1.5">{title}</p>
+      <div className="flex flex-wrap gap-2">
+        {links.map((l) => (
+          <a key={l.id} href={l.url} target="_blank" rel="noopener noreferrer">
+            <Badge variant="outline" className="hover:bg-accent cursor-pointer">
+              {l.label}
+              {l.isMostRecentYear ? " · année la plus récente" : ""} ↗
+              <span className="sr-only"> (ouvre un nouvel onglet)</span>
+            </Badge>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
   if (declarations.length === 0) return null;
 
-  // Find the latest DIA that has parsed details
+  // Latest DIA that has parsed details drives the metrics + detail sections.
   const latestDIA = declarations.find((d) => d.details !== null);
   const details = latestDIA?.details as DeclarationDetails | null;
 
-  // Build financial participation bars (top 5 by evaluation)
-  const allParticipations =
-    details?.financialParticipations.filter((p) => p.evaluation !== null && p.evaluation > 0) ?? [];
-  const sortedParticipations = [...allParticipations].sort(
-    (a, b) => (b.evaluation ?? 0) - (a.evaluation ?? 0)
-  );
-  const topParticipations = sortedParticipations.slice(0, 5);
-  const remainingParticipations = sortedParticipations.slice(5);
+  const links = groupDeclarationLinks(declarations);
 
-  const participationBars = topParticipations.map((p) => ({
-    label: cleanCompanyName(p.company),
-    value: p.evaluation!,
-    suffix: " €",
-  }));
+  // Collaborators: usable ones shown individually; "Néant"/empty grouped.
+  const usableCollaborators =
+    details?.collaborators.filter((c) => !isEmptyPlaceholder(c.employer)) ?? [];
+  const emptyCollaboratorsCount = (details?.collaborators.length ?? 0) - usableCollaborators.length;
+  const spouse = displayHatvpText(details?.spouseActivity);
+  const collaboratorsCount = (spouse ? 1 : 0) + usableCollaborators.length;
 
   return (
     <Card id={id}>
@@ -118,27 +142,8 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
         )}
 
         {/* Financial participations */}
-        {participationBars.length > 0 && (
-          <div>
-            <HorizontalBars bars={participationBars} title="Participations financières" />
-            {remainingParticipations.length > 0 && (
-              <details className="mt-3">
-                <summary className="cursor-pointer text-sm text-muted-foreground hover:underline">
-                  Voir les {sortedParticipations.length} participations
-                </summary>
-                <div className="pt-2 space-y-2">
-                  {remainingParticipations.map((p, i) => (
-                    <div key={`part-${i}`} className="flex items-center justify-between text-sm">
-                      <span className="mr-2">{cleanCompanyName(p.company)}</span>
-                      <span className="font-mono text-muted-foreground whitespace-nowrap">
-                        {new Intl.NumberFormat("fr-FR").format(p.evaluation!)} €
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </details>
-            )}
-          </div>
+        {details && details.financialParticipations.length > 0 && (
+          <FinancialParticipations participations={details.financialParticipations} />
         )}
 
         {/* Professional activities */}
@@ -149,24 +154,21 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
           >
             {details.professionalActivities.map((activity, i) => (
               <div key={`activity-${i}`} className="text-sm">
-                <div className="font-medium">{activity.description}</div>
-                <div className="text-muted-foreground">{activity.employer}</div>
+                <div className="font-medium">
+                  {displayHatvpText(activity.description) ?? "(non publié)"}
+                </div>
+                {displayHatvpText(activity.employer) && (
+                  <div className="text-muted-foreground">{displayHatvpText(activity.employer)}</div>
+                )}
                 {activity.startDate && (
                   <div className="text-xs text-muted-foreground">
                     {activity.startDate} — {activity.endDate || "en cours"}
                   </div>
                 )}
-                {activity.annualRevenues.length > 0 && (
-                  <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1">
-                    {activity.annualRevenues.map((r) => (
-                      <span key={r.year} className="text-xs font-mono">
-                        {r.year}: {new Intl.NumberFormat("fr-FR").format(r.amount)} €
-                      </span>
-                    ))}
-                  </div>
-                )}
+                <AnnualRevenueSeries revenues={activity.annualRevenues} />
               </div>
             ))}
+            <SectionTotal items={details.professionalActivities} />
           </CollapsibleSection>
         )}
 
@@ -178,23 +180,18 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
           >
             {details.electoralMandates.map((mandate, i) => (
               <div key={`mandate-${i}`} className="text-sm">
-                <div className="font-medium">{mandate.mandate}</div>
+                <div className="font-medium">
+                  {displayHatvpText(mandate.mandate) ?? "(non publié)"}
+                </div>
                 {mandate.startDate && (
                   <div className="text-xs text-muted-foreground">
                     {mandate.startDate} — {mandate.endDate || "en cours"}
                   </div>
                 )}
-                {mandate.annualRevenues.length > 0 && (
-                  <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1">
-                    {mandate.annualRevenues.map((r) => (
-                      <span key={r.year} className="text-xs font-mono">
-                        {r.year}: {new Intl.NumberFormat("fr-FR").format(r.amount)} €
-                      </span>
-                    ))}
-                  </div>
-                )}
+                <AnnualRevenueSeries revenues={mandate.annualRevenues} />
               </div>
             ))}
+            <SectionTotal items={details.electoralMandates} />
           </CollapsibleSection>
         )}
 
@@ -203,42 +200,41 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
           <CollapsibleSection title="Postes de direction" count={details.directorships.length}>
             {details.directorships.map((dir, i) => (
               <div key={`dir-${i}`} className="text-sm">
-                <div className="font-medium">{dir.company}</div>
-                <div className="text-muted-foreground">{dir.role}</div>
+                <div className="font-medium">{displayHatvpText(dir.company) ?? "(non publié)"}</div>
+                {displayHatvpText(dir.role) && (
+                  <div className="text-muted-foreground">{displayHatvpText(dir.role)}</div>
+                )}
                 {dir.startDate && (
                   <div className="text-xs text-muted-foreground">
                     {dir.startDate} — {dir.endDate || "en cours"}
                   </div>
                 )}
-                {dir.annualRevenues.length > 0 && (
-                  <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1">
-                    {dir.annualRevenues.map((r) => (
-                      <span key={r.year} className="text-xs font-mono">
-                        {r.year}: {new Intl.NumberFormat("fr-FR").format(r.amount)} €
-                      </span>
-                    ))}
-                  </div>
-                )}
+                <AnnualRevenueSeries revenues={dir.annualRevenues} />
               </div>
             ))}
+            <SectionTotal items={details.directorships} />
           </CollapsibleSection>
         )}
 
         {/* Spouse & collaborators */}
-        {details && (details.spouseActivity || details.collaborators.length > 0) && (
-          <CollapsibleSection
-            title="Conjoint & collaborateurs"
-            count={(details.spouseActivity ? 1 : 0) + details.collaborators.length}
-          >
-            {details.spouseActivity && (
-              <p className="text-sm text-muted-foreground">{details.spouseActivity}</p>
-            )}
-            {details.collaborators.map((c, i) => (
+        {details && (collaboratorsCount > 0 || emptyCollaboratorsCount > 0) && (
+          <CollapsibleSection title="Conjoint & collaborateurs" count={collaboratorsCount}>
+            {spouse && <p className="text-sm text-muted-foreground">{spouse}</p>}
+            {usableCollaborators.map((c, i) => (
               <div key={`collab-${i}`} className="text-sm">
-                <span className="font-medium">{c.name}</span>
-                <span className="text-muted-foreground"> — {c.employer}</span>
+                <span className="font-medium">{displayHatvpText(c.name) ?? "(non publié)"}</span>
+                <span className="text-muted-foreground">
+                  {" "}
+                  — {displayHatvpText(c.employer) ?? "(non publié)"}
+                </span>
               </div>
             ))}
+            {emptyCollaboratorsCount > 0 && (
+              <p className="text-sm text-muted-foreground">
+                {emptyCollaboratorsCount} collaborateur{emptyCollaboratorsCount > 1 ? "s" : ""}{" "}
+                déclaré{emptyCollaboratorsCount > 1 ? "s" : ""} « Néant » ou sans objet
+              </p>
+            )}
           </CollapsibleSection>
         )}
 
@@ -249,15 +245,10 @@ export function DeclarationCard({ id, declarations }: DeclarationCardProps) {
             .map((d) => ({ id: d.id, year: d.year, details: d.details }))}
         />
 
-        {/* All declaration links */}
-        <div className="flex flex-wrap gap-2 pt-4 border-t">
-          {declarations.map((d) => (
-            <a key={d.id} href={d.pdfUrl ?? d.hatvpUrl} target="_blank" rel="noopener noreferrer">
-              <Badge variant="outline" className="hover:bg-accent cursor-pointer">
-                {DECLARATION_LABEL[d.type] ?? d.type} {d.year} ↗
-              </Badge>
-            </a>
-          ))}
+        {/* Declaration links, grouped by type + sorted */}
+        <div className="space-y-3 pt-4 border-t">
+          <DeclarationLinkGroup title="Intérêts (DIA)" links={links.interets} />
+          <DeclarationLinkGroup title="Patrimoine (préfecture)" links={links.patrimoine} />
         </div>
       </CardContent>
     </Card>

--- a/src/components/declarations/DeclarationHistory.tsx
+++ b/src/components/declarations/DeclarationHistory.tsx
@@ -1,14 +1,9 @@
 import type { DeclarationDetails } from "@/types/hatvp";
+import { formatEuroExact } from "@/lib/declarations/hatvp-display";
 
 export type HistoryDeclaration = { id: string; year: number; details: DeclarationDetails | null };
 
 type StateKind = "value" | "none" | "unknown" | "unavailable";
-
-// Formats a REAL number of declared participations, including "0 €" for a
-// genuine zero. Deliberately NOT formatCompactCurrency (which maps 0 -> "—").
-function formatEuro(value: number): string {
-  return `${new Intl.NumberFormat("fr-FR").format(value)} €`;
-}
 
 // The model distinguishes "no usable evaluation" (totalPortfolioValue === null)
 // from a real zero sum. We never say "non déclaré" when the model can't tell.
@@ -21,7 +16,7 @@ export function declarationHistoryState(details: DeclarationDetails | null): {
   if (parts.length === 0) return { kind: "none", text: "Aucune participation financière déclarée" };
   if (details.totalPortfolioValue === null)
     return { kind: "unknown", text: "Montant non renseigné" };
-  return { kind: "value", text: formatEuro(details.totalPortfolioValue) };
+  return { kind: "value", text: formatEuroExact(details.totalPortfolioValue) };
 }
 
 export function DeclarationHistory({ declarations }: { declarations: HistoryDeclaration[] }) {

--- a/src/components/declarations/DeclarationMetrics.tsx
+++ b/src/components/declarations/DeclarationMetrics.tsx
@@ -37,19 +37,22 @@ export function DeclarationMetrics({
       term: "revenusAnnuels",
     },
     {
-      // Count elective mandates AND directorships (the old "totalDirectorships"
-      // counted directorships only, contradicting the label).
-      value: String(electoralMandatesCount + directorshipsCount),
-      label: "Mandats et fonctions de direction",
+      value: String(electoralMandatesCount),
+      label: "Mandats déclarés",
+      term: "mandatsDirections",
+    },
+    {
+      value: String(directorshipsCount),
+      label: "Fonctions de direction déclarées",
       term: "mandatsDirections",
     },
   ];
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
       {metrics.map((metric) => (
         <div key={metric.label} className="bg-muted/50 rounded-lg p-3">
-          <div className="text-2xl font-bold font-mono">{metric.value}</div>
+          <div className="text-2xl font-bold tabular-nums">{metric.value}</div>
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <span>{metric.label}</span>
             <InfoTooltip term={metric.term} href={HATVP_DI_URL} size="sm" />

--- a/src/components/declarations/FinancialParticipations.tsx
+++ b/src/components/declarations/FinancialParticipations.tsx
@@ -1,0 +1,69 @@
+import type { FinancialParticipation } from "@/types/hatvp";
+import { HorizontalBars } from "@/components/stats/HorizontalBars";
+import { displayHatvpText, formatEuroExact } from "@/lib/declarations/hatvp-display";
+
+const MAX_BARS = 5;
+
+function participationName(company: string): string {
+  return displayHatvpText(company) ?? "Société (nom non publié)";
+}
+
+function Line({ company, evaluation }: FinancialParticipation) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-sm">
+      <span>{participationName(company)}</span>
+      <span className="tabular-nums text-muted-foreground whitespace-nowrap">
+        {evaluation === null ? "Montant non renseigné" : formatEuroExact(evaluation)}
+      </span>
+    </div>
+  );
+}
+
+// Bars only when >= 2 comparable (evaluated) values, so a single value is never
+// a misleading always-full bar. Unevaluated (null) and zero are never dropped.
+export function FinancialParticipations({
+  participations,
+}: {
+  participations: FinancialParticipation[];
+}) {
+  if (participations.length === 0) return null;
+  const evaluated = participations.filter((p) => p.evaluation !== null);
+  const unevaluated = participations.filter((p) => p.evaluation === null);
+
+  if (evaluated.length < 2) {
+    return (
+      <div className="space-y-2">
+        {[...evaluated, ...unevaluated].map((p, i) => (
+          <Line key={`p-${i}`} {...p} />
+        ))}
+      </div>
+    );
+  }
+
+  const sorted = [...evaluated].sort((a, b) => (b.evaluation ?? 0) - (a.evaluation ?? 0));
+  const top = sorted.slice(0, MAX_BARS);
+  const rest = [...sorted.slice(MAX_BARS), ...unevaluated];
+  const bars = top.map((p) => ({
+    label: participationName(p.company),
+    value: p.evaluation as number,
+    suffix: " €",
+  }));
+
+  return (
+    <div>
+      <HorizontalBars bars={bars} title="Participations financières" />
+      {rest.length > 0 && (
+        <details className="mt-3">
+          <summary className="cursor-pointer text-sm text-muted-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            Voir les {participations.length} participations
+          </summary>
+          <div className="pt-2 space-y-2">
+            {rest.map((p, i) => (
+              <Line key={`rest-${i}`} {...p} />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/declarations/__tests__/AnnualRevenueSeries.test.tsx
+++ b/src/components/declarations/__tests__/AnnualRevenueSeries.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AnnualRevenueSeries } from "@/components/declarations/AnnualRevenueSeries";
+
+describe("AnnualRevenueSeries", () => {
+  it("renders one visible year:amount per present year, no gap-filling", () => {
+    render(
+      <AnnualRevenueSeries
+        revenues={[
+          { year: 2017, amount: 39655 },
+          { year: 2019, amount: 71416 },
+        ]}
+      />
+    );
+    expect(screen.getByText("2017")).toBeInTheDocument();
+    expect(screen.getByText("2019")).toBeInTheDocument();
+    expect(screen.queryByText("2018")).toBeNull();
+  });
+
+  it("shows a named period total", () => {
+    render(
+      <AnnualRevenueSeries
+        revenues={[
+          { year: 2017, amount: 39655 },
+          { year: 2019, amount: 71416 },
+        ]}
+      />
+    );
+    expect(screen.getByText(/Total déclaré sur la période/)).toBeInTheDocument();
+    expect(screen.getByText(/111\s?071/)).toBeInTheDocument();
+  });
+
+  it("shows a real zero as 0 €", () => {
+    render(<AnnualRevenueSeries revenues={[{ year: 2020, amount: 0 }]} />);
+    // "0 €" appears both in the year line and the period total (both are 0).
+    expect(screen.getAllByText(/0\s?€/).length).toBeGreaterThan(0);
+  });
+
+  it("renders nothing for empty input", () => {
+    const { container } = render(<AnnualRevenueSeries revenues={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/declarations/__tests__/DeclarationCard.test.tsx
+++ b/src/components/declarations/__tests__/DeclarationCard.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { DeclarationCard } from "@/components/declarations/DeclarationCard";
+import type { DeclarationDetails } from "@/types/hatvp";
+
+const details: DeclarationDetails = {
+  financialParticipations: [
+    {
+      company: "SCI X",
+      evaluation: 616800,
+      shares: null,
+      capitalPercent: null,
+      dividends: null,
+      isBoardMember: false,
+    },
+  ],
+  professionalActivities: [],
+  electoralMandates: [
+    {
+      mandate: "Député",
+      startDate: "2017",
+      endDate: "2024",
+      annualRevenues: [
+        { year: 2017, amount: 39655 },
+        { year: 2018, amount: 72932 },
+      ],
+    },
+  ],
+  directorships: [],
+  spouseActivity: null,
+  collaborators: [
+    { name: "KOTARAC ANDREA", employer: "Néant" },
+    { name: "RIBLE Raphael", employer: "Rassemblement National" },
+  ],
+  totalPortfolioValue: 616800,
+  totalCompanies: 1,
+  latestAnnualIncome: 72932,
+  totalDirectorships: 0,
+};
+
+const declarations = [
+  { id: "d1", type: "INTERETS", year: 2024, hatvpUrl: "H1", pdfUrl: null, details },
+  {
+    id: "d2",
+    type: "PATRIMOINE_DEBUT_MANDAT",
+    year: 2022,
+    hatvpUrl: "H2",
+    pdfUrl: null,
+    details: null,
+  },
+];
+
+function renderCard() {
+  return render(
+    <TooltipProvider>
+      <DeclarationCard declarations={declarations} />
+    </TooltipProvider>
+  );
+}
+
+describe("DeclarationCard (integration)", () => {
+  it("keeps the declarative banner", () => {
+    renderCard();
+    expect(screen.getByText(/Données déclaratives, non auditées/)).toBeInTheDocument();
+  });
+
+  it("shows a single participation as a value line (no bar chart)", () => {
+    renderCard();
+    // "616 800 €" appears in the participation line and in the DIA history row.
+    expect(screen.getAllByText(/616\s?800\s?€/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("shows a named section total", () => {
+    renderCard();
+    expect(screen.getByText(/Total des montants déclarés dans cette section/)).toBeInTheDocument();
+  });
+
+  it("groups empty collaborators and shows usable ones", () => {
+    renderCard();
+    expect(screen.getByText("RIBLE Raphael")).toBeInTheDocument();
+    expect(screen.getByText(/1 collaborateur déclaré « Néant » ou sans objet/)).toBeInTheDocument();
+  });
+
+  it("groups declaration links by type and marks the most recent year", () => {
+    renderCard();
+    expect(screen.getByText("Intérêts (DIA)")).toBeInTheDocument();
+    expect(screen.getByText("Patrimoine (préfecture)")).toBeInTheDocument();
+    expect(screen.getByText(/Intérêts 2024 · année la plus récente/)).toBeInTheDocument();
+    expect(screen.getByText(/Début mandat 2022/)).toBeInTheDocument();
+    expect(screen.getAllByText(/ouvre un nouvel onglet/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/declarations/__tests__/DeclarationMetrics.test.tsx
+++ b/src/components/declarations/__tests__/DeclarationMetrics.test.tsx
@@ -26,17 +26,18 @@ describe("DeclarationMetrics", () => {
     expect(screen.queryByText("Portefeuille total")).toBeNull();
   });
 
-  it("counts mandats + directions, not directorships alone", () => {
+  it("shows separate 'Mandats déclarés' and 'Fonctions de direction déclarées' tiles", () => {
     renderMetrics({
-      totalPortfolioValue: null,
-      totalCompanies: 0,
-      latestAnnualIncome: null,
+      totalPortfolioValue: 617000,
+      totalCompanies: 1,
+      latestAnnualIncome: 124000,
       electoralMandatesCount: 2,
       directorshipsCount: 1,
     });
-    const tile = screen
-      .getByText("Mandats et fonctions de direction")
-      .closest("div")?.parentElement;
-    expect(tile).toHaveTextContent("3");
+    const mandats = screen.getByText("Mandats déclarés").closest("div")?.parentElement;
+    expect(mandats).toHaveTextContent("2");
+    const dir = screen.getByText("Fonctions de direction déclarées").closest("div")?.parentElement;
+    expect(dir).toHaveTextContent("1");
+    expect(screen.queryByText("Mandats et fonctions de direction")).toBeNull();
   });
 });

--- a/src/components/declarations/__tests__/FinancialParticipations.test.tsx
+++ b/src/components/declarations/__tests__/FinancialParticipations.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FinancialParticipations } from "@/components/declarations/FinancialParticipations";
+import type { FinancialParticipation } from "@/types/hatvp";
+
+const p = (company: string, evaluation: number | null): FinancialParticipation => ({
+  company,
+  evaluation,
+  shares: null,
+  capitalPercent: null,
+  dividends: null,
+  isBoardMember: false,
+});
+
+describe("FinancialParticipations", () => {
+  it("renders nothing with no participations", () => {
+    const { container } = render(<FinancialParticipations participations={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("single evaluated: value line, no chart image", () => {
+    render(<FinancialParticipations participations={[p("SCI X", 616800)]} />);
+    expect(screen.getByText(/616\s?800\s?€/)).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("unevaluated participation is kept, shown as 'Montant non renseigné'", () => {
+    render(<FinancialParticipations participations={[p("SCI X", null)]} />);
+    expect(screen.getByText(/Montant non renseigné/)).toBeInTheDocument();
+  });
+
+  it("real zero shows 0 €", () => {
+    render(<FinancialParticipations participations={[p("SCI X", 0)]} />);
+    expect(screen.getByText(/0\s?€/)).toBeInTheDocument();
+  });
+
+  it("two or more evaluated: renders the bar chart", () => {
+    render(<FinancialParticipations participations={[p("A", 100), p("B", 50)]} />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("mixed one evaluated + one null: no chart, both as lines", () => {
+    render(<FinancialParticipations participations={[p("A", 100), p("B", null)]} />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText(/Montant non renseigné/)).toBeInTheDocument();
+    expect(screen.getByText(/100\s?€/)).toBeInTheDocument();
+  });
+});

--- a/src/lib/declarations/__tests__/declaration-links.test.ts
+++ b/src/lib/declarations/__tests__/declaration-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { groupDeclarationLinks } from "@/lib/declarations/declaration-links";
+import type { DeclarationInput } from "@/lib/declarations/declaration-links";
+
+const d = (id: string, type: string, year: number): DeclarationInput => ({
+  id,
+  type,
+  year,
+  hatvpUrl: `https://hatvp/${id}`,
+  pdfUrl: null,
+});
+
+describe("groupDeclarationLinks", () => {
+  it("splits interets/patrimoine, sorts year desc, marks most-recent year", () => {
+    const g = groupDeclarationLinks([
+      d("a", "INTERETS", 2025),
+      d("b", "INTERETS", 2026),
+      d("c", "PATRIMOINE_MODIFICATION", 2026),
+      d("e", "PATRIMOINE_DEBUT_MANDAT", 2025),
+    ]);
+    expect(g.interets.map((l) => l.year)).toEqual([2026, 2025]);
+    expect(g.interets[0]!.isMostRecentYear).toBe(true);
+    expect(g.interets[1]!.isMostRecentYear).toBe(false);
+    expect(g.interets[0]!.label).toBe("Intérêts 2026");
+    expect(g.patrimoine[0]!.label).toBe("Modification 2026");
+  });
+
+  it("deterministic type order at equal year (DEBUT < MODIF < FIN)", () => {
+    const g = groupDeclarationLinks([
+      d("x", "PATRIMOINE_FIN_MANDAT", 2025),
+      d("y", "PATRIMOINE_DEBUT_MANDAT", 2025),
+      d("z", "PATRIMOINE_MODIFICATION", 2025),
+    ]);
+    expect(g.patrimoine.map((l) => l.label)).toEqual([
+      "Début mandat 2025",
+      "Modification 2025",
+      "Fin mandat 2025",
+    ]);
+  });
+
+  it("marks all entries sharing the max year (no single-latest claim)", () => {
+    const g = groupDeclarationLinks([d("a", "INTERETS", 2026), d("b", "INTERETS", 2026)]);
+    expect(g.interets.every((l) => l.isMostRecentYear)).toBe(true);
+  });
+
+  it("uses pdfUrl when present, else hatvpUrl", () => {
+    const g = groupDeclarationLinks([
+      { id: "a", type: "INTERETS", year: 2026, hatvpUrl: "H", pdfUrl: "P" },
+    ]);
+    expect(g.interets[0]!.url).toBe("P");
+  });
+});

--- a/src/lib/declarations/__tests__/hatvp-display.test.ts
+++ b/src/lib/declarations/__tests__/hatvp-display.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  cleanRedactions,
+  isEmptyPlaceholder,
+  displayHatvpText,
+  formatEuroExact,
+  sortRevenuesAsc,
+  sumRevenues,
+  coveredPeriod,
+} from "@/lib/declarations/hatvp-display";
+
+describe("cleanRedactions", () => {
+  it("replaces every redaction token, mid-string too", () => {
+    expect(cleanRedactions("Salarié [Données non publiées] par X [Données non publiées]")).toBe(
+      "Salarié (non publié) par X (non publié)"
+    );
+  });
+});
+
+describe("isEmptyPlaceholder", () => {
+  it("true only when the whole value is a placeholder", () => {
+    expect(isEmptyPlaceholder("Néant")).toBe(true);
+    expect(isEmptyPlaceholder(" néant ")).toBe(true);
+    expect(isEmptyPlaceholder("sans objet")).toBe(true);
+    expect(isEmptyPlaceholder(null)).toBe(true);
+    expect(isEmptyPlaceholder("")).toBe(true);
+  });
+  it("false for a real sentence containing 'néant'", () => {
+    expect(isEmptyPlaceholder("Le risque est néant sur ce mandat")).toBe(false);
+  });
+});
+
+describe("displayHatvpText", () => {
+  it("returns null for empty placeholders, cleans redactions otherwise", () => {
+    expect(displayHatvpText("Néant")).toBeNull();
+    expect(displayHatvpText("[Données non publiées]")).toBe("(non publié)");
+    expect(displayHatvpText("SCI Les Tilleuls")).toBe("SCI Les Tilleuls");
+  });
+});
+
+describe("formatEuroExact", () => {
+  it("keeps 0 € distinct from a dash", () => {
+    expect(formatEuroExact(0)).toBe("0 €");
+    expect(formatEuroExact(617000)).toContain("617");
+    expect(formatEuroExact(617000)).toContain("€");
+  });
+});
+
+describe("revenue helpers", () => {
+  const rev = [
+    { year: 2019, amount: 71416 },
+    { year: 2017, amount: 39655 },
+  ];
+  it("sorts ascending without mutating", () => {
+    const copy = [...rev];
+    expect(sortRevenuesAsc(rev).map((r) => r.year)).toEqual([2017, 2019]);
+    expect(rev).toEqual(copy);
+  });
+  it("sums only present amounts (no missing-as-zero)", () => {
+    expect(sumRevenues(rev)).toBe(111071);
+    expect(sumRevenues([])).toBe(0);
+  });
+  it("covered period from present years", () => {
+    expect(coveredPeriod(rev)).toEqual({ from: 2017, to: 2019 });
+    expect(coveredPeriod([])).toBeNull();
+  });
+});

--- a/src/lib/declarations/declaration-links.ts
+++ b/src/lib/declarations/declaration-links.ts
@@ -1,0 +1,62 @@
+export type DeclarationInput = {
+  id: string;
+  type: string;
+  year: number;
+  hatvpUrl: string;
+  pdfUrl: string | null;
+};
+export type DeclarationLink = {
+  id: string;
+  url: string;
+  label: string;
+  year: number;
+  isMostRecentYear: boolean;
+};
+
+// Explicit, deterministic order for same-year documents (the model has no
+// sub-year date). Mandate life-cycle order.
+const TYPE_RANK: Record<string, number> = {
+  INTERETS: 0,
+  PATRIMOINE_DEBUT_MANDAT: 0,
+  PATRIMOINE_MODIFICATION: 1,
+  PATRIMOINE_FIN_MANDAT: 2,
+};
+const PATRIMOINE_LABEL: Record<string, string> = {
+  PATRIMOINE_DEBUT_MANDAT: "Début mandat",
+  PATRIMOINE_MODIFICATION: "Modification",
+  PATRIMOINE_FIN_MANDAT: "Fin mandat",
+};
+
+function sortGroup(arr: DeclarationInput[]): DeclarationInput[] {
+  return [...arr].sort(
+    (a, b) => b.year - a.year || (TYPE_RANK[a.type] ?? 9) - (TYPE_RANK[b.type] ?? 9)
+  );
+}
+function maxYear(arr: DeclarationInput[]): number | null {
+  return arr.length ? Math.max(...arr.map((d) => d.year)) : null;
+}
+
+export function groupDeclarationLinks(declarations: DeclarationInput[]): {
+  interets: DeclarationLink[];
+  patrimoine: DeclarationLink[];
+} {
+  const interetsRaw = declarations.filter((d) => d.type === "INTERETS");
+  const patrimoineRaw = declarations.filter((d) => d.type.startsWith("PATRIMOINE_"));
+  const iMax = maxYear(interetsRaw);
+  const pMax = maxYear(patrimoineRaw);
+  const interets = sortGroup(interetsRaw).map((d) => ({
+    id: d.id,
+    url: d.pdfUrl ?? d.hatvpUrl,
+    label: `Intérêts ${d.year}`,
+    year: d.year,
+    isMostRecentYear: d.year === iMax,
+  }));
+  const patrimoine = sortGroup(patrimoineRaw).map((d) => ({
+    id: d.id,
+    url: d.pdfUrl ?? d.hatvpUrl,
+    label: `${PATRIMOINE_LABEL[d.type] ?? d.type} ${d.year}`,
+    year: d.year,
+    isMostRecentYear: d.year === pMax,
+  }));
+  return { interets, patrimoine };
+}

--- a/src/lib/declarations/hatvp-display.ts
+++ b/src/lib/declarations/hatvp-display.ts
@@ -1,0 +1,41 @@
+import type { AnnualRevenue } from "@/types/hatvp";
+
+const REDACTED = /\[Données non publiées\]/gi;
+const EMPTY_PLACEHOLDERS = new Set(["néant", "neant", "sans objet", "n/a", "na", ""]);
+
+// Replace HATVP redaction markers wherever they appear (literal tokens, safe mid-string).
+export function cleanRedactions(text: string): string {
+  return text.replace(REDACTED, "(non publié)");
+}
+
+// True only when the ENTIRE value is an empty/absent placeholder. Never matches
+// a "néant" occurring inside a real sentence.
+export function isEmptyPlaceholder(text: string | null | undefined): boolean {
+  if (text == null) return true;
+  return EMPTY_PLACEHOLDERS.has(text.trim().toLowerCase());
+}
+
+export function displayHatvpText(text: string | null | undefined): string | null {
+  if (isEmptyPlaceholder(text)) return null;
+  return cleanRedactions(text as string);
+}
+
+// Exact euro formatting for detail lines: "0 €" for a real zero (never "—").
+export function formatEuroExact(value: number): string {
+  return `${new Intl.NumberFormat("fr-FR").format(value)} €`;
+}
+
+export function sortRevenuesAsc(rev: AnnualRevenue[]): AnnualRevenue[] {
+  return [...rev].sort((a, b) => a.year - b.year);
+}
+
+// Sum of the amounts actually declared; absent years are never treated as zero.
+export function sumRevenues(rev: AnnualRevenue[]): number {
+  return rev.reduce((sum, r) => sum + r.amount, 0);
+}
+
+export function coveredPeriod(rev: AnnualRevenue[]): { from: number; to: number } | null {
+  if (rev.length === 0) return null;
+  const years = rev.map((r) => r.year);
+  return { from: Math.min(...years), to: Math.max(...years) };
+}


### PR DESCRIPTION
Refonte lisibilité du détail HATVP déplié (`DeclarationCard`), suite de #493 (mergée). Une seule PR, sans changement de schéma / ingestion / requête / `DeclarationDetails` / cadrage DIA-DSP.

## Ce que fait cette PR

- **Revenus annuels en micro-séries** (`AnnualRevenueSeries`) : barres verticales décoratives (`aria-hidden`) + liste « année : montant » lisible (source de vérité, sans hover), triée par année croissante, normalisée par ligne, avec un **« Total déclaré sur la période »**. Chaque section affiche un **« Total des montants déclarés dans cette section »**. Les années absentes ne sont jamais comptées comme zéro, et on ne suggère pas que deux lignes sont comparables.
- **Participations financières** (`FinancialParticipations`) : correction du filtre qui écartait silencieusement les participations non évaluées et à 0. Règles : 0 → rien ; < 2 évaluées → lignes valeur (jamais de barre trompeuse) ; ≥ 2 évaluées → barres ; `null` → « Montant non renseigné » ; `0` réel → « 0 € ». Aucune omission.
- **Placeholders** : helper pur `displayHatvpText` appliqué à `company`/`employer`/`name`/`role`/`spouseActivity` ; `[Données non publiées]` → « (non publié) » ; « Néant » traité comme vide **uniquement en valeur entière** (jamais un « néant » dans une phrase). Collaborateurs « Néant » **regroupés** en une ligne compteur ; le badge de section ne compte que les exploitables.
- **Badges** (`declaration-links`) : groupés **Intérêts (DIA)** / **Patrimoine (préfecture)**, triés année desc., ordre déterministe explicite à année égale, marquage **« année la plus récente »** (le modèle n'a pas de date infra-annuelle, donc pas de « dernier publié »), lien externe + « ouvre un nouvel onglet ».
- **Métriques** : scission de « Mandats et fonctions de direction » en **« Mandats déclarés »** + **« Fonctions de direction déclarées »** (5 tuiles, grille `grid-cols-2 lg:grid-cols-5` lisible à 320 px), `tabular-nums` au lieu de `font-mono`. « Sociétés déclarées » conservée.

## Architecture
Helpers purs testés dans `src/lib/declarations/` (`hatvp-display.ts`, `declaration-links.ts`) ; composants `AnnualRevenueSeries` et `FinancialParticipations` dans `src/components/declarations/`. `DeclarationHistory` réutilise le formateur euro partagé (cohérence).

## Tests
36 tests (helpers purs, composants, + un smoke test d'intégration de `DeclarationCard`) : tri/somme/période des revenus, `null` ≠ `0` ≠ absent, participation unique sans barre, non évaluée conservée, nettoyage placeholders et « néant » légitime préservé, regroupement collaborateurs, groupement/tri des badges. `tsc --noEmit` : 0 erreur ; `eslint` : clean.

Refs #503
