### PR TITLE
fix(cache): invalide politician:<slug> sur les mutations d'affaires

### DIFF
--- a/src/app/api/admin/affaires/[id]/quick-update/route.ts
+++ b/src/app/api/admin/affaires/[id]/quick-update/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
 import { quickUpdateAffairSchema } from "@/lib/security/schemas/affair";
-import { invalidateEntity } from "@/lib/cache";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import { trackStatusChange } from "@/services/affairs/status-tracking";
 import {
   assertPublishable,
@@ -29,6 +29,7 @@ export const PATCH = withAdminAuth(
         slug: true,
         politicianId: true,
         publicationStatus: true,
+        politician: { select: { slug: true } },
       },
     });
 
@@ -116,6 +117,7 @@ export const PATCH = withAdminAuth(
     });
 
     invalidateEntity("affair", affair.slug);
+    invalidateAffectedPoliticians([affair.politician?.slug]);
 
     return NextResponse.json(updated);
   })

--- a/src/app/api/admin/affaires/__tests__/politician-invalidation.test.ts
+++ b/src/app/api/admin/affaires/__tests__/politician-invalidation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression: affair mutations must invalidate the affected politicians'
+// profiles (tagged `politician:<slug>`), not just the "affairs" tag — otherwise
+// a depublished affair lingers on the politician's page until the 24h backstop.
+
+const h = vi.hoisted(() => ({
+  invalidateEntity: vi.fn(),
+  invalidateAffectedPoliticians: vi.fn(),
+  db: {
+    affair: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+      deleteMany: vi.fn(),
+      update: vi.fn(),
+    },
+    auditLog: { create: vi.fn(), createMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateEntity: h.invalidateEntity,
+  invalidateAffectedPoliticians: h.invalidateAffectedPoliticians,
+}));
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+// Pass-through auth + validation wrappers (we test invalidation, not auth/zod).
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) =>
+    fn(req, ctx),
+}));
+vi.mock("@/lib/security/validate", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
+}));
+vi.mock("@/services/affairs/status-tracking", () => ({ trackStatusChange: vi.fn() }));
+vi.mock("@/lib/affairs/publish-guard", () => ({
+  assertPublishable: vi.fn(),
+  PublishGuardError: class PublishGuardError extends Error {},
+  VERIFIED_BY_MODERATION: "Poligraph Moderation",
+  PUBLISHED_STATUS: "PUBLISHED",
+}));
+
+import { POST as moderatePOST } from "@/app/api/admin/affaires/moderate/route";
+import { POST as bulkPOST } from "@/app/api/admin/affaires/bulk/route";
+import { PATCH as quickUpdatePATCH } from "@/app/api/admin/affaires/[id]/quick-update/route";
+
+const db = h.db;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function req(body: unknown): any {
+  return new Request("http://test/api", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctx(params: Record<string, string> = {}): any {
+  return { params: Promise.resolve(params) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.auditLog.create.mockResolvedValue({});
+  db.auditLog.createMany.mockResolvedValue({});
+});
+
+describe("affair mutations invalidate affected politician profiles", () => {
+  it("moderate (reject) invalidates each affected politician", async () => {
+    db.affair.findMany.mockResolvedValue([
+      { politician: { slug: "pol-a" } },
+      { politician: { slug: "pol-a" } },
+      { politician: { slug: "pol-b" } },
+    ]);
+    db.affair.updateMany.mockResolvedValue({ count: 3 });
+
+    await moderatePOST(req({ ids: ["1", "2", "3"], action: "reject" }), ctx());
+
+    expect(h.invalidateEntity).toHaveBeenCalledWith("affair");
+    expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["pol-a", "pol-a", "pol-b"]);
+  });
+
+  it("bulk (delete) captures politicians before deleting, then invalidates them", async () => {
+    db.affair.findMany.mockResolvedValue([{ politician: { slug: "pol-x" } }]);
+    db.affair.deleteMany.mockResolvedValue({ count: 1 });
+
+    await bulkPOST(req({ ids: ["1"], action: "delete" }), ctx());
+
+    expect(db.affair.findMany).toHaveBeenCalled();
+    expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["pol-x"]);
+  });
+
+  it("quick-update (depublish) invalidates the affair's politician", async () => {
+    db.affair.findUnique.mockResolvedValue({
+      id: "1",
+      status: "RELAXE",
+      involvement: "DIRECT",
+      slug: "aff-slug",
+      politicianId: "p1",
+      publicationStatus: "PUBLISHED",
+      politician: { slug: "pol-x" },
+    });
+    db.affair.update.mockResolvedValue({ id: "1" });
+
+    await quickUpdatePATCH(req({ publicationStatus: "DRAFT" }), ctx({ id: "1" }));
+
+    expect(h.invalidateEntity).toHaveBeenCalledWith("affair", "aff-slug");
+    expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["pol-x"]);
+  });
+});

