### PR TITLE
Unifier la fusion d'affaires et préserver les URLs

### DIFF
--- a/src/app/api/admin/affaires/__tests__/merge-route.test.ts
+++ b/src/app/api/admin/affaires/__tests__/merge-route.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #525 — the admin merge route no longer carries its own merge logic. It
+// checks the HTTP contract and delegates, so cache invalidation can only happen
+// after the service transaction committed.
+
+const order: string[] = [];
+
+const h = vi.hoisted(() => ({
+  mergeAffairs: vi.fn(),
+  invalidateEntity: vi.fn(),
+  findUnique: vi.fn(),
+}));
+
+vi.mock("@/services/affairs/reconciliation", () => ({ mergeAffairs: h.mergeAffairs }));
+vi.mock("@/lib/cache", () => ({ invalidateEntity: h.invalidateEntity }));
+vi.mock("@/lib/db", () => ({ db: { affair: { findUnique: h.findUnique } } }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) =>
+    fn(req, ctx),
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "203.0.113.1", userAgent: "test-agent" }),
+}));
+
+import { POST } from "@/app/api/admin/affaires/merge/route";
+
+// The merge route takes no dynamic segment, but the wrapper still expects a context.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ctx: any = { params: Promise.resolve({}) };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function req(body: unknown): any {
+  return new Request("http://test/api", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  h.mergeAffairs.mockImplementation(async () => {
+    order.push("merge");
+    return {
+      sourcesMoved: 2,
+      eventsMoved: 1,
+      articlesMoved: 0,
+      identifiersMerged: ["court"],
+      slugsPreserved: ["absorbee"],
+    };
+  });
+  h.invalidateEntity.mockImplementation(() => {
+    order.push("invalidate");
+  });
+});
+
+describe("POST /api/admin/affaires/merge — issue #525", () => {
+  it("rejects merging an affair into itself", async () => {
+    const res = await POST(req({ primaryId: "a", secondaryId: "a" }), ctx);
+
+    expect(res.status).toBe(400);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when either affair is missing", async () => {
+    h.findUnique.mockResolvedValueOnce({ id: "a", politician: { slug: "x" } });
+    h.findUnique.mockResolvedValueOnce(null);
+
+    const res = await POST(req({ primaryId: "a", secondaryId: "b" }), ctx);
+
+    expect(res.status).toBe(404);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the service with the request context", async () => {
+    h.findUnique.mockResolvedValueOnce({ id: "a", politician: { slug: "jean-dupont" } });
+    h.findUnique.mockResolvedValueOnce({ id: "b" });
+
+    const res = await POST(req({ primaryId: "a", secondaryId: "b" }), ctx);
+
+    expect(res.status).toBe(200);
+    expect(h.mergeAffairs).toHaveBeenCalledWith("a", "b", {
+      audit: { ipAddress: "203.0.113.1", userAgent: "test-agent" },
+    });
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      sourcesMoved: 2,
+      slugsPreserved: ["absorbee"],
+    });
+  });
+
+  it("invalidates caches only after the merge committed", async () => {
+    h.findUnique.mockResolvedValueOnce({ id: "a", politician: { slug: "jean-dupont" } });
+    h.findUnique.mockResolvedValueOnce({ id: "b" });
+
+    await POST(req({ primaryId: "a", secondaryId: "b" }), ctx);
+
+    expect(order[0]).toBe("merge");
+    expect(order.slice(1)).toEqual(["invalidate", "invalidate"]);
+    expect(h.invalidateEntity).toHaveBeenCalledWith("politician", "jean-dupont");
+  });
+
+  it("does not invalidate when the merge throws", async () => {
+    h.findUnique.mockResolvedValueOnce({ id: "a", politician: { slug: "jean-dupont" } });
+    h.findUnique.mockResolvedValueOnce({ id: "b" });
+    h.mergeAffairs.mockRejectedValueOnce(new Error("rollback"));
+
+    await expect(POST(req({ primaryId: "a", secondaryId: "b" }), ctx)).rejects.toThrow("rollback");
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/affaires/merge/route.ts
+++ b/src/app/api/admin/affaires/merge/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
 import { mergeAffairsSchema } from "@/lib/security/schemas/affair";
+import { mergeAffairs } from "@/services/affairs/reconciliation";
 import { invalidateEntity } from "@/lib/cache";
 import type { z } from "zod/v4";
 
@@ -17,125 +17,29 @@ export const POST = withAdminAuth(
       return NextResponse.json({ error: "Les deux affaires sont identiques" }, { status: 400 });
     }
 
+    // Existence is checked here so the caller gets a 404 rather than a 500 from
+    // the service, and the politician slug is needed for cache invalidation.
     const [primary, secondary] = await Promise.all([
       db.affair.findUnique({
         where: { id: primaryId },
-        include: {
-          sources: { select: { url: true } },
-          politician: { select: { slug: true } },
-        },
+        select: { id: true, politician: { select: { slug: true } } },
       }),
-      db.affair.findUnique({
-        where: { id: secondaryId },
-        include: {
-          sources: true,
-          events: true,
-        },
-      }),
+      db.affair.findUnique({ where: { id: secondaryId }, select: { id: true } }),
     ]);
-
-    // Capture identifiers before mutation so we can build a redirect row
-    // after the secondary affair is deleted. Any external citation pointing
-    // at the retired poligraphId must keep resolving to the survivor.
-    const secondaryPublicId = secondary?.publicId ?? null;
-    const primaryPublicId = primary?.publicId ?? null;
 
     if (!primary || !secondary) {
       return NextResponse.json({ error: "Affaire(s) non trouvée(s)" }, { status: 404 });
     }
 
-    const existingUrls = new Set(primary.sources.map((s) => s.url));
-
-    // Move non-duplicate sources from secondary to primary
-    const sourcesToMove = secondary.sources.filter((s) => !existingUrls.has(s.url));
-    if (sourcesToMove.length > 0) {
-      await db.source.updateMany({
-        where: { id: { in: sourcesToMove.map((s) => s.id) } },
-        data: { affairId: primaryId },
-      });
-    }
-
-    // Move affair events from secondary to primary
-    if (secondary.events.length > 0) {
-      await db.affairEvent.updateMany({
-        where: { affairId: secondaryId },
-        data: { affairId: primaryId },
-      });
-    }
-
-    // Move press article links from secondary to primary
-    await db.pressArticleAffair.updateMany({
-      where: { affairId: secondaryId },
-      data: { affairId: primaryId },
-    });
-
-    // Merge judicial identifiers if primary is missing them
-    const updates: Prisma.AffairUpdateInput = {};
-    if (!primary.ecli && secondary.ecli) updates.ecli = secondary.ecli;
-    if (!primary.pourvoiNumber && secondary.pourvoiNumber)
-      updates.pourvoiNumber = secondary.pourvoiNumber;
-    if (primary.caseNumbers.length === 0 && secondary.caseNumbers.length > 0)
-      updates.caseNumbers = secondary.caseNumbers;
-    if (!primary.court && secondary.court) updates.court = secondary.court;
-    if (!primary.chamber && secondary.chamber) updates.chamber = secondary.chamber;
-    if (!primary.caseNumber && secondary.caseNumber) updates.caseNumber = secondary.caseNumber;
-
-    if (Object.keys(updates).length > 0) {
-      await db.affair.update({
-        where: { id: primaryId },
-        data: updates,
-      });
-    }
-
-    // Delete secondary affair (remaining sources will cascade)
-    await db.affair.delete({ where: { id: secondaryId } });
-
-    // Preserve the retired poligraphId as a redirect so external citations
-    // keep resolving. Only write the redirect if both IDs exist and differ.
-    if (secondaryPublicId && primaryPublicId && secondaryPublicId !== primaryPublicId) {
-      await db.publicIdRedirect.upsert({
-        where: { fromPublicId: secondaryPublicId },
-        create: {
-          fromPublicId: secondaryPublicId,
-          toPublicId: primaryPublicId,
-          entityType: "affair",
-          reason: "merged",
-        },
-        update: {
-          toPublicId: primaryPublicId,
-          reason: "merged",
-        },
-      });
-    }
-
-    // Audit log
     const meta = getRequestMeta(request);
-    await db.auditLog.create({
-      data: {
-        action: "UPDATE",
-        entityType: "Affair",
-        entityId: primaryId,
-        changes: {
-          merged: true,
-          deletedAffairId: secondaryId,
-          deletedAffairTitle: secondary.title,
-          sourcesMoved: sourcesToMove.length,
-          eventsMoved: secondary.events.length,
-          identifiersMerged: Object.keys(updates),
-        },
-        ipAddress: meta.ip,
-        userAgent: meta.userAgent,
-      },
+    const result = await mergeAffairs(primaryId, secondaryId, {
+      audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
     });
 
+    // After the transaction commits, never before.
     invalidateEntity("affair");
     if (primary.politician?.slug) invalidateEntity("politician", primary.politician.slug);
 
-    return NextResponse.json({
-      success: true,
-      sourcesMoved: sourcesToMove.length,
-      eventsMoved: secondary.events.length,
-      identifiersMerged: Object.keys(updates),
-    });
+    return NextResponse.json({ success: true, ...result });
   })
 );

--- a/src/services/affairs/__tests__/merge-affairs.test.ts
+++ b/src/services/affairs/__tests__/merge-affairs.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Issue #525 — merging deletes a row, which frees its slug. Every URL form the
+ * absorbed affair served has to survive on the survivor, and nothing the
+ * survivor already states may be overwritten.
+ */
+
+type TxRecorder = {
+  affair: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+  source: { findMany: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  affairEvent: { findMany: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  pressArticleAffair: { findMany: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  publicIdRedirect: { upsert: ReturnType<typeof vi.fn> };
+  dismissedDuplicate: { deleteMany: ReturnType<typeof vi.fn> };
+  auditLog: { create: ReturnType<typeof vi.fn> };
+};
+
+const tx: TxRecorder = {
+  affair: { findUnique: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  source: { findMany: vi.fn(), update: vi.fn() },
+  affairEvent: { findMany: vi.fn(), update: vi.fn() },
+  pressArticleAffair: { findMany: vi.fn(), update: vi.fn() },
+  publicIdRedirect: { upsert: vi.fn() },
+  dismissedDuplicate: { deleteMany: vi.fn() },
+  auditLog: { create: vi.fn() },
+};
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    $transaction: (fn: (t: TxRecorder) => unknown) => fn(tx),
+    affair: { findMany: vi.fn() },
+    dismissedDuplicate: { findMany: vi.fn(), upsert: vi.fn() },
+  },
+}));
+
+vi.mock("../matching", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../matching")>();
+  return { ...actual, findMatchingAffairs: vi.fn() };
+});
+
+import { computePreservedSlugs, mergeAffairs } from "../reconciliation";
+import { buildPublicAffairLookupWheres } from "@/lib/affairs/affair-lookup";
+
+function affair(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "keep",
+    title: "Affaire conservée",
+    slug: "affaire-conservee",
+    publicId: "AF-000001",
+    oldSlugs: [],
+    politicianId: "p1",
+    ecli: null,
+    pourvoiNumber: null,
+    caseNumbers: [],
+    court: null,
+    chamber: null,
+    caseNumber: null,
+    ...overrides,
+  };
+}
+
+/** Wires the survivor/absorbed pair and empty relation sets by default. */
+function stub(keep: Record<string, unknown>, remove: Record<string, unknown>) {
+  tx.affair.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
+    Promise.resolve(where.id === keep.id ? keep : remove)
+  );
+  tx.source.findMany.mockResolvedValue([]);
+  tx.affairEvent.findMany.mockResolvedValue([]);
+  tx.pressArticleAffair.findMany.mockResolvedValue([]);
+}
+
+/** The payload of the single additive update, or null when nothing was written. */
+function updatePayload(): Record<string, unknown> | null {
+  const call = tx.affair.update.mock.calls[0];
+  return call ? (call[0].data as Record<string, unknown>) : null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("computePreservedSlugs — issue #525", () => {
+  it("carries the absorbed slug and its former slugs", () => {
+    expect(
+      computePreservedSlugs({
+        keepSlug: "gardee",
+        keepOldSlugs: [],
+        removeSlug: "absorbee",
+        removeOldSlugs: ["absorbee-ancien"],
+      })
+    ).toEqual(["absorbee", "absorbee-ancien"]);
+  });
+
+  it("never lists the survivor's own canonical slug", () => {
+    // Two affairs cannot share a canonical slug (unique), but the absorbed one
+    // may have answered to what is now the survivor's slug.
+    expect(
+      computePreservedSlugs({
+        keepSlug: "gardee",
+        keepOldSlugs: [],
+        removeSlug: "absorbee",
+        removeOldSlugs: ["gardee"],
+      })
+    ).toEqual(["absorbee"]);
+  });
+
+  it("does not repeat what the survivor already answers to", () => {
+    expect(
+      computePreservedSlugs({
+        keepSlug: "gardee",
+        keepOldSlugs: ["absorbee"],
+        removeSlug: "absorbee",
+        removeOldSlugs: [],
+      })
+    ).toEqual([]);
+  });
+
+  it("deduplicates", () => {
+    expect(
+      computePreservedSlugs({
+        keepSlug: "gardee",
+        keepOldSlugs: [],
+        removeSlug: "absorbee",
+        removeOldSlugs: ["absorbee", "absorbee"],
+      })
+    ).toEqual(["absorbee"]);
+  });
+});
+
+describe("mergeAffairs — URLs survive the merge (issue #525)", () => {
+  it("appends the absorbed slugs to the survivor without dropping its own", async () => {
+    stub(
+      affair({ id: "keep", slug: "gardee", oldSlugs: ["gardee-v1"] }),
+      affair({ id: "remove", slug: "absorbee", publicId: "AF-000002", oldSlugs: ["absorbee-v1"] })
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(updatePayload()?.oldSlugs).toEqual(["gardee-v1", "absorbee", "absorbee-v1"]);
+    expect(result.slugsPreserved).toEqual(["absorbee", "absorbee-v1"]);
+  });
+
+  it("makes the absorbed slug resolve to the survivor", async () => {
+    stub(
+      affair({ id: "keep", slug: "gardee" }),
+      affair({ id: "remove", slug: "absorbee", publicId: "AF-000002" })
+    );
+
+    await mergeAffairs("keep", "remove");
+    const survivorOldSlugs = updatePayload()?.oldSlugs as string[];
+
+    // The public resolver looks the retired slug up in oldSlugs, restricted to
+    // published affairs. Together with the write above, the old URL resolves.
+    const [, byOldSlug] = buildPublicAffairLookupWheres("absorbee");
+    expect(byOldSlug).toEqual({
+      oldSlugs: { has: "absorbee" },
+      publicationStatus: "PUBLISHED",
+    });
+    expect(survivorOldSlugs).toContain("absorbee");
+  });
+
+  it("keeps the retired publicId redirect", async () => {
+    stub(
+      affair({ id: "keep", publicId: "AF-000001" }),
+      affair({ id: "remove", slug: "absorbee", publicId: "AF-000002" })
+    );
+
+    await mergeAffairs("keep", "remove");
+
+    expect(tx.publicIdRedirect.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { fromPublicId: "AF-000002" },
+        create: expect.objectContaining({ toPublicId: "AF-000001", reason: "merged" }),
+      })
+    );
+  });
+
+  it("deletes the absorbed affair inside the same transaction", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+
+    await mergeAffairs("keep", "remove");
+
+    expect(tx.affair.delete).toHaveBeenCalledWith({ where: { id: "remove" } });
+  });
+});
+
+describe("mergeAffairs — additive only (issue #525)", () => {
+  it("fills a judicial field the survivor is missing", async () => {
+    stub(
+      affair({ id: "keep", court: null, chamber: null }),
+      affair({ id: "remove", slug: "absorbee", court: "Cour d'appel de Paris", chamber: "2e" })
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(updatePayload()).toMatchObject({ court: "Cour d'appel de Paris", chamber: "2e" });
+    expect(result.identifiersMerged).toEqual(expect.arrayContaining(["court", "chamber"]));
+  });
+
+  it("never overwrites a judicial field the survivor already states", async () => {
+    stub(
+      affair({ id: "keep", court: "Tribunal de Paris", ecli: "ECLI:FR:CCASS:2024:C100001" }),
+      affair({
+        id: "remove",
+        slug: "absorbee",
+        court: "Cour d'appel de Lyon",
+        ecli: "ECLI:FR:CCASS:2024:C900009",
+      })
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    const payload = updatePayload() ?? {};
+    expect(payload).not.toHaveProperty("court");
+    expect(payload).not.toHaveProperty("ecli");
+    expect(result.identifiersMerged).toEqual([]);
+  });
+
+  it("unions caseNumbers instead of replacing them", async () => {
+    stub(
+      affair({ id: "keep", caseNumbers: ["A1"] }),
+      affair({ id: "remove", slug: "absorbee", caseNumbers: ["A1", "B2"] })
+    );
+
+    await mergeAffairs("keep", "remove");
+
+    expect(updatePayload()?.caseNumbers).toEqual(["A1", "B2"]);
+  });
+
+  it("leaves editorial fields alone", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+
+    await mergeAffairs("keep", "remove");
+
+    const payload = updatePayload() ?? {};
+    for (const field of [
+      "title",
+      "description",
+      "status",
+      "verdictDate",
+      "factsDate",
+      "category",
+      "involvement",
+      "publicationStatus",
+      "sentence",
+    ]) {
+      expect(payload).not.toHaveProperty(field);
+    }
+  });
+});
+
+describe("mergeAffairs — transfers deduplicate (issue #525)", () => {
+  it("skips a source whose URL the survivor already carries", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.source.findMany
+      .mockResolvedValueOnce([{ url: "https://example.org/a" }]) // survivor
+      .mockResolvedValueOnce([
+        { id: "s1", url: "https://example.org/a" },
+        { id: "s2", url: "https://example.org/b" },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.sourcesMoved).toBe(1);
+    expect(tx.source.update).toHaveBeenCalledTimes(1);
+    expect(tx.source.update).toHaveBeenCalledWith({
+      where: { id: "s2" },
+      data: { affairId: "keep" },
+    });
+  });
+
+  it("skips an event the survivor already records", async () => {
+    // AffairEvent has no unique constraint, so identity is (date, type, title).
+    const date = new Date("2024-03-01T00:00:00Z");
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.affairEvent.findMany
+      .mockResolvedValueOnce([{ date, type: "CONDAMNATION", title: "Jugement" }])
+      .mockResolvedValueOnce([
+        { id: "e1", date, type: "CONDAMNATION", title: "Jugement" },
+        { id: "e2", date, type: "APPEL", title: "Appel interjeté" },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.eventsMoved).toBe(1);
+    expect(tx.affairEvent.update).toHaveBeenCalledWith({
+      where: { id: "e2" },
+      data: { affairId: "keep" },
+    });
+  });
+
+  it("skips a press link that would break the article uniqueness constraint", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.pressArticleAffair.findMany
+      .mockResolvedValueOnce([{ articleId: "art1" }])
+      .mockResolvedValueOnce([
+        { id: "l1", articleId: "art1" },
+        { id: "l2", articleId: "art2" },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.articlesMoved).toBe(1);
+    expect(tx.pressArticleAffair.update).toHaveBeenCalledWith({
+      where: { id: "l2" },
+      data: { affairId: "keep" },
+    });
+  });
+});
+
+describe("mergeAffairs — bookkeeping (issue #525)", () => {
+  it("records what moved in the audit trail", async () => {
+    stub(
+      affair({ id: "keep" }),
+      affair({ id: "remove", title: "Affaire absorbée", slug: "absorbee", publicId: "AF-000002" })
+    );
+
+    await mergeAffairs("keep", "remove", {
+      audit: { ipAddress: "203.0.113.1", userAgent: "test" },
+    });
+
+    expect(tx.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "MERGE",
+        entityId: "keep",
+        ipAddress: "203.0.113.1",
+        changes: expect.objectContaining({
+          mergedFrom: "remove",
+          mergedFromTitle: "Affaire absorbée",
+          slugsPreserved: ["absorbee"],
+        }),
+      }),
+    });
+  });
+
+  it("clears dismissals that referenced the absorbed affair", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+
+    await mergeAffairs("keep", "remove");
+
+    expect(tx.dismissedDuplicate.deleteMany).toHaveBeenCalledWith({
+      where: { OR: [{ affairIdA: "remove" }, { affairIdB: "remove" }] },
+    });
+  });
+
+  it("refuses to merge when an affair is missing", async () => {
+    tx.affair.findUnique.mockResolvedValue(null);
+
+    await expect(mergeAffairs("keep", "remove")).rejects.toThrow("Affair to keep not found");
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -188,28 +188,97 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
 // ============================================
 
 /**
- * Merge two affairs: keep affairA, transfer data from affairB, delete affairB.
- *
- * Transfers: sources, events, press article links.
- * Does NOT merge text fields (title, description) — admin should edit after.
+ * Fields filled on the survivor only when it does not already carry a value.
+ * Purely additive: a merge must never overwrite what the survivor states, but
+ * losing what the absorbed affair stated is data loss, since its row is deleted.
  */
-export async function mergeAffairs(keepId: string, removeId: string): Promise<void> {
-  await db.$transaction(async (tx) => {
-    // Verify both affairs exist and capture publicIds for redirect bookkeeping.
+const ADDITIVE_MERGE_FIELDS = ["ecli", "pourvoiNumber", "court", "chamber", "caseNumber"] as const;
+
+export interface MergeAffairsOptions {
+  /** Request context, when the merge is human-initiated from the admin. */
+  audit?: { ipAddress?: string | null; userAgent?: string | null };
+}
+
+export interface MergeAffairsResult {
+  sourcesMoved: number;
+  eventsMoved: number;
+  articlesMoved: number;
+  identifiersMerged: string[];
+  /** Slugs the survivor now answers to on behalf of the absorbed affair. */
+  slugsPreserved: string[];
+}
+
+/** Semantic identity of an event: it carries no unique constraint in the schema. */
+function eventKey(event: { date: Date; type: string; title: string }): string {
+  return [event.date.toISOString(), event.type, event.title].join("|");
+}
+
+/**
+ * Slugs the survivor must start answering to once the absorbed affair is deleted.
+ *
+ * Deleting the row frees its `slug`, so every URL form it served has to move to
+ * the survivor's `oldSlugs`, which `buildPublicAffairLookupWheres` resolves.
+ * Excludes the survivor's own canonical slug — listing it as a former slug would
+ * make the affair shadow itself — and anything it already answers to.
+ */
+export function computePreservedSlugs(input: {
+  keepSlug: string;
+  keepOldSlugs: string[];
+  removeSlug: string;
+  removeOldSlugs: string[];
+}): string[] {
+  const alreadyServed = new Set([input.keepSlug, ...input.keepOldSlugs]);
+  return [...new Set([input.removeSlug, ...input.removeOldSlugs])].filter(
+    (slug) => !alreadyServed.has(slug)
+  );
+}
+
+/**
+ * Merge two affairs: keep `keepId`, transfer what `removeId` holds, delete it.
+ *
+ * The single merge implementation. Everything runs in one transaction so a
+ * failure can never leave sources moved with the affair still present, nor an
+ * affair deleted without its redirects.
+ *
+ * Transfers additively: sources, events, press article links, and the judicial
+ * identifiers the survivor is missing. Never touches the survivor's editorial
+ * fields (title, description, status, dates, sentence) — those are a human
+ * decision, and for automated paths they belong in an AffairUpdateProposal.
+ *
+ * Preserves both URL forms of the absorbed affair, since deleting its row frees
+ * its slug: the retired publicId gets a redirect row, and its slug plus any slug
+ * it previously answered to move into the survivor's `oldSlugs`, which
+ * `buildPublicAffairLookupWheres` resolves (issue #525).
+ */
+export async function mergeAffairs(
+  keepId: string,
+  removeId: string,
+  options: MergeAffairsOptions = {}
+): Promise<MergeAffairsResult> {
+  return db.$transaction(async (tx) => {
+    const affairSelect = {
+      id: true,
+      title: true,
+      slug: true,
+      publicId: true,
+      oldSlugs: true,
+      politicianId: true,
+      ecli: true,
+      pourvoiNumber: true,
+      caseNumbers: true,
+      court: true,
+      chamber: true,
+      caseNumber: true,
+    } as const;
+
     const [keep, remove] = await Promise.all([
-      tx.affair.findUnique({
-        where: { id: keepId },
-        select: { id: true, publicId: true },
-      }),
-      tx.affair.findUnique({
-        where: { id: removeId },
-        select: { id: true, publicId: true },
-      }),
+      tx.affair.findUnique({ where: { id: keepId }, select: affairSelect }),
+      tx.affair.findUnique({ where: { id: removeId }, select: affairSelect }),
     ]);
     if (!keep) throw new Error(`Affair to keep not found: ${keepId}`);
     if (!remove) throw new Error(`Affair to remove not found: ${removeId}`);
 
-    // Transfer sources (skip duplicates by URL)
+    // --- Sources: unique on (affairId, url), so skip URLs already present.
     const existingSources = await tx.source.findMany({
       where: { affairId: keepId },
       select: { url: true },
@@ -218,23 +287,37 @@ export async function mergeAffairs(keepId: string, removeId: string): Promise<vo
 
     const sourcesToTransfer = await tx.source.findMany({
       where: { affairId: removeId },
+      select: { id: true, url: true },
     });
+    let sourcesMoved = 0;
     for (const source of sourcesToTransfer) {
-      if (!existingUrls.has(source.url)) {
-        await tx.source.update({
-          where: { id: source.id },
-          data: { affairId: keepId },
-        });
-      }
+      if (existingUrls.has(source.url)) continue;
+      await tx.source.update({ where: { id: source.id }, data: { affairId: keepId } });
+      existingUrls.add(source.url);
+      sourcesMoved++;
     }
 
-    // Transfer events
-    await tx.affairEvent.updateMany({
-      where: { affairId: removeId },
-      data: { affairId: keepId },
+    // --- Events: no unique constraint, so deduplicate on their semantic key.
+    const existingEvents = await tx.affairEvent.findMany({
+      where: { affairId: keepId },
+      select: { date: true, type: true, title: true },
     });
+    const existingEventKeys = new Set(existingEvents.map(eventKey));
 
-    // Transfer press article links (skip duplicates)
+    const eventsToTransfer = await tx.affairEvent.findMany({
+      where: { affairId: removeId },
+      select: { id: true, date: true, type: true, title: true },
+    });
+    let eventsMoved = 0;
+    for (const event of eventsToTransfer) {
+      const key = eventKey(event);
+      if (existingEventKeys.has(key)) continue;
+      await tx.affairEvent.update({ where: { id: event.id }, data: { affairId: keepId } });
+      existingEventKeys.add(key);
+      eventsMoved++;
+    }
+
+    // --- Press links: unique on (articleId, affairId), so a blanket move would throw.
     const existingLinks = await tx.pressArticleAffair.findMany({
       where: { affairId: keepId },
       select: { articleId: true },
@@ -243,48 +326,54 @@ export async function mergeAffairs(keepId: string, removeId: string): Promise<vo
 
     const linksToTransfer = await tx.pressArticleAffair.findMany({
       where: { affairId: removeId },
+      select: { id: true, articleId: true },
     });
+    let articlesMoved = 0;
     for (const link of linksToTransfer) {
-      if (!existingArticleIds.has(link.articleId)) {
-        await tx.pressArticleAffair.update({
-          where: { id: link.id },
-          data: { affairId: keepId },
-        });
+      if (existingArticleIds.has(link.articleId)) continue;
+      await tx.pressArticleAffair.update({
+        where: { id: link.id },
+        data: { affairId: keepId },
+      });
+      existingArticleIds.add(link.articleId);
+      articlesMoved++;
+    }
+
+    // --- Additive field fill, plus the absorbed affair's URLs.
+    const updates: Prisma.AffairUpdateInput = {};
+    const identifiersMerged: string[] = [];
+    for (const field of ADDITIVE_MERGE_FIELDS) {
+      if (!keep[field] && remove[field]) {
+        updates[field] = remove[field];
+        identifiersMerged.push(field);
+      }
+    }
+    if (remove.caseNumbers.length > 0) {
+      const merged = [...new Set([...keep.caseNumbers, ...remove.caseNumbers])];
+      if (merged.length !== keep.caseNumbers.length) {
+        updates.caseNumbers = merged;
+        identifiersMerged.push("caseNumbers");
       }
     }
 
-    // Merge judicial identifiers if the kept affair is missing them
-    const removeAffair = await tx.affair.findUnique({
-      where: { id: removeId },
-      select: { ecli: true, pourvoiNumber: true, caseNumbers: true },
+    const slugsPreserved = computePreservedSlugs({
+      keepSlug: keep.slug,
+      keepOldSlugs: keep.oldSlugs,
+      removeSlug: remove.slug,
+      removeOldSlugs: remove.oldSlugs,
     });
-    const keepAffair = await tx.affair.findUnique({
-      where: { id: keepId },
-      select: { ecli: true, pourvoiNumber: true, caseNumbers: true },
-    });
-    if (removeAffair && keepAffair) {
-      const updates: Prisma.AffairUpdateInput = {};
-      if (!keepAffair.ecli && removeAffair.ecli) {
-        updates.ecli = removeAffair.ecli;
-      }
-      if (!keepAffair.pourvoiNumber && removeAffair.pourvoiNumber) {
-        updates.pourvoiNumber = removeAffair.pourvoiNumber;
-      }
-      if (removeAffair.caseNumbers.length > 0) {
-        const merged = new Set([...keepAffair.caseNumbers, ...removeAffair.caseNumbers]);
-        updates.caseNumbers = Array.from(merged);
-      }
-      if (Object.keys(updates).length > 0) {
-        await tx.affair.update({ where: { id: keepId }, data: updates });
-      }
+    if (slugsPreserved.length > 0) {
+      updates.oldSlugs = [...keep.oldSlugs, ...slugsPreserved];
     }
 
-    // Delete the merged affair (cascades sources, events, press links that weren't transferred)
+    if (Object.keys(updates).length > 0) {
+      await tx.affair.update({ where: { id: keepId }, data: updates });
+    }
+
+    // Cascades whatever was not transferred above.
     await tx.affair.delete({ where: { id: removeId } });
 
-    // Preserve the retired poligraphId as a redirect so external citations
-    // keep resolving to the survivor. Written inside the transaction so the
-    // redirect and deletion commit or roll back together.
+    // The retired poligraphId keeps resolving for external citations.
     if (remove.publicId && keep.publicId && remove.publicId !== keep.publicId) {
       await tx.publicIdRedirect.upsert({
         where: { fromPublicId: remove.publicId },
@@ -294,29 +383,34 @@ export async function mergeAffairs(keepId: string, removeId: string): Promise<vo
           entityType: "affair",
           reason: "merged",
         },
-        update: {
-          toPublicId: keep.publicId,
-          reason: "merged",
-        },
+        update: { toPublicId: keep.publicId, reason: "merged" },
       });
     }
 
-    // Clean up any dismissed duplicates referencing the removed affair
     await tx.dismissedDuplicate.deleteMany({
-      where: {
-        OR: [{ affairIdA: removeId }, { affairIdB: removeId }],
-      },
+      where: { OR: [{ affairIdA: removeId }, { affairIdB: removeId }] },
     });
 
-    // Audit log
     await tx.auditLog.create({
       data: {
         action: "MERGE",
         entityType: "Affair",
         entityId: keepId,
-        changes: { mergedFrom: removeId },
+        changes: {
+          mergedFrom: removeId,
+          mergedFromTitle: remove.title,
+          sourcesMoved,
+          eventsMoved,
+          articlesMoved,
+          identifiersMerged,
+          slugsPreserved,
+        },
+        ipAddress: options.audit?.ipAddress ?? null,
+        userAgent: options.audit?.userAgent ?? null,
       },
     });
+
+    return { sourcesMoved, eventsMoved, articlesMoved, identifiersMerged, slugsPreserved };
   });
 }
 


### PR DESCRIPTION
## Description

Part of #525. **PR 1 sur 3.** Ne modifie ni le périmètre de détection ni les règles d'auto-fusion : uniquement la fusion elle-même.

### Deux implémentations de fusion, dont une non transactionnelle

`mergeAffairs()` dans `reconciliation.ts` et une seconde, indépendante, dans la route admin. Cette dernière enchaînait des `await db.*` **hors transaction** : un échec en cours de route laissait des sources déplacées avec l'affaire encore présente, ou l'affaire supprimée sans sa redirection.

Elle portait aussi un `updateMany` en bloc sur les liens d'articles, alors que `PressArticleAffair` a un `@@unique([articleId, affairId])`. Fusionner deux affaires citées par le même article levait une erreur.

`mergeAffairs()` devient l'unique implémentation. La route valide, vérifie l'existence, délègue, puis invalide les caches **après** le commit.

### Les URLs de l'affaire absorbée disparaissaient

Une fusion supprime la ligne absorbée, ce qui libère son `slug`. Le champ `Affair.oldSlugs` existe et **est** lu pour résoudre les URLs publiques (`buildPublicAffairLookupWheres`), mais aucun des deux chemins de fusion ne l'alimentait.

Conséquence : toute URL de l'affaire absorbée cessait de résoudre. La redirection sur `publicId` était bien écrite, donc les citations par identifiant survivaient, mais pas les liens par slug.

`computePreservedSlugs()` est extraite en fonction pure : elle reprend le slug de l'absorbée et ceux qu'elle servait déjà, sans jamais y placer le slug canonique du survivant (il se masquerait lui-même), et sans répéter ce qu'il sert déjà.

### Déduplication des transferts

| Relation | Identité | Avant |
| --- | --- | --- |
| `Source` | `@@unique([affairId, url])` | dédupliqué des deux côtés |
| `PressArticleAffair` | `@@unique([articleId, affairId])` | dédupliqué dans le service, **en bloc dans la route** |
| `AffairEvent` | aucune contrainte | jamais dédupliqué |

Les événements n'ont pas de contrainte d'unicité : la déduplication se fait sur leur identité sémantique `(date, type, title)`.

### Champs : strictement additif

Le remplissage ne touche un champ que s'il est **absent** sur le survivant, et `caseNumbers` est unionné plutôt que remplacé. Les champs éditoriaux (`title`, `description`, `status`, dates, peines, `category`, `involvement`, `publicationStatus`) ne sont jamais écrits.

**Un changement de comportement à noter** : le service reprend désormais `court`, `chamber` et `caseNumber` quand le survivant ne les porte pas, ce que seule la route faisait. Le chemin automatique `DRAFT + DRAFT` remplit donc trois champs de plus, uniquement lorsqu'ils sont vides. Ne pas les reprendre revenait à perdre ces données à la suppression de la ligne.

## Type de changement

- [x] Bug fix

## Issue liée

Part of #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre
- **2270 tests** passés, 0 échec (2247 avant cette PR)
- 23 tests ajoutés
- Les 2 tests de préservation d'URL **échouent** si l'écriture dans `oldSlugs` est neutralisée, vérifié en désactivant la ligne

## Points de revue

**Le test de résolution est en deux moitiés assemblées.** Il vérifie que la fusion écrit le slug retiré dans `oldSlugs` du survivant, **et** que `buildPublicAffairLookupWheres` interroge bien `oldSlugs` avec `publicationStatus: "PUBLISHED"`. Les deux moitiés se rejoignent sur la même chaîne, ce qui prouve la résolution sans base de données.

**L'invariant RGPD tient.** La clause de résolution par `oldSlugs` impose `PUBLISHED`. Reprendre le slug d'un brouillon absorbé ne le rend donc pas résolvable, sauf si le survivant est lui-même publié, ce qui est le cas attendu.

**`ecli` est `@unique`.** Le remplissage additif de ce champ ne peut donc jamais s'appliquer entre deux lignes existantes portant le même ECLI, puisque c'est impossible en base. Le code le gère quand même, pour le cas où seule l'absorbée en porte un.

## Suite

- PR 2 : élargissement de la détection aux statuts `DRAFT` et `PUBLISHED`, `decideMergeAction()`, absorption dirigée sous identité déterministe.
- PR 3 : file de revue et classification.
