### PR TITLE
Resserrer le rapprochement d'affaires : containment, date de verdict, ambiguïté

### DIFF
--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -4,7 +4,12 @@ import { describe, it, expect, vi } from "vitest";
 // (sameCategoryFamily is pure, but matching.ts imports @/lib/db at module level).
 vi.mock("@/lib/db", () => ({ db: {} }));
 
-import { sameCategoryFamily } from "./matching";
+import {
+  pickConfidentMatch,
+  sameCategoryFamily,
+  titleContainmentMatch,
+  verdictDatesConflict,
+} from "./matching";
 
 // We need to test the normalizeAffairTitle function indirectly since it's private.
 // Instead, we test the exported behavior by importing and calling it via a test helper.
@@ -111,5 +116,140 @@ describe("sameCategoryFamily", () => {
 
   it("rejects unknown categories that are not AUTRE", () => {
     expect(sameCategoryFamily("UNKNOWN_A", "UNKNOWN_B")).toBe(false);
+  });
+});
+
+// Issue #520 — a short Wikidata offense label is a substring of most descriptive
+// titles in the same category, so bidirectional containment used to return HIGH
+// for genuinely distinct affairs. Measured on production data: the label
+// "Diffamation" matched three separate Zemmour defamation cases (2012, 2018,
+// 2025) in HIGH, and discover-affairs took the first one arbitrarily.
+describe("titleContainmentMatch — issue #520", () => {
+  it("garde le HIGH sur une containment substantielle, même catégorie", () => {
+    // Le cas légitime que la containment protège : deux formats d'import du même
+    // fait. Ratio 32/45 = 0.71.
+    const result = titleContainmentMatch(
+      "violences volontaires en réunion",
+      "condamnation violences volontaires en réunion",
+      true
+    );
+    expect(result?.confidence).toBe("HIGH");
+    expect(result?.matchedBy).toBe("title+category");
+  });
+
+  it("rétrograde un libellé court noyé dans un titre descriptif", () => {
+    // Ratio 11/63 = 0.17 : vocabulaire partagé, pas doublon.
+    const result = titleContainmentMatch(
+      "diffamation",
+      "condamnation definitive pour diffamation envers patrick klugman",
+      true
+    );
+    expect(result?.confidence).not.toBe("HIGH");
+    expect(result?.confidence).toBe("POSSIBLE");
+  });
+
+  it("rétrograde aussi « injure » dans un titre long", () => {
+    // Ratio 6/60 = 0.10.
+    const result = titleContainmentMatch(
+      "injure",
+      "condamnation pour injure envers les mineurs isoles etrangers",
+      true
+    );
+    expect(result?.confidence).toBe("POSSIBLE");
+  });
+
+  it("ne signale rien sans containment", () => {
+    expect(titleContainmentMatch("fraude fiscale", "emploi fictif", true)).toBeNull();
+  });
+
+  it("reste POSSIBLE sur containment substantielle mais catégorie différente", () => {
+    const result = titleContainmentMatch(
+      "violences volontaires en réunion",
+      "condamnation violences volontaires en réunion",
+      false
+    );
+    expect(result?.confidence).toBe("POSSIBLE");
+    expect(result?.matchedBy).toBe("title-partial");
+  });
+
+  it("conserve le signal POSSIBLE, consommé par reconcile-affairs", () => {
+    // Rien ne doit disparaître : reconcile-affairs.ts compte les POSSIBLE.
+    for (const [a, b] of [
+      ["diffamation", "condamnation definitive pour diffamation envers patrick klugman"],
+      ["injure", "condamnation pour injure envers les mineurs isoles etrangers"],
+    ] as const) {
+      expect(titleContainmentMatch(a, b, true)).not.toBeNull();
+    }
+  });
+});
+
+// Issue #520, second mechanism: when no existing affair matches, discover-affairs
+// creates one whose title is the bare offense label. Every later claim carrying the
+// same label then matches it in title-exact, so distinct convictions collapse onto
+// one affair, each proposing its own verdict date. The verdict date is the
+// discriminator that was available but never passed to the matcher.
+describe("verdictDatesConflict — issue #520", () => {
+  it("deux dates éloignées sont un signal de condamnations distinctes", () => {
+    expect(verdictDatesConflict(new Date("2011-02-18"), new Date("2024-02-22"))).toBe(true);
+  });
+
+  it("deux dates proches ne s'opposent pas (même décision, sources divergentes)", () => {
+    expect(verdictDatesConflict(new Date("2024-02-22"), new Date("2024-03-05"))).toBe(false);
+  });
+
+  it("une date absente ne permet aucune conclusion", () => {
+    expect(verdictDatesConflict(null, new Date("2024-02-22"))).toBe(false);
+    expect(verdictDatesConflict(new Date("2024-02-22"), undefined)).toBe(false);
+    expect(verdictDatesConflict(null, null)).toBe(false);
+  });
+
+  it("dates identiques : aucun conflit", () => {
+    const d = new Date("2024-02-22");
+    expect(verdictDatesConflict(d, new Date(d))).toBe(false);
+  });
+});
+
+// Issue #520 — the three importers each took the first HIGH match without noticing
+// several affairs could tie. Under the project's priority (a false match costs more
+// than a draft to triage), ambiguity must never resolve silently: creating a
+// duplicate draft that merge tooling can fold in is strictly safer than enriching
+// possibly the wrong affair.
+describe("pickConfidentMatch — issue #520", () => {
+  const m = (affairId: string, confidence: "CERTAIN" | "HIGH" | "POSSIBLE", score: number) => ({
+    affairId,
+    confidence,
+    score,
+    matchedBy: "test",
+  });
+
+  it("un seul HIGH : on rapproche", () => {
+    const r = pickConfidentMatch([m("a", "HIGH", 0.85), m("b", "POSSIBLE", 0.3)]);
+    expect(r.kind).toBe("match");
+    expect(r.kind === "match" && r.match.affairId).toBe("a");
+  });
+
+  it("plusieurs HIGH : ambigu, on ne rapproche pas", () => {
+    const r = pickConfidentMatch([m("a", "HIGH", 0.75), m("b", "HIGH", 0.75)]);
+    expect(r.kind).toBe("ambiguous");
+    expect(r.kind === "ambiguous" && r.candidates).toHaveLength(2);
+  });
+
+  it("un CERTAIN l'emporte sur des HIGH concurrents (ECLI est unique)", () => {
+    const r = pickConfidentMatch([
+      m("a", "CERTAIN", 1),
+      m("b", "HIGH", 0.75),
+      m("c", "HIGH", 0.75),
+    ]);
+    expect(r.kind).toBe("match");
+    expect(r.kind === "match" && r.match.affairId).toBe("a");
+  });
+
+  it("aucun HIGH : rien, même avec des POSSIBLE", () => {
+    expect(pickConfidentMatch([m("a", "POSSIBLE", 0.5)]).kind).toBe("none");
+    expect(pickConfidentMatch([]).kind).toBe("none");
+  });
+
+  it("plusieurs CERTAIN : ambigu aussi, on ne devine pas", () => {
+    expect(pickConfidentMatch([m("a", "CERTAIN", 1), m("b", "CERTAIN", 1)]).kind).toBe("ambiguous");
   });
 });

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -74,6 +74,108 @@ export interface MatchResult {
   matchedBy: string;
 }
 
