### PR TITLE
fix(policy-titles): polarité inversée sur amendements de suppression

### DIFF
--- a/scripts/backfill-regen-suppression-titles.ts
+++ b/scripts/backfill-regen-suppression-titles.ts
@@ -1,0 +1,142 @@
+/**
+ * User-accord-gated: regenerate the policy titles of "de suppression" scrutins
+ * with the polarity-fixed prompt (policy-title-v3) + the suppression-polarity
+ * validator.
+ *
+ * Why a dedicated driver: the normal backlog generator only picks UNTITLED
+ * scrutins, but the suppression population is already titled. This forces an
+ * in-place regeneration (force: true → overwrite + "regenerated" revision) for a
+ * scoped, id-based selection.
+ *
+ * Scope: legislature 17 / AN scrutins whose official title carries "de
+ * suppression", that are linked, whose policy row is APPROVED / NEEDS_REVIEW /
+ * STALE (REJECTED rows are human decisions, left untouched), and whose title was
+ * NOT already regenerated at the current prompt version (so re-running is
+ * resumable and never double-spends). V4000 is EXCLUDED: it is a mislink (its
+ * linked amendment is a DGF revaluation on another article, not a suppression),
+ * reported separately, not a polarity case.
+ *
+ * Cost guard: same Mistral token meter + hard-stop (default €15) as the backlog
+ * driver. Regenerates in bounded id-chunks; projects full-scope cost after each
+ * chunk and STOPS if it exceeds the ceiling.
+ *
+ * Writes DRAFT / NEEDS_REVIEW rows only (never approves). Approval is a separate,
+ * HIGH-only step (backfill-approve-high.ts).
+ */
+import { generateScrutinPolicyTitles } from "@/services/sync/generate-scrutin-policy-titles";
+import { PROMPT_VERSION } from "@/services/scrutin-policy-title/prompt";
+import { getMistralTokensUsed, resetMistralTokensUsed } from "@/lib/api/mistral";
+import { db } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma";
+
+const CHUNK = Number(process.env.GEN_CHUNK ?? "25");
+const EUR_PER_1M = Number(process.env.MISTRAL_EUR_PER_1M ?? "3"); // conservative blended large-latest
+const HARD_STOP_EUR = Number(process.env.GEN_HARD_STOP_EUR ?? "15");
+const EXCLUDE_EXTERNAL_SUFFIX = "V4000"; // documented mislink, out of scope
+
+const scopeWhere: Prisma.ScrutinWhereInput = {
+  legislature: 17,
+  chamber: "AN",
+  title: { contains: "suppression", mode: "insensitive" },
+  amendmentLinks: { some: {} },
+  externalId: { not: { endsWith: EXCLUDE_EXTERNAL_SUFFIX } },
+  policyTitle: {
+    is: {
+      status: { in: ["APPROVED", "NEEDS_REVIEW", "STALE"] },
+      // resumable: skip rows already regenerated at the current prompt version
+      promptVersion: { not: PROMPT_VERSION },
+    },
+  },
+};
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+(async () => {
+  if (!process.env.MISTRAL_API_KEY) {
+    console.log("NO_MISTRAL_KEY");
+    await db.$disconnect();
+    process.exit(2);
+  }
+  resetMistralTokensUsed();
+
+  const scope = await db.scrutin.findMany({
+    where: scopeWhere,
+    select: { id: true },
+    orderBy: { votingDate: "desc" },
+  });
+  const ids = scope.map((s) => s.id);
+  console.log(
+    `[regen] scope=${ids.length} promptVersion=${PROMPT_VERSION} chunk=${CHUNK} rate=${EUR_PER_1M}EUR/1M hardStop=${HARD_STOP_EUR}EUR`
+  );
+  if (ids.length === 0) {
+    console.log("[regen] nothing to do (scope empty — already regenerated?).");
+    await db.$disconnect();
+    return;
+  }
+
+  let generated = 0;
+  let fallbacks = 0;
+  let skipped = 0;
+  let suppressionBlocked = 0;
+  const errors: Array<{ scrutinId: string; error: string }> = [];
+  const chunks = chunk(ids, CHUNK);
+  let processed = 0;
+
+  for (let c = 0; c < chunks.length; c++) {
+    const batch = chunks[c]!;
+    const stats = await generateScrutinPolicyTitles({ scrutinIds: batch, force: true });
+    generated += stats.generated;
+    fallbacks += stats.fallbacks;
+    skipped += stats.skipped;
+    errors.push(...stats.errors);
+    processed += stats.processed;
+    for (const r of stats.results) {
+      if (r.warnings.some((w) => w.code === "SUPPRESSION_POLARITY")) suppressionBlocked++;
+    }
+
+    const tokens = getMistralTokensUsed();
+    const eur = (tokens / 1_000_000) * EUR_PER_1M;
+    const projectedEur = processed > 0 ? (eur / processed) * ids.length : eur;
+    console.log(
+      `[regen] chunk ${c + 1}/${chunks.length}: generated=${stats.generated} fallbacks=${stats.fallbacks} errors=${stats.errors.length} suppBlocked+=${stats.results.filter((r) => r.warnings.some((w) => w.code === "SUPPRESSION_POLARITY")).length} | cumul processed=${processed}/${ids.length} tokens=${tokens} eur=${eur.toFixed(2)} projected=${projectedEur.toFixed(2)}`
+    );
+
+    if (projectedEur > HARD_STOP_EUR) {
+      console.log(
+        `[regen] STOP: projected cost ${projectedEur.toFixed(2)}EUR exceeds hard stop ${HARD_STOP_EUR}EUR. Halting for review.`
+      );
+      break;
+    }
+  }
+
+  const tokens = getMistralTokensUsed();
+  console.log(
+    "[regen] DONE " +
+      JSON.stringify({
+        scope: ids.length,
+        processed,
+        generated,
+        fallbacks,
+        skipped,
+        suppressionBlocked,
+        errorCount: errors.length,
+        tokensUsed: tokens,
+        estEUR: Number(((tokens / 1_000_000) * EUR_PER_1M).toFixed(2)),
+        rateEURper1M: EUR_PER_1M,
+      })
+  );
+  if (errors.length) console.log("[regen] first errors:", JSON.stringify(errors.slice(0, 10)));
+  await db.$disconnect();
+})().catch(async (e) => {
+  console.error("[regen] FAILED:", e);
+  try {
+    await db.$disconnect();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/src/app/admin/policy-titles/_data/review-query.ts
+++ b/src/app/admin/policy-titles/_data/review-query.ts
@@ -113,7 +113,8 @@ export async function loadReview(scrutinId: string): Promise<ReviewData | null> 
     policyRow.policyTitle,
     policyRow.policySubtitle,
     evidenceQuotes,
-    resolved.blocks
+    resolved.blocks,
+    scrutin.title
   );
   const evidenceDrift = detectEvidenceDrift(evidenceQuotes, resolved.blocks);
   const inputDrift = currentInputHash !== policyRow.inputHash;

--- a/src/app/admin/policy-titles/actions.ts
+++ b/src/app/admin/policy-titles/actions.ts
@@ -60,7 +60,13 @@ export async function editScrutinPolicyTitle(
   const { row, blocks } = ctx;
 
   const evidenceQuotes = (row.evidenceQuotes ?? []) as unknown as EvidenceQuote[];
-  const newWarnings = computeCurrentWarnings(policyTitle, policySubtitle, evidenceQuotes, blocks);
+  const newWarnings = computeCurrentWarnings(
+    policyTitle,
+    policySubtitle,
+    evidenceQuotes,
+    blocks,
+    ctx.scrutin.title
+  );
 
   await db.$transaction(async (tx) => {
     await tx.scrutinPolicyTitleRevision.create({

--- a/src/app/admin/policy-titles/approve-guard.ts
+++ b/src/app/admin/policy-titles/approve-guard.ts
@@ -67,9 +67,16 @@ export function computeCurrentWarnings(
   policyTitle: string | null,
   policySubtitle: string | null,
   evidenceQuotes: EvidenceQuote[],
-  blocks: SubstanceTextBlock[]
+  blocks: SubstanceTextBlock[],
+  officialTitle?: string
 ): GenerationWarning[] {
-  return runValidators({ policyTitle: policyTitle ?? "", policySubtitle, evidenceQuotes, blocks });
+  return runValidators({
+    policyTitle: policyTitle ?? "",
+    policySubtitle,
+    evidenceQuotes,
+    blocks,
+    officialTitle,
+  });
 }
 
 /**

--- a/src/services/scrutin-policy-title/__tests__/prompt.test.ts
+++ b/src/services/scrutin-policy-title/__tests__/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildPrompt } from "@/services/scrutin-policy-title/prompt";
+import { buildPrompt, PROMPT_VERSION } from "@/services/scrutin-policy-title/prompt";
 import type { SubstanceTextBlock, EvidenceCandidate } from "@/services/scrutin-policy-title/types";
 
 const block: SubstanceTextBlock = {
@@ -59,5 +59,18 @@ describe("buildPrompt", () => {
   });
   it("requests JSON-only output", () => {
     expect(out.user.toLowerCase()).toContain("json");
+  });
+
+  it("carries a direction/polarity rule for suppression amendments", () => {
+    const sys = out.system.toLowerCase();
+    expect(sys).toContain("suppression");
+    // Must instruct to describe what the vote REMOVES, and forbid restating the
+    // suppressed article's content in positive polarity.
+    expect(sys).toMatch(/supprim|retir|ce que le vote|sens du vote/);
+  });
+
+  it("bumps PROMPT_VERSION past the polarity-blind v2", () => {
+    expect(PROMPT_VERSION).not.toBe("policy-title-v2");
+    expect(PROMPT_VERSION).toMatch(/^policy-title-v\d+$/);
   });
 });

--- a/src/services/scrutin-policy-title/__tests__/validators.test.ts
+++ b/src/services/scrutin-policy-title/__tests__/validators.test.ts
@@ -188,6 +188,111 @@ describe("runValidators — SubTargetGrounding", () => {
   });
 });
 
+describe("runValidators — suppression polarity", () => {
+  // A grounded suppression input: the official title carries "de suppression",
+  // the amendment dispositif is the uniform "Supprimer cet article.", and the
+  // summary block + quote keep the other validators satisfied.
+  const contentBlock = officialBlock({
+    sourceType: "amendment",
+    sourceId: "amd1",
+    field: "Amendment.content",
+    text: "Supprimer cet article.",
+  });
+  function suppInput(title: string, over: { officialTitle?: string; withContent?: boolean } = {}) {
+    const withContent = over.withContent ?? false;
+    return {
+      policyTitle: title,
+      policySubtitle: null,
+      evidenceQuotes: [quote()],
+      blocks: withContent ? [officialBlock(), contentBlock] : [officialBlock()],
+      officialTitle:
+        over.officialTitle ??
+        "l'amendement n° 937 de Mme Cathala de suppression de l'article 11 bis du projet de loi relatif à la protection des enfants (première lecture).",
+    };
+  }
+  const hasSuppFlag = (flags: ReturnType<typeof runValidators>) =>
+    flags.some((f) => f.severity === "blocker" && f.code === "SUPPRESSION_POLARITY");
+
+  it("blocks a suppression titled with a creative verb (positive polarity)", () => {
+    expect(hasSuppFlag(runValidators(suppInput("Autoriser un examen psychiatrique forcé")))).toBe(
+      true
+    );
+  });
+
+  it("passes a suppression titled with a removal verb", () => {
+    expect(
+      hasSuppFlag(runValidators(suppInput("Supprimer le régime de garde à vue de 72 heures")))
+    ).toBe(false);
+  });
+
+  it("passes a suppression titled with a negation lead", () => {
+    expect(
+      hasSuppFlag(runValidators(suppInput("Ne pas créer la perpétuité pour viol sur mineur")))
+    ).toBe(false);
+  });
+
+  it("passes a suppression titled with a status-quo lead (Maintenir)", () => {
+    expect(
+      hasSuppFlag(runValidators(suppInput("Maintenir les règles actuelles de placement")))
+    ).toBe(false);
+  });
+
+  it("does NOT fire on a non-suppression scrutin titled with a creative verb", () => {
+    expect(
+      hasSuppFlag(
+        runValidators(
+          suppInput("Autoriser le partage d'informations", {
+            officialTitle:
+              "l'amendement n° 12 de Mme X portant sur l'article 5 du projet de loi (première lecture).",
+          })
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("detects suppression from the dispositif when no official title is passed", () => {
+    const flags = runValidators({
+      policyTitle: "Prolonger la garde à vue à 72 heures",
+      policySubtitle: null,
+      evidenceQuotes: [quote()],
+      blocks: [officialBlock(), contentBlock],
+      // officialTitle intentionally omitted → fallback on the "Supprimer cet article." dispositif
+    });
+    expect(hasSuppFlag(flags)).toBe(true);
+  });
+
+  it("does NOT block a budgetary (PLF) suppression titled with a creative verb", () => {
+    expect(
+      hasSuppFlag(
+        runValidators(
+          suppInput("Augmenter de 301 millions d'euros les dotations aux communes", {
+            officialTitle:
+              "l'amendement n° 1277 de M. Le Coq de suppression de l'article 23 du projet de loi de finances pour 2026 (première lecture).",
+          })
+        )
+      )
+    ).toBe(false);
+  });
+
+  // Regression guard: the nine titles un-published on 2026-07-23 must all be caught.
+  const DEPUBLISHED = [
+    "Autoriser un examen psychiatrique forcé sur simple soupçon de menace",
+    "Prolonger la garde à vue à 72 heures pour la criminalité organisée",
+    "Rendre automatiques les sanctions pour fraude aux aides sociales",
+    "Autoriser les agents des transports à saisir des stocks de marchandises dans leurs locaux",
+    "Autoriser la suspension de permis bateau pour des délits douaniers en bande organisée",
+    "Autoriser les agents des transports à verbaliser la vente à la sauvette en gares routières",
+    "Autoriser les MDPH à échanger des données pour traquer la fraude sociale",
+    "Élargir les avantages fiscaux pour les bailleurs privés",
+    "Autoriser le démarchage téléphonique pour la livraison de produits alimentaires",
+  ];
+  for (const title of DEPUBLISHED) {
+    it(`regression — blocks the inverted title: ${title.slice(0, 40)}…`, () => {
+      expect(hasSuppFlag(runValidators(suppInput(title)))).toBe(true);
+    });
+  }
+});
+
 describe("runValidators — style", () => {
   it("ACCENTS blocker on missing French accents", () => {
     const flags = runValidators({

--- a/src/services/scrutin-policy-title/approval.ts
+++ b/src/services/scrutin-policy-title/approval.ts
@@ -99,7 +99,8 @@ export async function recomputeApprovalContext(scrutinId: string): Promise<Appro
     row.policyTitle,
     row.policySubtitle,
     evidenceQuotes,
-    resolved.blocks
+    resolved.blocks,
+    scrutin.title
   );
   const evidenceDrift = detectEvidenceDrift(evidenceQuotes, resolved.blocks);
 

--- a/src/services/scrutin-policy-title/index.ts
+++ b/src/services/scrutin-policy-title/index.ts
@@ -426,6 +426,7 @@ export async function generateScrutinPolicyTitle(
     policySubtitle: output.policySubtitle,
     evidenceQuotes: output.evidenceQuotes,
     blocks: resolved.blocks,
+    officialTitle: scrutin.title,
   });
   const hasBlocker = flags.some((f) => f.severity === "blocker");
   const flagCodes = flags.map((f) => f.code);

--- a/src/services/scrutin-policy-title/prompt.ts
+++ b/src/services/scrutin-policy-title/prompt.ts
@@ -1,7 +1,7 @@
 import { escapeXmlText } from "@/lib/text/escape-xml";
 import type { SubstanceTextBlock, EvidenceCandidate } from "./types";
 
-export const PROMPT_VERSION = "policy-title-v2";
+export const PROMPT_VERSION = "policy-title-v3";
 
 export interface BuildPromptArgs {
   scrutinTitle: string;
@@ -27,6 +27,12 @@ Bon exemple (concret, parle au citoyen) :
 - "Limiter les dérogations aux seuils de qualité de l'eau"
 
 Neutralité absolue : décris UNIQUEMENT ce que la mesure ferait, jamais l'intention, l'opinion ou la critique de son auteur. L'exposé sommaire contient souvent le point de vue de l'auteur (par exemple "dispositif inefficace", "coût excessif", "concurrence déloyale") : ce sont des arguments, PAS des faits, ne les reprends jamais dans le titre ni le sous-titre. N'emploie aucun jugement même implicite, aucune comparaison appréciative ("plus … que …", "critiquée pour…"), aucun adjectif évaluatif. Si la mesure demande un rapport, dis "Demander un rapport sur X", pas "Évaluer l'utilité de X critiquée pour…".
+
+Sens du vote (direction) : c'est la règle la plus importante. Beaucoup d'amendements sont "de suppression" ; leur dispositif est "Supprimer cet article". Voter pour un tel amendement RETIRE l'article du texte. Le titre doit alors décrire ce que la suppression produit, jamais le contenu de l'article comme s'il était adopté. Ouvre sur un verbe de retrait, de refus ou de statu quo ("Supprimer…", "Ne pas créer…", "Ne pas étendre…", "Maintenir…"). N'ouvre JAMAIS sur un verbe qui crée ou étend la mesure supprimée ("Autoriser", "Créer", "Prolonger", "Étendre", "Rendre…", "Renforcer") : ce serait inverser le sens du vote.
+Exemple, pour un amendement de suppression d'un article qui allonge la garde à vue à 72 heures :
+- bon : "Supprimer le régime de garde à vue de 72 heures"
+- mauvais : "Prolonger la garde à vue à 72 heures" (ce titre décrit l'article supprimé et inverse le sens du vote)
+Cas budgétaire particulier : supprimer un article de loi de finances qui réduit des crédits revient à rétablir ces crédits ; dans ce seul cas, un verbe comme "Rétablir" ou "Augmenter" décrit correctement l'effet de la suppression.
 
 Règle d'ancrage stricte : chaque affirmation concrète doit provenir des extraits du bloc <evidence> ; cite-les dans evidenceQuotes ; ne cite jamais d'autre source. Le bloc <contexte-editorial> est purement informatif et ne constitue PAS une source : n'en extrais aucune citation, ne le mentionne dans aucun evidenceQuotes.
 

--- a/src/services/scrutin-policy-title/validators.ts
+++ b/src/services/scrutin-policy-title/validators.ts
@@ -5,6 +5,10 @@ export interface ValidatorInput {
   policySubtitle: string | null;
   evidenceQuotes: EvidenceQuote[];
   blocks: SubstanceTextBlock[];
+  /** The scrutin's official (procedural) title. Optional: enables suppression +
+   *  budgetary detection for the polarity validator. When absent, suppression is
+   *  inferred from the amendment dispositif in `blocks`. */
+  officialTitle?: string;
 }
 
 /** Lowercase + strip diacritics. */
@@ -389,6 +393,93 @@ function validateAccents(title: string): GenerationWarning[] {
   return [];
 }
 
+/** Leading verb stems (accent-normalized) that assert a CREATED / EXTENDED /
+ *  REINFORCED policy. When a "de suppression" scrutin's title opens on one of
+ *  these, it restates the suppressed article's content in positive polarity —
+ *  i.e. the vote's meaning is inverted (voting to suppress ≠ enacting the
+ *  article). Removal / negation / status-quo leads (supprimer, ne pas…,
+ *  maintenir, rétablir) are deliberately absent: they are the correct framing. */
+const CREATIVE_LEAD_STEMS = [
+  "autoris",
+  "creer",
+  "cree",
+  "prolong",
+  "etend",
+  "elargi",
+  "instaur",
+  "rendre",
+  "augment",
+  "oblig",
+  "impos",
+  "aggrav",
+  "doubl",
+  "renforc",
+  "generalis",
+  "facilit",
+  "acceler",
+  "octroi",
+  "octroy",
+  "attribu",
+  "permett",
+  "ajout",
+  "consacr",
+  "assujetti",
+  "soumett",
+] as const;
+
+/** Full-article suppression dispositif ("Supprimer cet article." / "…l'article") —
+ *  the AN-uniform content of a suppression amendment. Alinéa/word-level removals
+ *  inside a modifying amendment do NOT match (they are not article suppressions). */
+const SUPPRESSION_DISPOSITIF = /^\s*supprimer\s+(cet\s+article|l['’]?\s*article|les\s+articles)\b/i;
+
+/** Official-title marker of a suppression scrutin ("… de suppression de l'article X …"). */
+const SUPPRESSION_TITLE = /\bde suppression\b/i;
+
+/** Budgetary bills (PLF / PLFSS): suppressing a credit-cutting article legitimately
+ *  restores or raises credits, so a "creative" verb there is a valid double
+ *  negative, not an inversion. */
+const BUDGETARY_TITLE =
+  /\b(projet de loi de finances|loi de finances|financement de la s[eé]curit[eé] sociale|plf(ss)?)\b/i;
+
+function titleLeadsCreative(title: string): boolean {
+  const n = stripDiacritics(title)
+    .replace(/^[\s"«»'’()-]+/, "")
+    .trim();
+  if (/^ne\s+(pas|plus)\b/.test(n)) return false; // explicit negation → not inverted
+  const first = n.split(/\s+/)[0] ?? "";
+  return CREATIVE_LEAD_STEMS.some((stem) => first.startsWith(stem));
+}
+
+function isSuppressionScrutin(input: ValidatorInput): boolean {
+  if (input.officialTitle && SUPPRESSION_TITLE.test(input.officialTitle)) return true;
+  return input.blocks.some(
+    (b) => b.field === "Amendment.content" && SUPPRESSION_DISPOSITIF.test(b.text)
+  );
+}
+
+/**
+ * Suppression-polarity guard. A "de suppression" amendment removes an article, so
+ * a faithful title describes what the removal DOES (a removal / negation /
+ * status-quo framing). When the title instead opens on a creation or extension
+ * verb, it restates the suppressed article's content in positive polarity and
+ * inverts the vote's meaning — the systemic bug that mislabelled 9 published
+ * titles. Budgetary (PLF/PLFSS) suppressions are excluded: restoring cut credits
+ * with a "creative" verb is a legitimate double negative.
+ */
+function validateSuppressionPolarity(input: ValidatorInput): GenerationWarning[] {
+  if (!isSuppressionScrutin(input)) return [];
+  if (input.officialTitle && BUDGETARY_TITLE.test(input.officialTitle)) return [];
+  if (!titleLeadsCreative(input.policyTitle)) return [];
+  return [
+    {
+      code: "SUPPRESSION_POLARITY",
+      severity: "blocker",
+      message:
+        "Le titre décrit le contenu de l'article en polarité positive alors que l'amendement le supprime : le sens du vote est inversé.",
+    },
+  ];
+}
+
 /**
  * Runs every rule-based validator on a candidate policy title and its grounding
  * evidence. Pure function: concatenates all flags, no side effects.
@@ -404,6 +495,7 @@ export function runValidators(input: ValidatorInput): GenerationWarning[] {
     ...validateEvidenceTrust(input),
     ...validateEvidenceGrounding(input),
     ...validateSubTarget(input),
+    ...validateSuppressionPolarity(input),
     ...validateToneNeutrality(policyTitle),
     ...validateNoDash(policyTitle),
     ...validateAccents(policyTitle),


### PR DESCRIPTION
## Problème

La génération de titres de scrutin inversait le sens du vote sur les amendements « de suppression de l'article X ». Le dispositif est « Supprimer cet article », mais le titre restituait le contenu de l'article supprimé en polarité positive (« Autoriser… », « Prolonger… », « Rendre automatiques… »). Un député ayant voté POUR l'amendement était présenté comme votant POUR la mesure qu'il votait à supprimer, une atteinte directe à l'exactitude des données.

9 titres inversés avaient été dépubliés à la main le 2026-07-23. L'audit a montré que d'autres inversions se cachaient parmi les titres encore publiés (l'heuristique de détection est un plancher, pas un plafond).

## Correctif

1. **Prompt (`prompt.ts`, `policy-title-v2` → `v3`)** : règle de direction explicite. Pour un amendement de suppression, décrire ce que le vote retire (formulation de retrait, de refus ou de statu quo), jamais le contenu de l'article comme s'il était adopté. Exemple bon/mauvais fourni. Cas budgétaire (loi de finances) traité : supprimer un article qui réduit des crédits revient à les rétablir.
2. **Validateur `validateSuppressionPolarity` (`validators.ts`)** : bloquant quand le scrutin est une suppression (titre officiel « de suppression » ou dispositif « Supprimer cet article ») et que le titre ouvre sur un verbe créateur non nié. Exclut les lois de finances (double négation budgétaire légitime). Rend toute inversion non auto-approuvable (générée en NEEDS_REVIEW, jamais publiable par le garde d'approbation).
3. **Signal `officialTitle`** transmis au validateur à la génération et à l'approbation (les deux recalculent les avertissements).
4. **Script gardé `backfill-regen-suppression-titles.ts`** : régénération in-place de la population suppression avec garde-coût Mistral (hard-stop 15 €), reprise via `promptVersion`.

## Régénération + publication (exécutées en prod)

- Scope régénéré : 182 scrutins de suppression titrés (APPROVED + NEEDS_REVIEW + STALE, liés), hors REJECTED (décisions humaines) et hors V4000. 179 générés, 3 fallbacks, 0 erreur.
- Coût Mistral réel : €2,13 (708 868 tokens, tarif conservateur 3 €/1M ; coût réel probablement inférieur).
- 139 titres HIGH ré-approuvés (garde d'approbation, scope suppression uniquement), 140 pages revalidées (ISR + purge du tag `votes`).
- 1 inversion résiduelle produite par le prompt v3 a été capturée par le validateur (V5929, en NEEDS_REVIEW, non publiée) : la défense en profondeur fonctionne.
- 43 titres en NEEDS_REVIEW (MEDIUM/LOW/fallback) laissés en revue humaine ; ils servent le titre officiel en attendant.
- Les 9 anciens titres inversés régénérés et republiés correctement (vérifié en prod : « Autoriser un examen psychiatrique forcé » → « Supprimer l'obligation d'examen psychiatrique préventif par le préfet » ; « Prolonger la garde à vue à 72 heures » → « Ne pas créer un régime de garde à vue de 72 heures »).
- Vérification finale : 0 titre APPROVED de suppression non budgétaire ouvrant sur un verbe créateur (heuristique de détection à sec), 0 titre APPROVED portant l'avertissement SUPPRESSION_POLARITY.

## Hors périmètre

- **V4000** : mauvais lien d'amendement (le scrutin « suppression de l'article 23 du PLF » pointe un amendement de revalorisation de la DGF sur l'article 31). Signalé séparément, non régénéré, laissé tel quel.

## Tests

- `validateSuppressionPolarity` : suppression + verbe créateur = bloquant ; retrait / négation / statu quo = OK ; non-suppression inchangé ; détection par dispositif ; exclusion budgétaire ; les 9 titres dépubliés servent de garde anti-régression.
- Prompt : règle de direction présente + `PROMPT_VERSION` bumpé.
- Intégration (harness Docker jetable) : génération, auto-approbation, force-regen, actions admin, review-query, batch-actions verts.
- `tsc` propre, suite verte.