--- a/src/app/api/admin/affaires/bulk/route.ts
+++ b/src/app/api/admin/affaires/bulk/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation } from "@/lib/security/validate";
 import { bulkAffairSchema } from "@/lib/security/schemas/affair";
-import { invalidateEntity } from "@/lib/cache";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import {
   assertPublishable,
   PublishGuardError,
@@ -18,6 +18,14 @@ export const POST = withAdminAuth(
   withValidation(bulkAffairSchema, async (_request, _context, body: BulkBody) => {
     const { ids, action, value } = body;
     const rejectionReason = typeof value === "string" ? value : undefined;
+
+    // Capture affected politicians BEFORE mutating (required for delete, where
+    // the rows disappear) so their profiles are invalidated too.
+    const affected = await db.affair.findMany({
+      where: { id: { in: ids } },
+      select: { politician: { select: { slug: true } } },
+    });
+    const politicianSlugs = affected.map((a) => a.politician.slug);
 
     if (action === "delete") {
       const result = await db.affair.deleteMany({
@@ -34,6 +42,7 @@ export const POST = withAdminAuth(
       });
 
       invalidateEntity("affair");
+      invalidateAffectedPoliticians(politicianSlugs);
 
       return NextResponse.json({ deleted: result.count });
     }
@@ -66,6 +75,7 @@ export const POST = withAdminAuth(
           })),
         });
         invalidateEntity("affair");
+        invalidateAffectedPoliticians(politicianSlugs);
       }
 
       return NextResponse.json({ updated: published.length, failed });
@@ -91,6 +101,7 @@ export const POST = withAdminAuth(
     });
 
     invalidateEntity("affair");
+    invalidateAffectedPoliticians(politicianSlugs);
 
     return NextResponse.json({ updated: result.count });
   })

--- a/src/app/api/admin/affaires/moderate/route.ts
+++ b/src/app/api/admin/affaires/moderate/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation } from "@/lib/security/validate";
 import { moderateAffairSchema } from "@/lib/security/schemas/affair";
-import { invalidateEntity } from "@/lib/cache";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import {
   assertPublishable,
   PublishGuardError,
@@ -70,6 +70,14 @@ export const POST = withAdminAuth(
   withValidation(moderateAffairSchema, async (_request, _context, body: ModerateBody) => {
     const { ids, action } = body;
 
+    // Capture affected politicians before mutating, so their profiles
+    // (tagged `politician:<slug>`) are invalidated too (not just "affairs").
+    const affected = await db.affair.findMany({
+      where: { id: { in: ids } },
+      select: { politician: { select: { slug: true } } },
+    });
+    const politicianSlugs = affected.map((a) => a.politician.slug);
+
     if (action === "publish") {
       // RGPD art. 10 : la publication passe par le guard, qui exige sources
       // + rattachements validés et écrit verifiedAt/verifiedBy atomiquement.
@@ -103,6 +111,7 @@ export const POST = withAdminAuth(
           })),
         });
         invalidateEntity("affair");
+        invalidateAffectedPoliticians(politicianSlugs);
       }
 
       return NextResponse.json({ updated: published.length, failed });
@@ -125,6 +134,7 @@ export const POST = withAdminAuth(
     });
 
     invalidateEntity("affair");