+/**
+ * Minimum share of the longer title that the shorter one must cover for
+ * containment to count as a duplicate signal.
+ *
+ * Measured on production data (issue #520):
+ *   0.71  "violences volontaires en réunion" inside
+ *         "condamnation violences volontaires en réunion"
+ *         → same fact, two import formats. This is what containment protects.
+ *   0.17  "diffamation" inside
+ *         "condamnation definitive pour diffamation envers patrick klugman"
+ *   0.10  "injure" inside
+ *         "condamnation pour injure envers les mineurs isoles etrangers"
+ *
+ * Below the threshold, containment only means the two titles share vocabulary,
+ * which is expected within a category and is not evidence of duplication. The
+ * Wikidata offense labels are short ("Injure", "Diffamation"), so without this
+ * guard a single label matched every affair of that category in HIGH.
+ */
+export const TITLE_CONTAINMENT_MIN_RATIO = 0.6;
+
+/**
+ * Two decisions on the same offense are the same event only if they were handed
+ * down at around the same time. Beyond this window they are distinct convictions.
+ */
+export const VERDICT_DATE_TOLERANCE_DAYS = 30;
+
+/**
+ * Whether two verdict dates rule out that the affairs are the same one.
+ *
+ * Only conclusive when both dates are known: a missing date proves nothing, so it
+ * never blocks a match (issue #520).
+ */
+export function verdictDatesConflict(
+  a: Date | null | undefined,
+  b: Date | null | undefined,
+  toleranceDays: number = VERDICT_DATE_TOLERANCE_DAYS
+): boolean {
+  if (!a || !b) return false;
+  const deltaDays = Math.abs(a.getTime() - b.getTime()) / 86_400_000;
+  return deltaDays > toleranceDays;
+}
+
+/**
+ * Confidence of a bidirectional-containment title match, or null when the titles
+ * do not contain one another.
+ *
+ * Extracted from findMatchingAffairs to be testable without a database.
+ */
+export function titleContainmentMatch(
+  normalizedCandidate: string,
+  normalizedExisting: string,
+  sameCategory: boolean
+): Omit<MatchResult, "affairId"> | null {
+  // An empty normalized title contains and is contained by everything.
+  if (normalizedCandidate.length === 0 || normalizedExisting.length === 0) return null;
+
+  const contains =
+    normalizedExisting.includes(normalizedCandidate) ||
+    normalizedCandidate.includes(normalizedExisting);
+  if (!contains) return null;
+
+  const shorter = Math.min(normalizedCandidate.length, normalizedExisting.length);
+  const longer = Math.max(normalizedCandidate.length, normalizedExisting.length);
+  const substantial = shorter / longer >= TITLE_CONTAINMENT_MIN_RATIO;
+
+  if (sameCategory && substantial) {
+    return { confidence: "HIGH", score: 0.75, matchedBy: "title+category" };
+  }
+
+  // Downgraded, not dropped: reconcile-affairs counts POSSIBLE duplicates.
+  return { confidence: "POSSIBLE", score: substantial ? 0.5 : 0.3, matchedBy: "title-partial" };
+}
+
+export type ConfidentMatch =
+  | { kind: "match"; match: MatchResult }
+  | { kind: "none" }
+  | { kind: "ambiguous"; candidates: MatchResult[] };
+
+/**
+ * Picks the one match an importer may act on, or reports that there is none.
+ *
+ * Design priority for this project: a wrong match costs more than a duplicate
+ * draft to triage. A draft is not public and merge tooling can fold it in; an
+ * affair enriched from the wrong decision silently corrupts a published record.
+ *
+ * So ambiguity never resolves silently. Several affairs tied at HIGH means the
+ * evidence does not identify one, and the caller must treat it as "no match"
+ * rather than take the first row. CERTAIN is exempt from ties by construction
+ * (it comes from the unique ECLI), but is still checked.
+ */
+export function pickConfidentMatch(matches: MatchResult[]): ConfidentMatch {
+  const certain = matches.filter((m) => m.confidence === "CERTAIN");
+  if (certain.length === 1) return { kind: "match", match: certain[0]! };
+  if (certain.length > 1) return { kind: "ambiguous", candidates: certain };
+
+  const high = matches.filter((m) => m.confidence === "HIGH");
+  if (high.length === 1) return { kind: "match", match: high[0]! };
+  if (high.length > 1) return { kind: "ambiguous", candidates: high };
+
+  return { kind: "none" };
+}
+
 export interface MatchCandidate {
   politicianId: string;
   title: string;
@@ -198,7 +300,9 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
 
     const samePoliticianAffairs = await db.affair.findMany({
       where: { politicianId: candidate.politicianId },
-      select: { id: true, title: true, category: true },
+      // verdictDate discriminates repeated convictions for the same offense,
+      // which titles alone cannot (issue #520).
+      select: { id: true, title: true, category: true, verdictDate: true },
     });
 
     for (const existing of samePoliticianAffairs) {
@@ -206,29 +310,36 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
 
       const normalizedExisting = normalizeAffairTitle(existing.title, politicianName);
 
-      // Exact normalized title → HIGH
+      // Two convictions for the same offense carry the same title once the
+      // politician name is stripped, so the title alone cannot separate them.
+      // A materially different verdict date can.
+      const datesRuleOutSameAffair = verdictDatesConflict(
+        candidate.verdictDate,
+        existing.verdictDate
+      );
+
+      // Exact normalized title → HIGH, unless the verdict dates say otherwise
       if (normalizedExisting === normalizedCandidate) {
         matches.push({
           affairId: existing.id,
-          confidence: "HIGH",
-          score: 0.85,
-          matchedBy: "title-exact",
+          confidence: datesRuleOutSameAffair ? "POSSIBLE" : "HIGH",
+          score: datesRuleOutSameAffair ? 0.45 : 0.85,
+          matchedBy: datesRuleOutSameAffair ? "title-exact-date-conflict" : "title-exact",
         });
         continue;
       }
 
-      // One contains the other (bidirectional) → HIGH if same category, POSSIBLE otherwise
-      const aContainsB = normalizedExisting.includes(normalizedCandidate);
-      const bContainsA = normalizedCandidate.includes(normalizedExisting);
-
-      if (aContainsB || bContainsA) {
-        const sameCategory = candidate.category && existing.category === candidate.category;
-        matches.push({
-          affairId: existing.id,
-          confidence: sameCategory ? "HIGH" : "POSSIBLE",
-          score: sameCategory ? 0.75 : 0.5,
-          matchedBy: sameCategory ? "title+category" : "title-partial",
-        });
+      // One contains the other (bidirectional). HIGH only when the containment is
+      // substantial: a short offense label buried in a long descriptive title is
+      // shared vocabulary, not a duplicate (issue #520).
+      const containment = titleContainmentMatch(
+        normalizedCandidate,
+        normalizedExisting,
+        Boolean(candidate.category && existing.category === candidate.category) &&
+          !datesRuleOutSameAffair
+      );
+      if (containment) {
+        matches.push({ affairId: existing.id, ...containment });
       }
     }
   }

--- a/src/services/sync/__tests__/discover-affairs-builders.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-builders.test.ts
@@ -85,3 +85,42 @@ describe("sémantique des dates — factsDate n'est pas verdictDate", () => {
     expect(affair.factsDate).not.toEqual(affair.verdictDate);
   });
 });
