### PR TITLE
Ne plus rapprocher deux brouillons sur la seule absence de qualification

### DIFF
--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -5,9 +5,12 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/lib/db", () => ({ db: {} }));
 
 import {
+  pairingRestsOnWildcard,
   pickConfidentMatch,
   sameCategoryFamily,
+  significantTitleWords,
   titleContainmentMatch,
+  titlesShareVocabulary,
   verdictDatesConflict,
 } from "./matching";
 
@@ -251,5 +254,86 @@ describe("pickConfidentMatch — issue #520", () => {
 
   it("plusieurs CERTAIN : ambigu aussi, on ne devine pas", () => {
     expect(pickConfidentMatch([m("a", "CERTAIN", 1), m("b", "CERTAIN", 1)]).kind).toBe("ambiguous");
+  });
+});
+
+// Issue #521 — AUTRE pairs with every family, so on its own it says nothing
+// about the facts. Fixtures below use generic legal phrasings rather than real
+// affair titles: the cases that motivated this guard are unpublished drafts.
+describe("significantTitleWords — issue #521", () => {
+  it("strips accents so the same word matches across spellings", () => {
+    expect(significantTitleWords("Étouffement")).toEqual(new Set(["etouffement"]));
+    expect(significantTitleWords("referes")).toEqual(significantTitleWords("référés"));
+  });
+
+  it("drops words too short to identify anything", () => {
+    expect(significantTitleWords("Vol de la clé")).toEqual(new Set([]));
+  });
+
+  it("drops judicial filler that every title carries", () => {
+    // Two unrelated cases both start with "Affaire": the word is not evidence.
+    expect(significantTitleWords("Affaire Untel")).toEqual(new Set(["untel"]));
+    expect(significantTitleWords("Enquête préliminaire pour recel")).toEqual(new Set(["recel"]));
+  });
+
+  it("keeps the words that name the facts", () => {
+    expect(significantTitleWords("Tentative d'étouffement judiciaire")).toEqual(
+      new Set(["tentative", "etouffement", "judiciaire"])
+    );
+  });
+});
+
+describe("titlesShareVocabulary — issue #521", () => {
+  it("recognises two wordings of the same facts", () => {
+    expect(
+      titlesShareVocabulary(
+        "Soupçons de tentative d'étouffement d'une procédure",
+        "Tentative présumée d'étouffement d'une procédure"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects two sets of facts that share no vocabulary", () => {
+    expect(
+      titlesShareVocabulary(
+        "Ordonnance du juge des référés sur les conditions de détention",
+        "Enlèvement suivi de meurtre"
+      )
+    ).toBe(false);
+  });
+
+  it("is not fooled by filler alone", () => {
+    // Both are "Affaire X" and share nothing else.
+    expect(titlesShareVocabulary("Affaire Untel", "Affaire Machin")).toBe(false);
+  });
+
+  it("accepts a single shared name, which is enough of a lead to review", () => {
+    expect(
+      titlesShareVocabulary(
+        "Gestion présumée illégale au Havre",
+        "Soupçons de favoritisme au Havre"
+      )
+    ).toBe(true);
+  });
+});
+
+describe("pairingRestsOnWildcard — issue #521", () => {
+  it("is true when only AUTRE brings the two categories together", () => {
+    expect(pairingRestsOnWildcard("AUTRE", "AGRESSION_SEXUELLE")).toBe(true);
+    expect(pairingRestsOnWildcard("RECEL", "AUTRE")).toBe(true);
+  });
+
+  it("is false for identical categories, AUTRE included", () => {
+    expect(pairingRestsOnWildcard("AUTRE", "AUTRE")).toBe(false);
+    expect(pairingRestsOnWildcard("MENACE", "MENACE")).toBe(false);
+  });
+
+  it("is false when a named family already pairs them", () => {
+    expect(pairingRestsOnWildcard("DETOURNEMENT_FONDS_PUBLICS", "FAVORITISME")).toBe(false);
+    expect(pairingRestsOnWildcard("VIOLENCE", "MENACE")).toBe(false);
+  });
+
+  it("is false when nothing pairs them at all", () => {
+    expect(pairingRestsOnWildcard("MENACE", "FRAUDE_FISCALE")).toBe(false);
   });
 });

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -54,6 +54,13 @@ function categoryFamily(category: string): string | null {
   return null;
 }
 
+/** Whether a named family pairs these two categories, wildcard aside. */
+function sameNamedFamily(a: string, b: string): boolean {
+  const familyA = categoryFamily(a);
+  const familyB = categoryFamily(b);
+  return familyA !== null && familyA === familyB;
+}
+
 /**
  * Check whether two affair categories belong to the same family.
  * AUTRE matches any family (imports frequently fall back to AUTRE
@@ -62,9 +69,113 @@ function categoryFamily(category: string): string | null {
 export function sameCategoryFamily(a: string, b: string): boolean {
   if (a === b) return true;
   if (a === "AUTRE" || b === "AUTRE") return true;
-  const familyA = categoryFamily(a);
-  const familyB = categoryFamily(b);
-  return familyA !== null && familyA === familyB;
+  return sameNamedFamily(a, b);
+}
+
+/**
+ * Whether the AUTRE wildcard is the only reason these categories pair up.
+ *
+ * A shared family is evidence about the facts; the wildcard is not, since AUTRE
+ * means "the legal qualification was not established". Callers use this to ask
+ * for a second signal before pairing (issue #521).
+ */
+export function pairingRestsOnWildcard(a: string, b: string): boolean {
+  if (a === b) return false;
+  if (a !== "AUTRE" && b !== "AUTRE") return false;
+  return !sameNamedFamily(a, b);
+}
+
+/**
+ * Words that appear in affair titles regardless of which facts they describe:
+ * French function words of four letters or more (shorter ones are already
+ * dropped by the length filter) and judicial boilerplate.
+ *
+ * They must not count as shared vocabulary. "Affaire X" and "Affaire Y" have
+ * nothing in common but the word "affaire", and procedural stage is carried by
+ * the status field, not by the title.
+ */
+const TITLE_NOISE_WORDS = new Set([
+  // Function words
+  "pour",
+  "dans",
+  "avec",
+  "sans",
+  "sous",
+  "mais",
+  "leur",
+  "leurs",
+  "cette",
+  "entre",
+  "contre",
+  "apres",
+  "avant",
+  "chez",
+  "meme",
+  "aussi",
+  "donc",
+  "ainsi",
+  "plus",
+  "tout",
+  "tous",
+  "toute",
+  "toutes",
+  // Judicial and editorial boilerplate
+  "affaire",
+  "affaires",
+  "dossier",
+  "dossiers",
+  "enquete",
+  "enquetes",
+  "preliminaire",
+  "procedure",
+  "procedures",
+  "plainte",
+  "plaintes",
+  "proces",
+  "examen",
+  "soupcon",
+  "soupcons",
+  "suspicion",
+  "suspicions",
+  "accusation",
+  "accusations",
+  "presume",
+  "presumee",
+  "presumes",
+  "presumees",
+]);
+
+/**
+ * The words of a title that can identify which facts it describes.
+ *
+ * Accents are folded so that the same word matches across import spellings.
+ */
+export function significantTitleWords(title: string): Set<string> {
+  return new Set(
+    title
+      .normalize("NFD")
+      // \p{Mn} keeps this ASCII-only: a literal combining-mark range is invisible in source.
+      .replace(/\p{Mn}/gu, "")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((word) => word.length >= 4 && !TITLE_NOISE_WORDS.has(word))
+  );
+}
+
+/**
+ * Whether two titles share at least one word that names the facts.
+ *
+ * Deliberately a single shared word rather than a ratio: measured on production
+ * data, the pairs worth keeping shared several words and the ones worth dropping
+ * shared none, so any threshold in between would be an unmeasurable knob. One
+ * shared word is a lead a reviewer can follow; zero is not.
+ */
+export function titlesShareVocabulary(a: string, b: string): boolean {
+  const wordsA = significantTitleWords(a);
+  for (const word of significantTitleWords(b)) {
+    if (wordsA.has(word)) return true;
+  }
+  return false;
 }
 
 export interface MatchResult {

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -74,12 +74,74 @@ describe("findPotentialDuplicates — draft window clustering", () => {
 
     const duplicates = await findPotentialDuplicates();
 
-    expect(duplicates).toHaveLength(3); // a1-a2, a1-a3, a2-a3
+    // a1-a2 pair on the probity family. a1-a3 rests on the AUTRE wildcard but
+    // both titles name Le Havre. a2-a3 rests on the wildcard and shares no
+    // vocabulary, so it is dropped (issue #521) — the cluster stays reachable
+    // because a3 is still connected through a1.
+    const pairs = duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join("-")).sort();
+    expect(pairs).toEqual(["a1-a2", "a1-a3"]);
     for (const pair of duplicates) {
       expect(pair.matchedBy).toBe("politician+category+window");
       expect(pair.confidence).toBe("POSSIBLE");
       expect(pair.score).toBe(0.45);
     }
+  });
+
+  it("keeps a wildcard pair whose titles share a word naming the facts", async () => {
+    // Regression guard for #521: the wildcard must stay useful. This is the
+    // shape that nothing else catches — sibling categories from different
+    // families, same facts, so neither identifiers nor title containment pair
+    // them.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Soupçons de tentative d'étouffement d'une procédure",
+        category: "RECEL",
+      }),
+      makeDraft("a2", {
+        title: "Tentative présumée d'étouffement d'une procédure",
+        category: "AUTRE",
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.confidence).toBe("POSSIBLE");
+  });
+
+  it("drops a wildcard pair whose titles share nothing", async () => {
+    // A minister named in unrelated coverage: without this guard, every draft
+    // about them pairs with every other one (issue #521).
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Ordonnance du juge des référés sur les conditions de détention",
+        category: "AUTRE",
+      }),
+      makeDraft("a2", {
+        title: "Enlèvement suivi de meurtre",
+        category: "AGRESSION_SEXUELLE",
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("does not ask for shared vocabulary when a named family already pairs them", async () => {
+    // The guard is scoped to the wildcard. Sibling categories are evidence on
+    // their own, so a family pair survives with no vocabulary in common.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { title: "Emplois familiaux au Parlement", category: "EMPLOI_FICTIF" }),
+      makeDraft("a2", {
+        title: "Marché public attribué sans mise en concurrence",
+        category: "FAVORITISME",
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
   });
 
   it("does not pair drafts created more than 14 days apart", async () => {

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -7,7 +7,13 @@
 
 import { db } from "@/lib/db";
 import { Prisma, type SourceType } from "@/generated/prisma";
-import { findMatchingAffairs, sameCategoryFamily, type MatchConfidence } from "./matching";
+import {
+  findMatchingAffairs,
+  pairingRestsOnWildcard,
+  sameCategoryFamily,
+  titlesShareVocabulary,
+  type MatchConfidence,
+} from "./matching";
 
 // ============================================
 // TYPES
@@ -157,6 +163,17 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
           Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);
         if (daysApart > DRAFT_CLUSTER_WINDOW_DAYS) continue;
         if (!sameCategoryFamily(a.category, b.category)) continue;
+
+        // When only the AUTRE wildcard brings the categories together, the pair
+        // rests on the absence of a qualification rather than on evidence. Ask
+        // the titles for a second signal (issue #521): a minister mentioned in
+        // unrelated coverage otherwise pairs with every other draft about them.
+        if (
+          pairingRestsOnWildcard(a.category, b.category) &&
+          !titlesShareVocabulary(a.title, b.title)
+        ) {
+          continue;
+        }
 
         foundPairs.add(pairKey);
         duplicates.push({


### PR DESCRIPTION
## Description

Closes #521.

Le joker `AUTRE` de `sameCategoryFamily()` rapproche deux brouillons sur la seule absence de qualification juridique. Une personnalité citée dans des couvertures de presse sans rapport voyait chacun de ses brouillons appairé à tous les autres.

**La description d'origine de l'issue était fausse sur trois points, corrigés publiquement dans #521 avant d'écrire ce correctif.** En résumé : la portée du joker est de 14 affaires et non 27 % de la base, il ne peut produire aucune écriture, et la piste que l'issue recommandait décrivait déjà le comportement existant.

### Le mécanisme

`sameCategoryFamily` n'est appelé qu'au second passage de `findPotentialDuplicates`, celui qui regroupe les brouillons d'une même personnalité créés à moins de 14 jours d'écart. Ce passage n'émet que du `POSSIBLE` à 0,45, jamais auto-fusionné.

Le joker y a un effet asymétrique : une famille partagée est un indice sur les faits, `AUTRE` signifie qu'aucune qualification n'a été établie. Rapprocher sur cette base revient à rapprocher sur une absence d'information.

### Le correctif

Le joker reste. Quand il est la **seule** raison du rapprochement, les titres doivent partager au moins un mot porteur de sens.

Trois ajouts dans `matching.ts` :

- `pairingRestsOnWildcard()` sépare « seul `AUTRE` les rapproche » de « une famille les rapproche déjà ». Le garde ne s'applique qu'au premier cas.
- `significantTitleWords()` replie les accents et écarte les mots qu'un titre porte quelle que soit l'affaire : mots grammaticaux de quatre lettres ou plus, et boilerplate judiciaire. Sans cette liste, deux dossiers sans rapport se rapprocheraient sur le seul mot « affaire », et l'étape procédurale est déjà portée par `status`.
- `titlesShareVocabulary()` demande un mot en commun.

**Un mot en commun plutôt qu'un ratio, délibérément.** Les paires à conserver en partageaient plusieurs, celles à écarter aucune. Tout seuil intermédiaire aurait été un réglage sans mesure pour le justifier. Un mot partagé est une piste qu'un relecteur peut suivre, zéro n'en est pas une.

### Effet mesuré

| | Avant | Après |
| --- | --- | --- |
| paires suggérées | 9 | **6** |
| dont dépendantes du joker | 5 | **2** |
| paires auto-fusionnables | 0 | **0** |
| vrais doublons perdus | | **0** |

Les 3 paires écartées : une entre deux faits sans aucun rapport, deux entre des volets distincts d'un même dossier, désormais présentés comme deux groupes.

### L'arbitrage, assumé

Le garde est volontairement permissif. Il n'écarte que les paires à vocabulaire **nul**. Sur ce projet, une suggestion de trop coûte un rejet, alors qu'un doublon manqué laisse deux fiches dans la base. Le garde ne coupe donc que là où la preuve est absente, pas là où elle est faible.

## Type de changement

- [x] Bug fix

## Issue liée

Closes #521

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre
- **2262 tests** passés, 0 échec (2247 avant cette PR)
- 15 tests ajoutés, écrits avant le correctif
- Comportement revérifié sur la base réelle après correctif : 6 paires, dont les 2 vraies conservées

## Points de revue

**Un test existant change d'attente, volontairement.** Le cluster à trois brouillons passe de 3 paires à 2 : celle dont les deux titres ne partagent aucun mot disparaît. Le groupe reste entièrement connexe par le troisième brouillon, donc rien ne sort de la file. Le test assère maintenant les paires nommées plutôt qu'un simple compte, pour que ce soit lisible.

**Les fixtures de test sont des tournures juridiques génériques, pas de vrais titres.** Les affaires qui ont motivé ce correctif sont des brouillons non publiés : recopier leurs titres dans un fichier suivi par git aurait publié des allégations judiciaires non modérées concernant des personnes nommées. Le dépôt est public.

**La liste de mots écartés est une liste, donc une dette.** Elle est courte, justifiée en deux groupes dans le code, et son effet est borné : elle ne peut qu'empêcher un rapprochement, jamais en créer un.

## Suites identifiées, hors périmètre

- **La détection de doublons n'examine jamais les affaires vérifiées**, soit 327 affaires publiées. Un doublon entre deux fiches publiées est aujourd'hui structurellement invisible. Issue séparée.
- 128 affaires sans qualification juridique restent un problème de données, traité par #523.
