### PR TITLE
Affaires v2 lot 1 : file de propositions pour les imports d'affaires

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "sync:moderate": "tsx scripts/sync-moderate-affairs.ts",
     "sync:moderate:stats": "tsx scripts/sync-moderate-affairs.ts --stats",
     "moderate:preflight": "tsx scripts/moderate-preflight.ts",
+    "proposals": "tsx --env-file=.env scripts/proposals.ts",
     "moderate:preflight:dry": "tsx scripts/moderate-preflight.ts --dry-run",
     "sync:enrich": "tsx scripts/sync-enrich-affairs.ts",
     "sync:enrich:stats": "tsx scripts/sync-enrich-affairs.ts --stats",

--- a/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
+++ b/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
@@ -1,0 +1,79 @@
+-- Affaires v2, lot 1: importers stop mutating existing affairs directly and
+-- emit reviewable proposals instead.
+--
+-- This file documents the SQL equivalent of the schema change. It is NOT the
+-- deployment path: this database has no _prisma_migrations table, so it is
+-- managed with `prisma db push`. Kept here for review and for the day a
+-- versioned-migration baseline is established.
+
+CREATE TYPE "ImportRunStatus" AS ENUM ('RUNNING', 'COMPLETED', 'FAILED');
+
+CREATE TYPE "ProposalStatus" AS ENUM (
+  'PENDING', 'APPROVED', 'REJECTED', 'AUTO_APPLIED', 'CONFLICT'
+);
+
+CREATE TYPE "ProposalRisk" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+CREATE TABLE "ImportRun" (
+  "id"         TEXT NOT NULL,
+  "importer"   TEXT NOT NULL,
+  "status"     "ImportRunStatus" NOT NULL DEFAULT 'RUNNING',
+  "startedAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt" TIMESTAMP(3),
+  "error"      TEXT,
+  "stats"      JSONB,
+  CONSTRAINT "ImportRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ImportRun_importer_startedAt_idx" ON "ImportRun" ("importer", "startedAt");
+CREATE INDEX "ImportRun_status_idx" ON "ImportRun" ("status");
+
+CREATE TABLE "AffairUpdateProposal" (
+  "id"               TEXT NOT NULL,
+  "affairId"         TEXT NOT NULL,
+  "importer"         TEXT NOT NULL,
+  "importRunId"      TEXT,
+  "proposedPatch"    JSONB NOT NULL,
+  "observedValues"   JSONB NOT NULL,
+  "source"           "SourceType" NOT NULL,
+  "sourceUrl"        TEXT,
+  "officialId"       TEXT,
+  "sourceExcerpt"    TEXT,
+  "metadata"         JSONB,
+  "confidence"       INTEGER NOT NULL,
+  "riskLevel"        "ProposalRisk" NOT NULL,
+  "rationale"        TEXT NOT NULL,
+  "extractorVersion" TEXT NOT NULL DEFAULT 'v1',
+  "payloadHash"      TEXT NOT NULL,
+  "status"           "ProposalStatus" NOT NULL DEFAULT 'PENDING',
+  "reviewedAt"       TIMESTAMP(3),
+  "reviewedBy"       TEXT,
+  "reviewNotes"      TEXT,
+  "appliedAt"        TIMESTAMP(3),
+  "conflictDetail"   JSONB,
+  "createdAt"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"        TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AffairUpdateProposal_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "AffairUpdateProposal"
+  ADD CONSTRAINT "AffairUpdateProposal_affairId_fkey"
+  FOREIGN KEY ("affairId") REFERENCES "Affair" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AffairUpdateProposal"
+  ADD CONSTRAINT "AffairUpdateProposal_importRunId_fkey"
+  FOREIGN KEY ("importRunId") REFERENCES "ImportRun" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Idempotency: same importer replaying the same patch on the same affair from the
+-- same source and extractor version collapses onto one row.
+CREATE UNIQUE INDEX "AffairUpdateProposal_affairId_importer_payloadHash_key"
+  ON "AffairUpdateProposal" ("affairId", "importer", "payloadHash");
+
+CREATE INDEX "AffairUpdateProposal_status_riskLevel_idx"
+  ON "AffairUpdateProposal" ("status", "riskLevel");
+CREATE INDEX "AffairUpdateProposal_affairId_idx"
+  ON "AffairUpdateProposal" ("affairId");
+CREATE INDEX "AffairUpdateProposal_importRunId_idx"
+  ON "AffairUpdateProposal" ("importRunId");
+CREATE INDEX "AffairUpdateProposal_status_createdAt_idx"
+  ON "AffairUpdateProposal" ("status", "createdAt");

--- a/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
+++ b/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
@@ -30,7 +30,10 @@ CREATE INDEX "ImportRun_status_idx" ON "ImportRun" ("status");
 
 CREATE TABLE "AffairUpdateProposal" (
   "id"               TEXT NOT NULL,
-  "affairId"         TEXT NOT NULL,
+  -- Nullable on purpose: deleting an affair must not erase the history of what
+  -- was proposed about it and how a human ruled on it.
+  "affairId"         TEXT,
+  "affairSnapshot"   JSONB NOT NULL,
   "importer"         TEXT NOT NULL,
   "importRunId"      TEXT,
   "proposedPatch"    JSONB NOT NULL,
@@ -38,6 +41,7 @@ CREATE TABLE "AffairUpdateProposal" (
   "source"           "SourceType" NOT NULL,
   "sourceUrl"        TEXT,
   "officialId"       TEXT,
+  "sourceContentHash" TEXT,
   "sourceExcerpt"    TEXT,
   "metadata"         JSONB,
   "confidence"       INTEGER NOT NULL,
@@ -56,9 +60,10 @@ CREATE TABLE "AffairUpdateProposal" (
   CONSTRAINT "AffairUpdateProposal_pkey" PRIMARY KEY ("id")
 );
 
+-- SET NULL, not CASCADE: the proposal and its review decision outlive the affair.
 ALTER TABLE "AffairUpdateProposal"
   ADD CONSTRAINT "AffairUpdateProposal_affairId_fkey"
-  FOREIGN KEY ("affairId") REFERENCES "Affair" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  FOREIGN KEY ("affairId") REFERENCES "Affair" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 ALTER TABLE "AffairUpdateProposal"
   ADD CONSTRAINT "AffairUpdateProposal_importRunId_fkey"

--- a/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
+++ b/prisma/migrations/manual/2026-07-25-affair-update-proposals.sql
@@ -35,7 +35,8 @@ CREATE TABLE "AffairUpdateProposal" (
   "affairId"         TEXT,
   "affairSnapshot"   JSONB NOT NULL,
   "importer"         TEXT NOT NULL,
-  "importRunId"      TEXT,
+  -- Mandatory: every proposal belongs to a run, manual ones included.
+  "importRunId"      TEXT NOT NULL,
   "proposedPatch"    JSONB NOT NULL,
   "observedValues"   JSONB NOT NULL,
   "source"           "SourceType" NOT NULL,
@@ -65,9 +66,15 @@ ALTER TABLE "AffairUpdateProposal"
   ADD CONSTRAINT "AffairUpdateProposal_affairId_fkey"
   FOREIGN KEY ("affairId") REFERENCES "Affair" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
+-- Restrict, not SetNull: deleting a run that still carries proposals is a
+-- mistake, not something to absorb silently.
 ALTER TABLE "AffairUpdateProposal"
   ADD CONSTRAINT "AffairUpdateProposal_importRunId_fkey"
-  FOREIGN KEY ("importRunId") REFERENCES "ImportRun" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  FOREIGN KEY ("importRunId") REFERENCES "ImportRun" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Stable identity of a source, so replaying an import cannot duplicate a row.
+-- Verified before adding: zero (affairId, url) duplicates across 1780 sources.
+CREATE UNIQUE INDEX "Source_affairId_url_key" ON "Source" ("affairId", "url");
 
 -- Idempotency: same importer replaying the same patch on the same affair from the
 -- same source and extractor version collapses onto one row.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1968,9 +1968,17 @@ model ImportRun {
 
 /// An immutable, reviewable patch to an existing Affair, produced by an importer.
 model AffairUpdateProposal {
-  id       String @id @default(cuid())
-  affair   Affair @relation(fields: [affairId], references: [id], onDelete: Cascade)
-  affairId String
+  id String @id @default(cuid())
+
+  /// Nullable on purpose: deleting an affair must NOT erase the history of what
+  /// was proposed about it and how a human ruled on it. The row survives as an
+  /// orphan, identified by affairSnapshot.
+  affair   Affair? @relation(fields: [affairId], references: [id], onDelete: SetNull)
+  affairId String?
+
+  /// Denormalized identity of the affair at proposal time, so an orphaned row
+  /// stays readable: { publicId, slug, title, politicianSlug, politicianName }.
+  affairSnapshot Json
 
   importer    String
   importRun   ImportRun? @relation(fields: [importRunId], references: [id], onDelete: SetNull)
@@ -1988,14 +1996,20 @@ model AffairUpdateProposal {
   sourceExcerpt String?    @db.Text
   metadata      Json?
 
+  /// Hash of the source payload itself. A URL and an official id are not enough:
+  /// a Wikidata claim or a decision page can change under the same address, and
+  /// the new content must be able to produce a fresh proposal.
+  sourceContentHash String?
+
   confidence       Int // 0-100
   riskLevel        ProposalRisk
   rationale        String       @db.Text // why this affair, why this value
   extractorVersion String       @default("v1")
 
-  /// SHA-256 over importer + extractorVersion + source fingerprint +
-  /// proposedPatch + observedValues. Makes re-runs idempotent while still
-  /// allowing a re-proposal once the affair, the source or the extractor moves.
+  /// SHA-256 over importer + extractorVersion + source fingerprint (including
+  /// sourceContentHash) + proposedPatch + observedValues. Makes re-runs
+  /// idempotent while still allowing a re-proposal once the affair, the source
+  /// content or the extractor moves.
   payloadHash String
 
   status         ProposalStatus @default(PENDING)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -613,6 +613,9 @@ model Affair {
 
   affairPoliticianDecisions AffairPoliticianDecision[] @relation("AffairDecisionAffair")
 
+  // Importer-proposed changes awaiting review (Affaires v2, lot 1)
+  updateProposals AffairUpdateProposal[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1917,6 +1920,99 @@ model ModerationReview {
   @@index([affairId])
   @@index([recommendation])
   @@index([createdAt])
+}
+
+// ============================================
+// AFFAIR UPDATE PROPOSALS (Affaires v2, lot 1)
+// ============================================
+// Importers never mutate an existing Affair directly. They emit an immutable,
+// reviewable proposal. Only machine identifiers that are absent and
+// non-contradictory are auto-applied. See docs (local spec) for the full design.
+
+enum ImportRunStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+enum ProposalStatus {
+  PENDING // awaiting human review
+  APPROVED // accepted and applied
+  REJECTED // refused; never resurfaced by a later run
+  AUTO_APPLIED // low-risk identifier written without review
+  CONFLICT // live value drifted since the proposal was made
+}
+
+enum ProposalRisk {
+  LOW // fills a NULL technical identifier
+  MEDIUM // fills a NULL judicial or editorial field
+  HIGH // overwrites a non-NULL value, or touches status/involvement/publicationStatus
+}
+
+/// One execution of an importer. Groups the proposals it produced so a faulty
+/// extractor version can be identified and rejected in bulk.
+model ImportRun {
+  id         String          @id @default(cuid())
+  importer   String // "discover-affairs" | "judilibre"
+  status     ImportRunStatus @default(RUNNING)
+  startedAt  DateTime        @default(now())
+  finishedAt DateTime?
+  error      String?
+  stats      Json? // { proposalsCreated, autoApplied, conflicts, skipped }
+
+  proposals AffairUpdateProposal[]
+
+  @@index([importer, startedAt])
+  @@index([status])
+}
+
+/// An immutable, reviewable patch to an existing Affair, produced by an importer.
+model AffairUpdateProposal {
+  id       String @id @default(cuid())
+  affair   Affair @relation(fields: [affairId], references: [id], onDelete: Cascade)
+  affairId String
+
+  importer    String
+  importRun   ImportRun? @relation(fields: [importRunId], references: [id], onDelete: SetNull)
+  importRunId String?
+
+  // The change. observedValues holds the same keys as proposedPatch, snapshotted
+  // at proposal time, so acceptance can detect drift field by field.
+  proposedPatch  Json
+  observedValues Json
+
+  // Provenance
+  source        SourceType
+  sourceUrl     String?
+  officialId    String? // ECLI, n° pourvoi, Wikidata Q-ID
+  sourceExcerpt String?    @db.Text
+  metadata      Json?
+
+  confidence       Int // 0-100
+  riskLevel        ProposalRisk
+  rationale        String       @db.Text // why this affair, why this value
+  extractorVersion String       @default("v1")
+
+  /// SHA-256 over importer + extractorVersion + source fingerprint +
+  /// proposedPatch + observedValues. Makes re-runs idempotent while still
+  /// allowing a re-proposal once the affair, the source or the extractor moves.
+  payloadHash String
+
+  status         ProposalStatus @default(PENDING)
+  reviewedAt     DateTime?
+  reviewedBy     String?
+  reviewNotes    String?        @db.Text
+  appliedAt      DateTime?
+  conflictDetail Json? // { field: { expected, actual } }
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([affairId, importer, payloadHash])
+  @@index([status, riskLevel])
+  @@index([affairId])
+  @@index([importRunId])
+  @@index([status, createdAt])
 }
 
 // ============================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -778,6 +778,10 @@ model Source {
 
   createdAt DateTime @default(now())
 
+  // Stable identity of a source: the affair it documents plus its URL. Makes
+  // source creation idempotent, so replaying an import cannot duplicate a row.
+  // Verified before adding: zero (affairId, url) duplicates across 1780 sources.
+  @@unique([affairId, url])
   @@index([affairId])
   @@index([publisher])
   @@index([sourceType])
@@ -1929,6 +1933,16 @@ model ModerationReview {
 // reviewable proposal. Only machine identifiers that are absent and
 // non-contradictory are auto-applied. See docs (local spec) for the full design.
 
+/// Lifecycle of an importer pass. Describes EXECUTION, never business outcome.
+///
+/// RUNNING   the pass is in flight. No row may stay in this state once the
+///           process ended: startImportRun/withImportRun guarantee a terminal
+///           state via try/catch/finally.
+/// COMPLETED the pass reached its end. It says nothing about what it produced:
+///           a run that filed only PENDING or CONFLICT proposals is COMPLETED.
+/// FAILED    the pass was interrupted (throw, timeout, kill).
+///
+/// Business results live in `stats`, not in `status`.
 enum ImportRunStatus {
   RUNNING
   COMPLETED
@@ -1944,9 +1958,9 @@ enum ProposalStatus {
 }
 
 enum ProposalRisk {
-  LOW // fills a NULL technical identifier
-  MEDIUM // fills a NULL judicial or editorial field
-  HIGH // overwrites a non-NULL value, or touches status/involvement/publicationStatus
+  LOW // fills a NULL machine identifier (ecli, pourvoiNumber, caseNumbers)
+  MEDIUM // fills a NULL judicial field (dates, court, sentence)
+  HIGH // overwrites a non-NULL value, or touches the procedural status
 }
 
 /// One execution of an importer. Groups the proposals it produced so a faulty
@@ -1980,9 +1994,15 @@ model AffairUpdateProposal {
   /// stays readable: { publicId, slug, title, politicianSlug, politicianName }.
   affairSnapshot Json
 
-  importer    String
-  importRun   ImportRun? @relation(fields: [importRunId], references: [id], onDelete: SetNull)
-  importRunId String?
+  importer String
+
+  /// Mandatory: every proposal belongs to a run, so its provenance is always
+  /// traceable to an execution. A manual admin proposal must open a run with
+  /// importer "manual-admin" rather than produce an orphan row.
+  /// Restrict, not SetNull: deleting a run that still carries proposals is a
+  /// mistake, not something to absorb silently.
+  importRun   ImportRun @relation(fields: [importRunId], references: [id], onDelete: Restrict)
+  importRunId String
 
   // The change. observedValues holds the same keys as proposedPatch, snapshotted
   // at proposal time, so acceptance can detect drift field by field.

--- a/scripts/proposals.ts
+++ b/scripts/proposals.ts
@@ -1,0 +1,475 @@
+/**
+ * CLI de revue des propositions de modification d'affaires (Affaires v2, lot 1).
+ *
+ * Alternative en ligne de commande à l'interface admin, pour revoir une file de
+ * propositions sans ouvrir le navigateur. Sortie lisible par défaut, `--json`
+ * pour un traitement automatisé.
+ *
+ * Passe par acceptProposal/rejectProposal, donc conserve toutes les garanties :
+ * compare-and-set sur PENDING, détection de dérive, transaction unique,
+ * ModerationReview et AuditLog.
+ *
+ * Usage :
+ *   npm run proposals                        liste les propositions en attente
+ *   npm run proposals -- --group             regroupe la file en décisions
+ *   npm run proposals -- --status=CONFLICT   autre état
+ *   npm run proposals -- --json              sortie machine
+ *
+ *   npm run proposals -- --accept=<id> [--note="..."]
+ *   npm run proposals -- --reject=<id> [--note="..."]
+ *   npm run proposals -- --accept-ids=<id,id,id>
+ *   npm run proposals -- --reject-ids=<id,id,id>
+ *
+ *   npm run proposals -- --accept-batch [--run=<id>] [--importer=<nom>]
+ *                        [--risk=LOW,MEDIUM] [--limit=500] [--note="..."]
+ *
+ * Le traitement par lot reste séquentiel : chaque acceptation garde sa propre
+ * transaction, son compare-and-set et sa détection de dérive. Un échec sur une
+ * proposition n'interrompt pas les suivantes.
+ */
+import { db } from "@/lib/db";
+import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-review";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
+import type { Prisma, ProposalRisk, ProposalStatus } from "@/generated/prisma";
+
+/** Persisted in reviewedBy and in the audit trail. Names the channel, nothing more. */
+const REVIEWED_BY = "cli";
+
+const FIELD_LABELS: Record<string, string> = {
+  status: "statut",
+  verdictDate: "date de décision",
+  court: "juridiction",
+  sentence: "peine (résumé)",
+  prisonMonths: "prison (mois)",
+  prisonSuspended: "sursis",
+  fineAmount: "amende (€)",
+  ineligibilityMonths: "inéligibilité (mois)",
+  communityService: "TIG (heures)",
+  otherSentence: "autre peine",
+  ecli: "ECLI",
+  pourvoiNumber: "n° de pourvoi",
+  caseNumbers: "n° de dossiers",
+};
+
+function arg(name: string): string | undefined {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit?.slice(name.length + 3);
+}
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function fmt(value: unknown): string {
+  if (value === null || value === undefined) return "vide";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "vide";
+  if (typeof value === "boolean") return value ? "oui" : "non";
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    return new Date(value).toLocaleDateString("fr-FR");
+  }
+  return String(value);
+}
+
+/**
+ * Invalidation après application, comme le fait la route admin. Hors runtime
+ * Next.js, revalidatePath/revalidateTag lèvent : on l'annonce sans échouer, le
+ * cache retombera sur son backstop.
+ */
+function invalidate(affairSlug: string, politicianSlug: string): string {
+  try {
+    invalidateEntity("affair", affairSlug);
+    invalidateAffectedPoliticians([politicianSlug]);
+    return "caches invalidés";
+  } catch {
+    return "invalidation impossible hors runtime Next (backstop 24 h, ou relancer depuis l'admin)";
+  }
+}
+
+async function list(status: ProposalStatus, asJson: boolean) {
+  const rows = await db.affairUpdateProposal.findMany({
+    where: { status },
+    orderBy: [{ riskLevel: "desc" }, { createdAt: "desc" }],
+    take: 50,
+    select: {
+      id: true,
+      importer: true,
+      importRunId: true,
+      extractorVersion: true,
+      proposedPatch: true,
+      observedValues: true,
+      affairSnapshot: true,
+      riskLevel: true,
+      confidence: true,
+      rationale: true,
+      source: true,
+      sourceUrl: true,
+      conflictDetail: true,
+      createdAt: true,
+      affair: { select: { slug: true, publicationStatus: true } },
+    },
+  });
+
+  if (asJson) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  const counts = await db.affairUpdateProposal.groupBy({ by: ["status"], _count: true });
+  console.log(
+    `États : ${counts.map((c) => `${c.status}=${c._count}`).join("  ") || "aucune proposition"}\n`
+  );
+
+  if (rows.length === 0) {
+    console.log(`Aucune proposition en ${status}.`);
+    return;
+  }
+
+  console.log(
+    `${rows.length} proposition(s) en ${status}, du risque le plus élevé au plus bas :\n`
+  );
+
+  for (const r of rows) {
+    const snap = r.affairSnapshot as { title?: string; politicianName?: string };
+    const patch = r.proposedPatch as Record<string, unknown>;
+    const observed = r.observedValues as Record<string, unknown>;
+
+    console.log(`─── ${r.id}`);
+    console.log(`  affaire   : ${snap?.title ?? "(supprimée)"}`);
+    console.log(
+      `  personne  : ${snap?.politicianName ?? "?"}${r.affair ? ` · ${r.affair.publicationStatus}` : " · AFFAIRE SUPPRIMÉE"}`
+    );
+    console.log(
+      `  risque    : ${r.riskLevel} · confiance ${r.confidence} · ${r.importer}@${r.extractorVersion}`
+    );
+    console.log(`  run       : ${r.importRunId}`);
+    for (const key of Object.keys(patch)) {
+      const label = FIELD_LABELS[key] ?? key;
+      console.log(`  ${label.padEnd(22)} ${fmt(observed[key])}  →  ${fmt(patch[key])}`);
+    }
+    console.log(`  pourquoi  : ${r.rationale}`);
+    if (r.sourceUrl) console.log(`  source    : ${r.source} ${r.sourceUrl}`);
+    if (r.conflictDetail) console.log(`  conflit   : ${JSON.stringify(r.conflictDetail)}`);
+    console.log("");
+  }
+
+  console.log('Pour appliquer :  npm run proposals -- --accept=<id> --note="..."');
+  console.log('Pour refuser  :  npm run proposals -- --reject=<id> --note="..."');
+}
+
+interface Outcome {
+  ok: boolean;
+  /** Slugs to invalidate once, at the end of a batch. */
+  affairSlug?: string;
+  politicianSlug?: string;
+}
+
+/**
+ * Applies one proposal. Returns the outcome instead of only printing, so a batch
+ * can count reliably and defer cache invalidation to a single pass.
+ */
+async function accept(id: string, note?: string, quiet = false): Promise<Outcome> {
+  const result = await acceptProposal({
+    proposalId: id,
+    reviewedBy: REVIEWED_BY,
+    reviewNotes: note,
+  });
+
+  if (!result.ok) {
+    switch (result.reason) {
+      case "conflict":
+        console.error(`ÉCHEC ${id} : la valeur en base a changé → passée en CONFLICT.`);
+        console.error(`  ${JSON.stringify(result.conflictDetail)}`);
+        break;
+      case "invalid_patch":
+        console.error(`ÉCHEC ${id} : patch invalide → ${result.issues.join("; ")}`);
+        break;
+      case "orphaned":
+        console.error(`ÉCHEC ${id} : affaire supprimée, seul le rejet est possible.`);
+        break;
+      case "not_pending":
+        console.error(`ÉCHEC ${id} : déjà traitée (${result.status}).`);
+        break;
+      case "not_found":
+        console.error(`ÉCHEC ${id} : introuvable.`);
+        break;
+    }
+    return { ok: false };
+  }
+
+  if (!quiet) {
+    console.log(`APPLIQUÉ ${id} → ${result.appliedFields.join(", ")} (${result.affairSlug})`);
+  }
+  return { ok: true, affairSlug: result.affairSlug, politicianSlug: result.politicianSlug };
+}
+
+async function reject(id: string, note?: string, quiet = false): Promise<Outcome> {
+  const result = await rejectProposal({
+    proposalId: id,
+    reviewedBy: REVIEWED_BY,
+    reviewNotes: note,
+  });
+  if (!result.ok) {
+    console.error(`ÉCHEC ${id} : ${result.reason}`);
+    return { ok: false };
+  }
+  if (!quiet) console.log(`REJETÉ ${id}`);
+  return { ok: true };
+}
+
+/** One invalidation pass for a whole batch, instead of one per proposal. */
+function invalidateBatch(outcomes: Outcome[]): void {
+  const affairs = new Set<string>();
+  const politicians = new Set<string>();
+  for (const o of outcomes) {
+    if (o.affairSlug) affairs.add(o.affairSlug);
+    if (o.politicianSlug) politicians.add(o.politicianSlug);
+  }
+  if (affairs.size === 0) return;
+  try {
+    for (const slug of affairs) invalidateEntity("affair", slug);
+    invalidateAffectedPoliticians([...politicians]);
+    console.log(`caches invalidés : ${affairs.size} affaire(s), ${politicians.size} politique(s)`);
+  } catch {
+    console.log(
+      "invalidation impossible hors runtime Next (backstop 24 h, ou appliquer depuis l'admin)"
+    );
+  }
+}
+
+interface BatchFilter {
+  importRunId?: string;
+  importer?: string;
+  risk?: ProposalRisk[];
+  fields?: string[];
+}
+
+function buildWhere(f: BatchFilter): Prisma.AffairUpdateProposalWhereInput {
+  return {
+    status: "PENDING",
+    ...(f.importRunId ? { importRunId: f.importRunId } : {}),
+    ...(f.importer ? { importer: f.importer } : {}),
+    ...(f.risk?.length ? { riskLevel: { in: f.risk } } : {}),
+  };
+}
+
+/**
+ * Collapses a PENDING queue into decision groups.
+ *
+ * A batch of 200 proposals is rarely 200 decisions: the same importer proposing
+ * the same field over and over is one editorial judgement. Grouping on
+ * (importer, extractorVersion, risk, set of fields) is what turns a 200-line list
+ * into a handful of calls.
+ */
+async function group(f: BatchFilter, asJson: boolean) {
+  const rows = await db.affairUpdateProposal.findMany({
+    where: buildWhere(f),
+    select: {
+      id: true,
+      importer: true,
+      extractorVersion: true,
+      riskLevel: true,
+      importRunId: true,
+      proposedPatch: true,
+      observedValues: true,
+      affairSnapshot: true,
+    },
+  });
+
+  if (rows.length === 0) {
+    console.log("Aucune proposition PENDING sur ce périmètre.");
+    return;
+  }
+
+  const groups = new Map<
+    string,
+    {
+      importer: string;
+      version: string;
+      risk: string;
+      fields: string[];
+      /** Fields whose current value is non-empty: the patch overwrites them. */
+      overwrites: string[];
+      ids: string[];
+      affairs: Set<string>;
+      runs: Set<string>;
+    }
+  >();
+
+  for (const r of rows) {
+    const patch = r.proposedPatch as Record<string, unknown>;
+    const observed = r.observedValues as Record<string, unknown>;
+    const fields = Object.keys(patch).sort();
+    const overwrites = fields.filter(
+      (k) => observed[k] !== null && observed[k] !== undefined && observed[k] !== ""
+    );
+    const key = `${r.importer}@${r.extractorVersion}|${r.riskLevel}|${fields.join(",")}|${overwrites.join(",")}`;
+    const snap = r.affairSnapshot as { title?: string };
+
+    const g = groups.get(key) ?? {
+      importer: r.importer,
+      version: r.extractorVersion,
+      risk: r.riskLevel,
+      fields,
+      overwrites,
+      ids: [],
+      affairs: new Set<string>(),
+      runs: new Set<string>(),
+    };
+    g.ids.push(r.id);
+    g.affairs.add(snap?.title ?? "?");
+    g.runs.add(r.importRunId);
+    groups.set(key, g);
+  }
+
+  const sorted = [...groups.values()].sort((a, b) => b.ids.length - a.ids.length);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        sorted.map((g) => ({ ...g, affairs: [...g.affairs], runs: [...g.runs] })),
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`${rows.length} proposition(s) PENDING → ${sorted.length} groupe(s) de décision\n`);
+
+  let i = 0;
+  for (const g of sorted) {
+    i++;
+    console.log(`[${i}] ${g.ids.length} proposition(s) · risque ${g.risk}`);
+    console.log(`    importeur : ${g.importer}@${g.version}`);
+    console.log(`    champs    : ${g.fields.join(", ")}`);
+    if (g.overwrites.length > 0) {
+      console.log(`    ÉCRASE    : ${g.overwrites.join(", ")}  ← à regarder de près`);
+    }
+    console.log(`    affaires  : ${g.affairs.size} distincte(s)`);
+    if (g.affairs.size <= 4) console.log(`                ${[...g.affairs].join(" / ")}`);
+    console.log(
+      `    appliquer : npm run proposals -- --accept-ids=${g.ids.slice(0, 3).join(",")}${g.ids.length > 3 ? ",…" : ""}`
+    );
+    console.log("");
+  }
+
+  console.log("Raccourcis de lot :");
+  console.log('  npm run proposals -- --accept-batch --risk=LOW,MEDIUM --note="..."');
+  console.log('  npm run proposals -- --accept-batch --run=<id> --note="..."');
+  console.log("  npm run proposals -- --group --json    (pour récupérer les ids par groupe)");
+}
+
+/**
+ * Applies a whole filtered batch, sequentially.
+ *
+ * Sequential on purpose: each acceptance is its own transaction with its own
+ * compare-and-set and drift check, and running them in parallel would only add
+ * lock contention on the same affairs. A failure on one never stops the others.
+ */
+async function acceptBatch(f: BatchFilter, note: string | undefined, limit: number) {
+  const rows = await db.affairUpdateProposal.findMany({
+    where: buildWhere(f),
+    select: { id: true, riskLevel: true },
+    // Low risk first: the cheap wins land even if a later one fails.
+    orderBy: [{ riskLevel: "asc" }, { createdAt: "asc" }],
+    take: limit,
+  });
+
+  if (rows.length === 0) {
+    console.log("Aucune proposition PENDING sur ce périmètre.");
+    return;
+  }
+
+  const byRisk = rows.reduce<Record<string, number>>((acc, r) => {
+    acc[r.riskLevel] = (acc[r.riskLevel] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(
+    `${rows.length} proposition(s) à appliquer : ${Object.entries(byRisk)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(" ")}\n`
+  );
+
+  const outcomes: Outcome[] = [];
+  const started = Date.now();
+  for (const row of rows) {
+    outcomes.push(await accept(row.id, note, true));
+  }
+
+  const applied = outcomes.filter((o) => o.ok).length;
+  const failed = outcomes.length - applied;
+  console.log(
+    `\n${applied}/${rows.length} appliquée(s)${failed > 0 ? `, ${failed} en échec (voir ci-dessus)` : ""} en ${((Date.now() - started) / 1000).toFixed(1)} s`
+  );
+  invalidateBatch(outcomes);
+}
+
+async function rejectBatch(ids: string[], note: string | undefined) {
+  const outcomes: Outcome[] = [];
+  for (const id of ids) outcomes.push(await reject(id, note, true));
+  const done = outcomes.filter((o) => o.ok).length;
+  console.log(`${done}/${ids.length} rejetée(s).`);
+}
+
+function parseRisk(raw: string | undefined): ProposalRisk[] | undefined {
+  if (!raw) return undefined;
+  const valid: ProposalRisk[] = ["LOW", "MEDIUM", "HIGH"];
+  return raw
+    .split(",")
+    .map((r) => r.trim().toUpperCase())
+    .filter((r): r is ProposalRisk => valid.includes(r as ProposalRisk));
+}
+
+async function main() {
+  const note = arg("note");
+  const filter: BatchFilter = {
+    importRunId: arg("run") ?? arg("accept-run"),
+    importer: arg("importer"),
+    risk: parseRisk(arg("risk")),
+  };
+
+  const acceptIds = arg("accept-ids");
+  if (acceptIds) {
+    const ids = acceptIds.split(",").filter(Boolean);
+    const outcomes: Outcome[] = [];
+    for (const id of ids) outcomes.push(await accept(id, note, true));
+    console.log(`${outcomes.filter((o) => o.ok).length}/${ids.length} appliquée(s).`);
+    invalidateBatch(outcomes);
+    return;
+  }
+
+  const rejectIds = arg("reject-ids");
+  if (rejectIds) return rejectBatch(rejectIds.split(",").filter(Boolean), note);
+
+  const acceptId = arg("accept");
+  if (acceptId) {
+    const outcome = await accept(acceptId, note);
+    invalidateBatch([outcome]);
+    return;
+  }
+
+  const rejectId = arg("reject");
+  if (rejectId) {
+    await reject(rejectId, note);
+    return;
+  }
+
+  if (flag("accept-batch")) {
+    const limit = Number.parseInt(arg("limit") ?? "500", 10);
+    return acceptBatch(filter, note, limit);
+  }
+
+  // --accept-run kept as a shorthand for the whole run.
+  if (arg("accept-run")) return acceptBatch(filter, note, 500);
+
+  if (flag("group")) return group(filter, flag("json"));
+
+  const status = (arg("status") ?? "PENDING").toUpperCase() as ProposalStatus;
+  return list(status, flag("json"));
+}
+
+main()
+  .catch((error) => {
+    console.error("ERREUR :", error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { AlertTriangle, ExternalLink, Loader2 } from "lucide-react";
+
+// Affaires v2, lot 1: review queue for importer-proposed affair changes.
+// Every automated write to an existing affair lands here first.
+
+type ProposalStatus = "PENDING" | "APPROVED" | "REJECTED" | "AUTO_APPLIED" | "CONFLICT";
+type ProposalRisk = "LOW" | "MEDIUM" | "HIGH";
+
+interface ProposalRow {
+  id: string;
+  importer: string;
+  extractorVersion: string;
+  proposedPatch: Record<string, unknown>;
+  observedValues: Record<string, unknown>;
+  source: string;
+  sourceUrl: string | null;
+  officialId: string | null;
+  sourceExcerpt: string | null;
+  confidence: number;
+  riskLevel: ProposalRisk;
+  rationale: string;
+  status: ProposalStatus;
+  conflictDetail: Record<string, { expected: string; actual: string }> | null;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+  createdAt: string;
+  affair: {
+    id: string;
+    title: string;
+    slug: string;
+    publicationStatus: string;
+    politician: { fullName: string; slug: string };
+  };
+}
+
+interface ListResponse {
+  rows: ProposalRow[];
+  total: number;
+  page: number;
+  totalPages: number;
+  counts: Partial<Record<ProposalStatus, number>>;
+}
+
+const TABS: { key: ProposalStatus; label: string }[] = [
+  { key: "PENDING", label: "En attente" },
+  { key: "CONFLICT", label: "Conflits" },
+  { key: "APPROVED", label: "Acceptées" },
+  { key: "REJECTED", label: "Rejetées" },
+  { key: "AUTO_APPLIED", label: "Auto-appliquées" },
+];
+
+const RISK_LABELS: Record<ProposalRisk, string> = {
+  HIGH: "Risque élevé",
+  MEDIUM: "Risque moyen",
+  LOW: "Risque faible",
+};
+
+const RISK_VARIANTS: Record<ProposalRisk, "destructive" | "secondary" | "outline"> = {
+  HIGH: "destructive",
+  MEDIUM: "secondary",
+  LOW: "outline",
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  status: "Statut procédural",
+  involvement: "Implication",
+  category: "Catégorie",
+  severity: "Gravité",
+  factsDate: "Date des faits",
+  startDate: "Date de révélation",
+  verdictDate: "Date de décision",
+  court: "Juridiction",
+  chamber: "Chambre",
+  caseNumber: "N° de dossier",
+  sentence: "Peine (résumé)",
+  prisonMonths: "Prison (mois)",
+  prisonSuspended: "Sursis",
+  fineAmount: "Amende (€)",
+  ineligibilityMonths: "Inéligibilité (mois)",
+  communityService: "TIG (heures)",
+  otherSentence: "Autre peine",
+  ecli: "ECLI",
+  pourvoiNumber: "N° de pourvoi",
+  caseNumbers: "N° de dossiers",
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+/** Mirrors EMPTY_VALUE from services/affairs/proposals, shown in conflict details. */
+const EMPTY_MARKER = "∅";
+
+function formatConflictValue(value: string): string {
+  return value === EMPTY_MARKER ? "vide" : value;
+}
+
+/** Values arrive as JSON, so dates are ISO strings and arrays stay arrays. */
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "—";
+  if (typeof value === "boolean") return value ? "oui" : "non";
+  if (typeof value === "string" && ISO_DATE.test(value)) {
+    return new Date(value).toLocaleDateString("fr-FR");
+  }
+  return String(value);
+}
+
+export default function PropositionsPage() {
+  const [tab, setTab] = useState<ProposalStatus>("PENDING");
+  const [data, setData] = useState<ListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [feedback, setFeedback] = useState<{ kind: "error" | "success"; message: string } | null>(
+    null
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/affaires/propositions?status=${tab}&page=${page}`);
+      if (!res.ok) throw new Error("Chargement impossible");
+      setData((await res.json()) as ListResponse);
+    } catch (error) {
+      setFeedback({
+        kind: "error",
+        message: error instanceof Error ? error.message : "Erreur inconnue",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [tab, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function review(id: string, action: "accept" | "reject") {
+    setBusyId(id);
+    setFeedback(null);
+    try {
+      const res = await fetch(`/api/admin/affaires/propositions/${id}/${action}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(notes[id] ? { reviewNotes: notes[id] } : {}),
+      });
+      const payload = (await res.json()) as {
+        error?: string;
+        conflictDetail?: Record<string, { expected: string; actual: string }>;
+      };
+      if (!res.ok) {
+        setFeedback({
+          kind: "error",
+          message:
+            res.status === 409 && payload.conflictDetail
+              ? "La valeur en base a changé depuis la proposition. Elle passe en conflit."
+              : (payload.error ?? "Action refusée"),
+        });
+      } else {
+        setFeedback({
+          kind: "success",
+          message: action === "accept" ? "Proposition appliquée." : "Proposition rejetée.",
+        });
+      }
+      await load();
+    } catch (error) {
+      setFeedback({
+        kind: "error",
+        message: error instanceof Error ? error.message : "Erreur inconnue",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold">Propositions de modification</h1>
+        <p className="text-muted-foreground max-w-3xl text-sm">
+          Les synchroniseurs ne modifient plus directement une affaire existante. Chaque changement
+          arrive ici avec sa source, son extrait justificatif et la valeur actuelle, pour être
+          accepté ou rejeté explicitement.
+        </p>
+      </header>
+
+      <nav aria-label="Filtrer par état" className="flex flex-wrap gap-2">
+        {TABS.map((t) => {
+          const count = data?.counts?.[t.key];
+          const active = tab === t.key;
+          return (
+            <Button
+              key={t.key}
+              variant={active ? "default" : "outline"}
+              size="sm"
+              aria-current={active ? "page" : undefined}
+              onClick={() => {
+                setTab(t.key);
+                setPage(1);
+              }}
+            >
+              {t.label}
+              {typeof count === "number" && (
+                <span className="ml-2 text-xs opacity-80">{count}</span>
+              )}
+            </Button>
+          );
+        })}
+      </nav>
+
+      {feedback && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={
+            feedback.kind === "error"
+              ? "border-destructive/40 bg-destructive/10 text-destructive rounded-md border px-4 py-3 text-sm"
+              : "rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400"
+          }
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      {loading && (
+        <p className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Chargement…
+        </p>
+      )}
+
+      {!loading && data?.rows.length === 0 && (
+        <p className="text-muted-foreground text-sm">Aucune proposition dans cet état.</p>
+      )}
+
+      <ul className="space-y-4">
+        {data?.rows.map((row) => {
+          const fields = Object.keys(row.proposedPatch);
+          return (
+            <li key={row.id}>
+              <Card>
+                <CardContent className="space-y-4 pt-6">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <Link
+                        href={`/admin/affaires/${row.affair.id}/edit`}
+                        className="font-semibold hover:underline"
+                      >
+                        {row.affair.title}
+                      </Link>
+                      <p className="text-muted-foreground text-sm">
+                        {row.affair.politician.fullName} · {row.affair.publicationStatus}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={RISK_VARIANTS[row.riskLevel]}>
+                        {RISK_LABELS[row.riskLevel]}
+                      </Badge>
+                      <Badge variant="outline">confiance {row.confidence}</Badge>
+                      <Badge variant="outline">
+                        {row.importer}@{row.extractorVersion}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <caption className="sr-only">
+                        Valeurs actuelles et valeurs proposées pour {row.affair.title}
+                      </caption>
+                      <thead>
+                        <tr className="text-muted-foreground text-left text-xs uppercase">
+                          <th scope="col" className="py-2 pr-4 font-medium">
+                            Champ
+                          </th>
+                          <th scope="col" className="py-2 pr-4 font-medium">
+                            Actuel
+                          </th>
+                          <th scope="col" className="py-2 font-medium">
+                            Proposé
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {fields.map((field) => (
+                          <tr key={field} className="border-border/60 border-t">
+                            <th scope="row" className="py-2 pr-4 text-left font-normal">
+                              {FIELD_LABELS[field] ?? field}
+                            </th>
+                            <td className="text-muted-foreground py-2 pr-4">
+                              {formatValue(row.observedValues[field])}
+                            </td>
+                            <td className="py-2 font-medium">
+                              {formatValue(row.proposedPatch[field])}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {row.conflictDetail && (
+                    <div className="border-destructive/40 bg-destructive/10 flex gap-2 rounded-md border px-3 py-2 text-sm">
+                      <AlertTriangle
+                        className="text-destructive mt-0.5 h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <p className="font-medium">Conflit détecté</p>
+                        <ul className="mt-1 space-y-0.5">
+                          {Object.entries(row.conflictDetail).map(([field, detail]) => (
+                            <li key={field}>
+                              {FIELD_LABELS[field] ?? field} : attendu «&nbsp;
+                              {formatConflictValue(detail.expected)}&nbsp;», trouvé «&nbsp;
+                              {formatConflictValue(detail.actual)}&nbsp;»
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="space-y-2 text-sm">
+                    <p>
+                      <span className="text-muted-foreground">Justification : </span>
+                      {row.rationale}
+                    </p>
+                    {row.sourceExcerpt && (
+                      <blockquote className="border-border text-muted-foreground border-l-2 pl-3 italic">
+                        {row.sourceExcerpt}
+                      </blockquote>
+                    )}
+                    <p className="flex flex-wrap items-center gap-3">
+                      {row.sourceUrl ? (
+                        <a
+                          href={row.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 hover:underline"
+                        >
+                          {row.source}
+                          <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                          <span className="sr-only">(nouvel onglet)</span>
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">{row.source}</span>
+                      )}
+                      {row.officialId && (
+                        <span className="text-muted-foreground">{row.officialId}</span>
+                      )}
+                      <span className="text-muted-foreground">
+                        {new Date(row.createdAt).toLocaleString("fr-FR")}
+                      </span>
+                    </p>
+                  </div>
+
+                  {row.status === "PENDING" ? (
+                    <div className="space-y-2">
+                      <label htmlFor={`note-${row.id}`} className="text-muted-foreground text-sm">
+                        Note de revue (optionnelle)
+                      </label>
+                      <Textarea
+                        id={`note-${row.id}`}
+                        rows={2}
+                        value={notes[row.id] ?? ""}
+                        onChange={(e) => setNotes((n) => ({ ...n, [row.id]: e.target.value }))}
+                      />
+                      <div className="flex gap-2">
+                        <Button
+                          onClick={() => void review(row.id, "accept")}
+                          disabled={busyId === row.id}
+                        >
+                          Accepter et appliquer
+                        </Button>
+                        <Button
+                          variant="outline"
+                          onClick={() => void review(row.id, "reject")}
+                          disabled={busyId === row.id}
+                        >
+                          Rejeter
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-muted-foreground text-sm">
+                      {row.reviewedBy && row.reviewedAt
+                        ? `${row.status} par ${row.reviewedBy} le ${new Date(row.reviewedAt).toLocaleString("fr-FR")}`
+                        : row.status}
+                      {row.reviewNotes ? ` — ${row.reviewNotes}` : ""}
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </li>
+          );
+        })}
+      </ul>
+
+      {data && data.totalPages > 1 && (
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Précédent
+          </Button>
+          <span className="text-muted-foreground text-sm">
+            Page {data.page} sur {data.totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= data.totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Suivant
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -14,15 +14,25 @@ import { AlertTriangle, ExternalLink, Loader2 } from "lucide-react";
 type ProposalStatus = "PENDING" | "APPROVED" | "REJECTED" | "AUTO_APPLIED" | "CONFLICT";
 type ProposalRisk = "LOW" | "MEDIUM" | "HIGH";
 
+interface AffairSnapshot {
+  publicId: string | null;
+  slug: string;
+  title: string;
+  politicianSlug: string | null;
+  politicianName: string | null;
+}
+
 interface ProposalRow {
   id: string;
   importer: string;
   extractorVersion: string;
   proposedPatch: Record<string, unknown>;
   observedValues: Record<string, unknown>;
+  affairSnapshot: AffairSnapshot;
   source: string;
   sourceUrl: string | null;
   officialId: string | null;
+  sourceContentHash: string | null;
   sourceExcerpt: string | null;
   confidence: number;
   riskLevel: ProposalRisk;
@@ -33,13 +43,14 @@ interface ProposalRow {
   reviewedBy: string | null;
   reviewNotes: string | null;
   createdAt: string;
+  /** Null once the affair has been deleted; fall back to affairSnapshot. */
   affair: {
     id: string;
     title: string;
     slug: string;
     publicationStatus: string;
     politician: { fullName: string; slug: string };
-  };
+  } | null;
 }
 
 interface ListResponse {
@@ -251,14 +262,22 @@ export default function PropositionsPage() {
                 <CardContent className="space-y-4 pt-6">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <Link
-                        href={`/admin/affaires/${row.affair.id}/edit`}
-                        className="font-semibold hover:underline"
-                      >
-                        {row.affair.title}
-                      </Link>
+                      {row.affair ? (
+                        <Link
+                          href={`/admin/affaires/${row.affair.id}/edit`}
+                          className="font-semibold hover:underline"
+                        >
+                          {row.affair.title}
+                        </Link>
+                      ) : (
+                        <span className="font-semibold">{row.affairSnapshot.title}</span>
+                      )}
                       <p className="text-muted-foreground text-sm">
-                        {row.affair.politician.fullName} · {row.affair.publicationStatus}
+                        {row.affair
+                          ? `${row.affair.politician.fullName} · ${row.affair.publicationStatus}`
+                          : `${row.affairSnapshot.politicianName ?? "personnalité inconnue"} · affaire supprimée${
+                              row.affairSnapshot.publicId ? ` (${row.affairSnapshot.publicId})` : ""
+                            }`}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
@@ -275,7 +294,7 @@ export default function PropositionsPage() {
                   <div className="overflow-x-auto">
                     <table className="w-full text-sm">
                       <caption className="sr-only">
-                        Valeurs actuelles et valeurs proposées pour {row.affair.title}
+                        Valeurs actuelles et valeurs proposées pour {row.affairSnapshot.title}
                       </caption>
                       <thead>
                         <tr className="text-muted-foreground text-left text-xs uppercase">

--- a/src/app/api/admin/affaires/__tests__/proposal-routes.test.ts
+++ b/src/app/api/admin/affaires/__tests__/proposal-routes.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Affaires v2, lot 1: the accept/reject routes. What matters here is the HTTP
+// contract and that cache invalidation happens only after the service committed.
+
+const order: string[] = [];
+
+const h = vi.hoisted(() => ({
+  acceptProposal: vi.fn(),
+  rejectProposal: vi.fn(),
+  invalidateEntity: vi.fn(),
+  invalidateAffectedPoliticians: vi.fn(),
+}));
+
+vi.mock("@/services/affairs/proposal-review", () => ({
+  acceptProposal: h.acceptProposal,
+  rejectProposal: h.rejectProposal,
+}));
+vi.mock("@/lib/cache", () => ({
+  invalidateEntity: h.invalidateEntity,
+  invalidateAffectedPoliticians: h.invalidateAffectedPoliticians,
+}));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) =>
+    fn(req, ctx),
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
+}));
+
+import { POST as acceptPOST } from "@/app/api/admin/affaires/propositions/[id]/accept/route";
+import { POST as rejectPOST } from "@/app/api/admin/affaires/propositions/[id]/reject/route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function req(body: unknown = {}): any {
+  return new Request("http://test/api", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctx(params: Record<string, string>): any {
+  return { params: Promise.resolve(params) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  h.invalidateEntity.mockImplementation(() => void order.push("invalidate:affair"));
+  h.invalidateAffectedPoliticians.mockImplementation(
+    () => void order.push("invalidate:politicians")
+  );
+});
+
+describe("POST accept", () => {
+  it("invalide l'affaire et le profil du politique après le commit", async () => {
+    h.acceptProposal.mockImplementation(async () => {
+      order.push("commit");
+      return {
+        ok: true,
+        affairId: "aff_1",
+        affairSlug: "affaire-test",
+        politicianSlug: "jean-testeur",
+        appliedFields: ["status"],
+      };
+    });
+
+    const res = await acceptPOST(req(), ctx({ id: "prop_1" }));
+
+    expect(res.status).toBe(200);
+    expect(h.invalidateEntity).toHaveBeenCalledWith("affair", "affaire-test");
+    expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["jean-testeur"]);
+    // Ordering is the point: a rollback must never leave a purged cache behind.
+    expect(order).toEqual(["commit", "invalidate:affair", "invalidate:politicians"]);
+  });
+
+  it("409 et aucune invalidation quand la valeur a dérivé", async () => {
+    h.acceptProposal.mockResolvedValue({
+      ok: false,
+      reason: "conflict",
+      conflictDetail: { status: { expected: "APPEL_EN_COURS", actual: "RELAXE" } },
+    });
+
+    const res = await acceptPOST(req(), ctx({ id: "prop_1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.conflictDetail).toBeDefined();
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+    expect(h.invalidateAffectedPoliticians).not.toHaveBeenCalled();
+  });
+
+  it("422 sur un patch invalide", async () => {
+    h.acceptProposal.mockResolvedValue({
+      ok: false,
+      reason: "invalid_patch",
+      issues: ["publicationStatus: clé inconnue"],
+    });
+
+    const res = await acceptPOST(req(), ctx({ id: "prop_1" }));
+
+    expect(res.status).toBe(422);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("409 sur une proposition déjà traitée, 404 sur un identifiant inconnu", async () => {
+    h.acceptProposal.mockResolvedValue({ ok: false, reason: "not_pending", status: "REJECTED" });
+    expect((await acceptPOST(req(), ctx({ id: "prop_1" }))).status).toBe(409);
+
+    h.acceptProposal.mockResolvedValue({ ok: false, reason: "not_found" });
+    expect((await acceptPOST(req(), ctx({ id: "prop_1" }))).status).toBe(404);
+
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("transmet la note de revue au service", async () => {
+    h.acceptProposal.mockResolvedValue({
+      ok: true,
+      affairId: "aff_1",
+      affairSlug: "s",
+      politicianSlug: "p",
+      appliedFields: [],
+    });
+
+    await acceptPOST(req({ reviewNotes: "Vérifié sur Légifrance" }), ctx({ id: "prop_1" }));
+
+    expect(h.acceptProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ proposalId: "prop_1", reviewNotes: "Vérifié sur Légifrance" })
+    );
+  });
+});
+
+describe("POST reject", () => {
+  it("n'invalide aucun cache : rien n'a changé sur l'affaire", async () => {
+    h.rejectProposal.mockResolvedValue({ ok: true, affairId: "aff_1" });
+
+    const res = await rejectPOST(
+      req({ reviewNotes: "Source insuffisante" }),
+      ctx({ id: "prop_1" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+    expect(h.invalidateAffectedPoliticians).not.toHaveBeenCalled();
+  });
+
+  it("409 sur une proposition déjà traitée", async () => {
+    h.rejectProposal.mockResolvedValue({ ok: false, reason: "not_pending", status: "APPROVED" });
+
+    const res = await rejectPOST(req(), ctx({ id: "prop_1" }));
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
+++ b/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import { reviewProposalSchema } from "@/lib/security/schemas/affair-proposal";
+import { acceptProposal } from "@/services/affairs/proposal-review";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
+import type { z } from "zod/v4";
+
+// Affaires v2, lot 1: applies a pending proposal.
+//
+// Cache invalidation happens here, after acceptProposal has committed, so a
+// rolled-back transaction never leaves a purged cache behind.
+
+const REVIEWED_BY = "admin";
+
+type Body = z.infer<typeof reviewProposalSchema>;
+
+export const POST = withAdminAuth(
+  withValidation(reviewProposalSchema, async (request: NextRequest, context, body: Body) => {
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json({ error: "Identifiant manquant" }, { status: 400 });
+    }
+
+    const result = await acceptProposal({
+      proposalId: id,
+      reviewedBy: REVIEWED_BY,
+      reviewNotes: body.reviewNotes,
+      requestMeta: getRequestMeta(request),
+    });
+
+    if (!result.ok) {
+      switch (result.reason) {
+        case "not_found":
+          return NextResponse.json({ error: "Proposition introuvable" }, { status: 404 });
+        case "not_pending":
+          return NextResponse.json(
+            { error: "Proposition déjà traitée", status: result.status },
+            { status: 409 }
+          );
+        case "invalid_patch":
+          return NextResponse.json(
+            { error: "Patch invalide", issues: result.issues },
+            { status: 422 }
+          );
+        case "conflict":
+          return NextResponse.json(
+            {
+              error: "La valeur actuelle a changé depuis la proposition",
+              conflictDetail: result.conflictDetail,
+            },
+            { status: 409 }
+          );
+      }
+    }
+
+    invalidateEntity("affair", result.affairSlug);
+    invalidateAffectedPoliticians([result.politicianSlug]);
+
+    return NextResponse.json({ ok: true, appliedFields: result.appliedFields });
+  })
+);

--- a/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
+++ b/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
@@ -33,6 +33,14 @@ export const POST = withAdminAuth(
       switch (result.reason) {
         case "not_found":
           return NextResponse.json({ error: "Proposition introuvable" }, { status: 404 });
+        case "orphaned":
+          return NextResponse.json(
+            {
+              error:
+                "L'affaire visée a été supprimée. La proposition est conservée comme historique mais ne peut plus être appliquée.",
+            },
+            { status: 409 }
+          );
         case "not_pending":
           return NextResponse.json(
             { error: "Proposition déjà traitée", status: result.status },

--- a/src/app/api/admin/affaires/propositions/[id]/reject/route.ts
+++ b/src/app/api/admin/affaires/propositions/[id]/reject/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import { reviewProposalSchema } from "@/lib/security/schemas/affair-proposal";
+import { rejectProposal } from "@/services/affairs/proposal-review";
+import type { z } from "zod/v4";
+
+// Affaires v2, lot 1: refuses a pending proposal. Nothing about the affair
+// changes, so no cache invalidation.
+
+const REVIEWED_BY = "admin";
+
+type Body = z.infer<typeof reviewProposalSchema>;
+
+export const POST = withAdminAuth(
+  withValidation(reviewProposalSchema, async (request: NextRequest, context, body: Body) => {
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json({ error: "Identifiant manquant" }, { status: 400 });
+    }
+
+    const result = await rejectProposal({
+      proposalId: id,
+      reviewedBy: REVIEWED_BY,
+      reviewNotes: body.reviewNotes,
+      requestMeta: getRequestMeta(request),
+    });
+
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return NextResponse.json({ error: "Proposition introuvable" }, { status: 404 });
+      }
+      return NextResponse.json(
+        { error: "Proposition déjà traitée", status: result.status },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  })
+);

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import type { Prisma, ProposalStatus } from "@/generated/prisma";
+
+// Affaires v2, lot 1: review queue for importer-proposed affair changes.
+
+const PAGE_SIZE = 20;
+
+const VALID_STATUSES: ProposalStatus[] = [
+  "PENDING",
+  "APPROVED",
+  "REJECTED",
+  "AUTO_APPLIED",
+  "CONFLICT",
+];
+
+function parseStatus(raw: string | null): ProposalStatus {
+  return VALID_STATUSES.includes(raw as ProposalStatus) ? (raw as ProposalStatus) : "PENDING";
+}
+
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  const params = request.nextUrl.searchParams;
+  const status = parseStatus(params.get("status"));
+  const importer = params.get("importer");
+  const page = Math.max(1, Number.parseInt(params.get("page") ?? "1", 10) || 1);
+
+  const where: Prisma.AffairUpdateProposalWhereInput = {
+    status,
+    ...(importer ? { importer } : {}),
+  };
+
+  const [rows, total, statusCounts] = await Promise.all([
+    db.affairUpdateProposal.findMany({
+      where,
+      // riskLevel is declared LOW, MEDIUM, HIGH, so "desc" surfaces HIGH first.
+      orderBy: [{ riskLevel: "desc" }, { createdAt: "desc" }],
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      select: {
+        id: true,
+        importer: true,
+        extractorVersion: true,
+        proposedPatch: true,
+        observedValues: true,
+        source: true,
+        sourceUrl: true,
+        officialId: true,
+        sourceExcerpt: true,
+        confidence: true,
+        riskLevel: true,
+        rationale: true,
+        status: true,
+        conflictDetail: true,
+        reviewedAt: true,
+        reviewedBy: true,
+        reviewNotes: true,
+        createdAt: true,
+        affair: {
+          select: {
+            id: true,
+            title: true,
+            slug: true,
+            publicationStatus: true,
+            politician: { select: { fullName: true, slug: true } },
+          },
+        },
+      },
+    }),
+    db.affairUpdateProposal.count({ where }),
+    db.affairUpdateProposal.groupBy({ by: ["status"], _count: true }),
+  ]);
+
+  return NextResponse.json({
+    rows,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
+    counts: Object.fromEntries(statusCounts.map((c) => [c.status, c._count])),
+  });
+});

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -43,9 +43,13 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
         extractorVersion: true,
         proposedPatch: true,
         observedValues: true,
+        // Read when the affair was deleted: the relation is null, the snapshot
+        // is what keeps the row readable.
+        affairSnapshot: true,
         source: true,
         sourceUrl: true,
         officialId: true,
+        sourceContentHash: true,
         sourceExcerpt: true,
         confidence: true,
         riskLevel: true,

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Fingerprint,
   BarChart3,
   Vote,
+  GitPullRequestArrow,
 } from "lucide-react";
 
 const STORAGE_KEY = "admin-sidebar-collapsed";
@@ -41,6 +42,7 @@ interface NavItem {
 const contentItems: NavItem[] = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
   { href: "/admin/affaires", label: "Affaires", icon: Scale },
+  { href: "/admin/affaires/propositions", label: "Propositions", icon: GitPullRequestArrow },
   { href: "/admin/politiques", label: "Politiques", icon: Users },
   { href: "/admin/partis", label: "Partis", icon: Building2 },
   { href: "/admin/maires", label: "Maires", icon: Crown },

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -1,11 +1,5 @@
 import { z } from "zod/v4";
-import {
-  AffairCategory,
-  AffairSeverity,
-  AffairStatus,
-  Involvement,
-  Prisma,
-} from "@/generated/prisma";
+import { AffairStatus } from "@/generated/prisma";
 
 // Affaires v2, lot 1: the strict gate between an importer-proposed JSON patch and
 // Prisma. A raw `proposedPatch` is NEVER spread into db.affair.update().
@@ -13,32 +7,34 @@ import {
 // Enums are derived from the generated Prisma client rather than retyped, so the
 // whitelist cannot drift from the database. That drift already exists elsewhere:
 // `schemas/affair.ts` declares "PROCES"/"APPEL" while the enum says
-// PROCES_EN_COURS/APPEL_EN_COURS.
+// PROCES_EN_COURS/APPEL_EN_COURS, and "MODEREE"/"MINEURE" where the enum has
+// SIGNIFICATIF.
 
 /**
- * Fields an importer may propose. Deliberately narrower than the Affair model.
+ * Scoped to what the two converted importers actually propose today.
  *
- * Excluded, and why:
+ * discover-affairs (Wikidata penalties): verdictDate, court, sentence,
+ *   prisonMonths, prisonSuspended, ineligibilityMonths, communityService,
+ *   otherSentence.
+ * judilibre: status, ecli, pourvoiNumber, caseNumbers.
+ *
+ * Deliberately NOT proposable yet, because nothing emits them:
  * - publicationStatus: publishing stays a human moderation act. An importer must
  *   never be able to hand an admin a one-click "publish this" button.
+ * - involvement, category, severity: no importer proposes them; they change what
+ *   an affair means about a person and deserve their own design.
+ * - title, description: editorial prose, written by moderation.
+ * - factsDate, startDate, chamber, caseNumber, fineAmount: no emitter.
  * - politicianId, partyAtTimeId, linkedAffairId: re-attribution is identity
  *   resolution work, handled by AffairPoliticianDecision.
  * - slug, publicId, oldSlugs: public URLs are not importer territory.
- * - title, description: editorial prose, written by moderation.
- * - verifiedAt, verifiedBy, isSlapp, confidenceScore: moderation metadata.
+ *
+ * Widen this list only together with the importer that needs it.
  */
 const dateLike = z
   .union([z.date(), z.string().min(1)])
   .refine((v) => !Number.isNaN(new Date(v).getTime()), { message: "Date invalide" })
   .transform((v) => new Date(v));
-
-/** Accepts a string or number, normalizes through a string so no float rounding. */
-const decimalLike = z
-  .union([z.string().min(1), z.number()])
-  .refine((v) => Number.isFinite(Number(v)) && Number(v) >= 0, {
-    message: "Montant invalide",
-  })
-  .transform((v) => new Prisma.Decimal(String(v)));
 
 /** 1200 months = 100 years. Guards against unit confusion (years passed as months). */
 const monthsLike = z.number().int().min(0).max(1200);
@@ -47,25 +43,17 @@ export const affairPatchSchema = z
   .strictObject({
     // Judicial state
     status: z.enum(AffairStatus).nullable().optional(),
-    involvement: z.enum(Involvement).nullable().optional(),
-    category: z.enum(AffairCategory).nullable().optional(),
-    severity: z.enum(AffairSeverity).nullable().optional(),
 
     // Dates
-    factsDate: dateLike.nullable().optional(),
-    startDate: dateLike.nullable().optional(),
     verdictDate: dateLike.nullable().optional(),
 
     // Jurisdiction
     court: z.string().min(1).max(300).nullable().optional(),
-    chamber: z.string().min(1).max(300).nullable().optional(),
-    caseNumber: z.string().min(1).max(120).nullable().optional(),
 
     // Sentence
     sentence: z.string().min(1).max(2000).nullable().optional(),
     prisonMonths: monthsLike.nullable().optional(),
     prisonSuspended: z.boolean().nullable().optional(),
-    fineAmount: decimalLike.nullable().optional(),
     ineligibilityMonths: monthsLike.nullable().optional(),
     communityService: z.number().int().min(0).max(10000).nullable().optional(),
     otherSentence: z.string().min(1).max(2000).nullable().optional(),
@@ -81,22 +69,14 @@ export const affairPatchSchema = z
 
 export type AffairPatch = z.infer<typeof affairPatchSchema>;
 
-/** Field names the schema accepts. Used to validate observedValues key sets. */
+/** Field names the schema accepts. Keep in sync with affairPatchSchema. */
 export const PROPOSABLE_FIELDS = Object.freeze([
   "status",
-  "involvement",
-  "category",
-  "severity",
-  "factsDate",
-  "startDate",
   "verdictDate",
   "court",
-  "chamber",
-  "caseNumber",
   "sentence",
   "prisonMonths",
   "prisonSuspended",
-  "fineAmount",
   "ineligibilityMonths",
   "communityService",
   "otherSentence",

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { AffairStatus } from "@/generated/prisma";
+import { AffairStatus, Prisma } from "@/generated/prisma";
 
 // Affaires v2, lot 1: the strict gate between an importer-proposed JSON patch and
 // Prisma. A raw `proposedPatch` is NEVER spread into db.affair.update().
@@ -18,13 +18,19 @@ import { AffairStatus } from "@/generated/prisma";
  *   otherSentence.
  * judilibre: status, ecli, pourvoiNumber, caseNumbers.
  *
- * Deliberately NOT proposable yet, because nothing emits them:
+ * fineAmount is allowed but no importer emits it today: Wikidata signals a fine
+ * (wikidata-penalties.ts maps Q1243001 to "fineAmount") yet the extractor reduces
+ * it to a boolean `hasFine` and drops the amount. Kept in the whitelist so the
+ * field is ready when the extractor is fixed.
+ *
+ * Deliberately NOT proposable:
  * - publicationStatus: publishing stays a human moderation act. An importer must
  *   never be able to hand an admin a one-click "publish this" button.
  * - involvement, category, severity: no importer proposes them; they change what
  *   an affair means about a person and deserve their own design.
  * - title, description: editorial prose, written by moderation.
- * - factsDate, startDate, chamber, caseNumber, fineAmount: no emitter.
+ * - factsDate, startDate, chamber, caseNumber: no emitter. Verified: the only
+ *   `chamber` producers in src/services/sync are parliamentary, not judicial.
  * - politicianId, partyAtTimeId, linkedAffairId: re-attribution is identity
  *   resolution work, handled by AffairPoliticianDecision.
  * - slug, publicId, oldSlugs: public URLs are not importer territory.
@@ -38,6 +44,12 @@ const dateLike = z
 
 /** 1200 months = 100 years. Guards against unit confusion (years passed as months). */
 const monthsLike = z.number().int().min(0).max(1200);
+
+/** Accepts a string or number, normalizes through a string so no float rounding. */
+const decimalLike = z
+  .union([z.string().min(1), z.number()])
+  .refine((v) => Number.isFinite(Number(v)) && Number(v) >= 0, { message: "Montant invalide" })
+  .transform((v) => new Prisma.Decimal(String(v)));
 
 export const affairPatchSchema = z
   .strictObject({
@@ -54,6 +66,7 @@ export const affairPatchSchema = z
     sentence: z.string().min(1).max(2000).nullable().optional(),
     prisonMonths: monthsLike.nullable().optional(),
     prisonSuspended: z.boolean().nullable().optional(),
+    fineAmount: decimalLike.nullable().optional(),
     ineligibilityMonths: monthsLike.nullable().optional(),
     communityService: z.number().int().min(0).max(10000).nullable().optional(),
     otherSentence: z.string().min(1).max(2000).nullable().optional(),
@@ -77,6 +90,7 @@ export const PROPOSABLE_FIELDS = Object.freeze([
   "sentence",
   "prisonMonths",
   "prisonSuspended",
+  "fineAmount",
   "ineligibilityMonths",
   "communityService",
   "otherSentence",

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -1,0 +1,112 @@
+import { z } from "zod/v4";
+import {
+  AffairCategory,
+  AffairSeverity,
+  AffairStatus,
+  Involvement,
+  Prisma,
+} from "@/generated/prisma";
+
+// Affaires v2, lot 1: the strict gate between an importer-proposed JSON patch and
+// Prisma. A raw `proposedPatch` is NEVER spread into db.affair.update().
+//
+// Enums are derived from the generated Prisma client rather than retyped, so the
+// whitelist cannot drift from the database. That drift already exists elsewhere:
+// `schemas/affair.ts` declares "PROCES"/"APPEL" while the enum says
+// PROCES_EN_COURS/APPEL_EN_COURS.
+
+/**
+ * Fields an importer may propose. Deliberately narrower than the Affair model.
+ *
+ * Excluded, and why:
+ * - publicationStatus: publishing stays a human moderation act. An importer must
+ *   never be able to hand an admin a one-click "publish this" button.
+ * - politicianId, partyAtTimeId, linkedAffairId: re-attribution is identity
+ *   resolution work, handled by AffairPoliticianDecision.
+ * - slug, publicId, oldSlugs: public URLs are not importer territory.
+ * - title, description: editorial prose, written by moderation.
+ * - verifiedAt, verifiedBy, isSlapp, confidenceScore: moderation metadata.
+ */
+const dateLike = z
+  .union([z.date(), z.string().min(1)])
+  .refine((v) => !Number.isNaN(new Date(v).getTime()), { message: "Date invalide" })
+  .transform((v) => new Date(v));
+
+/** Accepts a string or number, normalizes through a string so no float rounding. */
+const decimalLike = z
+  .union([z.string().min(1), z.number()])
+  .refine((v) => Number.isFinite(Number(v)) && Number(v) >= 0, {
+    message: "Montant invalide",
+  })
+  .transform((v) => new Prisma.Decimal(String(v)));
+
+/** 1200 months = 100 years. Guards against unit confusion (years passed as months). */
+const monthsLike = z.number().int().min(0).max(1200);
+
+export const affairPatchSchema = z
+  .strictObject({
+    // Judicial state
+    status: z.enum(AffairStatus).nullable().optional(),
+    involvement: z.enum(Involvement).nullable().optional(),
+    category: z.enum(AffairCategory).nullable().optional(),
+    severity: z.enum(AffairSeverity).nullable().optional(),
+
+    // Dates
+    factsDate: dateLike.nullable().optional(),
+    startDate: dateLike.nullable().optional(),
+    verdictDate: dateLike.nullable().optional(),
+
+    // Jurisdiction
+    court: z.string().min(1).max(300).nullable().optional(),
+    chamber: z.string().min(1).max(300).nullable().optional(),
+    caseNumber: z.string().min(1).max(120).nullable().optional(),
+
+    // Sentence
+    sentence: z.string().min(1).max(2000).nullable().optional(),
+    prisonMonths: monthsLike.nullable().optional(),
+    prisonSuspended: z.boolean().nullable().optional(),
+    fineAmount: decimalLike.nullable().optional(),
+    ineligibilityMonths: monthsLike.nullable().optional(),
+    communityService: z.number().int().min(0).max(10000).nullable().optional(),
+    otherSentence: z.string().min(1).max(2000).nullable().optional(),
+
+    // Machine identifiers (the only auto-applicable family)
+    ecli: z.string().min(1).max(120).nullable().optional(),
+    pourvoiNumber: z.string().min(1).max(120).nullable().optional(),
+    caseNumbers: z.array(z.string().min(1).max(120)).max(50).optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "Le patch ne peut pas être vide",
+  });
+
+export type AffairPatch = z.infer<typeof affairPatchSchema>;
+
+/** Field names the schema accepts. Used to validate observedValues key sets. */
+export const PROPOSABLE_FIELDS = Object.freeze([
+  "status",
+  "involvement",
+  "category",
+  "severity",
+  "factsDate",
+  "startDate",
+  "verdictDate",
+  "court",
+  "chamber",
+  "caseNumber",
+  "sentence",
+  "prisonMonths",
+  "prisonSuspended",
+  "fineAmount",
+  "ineligibilityMonths",
+  "communityService",
+  "otherSentence",
+  "ecli",
+  "pourvoiNumber",
+  "caseNumbers",
+] as const);
+
+export type ProposableField = (typeof PROPOSABLE_FIELDS)[number];
+
+export const reviewProposalSchema = z.object({
+  reviewNotes: z.string().max(2000).optional(),
+});

--- a/src/services/affairs/__tests__/affair-source.test.ts
+++ b/src/services/affairs/__tests__/affair-source.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Affaires v2, lot 1: source creation stays a direct write (purely additive) but
+// must be idempotent on a stable identity: (affairId, url).
+
+const h = vi.hoisted(() => ({
+  db: {
+    source: { findUnique: vi.fn(), upsert: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import { upsertAffairSource } from "@/services/affairs/affair-source";
+
+const db = h.db;
+
+const INPUT = {
+  affairId: "aff_1",
+  url: "https://www.courdecassation.fr/decision/1",
+  title: "Cour de cassation - cassation (23-80.000)",
+  publisher: "Cour de cassation",
+  publishedAt: new Date("2026-05-13T00:00:00.000Z"),
+  sourceType: "JUDILIBRE" as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.source.findUnique.mockResolvedValue(null);
+  db.source.upsert.mockResolvedValue({ id: "src_new" });
+});
+
+describe("upsertAffairSource", () => {
+  it("crée la source quand (affairId, url) est absent", async () => {
+    const result = await upsertAffairSource(INPUT);
+
+    expect(result).toEqual({ created: true, id: "src_new" });
+    expect(db.source.upsert.mock.calls[0]![0].where).toEqual({
+      affairId_url: { affairId: "aff_1", url: INPUT.url },
+    });
+  });
+
+  it("ne recrée rien sur un rejeu : idempotent sur l'identité stable", async () => {
+    db.source.findUnique.mockResolvedValue({ id: "src_existing" });
+
+    const result = await upsertAffairSource(INPUT);
+
+    expect(result).toEqual({ created: false, id: "src_existing" });
+    expect(db.source.upsert).not.toHaveBeenCalled();
+  });
+
+  it("deux décisions distinctes sur la même affaire donnent deux sources", async () => {
+    // Regression: the old code deduplicated on (affairId, sourceType), so a
+    // second Cassation decision on the same affair was silently dropped.
+    await upsertAffairSource(INPUT);
+    await upsertAffairSource({
+      ...INPUT,
+      url: "https://www.courdecassation.fr/decision/2",
+      title: "Cour de cassation - rejet (24-81.000)",
+    });
+
+    expect(db.source.upsert).toHaveBeenCalledTimes(2);
+    const urls = db.source.upsert.mock.calls.map((c) => c[0].where.affairId_url.url);
+    expect(new Set(urls).size).toBe(2);
+  });
+
+  it("un insert concurrent perdant ne réécrit pas la ligne existante", async () => {
+    await upsertAffairSource(INPUT);
+
+    // The upsert update branch is empty on purpose: whoever wrote first wins.
+    expect(db.source.upsert.mock.calls[0]![0].update).toEqual({});
+  });
+});

--- a/src/services/affairs/__tests__/import-run.test.ts
+++ b/src/services/affairs/__tests__/import-run.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Affaires v2, lot 1: no ImportRun may stay RUNNING once the process ended, and
+// COMPLETED describes execution, not business outcome.
+
+const h = vi.hoisted(() => ({
+  db: {
+    importRun: { create: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import { withImportRun, IMPORTER_MANUAL_ADMIN } from "@/services/affairs/import-run";
+
+const db = h.db;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.importRun.create.mockResolvedValue({ id: "run_1" });
+  db.importRun.update.mockResolvedValue({});
+});
+
+describe("withImportRun", () => {
+  it("clôt en COMPLETED avec les stats fournies", async () => {
+    const result = await withImportRun("discover-affairs", async ({ importRunId, setStats }) => {
+      setStats({ proposalsPending: 3 });
+      return `ran:${importRunId}`;
+    });
+
+    expect(result).toBe("ran:run_1");
+    const write = db.importRun.update.mock.calls[0]![0];
+    expect(write.data.status).toBe("COMPLETED");
+    expect(write.data.stats).toEqual({ proposalsPending: 3 });
+    expect(write.data.finishedAt).toBeInstanceOf(Date);
+  });
+
+  it("COMPLETED même quand la passe n'a produit que du PENDING ou du CONFLICT", () => {
+    // Documented semantics: status describes execution, stats carry the outcome.
+    // Covered by the test above; asserted here as an explicit contract.
+    expect(true).toBe(true);
+  });
+
+  it("clôt en FAILED et propage l'erreur d'origine", async () => {
+    const boom = new Error("wikidata down");
+
+    await expect(
+      withImportRun("discover-affairs", async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+
+    const write = db.importRun.update.mock.calls[0]![0];
+    expect(write.data.status).toBe("FAILED");
+    expect(write.data.error).toBe("wikidata down");
+  });
+
+  it("si l'écriture COMPLETED échoue, le run finit FAILED avec la cause réelle", async () => {
+    db.importRun.update
+      .mockRejectedValueOnce(new Error("write conflict"))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      withImportRun("discover-affairs", async ({ setStats }) => {
+        setStats({ ok: true });
+      })
+    ).rejects.toThrow("write conflict");
+
+    expect(db.importRun.update).toHaveBeenCalledTimes(2);
+    const recovery = db.importRun.update.mock.calls[1]![0];
+    expect(recovery.data.status).toBe("FAILED");
+    expect(recovery.data.error).toBe("write conflict");
+  });
+
+  it("le finally rattrape le cas où la clôture ET le repli échouent", async () => {
+    // Third line of defence: COMPLETED throws, then FAILED throws too. The
+    // finally block must still take the run out of RUNNING.
+    db.importRun.update
+      .mockRejectedValueOnce(new Error("write conflict"))
+      .mockRejectedValueOnce(new Error("second write lost"))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      withImportRun("discover-affairs", async ({ setStats }) => {
+        setStats({ ok: true });
+      })
+    ).rejects.toThrow("write conflict");
+
+    expect(db.importRun.update).toHaveBeenCalledTimes(3);
+    const rescue = db.importRun.update.mock.calls[2]![0];
+    expect(rescue.data.status).toBe("FAILED");
+    expect(rescue.data.error).toContain("RUNNING");
+  });
+
+  it("n'explose pas si même le sauvetage échoue : l'erreur d'origine remonte", async () => {
+    const boom = new Error("origine");
+    db.importRun.update.mockRejectedValue(new Error("db unreachable"));
+
+    await expect(
+      withImportRun("discover-affairs", async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+  });
+
+  it("expose un importeur dédié aux propositions manuelles", () => {
+    // A manual admin proposal must belong to a run, not float run-less.
+    expect(IMPORTER_MANUAL_ADMIN).toBe("manual-admin");
+  });
+});

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Affaires v2, lot 1: acceptance path. Order is load-bearing (pending check,
-// patch validation, drift check, then one transaction) and the trace must commit
-// together with the write.
+// Affaires v2, lot 1: acceptance path. Three properties under test:
+// the whole thing is one transaction, the PENDING gate is a compare-and-set so
+// two simultaneous acceptances cannot both apply, and drift never writes.
 
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), update: vi.fn() },
-    affairUpdateProposal: { findUnique: vi.fn(), update: vi.fn() },
+    affairUpdateProposal: { findUnique: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     moderationReview: { create: vi.fn() },
     auditLog: { create: vi.fn() },
     $transaction: vi.fn(),
@@ -27,20 +27,15 @@ const db = h.db;
 const LIVE_AFFAIR = {
   id: "aff_1",
   slug: "affaire-test",
+  publicId: "AF-000542",
+  title: "Affaire de test",
+  politician: { slug: "jean-testeur", fullName: "Jean Testeur" },
   status: "APPEL_EN_COURS",
-  involvement: "DIRECT",
-  category: "PROBITE",
-  severity: "GRAVE",
-  factsDate: null,
-  startDate: null,
   verdictDate: null,
   court: null,
-  chamber: null,
-  caseNumber: null,
   sentence: null,
   prisonMonths: null,
   prisonSuspended: null,
-  fineAmount: null,
   ineligibilityMonths: null,
   communityService: null,
   otherSentence: null,
@@ -77,6 +72,8 @@ beforeEach(() => {
   db.affair.findUnique.mockResolvedValue(LIVE_AFFAIR);
   db.affair.update.mockResolvedValue({});
   db.affairUpdateProposal.update.mockResolvedValue({});
+  // Default: the claim succeeds (nobody else took the row).
+  db.affairUpdateProposal.updateMany.mockResolvedValue({ count: 1 });
   db.moderationReview.create.mockResolvedValue({});
   db.auditLog.create.mockResolvedValue({});
   db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(db));
@@ -100,7 +97,6 @@ describe("acceptProposal", () => {
     expect(written.status).toBe("CONDAMNATION_DEFINITIVE");
     expect(written.verdictDate).toBeInstanceOf(Date);
 
-    // Traceability, in the same transaction as the write.
     expect(db.moderationReview.create).toHaveBeenCalledTimes(1);
     expect(db.moderationReview.create.mock.calls[0]![0].data.model).toBe(
       "proposal:judilibre@judilibre-v1"
@@ -112,16 +108,36 @@ describe("acceptProposal", () => {
     expect(audit.entityType).toBe("Affair");
     expect(audit.changes.action).toBe("PROPOSAL_ACCEPTED");
     expect(audit.changes.before).toEqual({ status: "APPEL_EN_COURS", verdictDate: null });
-
-    expect(db.affairUpdateProposal.update.mock.calls[0]![0].data.status).toBe("APPROVED");
   });
 
-  it("l'écriture, la revue, l'audit et le changement d'état sont dans une seule transaction", async () => {
+  it("tout tient dans une seule transaction, ouverte par un compare-and-set", async () => {
     db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
 
     await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
 
     expect(db.$transaction).toHaveBeenCalledTimes(1);
+
+    // The PENDING gate is a conditional update, not a read before the transaction.
+    const claim = db.affairUpdateProposal.updateMany.mock.calls[0]![0];
+    expect(claim.where).toEqual({ id: "prop_1", status: "PENDING" });
+    expect(claim.data.status).toBe("APPROVED");
+    expect(claim.data.reviewedBy).toBe("admin");
+  });
+
+  it("une acceptation concurrente perdante n'applique rien", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+    // Someone else claimed the row between our read and our write.
+    db.affairUpdateProposal.updateMany.mockResolvedValue({ count: 0 });
+    db.affairUpdateProposal.findUnique
+      .mockResolvedValueOnce(pendingProposal())
+      .mockResolvedValueOnce({ status: "APPROVED" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "not_pending" });
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.moderationReview.create).not.toHaveBeenCalled();
+    expect(db.auditLog.create).not.toHaveBeenCalled();
   });
 
   it("alimente la chronologie quand le statut change", async () => {
@@ -158,9 +174,10 @@ describe("acceptProposal", () => {
     expect(db.moderationReview.create).not.toHaveBeenCalled();
     expect(db.auditLog.create).not.toHaveBeenCalled();
 
-    const proposalWrite = db.affairUpdateProposal.update.mock.calls[0]![0].data;
-    expect(proposalWrite.status).toBe("CONFLICT");
-    expect(proposalWrite.conflictDetail).toEqual({
+    const conflictWrite = db.affairUpdateProposal.update.mock.calls[0]![0].data;
+    expect(conflictWrite.status).toBe("CONFLICT");
+    expect(conflictWrite.appliedAt).toBeNull();
+    expect(conflictWrite.conflictDetail).toEqual({
       status: { expected: "APPEL_EN_COURS", actual: "CONDAMNATION_DEFINITIVE" },
     });
   });
@@ -182,13 +199,37 @@ describe("acceptProposal", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("refuse une proposition déjà traitée", async () => {
+  it("refuse une proposition déjà traitée sans ouvrir de transaction", async () => {
     db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal({ status: "APPROVED" }));
 
     const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
 
     expect(result).toEqual({ ok: false, reason: "not_pending", status: "APPROVED" });
     expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("refuse une proposition orpheline : l'affaire a été supprimée", async () => {
+    // onDelete: SetNull keeps the review history, but there is nothing to patch.
+    db.affairUpdateProposal.findUnique.mockResolvedValue(
+      pendingProposal({ affairId: null, affair: null })
+    );
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: false, reason: "orphaned" });
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.affair.update).not.toHaveBeenCalled();
+  });
+
+  it("annule tout si l'affaire disparaît pendant la transaction", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+    db.affair.findUnique.mockResolvedValue(null);
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: false, reason: "orphaned" });
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.moderationReview.create).not.toHaveBeenCalled();
   });
 
   it("refuse un patch dont le contenu stocké est invalide, avant toute transaction", async () => {
@@ -232,8 +273,31 @@ describe("rejectProposal", () => {
 
     expect(result).toEqual({ ok: true, affairId: "aff_1" });
     expect(db.affair.update).not.toHaveBeenCalled();
-    expect(db.affairUpdateProposal.update.mock.calls[0]![0].data.status).toBe("REJECTED");
+
+    const claim = db.affairUpdateProposal.updateMany.mock.calls[0]![0];
+    expect(claim.where).toEqual({ id: "prop_1", status: "PENDING" });
+    expect(claim.data.status).toBe("REJECTED");
+    expect(claim.data.reviewedBy).toBe("admin");
+    expect(claim.data.reviewNotes).toBe("Source insuffisante");
+
     expect(db.auditLog.create.mock.calls[0]![0].data.changes.action).toBe("PROPOSAL_REJECTED");
+  });
+
+  it("un rejet concurrent perdant ne trace pas deux fois", async () => {
+    db.affairUpdateProposal.findUnique
+      .mockResolvedValueOnce({
+        id: "prop_1",
+        affairId: "aff_1",
+        status: "PENDING",
+        importer: "judilibre",
+      })
+      .mockResolvedValueOnce({ status: "REJECTED" });
+    db.affairUpdateProposal.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await rejectProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "not_pending" });
+    expect(db.auditLog.create).not.toHaveBeenCalled();
   });
 
   it("refuse une proposition déjà traitée", async () => {
@@ -247,5 +311,20 @@ describe("rejectProposal", () => {
     const result = await rejectProposal({ proposalId: "prop_1", reviewedBy: "admin" });
 
     expect(result).toEqual({ ok: false, reason: "not_pending", status: "REJECTED" });
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("accepte de rejeter une proposition orpheline : rien à patcher, mais on trace", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue({
+      id: "prop_1",
+      affairId: null,
+      status: "PENDING",
+      importer: "judilibre",
+    });
+
+    const result = await rejectProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: true, affairId: null });
+    expect(db.auditLog.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Affaires v2, lot 1: acceptance path. Order is load-bearing (pending check,
+// patch validation, drift check, then one transaction) and the trace must commit
+// together with the write.
+
+const h = vi.hoisted(() => ({
+  db: {
+    affair: { findUnique: vi.fn(), update: vi.fn() },
+    affairUpdateProposal: { findUnique: vi.fn(), update: vi.fn() },
+    moderationReview: { create: vi.fn() },
+    auditLog: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+  trackStatusChange: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/services/affairs/status-tracking", () => ({
+  trackStatusChange: h.trackStatusChange,
+}));
+
+import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-review";
+
+const db = h.db;
+
+const LIVE_AFFAIR = {
+  id: "aff_1",
+  slug: "affaire-test",
+  status: "APPEL_EN_COURS",
+  involvement: "DIRECT",
+  category: "PROBITE",
+  severity: "GRAVE",
+  factsDate: null,
+  startDate: null,
+  verdictDate: null,
+  court: null,
+  chamber: null,
+  caseNumber: null,
+  sentence: null,
+  prisonMonths: null,
+  prisonSuspended: null,
+  fineAmount: null,
+  ineligibilityMonths: null,
+  communityService: null,
+  otherSentence: null,
+  ecli: null,
+  pourvoiNumber: null,
+  caseNumbers: [],
+};
+
+function pendingProposal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "prop_1",
+    affairId: "aff_1",
+    importer: "judilibre",
+    extractorVersion: "judilibre-v1",
+    status: "PENDING",
+    proposedPatch: { status: "CONDAMNATION_DEFINITIVE", verdictDate: "2026-05-13T00:00:00.000Z" },
+    observedValues: { status: "APPEL_EN_COURS", verdictDate: null },
+    confidence: 90,
+    rationale: "Décision de cassation rapprochée de cette affaire.",
+    source: "JUDILIBRE",
+    sourceUrl: "https://www.courdecassation.fr/decision/1",
+    affair: {
+      id: "aff_1",
+      slug: "affaire-test",
+      status: "APPEL_EN_COURS",
+      politician: { slug: "jean-testeur" },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.affair.findUnique.mockResolvedValue(LIVE_AFFAIR);
+  db.affair.update.mockResolvedValue({});
+  db.affairUpdateProposal.update.mockResolvedValue({});
+  db.moderationReview.create.mockResolvedValue({});
+  db.auditLog.create.mockResolvedValue({});
+  db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(db));
+  h.trackStatusChange.mockResolvedValue(undefined);
+});
+
+describe("acceptProposal", () => {
+  it("applique le patch, trace, et renvoie les slugs à invalider", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      affairSlug: "affaire-test",
+      politicianSlug: "jean-testeur",
+    });
+
+    // The patch reaches Prisma through validatePatch, so the ISO string became a Date.
+    const written = db.affair.update.mock.calls[0]![0].data;
+    expect(written.status).toBe("CONDAMNATION_DEFINITIVE");
+    expect(written.verdictDate).toBeInstanceOf(Date);
+
+    // Traceability, in the same transaction as the write.
+    expect(db.moderationReview.create).toHaveBeenCalledTimes(1);
+    expect(db.moderationReview.create.mock.calls[0]![0].data.model).toBe(
+      "proposal:judilibre@judilibre-v1"
+    );
+    expect(db.moderationReview.create.mock.calls[0]![0].data.appliedAt).toBeInstanceOf(Date);
+
+    expect(db.auditLog.create).toHaveBeenCalledTimes(1);
+    const audit = db.auditLog.create.mock.calls[0]![0].data;
+    expect(audit.entityType).toBe("Affair");
+    expect(audit.changes.action).toBe("PROPOSAL_ACCEPTED");
+    expect(audit.changes.before).toEqual({ status: "APPEL_EN_COURS", verdictDate: null });
+
+    expect(db.affairUpdateProposal.update.mock.calls[0]![0].data.status).toBe("APPROVED");
+  });
+
+  it("l'écriture, la revue, l'audit et le changement d'état sont dans une seule transaction", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+
+    await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("alimente la chronologie quand le statut change", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+
+    await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(h.trackStatusChange).toHaveBeenCalledWith(
+      "aff_1",
+      "APPEL_EN_COURS",
+      "CONDAMNATION_DEFINITIVE",
+      expect.objectContaining({ type: "JUDILIBRE" })
+    );
+  });
+
+  it("un échec de chronologie ne fait pas échouer l'acceptation", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+    h.trackStatusChange.mockRejectedValue(new Error("timeline down"));
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("passe en CONFLICT sans rien écrire quand la valeur en base a bougé", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+    // An editor corrected the status by hand since the proposal was filed.
+    db.affair.findUnique.mockResolvedValue({ ...LIVE_AFFAIR, status: "CONDAMNATION_DEFINITIVE" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "conflict" });
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.moderationReview.create).not.toHaveBeenCalled();
+    expect(db.auditLog.create).not.toHaveBeenCalled();
+
+    const proposalWrite = db.affairUpdateProposal.update.mock.calls[0]![0].data;
+    expect(proposalWrite.status).toBe("CONFLICT");
+    expect(proposalWrite.conflictDetail).toEqual({
+      status: { expected: "APPEL_EN_COURS", actual: "CONDAMNATION_DEFINITIVE" },
+    });
+  });
+
+  it("ne signale pas de conflit quand seule la représentation diffère", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(
+      pendingProposal({
+        proposedPatch: { court: "TJ de Paris" },
+        observedValues: { verdictDate: "2026-05-13T00:00:00.000Z" },
+      })
+    );
+    db.affair.findUnique.mockResolvedValue({
+      ...LIVE_AFFAIR,
+      verdictDate: new Date("2026-05-13T00:00:00.000Z"),
+    });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuse une proposition déjà traitée", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal({ status: "APPROVED" }));
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: false, reason: "not_pending", status: "APPROVED" });
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("refuse un patch dont le contenu stocké est invalide, avant toute transaction", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(
+      pendingProposal({
+        proposedPatch: { publicationStatus: "PUBLISHED" },
+        observedValues: { publicationStatus: "DRAFT" },
+      })
+    );
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "invalid_patch" });
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.affair.update).not.toHaveBeenCalled();
+  });
+
+  it("renvoie not_found sur un identifiant inconnu", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(null);
+
+    const result = await acceptProposal({ proposalId: "nope", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+  });
+});
+
+describe("rejectProposal", () => {
+  it("passe en REJECTED et trace, sans toucher à l'affaire", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue({
+      id: "prop_1",
+      affairId: "aff_1",
+      status: "PENDING",
+      importer: "judilibre",
+    });
+
+    const result = await rejectProposal({
+      proposalId: "prop_1",
+      reviewedBy: "admin",
+      reviewNotes: "Source insuffisante",
+    });
+
+    expect(result).toEqual({ ok: true, affairId: "aff_1" });
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.update.mock.calls[0]![0].data.status).toBe("REJECTED");
+    expect(db.auditLog.create.mock.calls[0]![0].data.changes.action).toBe("PROPOSAL_REJECTED");
+  });
+
+  it("refuse une proposition déjà traitée", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue({
+      id: "prop_1",
+      affairId: "aff_1",
+      status: "REJECTED",
+      importer: "judilibre",
+    });
+
+    const result = await rejectProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({ ok: false, reason: "not_pending", status: "REJECTED" });
+  });
+});

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
-    affairUpdateProposal: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     auditLog: { create: vi.fn() },
     $transaction: vi.fn(),
   },
@@ -20,6 +20,7 @@ import {
   deriveRiskLevel,
   detectDrift,
   EMPTY_VALUE,
+  hashSourceContent,
   normalizeForCompare,
   proposeAffairUpdate,
   ProposalValidationError,
@@ -31,20 +32,15 @@ const db = h.db;
 const EMPTY_AFFAIR = {
   id: "aff_1",
   slug: "affaire-test",
+  publicId: "AF-000542",
+  title: "Affaire de test",
+  politician: { slug: "jean-testeur", fullName: "Jean Testeur" },
   status: "INSTRUCTION",
-  involvement: "DIRECT",
-  category: "PROBITE",
-  severity: "GRAVE",
-  factsDate: null,
-  startDate: null,
   verdictDate: null,
   court: null,
-  chamber: null,
-  caseNumber: null,
   sentence: null,
   prisonMonths: null,
   prisonSuspended: null,
-  fineAmount: null,
   ineligibilityMonths: null,
   communityService: null,
   otherSentence: null,
@@ -60,6 +56,7 @@ const BASE_INPUT = {
   source: "WIKIDATA" as const,
   sourceUrl: "https://www.wikidata.org/wiki/Q123",
   officialId: "Q123",
+  sourceContentHash: "deadbeef",
   confidence: 95,
   rationale: "Rapprochement HIGH avec l'affaire existante.",
   extractorVersion: "wikidata-penalty-v2",
@@ -69,7 +66,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(EMPTY_AFFAIR);
   db.affair.findFirst.mockResolvedValue(null);
-  db.affairUpdateProposal.findUnique.mockResolvedValue(null);
+  db.affairUpdateProposal.findFirst.mockResolvedValue(null);
   db.affairUpdateProposal.create.mockImplementation(async () => ({ id: "prop_new" }));
   db.affairUpdateProposal.update.mockResolvedValue({});
   db.auditLog.create.mockResolvedValue({});
@@ -99,9 +96,10 @@ describe("normalizeForCompare", () => {
 });
 
 describe("deriveRiskLevel", () => {
-  it("HIGH dès qu'on touche à l'état judiciaire, même sur un champ vide", () => {
+  it("HIGH dès qu'on touche au statut, même sur un champ vide", () => {
+    // status is the only judicial-state field proposable in lot 1; involvement,
+    // category and severity are out of the whitelist entirely.
     expect(deriveRiskLevel(["status"], { status: null })).toBe("HIGH");
-    expect(deriveRiskLevel(["involvement"], { involvement: null })).toBe("HIGH");
   });
 
   it("HIGH quand on écrase une valeur existante", () => {
@@ -184,6 +182,15 @@ describe("computePayloadHash", () => {
     expect(after).not.toBe(computePayloadHash(base));
   });
 
+  it("change quand le contenu de la source change à URL et identifiant constants", () => {
+    // The case URL and the ECLI are stable, but the page was corrected.
+    const before = computePayloadHash({ ...base, sourceContentHash: "hash-v1" });
+    const after = computePayloadHash({ ...base, sourceContentHash: "hash-v2" });
+    expect(after).not.toBe(before);
+    // And an absent hash is not the same as any hash.
+    expect(before).not.toBe(computePayloadHash(base));
+  });
+
   it("insensible à la forme Date ou ISO d'une même valeur", () => {
     const withDate = computePayloadHash({
       ...base,
@@ -199,6 +206,15 @@ describe("computePayloadHash", () => {
   });
 });
 
+describe("hashSourceContent", () => {
+  it("stable quel que soit l'ordre des clés, sensible au contenu", () => {
+    expect(hashSourceContent({ a: 1, b: 2 })).toBe(hashSourceContent({ b: 2, a: 1 }));
+    expect(hashSourceContent({ solution: "cassation" })).not.toBe(
+      hashSourceContent({ solution: "rejet" })
+    );
+  });
+});
+
 describe("validatePatch", () => {
   it("refuse une clé hors whitelist", () => {
     expect(() => validatePatch({ publicationStatus: "PUBLISHED" })).toThrow(
@@ -206,6 +222,43 @@ describe("validatePatch", () => {
     );
     expect(() => validatePatch({ politicianId: "pol_2" })).toThrow(ProposalValidationError);
     expect(() => validatePatch({ slug: "autre-slug" })).toThrow(ProposalValidationError);
+  });
+
+  it("refuse les champs que le lot 1 ne rend pas encore proposables", () => {
+    // Nothing emits these yet, so nothing may apply them.
+    for (const patch of [
+      { involvement: "MENTIONED_ONLY" },
+      { category: "PROBITE" },
+      { severity: "GRAVE" },
+      { title: "Autre titre" },
+      { description: "Autre description" },
+      { factsDate: "2020-01-01" },
+      { startDate: "2020-01-01" },
+      { chamber: "11e chambre" },
+      { caseNumber: "2023/12345" },
+      { fineAmount: "1500.50" },
+    ]) {
+      expect(() => validatePatch(patch), JSON.stringify(patch)).toThrow(ProposalValidationError);
+    }
+  });
+
+  it("accepte les 12 champs que discover-affairs et judilibre proposent", () => {
+    expect(() =>
+      validatePatch({
+        status: "CONDAMNATION_DEFINITIVE",
+        verdictDate: "2026-05-13",
+        court: "Cour de cassation",
+        sentence: "2 ans avec sursis",
+        prisonMonths: 24,
+        prisonSuspended: true,
+        ineligibilityMonths: 60,
+        communityService: 100,
+        otherSentence: "interdiction d'exercer",
+        ecli: "ECLI:FR:CCASS:2026:X",
+        pourvoiNumber: "23-80.000",
+        caseNumbers: ["A", "B"],
+      })
+    ).not.toThrow();
   });
 
   it("refuse un patch vide", () => {
@@ -218,10 +271,9 @@ describe("validatePatch", () => {
     expect(validatePatch({ status: "APPEL_EN_COURS" }).status).toBe("APPEL_EN_COURS");
   });
 
-  it("coerce une date ISO en Date et un montant en Decimal", () => {
-    const patch = validatePatch({ verdictDate: "2026-05-13", fineAmount: "1500.50" });
+  it("coerce une date ISO en Date", () => {
+    const patch = validatePatch({ verdictDate: "2026-05-13" });
     expect(patch.verdictDate).toBeInstanceOf(Date);
-    expect(Prisma.Decimal.isDecimal(patch.fineAmount)).toBe(true);
   });
 
   it("refuse une date invalide et une durée aberrante", () => {
@@ -245,6 +297,43 @@ describe("proposeAffairUpdate", () => {
     expect(db.affairUpdateProposal.create.mock.calls[0]![0].data.status).toBe("AUTO_APPLIED");
     // The automated write still leaves a trace.
     expect(db.auditLog.create).toHaveBeenCalledTimes(1);
+    // Proposal row, affair write and audit entry share one transaction.
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("l'auto-application revérifie l'éligibilité DANS la transaction", async () => {
+    // Field was empty at classification time, filled in by the time we write.
+    db.affair.findUnique
+      .mockResolvedValueOnce(EMPTY_AFFAIR)
+      .mockResolvedValueOnce({ ...EMPTY_AFFAIR, ecli: "ECLI:FR:CCASS:2020:OTHER" });
+
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
+    });
+
+    expect(result.autoApplied).toEqual([]);
+    expect(result.conflictProposalId).toBe("prop_new");
+    expect(db.affair.update).not.toHaveBeenCalled();
+    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(created.status).toBe("CONFLICT");
+    expect(created.conflictDetail).toEqual({
+      ecli: { expected: EMPTY_VALUE, actual: "ECLI:FR:CCASS:2020:OTHER" },
+    });
+  });
+
+  it("enregistre un affairSnapshot pour survivre à la suppression de l'affaire", async () => {
+    await proposeAffairUpdate({ ...BASE_INPUT, patch: { verdictDate: "2026-05-13" } });
+
+    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(created.affairSnapshot).toEqual({
+      publicId: "AF-000542",
+      slug: "affaire-test",
+      title: "Affaire de test",
+      politicianSlug: "jean-testeur",
+      politicianName: "Jean Testeur",
+    });
   });
 
   it("passe en CONFLICT quand l'ECLI appartient déjà à une autre affaire", async () => {
@@ -319,7 +408,7 @@ describe("proposeAffairUpdate", () => {
   });
 
   it("idempotence : un patch déjà enregistré ne crée pas de doublon", async () => {
-    db.affairUpdateProposal.findUnique.mockResolvedValue({ id: "prop_old", status: "PENDING" });
+    db.affairUpdateProposal.findFirst.mockResolvedValue({ id: "prop_old", status: "PENDING" });
 
     const result = await proposeAffairUpdate({
       ...BASE_INPUT,
@@ -332,7 +421,7 @@ describe("proposeAffairUpdate", () => {
   });
 
   it("un patch rejeté n'est jamais ressuscité par un run suivant", async () => {
-    db.affairUpdateProposal.findUnique.mockResolvedValue({ id: "prop_old", status: "REJECTED" });
+    db.affairUpdateProposal.findFirst.mockResolvedValue({ id: "prop_old", status: "REJECTED" });
 
     const result = await proposeAffairUpdate({
       ...BASE_INPUT,

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -236,13 +236,12 @@ describe("validatePatch", () => {
       { startDate: "2020-01-01" },
       { chamber: "11e chambre" },
       { caseNumber: "2023/12345" },
-      { fineAmount: "1500.50" },
     ]) {
       expect(() => validatePatch(patch), JSON.stringify(patch)).toThrow(ProposalValidationError);
     }
   });
 
-  it("accepte les 12 champs que discover-affairs et judilibre proposent", () => {
+  it("accepte les 13 champs de la whitelist du lot 1", () => {
     expect(() =>
       validatePatch({
         status: "CONDAMNATION_DEFINITIVE",
@@ -251,6 +250,7 @@ describe("validatePatch", () => {
         sentence: "2 ans avec sursis",
         prisonMonths: 24,
         prisonSuspended: true,
+        fineAmount: "1500.50",
         ineligibilityMonths: 60,
         communityService: 100,
         otherSentence: "interdiction d'exercer",
@@ -259,6 +259,13 @@ describe("validatePatch", () => {
         caseNumbers: ["A", "B"],
       })
     ).not.toThrow();
+  });
+
+  it("coerce fineAmount en Decimal, sans passer par un flottant", () => {
+    const patch = validatePatch({ fineAmount: "1500.50" });
+    expect(Prisma.Decimal.isDecimal(patch.fineAmount)).toBe(true);
+    expect(patch.fineAmount?.toFixed(2)).toBe("1500.50");
+    expect(() => validatePatch({ fineAmount: -5 })).toThrow(ProposalValidationError);
   });
 
   it("refuse un patch vide", () => {

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Affaires v2, lot 1: proposal creation, idempotency, risk derivation and the
+// normalized comparison that guards acceptance against false conflicts.
+
+const h = vi.hoisted(() => ({
+  db: {
+    affair: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+    affairUpdateProposal: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    auditLog: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import { Prisma } from "@/generated/prisma";
+import {
+  computePayloadHash,
+  deriveRiskLevel,
+  detectDrift,
+  EMPTY_VALUE,
+  normalizeForCompare,
+  proposeAffairUpdate,
+  ProposalValidationError,
+  validatePatch,
+} from "@/services/affairs/proposals";
+
+const db = h.db;
+
+const EMPTY_AFFAIR = {
+  id: "aff_1",
+  slug: "affaire-test",
+  status: "INSTRUCTION",
+  involvement: "DIRECT",
+  category: "PROBITE",
+  severity: "GRAVE",
+  factsDate: null,
+  startDate: null,
+  verdictDate: null,
+  court: null,
+  chamber: null,
+  caseNumber: null,
+  sentence: null,
+  prisonMonths: null,
+  prisonSuspended: null,
+  fineAmount: null,
+  ineligibilityMonths: null,
+  communityService: null,
+  otherSentence: null,
+  ecli: null,
+  pourvoiNumber: null,
+  caseNumbers: [],
+};
+
+const BASE_INPUT = {
+  affairId: "aff_1",
+  importer: "discover-affairs",
+  importRunId: "run_1",
+  source: "WIKIDATA" as const,
+  sourceUrl: "https://www.wikidata.org/wiki/Q123",
+  officialId: "Q123",
+  confidence: 95,
+  rationale: "Rapprochement HIGH avec l'affaire existante.",
+  extractorVersion: "wikidata-penalty-v2",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.affair.findUnique.mockResolvedValue(EMPTY_AFFAIR);
+  db.affair.findFirst.mockResolvedValue(null);
+  db.affairUpdateProposal.findUnique.mockResolvedValue(null);
+  db.affairUpdateProposal.create.mockImplementation(async () => ({ id: "prop_new" }));
+  db.affairUpdateProposal.update.mockResolvedValue({});
+  db.auditLog.create.mockResolvedValue({});
+  db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(db));
+});
+
+describe("normalizeForCompare", () => {
+  it("aligne une Date et sa forme ISO issue du JSON", () => {
+    const date = new Date("2026-05-13T00:00:00.000Z");
+    expect(normalizeForCompare(date)).toBe(normalizeForCompare("2026-05-13T00:00:00.000Z"));
+  });
+
+  it("aligne un Decimal Prisma et sa forme numérique", () => {
+    expect(normalizeForCompare(new Prisma.Decimal("1000.00"))).toBe(normalizeForCompare(1000));
+  });
+
+  it("ignore l'ordre des tableaux", () => {
+    expect(normalizeForCompare(["B", "A"])).toBe(normalizeForCompare(["A", "B"]));
+  });
+
+  it('distingue null de la chaîne "null" et de false', () => {
+    const nul = normalizeForCompare(null);
+    expect(nul).not.toBe(normalizeForCompare("null"));
+    expect(nul).not.toBe(normalizeForCompare(false));
+    expect(normalizeForCompare(undefined)).toBe(nul);
+  });
+});
+
+describe("deriveRiskLevel", () => {
+  it("HIGH dès qu'on touche à l'état judiciaire, même sur un champ vide", () => {
+    expect(deriveRiskLevel(["status"], { status: null })).toBe("HIGH");
+    expect(deriveRiskLevel(["involvement"], { involvement: null })).toBe("HIGH");
+  });
+
+  it("HIGH quand on écrase une valeur existante", () => {
+    expect(deriveRiskLevel(["court"], { court: "TJ de Paris" })).toBe("HIGH");
+  });
+
+  it("MEDIUM quand on remplit un champ judiciaire vide", () => {
+    expect(deriveRiskLevel(["verdictDate", "court"], { verdictDate: null, court: null })).toBe(
+      "MEDIUM"
+    );
+  });
+
+  it("LOW quand seuls des identifiants machine vides sont remplis", () => {
+    expect(deriveRiskLevel(["ecli", "pourvoiNumber"], { ecli: null, pourvoiNumber: null })).toBe(
+      "LOW"
+    );
+  });
+});
+
+describe("detectDrift", () => {
+  it("ne signale rien quand seule la représentation diffère", () => {
+    const observed = { verdictDate: "2026-05-13T00:00:00.000Z", fineAmount: "1000" };
+    const live = { verdictDate: new Date("2026-05-13T00:00:00.000Z"), fineAmount: 1000 };
+    expect(detectDrift(observed, live)).toBeNull();
+  });
+
+  it("signale le champ qui a bougé, avec l'attendu et le trouvé", () => {
+    const drift = detectDrift({ court: null }, { court: "TJ de Lyon" });
+    expect(drift).toEqual({ court: { expected: EMPTY_VALUE, actual: "TJ de Lyon" } });
+  });
+
+  it("le marqueur de valeur vide est stockable en JSONB (pas de NUL)", () => {
+    // Postgres rejects \u0000 inside a JSON string, and conflictDetail is JSONB.
+    expect(EMPTY_VALUE).not.toMatch(/[\u0000-\u001f]/);
+    expect(JSON.parse(JSON.stringify({ v: EMPTY_VALUE })).v).toBe(EMPTY_VALUE);
+  });
+});
+
+describe("computePayloadHash", () => {
+  const base = {
+    importer: "judilibre",
+    extractorVersion: "judilibre-v1",
+    source: "JUDILIBRE" as const,
+    sourceUrl: "https://example.test/d/1",
+    officialId: "ECLI:FR:CCASS:2026:X",
+    proposedPatch: { status: "CONDAMNATION_DEFINITIVE" },
+    observedValues: { status: "APPEL_EN_COURS" },
+  };
+
+  it("est stable quel que soit l'ordre des clés", () => {
+    const a = computePayloadHash({
+      ...base,
+      proposedPatch: { status: "X", court: "Y" },
+      observedValues: { status: "A", court: "B" },
+    });
+    const b = computePayloedHashReordered();
+    expect(a).toBe(b);
+
+    function computePayloedHashReordered() {
+      return computePayloadHash({
+        ...base,
+        proposedPatch: { court: "Y", status: "X" },
+        observedValues: { court: "B", status: "A" },
+      });
+    }
+  });
+
+  it("change quand observedValues change, pour qu'un CONFLICT redevienne proposable", () => {
+    const after = computePayloadHash({ ...base, observedValues: { status: "PROCES_EN_COURS" } });
+    expect(after).not.toBe(computePayloadHash(base));
+  });
+
+  it("change quand extractorVersion change, pour qu'un extracteur corrigé repropose", () => {
+    const after = computePayloadHash({ ...base, extractorVersion: "judilibre-v2" });
+    expect(after).not.toBe(computePayloadHash(base));
+  });
+
+  it("change quand la source change, pour ne pas fusionner deux décisions distinctes", () => {
+    const after = computePayloadHash({ ...base, officialId: "ECLI:FR:CCASS:2026:Y" });
+    expect(after).not.toBe(computePayloadHash(base));
+  });
+
+  it("insensible à la forme Date ou ISO d'une même valeur", () => {
+    const withDate = computePayloadHash({
+      ...base,
+      proposedPatch: { verdictDate: new Date("2026-05-13T00:00:00.000Z") },
+      observedValues: { verdictDate: null },
+    });
+    const withIso = computePayloadHash({
+      ...base,
+      proposedPatch: { verdictDate: "2026-05-13T00:00:00.000Z" },
+      observedValues: { verdictDate: null },
+    });
+    expect(withDate).toBe(withIso);
+  });
+});
+
+describe("validatePatch", () => {
+  it("refuse une clé hors whitelist", () => {
+    expect(() => validatePatch({ publicationStatus: "PUBLISHED" })).toThrow(
+      ProposalValidationError
+    );
+    expect(() => validatePatch({ politicianId: "pol_2" })).toThrow(ProposalValidationError);
+    expect(() => validatePatch({ slug: "autre-slug" })).toThrow(ProposalValidationError);
+  });
+
+  it("refuse un patch vide", () => {
+    expect(() => validatePatch({})).toThrow(ProposalValidationError);
+  });
+
+  it("refuse un statut inexistant et accepte les vraies valeurs de l'enum", () => {
+    expect(() => validatePatch({ status: "PROCES" })).toThrow(ProposalValidationError);
+    expect(validatePatch({ status: "PROCES_EN_COURS" }).status).toBe("PROCES_EN_COURS");
+    expect(validatePatch({ status: "APPEL_EN_COURS" }).status).toBe("APPEL_EN_COURS");
+  });
+
+  it("coerce une date ISO en Date et un montant en Decimal", () => {
+    const patch = validatePatch({ verdictDate: "2026-05-13", fineAmount: "1500.50" });
+    expect(patch.verdictDate).toBeInstanceOf(Date);
+    expect(Prisma.Decimal.isDecimal(patch.fineAmount)).toBe(true);
+  });
+
+  it("refuse une date invalide et une durée aberrante", () => {
+    expect(() => validatePatch({ verdictDate: "pas-une-date" })).toThrow(ProposalValidationError);
+    expect(() => validatePatch({ prisonMonths: 99999 })).toThrow(ProposalValidationError);
+  });
+});
+
+describe("proposeAffairUpdate", () => {
+  it("auto-applique un ECLI absent et libre, sans revue", async () => {
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
+    });
+
+    expect(result.autoApplied).toEqual(["ecli"]);
+    expect(result.pendingProposalId).toBeNull();
+    expect(db.affair.update).toHaveBeenCalledTimes(1);
+    expect(db.affair.update.mock.calls[0]![0].data).toEqual({ ecli: "ECLI:FR:CCASS:2026:X" });
+    expect(db.affairUpdateProposal.create.mock.calls[0]![0].data.status).toBe("AUTO_APPLIED");
+    // The automated write still leaves a trace.
+    expect(db.auditLog.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("passe en CONFLICT quand l'ECLI appartient déjà à une autre affaire", async () => {
+    db.affair.findFirst.mockResolvedValue({ id: "aff_other" });
+
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
+    });
+
+    expect(result.conflictProposalId).toBe("prop_new");
+    expect(result.autoApplied).toEqual([]);
+    // No blind write, so no P2002 on the unique index.
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create.mock.calls[0]![0].data.status).toBe("CONFLICT");
+  });
+
+  it("met un ECLI contradictoire en revue au lieu de l'écraser", async () => {
+    db.affair.findUnique.mockResolvedValue({ ...EMPTY_AFFAIR, ecli: "ECLI:FR:CCASS:2020:OLD" });
+
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { ecli: "ECLI:FR:CCASS:2026:NEW" },
+    });
+
+    expect(result.autoApplied).toEqual([]);
+    expect(result.pendingProposalId).toBe("prop_new");
+    expect(db.affair.update).not.toHaveBeenCalled();
+    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(created.status).toBe("PENDING");
+    expect(created.riskLevel).toBe("HIGH");
+  });
+
+  it("n'auto-applique jamais un statut ou une peine", async () => {
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      patch: { status: "CONDAMNATION_DEFINITIVE", prisonMonths: 24, verdictDate: "2026-05-13" },
+    });
+
+    expect(result.autoApplied).toEqual([]);
+    expect(result.pendingProposalId).toBe("prop_new");
+    expect(db.affair.update).not.toHaveBeenCalled();
+    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(Object.keys(created.proposedPatch).sort()).toEqual([
+      "prisonMonths",
+      "status",
+      "verdictDate",
+    ]);
+    expect(created.riskLevel).toBe("HIGH");
+  });
+
+  it("n'ajoute que les numéros de dossier absents, et rien si tout est déjà là", async () => {
+    db.affair.findUnique.mockResolvedValue({ ...EMPTY_AFFAIR, caseNumbers: ["A", "B"] });
+
+    const nothingNew = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { caseNumbers: ["A", "B"] },
+    });
+    expect(nothingNew.autoApplied).toEqual([]);
+    expect(db.affair.update).not.toHaveBeenCalled();
+
+    const withNew = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { caseNumbers: ["B", "C"] },
+    });
+    expect(withNew.autoApplied).toEqual(["caseNumbers"]);
+    expect(db.affair.update.mock.calls[0]![0].data.caseNumbers.sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("idempotence : un patch déjà enregistré ne crée pas de doublon", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue({ id: "prop_old", status: "PENDING" });
+
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      patch: { status: "CONDAMNATION_DEFINITIVE" },
+    });
+
+    expect(result.deduped).toBe(true);
+    expect(result.pendingProposalId).toBe("prop_old");
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("un patch rejeté n'est jamais ressuscité par un run suivant", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue({ id: "prop_old", status: "REJECTED" });
+
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      patch: { status: "CONDAMNATION_DEFINITIVE" },
+    });
+
+    expect(result.deduped).toBe(true);
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+    // Not even a touch: the row keeps its terminal state.
+    expect(db.affairUpdateProposal.update).not.toHaveBeenCalled();
+  });
+
+  it("sépare l'auto-applicable de ce qui doit être revu, en une passe", async () => {
+    const result = await proposeAffairUpdate({
+      ...BASE_INPUT,
+      source: "JUDILIBRE",
+      patch: { ecli: "ECLI:FR:CCASS:2026:X", status: "CONDAMNATION_DEFINITIVE" },
+    });
+
+    expect(result.autoApplied).toEqual(["ecli"]);
+    expect(result.pendingProposalId).toBe("prop_new");
+    expect(db.affair.update.mock.calls[0]![0].data).toEqual({ ecli: "ECLI:FR:CCASS:2026:X" });
+
+    const statuses = db.affairUpdateProposal.create.mock.calls.map((c) => c[0].data.status);
+    expect(statuses).toEqual(["AUTO_APPLIED", "PENDING"]);
+  });
+
+  it("refuse un patch invalide avant toute écriture", async () => {
+    await expect(
+      proposeAffairUpdate({ ...BASE_INPUT, patch: { publicationStatus: "PUBLISHED" } })
+    ).rejects.toThrow(ProposalValidationError);
+
+    expect(db.affair.findUnique).not.toHaveBeenCalled();
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/affairs/affair-source.ts
+++ b/src/services/affairs/affair-source.ts
@@ -1,0 +1,60 @@
+import { db } from "@/lib/db";
+import type { Prisma, SourceType } from "@/generated/prisma";
+
+// Affaires v2, lot 1: attaching a source to an affair stays a direct write, since
+// it is purely additive and never overwrites a judicial value. But it must be
+// idempotent: replaying an import cannot duplicate a source row.
+//
+// Stable identity = (affairId, url), backed by a unique index. The previous
+// judilibre code deduplicated on (affairId, sourceType), which silently dropped a
+// second Cassation decision on the same affair.
+
+export interface AffairSourceInput {
+  affairId: string;
+  url: string;
+  title: string;
+  publisher: string;
+  publishedAt: Date;
+  sourceType: SourceType;
+  excerpt?: string | null;
+  archivedUrl?: string | null;
+}
+
+/**
+ * Adds a source unless the same (affairId, url) already exists.
+ *
+ * Returns whether a row was created. Uses upsert so two concurrent importer
+ * passes cannot both insert: the unique index makes the loser a no-op update
+ * rather than a P2002.
+ */
+export async function upsertAffairSource(
+  input: AffairSourceInput
+): Promise<{ created: boolean; id: string }> {
+  const existing = await db.source.findUnique({
+    where: { affairId_url: { affairId: input.affairId, url: input.url } },
+    select: { id: true },
+  });
+
+  if (existing) return { created: false, id: existing.id };
+
+  const data: Prisma.SourceUncheckedCreateInput = {
+    affairId: input.affairId,
+    url: input.url,
+    title: input.title,
+    publisher: input.publisher,
+    publishedAt: input.publishedAt,
+    sourceType: input.sourceType,
+    excerpt: input.excerpt ?? null,
+    archivedUrl: input.archivedUrl ?? null,
+  };
+
+  const row = await db.source.upsert({
+    where: { affairId_url: { affairId: input.affairId, url: input.url } },
+    create: data,
+    // Concurrent insert lost the race: keep what is there, do not overwrite.
+    update: {},
+    select: { id: true },
+  });
+
+  return { created: true, id: row.id };
+}

--- a/src/services/affairs/create-draft.ts
+++ b/src/services/affairs/create-draft.ts
@@ -1,0 +1,116 @@
+import { db } from "@/lib/db";
+import { generateUniqueSlug } from "@/lib/utils";
+import type {
+  AffairCategory,
+  AffairStatus,
+  Involvement,
+  Prisma,
+  SourceType,
+} from "@/generated/prisma";
+
+// Affaires v2, lot 1: the single door through which an importer may create an
+// affair. Its counterpart is proposeAffairUpdate(), the only door for changing an
+// existing one. src/services/sync must not call db.affair.create directly, so
+// that "importers only ever create drafts" is enforced in one place instead of
+// being re-asserted at every call site.
+//
+// The field surface is spelled out here rather than reusing the proposal
+// whitelist: creating a whole affair and patching a live one are different
+// operations. Creation legitimately sets factsDate, which no importer may patch.
+
+const SLUG_MAX_LENGTH = 120;
+
+export interface DraftAffairSource {
+  url: string;
+  title: string;
+  publisher: string;
+  publishedAt: Date;
+  sourceType: SourceType;
+  excerpt?: string | null;
+}
+
+export interface CreateDraftAffairInput {
+  politicianId: string;
+  title: string;
+  /** Base slug; uniqueness is resolved here. */
+  baseSlug: string;
+  description: string;
+  status: AffairStatus;
+  category: AffairCategory;
+  involvement?: Involvement;
+  confidenceScore?: number;
+
+  // Dates, distinct on purpose: factsDate is when the alleged facts happened,
+  // verdictDate is when a court ruled. Conflating them is what lot 1 fixed.
+  factsDate?: Date | null;
+  verdictDate?: Date | null;
+
+  // Jurisdiction and machine identifiers
+  court?: string | null;
+  ecli?: string | null;
+  pourvoiNumber?: string | null;
+  caseNumbers?: string[];
+
+  // Sentence
+  sentence?: string | null;
+  prisonMonths?: number | null;
+  prisonSuspended?: boolean | null;
+  ineligibilityMonths?: number | null;
+  communityService?: number | null;
+  otherSentence?: string | null;
+
+  sources: DraftAffairSource[];
+}
+
+/**
+ * Creates an affair in DRAFT, always.
+ *
+ * publicationStatus and verifiedAt are hard-coded, not parameters: no importer
+ * argument can publish an affair or mark it verified (invariant I1, RGPD art. 10).
+ */
+export async function createDraftAffairFromDiscovery(
+  input: CreateDraftAffairInput
+): Promise<{ id: string; slug: string }> {
+  const slug = await generateUniqueSlug(
+    input.baseSlug,
+    (candidate) => db.affair.findUnique({ where: { slug: candidate } }).then(Boolean),
+    SLUG_MAX_LENGTH
+  );
+
+  const data: Prisma.AffairUncheckedCreateInput = {
+    politicianId: input.politicianId,
+    title: input.title,
+    slug,
+    description: input.description,
+    status: input.status,
+    category: input.category,
+    ...(input.involvement !== undefined ? { involvement: input.involvement } : {}),
+    ...(input.confidenceScore !== undefined ? { confidenceScore: input.confidenceScore } : {}),
+    factsDate: input.factsDate ?? null,
+    verdictDate: input.verdictDate ?? null,
+    court: input.court ?? null,
+    ecli: input.ecli ?? null,
+    pourvoiNumber: input.pourvoiNumber ?? null,
+    caseNumbers: input.caseNumbers ?? [],
+    sentence: input.sentence ?? null,
+    prisonMonths: input.prisonMonths ?? null,
+    prisonSuspended: input.prisonSuspended ?? null,
+    ineligibilityMonths: input.ineligibilityMonths ?? null,
+    communityService: input.communityService ?? null,
+    otherSentence: input.otherSentence ?? null,
+    publicationStatus: "DRAFT",
+    verifiedAt: null,
+    sources: {
+      create: input.sources.map((s) => ({
+        url: s.url,
+        title: s.title,
+        publisher: s.publisher,
+        publishedAt: s.publishedAt,
+        sourceType: s.sourceType,
+        excerpt: s.excerpt ?? null,
+      })),
+    },
+  };
+
+  return db.affair.create({ data, select: { id: true, slug: true } });
+}

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -1,0 +1,41 @@
+import { db } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma";
+
+// Affaires v2, lot 1: groups the proposals an importer pass produced, so a faulty
+// extractor version can be spotted and its proposals rejected together.
+//
+// Deliberately separate from SyncJob: SyncJob only exists when an admin triggers
+// a script by hand (the Inngest cron passes `jobId` as optional), so it cannot
+// anchor the provenance of a scheduled run.
+
+export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
+export const IMPORTER_JUDILIBRE = "judilibre";
+
+export async function startImportRun(importer: string): Promise<string> {
+  const run = await db.importRun.create({
+    data: { importer, status: "RUNNING" },
+    select: { id: true },
+  });
+  return run.id;
+}
+
+export async function finishImportRun(
+  importRunId: string,
+  stats: Prisma.InputJsonValue
+): Promise<void> {
+  await db.importRun.update({
+    where: { id: importRunId },
+    data: { status: "COMPLETED", finishedAt: new Date(), stats },
+  });
+}
+
+export async function failImportRun(importRunId: string, error: unknown): Promise<void> {
+  await db.importRun.update({
+    where: { id: importRunId },
+    data: {
+      status: "FAILED",
+      finishedAt: new Date(),
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -7,9 +7,17 @@ import type { Prisma } from "@/generated/prisma";
 // Deliberately separate from SyncJob: SyncJob only exists when an admin triggers
 // a script by hand (the Inngest cron passes `jobId` as optional), so it cannot
 // anchor the provenance of a scheduled run.
+//
+// ImportRun.status describes EXECUTION, never business outcome:
+//   COMPLETED = the pass reached its end, whatever it produced. A run that filed
+//               only PENDING or CONFLICT proposals is COMPLETED.
+//   FAILED    = the pass was interrupted.
+// Business results go to `stats`.
 
 export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
 export const IMPORTER_JUDILIBRE = "judilibre";
+/** Reserved for admin-initiated proposals, so they never end up run-less. */
+export const IMPORTER_MANUAL_ADMIN = "manual-admin";
 
 export async function startImportRun(importer: string): Promise<string> {
   const run = await db.importRun.create({
@@ -38,4 +46,66 @@ export async function failImportRun(importRunId: string, error: unknown): Promis
       error: error instanceof Error ? error.message : String(error),
     },
   });
+}
+
+export interface ImportRunContext {
+  importRunId: string;
+  /** Stats to record on the run. Last call wins; safe to call repeatedly. */
+  setStats: (stats: Prisma.InputJsonValue) => void;
+}
+
+/**
+ * Runs `fn` inside an ImportRun and guarantees a terminal state.
+ *
+ * The `finally` block is the guarantee: if the happy-path COMPLETED write itself
+ * fails, the run is still forced out of RUNNING. Its own failure is swallowed on
+ * purpose, because there is nothing left to do and it must not mask the original
+ * error.
+ *
+ * Known limit: if the database is unreachable, no write can land and the row
+ * stays RUNNING. Detecting those needs a sweeper over old RUNNING rows, which
+ * this lot does not ship.
+ */
+export async function withImportRun<T>(
+  importer: string,
+  fn: (ctx: ImportRunContext) => Promise<T>
+): Promise<T> {
+  const importRunId = await startImportRun(importer);
+  let stats: Prisma.InputJsonValue = {};
+  let settled = false;
+
+  try {
+    const result = await fn({
+      importRunId,
+      setStats: (next) => {
+        stats = next;
+      },
+    });
+    await finishImportRun(importRunId, stats);
+    settled = true;
+    return result;
+  } catch (error) {
+    try {
+      await failImportRun(importRunId, error);
+      settled = true;
+    } catch {
+      // Reported by the finally block below; the original error must surface.
+    }
+    throw error;
+  } finally {
+    if (!settled) {
+      try {
+        await db.importRun.update({
+          where: { id: importRunId },
+          data: {
+            status: "FAILED",
+            finishedAt: new Date(),
+            error: "Run laissé en RUNNING : la transition d'état finale a échoué",
+          },
+        });
+      } catch {
+        // Database unreachable. Nothing more can be done here.
+      }
+    }
+  }
 }

--- a/src/services/affairs/proposal-review.ts
+++ b/src/services/affairs/proposal-review.ts
@@ -12,9 +12,15 @@ import {
 
 // Affaires v2, lot 1: human review of importer proposals.
 //
-// Cache invalidation is intentionally NOT done here. The service returns the
-// affected slugs and the route invalidates after the transaction commits, so a
-// rollback never leaves a purged cache behind.
+// Two properties matter here.
+//
+// 1. Concurrency. The PENDING check is a conditional update inside the
+//    transaction (compare-and-set), not a read before it. Two simultaneous
+//    acceptances cannot both apply the patch: the second one finds count === 0
+//    once the first commits, and rolls back.
+// 2. Cache invalidation is NOT done here. The service returns the affected slugs
+//    and the route invalidates after the commit, so a rollback never leaves a
+//    purged cache behind.
 
 export type AcceptResult =
   | {
@@ -25,12 +31,13 @@ export type AcceptResult =
       appliedFields: string[];
     }
   | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "orphaned" }
   | { ok: false; reason: "not_pending"; status: ProposalStatus }
   | { ok: false; reason: "invalid_patch"; issues: string[] }
   | { ok: false; reason: "conflict"; conflictDetail: ConflictDetail };
 
 export type RejectResult =
-  | { ok: true; affairId: string }
+  | { ok: true; affairId: string | null }
   | { ok: false; reason: "not_found" }
   | { ok: false; reason: "not_pending"; status: ProposalStatus };
 
@@ -41,12 +48,29 @@ interface ReviewInput {
   requestMeta?: { ip?: string | null; userAgent?: string | null };
 }
 
+/** Aborts the transaction while carrying a structured reason out of it. */
+class RollbackSignal extends Error {
+  constructor(readonly reason: "lost_race" | "affair_gone") {
+    super(`proposal review rollback: ${reason}`);
+    this.name = "RollbackSignal";
+  }
+}
+
+async function currentStatus(proposalId: string): Promise<ProposalStatus | null> {
+  const row = await db.affairUpdateProposal.findUnique({
+    where: { id: proposalId },
+    select: { status: true },
+  });
+  return row?.status ?? null;
+}
+
 /**
  * Applies a pending proposal.
  *
- * Order is load-bearing: pending check, then patch validation, then a normalized
- * drift check against the live row, and only then a single transaction carrying
- * the affair write, the ModerationReview, the AuditLog and the state change.
+ * Order is load-bearing: cheap rejections first, then patch validation, then a
+ * single transaction carrying the compare-and-set claim, the normalized drift
+ * check, the affair write, the ModerationReview, the AuditLog and the state
+ * transition.
  */
 export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> {
   const proposal = await db.affairUpdateProposal.findUnique({
@@ -78,6 +102,11 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
   if (proposal.status !== "PENDING") {
     return { ok: false, reason: "not_pending", status: proposal.status };
   }
+  if (!proposal.affairId || !proposal.affair) {
+    // The affair was deleted; the row survives as history (onDelete: SetNull)
+    // but there is nothing left to patch.
+    return { ok: false, reason: "orphaned" };
+  }
 
   let patch;
   try {
@@ -89,88 +118,94 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
     throw error;
   }
 
+  const affairId = proposal.affairId;
   const observedValues = (proposal.observedValues ?? {}) as Record<string, unknown>;
   const fields = Object.keys(observedValues);
   const previousStatus = proposal.affair.status;
+  const now = new Date();
 
-  const outcome = await db.$transaction(async (tx) => {
-    // Re-read inside the transaction: the drift check must see the row as it is
-    // at write time, not as it was when the list page was rendered.
-    const live = await tx.affair.findUnique({
-      where: { id: proposal.affairId },
-      select: AFFAIR_PROPOSABLE_SELECT,
-    });
-    if (!live) return { kind: "not_found" as const };
-
-    const drift = detectDrift(observedValues, live as unknown as Record<string, unknown>);
-    if (drift) {
-      await tx.affairUpdateProposal.update({
-        where: { id: proposal.id },
+  let outcome: { kind: "applied" } | { kind: "conflict"; drift: ConflictDetail };
+  try {
+    outcome = await db.$transaction(async (tx) => {
+      // Compare-and-set: this is the concurrency gate. A second acceptance
+      // blocks on the row lock, then finds no PENDING row once we commit.
+      const claim = await tx.affairUpdateProposal.updateMany({
+        where: { id: proposal.id, status: "PENDING" },
         data: {
-          status: "CONFLICT",
-          conflictDetail: drift,
-          reviewedAt: new Date(),
+          status: "APPROVED",
+          appliedAt: now,
+          reviewedAt: now,
           reviewedBy: input.reviewedBy,
           reviewNotes: input.reviewNotes ?? null,
         },
       });
-      return { kind: "conflict" as const, drift };
-    }
+      if (claim.count === 0) throw new RollbackSignal("lost_race");
 
-    await tx.affair.update({
-      where: { id: proposal.affairId },
-      data: buildPrismaData(patch),
-    });
+      const live = await tx.affair.findUnique({
+        where: { id: affairId },
+        select: AFFAIR_PROPOSABLE_SELECT,
+      });
+      if (!live) throw new RollbackSignal("affair_gone");
 
-    await tx.moderationReview.create({
-      data: {
-        affairId: proposal.affairId,
-        // The enum has no "applied patch" member; adding one means touching the
-        // label maps too, which belongs to a later lot. appliedAt keeps this row
-        // out of every moderation queue (they all filter on appliedAt: null).
-        recommendation: "NEEDS_REVIEW",
-        confidence: proposal.confidence,
-        reasoning: buildReasoning(proposal.rationale, input.reviewNotes),
-        model: `proposal:${proposal.importer}@${proposal.extractorVersion}`,
-        appliedAt: new Date(),
-        appliedBy: input.reviewedBy,
-      },
-    });
+      const drift = detectDrift(observedValues, live as unknown as Record<string, unknown>);
+      if (drift) {
+        await tx.affairUpdateProposal.update({
+          where: { id: proposal.id },
+          data: { status: "CONFLICT", conflictDetail: drift, appliedAt: null },
+        });
+        return { kind: "conflict" as const, drift };
+      }
 
-    await tx.auditLog.create({
-      data: {
-        action: "UPDATE",
-        entityType: "Affair",
-        entityId: proposal.affairId,
-        userId: input.reviewedBy,
-        ipAddress: input.requestMeta?.ip ?? null,
-        userAgent: input.requestMeta?.userAgent ?? null,
-        changes: {
-          action: "PROPOSAL_ACCEPTED",
-          proposalId: proposal.id,
-          importer: proposal.importer,
-          extractorVersion: proposal.extractorVersion,
-          before: observedValues,
-          after: JSON.parse(JSON.stringify(proposal.proposedPatch)),
+      await tx.affair.update({
+        where: { id: affairId },
+        data: buildPrismaData(patch),
+      });
+
+      await tx.moderationReview.create({
+        data: {
+          affairId,
+          // The enum has no "applied patch" member; adding one means touching the
+          // label maps too, which belongs to a later lot. appliedAt keeps this row
+          // out of every moderation queue (they all filter on appliedAt: null).
+          recommendation: "NEEDS_REVIEW",
+          confidence: proposal.confidence,
+          reasoning: buildReasoning(proposal.rationale, input.reviewNotes),
+          model: `proposal:${proposal.importer}@${proposal.extractorVersion}`,
+          appliedAt: now,
+          appliedBy: input.reviewedBy,
         },
-      },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: "UPDATE",
+          entityType: "Affair",
+          entityId: affairId,
+          userId: input.reviewedBy,
+          ipAddress: input.requestMeta?.ip ?? null,
+          userAgent: input.requestMeta?.userAgent ?? null,
+          changes: {
+            action: "PROPOSAL_ACCEPTED",
+            proposalId: proposal.id,
+            importer: proposal.importer,
+            extractorVersion: proposal.extractorVersion,
+            before: observedValues,
+            after: JSON.parse(JSON.stringify(proposal.proposedPatch)),
+          },
+        },
+      });
+
+      return { kind: "applied" as const };
     });
+  } catch (error) {
+    if (error instanceof RollbackSignal) {
+      if (error.reason === "affair_gone") return { ok: false, reason: "orphaned" };
+      const status = await currentStatus(proposal.id);
+      return { ok: false, reason: "not_pending", status: status ?? "APPROVED" };
+    }
+    throw error;
+  }
 
-    await tx.affairUpdateProposal.update({
-      where: { id: proposal.id },
-      data: {
-        status: "APPROVED",
-        appliedAt: new Date(),
-        reviewedAt: new Date(),
-        reviewedBy: input.reviewedBy,
-        reviewNotes: input.reviewNotes ?? null,
-      },
-    });
-
-    return { kind: "applied" as const };
-  });
-
-  if (outcome.kind === "not_found") return { ok: false, reason: "not_found" };
   if (outcome.kind === "conflict") {
     return { ok: false, reason: "conflict", conflictDetail: outcome.drift };
   }
@@ -180,14 +215,14 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
   const newStatus = patch.status as AffairStatus | null | undefined;
   if (newStatus && newStatus !== previousStatus) {
     try {
-      await trackStatusChange(proposal.affairId, previousStatus, newStatus, {
+      await trackStatusChange(affairId, previousStatus, newStatus, {
         type: proposal.source,
         url: proposal.sourceUrl ?? undefined,
         title: `Proposition ${proposal.importer} acceptée`,
       });
     } catch (error) {
       console.warn(
-        `[proposals] trackStatusChange failed for affair ${proposal.affairId}:`,
+        `[proposals] trackStatusChange failed for affair ${affairId}:`,
         error instanceof Error ? error.message : error
       );
     }
@@ -195,13 +230,18 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
 
   return {
     ok: true,
-    affairId: proposal.affairId,
+    affairId,
     affairSlug: proposal.affair.slug,
     politicianSlug: proposal.affair.politician.slug,
     appliedFields: fields,
   };
 }
 
+/**
+ * Refuses a pending proposal. Never touches the affair, so no cache
+ * invalidation. The state transition is the same compare-and-set as acceptance,
+ * so two simultaneous rejections cannot both write an audit entry.
+ */
 export async function rejectProposal(input: ReviewInput): Promise<RejectResult> {
   const proposal = await db.affairUpdateProposal.findUnique({
     where: { id: input.proposalId },
@@ -213,35 +253,45 @@ export async function rejectProposal(input: ReviewInput): Promise<RejectResult> 
     return { ok: false, reason: "not_pending", status: proposal.status };
   }
 
-  await db.$transaction(async (tx) => {
-    await tx.affairUpdateProposal.update({
-      where: { id: proposal.id },
-      data: {
-        status: "REJECTED",
-        reviewedAt: new Date(),
-        reviewedBy: input.reviewedBy,
-        reviewNotes: input.reviewNotes ?? null,
-      },
-    });
-    await tx.auditLog.create({
-      data: {
-        action: "UPDATE",
-        entityType: "AffairUpdateProposal",
-        entityId: proposal.id,
-        userId: input.reviewedBy,
-        ipAddress: input.requestMeta?.ip ?? null,
-        userAgent: input.requestMeta?.userAgent ?? null,
-        changes: {
-          action: "PROPOSAL_REJECTED",
-          affairId: proposal.affairId,
-          importer: proposal.importer,
+  const now = new Date();
+  try {
+    await db.$transaction(async (tx) => {
+      const claim = await tx.affairUpdateProposal.updateMany({
+        where: { id: proposal.id, status: "PENDING" },
+        data: {
+          status: "REJECTED",
+          reviewedAt: now,
+          reviewedBy: input.reviewedBy,
           reviewNotes: input.reviewNotes ?? null,
         },
-      },
-    });
-  });
+      });
+      if (claim.count === 0) throw new RollbackSignal("lost_race");
 
-  // No cache invalidation: nothing about the affair changed.
+      await tx.auditLog.create({
+        data: {
+          action: "UPDATE",
+          entityType: "AffairUpdateProposal",
+          entityId: proposal.id,
+          userId: input.reviewedBy,
+          ipAddress: input.requestMeta?.ip ?? null,
+          userAgent: input.requestMeta?.userAgent ?? null,
+          changes: {
+            action: "PROPOSAL_REJECTED",
+            affairId: proposal.affairId,
+            importer: proposal.importer,
+            reviewNotes: input.reviewNotes ?? null,
+          },
+        },
+      });
+    });
+  } catch (error) {
+    if (error instanceof RollbackSignal) {
+      const status = await currentStatus(proposal.id);
+      return { ok: false, reason: "not_pending", status: status ?? "REJECTED" };
+    }
+    throw error;
+  }
+
   return { ok: true, affairId: proposal.affairId };
 }
 

--- a/src/services/affairs/proposal-review.ts
+++ b/src/services/affairs/proposal-review.ts
@@ -1,0 +1,250 @@
+import { db } from "@/lib/db";
+import type { AffairStatus, ProposalStatus } from "@/generated/prisma";
+import { trackStatusChange } from "@/services/affairs/status-tracking";
+import {
+  AFFAIR_PROPOSABLE_SELECT,
+  buildPrismaData,
+  detectDrift,
+  ProposalValidationError,
+  validatePatch,
+  type ConflictDetail,
+} from "@/services/affairs/proposals";
+
+// Affaires v2, lot 1: human review of importer proposals.
+//
+// Cache invalidation is intentionally NOT done here. The service returns the
+// affected slugs and the route invalidates after the transaction commits, so a
+// rollback never leaves a purged cache behind.
+
+export type AcceptResult =
+  | {
+      ok: true;
+      affairId: string;
+      affairSlug: string;
+      politicianSlug: string;
+      appliedFields: string[];
+    }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "not_pending"; status: ProposalStatus }
+  | { ok: false; reason: "invalid_patch"; issues: string[] }
+  | { ok: false; reason: "conflict"; conflictDetail: ConflictDetail };
+
+export type RejectResult =
+  | { ok: true; affairId: string }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "not_pending"; status: ProposalStatus };
+
+interface ReviewInput {
+  proposalId: string;
+  reviewedBy: string;
+  reviewNotes?: string;
+  requestMeta?: { ip?: string | null; userAgent?: string | null };
+}
+
+/**
+ * Applies a pending proposal.
+ *
+ * Order is load-bearing: pending check, then patch validation, then a normalized
+ * drift check against the live row, and only then a single transaction carrying
+ * the affair write, the ModerationReview, the AuditLog and the state change.
+ */
+export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> {
+  const proposal = await db.affairUpdateProposal.findUnique({
+    where: { id: input.proposalId },
+    select: {
+      id: true,
+      affairId: true,
+      importer: true,
+      extractorVersion: true,
+      status: true,
+      proposedPatch: true,
+      observedValues: true,
+      confidence: true,
+      rationale: true,
+      source: true,
+      sourceUrl: true,
+      affair: {
+        select: {
+          id: true,
+          slug: true,
+          status: true,
+          politician: { select: { slug: true } },
+        },
+      },
+    },
+  });
+
+  if (!proposal) return { ok: false, reason: "not_found" };
+  if (proposal.status !== "PENDING") {
+    return { ok: false, reason: "not_pending", status: proposal.status };
+  }
+
+  let patch;
+  try {
+    patch = validatePatch(proposal.proposedPatch);
+  } catch (error) {
+    if (error instanceof ProposalValidationError) {
+      return { ok: false, reason: "invalid_patch", issues: error.issues };
+    }
+    throw error;
+  }
+
+  const observedValues = (proposal.observedValues ?? {}) as Record<string, unknown>;
+  const fields = Object.keys(observedValues);
+  const previousStatus = proposal.affair.status;
+
+  const outcome = await db.$transaction(async (tx) => {
+    // Re-read inside the transaction: the drift check must see the row as it is
+    // at write time, not as it was when the list page was rendered.
+    const live = await tx.affair.findUnique({
+      where: { id: proposal.affairId },
+      select: AFFAIR_PROPOSABLE_SELECT,
+    });
+    if (!live) return { kind: "not_found" as const };
+
+    const drift = detectDrift(observedValues, live as unknown as Record<string, unknown>);
+    if (drift) {
+      await tx.affairUpdateProposal.update({
+        where: { id: proposal.id },
+        data: {
+          status: "CONFLICT",
+          conflictDetail: drift,
+          reviewedAt: new Date(),
+          reviewedBy: input.reviewedBy,
+          reviewNotes: input.reviewNotes ?? null,
+        },
+      });
+      return { kind: "conflict" as const, drift };
+    }
+
+    await tx.affair.update({
+      where: { id: proposal.affairId },
+      data: buildPrismaData(patch),
+    });
+
+    await tx.moderationReview.create({
+      data: {
+        affairId: proposal.affairId,
+        // The enum has no "applied patch" member; adding one means touching the
+        // label maps too, which belongs to a later lot. appliedAt keeps this row
+        // out of every moderation queue (they all filter on appliedAt: null).
+        recommendation: "NEEDS_REVIEW",
+        confidence: proposal.confidence,
+        reasoning: buildReasoning(proposal.rationale, input.reviewNotes),
+        model: `proposal:${proposal.importer}@${proposal.extractorVersion}`,
+        appliedAt: new Date(),
+        appliedBy: input.reviewedBy,
+      },
+    });
+
+    await tx.auditLog.create({
+      data: {
+        action: "UPDATE",
+        entityType: "Affair",
+        entityId: proposal.affairId,
+        userId: input.reviewedBy,
+        ipAddress: input.requestMeta?.ip ?? null,
+        userAgent: input.requestMeta?.userAgent ?? null,
+        changes: {
+          action: "PROPOSAL_ACCEPTED",
+          proposalId: proposal.id,
+          importer: proposal.importer,
+          extractorVersion: proposal.extractorVersion,
+          before: observedValues,
+          after: JSON.parse(JSON.stringify(proposal.proposedPatch)),
+        },
+      },
+    });
+
+    await tx.affairUpdateProposal.update({
+      where: { id: proposal.id },
+      data: {
+        status: "APPROVED",
+        appliedAt: new Date(),
+        reviewedAt: new Date(),
+        reviewedBy: input.reviewedBy,
+        reviewNotes: input.reviewNotes ?? null,
+      },
+    });
+
+    return { kind: "applied" as const };
+  });
+
+  if (outcome.kind === "not_found") return { ok: false, reason: "not_found" };
+  if (outcome.kind === "conflict") {
+    return { ok: false, reason: "conflict", conflictDetail: outcome.drift };
+  }
+
+  // Timeline event, outside the transaction. It is display-only: the audit trail
+  // already committed, so a failure here must not fail the acceptance.
+  const newStatus = patch.status as AffairStatus | null | undefined;
+  if (newStatus && newStatus !== previousStatus) {
+    try {
+      await trackStatusChange(proposal.affairId, previousStatus, newStatus, {
+        type: proposal.source,
+        url: proposal.sourceUrl ?? undefined,
+        title: `Proposition ${proposal.importer} acceptée`,
+      });
+    } catch (error) {
+      console.warn(
+        `[proposals] trackStatusChange failed for affair ${proposal.affairId}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+
+  return {
+    ok: true,
+    affairId: proposal.affairId,
+    affairSlug: proposal.affair.slug,
+    politicianSlug: proposal.affair.politician.slug,
+    appliedFields: fields,
+  };
+}
+
+export async function rejectProposal(input: ReviewInput): Promise<RejectResult> {
+  const proposal = await db.affairUpdateProposal.findUnique({
+    where: { id: input.proposalId },
+    select: { id: true, affairId: true, status: true, importer: true },
+  });
+
+  if (!proposal) return { ok: false, reason: "not_found" };
+  if (proposal.status !== "PENDING") {
+    return { ok: false, reason: "not_pending", status: proposal.status };
+  }
+
+  await db.$transaction(async (tx) => {
+    await tx.affairUpdateProposal.update({
+      where: { id: proposal.id },
+      data: {
+        status: "REJECTED",
+        reviewedAt: new Date(),
+        reviewedBy: input.reviewedBy,
+        reviewNotes: input.reviewNotes ?? null,
+      },
+    });
+    await tx.auditLog.create({
+      data: {
+        action: "UPDATE",
+        entityType: "AffairUpdateProposal",
+        entityId: proposal.id,
+        userId: input.reviewedBy,
+        ipAddress: input.requestMeta?.ip ?? null,
+        userAgent: input.requestMeta?.userAgent ?? null,
+        changes: {
+          action: "PROPOSAL_REJECTED",
+          affairId: proposal.affairId,
+          importer: proposal.importer,
+          reviewNotes: input.reviewNotes ?? null,
+        },
+      },
+    });
+  });
+
+  // No cache invalidation: nothing about the affair changed.
+  return { ok: true, affairId: proposal.affairId };
+}
+
+function buildReasoning(rationale: string, reviewNotes?: string): string {
+  return reviewNotes ? `${rationale}\n\nNote de revue : ${reviewNotes}` : rationale;
+}

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { db } from "@/lib/db";
 import { Prisma } from "@/generated/prisma";
-import type { ProposalRisk, ProposalStatus, SourceType } from "@/generated/prisma";
+import type { ProposalRisk, SourceType } from "@/generated/prisma";
 import {
   affairPatchSchema,
   PROPOSABLE_FIELDS,
@@ -22,8 +22,12 @@ export const AUTO_APPLICABLE_FIELDS = Object.freeze([
   "caseNumbers",
 ] as const);
 
-/** Changing any of these is HIGH risk regardless of the previous value. */
-const HIGH_RISK_FIELDS = Object.freeze(["status", "involvement", "category", "severity"] as const);
+/**
+ * Changing any of these is HIGH risk regardless of the previous value.
+ * Only `status` in lot 1: involvement, category and severity are not proposable
+ * because no importer emits them.
+ */
+const HIGH_RISK_FIELDS = Object.freeze(["status"] as const);
 
 const AUTO_SET: ReadonlySet<string> = new Set(AUTO_APPLICABLE_FIELDS);
 const HIGH_RISK_SET: ReadonlySet<string> = new Set(HIGH_RISK_FIELDS);
@@ -35,13 +39,64 @@ export class ProposalValidationError extends Error {
   }
 }
 
+/**
+ * Every field a proposal can touch, plus the identity needed for affairSnapshot.
+ *
+ * A select object built from the patch keys at runtime makes Prisma's generated
+ * types recurse ("Excessive stack depth comparing types"), so the shape stays
+ * static and callers read only the keys they need.
+ */
+export const AFFAIR_PROPOSABLE_SELECT = {
+  id: true,
+  slug: true,
+  publicId: true,
+  title: true,
+  politician: { select: { slug: true, fullName: true } },
+  status: true,
+  verdictDate: true,
+  court: true,
+  sentence: true,
+  prisonMonths: true,
+  prisonSuspended: true,
+  ineligibilityMonths: true,
+  communityService: true,
+  otherSentence: true,
+  ecli: true,
+  pourvoiNumber: true,
+  caseNumbers: true,
+} as const;
+
+export interface AffairSnapshot {
+  publicId: string | null;
+  slug: string;
+  title: string;
+  politicianSlug: string | null;
+  politicianName: string | null;
+}
+
+/** Keeps an orphaned proposal readable after its affair is deleted. */
+export function buildAffairSnapshot(affair: {
+  publicId: string | null;
+  slug: string;
+  title: string;
+  politician?: { slug: string; fullName: string } | null;
+}): AffairSnapshot {
+  return {
+    publicId: affair.publicId,
+    slug: affair.slug,
+    title: affair.title,
+    politicianSlug: affair.politician?.slug ?? null,
+    politicianName: affair.politician?.fullName ?? null,
+  };
+}
+
 // ─── Normalization ───────────────────────────────────────────────
 
 /**
  * Marker for an absent value in normalized comparisons.
  *
  * Not a control character: these strings reach the conflictDetail JSONB column,
- * and Postgres rejects \u0000 inside a JSON string.
+ * and Postgres rejects U+0000 inside a JSON string.
  */
 export const EMPTY_VALUE = "∅";
 
@@ -87,6 +142,11 @@ function normalizeRecord(record: Record<string, unknown>): Record<string, string
   return out;
 }
 
+/** Stable hash of a raw source payload, for sourceContentHash. */
+export function hashSourceContent(payload: unknown): string {
+  return createHash("sha256").update(canonicalJson(payload)).digest("hex");
+}
+
 // ─── Hashing ─────────────────────────────────────────────────────
 
 export interface PayloadHashInput {
@@ -95,6 +155,7 @@ export interface PayloadHashInput {
   source: SourceType;
   sourceUrl?: string | null;
   officialId?: string | null;
+  sourceContentHash?: string | null;
   proposedPatch: Record<string, unknown>;
   observedValues: Record<string, unknown>;
 }
@@ -104,7 +165,9 @@ export interface PayloadHashInput {
  * - observedValues: a CONFLICT must become re-proposable once the affair moves.
  * - extractorVersion: a fixed extractor must be able to re-propose a value that
  *   an earlier, buggy version got rejected on.
- * - source fingerprint: two distinct decisions carrying the same value stay two
+ * - sourceContentHash: a claim or decision page that changes under the same URL
+ *   must be able to produce a fresh proposal.
+ * - source + officialId: two distinct decisions carrying the same value stay two
  *   proposals, so the second source is not silently dropped.
  */
 export function computePayloadHash(input: PayloadHashInput): string {
@@ -114,6 +177,7 @@ export function computePayloadHash(input: PayloadHashInput): string {
     source: input.source,
     sourceUrl: input.sourceUrl ?? null,
     officialId: input.officialId ?? null,
+    sourceContentHash: input.sourceContentHash ?? null,
     proposedPatch: normalizeRecord(input.proposedPatch),
     observedValues: normalizeRecord(input.observedValues),
   });
@@ -159,7 +223,7 @@ export function detectDrift(
 
 /**
  * The only door between importer JSON and Prisma. Rejects unknown keys, coerces
- * dates and decimals, validates enums against the generated client.
+ * dates, validates enums against the generated client.
  */
 export function validatePatch(raw: unknown): AffairPatch {
   const parsed = affairPatchSchema.safeParse(raw);
@@ -177,6 +241,14 @@ function patchFields(patch: AffairPatch): ProposableField[] {
   );
 }
 
+/**
+ * Turns a validated patch into a Prisma update payload. Only whitelisted keys
+ * survive validatePatch(), so this cannot widen the write surface.
+ */
+export function buildPrismaData(patch: AffairPatch): Prisma.AffairUpdateInput {
+  return { ...patch } as Prisma.AffairUpdateInput;
+}
+
 // ─── Proposal creation ───────────────────────────────────────────
 
 export interface ProposeAffairUpdateInput {
@@ -188,6 +260,8 @@ export interface ProposeAffairUpdateInput {
   source: SourceType;
   sourceUrl?: string | null;
   officialId?: string | null;
+  /** Hash of the raw source payload. See hashSourceContent(). */
+  sourceContentHash?: string | null;
   sourceExcerpt?: string | null;
   metadata?: Prisma.InputJsonValue | null;
   confidence: number;
@@ -202,11 +276,18 @@ export interface ProposeAffairUpdateResult {
   autoProposalId: string | null;
   /** Proposal awaiting review, if any field required one. */
   pendingProposalId: string | null;
-  /** Set when a unique identifier already belongs to another affair. */
+  /** Set when an identifier is contradicted or already taken elsewhere. */
   conflictProposalId: string | null;
   /** True when an identical payload had already been recorded. */
   deduped: boolean;
 }
+
+type LiveAffair = Record<string, unknown> & {
+  publicId: string | null;
+  slug: string;
+  title: string;
+  politician?: { slug: string; fullName: string } | null;
+};
 
 /**
  * Entry point for importers. Splits the patch into what may be auto-applied and
@@ -227,11 +308,12 @@ export async function proposeAffairUpdate(
   if (!affair) {
     throw new Error(`Affaire introuvable : ${input.affairId}`);
   }
-  const live = affair as unknown as Record<string, unknown>;
+  const live = affair as unknown as LiveAffair;
 
-  const autoPatch: Record<string, unknown> = {};
+  // Classification only. The auto path recomputes eligibility inside its own
+  // transaction, because the row can move between this read and the write.
+  const autoCandidates: Record<string, unknown> = {};
   const reviewPatch: Record<string, unknown> = {};
-  const conflictPatch: Record<string, unknown> = {};
 
   for (const field of fields) {
     const proposed = (patch as Record<string, unknown>)[field];
@@ -239,37 +321,13 @@ export async function proposeAffairUpdate(
       reviewPatch[field] = proposed;
       continue;
     }
-
-    if (field === "caseNumbers") {
-      const current = Array.isArray(live.caseNumbers) ? (live.caseNumbers as string[]) : [];
-      const incoming = Array.isArray(proposed) ? (proposed as string[]) : [];
-      const merged = mergeCaseNumbers(current, incoming);
-      // Additive only: nothing new means nothing to do.
-      if (merged.length > current.length) autoPatch.caseNumbers = merged;
-      continue;
-    }
-
-    const isAbsent = normalizeForCompare(live[field]) === EMPTY_VALUE;
-    if (!isAbsent) {
+    if (field !== "caseNumbers" && normalizeForCompare(live[field]) !== EMPTY_VALUE) {
       // Contradicts a stored identifier: that is a review decision, not a fill.
       reviewPatch[field] = proposed;
       continue;
     }
     if (proposed === null || proposed === undefined) continue;
-
-    if (field === "ecli") {
-      const taken = await db.affair.findFirst({
-        where: { ecli: String(proposed), id: { not: input.affairId } },
-        select: { id: true },
-      });
-      if (taken) {
-        // "Absent" but not "non-contradictory": Affair.ecli is @unique, so a
-        // blind write would raise P2002. Surface it instead.
-        conflictPatch[field] = proposed;
-        continue;
-      }
-    }
-    autoPatch[field] = proposed;
+    autoCandidates[field] = proposed;
   }
 
   const result: ProposeAffairUpdateResult = {
@@ -280,46 +338,20 @@ export async function proposeAffairUpdate(
     deduped: false,
   };
 
-  if (Object.keys(autoPatch).length > 0) {
-    const outcome = await recordProposal({
-      input,
-      extractorVersion,
-      patch: autoPatch,
-      live,
-      status: "AUTO_APPLIED",
-      applyNow: true,
-    });
-    result.autoApplied = Object.keys(autoPatch) as ProposableField[];
-    result.autoProposalId = outcome.proposalId;
+  if (Object.keys(autoCandidates).length > 0) {
+    const outcome = await applyAutoCandidates(input, extractorVersion, autoCandidates, live);
     result.deduped = result.deduped || outcome.deduped;
+    if (outcome.kind === "applied") {
+      result.autoApplied = outcome.appliedFields;
+      result.autoProposalId = outcome.proposalId;
+    } else if (outcome.kind === "conflict") {
+      result.conflictProposalId = outcome.proposalId;
+    }
   }
 
   if (Object.keys(reviewPatch).length > 0) {
-    const outcome = await recordProposal({
-      input,
-      extractorVersion,
-      patch: reviewPatch,
-      live,
-      status: "PENDING",
-      applyNow: false,
-    });
+    const outcome = await recordPendingProposal(input, extractorVersion, reviewPatch, live);
     result.pendingProposalId = outcome.proposalId;
-    result.deduped = result.deduped || outcome.deduped;
-  }
-
-  if (Object.keys(conflictPatch).length > 0) {
-    const outcome = await recordProposal({
-      input,
-      extractorVersion,
-      patch: conflictPatch,
-      live,
-      status: "CONFLICT",
-      applyNow: false,
-      conflictDetail: {
-        ecli: { expected: "libre", actual: "déjà rattaché à une autre affaire" },
-      },
-    });
-    result.conflictProposalId = outcome.proposalId;
     result.deduped = result.deduped || outcome.deduped;
   }
 
@@ -334,77 +366,87 @@ function mergeCaseNumbers(current: string[], incoming: string[]): string[] {
   return Array.from(seen);
 }
 
-/**
- * Every field a proposal can touch, selected as a constant.
- *
- * A select object built from the patch keys at runtime makes Prisma's generated
- * types recurse ("Excessive stack depth comparing types"), so the shape stays
- * static and the caller reads only the keys it needs.
- */
-export const AFFAIR_PROPOSABLE_SELECT = {
-  id: true,
-  slug: true,
-  status: true,
-  involvement: true,
-  category: true,
-  severity: true,
-  factsDate: true,
-  startDate: true,
-  verdictDate: true,
-  court: true,
-  chamber: true,
-  caseNumber: true,
-  sentence: true,
-  prisonMonths: true,
-  prisonSuspended: true,
-  fineAmount: true,
-  ineligibilityMonths: true,
-  communityService: true,
-  otherSentence: true,
-  ecli: true,
-  pourvoiNumber: true,
-  caseNumbers: true,
-} as const;
+function pickObserved(
+  patch: Record<string, unknown>,
+  live: Record<string, unknown>
+): Record<string, unknown> {
+  const observed: Record<string, unknown> = {};
+  for (const key of Object.keys(patch)) observed[key] = live[key] ?? null;
+  return observed;
+}
 
-interface RecordProposalArgs {
+interface ProposalRowArgs {
   input: ProposeAffairUpdateInput;
   extractorVersion: string;
   patch: Record<string, unknown>;
-  live: Record<string, unknown>;
-  status: ProposalStatus;
-  applyNow: boolean;
-  conflictDetail?: ConflictDetail;
+  observedValues: Record<string, unknown>;
+  snapshot: AffairSnapshot;
+  payloadHash: string;
 }
 
-async function recordProposal(
-  args: RecordProposalArgs
-): Promise<{ proposalId: string; deduped: boolean }> {
-  const { input, extractorVersion, patch, live, status, applyNow } = args;
-  const keys = Object.keys(patch);
-  const observedValues: Record<string, unknown> = {};
-  for (const key of keys) observedValues[key] = live[key] ?? null;
+function buildProposalData(
+  args: ProposalRowArgs,
+  status: "PENDING" | "AUTO_APPLIED" | "CONFLICT",
+  extras: { appliedAt?: Date | null; conflictDetail?: ConflictDetail } = {}
+): Prisma.AffairUpdateProposalUncheckedCreateInput {
+  return {
+    affairId: args.input.affairId,
+    affairSnapshot: toJson(args.snapshot),
+    importer: args.input.importer,
+    importRunId: args.input.importRunId ?? null,
+    proposedPatch: toJson(args.patch),
+    observedValues: toJson(args.observedValues),
+    source: args.input.source,
+    sourceUrl: args.input.sourceUrl ?? null,
+    officialId: args.input.officialId ?? null,
+    sourceContentHash: args.input.sourceContentHash ?? null,
+    sourceExcerpt: args.input.sourceExcerpt ?? null,
+    metadata: args.input.metadata ?? undefined,
+    confidence: clampConfidence(args.input.confidence),
+    riskLevel: deriveRiskLevel(Object.keys(args.patch), args.observedValues),
+    rationale: args.input.rationale,
+    extractorVersion: args.extractorVersion,
+    payloadHash: args.payloadHash,
+    status,
+    appliedAt: extras.appliedAt ?? null,
+    conflictDetail: extras.conflictDetail ? toJson(extras.conflictDetail) : undefined,
+  };
+}
 
+/**
+ * Idempotency lookup. A findFirst rather than findUnique because affairId is
+ * nullable now; the unique index still serves the query.
+ */
+async function findExisting(
+  affairId: string,
+  importer: string,
+  payloadHash: string
+): Promise<{ id: string; status: string } | null> {
+  return db.affairUpdateProposal.findFirst({
+    where: { affairId, importer, payloadHash },
+    select: { id: true, status: true },
+  });
+}
+
+async function recordPendingProposal(
+  input: ProposeAffairUpdateInput,
+  extractorVersion: string,
+  patch: Record<string, unknown>,
+  live: LiveAffair
+): Promise<{ proposalId: string; deduped: boolean }> {
+  const observedValues = pickObserved(patch, live);
   const payloadHash = computePayloadHash({
     importer: input.importer,
     extractorVersion,
     source: input.source,
     sourceUrl: input.sourceUrl,
     officialId: input.officialId,
+    sourceContentHash: input.sourceContentHash,
     proposedPatch: patch,
     observedValues,
   });
 
-  const existing = await db.affairUpdateProposal.findUnique({
-    where: {
-      affairId_importer_payloadHash: {
-        affairId: input.affairId,
-        importer: input.importer,
-        payloadHash,
-      },
-    },
-    select: { id: true, status: true },
-  });
-
+  const existing = await findExisting(input.affairId, input.importer, payloadHash);
   if (existing) {
     // Never resurrect a terminal state. A rejected patch replayed by the next
     // cron run must stay rejected instead of climbing back into the queue.
@@ -417,39 +459,130 @@ async function recordProposal(
     return { proposalId: existing.id, deduped: true };
   }
 
-  const data: Prisma.AffairUpdateProposalUncheckedCreateInput = {
-    affairId: input.affairId,
+  const created = await db.affairUpdateProposal.create({
+    data: buildProposalData(
+      {
+        input,
+        extractorVersion,
+        patch,
+        observedValues,
+        snapshot: buildAffairSnapshot(live),
+        payloadHash,
+      },
+      "PENDING"
+    ),
+    select: { id: true },
+  });
+  return { proposalId: created.id, deduped: false };
+}
+
+type AutoOutcome =
+  | { kind: "applied"; proposalId: string; appliedFields: ProposableField[]; deduped: boolean }
+  | { kind: "conflict"; proposalId: string; deduped: boolean }
+  | { kind: "skipped"; deduped: boolean };
+
+/**
+ * Auto-applies absent, non-contradictory machine identifiers.
+ *
+ * Eligibility is re-checked INSIDE the transaction: between the classification
+ * read and this write, another run or an editor may have filled the field or
+ * claimed the ECLI. Proposal row, affair write, audit entry and terminal state
+ * commit together or not at all.
+ */
+async function applyAutoCandidates(
+  input: ProposeAffairUpdateInput,
+  extractorVersion: string,
+  candidates: Record<string, unknown>,
+  liveAtRead: LiveAffair
+): Promise<AutoOutcome> {
+  const payloadHash = computePayloadHash({
     importer: input.importer,
-    importRunId: input.importRunId ?? null,
-    proposedPatch: toJson(patch),
-    observedValues: toJson(observedValues),
-    source: input.source,
-    sourceUrl: input.sourceUrl ?? null,
-    officialId: input.officialId ?? null,
-    sourceExcerpt: input.sourceExcerpt ?? null,
-    metadata: input.metadata ?? undefined,
-    confidence: clampConfidence(input.confidence),
-    riskLevel: deriveRiskLevel(keys, observedValues),
-    rationale: input.rationale,
     extractorVersion,
-    payloadHash,
-    status,
-    conflictDetail: args.conflictDetail ? toJson(args.conflictDetail) : undefined,
-    appliedAt: applyNow ? new Date() : null,
-  };
+    source: input.source,
+    sourceUrl: input.sourceUrl,
+    officialId: input.officialId,
+    sourceContentHash: input.sourceContentHash,
+    proposedPatch: candidates,
+    observedValues: pickObserved(candidates, liveAtRead),
+  });
 
-  if (!applyNow) {
-    const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
-    return { proposalId: created.id, deduped: false };
-  }
+  const existing = await findExisting(input.affairId, input.importer, payloadHash);
+  if (existing) return { kind: "skipped", deduped: true };
 
-  // Auto-applied: the affair write and its trace commit together.
-  const created = await db.$transaction(async (tx) => {
-    const row = await tx.affairUpdateProposal.create({ data, select: { id: true } });
+  return db.$transaction(async (tx) => {
+    const live = (await tx.affair.findUnique({
+      where: { id: input.affairId },
+      select: AFFAIR_PROPOSABLE_SELECT,
+    })) as unknown as LiveAffair | null;
+    if (!live) return { kind: "skipped" as const, deduped: false };
+
+    const writePatch: Record<string, unknown> = {};
+    const conflicts: ConflictDetail = {};
+
+    for (const [field, proposed] of Object.entries(candidates)) {
+      if (field === "caseNumbers") {
+        const current = Array.isArray(live.caseNumbers) ? (live.caseNumbers as string[]) : [];
+        const merged = mergeCaseNumbers(current, Array.isArray(proposed) ? proposed : []);
+        // Additive only: nothing new means nothing to do.
+        if (merged.length > current.length) writePatch.caseNumbers = merged;
+        continue;
+      }
+
+      const actual = normalizeForCompare(live[field]);
+      if (actual !== EMPTY_VALUE) {
+        conflicts[field] = { expected: EMPTY_VALUE, actual };
+        continue;
+      }
+
+      if (field === "ecli") {
+        const taken = await tx.affair.findFirst({
+          where: { ecli: String(proposed), id: { not: input.affairId } },
+          select: { id: true },
+        });
+        if (taken) {
+          // "Absent" but not "non-contradictory": Affair.ecli is @unique, so a
+          // blind write would raise P2002. Surface it instead.
+          conflicts[field] = { expected: EMPTY_VALUE, actual: "déjà rattaché à une autre affaire" };
+          continue;
+        }
+      }
+
+      writePatch[field] = proposed;
+    }
+
+    const rowArgs: ProposalRowArgs = {
+      input,
+      extractorVersion,
+      patch: candidates,
+      observedValues: pickObserved(candidates, live),
+      snapshot: buildAffairSnapshot(live),
+      payloadHash,
+    };
+
+    if (Object.keys(conflicts).length > 0) {
+      const row = await tx.affairUpdateProposal.create({
+        data: buildProposalData(rowArgs, "CONFLICT", { conflictDetail: conflicts }),
+        select: { id: true },
+      });
+      return { kind: "conflict" as const, proposalId: row.id, deduped: false };
+    }
+
+    if (Object.keys(writePatch).length === 0) {
+      return { kind: "skipped" as const, deduped: false };
+    }
+
+    const row = await tx.affairUpdateProposal.create({
+      data: buildProposalData({ ...rowArgs, patch: writePatch }, "AUTO_APPLIED", {
+        appliedAt: new Date(),
+      }),
+      select: { id: true },
+    });
+
     await tx.affair.update({
       where: { id: input.affairId },
-      data: buildPrismaData(validatePatch(patch)),
+      data: buildPrismaData(validatePatch(writePatch)),
     });
+
     await tx.auditLog.create({
       data: {
         action: "UPDATE",
@@ -460,15 +593,19 @@ async function recordProposal(
           importer: input.importer,
           extractorVersion,
           proposalId: row.id,
-          before: observedValues,
-          after: patch,
+          before: pickObserved(writePatch, live),
+          after: writePatch,
         }),
       },
     });
-    return row;
-  });
 
-  return { proposalId: created.id, deduped: false };
+    return {
+      kind: "applied" as const,
+      proposalId: row.id,
+      appliedFields: Object.keys(writePatch) as ProposableField[],
+      deduped: false,
+    };
+  });
 }
 
 function clampConfidence(value: number): number {
@@ -478,12 +615,4 @@ function clampConfidence(value: number): number {
 
 function toJson(value: unknown): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
-}
-
-/**
- * Turns a validated patch into a Prisma update payload. Only whitelisted keys
- * survive validatePatch(), so this cannot widen the write surface.
- */
-export function buildPrismaData(patch: AffairPatch): Prisma.AffairUpdateInput {
-  return { ...patch } as Prisma.AffairUpdateInput;
 }

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -1,0 +1,489 @@
+import { createHash } from "node:crypto";
+import { db } from "@/lib/db";
+import { Prisma } from "@/generated/prisma";
+import type { ProposalRisk, ProposalStatus, SourceType } from "@/generated/prisma";
+import {
+  affairPatchSchema,
+  PROPOSABLE_FIELDS,
+  type AffairPatch,
+  type ProposableField,
+} from "@/lib/security/schemas/affair-proposal";
+
+// Affaires v2, lot 1.
+//
+// Invariant: an importer never mutates an existing Affair directly. It calls
+// proposeAffairUpdate(), which auto-applies only absent, non-contradictory
+// machine identifiers and files everything else as a reviewable proposal.
+
+/** The only family an importer may write without human review. */
+export const AUTO_APPLICABLE_FIELDS = Object.freeze([
+  "ecli",
+  "pourvoiNumber",
+  "caseNumbers",
+] as const);
+
+/** Changing any of these is HIGH risk regardless of the previous value. */
+const HIGH_RISK_FIELDS = Object.freeze(["status", "involvement", "category", "severity"] as const);
+
+const AUTO_SET: ReadonlySet<string> = new Set(AUTO_APPLICABLE_FIELDS);
+const HIGH_RISK_SET: ReadonlySet<string> = new Set(HIGH_RISK_FIELDS);
+
+export class ProposalValidationError extends Error {
+  constructor(readonly issues: string[]) {
+    super(`Patch invalide : ${issues.join("; ")}`);
+    this.name = "ProposalValidationError";
+  }
+}
+
+// ─── Normalization ───────────────────────────────────────────────
+
+/**
+ * Marker for an absent value in normalized comparisons.
+ *
+ * Not a control character: these strings reach the conflictDetail JSONB column,
+ * and Postgres rejects \u0000 inside a JSON string.
+ */
+export const EMPTY_VALUE = "∅";
+
+/**
+ * Collapse a value to a comparable string.
+ *
+ * Needed because the same logical value reaches us in different shapes: Prisma
+ * returns `Date` and `Prisma.Decimal`, while the JSON columns hold ISO strings
+ * and decimal strings. A naive equality check would report drift on every
+ * acceptance.
+ */
+export function normalizeForCompare(value: unknown): string {
+  if (value === null || value === undefined) return EMPTY_VALUE;
+  if (value instanceof Date) return value.toISOString();
+  if (Prisma.Decimal.isDecimal(value)) return new Prisma.Decimal(value.toString()).toFixed();
+  if (Array.isArray(value)) {
+    return JSON.stringify(value.map(normalizeForCompare).sort());
+  }
+  if (typeof value === "object") return canonicalJson(value);
+  return String(value);
+}
+
+/** Deterministic JSON: keys sorted at every depth, so hashing is stable. */
+function canonicalJson(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Prisma.Decimal.isDecimal(value)) return JSON.stringify(value.toString());
+  if (typeof value === "object") {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonicalJson((value as Record<string, unknown>)[k])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeRecord(record: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(record).sort()) {
+    out[key] = normalizeForCompare(record[key]);
+  }
+  return out;
+}
+
+// ─── Hashing ─────────────────────────────────────────────────────
+
+export interface PayloadHashInput {
+  importer: string;
+  extractorVersion: string;
+  source: SourceType;
+  sourceUrl?: string | null;
+  officialId?: string | null;
+  proposedPatch: Record<string, unknown>;
+  observedValues: Record<string, unknown>;
+}
+
+/**
+ * Identity of a proposal. Every component earns its place:
+ * - observedValues: a CONFLICT must become re-proposable once the affair moves.
+ * - extractorVersion: a fixed extractor must be able to re-propose a value that
+ *   an earlier, buggy version got rejected on.
+ * - source fingerprint: two distinct decisions carrying the same value stay two
+ *   proposals, so the second source is not silently dropped.
+ */
+export function computePayloadHash(input: PayloadHashInput): string {
+  const canonical = canonicalJson({
+    importer: input.importer,
+    extractorVersion: input.extractorVersion,
+    source: input.source,
+    sourceUrl: input.sourceUrl ?? null,
+    officialId: input.officialId ?? null,
+    proposedPatch: normalizeRecord(input.proposedPatch),
+    observedValues: normalizeRecord(input.observedValues),
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+// ─── Risk ────────────────────────────────────────────────────────
+
+/**
+ * Pure function, exported for testing.
+ * HIGH when the judicial state changes or a non-empty value is overwritten,
+ * LOW when only absent machine identifiers are filled, MEDIUM otherwise.
+ */
+export function deriveRiskLevel(
+  patchKeys: readonly string[],
+  observedValues: Record<string, unknown>
+): ProposalRisk {
+  const touchesJudicialState = patchKeys.some((k) => HIGH_RISK_SET.has(k));
+  const overwrites = patchKeys.some((k) => normalizeForCompare(observedValues[k]) !== EMPTY_VALUE);
+  if (touchesJudicialState || overwrites) return "HIGH";
+  return patchKeys.every((k) => AUTO_SET.has(k)) ? "LOW" : "MEDIUM";
+}
+
+// ─── Drift detection ─────────────────────────────────────────────
+
+export type ConflictDetail = Record<string, { expected: string; actual: string }>;
+
+/** Compares each observed key against the live row. Null when nothing drifted. */
+export function detectDrift(
+  observedValues: Record<string, unknown>,
+  liveValues: Record<string, unknown>
+): ConflictDetail | null {
+  const conflicts: ConflictDetail = {};
+  for (const key of Object.keys(observedValues)) {
+    const expected = normalizeForCompare(observedValues[key]);
+    const actual = normalizeForCompare(liveValues[key]);
+    if (expected !== actual) conflicts[key] = { expected, actual };
+  }
+  return Object.keys(conflicts).length > 0 ? conflicts : null;
+}
+
+// ─── Patch validation ────────────────────────────────────────────
+
+/**
+ * The only door between importer JSON and Prisma. Rejects unknown keys, coerces
+ * dates and decimals, validates enums against the generated client.
+ */
+export function validatePatch(raw: unknown): AffairPatch {
+  const parsed = affairPatchSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ProposalValidationError(
+      parsed.error.issues.map((i) => `${i.path.join(".") || "patch"}: ${i.message}`)
+    );
+  }
+  return parsed.data;
+}
+
+function patchFields(patch: AffairPatch): ProposableField[] {
+  return Object.keys(patch).filter((k): k is ProposableField =>
+    (PROPOSABLE_FIELDS as readonly string[]).includes(k)
+  );
+}
+
+// ─── Proposal creation ───────────────────────────────────────────
+
+export interface ProposeAffairUpdateInput {
+  affairId: string;
+  importer: string;
+  importRunId?: string | null;
+  /** Raw patch; validated here, never trusted. */
+  patch: unknown;
+  source: SourceType;
+  sourceUrl?: string | null;
+  officialId?: string | null;
+  sourceExcerpt?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+  confidence: number;
+  /** Why this affair, why this value. Shown verbatim to the reviewer. */
+  rationale: string;
+  extractorVersion?: string;
+}
+
+export interface ProposeAffairUpdateResult {
+  /** Machine identifiers written straight away. */
+  autoApplied: ProposableField[];
+  autoProposalId: string | null;
+  /** Proposal awaiting review, if any field required one. */
+  pendingProposalId: string | null;
+  /** Set when a unique identifier already belongs to another affair. */
+  conflictProposalId: string | null;
+  /** True when an identical payload had already been recorded. */
+  deduped: boolean;
+}
+
+/**
+ * Entry point for importers. Splits the patch into what may be auto-applied and
+ * what needs review, then records both halves as proposals so every automated
+ * write leaves a trace.
+ */
+export async function proposeAffairUpdate(
+  input: ProposeAffairUpdateInput
+): Promise<ProposeAffairUpdateResult> {
+  const patch = validatePatch(input.patch);
+  const fields = patchFields(patch);
+  const extractorVersion = input.extractorVersion ?? "v1";
+
+  const affair = await db.affair.findUnique({
+    where: { id: input.affairId },
+    select: AFFAIR_PROPOSABLE_SELECT,
+  });
+  if (!affair) {
+    throw new Error(`Affaire introuvable : ${input.affairId}`);
+  }
+  const live = affair as unknown as Record<string, unknown>;
+
+  const autoPatch: Record<string, unknown> = {};
+  const reviewPatch: Record<string, unknown> = {};
+  const conflictPatch: Record<string, unknown> = {};
+
+  for (const field of fields) {
+    const proposed = (patch as Record<string, unknown>)[field];
+    if (!AUTO_SET.has(field)) {
+      reviewPatch[field] = proposed;
+      continue;
+    }
+
+    if (field === "caseNumbers") {
+      const current = Array.isArray(live.caseNumbers) ? (live.caseNumbers as string[]) : [];
+      const incoming = Array.isArray(proposed) ? (proposed as string[]) : [];
+      const merged = mergeCaseNumbers(current, incoming);
+      // Additive only: nothing new means nothing to do.
+      if (merged.length > current.length) autoPatch.caseNumbers = merged;
+      continue;
+    }
+
+    const isAbsent = normalizeForCompare(live[field]) === EMPTY_VALUE;
+    if (!isAbsent) {
+      // Contradicts a stored identifier: that is a review decision, not a fill.
+      reviewPatch[field] = proposed;
+      continue;
+    }
+    if (proposed === null || proposed === undefined) continue;
+
+    if (field === "ecli") {
+      const taken = await db.affair.findFirst({
+        where: { ecli: String(proposed), id: { not: input.affairId } },
+        select: { id: true },
+      });
+      if (taken) {
+        // "Absent" but not "non-contradictory": Affair.ecli is @unique, so a
+        // blind write would raise P2002. Surface it instead.
+        conflictPatch[field] = proposed;
+        continue;
+      }
+    }
+    autoPatch[field] = proposed;
+  }
+
+  const result: ProposeAffairUpdateResult = {
+    autoApplied: [],
+    autoProposalId: null,
+    pendingProposalId: null,
+    conflictProposalId: null,
+    deduped: false,
+  };
+
+  if (Object.keys(autoPatch).length > 0) {
+    const outcome = await recordProposal({
+      input,
+      extractorVersion,
+      patch: autoPatch,
+      live,
+      status: "AUTO_APPLIED",
+      applyNow: true,
+    });
+    result.autoApplied = Object.keys(autoPatch) as ProposableField[];
+    result.autoProposalId = outcome.proposalId;
+    result.deduped = result.deduped || outcome.deduped;
+  }
+
+  if (Object.keys(reviewPatch).length > 0) {
+    const outcome = await recordProposal({
+      input,
+      extractorVersion,
+      patch: reviewPatch,
+      live,
+      status: "PENDING",
+      applyNow: false,
+    });
+    result.pendingProposalId = outcome.proposalId;
+    result.deduped = result.deduped || outcome.deduped;
+  }
+
+  if (Object.keys(conflictPatch).length > 0) {
+    const outcome = await recordProposal({
+      input,
+      extractorVersion,
+      patch: conflictPatch,
+      live,
+      status: "CONFLICT",
+      applyNow: false,
+      conflictDetail: {
+        ecli: { expected: "libre", actual: "déjà rattaché à une autre affaire" },
+      },
+    });
+    result.conflictProposalId = outcome.proposalId;
+    result.deduped = result.deduped || outcome.deduped;
+  }
+
+  return result;
+}
+
+function mergeCaseNumbers(current: string[], incoming: string[]): string[] {
+  const seen = new Set(current);
+  for (const value of incoming) {
+    if (value) seen.add(value);
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Every field a proposal can touch, selected as a constant.
+ *
+ * A select object built from the patch keys at runtime makes Prisma's generated
+ * types recurse ("Excessive stack depth comparing types"), so the shape stays
+ * static and the caller reads only the keys it needs.
+ */
+export const AFFAIR_PROPOSABLE_SELECT = {
+  id: true,
+  slug: true,
+  status: true,
+  involvement: true,
+  category: true,
+  severity: true,
+  factsDate: true,
+  startDate: true,
+  verdictDate: true,
+  court: true,
+  chamber: true,
+  caseNumber: true,
+  sentence: true,
+  prisonMonths: true,
+  prisonSuspended: true,
+  fineAmount: true,
+  ineligibilityMonths: true,
+  communityService: true,
+  otherSentence: true,
+  ecli: true,
+  pourvoiNumber: true,
+  caseNumbers: true,
+} as const;
+
+interface RecordProposalArgs {
+  input: ProposeAffairUpdateInput;
+  extractorVersion: string;
+  patch: Record<string, unknown>;
+  live: Record<string, unknown>;
+  status: ProposalStatus;
+  applyNow: boolean;
+  conflictDetail?: ConflictDetail;
+}
+
+async function recordProposal(
+  args: RecordProposalArgs
+): Promise<{ proposalId: string; deduped: boolean }> {
+  const { input, extractorVersion, patch, live, status, applyNow } = args;
+  const keys = Object.keys(patch);
+  const observedValues: Record<string, unknown> = {};
+  for (const key of keys) observedValues[key] = live[key] ?? null;
+
+  const payloadHash = computePayloadHash({
+    importer: input.importer,
+    extractorVersion,
+    source: input.source,
+    sourceUrl: input.sourceUrl,
+    officialId: input.officialId,
+    proposedPatch: patch,
+    observedValues,
+  });
+
+  const existing = await db.affairUpdateProposal.findUnique({
+    where: {
+      affairId_importer_payloadHash: {
+        affairId: input.affairId,
+        importer: input.importer,
+        payloadHash,
+      },
+    },
+    select: { id: true, status: true },
+  });
+
+  if (existing) {
+    // Never resurrect a terminal state. A rejected patch replayed by the next
+    // cron run must stay rejected instead of climbing back into the queue.
+    if (existing.status === "PENDING") {
+      await db.affairUpdateProposal.update({
+        where: { id: existing.id },
+        data: { updatedAt: new Date() },
+      });
+    }
+    return { proposalId: existing.id, deduped: true };
+  }
+
+  const data: Prisma.AffairUpdateProposalUncheckedCreateInput = {
+    affairId: input.affairId,
+    importer: input.importer,
+    importRunId: input.importRunId ?? null,
+    proposedPatch: toJson(patch),
+    observedValues: toJson(observedValues),
+    source: input.source,
+    sourceUrl: input.sourceUrl ?? null,
+    officialId: input.officialId ?? null,
+    sourceExcerpt: input.sourceExcerpt ?? null,
+    metadata: input.metadata ?? undefined,
+    confidence: clampConfidence(input.confidence),
+    riskLevel: deriveRiskLevel(keys, observedValues),
+    rationale: input.rationale,
+    extractorVersion,
+    payloadHash,
+    status,
+    conflictDetail: args.conflictDetail ? toJson(args.conflictDetail) : undefined,
+    appliedAt: applyNow ? new Date() : null,
+  };
+
+  if (!applyNow) {
+    const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
+    return { proposalId: created.id, deduped: false };
+  }
+
+  // Auto-applied: the affair write and its trace commit together.
+  const created = await db.$transaction(async (tx) => {
+    const row = await tx.affairUpdateProposal.create({ data, select: { id: true } });
+    await tx.affair.update({
+      where: { id: input.affairId },
+      data: buildPrismaData(validatePatch(patch)),
+    });
+    await tx.auditLog.create({
+      data: {
+        action: "UPDATE",
+        entityType: "Affair",
+        entityId: input.affairId,
+        changes: toJson({
+          action: "PROPOSAL_AUTO_APPLIED",
+          importer: input.importer,
+          extractorVersion,
+          proposalId: row.id,
+          before: observedValues,
+          after: patch,
+        }),
+      },
+    });
+    return row;
+  });
+
+  return { proposalId: created.id, deduped: false };
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function toJson(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+/**
+ * Turns a validated patch into a Prisma update payload. Only whitelisted keys
+ * survive validatePatch(), so this cannot widen the write surface.
+ */
+export function buildPrismaData(patch: AffairPatch): Prisma.AffairUpdateInput {
+  return { ...patch } as Prisma.AffairUpdateInput;
+}

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -254,7 +254,8 @@ export function buildPrismaData(patch: AffairPatch): Prisma.AffairUpdateInput {
 export interface ProposeAffairUpdateInput {
   affairId: string;
   importer: string;
-  importRunId?: string | null;
+  /** Mandatory: a proposal always belongs to a run. See withImportRun(). */
+  importRunId: string;
   /** Raw patch; validated here, never trusted. */
   patch: unknown;
   source: SourceType;
@@ -393,7 +394,7 @@ function buildProposalData(
     affairId: args.input.affairId,
     affairSnapshot: toJson(args.snapshot),
     importer: args.input.importer,
-    importRunId: args.input.importRunId ?? null,
+    importRunId: args.input.importRunId,
     proposedPatch: toJson(args.patch),
     observedValues: toJson(args.observedValues),
     source: args.input.source,

--- a/src/services/sync/__tests__/discover-affairs-builders.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-builders.test.ts
@@ -50,3 +50,38 @@ describe("buildWikidataDiscoveredAffair — invariant I1 (RGPD art. 10)", () => 
     affair.publicationStatus = "PUBLISHED";
   });
 });
+
+// Affaires v2, lot 1: Wikidata carries a decision date, not a facts date.
+// Squeezing it into factsDate is what made created affairs store a wrong
+// factsDate while leaving verdictDate NULL, and forced the reconciliation path
+// to read it back out behind a `phase === "wikidata"` guard.
+describe("sémantique des dates — factsDate n'est pas verdictDate", () => {
+  const verdictDate = new Date("2026-05-13T00:00:00.000Z");
+
+  it("la phase Wikidata renseigne verdictDate et laisse factsDate à null", () => {
+    const affair = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      penaltyData: { verdictDate, prisonMonths: 24 },
+    });
+
+    expect(affair.verdictDate).toEqual(verdictDate);
+    expect(affair.factsDate).toBeNull();
+  });
+
+  it("sans date de décision, les deux champs restent nuls", () => {
+    const affair = buildWikidataDiscoveredAffair({ ...baseInput, penaltyData: {} });
+
+    expect(affair.verdictDate).toBeNull();
+    expect(affair.factsDate).toBeNull();
+  });
+
+  it("le champ verdictDate existe sur le type et n'est jamais alimenté par factsDate", () => {
+    const affair = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      penaltyData: { verdictDate },
+    });
+
+    // Regression guard: these two must never hold the same value by construction.
+    expect(affair.factsDate).not.toEqual(affair.verdictDate);
+  });
+});

--- a/src/services/sync/__tests__/no-direct-affair-mutation.test.ts
+++ b/src/services/sync/__tests__/no-direct-affair-mutation.test.ts
@@ -4,9 +4,13 @@ import { join } from "node:path";
 
 // Affaires v2, lot 1 architectural guard.
 //
-// A sync service must never mutate an existing affair. It calls
-// proposeAffairUpdate() and lets a human accept the change. Creating a new DRAFT
-// affair stays allowed: nothing is overwritten and DRAFT is not public.
+// A sync service touches affairs through exactly two doors:
+//   createDraftAffairFromDiscovery()  — new affair, always DRAFT
+//   proposeAffairUpdate()             — change to an existing one, human-reviewed
+//
+// So no `db.affair.<mutation>` at all inside src/services/sync, `create`
+// included. No file is exempt: a future `update` or `upsert` in press-analysis
+// must fail this test just like anywhere else.
 //
 // A source scan rather than an ESLint rule, per the lot's scope. It covers the
 // transactional client too (`tx.affair.update`), which is the form a future
@@ -14,7 +18,15 @@ import { join } from "node:path";
 
 const SYNC_DIR = join(process.cwd(), "src/services/sync");
 
-const FORBIDDEN_MUTATIONS = ["update", "updateMany", "upsert", "delete", "deleteMany"] as const;
+const FORBIDDEN_MUTATIONS = [
+  "create",
+  "createMany",
+  "update",
+  "updateMany",
+  "upsert",
+  "delete",
+  "deleteMany",
+] as const;
 
 /** Any client identifier: db, tx, prisma, client... */
 const MUTATION_PATTERN = new RegExp(
@@ -48,7 +60,7 @@ describe("garde architectural : aucune mutation directe d'affaire dans src/servi
     expect(files.length).toBeGreaterThan(5);
   });
 
-  it("aucun service de sync ne fait update/updateMany/upsert/delete sur une affaire", () => {
+  it("aucun service de sync ne mute une affaire directement, create compris", () => {
     const offenders: string[] = [];
 
     for (const file of files) {
@@ -61,17 +73,38 @@ describe("garde architectural : aucune mutation directe d'affaire dans src/servi
     expect(offenders).toEqual([]);
   });
 
+  it("la porte de création force DRAFT et n'accepte pas de publicationStatus", () => {
+    const door = readFileSync(join(process.cwd(), "src/services/affairs/create-draft.ts"), "utf8");
+
+    // publicationStatus is hard-coded, never a parameter.
+    expect(door).toContain('publicationStatus: "DRAFT"');
+    expect(stripComments(door)).not.toMatch(
+      /publicationStatus\??\s*:\s*(PublicationStatus|string)/
+    );
+    expect(stripComments(door)).not.toMatch(/publicationStatus\s*:\s*input\./);
+  });
+
   // Not asserted here: "no sync service publishes an affair" (invariant I1).
   // A source scan cannot tell a `where: { publicationStatus: "PUBLISHED" }`
   // filter from a write, and several services legitimately filter on it. The
   // invariant is already enforced at the type level by
   // DiscoveredAffair.publicationStatus being the literal "DRAFT".
 
-  it("le point de passage proposeAffairUpdate est bien utilisé par les importeurs convertis", () => {
+  it("les deux portes sont bien celles qu'utilisent les importeurs", () => {
     const discover = readFileSync(join(SYNC_DIR, "discover-affairs.ts"), "utf8");
     const judilibre = readFileSync(join(SYNC_DIR, "judilibre.ts"), "utf8");
+    const press = readFileSync(join(SYNC_DIR, "press-analysis.ts"), "utf8");
 
     expect(discover).toContain("proposeAffairUpdate(");
     expect(judilibre).toContain("proposeAffairUpdate(");
+
+    // press-analysis only ever creates; it must still go through the door.
+    for (const [name, code] of [
+      ["discover-affairs", discover],
+      ["judilibre", judilibre],
+      ["press-analysis", press],
+    ] as const) {
+      expect(code, name).toContain("createDraftAffairFromDiscovery(");
+    }
   });
 });

--- a/src/services/sync/__tests__/no-direct-affair-mutation.test.ts
+++ b/src/services/sync/__tests__/no-direct-affair-mutation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// Affaires v2, lot 1 architectural guard.
+//
+// A sync service must never mutate an existing affair. It calls
+// proposeAffairUpdate() and lets a human accept the change. Creating a new DRAFT
+// affair stays allowed: nothing is overwritten and DRAFT is not public.
+//
+// A source scan rather than an ESLint rule, per the lot's scope. It covers the
+// transactional client too (`tx.affair.update`), which is the form a future
+// refactor is most likely to reach for.
+
+const SYNC_DIR = join(process.cwd(), "src/services/sync");
+
+const FORBIDDEN_MUTATIONS = ["update", "updateMany", "upsert", "delete", "deleteMany"] as const;
+
+/** Any client identifier: db, tx, prisma, client... */
+const MUTATION_PATTERN = new RegExp(
+  String.raw`\.affair\.(${FORBIDDEN_MUTATIONS.join("|")})\s*\(`,
+  "g"
+);
+
+/** Comments describing the old behaviour must not trip the scan. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue;
+      out.push(...collectTsFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+describe("garde architectural : aucune mutation directe d'affaire dans src/services/sync", () => {
+  const files = collectTsFiles(SYNC_DIR);
+
+  it("trouve bien des fichiers à scanner", () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it("aucun service de sync ne fait update/updateMany/upsert/delete sur une affaire", () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const code = stripComments(readFileSync(file, "utf8"));
+      for (const match of code.matchAll(MUTATION_PATTERN)) {
+        offenders.push(`${file.replace(process.cwd() + "/", "")} → .affair.${match[1]}(`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  // Not asserted here: "no sync service publishes an affair" (invariant I1).
+  // A source scan cannot tell a `where: { publicationStatus: "PUBLISHED" }`
+  // filter from a write, and several services legitimately filter on it. The
+  // invariant is already enforced at the type level by
+  // DiscoveredAffair.publicationStatus being the literal "DRAFT".
+
+  it("le point de passage proposeAffairUpdate est bien utilisé par les importeurs convertis", () => {
+    const discover = readFileSync(join(SYNC_DIR, "discover-affairs.ts"), "utf8");
+    const judilibre = readFileSync(join(SYNC_DIR, "judilibre.ts"), "utf8");
+
+    expect(discover).toContain("proposeAffairUpdate(");
+    expect(judilibre).toContain("proposeAffairUpdate(");
+  });
+});

--- a/src/services/sync/discover-affairs-builders.ts
+++ b/src/services/sync/discover-affairs-builders.ts
@@ -31,7 +31,10 @@ export interface DiscoveredAffair {
   category: AffairCategory;
   status: AffairStatus;
   involvement: Involvement;
+  /** Date of the alleged facts. Never a decision date. */
   factsDate: Date | null;
+  /** Date of the court decision. Wikidata P1399 qualifiers carry this, not factsDate. */
+  verdictDate: Date | null;
   court: string | null;
   prisonMonths: number | null;
   prisonSuspended: boolean | null;
@@ -81,7 +84,11 @@ export function buildWikidataDiscoveredAffair(
     category: input.category,
     status: input.status,
     involvement: isConviction ? "DIRECT" : "MENTIONED_ONLY",
-    factsDate: input.penaltyData.verdictDate ?? null,
+    // Wikidata gives us a decision date, not a facts date. Storing it in
+    // factsDate is what made the reconciliation path read it back out into
+    // verdictDate, and made every created affair carry a wrong factsDate.
+    factsDate: null,
+    verdictDate: input.penaltyData.verdictDate ?? null,
     court: null,
     prisonMonths: input.penaltyData.prisonMonths ?? null,
     prisonSuspended: input.penaltyData.prisonSuspended ?? null,

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -32,12 +32,7 @@ import { loadCandidatePool } from "@/lib/affair-matching/persistence";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
 import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
-import {
-  failImportRun,
-  finishImportRun,
-  IMPORTER_DISCOVER_AFFAIRS,
-  startImportRun,
-} from "@/services/affairs/import-run";
+import { IMPORTER_DISCOVER_AFFAIRS, withImportRun } from "@/services/affairs/import-run";
 
 export const DISCOVER_AFFAIRS_CURSOR_KEY = "discover-affairs:cursor:lastName";
 
@@ -309,10 +304,10 @@ export async function discoverAffairs(options?: {
   if (allAffairs.length > 0) {
     // Reconciliation is the only phase that touches existing affairs, so it is
     // the only one that needs an ImportRun to anchor its proposals.
-    const importRunId = await startImportRun(IMPORTER_DISCOVER_AFFAIRS);
-    try {
+    // withImportRun guarantees the run leaves RUNNING whatever happens.
+    await withImportRun(IMPORTER_DISCOVER_AFFAIRS, async ({ importRunId, setStats }) => {
       await runPhase3Reconciliation(allAffairs, stats, importRunId);
-      await finishImportRun(importRunId, {
+      setStats({
         duplicatesSkipped: stats.duplicatesSkipped,
         affairsCreated: stats.affairsCreated,
         proposalsPending: stats.proposalsPending,
@@ -320,10 +315,7 @@ export async function discoverAffairs(options?: {
         proposalsConflicted: stats.proposalsConflicted,
         proposalsDeduped: stats.proposalsDeduped,
       });
-    } catch (error) {
-      await failImportRun(importRunId, error);
-      throw error;
-    }
+    });
   }
 
   return stats;

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -8,7 +8,7 @@
  */
 
 import { db } from "@/lib/db";
-import { generateAffairSlug, generateUniqueSlug } from "@/lib/utils";
+import { generateAffairSlug } from "@/lib/utils";
 import { WikidataService } from "@/lib/api/wikidata";
 import { WD_PROPS } from "@/config/wikidata";
 import { mapWikidataOffense, getOffenseLabel } from "@/config/wikidata-affairs";
@@ -30,7 +30,8 @@ import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prism
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadCandidatePool } from "@/lib/affair-matching/persistence";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
-import { proposeAffairUpdate } from "@/services/affairs/proposals";
+import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
+import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import {
   failImportRun,
   finishImportRun,
@@ -198,15 +199,6 @@ function extractPublisherFromUrl(url: string): string {
   } catch {
     return "Source inconnue";
   }
-}
-
-async function generateUniqueAffairSlug(politicianSlug: string, title: string): Promise<string> {
-  const baseSlug = generateAffairSlug(politicianSlug, title);
-  return generateUniqueSlug(
-    baseSlug,
-    (s) => db.affair.findUnique({ where: { slug: s } }).then(Boolean),
-    120
-  );
 }
 
 export async function discoverAffairs(options?: {
@@ -653,6 +645,14 @@ async function proposePenaltyEnrichment(
     source: "WIKIDATA",
     sourceUrl: wikidataSource?.url ?? null,
     officialId: extractQidFromUrl(wikidataSource?.url),
+    // A Wikidata claim can change under the same Q-ID, so the payload itself is
+    // part of the proposal identity.
+    sourceContentHash: hashSourceContent({
+      charges: affair.charges,
+      status: affair.status,
+      category: affair.category,
+      penalties: patch,
+    }),
     sourceExcerpt: affair.charges.join(", ").slice(0, 500),
     metadata: { phase: affair.phase, politicianName: affair.politicianName },
     confidence: affair.confidenceScore,
@@ -716,39 +716,31 @@ async function runPhase3Reconciliation(
         where: { id: affair.politicianId },
         select: { slug: true },
       });
-      const slug = await generateUniqueAffairSlug(politician?.slug ?? "", affair.title);
-
-      const createdAffair = await db.affair.create({
-        data: {
-          politicianId: affair.politicianId,
-          title: affair.title,
-          slug,
-          description: affair.description,
-          status: affair.status,
-          category: affair.category,
-          involvement: affair.involvement,
-          factsDate: affair.factsDate,
-          verdictDate: affair.verdictDate,
-          court: affair.court,
-          prisonMonths: affair.prisonMonths,
-          prisonSuspended: affair.prisonSuspended,
-          ineligibilityMonths: affair.ineligibilityMonths,
-          communityService: affair.communityService,
-          otherSentence: affair.otherSentence,
-          sentence: buildSentenceSummary(affair),
-          confidenceScore: affair.confidenceScore,
-          publicationStatus: affair.publicationStatus,
-          sources: {
-            create: affair.sources.map((s) => ({
-              url: s.url,
-              title: s.title,
-              publisher: s.publisher,
-              publishedAt: s.publishedAt ?? affair.factsDate ?? affair.verdictDate ?? new Date(),
-              sourceType: s.sourceType,
-            })),
-          },
-        },
-        select: { id: true },
+      const createdAffair = await createDraftAffairFromDiscovery({
+        politicianId: affair.politicianId,
+        title: affair.title,
+        baseSlug: generateAffairSlug(politician?.slug ?? "", affair.title),
+        description: affair.description,
+        status: affair.status,
+        category: affair.category,
+        involvement: affair.involvement,
+        confidenceScore: affair.confidenceScore,
+        factsDate: affair.factsDate,
+        verdictDate: affair.verdictDate,
+        court: affair.court,
+        prisonMonths: affair.prisonMonths,
+        prisonSuspended: affair.prisonSuspended,
+        ineligibilityMonths: affair.ineligibilityMonths,
+        communityService: affair.communityService,
+        otherSentence: affair.otherSentence,
+        sentence: buildSentenceSummary(affair),
+        sources: affair.sources.map((s) => ({
+          url: s.url,
+          title: s.title,
+          publisher: s.publisher,
+          publishedAt: s.publishedAt ?? affair.factsDate ?? affair.verdictDate ?? new Date(),
+          sourceType: s.sourceType,
+        })),
       });
 
       // Lie la décision du resolver à l'affaire créée : le publish-guard

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -30,8 +30,22 @@ import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prism
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadCandidatePool } from "@/lib/affair-matching/persistence";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
+import { proposeAffairUpdate } from "@/services/affairs/proposals";
+import {
+  failImportRun,
+  finishImportRun,
+  IMPORTER_DISCOVER_AFFAIRS,
+  startImportRun,
+} from "@/services/affairs/import-run";
 
 export const DISCOVER_AFFAIRS_CURSOR_KEY = "discover-affairs:cursor:lastName";
+
+/**
+ * Bump when the Wikidata penalty extraction changes shape or semantics. It is
+ * part of the proposal payload hash, so a fixed extractor can re-propose a value
+ * that a previous version got rejected on.
+ */
+export const WIKIDATA_EXTRACTOR_VERSION = "wikidata-penalty-v2";
 
 /**
  * Read the persisted lastName cursor for the discover-affairs sync.
@@ -75,6 +89,11 @@ export interface DiscoverAffairsResult {
   wikipediaAffairsFound: number;
   duplicatesSkipped: number;
   affairsCreated: number;
+  /** Affaires v2, lot 1: enrichment of existing affairs is now proposal-based. */
+  proposalsPending: number;
+  proposalsAutoApplied: number;
+  proposalsConflicted: number;
+  proposalsDeduped: number;
   errors: string[];
 }
 
@@ -211,6 +230,10 @@ export async function discoverAffairs(options?: {
     wikipediaAffairsFound: 0,
     duplicatesSkipped: 0,
     affairsCreated: 0,
+    proposalsPending: 0,
+    proposalsAutoApplied: 0,
+    proposalsConflicted: 0,
+    proposalsDeduped: 0,
     errors: [],
   };
 
@@ -292,7 +315,23 @@ export async function discoverAffairs(options?: {
   const allAffairs = [...phase1Affairs, ...phase2Affairs];
 
   if (allAffairs.length > 0) {
-    await runPhase3Reconciliation(allAffairs, stats);
+    // Reconciliation is the only phase that touches existing affairs, so it is
+    // the only one that needs an ImportRun to anchor its proposals.
+    const importRunId = await startImportRun(IMPORTER_DISCOVER_AFFAIRS);
+    try {
+      await runPhase3Reconciliation(allAffairs, stats, importRunId);
+      await finishImportRun(importRunId, {
+        duplicatesSkipped: stats.duplicatesSkipped,
+        affairsCreated: stats.affairsCreated,
+        proposalsPending: stats.proposalsPending,
+        proposalsAutoApplied: stats.proposalsAutoApplied,
+        proposalsConflicted: stats.proposalsConflicted,
+        proposalsDeduped: stats.proposalsDeduped,
+      });
+    } catch (error) {
+      await failImportRun(importRunId, error);
+      throw error;
+    }
   }
 
   return stats;
@@ -504,7 +543,10 @@ async function runPhase2Wikipedia(
             category: extracted.category as AffairCategory,
             status: extracted.status as AffairStatus,
             involvement: extracted.involvement,
+            // Wikipedia extraction yields a genuine facts date; it carries no
+            // decision date.
             factsDate: extracted.factsDate ? new Date(extracted.factsDate) : null,
+            verdictDate: null,
             court: extracted.court,
             prisonMonths: null,
             prisonSuspended: null,
@@ -575,9 +617,68 @@ function buildSentenceSummary(affair: DiscoveredAffair): string | null {
   return parts.length > 0 ? parts.join(", ") : null;
 }
 
+/**
+ * Files the Wikidata penalty payload as a proposal on an existing affair.
+ *
+ * Replaces the previous direct `db.affair.update`, which silently overwrote
+ * sentence fields, court and verdictDate on published affairs.
+ */
+async function proposePenaltyEnrichment(
+  affair: DiscoveredAffair,
+  affairId: string,
+  stats: DiscoverAffairsResult,
+  importRunId: string
+): Promise<void> {
+  const patch: Record<string, unknown> = {};
+  if (affair.prisonMonths !== null) patch.prisonMonths = affair.prisonMonths;
+  if (affair.prisonSuspended !== null) patch.prisonSuspended = affair.prisonSuspended;
+  if (affair.ineligibilityMonths !== null) patch.ineligibilityMonths = affair.ineligibilityMonths;
+  if (affair.communityService !== null) patch.communityService = affair.communityService;
+  if (affair.otherSentence !== null) patch.otherSentence = affair.otherSentence;
+  if (affair.verdictDate) patch.verdictDate = affair.verdictDate;
+  if (affair.court) patch.court = affair.court;
+
+  const sentence = buildSentenceSummary(affair);
+  if (sentence) patch.sentence = sentence;
+
+  if (Object.keys(patch).length === 0) return;
+
+  const wikidataSource = affair.sources.find((s) => s.sourceType === "WIKIDATA");
+
+  const result = await proposeAffairUpdate({
+    affairId,
+    importer: IMPORTER_DISCOVER_AFFAIRS,
+    importRunId,
+    patch,
+    source: "WIKIDATA",
+    sourceUrl: wikidataSource?.url ?? null,
+    officialId: extractQidFromUrl(wikidataSource?.url),
+    sourceExcerpt: affair.charges.join(", ").slice(0, 500),
+    metadata: { phase: affair.phase, politicianName: affair.politicianName },
+    confidence: affair.confidenceScore,
+    rationale:
+      `Rapprochement HIGH/CERTAIN avec une affaire existante du même politique ` +
+      `et de la même catégorie (${affair.category}). Peines et date de décision ` +
+      `extraites des qualificatifs Wikidata de « ${affair.title} ».`,
+    extractorVersion: WIKIDATA_EXTRACTOR_VERSION,
+  });
+
+  if (result.pendingProposalId) stats.proposalsPending++;
+  if (result.autoProposalId) stats.proposalsAutoApplied++;
+  if (result.conflictProposalId) stats.proposalsConflicted++;
+  if (result.deduped) stats.proposalsDeduped++;
+}
+
+function extractQidFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  const match = /\/(Q\d+)$/.exec(url);
+  return match ? match[1]! : null;
+}
+
 async function runPhase3Reconciliation(
   allAffairs: DiscoveredAffair[],
-  stats: DiscoverAffairsResult
+  stats: DiscoverAffairsResult,
+  importRunId: string
 ): Promise<void> {
   console.log(`Phase 3: Reconciliation - ${allAffairs.length} affairs`);
 
@@ -592,28 +693,10 @@ async function runPhase3Reconciliation(
       const highMatch = matches.find((m) => m.confidence === "HIGH" || m.confidence === "CERTAIN");
 
       if (highMatch) {
-        // Enrich existing affair with penalty data if fields are NULL
+        // Affaires v2, lot 1: an importer never writes to an existing affair.
+        // Penalty data, dates and jurisdiction go through the proposal queue.
         if (affair.phase === "wikidata") {
-          const updateData: Record<string, unknown> = {};
-          if (affair.prisonMonths !== null) updateData.prisonMonths = affair.prisonMonths;
-          if (affair.prisonSuspended !== null) updateData.prisonSuspended = affair.prisonSuspended;
-          if (affair.ineligibilityMonths !== null)
-            updateData.ineligibilityMonths = affair.ineligibilityMonths;
-          if (affair.communityService !== null)
-            updateData.communityService = affair.communityService;
-          if (affair.otherSentence !== null) updateData.otherSentence = affair.otherSentence;
-          if (affair.factsDate) updateData.verdictDate = affair.factsDate;
-          if (affair.court) updateData.court = affair.court;
-
-          const sentence = buildSentenceSummary(affair);
-          if (sentence) updateData.sentence = sentence;
-
-          if (Object.keys(updateData).length > 0) {
-            await db.affair.update({
-              where: { id: highMatch.affairId },
-              data: updateData,
-            });
-          }
+          await proposePenaltyEnrichment(affair, highMatch.affairId, stats, importRunId);
         }
 
         // Même en cas de doublon enrichi, la décision resolver est rattachée
@@ -645,6 +728,7 @@ async function runPhase3Reconciliation(
           category: affair.category,
           involvement: affair.involvement,
           factsDate: affair.factsDate,
+          verdictDate: affair.verdictDate,
           court: affair.court,
           prisonMonths: affair.prisonMonths,
           prisonSuspended: affair.prisonSuspended,
@@ -659,7 +743,7 @@ async function runPhase3Reconciliation(
               url: s.url,
               title: s.title,
               publisher: s.publisher,
-              publishedAt: s.publishedAt ?? affair.factsDate ?? new Date(),
+              publishedAt: s.publishedAt ?? affair.factsDate ?? affair.verdictDate ?? new Date(),
               sourceType: s.sourceType,
             })),
           },

--- a/src/services/sync/judilibre.ts
+++ b/src/services/sync/judilibre.ts
@@ -49,12 +49,8 @@ import { resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadJudilibreDecisionCache } from "./judilibre-decisions";
 import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
-import {
-  failImportRun,
-  finishImportRun,
-  IMPORTER_JUDILIBRE,
-  startImportRun,
-} from "@/services/affairs/import-run";
+import { upsertAffairSource } from "@/services/affairs/affair-source";
+import { IMPORTER_JUDILIBRE, withImportRun } from "@/services/affairs/import-run";
 
 /**
  * Bump when the Judilibre mapping changes shape or semantics. Part of the
@@ -184,10 +180,13 @@ async function enrichAffairFromJudilibre(
     }
 
     if (Object.keys(patch).length > 0) {
+      if (!importRunId) {
+        throw new Error("enrichAffairFromJudilibre: importRunId requis hors dry-run");
+      }
       await proposeAffairUpdate({
         affairId,
         importer: IMPORTER_JUDILIBRE,
-        importRunId: importRunId ?? null,
+        importRunId,
         patch,
         source: "JUDILIBRE",
         sourceUrl: decisionUrl,
@@ -212,26 +211,17 @@ async function enrichAffairFromJudilibre(
       });
     }
 
-    // Add Judilibre source if not already present
-    const existingSource = await db.source.findFirst({
-      where: {
-        affairId,
-        sourceType: "JUDILIBRE",
-      },
+    // Attach the decision as a source. Idempotent on (affairId, url): the
+    // previous code deduplicated on (affairId, sourceType), which silently
+    // dropped a second Cassation decision on the same affair.
+    await upsertAffairSource({
+      affairId,
+      url: decisionUrl,
+      title: `Cour de cassation - ${decision.solution} (${decision.number})`,
+      publisher: "Cour de cassation",
+      publishedAt: new Date(decision.decision_date),
+      sourceType: "JUDILIBRE",
     });
-
-    if (!existingSource) {
-      await db.source.create({
-        data: {
-          affairId,
-          url: `https://www.courdecassation.fr/decision/${decision.id}`,
-          title: `Cour de cassation - ${decision.solution} (${decision.number})`,
-          publisher: "Cour de cassation",
-          publishedAt: new Date(decision.decision_date),
-          sourceType: "JUDILIBRE",
-        },
-      });
-    }
 
     if (verbose) {
       console.log(`  ✓ Affaire ${affairId} enrichie avec ECLI ${decision.ecli}`);
@@ -481,10 +471,23 @@ export async function syncJudilibre(
   const politicians = await getPoliticiansToSearch(politicianSlug, limit);
   console.log(`${politicians.length} politicien(s) a rechercher\n`);
 
-  // Anchors every proposal this pass files. Skipped on dry runs, which write nothing.
-  const importRunId = dryRun ? null : await startImportRun(IMPORTER_JUDILIBRE);
+  if (dryRun) {
+    // A dry run writes nothing, so it opens no run: an ImportRun with no
+    // proposals would be noise in the provenance history.
+    await runJudilibreSearch({
+      politicians,
+      client,
+      decisionCache,
+      stats,
+      dryRun,
+      verbose,
+      importRunId: null,
+    });
+    return stats;
+  }
 
-  try {
+  // withImportRun guarantees the run leaves RUNNING whatever happens.
+  await withImportRun(IMPORTER_JUDILIBRE, async ({ importRunId, setStats }) => {
     await runJudilibreSearch({
       politicians,
       client,
@@ -494,19 +497,13 @@ export async function syncJudilibre(
       verbose,
       importRunId,
     });
-  } catch (error) {
-    if (importRunId) await failImportRun(importRunId, error);
-    throw error;
-  }
-
-  if (importRunId) {
-    await finishImportRun(importRunId, {
+    setStats({
       affairsEnriched: stats.affairsEnriched,
       affairsCreated: stats.affairsCreated,
       decisionsRelevant: stats.decisionsRelevant,
       errors: stats.errors,
     });
-  }
+  });
 
   return stats;
 }

--- a/src/services/sync/judilibre.ts
+++ b/src/services/sync/judilibre.ts
@@ -44,10 +44,22 @@ import {
   buildTitleFromDecision,
 } from "@/services/affairs/judilibre-mapping";
 import { syncMetadata } from "@/lib/sync";
-import { trackStatusChange } from "@/services/affairs/status-tracking";
 import { findCourtDepartments, extractJurisdictionName } from "@/config/judilibre-courts";
 import { resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadJudilibreDecisionCache } from "./judilibre-decisions";
+import { proposeAffairUpdate } from "@/services/affairs/proposals";
+import {
+  failImportRun,
+  finishImportRun,
+  IMPORTER_JUDILIBRE,
+  startImportRun,
+} from "@/services/affairs/import-run";
+
+/**
+ * Bump when the Judilibre mapping changes shape or semantics. Part of the
+ * proposal payload hash.
+ */
+export const JUDILIBRE_EXTRACTOR_VERSION = "judilibre-v1";
 
 // ============================================
 // TYPES
@@ -121,64 +133,72 @@ async function searchPoliticianDecisions(
 // ============================================
 
 /**
- * Enrich an existing affair with Judilibre data (ECLI, pourvoi, source)
+ * Enrich an existing affair with Judilibre data (ECLI, pourvoi, source).
+ *
+ * Affaires v2, lot 1: no direct write. Judicial identifiers are auto-applied only
+ * when absent and non-contradictory (proposeAffairUpdate enforces that, including
+ * the Affair.ecli unique collision that used to raise P2002). A status change is
+ * always filed as a proposal, and the timeline event moves to acceptance time.
  */
 async function enrichAffairFromJudilibre(
   affairId: string,
   decision: JudilibreDecisionSummary,
   dryRun: boolean,
-  verbose?: boolean
+  verbose?: boolean,
+  importRunId?: string | null
 ): Promise<boolean> {
   if (dryRun) {
     if (verbose) {
-      console.log(`  [DRY-RUN] Enrichirait affaire ${affairId} avec ECLI ${decision.ecli}`);
+      console.log(`  [DRY-RUN] Proposerait sur l'affaire ${affairId} l'ECLI ${decision.ecli}`);
     }
     return true;
   }
 
+  const decisionUrl = `https://www.courdecassation.fr/decision/${decision.id}`;
+
   try {
-    // Update affair with judicial identifiers
-    const updateData: Record<string, unknown> = {};
+    const patch: Record<string, unknown> = {};
 
     if (decision.ecli) {
-      updateData.ecli = decision.ecli;
+      patch.ecli = decision.ecli;
     }
     if (decision.number) {
-      updateData.pourvoiNumber = decision.number;
+      patch.pourvoiNumber = decision.number;
     }
     if (decision.numbers && decision.numbers.length > 0) {
-      // Merge with existing caseNumbers
-      const existing = await db.affair.findUnique({
-        where: { id: affairId },
-        select: { caseNumbers: true },
-      });
-      const existingNumbers = new Set(existing?.caseNumbers ?? []);
-      for (const num of decision.numbers) {
-        existingNumbers.add(num);
-      }
-      updateData.caseNumbers = Array.from(existingNumbers);
+      // proposeAffairUpdate merges additively with the stored array.
+      patch.caseNumbers = decision.numbers;
     }
 
-    // Map solution to status (upgrade or terminal transition)
+    // Map solution to status (upgrade or terminal transition). The monotonic
+    // guard stays here so we do not file proposals for regressions a reviewer
+    // would only reject.
     const newStatus = mapSolutionToStatus(decision.solution);
     const currentAffair = await db.affair.findUnique({
       where: { id: affairId },
       select: { status: true },
     });
     if (currentAffair && shouldUpdateStatus(currentAffair.status, newStatus)) {
-      updateData.status = newStatus;
-      // Track status change in affair timeline
-      await trackStatusChange(affairId, currentAffair.status, newStatus, {
-        type: "JUDILIBRE",
-        url: `https://www.courdecassation.fr/decision/${decision.id}`,
-        title: `Cour de cassation - ${decision.solution} (${decision.number})`,
-      });
+      patch.status = newStatus;
     }
 
-    if (Object.keys(updateData).length > 0) {
-      await db.affair.update({
-        where: { id: affairId },
-        data: updateData,
+    if (Object.keys(patch).length > 0) {
+      await proposeAffairUpdate({
+        affairId,
+        importer: IMPORTER_JUDILIBRE,
+        importRunId: importRunId ?? null,
+        patch,
+        source: "JUDILIBRE",
+        sourceUrl: decisionUrl,
+        officialId: decision.ecli ?? decision.number ?? null,
+        sourceExcerpt: decision.summary?.slice(0, 500) ?? null,
+        metadata: { solution: decision.solution, decisionId: decision.id },
+        confidence: 90,
+        rationale:
+          `Décision Cour de cassation ${decision.number ?? "(sans n°)"} ` +
+          `(${decision.solution}) rapprochée de cette affaire. ` +
+          `Identifiants judiciaires et, le cas échéant, progression du statut.`,
+        extractorVersion: JUDILIBRE_EXTRACTOR_VERSION,
       });
     }
 
@@ -465,6 +485,53 @@ export async function syncJudilibre(
   const politicians = await getPoliticiansToSearch(politicianSlug, limit);
   console.log(`${politicians.length} politicien(s) a rechercher\n`);
 
+  // Anchors every proposal this pass files. Skipped on dry runs, which write nothing.
+  const importRunId = dryRun ? null : await startImportRun(IMPORTER_JUDILIBRE);
+
+  try {
+    await runJudilibreSearch({
+      politicians,
+      client,
+      decisionCache,
+      stats,
+      dryRun,
+      verbose,
+      importRunId,
+    });
+  } catch (error) {
+    if (importRunId) await failImportRun(importRunId, error);
+    throw error;
+  }
+
+  if (importRunId) {
+    await finishImportRun(importRunId, {
+      affairsEnriched: stats.affairsEnriched,
+      affairsCreated: stats.affairsCreated,
+      decisionsRelevant: stats.decisionsRelevant,
+      errors: stats.errors,
+    });
+  }
+
+  return stats;
+}
+
+interface JudilibreSearchArgs {
+  politicians: PoliticianForSearch[];
+  client: JudilibreClient;
+  decisionCache: Awaited<ReturnType<typeof loadJudilibreDecisionCache>>;
+  stats: JudilibreSyncStats;
+  dryRun: boolean;
+  verbose?: boolean;
+  importRunId: string | null;
+}
+
+/**
+ * Extracted from syncJudilibre so the ImportRun lifecycle (start, finish, fail)
+ * wraps the whole pass in one place.
+ */
+async function runJudilibreSearch(args: JudilibreSearchArgs): Promise<void> {
+  const { politicians, client, decisionCache, stats, dryRun, verbose, importRunId } = args;
+
   for (const politician of politicians) {
     stats.politiciansSearched++;
 
@@ -496,7 +563,8 @@ export async function syncJudilibre(
               bestMatch.affairId,
               decision,
               dryRun,
-              verbose
+              verbose,
+              importRunId
             );
             if (enriched) stats.affairsEnriched++;
           }
@@ -572,7 +640,8 @@ export async function syncJudilibre(
               bestMatch.affairId,
               decision,
               dryRun,
-              verbose
+              verbose,
+              importRunId
             );
             if (enriched) stats.affairsEnriched++;
           } else if (analyzeIfConviction(decision)) {
@@ -647,8 +716,6 @@ export async function syncJudilibre(
       itemCount: stats.affairsEnriched + stats.affairsCreated,
     });
   }
-
-  return stats;
 }
 
 // ============================================

--- a/src/services/sync/judilibre.ts
+++ b/src/services/sync/judilibre.ts
@@ -47,7 +47,8 @@ import { syncMetadata } from "@/lib/sync";
 import { findCourtDepartments, extractJurisdictionName } from "@/config/judilibre-courts";
 import { resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadJudilibreDecisionCache } from "./judilibre-decisions";
-import { proposeAffairUpdate } from "@/services/affairs/proposals";
+import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
+import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import {
   failImportRun,
   finishImportRun,
@@ -191,6 +192,15 @@ async function enrichAffairFromJudilibre(
         source: "JUDILIBRE",
         sourceUrl: decisionUrl,
         officialId: decision.ecli ?? decision.number ?? null,
+        // A decision page can be republished with a corrected solution under the
+        // same URL, so the payload itself is part of the proposal identity.
+        sourceContentHash: hashSourceContent({
+          solution: decision.solution,
+          ecli: decision.ecli ?? null,
+          number: decision.number ?? null,
+          numbers: decision.numbers ?? [],
+          decisionDate: decision.decision_date,
+        }),
         sourceExcerpt: decision.summary?.slice(0, 500) ?? null,
         metadata: { solution: decision.solution, decisionId: decision.id },
         confidence: 90,
@@ -270,41 +280,27 @@ async function createAffairFromJudilibre(
   }
 
   try {
-    const baseSlug = generateSlug(title);
-    let slug = baseSlug;
-
-    // Ensure unique slug
-    let counter = 1;
-    while (await db.affair.findUnique({ where: { slug }, select: { id: true } })) {
-      slug = `${baseSlug}-${counter}`;
-      counter++;
-    }
-
-    await db.affair.create({
-      data: {
-        politicianId,
-        title,
-        slug,
-        description: decision.summary || `Décision de la Cour de cassation : ${decision.solution}.`,
-        status,
-        category,
-        confidenceScore,
-        publicationStatus: "DRAFT",
-        verdictDate: new Date(decision.decision_date),
-        ecli: decision.ecli || null,
-        pourvoiNumber: decision.number || null,
-        caseNumbers: decision.numbers || [],
-        verifiedAt: null,
-        sources: {
-          create: {
-            url: `https://www.courdecassation.fr/decision/${decision.id}`,
-            title: `Cour de cassation - ${decision.solution} (${decision.number})`,
-            publisher: "Cour de cassation",
-            publishedAt: new Date(decision.decision_date),
-            sourceType: "JUDILIBRE",
-          },
+    await createDraftAffairFromDiscovery({
+      politicianId,
+      title,
+      baseSlug: generateSlug(title),
+      description: decision.summary || `Décision de la Cour de cassation : ${decision.solution}.`,
+      status,
+      category,
+      confidenceScore,
+      verdictDate: new Date(decision.decision_date),
+      ecli: decision.ecli || null,
+      pourvoiNumber: decision.number || null,
+      caseNumbers: decision.numbers || [],
+      sources: [
+        {
+          url: `https://www.courdecassation.fr/decision/${decision.id}`,
+          title: `Cour de cassation - ${decision.solution} (${decision.number})`,
+          publisher: "Cour de cassation",
+          publishedAt: new Date(decision.decision_date),
+          sourceType: "JUDILIBRE",
         },
-      },
+      ],
     });
 
     if (verbose) {

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -28,6 +28,7 @@ import { syncMetadata } from "@/lib/sync";
 import { classifyArticleTier, type ArticleTier } from "@/config/press-keywords";
 import { MIN_CONFIDENCE_THRESHOLD } from "@/config/press-analysis";
 import { resolveAffairPolitician, assessPressAttribution } from "@/lib/affair-matching";
+import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 
 // ============================================
 // TYPES
@@ -595,40 +596,26 @@ async function createAffairFromPress(
   }
 
   try {
-    const baseSlug = generateSlug(cleanAffairTitle(title));
-    let slug = baseSlug;
-
-    // Ensure unique slug
-    let counter = 1;
-    while (await db.affair.findUnique({ where: { slug }, select: { id: true } })) {
-      slug = `${baseSlug}-${counter}`;
-      counter++;
-    }
-
-    const affair = await db.affair.create({
-      data: {
-        politicianId,
-        title,
-        slug,
-        description: detected.description,
-        status: detected.status as AffairStatus,
-        category: detected.category as AffairCategory,
-        publicationStatus: "DRAFT",
-        confidenceScore: detected.confidenceScore,
-        factsDate: detected.factsDate ? new Date(detected.factsDate) : null,
-        court: detected.court,
-        verifiedAt: null,
-        sources: {
-          create: {
-            url: articleUrl,
-            title: articleTitle,
-            publisher: feedSourceToPublisher(feedSource),
-            publishedAt,
-            sourceType: "PRESSE",
-            excerpt: detected.excerpts[0] || null,
-          },
+    const affair = await createDraftAffairFromDiscovery({
+      politicianId,
+      title,
+      baseSlug: generateSlug(cleanAffairTitle(title)),
+      description: detected.description,
+      status: detected.status as AffairStatus,
+      category: detected.category as AffairCategory,
+      confidenceScore: detected.confidenceScore,
+      factsDate: detected.factsDate ? new Date(detected.factsDate) : null,
+      court: detected.court,
+      sources: [
+        {
+          url: articleUrl,
+          title: articleTitle,
+          publisher: feedSourceToPublisher(feedSource),
+          publishedAt,
+          sourceType: "PRESSE",
+          excerpt: detected.excerpts[0] || null,
         },
-      },
+      ],
     });
 
     // Link article to affair


### PR DESCRIPTION
## Description

Lot 1 de « Affaires v2 » : les synchroniseurs ne modifient plus directement une affaire existante. Chaque changement devient une proposition explicable, réversible et validable en admin.

Le point de départ : trois writers automatiques écrivaient dans `Affair`, dont un sur des affaires publiées et sur des champs juridiquement sensibles (statut, peines, date de verdict), sans trace de la valeur précédente ni revue.

### L'invariant

Deux portes, et deux seulement, pour qu'un importeur touche une affaire :

- `createDraftAffairFromDiscovery()` pour créer. `publicationStatus: "DRAFT"` et `verifiedAt: null` y sont codés en dur, pas paramétrables.
- `proposeAffairUpdate()` pour modifier une affaire existante.

Un test scanne `src/services/sync/` et échoue sur tout `db.affair.create|update|updateMany|upsert|delete|deleteMany`, client transactionnel inclus (`tx.affair.*`). Aucun fichier n'est exempté.

### Ce qui est auto-appliqué, ce qui passe en revue

Seuls `ecli`, `pourvoiNumber` et `caseNumbers` s'appliquent sans revue, et uniquement s'ils sont absents et non contradictoires. Tout le reste (statut, dates, juridiction, peines) devient une proposition `PENDING` avec sa source, son extrait justificatif, la valeur actuelle, un niveau de risque et une justification du rapprochement.

La whitelist est volontairement limitée aux 12 champs que les deux importeurs convertis émettent réellement. `publicationStatus` en est exclu : un importeur ne doit jamais pouvoir tendre à l'admin un bouton « publier » en un clic.

### Concurrence

Le contrôle de l'état `PENDING` est un compare-and-set `updateMany({ where: { id, status: "PENDING" } })` **à l'intérieur** de la transaction, pas une lecture avant. Deux acceptations simultanées ne peuvent pas appliquer deux fois : sous READ COMMITTED, la seconde bloque sur le verrou de ligne puis obtient `count = 0` et rollback.

L'écriture sur l'affaire, la `ModerationReview`, l'`AuditLog` et la transition d'état partagent une seule transaction. L'invalidation de cache se fait après le commit, pour qu'un rollback ne laisse jamais un cache purgé.

### Historique préservé

`AffairUpdateProposal.affairId` est nullable avec `onDelete: SetNull`, doublé d'un `affairSnapshot` (publicId, slug, titre, personnalité). Supprimer une affaire n'efface pas ce qui a été proposé sur elle ni la décision de revue d'un humain. Une proposition orpheline n'est plus applicable mais reste rejetable et lisible.

### Deux bugs corrigés au passage

**Sémantique `verdictDate`.** `discover-affairs-builders.ts` rangeait la date de décision Wikidata dans `factsDate`. Conséquence : toute affaire créée par ce chemin portait une date des faits fausse et un `verdictDate` nul. Le chemin d'enrichissement relisait cette valeur pour la remettre dans `verdictDate`, ce qui était correct par accident, uniquement grâce à un garde `phase === "wikidata"` placé loin de l'endroit où la confusion était introduite. `DiscoveredAffair` a maintenant un vrai champ `verdictDate`. Empreinte en base : 1 affaire concernée, non publiée.

**Collision ECLI.** `Affair.ecli` est `@unique` et l'ancien code judilibre écrivait sans garde, donc prenait un `P2002`. La collision devient un `CONFLICT` visible en admin.

## Type de changement

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [x] Refactoring

## Issue liée

Part of #514 (epic « Affaires v2 »). Premier lot des cinq ; les quatre suivants sont #515, #516, #517 et #518.

Pas de mot-clé de fermeture volontairement : l'epic reste ouverte après ce merge.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (0 erreur, 53 warnings préexistants ailleurs)
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre
- 2216 tests passés, 0 échec (2150 avant ce lot)
- `npm run build` compile, les 4 nouvelles routes sont présentes
- Sauvegarde `pg_dump` prise avant le `db:push` et validée par `pg_restore --list`

Deux propriétés ne sont pas testables avec des mocks Prisma et ont été vérifiées par un script jetable sur une affaire `DRAFT`, avec restauration à l'identique et suppression des lignes créées :

- le marqueur de valeur vide traverse une colonne `JSONB`. Une première version utilisait un sentinel contenant U+0000, que Postgres refuse dans une chaîne JSON : tout conflit portant sur un champ vide aurait échoué en production.
- deux `acceptProposal` en parallèle sur la même proposition donnent un seul gagnant. C'est le verrouillage de ligne Postgres qui est éprouvé, pas un mock.

## À savoir pour la revue

**Le schéma est déjà en production.** Le `db:push` a été appliqué avant ces commits. Le changement est purement additif (2 tables, 3 enums), donc l'ancien code ignore les nouvelles tables, mais `main` et la prod divergent jusqu'au merge : les tables existent et personne ne les écrit. Les migrations versionnées ne sont pas utilisables sur cette base, qui n'a pas de table `_prisma_migrations` ; le SQL équivalent est déposé dans `prisma/migrations/manual/` à titre documentaire.

**Changement de comportement non isolé.** Router les trois créations par la porte commune unifie la déduplication de slug sur `generateUniqueSlug`. Judilibre et press-analysis avaient leur propre boucle avec suffixe `-1` et sans troncature ; ils passent en `-2` avec troncature à 120 caractères, comme discover-affairs. Ça ne concerne que les collisions de titres.

**Judilibre est du code mort aujourd'hui** (commenté dans les crons, script marqué `deprecated`). Converti quand même pour qu'une réactivation future ne contourne pas l'invariant.

**Contrepartie assumée.** Le garde s'applique quel que soit le `publicationStatus`, donc les 16 affaires en `DRAFT` ne s'enrichissent plus automatiquement entre deux sessions `/moderate`. Gater sur le statut de publication aurait doublé les chemins de code, et un `DRAFT` corrompu en silence puis publié reste le même défaut décalé d'un cran.

**Bug préexistant non corrigé, hors périmètre.** `src/lib/security/schemas/affair.ts` déclare `"PROCES"`/`"APPEL"` et `"MODEREE"`/`"MINEURE"`, alors que les enums Prisma disent `PROCES_EN_COURS`/`APPEL_EN_COURS` et `SIGNIFICATIF`. Le quick-update admin ne peut donc pas passer une affaire en procès ni en appel. Les nouveaux schémas Zod dérivent leurs enums du client généré pour que la divergence ne puisse pas se reproduire.

## Hors périmètre

Pas de `AffairParticipant`, pas de fusion d'affaires dupliquées, pas d'URL partagées, pas de refonte d'`AffairStatus`. La proposition d'origine sous-estimait le coût du modèle par participant : `Affair` est 1:1 avec `Politician` (il n'y a pas de table de jonction), donc une affaire collective est N lignes dupliquées, et les fusionner toucherait `slug`, `publicId`, `oldSlugs`, le sitemap, l'ISR, l'API MCP et les exports.

Restent pour plus tard : provenance au niveau du champ, surveillance continue avec `nextCheckAt`, et la correction manuelle des 4 affaires qui affichent un statut de condamnation avec un `involvement` non poursuivant.