+
+// Issue #520 — the Wikidata title was the bare offense label, so several distinct
+// convictions for the same offense produced identical titles. Unreadable for a
+// moderator, and indistinguishable for title-based deduplication.
+describe("titre Wikidata — discriminant de décision (#520)", () => {
+  it("porte l'année de décision quand elle est connue", () => {
+    const affair = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      penaltyData: { verdictDate: new Date("2011-02-18") },
+    });
+    expect(affair.title).toBe("corruption (2011) — Jean Testeur");
+  });
+
+  it("deux condamnations de même infraction, années différentes, titres différents", () => {
+    const a = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      penaltyData: { verdictDate: new Date("2011-02-18") },
+    });
+    const b = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      penaltyData: { verdictDate: new Date("2024-02-22") },
+    });
+    expect(a.title).not.toBe(b.title);
+  });
+
+  it("sans date connue, le titre reste inchangé", () => {
+    const affair = buildWikidataDiscoveredAffair({ ...baseInput, penaltyData: {} });
+    expect(affair.title).toBe("corruption — Jean Testeur");
+  });
+
+  it("le préfixe de vérification reste en tête du titre", () => {
+    const affair = buildWikidataDiscoveredAffair({
+      ...baseInput,
+      prop: "P1595",
+      penaltyData: { verdictDate: new Date("2019-09-17") },
+    });
+    expect(affair.title).toBe("[À VÉRIFIER] corruption (2019) — Jean Testeur");
+  });
+});

