### PR TITLE
fix(affaires): tag cache "affairs" sur la page détail

### DIFF
--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -1,5 +1,5 @@
-import { cache } from "react";
 import { Metadata } from "next";
+import { cacheTag, cacheLife } from "next/cache";
 import { notFound, permanentRedirect } from "next/navigation";
 import Link from "next/link";
 import { db } from "@/lib/db";
@@ -126,9 +126,13 @@ async function findAffair(where: Prisma.AffairWhereInput) {
 
 type AffairResult = NonNullable<Awaited<ReturnType<typeof findAffair>>>;
 
-const getAffairWithRedirect = cache(async function getAffairWithRedirect(
+async function getAffairWithRedirect(
   slugOrId: string
 ): Promise<{ affair: AffairResult | null; redirect: string | null }> {
+  "use cache";
+  cacheTag("affairs");
+  cacheLife("synced");
+
   const [bySlug, byOldSlug, byId] = buildPublicAffairLookupWheres(slugOrId);
 
   // 1. Slug canonique
@@ -144,7 +148,7 @@ const getAffairWithRedirect = cache(async function getAffairWithRedirect(
   if (affair) return { affair, redirect: affair.slug };
 
   return { affair: null, redirect: null };
-});
+}
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -234,3 +234,22 @@ textarea:focus-visible,
     r: 4;
   }
 }
+
+/* Deep-link « Citer » : surbrillance temporaire de la cible (#483) */
+.cite-target {
+  animation: cite-flash 2.5s ease-out;
+}
+@keyframes cite-flash {
+  from {
+    box-shadow: 0 0 0 3px var(--ring);
+  }
+  to {
+    box-shadow: 0 0 0 3px transparent;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cite-target {
+    animation: none;
+    box-shadow: 0 0 0 3px var(--ring);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -235,7 +235,7 @@ textarea:focus-visible,
   }
 }
 
-/* Deep-link « Citer » : surbrillance temporaire de la cible (#483) */
+/* Deep-link "Cite": temporary highlight of the target (#483) */
 .cite-target {
   animation: cite-flash 2.5s ease-out;
 }

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -40,6 +40,7 @@ import { buildSourceLinks } from "@/lib/politicians/external-sources";
 import { PoliticianSignals } from "@/components/politicians/PoliticianSignals";
 import { PresumptionNotice } from "@/components/politicians/PresumptionNotice";
 import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
+import { DeepLinkHighlighter } from "@/components/politicians/DeepLinkHighlighter";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag
 
@@ -280,6 +281,7 @@ export default async function PoliticianPage({ params }: PageProps) {
         memberOf={memberOfOrgs.length > 0 ? memberOfOrgs : undefined}
       />
       <div className="container mx-auto px-4 pt-4 pb-8">
+        <DeepLinkHighlighter />
         <Breadcrumb
           items={[{ label: "Politiques", href: "/politiques" }, { label: politician.fullName }]}
         />

--- a/src/components/declarations/DeclarationHistory.tsx
+++ b/src/components/declarations/DeclarationHistory.tsx
@@ -1,5 +1,7 @@
 import type { DeclarationDetails } from "@/types/hatvp";
 import { formatEuroExact } from "@/lib/declarations/hatvp-display";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { citeAnchorId } from "@/lib/cite";
 
 export type HistoryDeclaration = { id: string; year: number; details: DeclarationDetails | null };
 
@@ -31,19 +33,26 @@ export function DeclarationHistory({ declarations }: { declarations: HistoryDecl
         {rows.map((d) => {
           const state = declarationHistoryState(d.details);
           return (
-            <li key={d.id} className="flex items-center justify-between gap-3 py-2 text-sm">
+            <li
+              key={d.id}
+              id={citeAnchorId.declaration(d.id)}
+              className="group flex items-center justify-between gap-3 py-2 text-sm"
+            >
               <span className="flex items-center gap-2">
                 <span className="font-mono text-muted-foreground">{d.year}</span>
                 <span className="rounded border px-1.5 py-0.5 text-xs text-muted-foreground">
                   DIA
                 </span>
               </span>
-              <span
-                className={
-                  state.kind === "value" ? "font-display font-semibold" : "text-muted-foreground"
-                }
-              >
-                {state.text}
+              <span className="flex items-center gap-2">
+                <span
+                  className={
+                    state.kind === "value" ? "font-display font-semibold" : "text-muted-foreground"
+                  }
+                >
+                  {state.text}
+                </span>
+                <CiteAnchor anchorId={citeAnchorId.declaration(d.id)} label="cette déclaration" />
               </span>
             </li>
           );

--- a/src/components/politicians/AffairCard.tsx
+++ b/src/components/politicians/AffairCard.tsx
@@ -33,7 +33,7 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
 
   return (
     <div
-      id={`affair-${affair.id}`}
+      id={citeAnchorId.affair(affair.id)}
       className={`group border rounded-lg p-4 overflow-hidden ${borderClass}`}
     >
       {/* Header */}

--- a/src/components/politicians/AffairCard.tsx
+++ b/src/components/politicians/AffairCard.tsx
@@ -11,6 +11,8 @@ import { ensureContrast } from "@/lib/contrast";
 import { SentenceDetails } from "@/components/affairs/SentenceDetails";
 import { AffairTimeline } from "@/components/affairs/AffairTimeline";
 import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { citeAnchorId } from "@/lib/cite";
 
 interface AffairCardProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,7 +34,7 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
   return (
     <div
       id={`affair-${affair.id}`}
-      className={`border rounded-lg p-4 overflow-hidden ${borderClass}`}
+      className={`group border rounded-lg p-4 overflow-hidden ${borderClass}`}
     >
       {/* Header */}
       <div className="mb-3">
@@ -57,11 +59,14 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
               </h3>
             </div>
           </div>
-          <Badge
-            className={`self-start whitespace-nowrap ${AFFAIR_STATUS_COLORS[affair.status as AffairStatus]}`}
-          >
-            {AFFAIR_STATUS_LABELS[affair.status as AffairStatus]}
-          </Badge>
+          <div className="flex items-center gap-2 self-start">
+            <Badge
+              className={`whitespace-nowrap ${AFFAIR_STATUS_COLORS[affair.status as AffairStatus]}`}
+            >
+              {AFFAIR_STATUS_LABELS[affair.status as AffairStatus]}
+            </Badge>
+            <CiteAnchor anchorId={citeAnchorId.affair(affair.id)} label="cette affaire" />
+          </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 mt-2">
           <Badge variant="outline" className="text-xs">

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -221,7 +221,7 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                 return (
                   <div
                     key={affair.id}
-                    id={`affair-${affair.id}`}
+                    id={citeAnchorId.affair(affair.id)}
                     className="group border rounded-lg p-4 border-blue-200 bg-blue-50/30"
                   >
                     <div className="mb-3">

--- a/src/components/politicians/AffairsSection.tsx
+++ b/src/components/politicians/AffairsSection.tsx
@@ -18,6 +18,8 @@ import {
 import { formatDate, stripMarkdown } from "@/lib/utils";
 import type { AffairStatus, AffairCategory, Involvement } from "@/types";
 import { AffairCard } from "./AffairCard";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { citeAnchorId } from "@/lib/cite";
 
 interface AffairsSectionProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -220,7 +222,7 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                   <div
                     key={affair.id}
                     id={`affair-${affair.id}`}
-                    className="border rounded-lg p-4 border-blue-200 bg-blue-50/30"
+                    className="group border rounded-lg p-4 border-blue-200 bg-blue-50/30"
                   >
                     <div className="mb-3">
                       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4">
@@ -254,6 +256,10 @@ export function AffairsSection({ affairs, civility }: AffairsSectionProps) {
                           <Badge variant="outline" className="whitespace-nowrap">
                             {AFFAIR_STATUS_LABELS[affair.status as AffairStatus]}
                           </Badge>
+                          <CiteAnchor
+                            anchorId={citeAnchorId.affair(affair.id)}
+                            label="cette affaire"
+                          />
                         </div>
                       </div>
                       <div className="flex flex-wrap items-center gap-2 mt-2">

--- a/src/components/politicians/DeepLinkHighlighter.tsx
+++ b/src/components/politicians/DeepLinkHighlighter.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+
+const HIGHLIGHT_CLASS = "cite-target";
+const HIGHLIGHT_MS = 2500;
+const WAIT_MS = 2000;
+
+/**
+ * Watches the URL hash and, once the target element is mounted (a Radix tab may
+ * need to activate first), scrolls to it, moves focus for screen readers and
+ * flashes a temporary highlight. Client-only; no server hash/query read (ISR-safe).
+ */
+export function DeepLinkHighlighter() {
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+    let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+    let waitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+    function reveal(id: string): boolean {
+      const el = document.getElementById(id);
+      if (!el) return false;
+      el.scrollIntoView({ block: "center", behavior: reduceMotion ? "auto" : "smooth" });
+      el.setAttribute("tabindex", "-1");
+      el.focus({ preventScroll: true });
+      el.classList.add(HIGHLIGHT_CLASS);
+      highlightTimer = setTimeout(() => el.classList.remove(HIGHLIGHT_CLASS), HIGHLIGHT_MS);
+      return true;
+    }
+
+    function stopWaiting() {
+      observer?.disconnect();
+      observer = null;
+      if (waitTimer) {
+        clearTimeout(waitTimer);
+        waitTimer = null;
+      }
+    }
+
+    function handle() {
+      stopWaiting();
+      const id = window.location.hash.slice(1);
+      if (!id) return;
+      if (reveal(id)) return;
+      // Target not mounted yet (tab activating). Wait for it to appear.
+      observer = new MutationObserver(() => {
+        if (reveal(id)) stopWaiting();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      waitTimer = setTimeout(stopWaiting, WAIT_MS);
+    }
+
+    handle();
+    window.addEventListener("hashchange", handle);
+    return () => {
+      window.removeEventListener("hashchange", handle);
+      stopWaiting();
+      if (highlightTimer) clearTimeout(highlightTimer);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/politicians/VotesSection.tsx
+++ b/src/components/politicians/VotesSection.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { scrutinPermalink } from "@/lib/cite";
 import { VOTE_POSITION_DOT_COLORS } from "@/config/labels";
 import { VotePositionBadge, ParliamentaryCard } from "@/components/votes";
 import {
@@ -181,7 +183,7 @@ export function VotesSection({
                       policyTitle: vote.scrutin.policyTitle,
                     });
                     return (
-                      <div key={vote.id} className="flex items-start gap-2 text-sm">
+                      <div key={vote.id} className="group flex items-start gap-2 text-sm">
                         <span
                           className={`w-2 h-2 mt-1.5 shrink-0 rounded-full ${VOTE_POSITION_DOT_COLORS[vote.position]}`}
                         />
@@ -201,6 +203,7 @@ export function VotesSection({
                           )}
                         </Link>
                         <VotePositionBadge position={vote.position} size="sm" />
+                        <CiteAnchor permalink={scrutinPermalink(vote.scrutin.id)} label="ce vote" />
                       </div>
                     );
                   })}

--- a/src/components/politicians/__tests__/AffairsSection.cite.test.tsx
+++ b/src/components/politicians/__tests__/AffairsSection.cite.test.tsx
@@ -24,7 +24,7 @@ const victimAffair = {
   linkedBy: null,
 };
 
-describe("AffairsSection — ancre de copie sur les victimes", () => {
+describe("AffairsSection : ancre de copie sur les victimes", () => {
   it("rend l'id d'ancre et le bouton CiteAnchor pour une affaire victime", () => {
     const { container } = render(
       <AffairsSection affairs={[victimAffair] as never} civility={null} />

--- a/src/components/politicians/__tests__/AffairsSection.cite.test.tsx
+++ b/src/components/politicians/__tests__/AffairsSection.cite.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { AffairsSection } from "@/components/politicians/AffairsSection";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Minimal victim affair; unrelated optional fields omitted on purpose.
+// involvement/category use real Prisma enum values (VICTIM / AUTRE), not the
+// brief's placeholder "VICTIME" / "OTHER", so the victim branch actually renders.
+const victimAffair = {
+  id: "v1",
+  slug: "affaire-victime",
+  title: "Affaire victime",
+  description: "desc",
+  category: "AUTRE",
+  status: "RELAXE",
+  involvement: "VICTIM",
+  factsDate: null,
+  startDate: null,
+  verdictDate: null,
+  sources: [],
+  events: [],
+  linkedAffair: null,
+  linkedBy: null,
+};
+
+describe("AffairsSection — ancre de copie sur les victimes", () => {
+  it("rend l'id d'ancre et le bouton CiteAnchor pour une affaire victime", () => {
+    const { container } = render(
+      <AffairsSection affairs={[victimAffair] as never} civility={null} />
+    );
+    expect(container.querySelector("#affair-v1")).not.toBeNull();
+    expect(
+      container.querySelector('#affair-v1 a[aria-label="Copier le lien vers cette affaire"]')
+    ).not.toBeNull();
+  });
+});

--- a/src/components/politicians/__tests__/DeepLinkHighlighter.test.tsx
+++ b/src/components/politicians/__tests__/DeepLinkHighlighter.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { DeepLinkHighlighter } from "@/components/politicians/DeepLinkHighlighter";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Element.prototype.scrollIntoView = vi.fn();
+  window.matchMedia = vi
+    .fn()
+    .mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia;
+});
+afterEach(() => {
+  vi.useRealTimers();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("DeepLinkHighlighter", () => {
+  it("scrolle et surligne un élément déjà présent, puis retire la surbrillance", () => {
+    const el = document.createElement("div");
+    el.id = "affair-1";
+    document.body.appendChild(el);
+    window.history.replaceState({}, "", "/politiques/x#affair-1");
+
+    render(<DeepLinkHighlighter />);
+
+    expect(el.scrollIntoView).toHaveBeenCalled();
+    expect(el.classList.contains("cite-target")).toBe(true);
+    vi.advanceTimersByTime(2500);
+    expect(el.classList.contains("cite-target")).toBe(false);
+
+    el.remove();
+  });
+
+  it("ne jette pas quand la cible est absente", () => {
+    window.history.replaceState({}, "", "/politiques/x#affair-absent");
+    expect(() => render(<DeepLinkHighlighter />)).not.toThrow();
+    vi.advanceTimersByTime(2000);
+  });
+
+  it("ne fait rien sans hash", () => {
+    window.history.replaceState({}, "", "/politiques/x");
+    const { unmount } = render(<DeepLinkHighlighter />);
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/src/components/ui/CiteAnchor.tsx
+++ b/src/components/ui/CiteAnchor.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Link2, Check } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { buildAnchorUrl } from "@/lib/cite";
+
+type CiteAnchorProps = { label: string; className?: string } & (
+  | { anchorId: string; permalink?: never }
+  | { permalink: string; anchorId?: never }
+);
+
+export function CiteAnchor(props: CiteAnchorProps) {
+  const { label, className } = props;
+  const [copied, setCopied] = useState(false);
+  const href = typeof props.anchorId === "string" ? `#${props.anchorId}` : props.permalink;
+
+  async function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    const url =
+      typeof props.anchorId === "string" ? buildAnchorUrl(props.anchorId) : props.permalink;
+    try {
+      await navigator.clipboard.writeText(url);
+      if (typeof props.anchorId === "string") {
+        window.history.replaceState(null, "", `#${props.anchorId}`);
+      }
+      setCopied(true);
+      toast.success("Lien copié");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Impossible de copier le lien");
+    }
+  }
+
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      aria-label={`Copier le lien vers ${label}`}
+      className={cn(
+        "inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+        "opacity-0 transition-opacity hover:bg-muted hover:text-foreground",
+        "group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "[@media(hover:none)]:opacity-100",
+        className
+      )}
+    >
+      {copied ? <Check className="size-4" aria-hidden /> : <Link2 className="size-4" aria-hidden />}
+    </a>
+  );
+}

--- a/src/components/ui/__tests__/CiteAnchor.test.tsx
+++ b/src/components/ui/__tests__/CiteAnchor.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { SITE_URL } from "@/config/site";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => toastSuccess(...a),
+    error: (...a: unknown[]) => toastError(...a),
+  },
+}));
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
+  window.history.replaceState({}, "", "/politiques/x?tab=affaires");
+});
+
+describe("CiteAnchor (variante anchorId)", () => {
+  it("copie le permalien d'ancre et affiche le toast", async () => {
+    render(<CiteAnchor anchorId="affair-1" label="cette affaire" />);
+    const link = screen.getByRole("link", { name: "Copier le lien vers cette affaire" });
+    expect(link).toHaveAttribute("href", "#affair-1");
+    await userEvent.click(link);
+    expect(writeText).toHaveBeenCalledWith(`${SITE_URL}/politiques/x?tab=affaires#affair-1`);
+    expect(toastSuccess).toHaveBeenCalledWith("Lien copié");
+    expect(window.location.hash).toBe("#affair-1");
+  });
+});
+
+describe("CiteAnchor (variante permalink)", () => {
+  it("copie le permalien d'entité", async () => {
+    render(<CiteAnchor permalink={`${SITE_URL}/parlement/votes/4521`} label="ce vote" />);
+    const link = screen.getByRole("link", { name: "Copier le lien vers ce vote" });
+    expect(link).toHaveAttribute("href", `${SITE_URL}/parlement/votes/4521`);
+    await userEvent.click(link);
+    expect(writeText).toHaveBeenCalledWith(`${SITE_URL}/parlement/votes/4521`);
+    expect(toastSuccess).toHaveBeenCalledWith("Lien copié");
+  });
+});
+
+describe("CiteAnchor (échec clipboard)", () => {
+  it("affiche un toast d'erreur", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    render(<CiteAnchor anchorId="affair-1" label="cette affaire" />);
+    await userEvent.click(screen.getByRole("link"));
+    expect(toastError).toHaveBeenCalledWith("Impossible de copier le lien");
+  });
+});

--- a/src/lib/__tests__/cite.test.ts
+++ b/src/lib/__tests__/cite.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { citeAnchorId, buildAnchorUrl, scrutinPermalink } from "@/lib/cite";
+import { SITE_URL } from "@/config/site";
+
+describe("citeAnchorId", () => {
+  it("prefixe les ids par type", () => {
+    expect(citeAnchorId.affair("abc")).toBe("affair-abc");
+    expect(citeAnchorId.declaration("def")).toBe("declaration-def");
+  });
+});
+
+describe("scrutinPermalink", () => {
+  it("construit l'URL absolue du scrutin", () => {
+    expect(scrutinPermalink("4521")).toBe(`${SITE_URL}/parlement/votes/4521`);
+  });
+});
+
+describe("buildAnchorUrl", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/politiques/jean-dupont");
+  });
+
+  it("ne garde que le param tab et ajoute l'ancre", () => {
+    window.history.replaceState({}, "", "/politiques/jean-dupont?tab=affaires&utm_source=z");
+    expect(buildAnchorUrl("affair-1")).toBe(
+      `${SITE_URL}/politiques/jean-dupont?tab=affaires#affair-1`
+    );
+  });
+
+  it("omet la query quand il n'y a pas de tab", () => {
+    window.history.replaceState({}, "", "/politiques/jean-dupont");
+    expect(buildAnchorUrl("declaration-9")).toBe(
+      `${SITE_URL}/politiques/jean-dupont#declaration-9`
+    );
+  });
+});

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -85,8 +85,10 @@ export function invalidateEntity(
 
     case "affair":
       revalidatePath("/api/affaires", "layout");
+      revalidatePath("/affaires", "layout");
       if (slug) {
         revalidatePath(`/api/affaires/${slug}`, "layout");
+        revalidatePath(`/affaires/${slug}`);
       }
       revalidateTag("affairs", DEFAULT_PROFILE);
       break;

--- a/src/lib/cite.ts
+++ b/src/lib/cite.ts
@@ -1,0 +1,20 @@
+import { SITE_URL } from "@/config/site";
+
+export const citeAnchorId = {
+  affair: (affairId: string) => `affair-${affairId}`,
+  declaration: (declarationId: string) => `declaration-${declarationId}`,
+};
+
+/**
+ * Client-only. Builds a canonical permalink to an in-page anchor, keeping only
+ * the `tab` query param (drops utm_*, fbclid, etc.) so the cited link stays clean.
+ */
+export function buildAnchorUrl(anchorId: string): string {
+  const { pathname } = window.location;
+  const tab = new URLSearchParams(window.location.search).get("tab");
+  const query = tab ? `?tab=${tab}` : "";
+  return `${SITE_URL}${pathname}${query}#${anchorId}`;
+}
+
+/** Absolute permalink to a scrutin detail page (used for recent-vote rows). */
+export const scrutinPermalink = (scrutinId: string) => `${SITE_URL}/parlement/votes/${scrutinId}`;


### PR DESCRIPTION
## Problème
La page détail d'une affaire (`/affaires/[slug]`) déclarait `export const revalidate = 86400` mais n'appelait jamais `cacheTag(...)`. Du coup `revalidateTag("affairs")` (utilisé par `invalidateEntity` et l'endpoint admin `{all:true}`) ne purgeait pas cette page : une affaire dépubliée restait visible jusqu'au backstop de 24h, et une édition admin ne rafraîchissait pas non plus la page publique.

## Correctif
- `getAffairWithRedirect` passe en segment `"use cache"` avec `cacheTag("affairs")` + `cacheLife("synced")`, aligné sur le pattern déjà utilisé sur la fiche politique (`getVoteStats`).
- `invalidateEntity("affair", slug)` revalide aussi les chemins de page `/affaires` et `/affaires/${slug}`.

## Effet
Les dépublications et éditions d'affaires se propagent à la demande, sans attendre le backstop 24h.

## Vérification
- `tsc --noEmit` propre (hors bruit `.next/`)
- `cache.test.ts` + `cache-tags.test.ts` verts (6/6)