### PR TITLE
fix(hatvp): micro-barres visibles + années complètes (#503)

### DIFF
--- a/src/components/declarations/AnnualRevenueSeries.tsx
+++ b/src/components/declarations/AnnualRevenueSeries.tsx
@@ -30,7 +30,7 @@ export function AnnualRevenueSeries({ revenues }: { revenues: AnnualRevenue[] })
                   style={{ height: `${pct}%` }}
                 />
               </div>
-              <span className="text-[10px] text-muted-foreground">{String(r.year).slice(2)}</span>
+              <span className="text-[10px] text-muted-foreground">{r.year}</span>
             </div>
           );
         })}

--- a/src/components/declarations/AnnualRevenueSeries.tsx
+++ b/src/components/declarations/AnnualRevenueSeries.tsx
@@ -17,18 +17,23 @@ export function AnnualRevenueSeries({ revenues }: { revenues: AnnualRevenue[] })
   const period = coveredPeriod(sorted);
   return (
     <div className="mt-2">
-      <div className="flex items-end gap-1 h-12" aria-hidden={true}>
-        {sorted.map((r) => (
-          <div key={r.year} className="flex flex-1 flex-col items-center justify-end">
-            <div
-              className="w-full max-w-[28px] rounded-t bg-primary/70"
-              style={{ height: `${Math.round((r.amount / max) * 100)}%` }}
-            />
-            <span className="mt-1 text-[10px] text-muted-foreground">
-              {String(r.year).slice(2)}
-            </span>
-          </div>
-        ))}
+      <div className="flex items-end gap-1" aria-hidden={true}>
+        {sorted.map((r) => {
+          // A real 0 collapses to no bar; non-zero gets a small floor so it
+          // stays visible. Percent resolves against the fixed-height track.
+          const pct = r.amount === 0 ? 0 : Math.max(8, Math.round((r.amount / max) * 100));
+          return (
+            <div key={r.year} className="flex flex-1 flex-col items-center gap-1">
+              <div className="flex h-10 w-full items-end justify-center">
+                <div
+                  className="w-full max-w-[28px] rounded-t bg-primary/70"
+                  style={{ height: `${pct}%` }}
+                />
+              </div>
+              <span className="text-[10px] text-muted-foreground">{String(r.year).slice(2)}</span>
+            </div>
+          );
+        })}
       </div>
       <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
         {sorted.map((r) => (

--- a/src/components/declarations/__tests__/AnnualRevenueSeries.test.tsx
+++ b/src/components/declarations/__tests__/AnnualRevenueSeries.test.tsx
@@ -12,9 +12,10 @@ describe("AnnualRevenueSeries", () => {
         ]}
       />
     );
-    expect(screen.getByText("2017")).toBeInTheDocument();
-    expect(screen.getByText("2019")).toBeInTheDocument();
-    expect(screen.queryByText("2018")).toBeNull();
+    // Full year appears under the bar and in the readable list.
+    expect(screen.getAllByText("2017").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2019").length).toBeGreaterThan(0);
+    expect(screen.queryByText("2018")).toBeNull(); // absent year is never invented
   });
 
   it("shows a named period total", () => {


### PR DESCRIPTION
Correctifs visuels validés qui manquaient à #504 (leurs pushes avaient échoué silencieusement, la PR n'a mergé que le commit de base).

- Micro-barres de revenus rendues visibles (le `height: %` se résolvait à 0 faute de parent à hauteur définie → piste `h-10`).
- Année complète (2021…) sous les barres au lieu de « 21 ».

Vérifié : rendu confirmé à l'écran (dark), source `tsc` 0, tests verts.

Refs #503