--- a/src/services/sync/discover-affairs-builders.ts
+++ b/src/services/sync/discover-affairs-builders.ts
@@ -76,10 +76,17 @@ export function buildWikidataDiscoveredAffair(
   const confidence = isConviction ? 95 : 75;
   const titlePrefix = isConviction ? "" : "[À VÉRIFIER] ";
 
+  // The offense label alone is not a title: a person convicted three times for the
+  // same offense produced three identical titles, unreadable for a moderator and
+  // indistinguishable for title-based deduplication (issue #520). The decision
+  // year is the discriminator Wikidata gives us.
+  const verdictYear = input.penaltyData.verdictDate?.getUTCFullYear();
+  const labelWithYear = verdictYear ? `${input.offenseLabel} (${verdictYear})` : input.offenseLabel;
+
   return {
     politicianId: input.politicianId,
     politicianName: input.politicianName,
-    title: `${titlePrefix}${input.offenseLabel} — ${input.politicianName}`,
+    title: `${titlePrefix}${labelWithYear} — ${input.politicianName}`,
     description: `${input.offenseLabel} (${isConviction ? "condamnation" : "mise en cause"}) — source Wikidata (${input.qid}, propriété ${input.prop}).`,
     category: input.category,
     status: input.status,

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -23,7 +23,7 @@ export type { ExtractedPenaltyData };
 import { wikipediaService } from "@/lib/api/wikipedia";
 import type { WikidataClaim } from "@/lib/api/wikidata";
 import { extractAffairsFromWikipedia } from "@/services/wikipedia-affair-extraction";
-import { findMatchingAffairs } from "@/services/affairs/matching";
+import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matching";
 import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { extractDateFromUrl } from "@/lib/extract-date-from-url";
 import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
@@ -90,6 +90,8 @@ export interface DiscoverAffairsResult {
   proposalsAutoApplied: number;
   proposalsConflicted: number;
   proposalsDeduped: number;
+  /** Several affairs tied at HIGH: no enrichment, a draft is created instead. */
+  ambiguousMatches: number;
   errors: string[];
 }
 
@@ -221,6 +223,7 @@ export async function discoverAffairs(options?: {
     proposalsAutoApplied: 0,
     proposalsConflicted: 0,
     proposalsDeduped: 0,
+    ambiguousMatches: 0,
     errors: [],
   };
 
@@ -314,6 +317,7 @@ export async function discoverAffairs(options?: {
         proposalsAutoApplied: stats.proposalsAutoApplied,
         proposalsConflicted: stats.proposalsConflicted,
         proposalsDeduped: stats.proposalsDeduped,
+        ambiguousMatches: stats.ambiguousMatches,
       });
     });
   }