+    invalidateAffectedPoliticians(politicianSlugs);
 
     return NextResponse.json({ updated: result.count });
   })

--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const updateTag = vi.fn();
+const revalidateTag = vi.fn();
+const revalidatePath = vi.fn();
 vi.mock("next/cache", () => ({
-  revalidateTag: vi.fn(),
-  revalidatePath: vi.fn(),
+  revalidateTag: (...args: unknown[]) => revalidateTag(...args),
+  revalidatePath: (...args: unknown[]) => revalidatePath(...args),
   updateTag: (...args: unknown[]) => updateTag(...args),
 }));
 
-import { updateTags } from "@/lib/cache";
+import { updateTags, invalidateAffectedPoliticians } from "@/lib/cache";
 
 describe("updateTags", () => {
   beforeEach(() => updateTag.mockClear());
@@ -16,5 +18,16 @@ describe("updateTags", () => {
     expect(updateTag).toHaveBeenCalledTimes(2);
     expect(updateTag).toHaveBeenNthCalledWith(1, "votes");
     expect(updateTag).toHaveBeenNthCalledWith(2, "dossiers");
+  });
+});
+
+describe("invalidateAffectedPoliticians", () => {
+  beforeEach(() => revalidateTag.mockClear());
+  it("invalidates each distinct politician once and skips falsy slugs", () => {
+    invalidateAffectedPoliticians(["a", "a", null, undefined, "b"]);
+    const politicianTags = revalidateTag.mock.calls
+      .map((c) => c[0])
+      .filter((t) => String(t).startsWith("politician:"));
+    expect(politicianTags).toEqual(["politician:a", "politician:b"]);
   });
 });

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -138,6 +138,21 @@ export function invalidateEntity(
   }
 }
 
+/**
+ * After an affair mutation, invalidate each affected politician profile so its
+ * affairs list reflects the change (getPolitician is tagged `politician:<slug>`).
+ * De-dupes and skips falsy slugs. Pair with invalidateEntity("affair", ...).
+ */
+export function invalidateAffectedPoliticians(slugs: Array<string | null | undefined>): void {
+  const seen = new Set<string>();
+  for (const slug of slugs) {
+    if (slug && !seen.has(slug)) {
+      seen.add(slug);
+      invalidateEntity("politician", slug);
+    }
+  }
+}
+
 // ─── Global revalidation (post-sync) ─────────────────────────────
 
 export const ALL_TAGS = [


### PR DESCRIPTION
## Problème
Après une dépublication (ou toute mutation) d'affaire, la fiche de la personnalité continuait d'afficher l'affaire jusqu'au backstop de 24h. `getPolitician()` est mis en cache sous le tag `politician:<slug>`, mais `quick-update`, `moderate` et `bulk` ne purgeaient que le tag `"affairs"` (jamais `politician:<slug>`). Constaté en direct : profil Spillebout encore à jour après dépublication.

## Correctif
- Nouveau helper `invalidateAffectedPoliticians(slugs)` dans `src/lib/cache.ts` (dédoublonne, ignore les slugs vides).
- `quick-update`, `moderate` (publish + reject/exclude/archive) et `bulk` (delete + publish + reject) récupèrent les slugs des personnalités concernées **avant** la mutation (indispensable pour `delete` où les lignes disparaissent), puis invalident chaque `politician:<slug>` en plus de `"affairs"`.
- `[id]/route.ts` (PUT/DELETE) et `route.ts` (POST) le faisaient déjà ; `merge` couvre la personnalité principale.

## Tests
- `politician-invalidation.test.ts` : chaque endpoint (quick-update, moderate, bulk) invalide bien la/les personnalité(s) concernée(s).
- `cache.test.ts` : `invalidateAffectedPoliticians` dédoublonne et ignore les slugs vides.
- Le contrat "affaire non publiée introuvable" (donc `notFound()` → `noindex` auto) reste couvert par `affair-lookup.test.ts`.

## Hors périmètre
Sémantique HTTP exacte (410 Gone) : voir #509. Le `noindex` automatique de `notFound()` (vérifié en prod) assure déjà la désindexation.