@@ -680,9 +684,18 @@ async function runPhase3Reconciliation(
         politicianId: affair.politicianId,
         title: affair.title,
         category: affair.category,
+        // Without it, two convictions for the same offense are indistinguishable:
+        // the Wikidata title is the bare offense label (issue #520).
+        verdictDate: affair.verdictDate,
       });
 
-      const highMatch = matches.find((m) => m.confidence === "HIGH" || m.confidence === "CERTAIN");
+      const picked = pickConfidentMatch(matches);
+      if (picked.kind === "ambiguous") {
+        // Several affairs tie: enriching one of them would be a coin flip. Fall
+        // through to creation and let the merge tooling decide (issue #520).
+        stats.ambiguousMatches++;
+      }
+      const highMatch = picked.kind === "match" ? picked.match : null;
 
       if (highMatch) {
         // Affaires v2, lot 1: an importer never writes to an existing affair.

--- a/src/services/sync/judilibre.ts
+++ b/src/services/sync/judilibre.ts
@@ -36,7 +36,7 @@ import {
   createJudilibreClient,
   type JudilibreDecisionSummary,
 } from "@/lib/api/judilibre";
-import { findMatchingAffairs } from "@/services/affairs/matching";
+import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matching";
 import {
   mapSolutionToStatus,
   mapJudilibreToCategory,
@@ -547,11 +547,11 @@ async function runJudilibreSearch(args: JudilibreSearchArgs): Promise<void> {
             category: mapJudilibreToCategory(decision.themes, decision.summary),
             verdictDate: new Date(decision.decision_date),
           });
-          const bestMatch = matches[0];
-          if (
-            bestMatch &&
-            (bestMatch.confidence === "CERTAIN" || bestMatch.confidence === "HIGH")
-          ) {
+          // Ambiguity never resolves silently: several affairs tied at HIGH means
+          // the evidence does not identify one (issue #520).
+          const picked = pickConfidentMatch(matches);
+          const bestMatch = picked.kind === "match" ? picked.match : null;
+          if (bestMatch) {
             const enriched = await enrichAffairFromJudilibre(
               bestMatch.affairId,
               decision,
@@ -623,12 +623,11 @@ async function runJudilibreSearch(args: JudilibreSearchArgs): Promise<void> {
             verdictDate: new Date(decision.decision_date),
           });
 
-          const bestMatch = matches[0];
-
-          if (
-            bestMatch &&
-            (bestMatch.confidence === "CERTAIN" || bestMatch.confidence === "HIGH")
-          ) {
+          // Ambiguity never resolves silently: several affairs tied at HIGH means
+          // the evidence does not identify one (issue #520).
+          const picked = pickConfidentMatch(matches);
+          const bestMatch = picked.kind === "match" ? picked.match : null;
+          if (bestMatch) {
             const enriched = await enrichAffairFromJudilibre(
               bestMatch.affairId,
               decision,

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -23,7 +23,7 @@ import {
   type DetectedAffair,
   type ArticleAnalysisResult,
 } from "@/services/press-analysis";
-import { findMatchingAffairs } from "@/services/affairs/matching";
+import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matching";
 import { syncMetadata } from "@/lib/sync";
 import { classifyArticleTier, type ArticleTier } from "@/config/press-keywords";
 import { MIN_CONFIDENCE_THRESHOLD } from "@/config/press-analysis";
@@ -391,9 +391,16 @@ export async function processAnalyzedArticle(
       category: detected.category as AffairCategory,
     });
 
-    const bestMatch = matches[0];
+    // Enrichment requires an unambiguous match: several affairs tied at HIGH means
+    // the evidence does not identify one (issue #520).
+    const picked = pickConfidentMatch(matches);
+    const bestMatch = picked.kind === "match" ? picked.match : null;
 
-    if (bestMatch && (bestMatch.confidence === "CERTAIN" || bestMatch.confidence === "HIGH")) {
+    // Weaker signal, kept for the MENTION link only. Associating an article with
+    // an affair is additive and reversible, unlike writing judicial fields.
+    const looseMatch = matches[0] ?? null;
+
+    if (bestMatch) {
       // Enrich existing affair
       const enriched = await enrichAffairFromPress(
         bestMatch.affairId,
@@ -436,13 +443,13 @@ export async function processAnalyzedArticle(
         verbose
       );
       if (created) stats.affairsCreated++;
-    } else if (bestMatch) {
-      // Possible match — link article to affair
+    } else if (looseMatch) {
+      // Weaker match — link the article as a MENTION, without touching the affair
       if (!dryRun) {
-        await linkArticleToAffair(article.id, bestMatch.affairId, "MENTION");
+        await linkArticleToAffair(article.id, looseMatch.affairId, "MENTION");
       }
       if (verbose) {
-        console.log(`  → Lien MENTION créé: article ↔ affaire ${bestMatch.affairId}`);
+        console.log(`  → Lien MENTION créé: article ↔ affaire ${looseMatch.affairId}`);
       }
     }
   }


### PR DESCRIPTION
## Description

Closes #520.

Plusieurs condamnations distinctes d'une même personne se rapprochaient d'une seule affaire, et l'importeur en enrichissait une **arbitrairement**.

### Le mécanisme réel

La containment bidirectionnelle de `findMatchingAffairs` (priorité 4). Les libellés d'infraction Wikidata sont courts (`Injure`, `Diffamation`), les titres en base sont descriptifs et longs. Une fois le nom de la personne retiré par `normalizeAffairTitle`, l'inclusion est donc vraie pour presque toute affaire de la même catégorie, et `sameCategory` la promouvait en `HIGH`.

Mesuré en base :

```
« Diffamation — Éric Zemmour » [DIFFAMATION] → 3 affaires DISTINCTES en HIGH
  HIGH  title+category  AF-000270  2012  Procès en diffamation contre Youssoupha
  HIGH  title+category  AF-000268  2018  Accusation de diffamation par Cécile Duflot
  HIGH  title+category  AF-000287  2025  Condamnation définitive... Patrick Klugman
```

Les trois importeurs prenaient ensuite la première ligne (`matches.find(HIGH)` ou `matches[0]`).

Ratios d'inclusion, qui séparent nettement le cas légitime du cas pathologique :

| Cas                                                                                                                              | Ratio    |
| -------------------------------------------------------------------------------------------------------------------------------- | -------- |
| légitime, couvert par un test existant : `violences volontaires en réunion` dans `condamnation violences volontaires en réunion` | **0,71** |
| `diffamation` dans `condamnation definitive pour diffamation envers patrick klugman`                                             | **0,17** |
| `injure` dans `condamnation pour injure envers les mineurs isoles etrangers`                                                     | **0,10** |

Exposition : **69** couples (personne, catégorie) portant plusieurs affaires, soit **194 affaires sur 466**.

### Quatre changements

1. **Seuil de containment** `TITLE_CONTAINMENT_MIN_RATIO = 0.6`. Une inclusion faible retombe en `POSSIBLE`. Rétrogradation uniquement : rien n'est promu, rien n'est supprimé, parce que `reconcile-affairs.ts` compte les `POSSIBLE`.
2. **Discriminant de date** `verdictDatesConflict()`. Deux dates de verdict écartées de plus de 30 jours interdisent le `HIGH` sur titre. `discover-affairs` transmet désormais `verdictDate`, champ qui existait dans `MatchCandidate` sans jamais être rempli.
3. **Année de décision dans le titre Wikidata**. Sans elle, les deux premiers changements produisent des brouillons au titre identique, impossibles à distinguer en revue.
4. **Garde d'ambiguïté** `pickConfidentMatch()`. Plusieurs affaires à égalité en `HIGH` signifie que la preuve n'en désigne aucune : les trois importeurs traitent ce cas comme une absence de rapprochement, et `DiscoverAffairsResult.ambiguousMatches` le compte pour qu'il soit visible.

### L'arbitrage, assumé

Le correctif produit **plus de brouillons à trier**. C'est voulu : sur des données judiciaires nominatives, un faux rapprochement corrompt une fiche publiée en silence, alors qu'un doublon en brouillon n'est pas public et peut être replié par l'outillage de fusion. L'asymétrie de coût justifie de resserrer.

Mesuré sur un run réel restreint à une personne :

|                                             | Avant                       | Après                   |
| ------------------------------------------- | --------------------------- | ----------------------- |
| Affaires existantes modifiées               | 1, avec une date arbitraire | **0**                   |
| Propositions concurrentes sur un même champ | 5 sur 2 affaires            | **0**                   |
| Brouillons créés                            | 1                           | 6, aux titres distincts |

## Type de changement

- [x] Bug fix

## Issue liée

Closes #520

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (0 erreur, 53 warnings préexistants ailleurs)
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre
- **2247 tests** passés, 0 échec (2242 avant cette PR)
- 15 tests ajoutés, écrits avant les correctifs : seuil de containment, conservation du signal `POSSIBLE`, discriminant de date, titres distincts par année, détection d'ambiguïté
- Aucune affaire existante modifiée pendant la validation, vérifié par comparaison d'empreintes avant/après sur les 466 lignes

## Points de revue

**Une régression attrapée par le compilateur.** Le garde d'ambiguïté a d'abord neutralisé une branche de `press-analysis` : un match `POSSIBLE` servait à lier l'article en `MENTION`. Restauré via un `looseMatch` distinct. Lier un article est additif et réversible ; écrire un champ judiciaire ne l'est pas, donc seul l'enrichissement est resserré.

**La tolérance de 30 jours est un choix, pas une vérité.** Deux condamnations pour injure à 35 jours d'écart restent deux brouillons au titre identique `Injure (2024)`. Impossible de trancher automatiquement entre deux décisions réelles et une seule mal datée selon la source.

**Le diagnostic initial de l'issue était faux** et a été corrigé publiquement dans #520 avant d'écrire une ligne de correctif. Il désignait `title-exact` ; l'instrumentation a montré 0 match sur ce chemin.

## Suites identifiées, hors périmètre

- #521 : `AUTRE` est un joker dans `sameCategoryFamily`, et concerne 27 % de la base.
- `caseNumbers: { hasSome }` donne un `HIGH` sur un seul numéro partagé. Mesuré : 0 cas aujourd'hui, donc pas urgent, mais la règle reste large.
- `press-analysis` ne transmet aucun discriminant temporel au matcher.
