### PR TITLE
Étendre la détection de doublons aux affaires publiées, sans fusion automatique

### DIFF
--- a/src/services/affairs/__tests__/absorb-draft.test.ts
+++ b/src/services/affairs/__tests__/absorb-draft.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #525 §4 — absorbing a draft into a published affair may add, never rewrite.
+// Anything the draft states about the judicial outcome goes to the proposal queue.
+
+const h = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  mergeAffairs: vi.fn(),
+  proposeAffairUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: { affair: { findUnique: h.findUnique } } }));
+vi.mock("../reconciliation", () => ({
+  mergeAffairs: h.mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS: ["ecli", "pourvoiNumber", "caseNumber"],
+}));
+vi.mock("../proposals", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proposals")>();
+  return {
+    normalizeForCompare: actual.normalizeForCompare,
+    proposeAffairUpdate: h.proposeAffairUpdate,
+  };
+});
+
+import { absorbDraftIntoPublished } from "../absorb-draft";
+
+function affair(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "x",
+    title: "Titre",
+    description: "Description",
+    category: "AUTRE",
+    status: null,
+    verdictDate: null,
+    court: null,
+    sentence: null,
+    prisonMonths: null,
+    prisonSuspended: null,
+    fineAmount: null,
+    ineligibilityMonths: null,
+    communityService: null,
+    otherSentence: null,
+    publicationStatus: "DRAFT",
+    sources: [],
+    ...overrides,
+  };
+}
+
+function stub(published: Record<string, unknown>, draft: Record<string, unknown>) {
+  h.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
+    Promise.resolve(where.id === published.id ? published : draft)
+  );
+}
+
+/** The patch handed to the proposal queue, or null when nothing was proposed. */
+function proposedPatch(): Record<string, unknown> | null {
+  const call = h.proposeAffairUpdate.mock.calls[0];
+  return call ? (call[0].patch as Record<string, unknown>) : null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.mergeAffairs.mockResolvedValue({
+    sourcesMoved: 0,
+    eventsMoved: 0,
+    articlesMoved: 0,
+    identifiersMerged: [],
+    slugsPreserved: [],
+  });
+  h.proposeAffairUpdate.mockResolvedValue({
+    autoApplied: [],
+    autoProposalId: null,
+    pendingProposalId: "prop_1",
+    conflictProposalId: null,
+    deduped: false,
+  });
+});
+
+const base = {
+  importRunId: "run_1",
+  reason: "Identifiant judiciaire commun (pourvoiNumber)",
+};
+
+describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (#525)", () => {
+  it("n'écrase aucun champ sensible non nul de l'affaire publiée", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        status: "CONDAMNATION_DEFINITIVE",
+        court: "Cour de cassation",
+        sentence: "6 mois avec sursis",
+        verdictDate: new Date("2024-01-15"),
+      }),
+      affair({
+        id: "draft",
+        status: "PROCES_EN_COURS",
+        court: "Tribunal correctionnel de Paris",
+        sentence: "réquisitions de 12 mois",
+        verdictDate: new Date("2024-01-20"),
+      })
+    );
+
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+
+    // Le service de fusion est appelé avec la seule liste additive restreinte :
+    // ni court ni chamber ne peuvent y être remplis.
+    const mergeOptions = h.mergeAffairs.mock.calls[0]![2];
+    expect(mergeOptions.additiveFields).toEqual(["ecli", "pourvoiNumber", "caseNumber"]);
+    expect(mergeOptions.additiveFields).not.toContain("court");
+    expect(mergeOptions.additiveFields).not.toContain("chamber");
+
+    // Et le survivant est bien l'affaire publiée.
+    expect(h.mergeAffairs).toHaveBeenCalledWith("pub", "draft", expect.anything());
+  });
+
+  it("crée une proposition pour chaque donnée sensible divergente", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        status: "CONDAMNATION_DEFINITIVE",
+        court: null,
+      }),
+      affair({
+        id: "draft",
+        status: "PROCES_EN_COURS",
+        court: "Tribunal correctionnel de Paris",
+        prisonMonths: 6,
+      })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(proposedPatch()).toEqual({
+      status: "PROCES_EN_COURS",
+      court: "Tribunal correctionnel de Paris",
+      prisonMonths: 6,
+    });
+    expect(result.proposalsCreated).toBe(1);
+    expect(h.proposeAffairUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ affairId: "pub", importRunId: "run_1" })
+    );
+  });
+
+  it("ne propose pas un champ que l'affaire publiée porte déjà à l'identique", async () => {
+    stub(
+      affair({ id: "pub", publicationStatus: "PUBLISHED", court: "Cour de cassation" }),
+      affair({ id: "draft", court: "Cour de cassation" })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(h.proposeAffairUpdate).not.toHaveBeenCalled();
+    expect(result.proposalsCreated).toBe(0);
+  });
+
+  it("garde trace des différences ni transférées ni proposables", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        category: "AUTRE",
+        title: "Titre publié",
+      }),
+      affair({ id: "draft", category: "RECEL", title: "Titre du brouillon" })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(result.recordedDifferences).toEqual(expect.arrayContaining(["title", "category"]));
+    // Rien n'est perdu en silence : la valeur absorbée part dans la piste d'audit.
+    const notes = h.mergeAffairs.mock.calls[0]![2].auditNotes;
+    expect(notes.recordedDifferences).toEqual(
+      expect.arrayContaining([{ field: "category", absorbedValue: "RECEL" }])
+    );
+  });
+});
+
+describe("absorbDraftIntoPublished — refuse de se tromper de sens (#525)", () => {
+  it("refuse si le survivant n'est pas publié", async () => {
+    stub(affair({ id: "pub", publicationStatus: "DRAFT" }), affair({ id: "draft" }));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("n'est pas publiée");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("refuse si l'affaire absorbée n'est pas un brouillon", async () => {
+    stub(
+      affair({ id: "pub", publicationStatus: "PUBLISHED" }),
+      affair({ id: "draft", publicationStatus: "PUBLISHED" })
+    );
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("n'est pas un brouillon");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("refuse si une des deux affaires a disparu", async () => {
+    h.findUnique.mockResolvedValue(null);
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("introuvable");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/affairs/__tests__/merge-decision.test.ts
+++ b/src/services/affairs/__tests__/merge-decision.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from "vitest";
+
+// matching.ts imports @/lib/db at module level; decideMergeAction is pure.
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { decideMergeAction, type MergeDecisionAffair } from "../merge-decision";
+import type { PublicationStatus, SourceType } from "@/generated/prisma";
+
+function side(overrides: Partial<MergeDecisionAffair> & { id: string }): MergeDecisionAffair {
+  return {
+    publicationStatus: "DRAFT" as PublicationStatus,
+    verifiedAt: null,
+    sources: [],
+    ...overrides,
+  };
+}
+
+const press = ["PRESSE"] as SourceType[];
+
+describe("decideMergeAction — deux brouillons (#525)", () => {
+  it("auto-fusionne sur une confiance suffisante", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", sources: press }),
+      affairB: side({ id: "b" }),
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(plan.decision).toBe("AUTO_MERGE_DRAFTS");
+    // Le plus riche en sources survit.
+    expect(plan.keepId).toBe("a");
+    expect(plan.removeId).toBe("b");
+  });
+
+  it("exige une revue sur un rapprochement POSSIBLE", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "b" }),
+      confidence: "POSSIBLE",
+      matchedBy: "politician+category+window",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("ne supprime jamais automatiquement un brouillon validé humainement", () => {
+    // « b » serait absorbé sur le critère des sources, mais il a été relu.
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", sources: press }),
+      affairB: side({ id: "b", verifiedAt: new Date("2026-01-01") }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.removeId).toBeUndefined();
+  });
+});
+
+describe("decideMergeAction — brouillon face à une affaire publiée (#525)", () => {
+  const published = side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus });
+  const draft = side({ id: "draft" });
+
+  it("absorbe toujours le brouillon dans l'affaire publiée sur identifiant judiciaire", () => {
+    for (const matchedBy of ["ecli", "pourvoiNumber", "caseNumbers"]) {
+      const plan = decideMergeAction({
+        affairA: published,
+        affairB: draft,
+        confidence: "HIGH",
+        matchedBy,
+      });
+
+      expect(plan.decision).toBe("AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
+      expect(plan.keepId).toBe("pub");
+      expect(plan.removeId).toBe("draft");
+    }
+  });
+
+  it("garde l'affaire publiée même quand le brouillon a plus de sources", () => {
+    // Le sens de la fusion ne dépend jamais du nombre de sources ici.
+    const plan = decideMergeAction({
+      affairA: side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      affairB: side({ id: "draft", sources: ["PRESSE", "OFFICIEL"] as SourceType[] }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.keepId).toBe("pub");
+    expect(plan.removeId).toBe("draft");
+  });
+
+  it("exige une revue quand seul le titre rapproche", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: draft,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("heuristique");
+  });
+
+  it("exige une revue quand le brouillon affirme autre chose sur un champ non transférable", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: draft,
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+      unpropagatableDifferences: ["involvement"],
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("involvement");
+  });
+
+  it("ne supprime jamais automatiquement un brouillon validé humainement", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: side({ id: "draft", verifiedAt: new Date("2026-01-01") }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+});
+
+describe("decideMergeAction — deux affaires publiées (#525)", () => {
+  it("n'auto-fusionne jamais, même en CERTAIN sur identifiant judiciaire", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      affairB: side({ id: "b", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.keepId).toBeUndefined();
+  });
+
+  it("une affaire publiée vérifiée n'est jamais supprimée automatiquement", () => {
+    const plan = decideMergeAction({
+      affairA: side({
+        id: "a",
+        publicationStatus: "PUBLISHED" as PublicationStatus,
+        verifiedAt: new Date("2026-01-01"),
+      }),
+      affairB: side({
+        id: "b",
+        publicationStatus: "PUBLISHED" as PublicationStatus,
+        verifiedAt: new Date("2026-01-02"),
+      }),
+      confidence: "CERTAIN",
+      matchedBy: "pourvoiNumber",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+});
+
+describe("decideMergeAction — garde-fous (#525)", () => {
+  it("toute contradiction judiciaire passe en revue, quelle que soit la confiance", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "b" }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+      contradictions: ["verdictDate"],
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("verdictDate");
+  });
+
+  it("refuse une affaire hors du périmètre de statuts", () => {
+    for (const status of ["REJECTED", "EXCLUDED", "ARCHIVED"] as PublicationStatus[]) {
+      const plan = decideMergeAction({
+        affairA: side({ id: "a", publicationStatus: status }),
+        affairB: side({ id: "b" }),
+        confidence: "CERTAIN",
+        matchedBy: "ecli",
+      });
+
+      expect(plan.decision).toBe("NOT_ELIGIBLE");
+    }
+  });
+
+  it("refuse une affaire face à elle-même", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "a" }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("NOT_ELIGIBLE");
+  });
+
+  it("est déterministe : l'ordre des deux côtés ne change pas le plan", () => {
+    // À sources égales, le départage se fait sur l'id, pas sur la place dans la paire.
+    const a = side({ id: "zzz" });
+    const b = side({ id: "aaa" });
+
+    const forward = decideMergeAction({
+      affairA: a,
+      affairB: b,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+    const backward = decideMergeAction({
+      affairA: b,
+      affairB: a,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(forward).toEqual(backward);
+    expect(forward.keepId).toBe("aaa");
+  });
+
+  it("reste déterministe quand les sources départagent", () => {
+    const rich = side({ id: "zzz", sources: ["PRESSE", "OFFICIEL"] as SourceType[] });
+    const poor = side({ id: "aaa", sources: press });
+
+    const forward = decideMergeAction({
+      affairA: rich,
+      affairB: poor,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+    const backward = decideMergeAction({
+      affairA: poor,
+      affairB: rich,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(forward).toEqual(backward);
+    expect(forward.keepId).toBe("zzz");
+  });
+});

--- a/src/services/affairs/absorb-draft.ts
+++ b/src/services/affairs/absorb-draft.ts
@@ -1,0 +1,164 @@
+/**
+ * Absorbing a draft into a published affair.
+ *
+ * The published fiche always survives and is never rewritten by this path. A
+ * merge is allowed to carry over what the absorbed row held in addition — its
+ * sources, its events, the court-assigned identifiers the published fiche lacks —
+ * but everything the draft *states* about the judicial outcome goes through the
+ * proposal queue instead, so a human decides whether a published record changes
+ * (issue #525, §4).
+ *
+ * Only reached when an official identifier already proved the two rows describe
+ * one decision. See decideMergeAction().
+ */
+
+import { db } from "@/lib/db";
+import type { SourceType } from "@/generated/prisma";
+import {
+  mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS,
+  type AdditiveMergeField,
+} from "./reconciliation";
+import { normalizeForCompare, proposeAffairUpdate } from "./proposals";
+
+/**
+ * Fields a draft may contribute to a published fiche, through review only.
+ *
+ * The proposal whitelist minus the identifiers the merge already carried over
+ * directly. `court` sits here rather than in the merge: it names the jurisdiction
+ * rather than identifying the decision, so even filling a gap is a review call.
+ */
+const PROPOSABLE_FROM_DRAFT = [
+  "status",
+  "verdictDate",
+  "court",
+  "sentence",
+  "prisonMonths",
+  "prisonSuspended",
+  "fineAmount",
+  "ineligibilityMonths",
+  "communityService",
+  "otherSentence",
+] as const;
+
+/**
+ * Differences that survive the merge without being carried or proposed.
+ *
+ * The published wording is authoritative once the pair is proven to be one
+ * decision, so these are not blockers. They are written to the merge audit trail
+ * rather than dropped, because the absorbed row is deleted.
+ */
+const RECORDED_ONLY_FIELDS = ["title", "description", "category"] as const;
+
+export interface AbsorbDraftInput {
+  publishedId: string;
+  draftId: string;
+  importRunId: string;
+  /** The merge plan's reason, kept verbatim in the audit trail and rationale. */
+  reason: string;
+  additiveFields?: readonly AdditiveMergeField[];
+}
+
+export interface AbsorbDraftResult {
+  proposalsCreated: number;
+  proposedFields: string[];
+  recordedDifferences: string[];
+}
+
+const AFFAIR_ABSORB_SELECT = {
+  id: true,
+  title: true,
+  description: true,
+  category: true,
+  status: true,
+  verdictDate: true,
+  court: true,
+  sentence: true,
+  prisonMonths: true,
+  prisonSuspended: true,
+  fineAmount: true,
+  ineligibilityMonths: true,
+  communityService: true,
+  otherSentence: true,
+  publicationStatus: true,
+  sources: { select: { sourceType: true, url: true }, take: 1 },
+} as const;
+
+export async function absorbDraftIntoPublished(
+  input: AbsorbDraftInput
+): Promise<AbsorbDraftResult> {
+  const [published, draft] = await Promise.all([
+    db.affair.findUnique({ where: { id: input.publishedId }, select: AFFAIR_ABSORB_SELECT }),
+    db.affair.findUnique({ where: { id: input.draftId }, select: AFFAIR_ABSORB_SELECT }),
+  ]);
+  if (!published) throw new Error(`Affaire publiée introuvable : ${input.publishedId}`);
+  if (!draft) throw new Error(`Brouillon introuvable : ${input.draftId}`);
+
+  // Re-checked here rather than trusted from the plan: the rows can move between
+  // detection and this call, and absorbing the wrong way deletes a public page.
+  if (published.publicationStatus !== "PUBLISHED") {
+    throw new Error(`L'affaire survivante n'est pas publiée : ${input.publishedId}`);
+  }
+  if (draft.publicationStatus !== "DRAFT") {
+    throw new Error(`L'affaire absorbée n'est pas un brouillon : ${input.draftId}`);
+  }
+
+  const live = published as unknown as Record<string, unknown>;
+  const incoming = draft as unknown as Record<string, unknown>;
+
+  // What the draft states that the published fiche does not.
+  const patch: Record<string, unknown> = {};
+  for (const field of PROPOSABLE_FROM_DRAFT) {
+    const value = incoming[field];
+    if (value === null || value === undefined) continue;
+    if (normalizeForCompare(value) === normalizeForCompare(live[field])) continue;
+    patch[field] = value;
+  }
+
+  const recordedDifferences = RECORDED_ONLY_FIELDS.filter(
+    (field) => normalizeForCompare(incoming[field]) !== normalizeForCompare(live[field])
+  );
+
+  // The merge is what deletes the draft, so it runs before proposing: a proposal
+  // on a pair that failed to merge would be unactionable.
+  await mergeAffairs(input.publishedId, input.draftId, {
+    additiveFields: input.additiveFields ?? ABSORPTION_ADDITIVE_FIELDS,
+    auditNotes: {
+      absorbedDraft: input.draftId,
+      reason: input.reason,
+      proposedFields: Object.keys(patch),
+      // Kept because the absorbed row no longer exists to be consulted.
+      recordedDifferences: recordedDifferences.map((field) => ({
+        field,
+        absorbedValue: String(incoming[field] ?? ""),
+      })),
+    },
+  });
+
+  if (Object.keys(patch).length === 0) {
+    return { proposalsCreated: 0, proposedFields: [], recordedDifferences };
+  }
+
+  const source = draft.sources[0];
+  const result = await proposeAffairUpdate({
+    affairId: input.publishedId,
+    importer: "reconcile-affairs",
+    importRunId: input.importRunId,
+    patch,
+    source: (source?.sourceType ?? "PRESSE") as SourceType,
+    sourceUrl: source?.url ?? null,
+    confidence: 70,
+    rationale:
+      `Absorption d'un brouillon dans cette affaire publiée. ${input.reason}. ` +
+      `Le brouillon renseignait ces champs différemment ; l'affaire publiée n'a pas été ` +
+      `modifiée automatiquement.`,
+  });
+
+  const proposalsCreated = [
+    result.autoProposalId,
+    result.pendingProposalId,
+    result.conflictProposalId,
+  ].filter(Boolean).length;
+
+  return { proposalsCreated, proposedFields: Object.keys(patch), recordedDifferences };
+}

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -18,6 +18,8 @@ export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
 export const IMPORTER_JUDILIBRE = "judilibre";
 /** Reserved for admin-initiated proposals, so they never end up run-less. */
 export const IMPORTER_MANUAL_ADMIN = "manual-admin";
+/** Absorbing a draft into a published affair proposes rather than writes (#525). */
+export const IMPORTER_RECONCILE = "reconcile-affairs";
 
 export async function startImportRun(importer: string): Promise<string> {
   const run = await db.importRun.create({

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -75,6 +75,25 @@ export interface MatchResult {
 }
 
 /**
+ * Signals that identify a decision rather than resemble one: official numbers
+ * assigned by a court, not words a title happens to share.
+ *
+ * Only these may carry a merge across the published boundary automatically
+ * (issue #525). Title, category, date and politician proximity are resemblance:
+ * they can be right, but they cannot prove two rows describe one decision.
+ */
+export const DETERMINISTIC_MATCH_SIGNALS: ReadonlySet<string> = new Set([
+  "ecli",
+  "pourvoiNumber",
+  "caseNumbers",
+]);
+
+/** Whether a match rests on an official identifier rather than on resemblance. */
+export function isDeterministicMatch(matchedBy: string): boolean {
+  return DETERMINISTIC_MATCH_SIGNALS.has(matchedBy);
+}
+
+/**
  * Minimum share of the longer title that the shorter one must cover for
  * containment to count as a duplicate signal.
  *
@@ -184,6 +203,14 @@ export interface MatchCandidate {
   caseNumbers?: string[];
   category?: AffairCategory;
   verdictDate?: Date | null;
+  /**
+   * Set when the candidate IS an existing row, so it cannot match itself.
+   *
+   * Importers leave this empty: they match a candidate that has no row yet.
+   * Duplicate detection must set it, otherwise the ECLI branch below returns the
+   * affair's own id and stops, hiding every other signal (issue #525).
+   */
+  excludeAffairId?: string;
 }
 
 /**
@@ -231,7 +258,9 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       where: { ecli: candidate.ecli },
       select: { id: true },
     });
-    if (ecliMatch) {
+    // A self-match proves nothing and must not short-circuit: ecli is unique, so
+    // when the candidate is an existing row this lookup finds that row itself.
+    if (ecliMatch && ecliMatch.id !== candidate.excludeAffairId) {
       matches.push({
         affairId: ecliMatch.id,
         confidence: "CERTAIN",
@@ -252,6 +281,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of pourvoiMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       matches.push({
         affairId: match.id,
         confidence: "HIGH",
@@ -271,6 +301,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of caseNumberMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       // Avoid duplicating matches already found by pourvoi
       if (!matches.some((m) => m.affairId === match.id)) {
         matches.push({
@@ -306,6 +337,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
     });
 
     for (const existing of samePoliticianAffairs) {
+      if (existing.id === candidate.excludeAffairId) continue;
       if (matches.some((m) => m.affairId === existing.id)) continue;
 
       const normalizedExisting = normalizeAffairTitle(existing.title, politicianName);
@@ -360,6 +392,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of categoryDateMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       if (!matches.some((m) => m.affairId === match.id)) {
         matches.push({
           affairId: match.id,

--- a/src/services/affairs/merge-decision.ts
+++ b/src/services/affairs/merge-decision.ts
@@ -1,0 +1,181 @@
+/**
+ * What may be done with a detected duplicate pair, and by whom.
+ *
+ * Detection was widened to published affairs (issue #525), which means the same
+ * queue now holds pairs that may be folded by a cron and pairs that must never
+ * be touched without a human. Keeping that judgement in one pure function makes
+ * it testable and keeps the rule out of the executor.
+ *
+ * The asymmetry is deliberate: a wrong merge between drafts costs a re-split of
+ * material nobody has read, while a wrong merge involving a published affair
+ * deletes a page, mixes two sets of judicial facts about a named person, and
+ * retires a URL. So automation stops at the published boundary unless an official
+ * identifier proves the two rows describe one decision.
+ */
+
+import type { PublicationStatus, SourceType } from "@/generated/prisma";
+import { isDeterministicMatch, type MatchConfidence } from "./matching";
+
+/** Statuses this lot handles. See the issue for ARCHIVED/EXCLUDED/REJECTED. */
+const MERGEABLE_STATUSES: ReadonlySet<PublicationStatus> = new Set([
+  "DRAFT",
+  "PUBLISHED",
+] as PublicationStatus[]);
+
+export type MergeDecision =
+  | "AUTO_MERGE_DRAFTS"
+  | "AUTO_ABSORB_DRAFT_INTO_PUBLISHED"
+  | "REVIEW_REQUIRED"
+  | "NOT_ELIGIBLE";
+
+export interface MergeDecisionAffair {
+  id: string;
+  publicationStatus: PublicationStatus;
+  verifiedAt: Date | null;
+  sources: SourceType[];
+}
+
+export interface MergeDecisionInput {
+  affairA: MergeDecisionAffair;
+  affairB: MergeDecisionAffair;
+  confidence: MatchConfidence;
+  matchedBy: string;
+  /**
+   * Fields whose values rule out that the two rows describe one decision, such as
+   * verdict dates months apart. Any contradiction sends the pair to review.
+   */
+  contradictions?: string[];
+  /**
+   * Sensitive fields the two rows state differently that a merge could neither
+   * write nor turn into a proposal, so absorbing would drop a claim in silence.
+   */
+  unpropagatableDifferences?: string[];
+}
+
+export interface MergePlan {
+  decision: MergeDecision;
+  /** Survivor and absorbed, set only for the two automatic decisions. */
+  keepId?: string;
+  removeId?: string;
+  /** Why, in French: surfaced in the review queue and in the merge audit trail. */
+  reason: string;
+}
+
+/**
+ * Survivor between two drafts: the richer row, then the lower id.
+ *
+ * The id tie-break is what makes the plan deterministic. Without it the outcome
+ * would depend on which side detection happened to label A, which varies with
+ * row order (requirement 12).
+ */
+function pickDraftSurvivor(
+  a: MergeDecisionAffair,
+  b: MergeDecisionAffair
+): [keep: MergeDecisionAffair, remove: MergeDecisionAffair] {
+  if (a.sources.length !== b.sources.length) {
+    return a.sources.length > b.sources.length ? [a, b] : [b, a];
+  }
+  return a.id < b.id ? [a, b] : [b, a];
+}
+
+export function decideMergeAction(input: MergeDecisionInput): MergePlan {
+  const { affairA: a, affairB: b, confidence, matchedBy } = input;
+  const contradictions = input.contradictions ?? [];
+  const unpropagatable = input.unpropagatableDifferences ?? [];
+
+  if (a.id === b.id) {
+    return { decision: "NOT_ELIGIBLE", reason: "Une affaire ne peut pas fusionner avec elle-même" };
+  }
+
+  for (const affair of [a, b]) {
+    if (!MERGEABLE_STATUSES.has(affair.publicationStatus)) {
+      return {
+        decision: "NOT_ELIGIBLE",
+        reason: `Statut hors périmètre : ${affair.publicationStatus}`,
+      };
+    }
+  }
+
+  // Contradictory judicial data means the pair may not be one affair at all.
+  if (contradictions.length > 0) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: `Données judiciaires contradictoires : ${contradictions.join(", ")}`,
+    };
+  }
+
+  const confident = confidence === "CERTAIN" || confidence === "HIGH";
+  const aPublished = a.publicationStatus === "PUBLISHED";
+  const bPublished = b.publicationStatus === "PUBLISHED";
+
+  // Two published affairs: never automatic, whatever the confidence. Merging
+  // them deletes a page a reader can reach today.
+  if (aPublished && bPublished) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: "Deux affaires publiées : la fusion retire une page publique",
+    };
+  }
+
+  // One of each: absorption is directed, the published affair always survives.
+  if (aPublished !== bPublished) {
+    const published = aPublished ? a : b;
+    const draft = aPublished ? b : a;
+
+    if (!confident) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Rapprochement non concluant (${confidence}) face à une affaire publiée`,
+      };
+    }
+    if (!isDeterministicMatch(matchedBy)) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Rapprochement heuristique (${matchedBy}) : pas d'identifiant judiciaire commun`,
+      };
+    }
+    if (unpropagatable.length > 0) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Le brouillon affirme autre chose sur : ${unpropagatable.join(", ")}`,
+      };
+    }
+    // A human already validated this draft; deciding it is a duplicate is theirs.
+    if (draft.verifiedAt !== null) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: "Le brouillon a déjà été validé par une relecture humaine",
+      };
+    }
+
+    return {
+      decision: "AUTO_ABSORB_DRAFT_INTO_PUBLISHED",
+      keepId: published.id,
+      removeId: draft.id,
+      reason: `Identifiant judiciaire commun (${matchedBy}) : le brouillon est absorbé par l'affaire publiée`,
+    };
+  }
+
+  // Two drafts: nothing public is at stake.
+  if (!confident) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: `Rapprochement non concluant (${confidence})`,
+    };
+  }
+
+  const [keep, remove] = pickDraftSurvivor(a, b);
+  if (remove.verifiedAt !== null) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: "Le brouillon à absorber a déjà été validé par une relecture humaine",
+    };
+  }
+
+  return {
+    decision: "AUTO_MERGE_DRAFTS",
+    keepId: keep.id,
+    removeId: remove.id,
+    reason: `Deux brouillons rapprochés en ${confidence} (${matchedBy})`,
+  };
+}

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -28,6 +28,10 @@ function makeDraft(
     createdAt: Date;
     publicationStatus: string;
     politicianId: string;
+    verifiedAt: Date | null;
+    involvement: string;
+    factsDate: Date | null;
+    verdictDate: Date | null;
   }> = {}
 ) {
   return {
@@ -37,10 +41,13 @@ function makeDraft(
     pourvoiNumber: null,
     caseNumbers: [],
     category: overrides.category ?? "AUTRE",
-    verdictDate: null,
+    involvement: overrides.involvement ?? "DIRECT",
+    factsDate: overrides.factsDate ?? null,
+    verdictDate: overrides.verdictDate ?? null,
     politicianId: overrides.politicianId ?? "p1",
     createdAt: overrides.createdAt ?? new Date("2026-05-19T10:00:00Z"),
     publicationStatus: overrides.publicationStatus ?? "DRAFT",
+    verifiedAt: overrides.verifiedAt ?? null,
     sources: [],
   };
 }
@@ -145,5 +152,159 @@ describe("findPotentialDuplicates — draft window clustering", () => {
 
     expect(duplicates).toHaveLength(1);
     expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+  });
+});
+
+// Issue #525 — verifying an affair used to remove it from detection for good,
+// which hid every duplicate involving a published fiche.
+describe("findPotentialDuplicates — périmètre élargi (#525)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([]);
+  });
+
+  it("n'exclut plus les affaires vérifiées de la requête", async () => {
+    mockedAffairFindMany.mockResolvedValue([]);
+
+    await findPotentialDuplicates();
+
+    const where = mockedAffairFindMany.mock.calls[0]![0].where;
+    expect(where).toEqual({ publicationStatus: { in: ["DRAFT", "PUBLISHED"] } });
+    expect(where).not.toHaveProperty("verifiedAt");
+  });
+
+  it("fait participer une affaire publiée et vérifiée à la détection", async () => {
+    const verifiedPublished = makeDraft("pub", {
+      publicationStatus: "PUBLISHED",
+      verifiedAt: new Date("2026-01-01"),
+      title: "Condamnation pour recel",
+    });
+    mockedAffairFindMany.mockResolvedValue([
+      verifiedPublished,
+      makeDraft("draft", { title: "Condamnation pour recel" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "pub", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    const summaries = [duplicates[0]!.affairA, duplicates[0]!.affairB];
+    const published = summaries.find((s) => s.id === "pub")!;
+    expect(published.publicationStatus).toBe("PUBLISHED");
+    expect(published.verifiedAt).toEqual(new Date("2026-01-01"));
+  });
+
+  it("appelle le matcher une fois par affaire, pas une fois par paire", async () => {
+    // 4 affaires d'une même personnalité : 6 paires, mais 4 appels suffisent.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1"),
+      makeDraft("a2"),
+      makeDraft("a3"),
+      makeDraft("a4"),
+    ]);
+
+    await findPotentialDuplicates();
+
+    expect(mockedFindMatchingAffairs).toHaveBeenCalledTimes(4);
+  });
+
+  it("passe excludeAffairId pour qu'une affaire ne se rapproche pas d'elle-même", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+
+    await findPotentialDuplicates();
+
+    for (const call of mockedFindMatchingAffairs.mock.calls) {
+      expect(call[0].excludeAffairId).toBeDefined();
+    }
+  });
+
+  it("ignore un self-match même si le matcher en renvoie un", async () => {
+    // Catégories de familles incompatibles, pour que seul le 1er passage joue.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { category: "MENACE" }),
+      makeDraft("a2", { category: "FRAUDE_FISCALE" }),
+    ]);
+    mockedFindMatchingAffairs.mockImplementation(
+      ({ excludeAffairId }: { excludeAffairId: string }) =>
+        Promise.resolve([
+          { affairId: excludeAffairId, confidence: "CERTAIN", score: 1, matchedBy: "ecli" },
+        ])
+    );
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("ne remonte pas un faux positif déjà écarté", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED" }),
+      makeDraft("a2", { publicationStatus: "PUBLISHED" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+    // Enregistré dans l'autre sens : la clé canonique doit quand même l'exclure.
+    mockedDismissedFindMany.mockResolvedValue([{ affairIdA: "a2", affairIdB: "a1" }]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("signale une contradiction de date de verdict sur la paire", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        publicationStatus: "PUBLISHED",
+        verdictDate: new Date("2020-01-01"),
+      }),
+      makeDraft("a2", { verdictDate: new Date("2024-06-01") }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates[0]!.contradictions).toContain("verdictDate");
+  });
+
+  it("signale un involvement divergent comme non transférable", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED", involvement: "MENTIONED_ONLY" }),
+      makeDraft("a2", { involvement: "DIRECT" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates[0]!.unpropagatableDifferences).toContain("involvement");
+  });
+
+  it("produit la même paire quel que soit le sens du rapprochement", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("zzz"), makeDraft("aaa")]);
+    // Chaque côté rapproche l'autre, avec des scores différents : le meilleur gagne.
+    mockedFindMatchingAffairs.mockImplementation(
+      ({ excludeAffairId }: { excludeAffairId: string }) =>
+        Promise.resolve(
+          excludeAffairId === "zzz"
+            ? [{ affairId: "aaa", confidence: "POSSIBLE", score: 0.3, matchedBy: "title-partial" }]
+            : [{ affairId: "zzz", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" }]
+        )
+    );
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.score).toBe(0.95);
+    expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+    // Ordre canonique : le plus petit id en A.
+    expect(duplicates[0]!.affairA.id).toBe("aaa");
+    expect(duplicates[0]!.affairB.id).toBe("zzz");
   });
 });

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -6,8 +6,19 @@
  */
 
 import { db } from "@/lib/db";
-import { Prisma, type SourceType } from "@/generated/prisma";
-import { findMatchingAffairs, sameCategoryFamily, type MatchConfidence } from "./matching";
+import {
+  Prisma,
+  type AffairCategory,
+  type PublicationStatus,
+  type SourceType,
+} from "@/generated/prisma";
+import {
+  findMatchingAffairs,
+  sameCategoryFamily,
+  verdictDatesConflict,
+  type MatchConfidence,
+  type MatchResult,
+} from "./matching";
 
 // ============================================
 // TYPES
@@ -17,6 +28,10 @@ export interface AffairSummary {
   id: string;
   title: string;
   sources: SourceType[];
+  /** Needed by decideMergeAction: automation stops at the published boundary. */
+  publicationStatus: PublicationStatus;
+  /** A verified affair is never deleted automatically (issue #525). */
+  verifiedAt: Date | null;
 }
 
 export interface PotentialDuplicate {
@@ -25,6 +40,10 @@ export interface PotentialDuplicate {
   confidence: MatchConfidence;
   matchedBy: string;
   score: number;
+  /** Judicial values that rule out the two rows describing one decision. */
+  contradictions: string[];
+  /** Differences a merge could neither write nor turn into a proposal. */
+  unpropagatableDifferences: string[];
 }
 
 export interface ReconciliationStats {
@@ -45,15 +64,99 @@ export interface ReconciliationStats {
 const DRAFT_CLUSTER_WINDOW_DAYS = 14;
 
 /**
- * Find potential duplicate pairs among unverified affairs.
+ * Statuses duplicate detection covers.
  *
- * Groups affairs by politician, then compares each pair using
- * the existing matching algorithm.
+ * Named explicitly rather than expressed as "everything except rejected", so
+ * adding a status to the enum cannot silently widen the queue. Left out for this
+ * lot: REJECTED (a moderator already ruled), EXCLUDED (a wrong exclusion is a
+ * moderation audit, not duplicate detection) and ARCHIVED (needs the reason for
+ * archiving to be read). Auditing those is a separate historical pass.
+ */
+const DETECTED_PUBLICATION_STATUSES = ["DRAFT", "PUBLISHED"] as const;
+
+/**
+ * Canonical key for an unordered pair.
+ *
+ * Every store and every exclusion goes through this, so (A, B) and (B, A) can
+ * never produce two rows for one pair.
+ */
+export function canonicalPair(idA: string, idB: string): { a: string; b: string; key: string } {
+  const [a, b] = [idA, idB].sort();
+  return { a: a!, b: b!, key: `${a}:${b}` };
+}
+
+type DetectedAffair = {
+  id: string;
+  title: string;
+  ecli: string | null;
+  pourvoiNumber: string | null;
+  caseNumbers: string[];
+  category: string;
+  involvement: string;
+  factsDate: Date | null;
+  verdictDate: Date | null;
+  politicianId: string;
+  createdAt: Date;
+  publicationStatus: PublicationStatus;
+  verifiedAt: Date | null;
+  sources: { sourceType: SourceType }[];
+};
+
+/** Judicial values that rule out the two rows being one decision. */
+function findContradictions(a: DetectedAffair, b: DetectedAffair): string[] {
+  const contradictions: string[] = [];
+  if (verdictDatesConflict(a.verdictDate, b.verdictDate)) contradictions.push("verdictDate");
+  if (a.ecli && b.ecli && a.ecli !== b.ecli) contradictions.push("ecli");
+  if (a.pourvoiNumber && b.pourvoiNumber && a.pourvoiNumber !== b.pourvoiNumber) {
+    contradictions.push("pourvoiNumber");
+  }
+  return contradictions;
+}
+
+/**
+ * Differences a merge could neither write nor propose, so absorbing would drop
+ * the claim in silence.
+ *
+ * `involvement` says what the person is accused of being, and `factsDate` says
+ * when: both are outside the proposal whitelist, so a disagreement has to stop
+ * automation. Title, description and category are left out on purpose — the
+ * surviving published fiche is the authoritative wording, and the merge audit
+ * trail records what the absorbed row said.
+ */
+function findUnpropagatableDifferences(a: DetectedAffair, b: DetectedAffair): string[] {
+  const differences: string[] = [];
+  if (a.involvement !== b.involvement) differences.push("involvement");
+  const factsA = a.factsDate?.getTime() ?? null;
+  const factsB = b.factsDate?.getTime() ?? null;
+  if (factsA !== null && factsB !== null && factsA !== factsB) differences.push("factsDate");
+  return differences;
+}
+
+function toSummary(affair: DetectedAffair): AffairSummary {
+  return {
+    id: affair.id,
+    title: affair.title,
+    sources: [...new Set(affair.sources.map((s) => s.sourceType))],
+    publicationStatus: affair.publicationStatus,
+    verifiedAt: affair.verifiedAt,
+  };
+}
+
+/**
+ * Find potential duplicate pairs among drafts and published affairs.
+ *
+ * Verifying an affair used to remove it from detection for good, which hid every
+ * duplicate involving a published fiche — the blind spot of issue #525. Scope is
+ * now publication status, not review state.
+ *
+ * Widening the outer loop made the previous shape untenable: findMatchingAffairs
+ * was called once per pair although it only depends on one side, so a politician
+ * with n affairs cost n(n-1)/2 calls where n suffice. It is now called once per
+ * affair and the results are folded into pairs.
  */
 export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
-  // Load all unverified affairs
   const affairs = await db.affair.findMany({
-    where: { verifiedAt: null },
+    where: { publicationStatus: { in: [...DETECTED_PUBLICATION_STATUSES] } },
     select: {
       id: true,
       title: true,
@@ -61,73 +164,87 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       pourvoiNumber: true,
       caseNumbers: true,
       category: true,
+      involvement: true,
+      factsDate: true,
       verdictDate: true,
       politicianId: true,
       createdAt: true,
       publicationStatus: true,
+      verifiedAt: true,
       sources: { select: { sourceType: true } },
     },
   });
 
-  // Load dismissed pairs to exclude
   const dismissed = await db.dismissedDuplicate.findMany({
     select: { affairIdA: true, affairIdB: true },
   });
-  const dismissedSet = new Set(dismissed.map((d) => [d.affairIdA, d.affairIdB].sort().join(":")));
+  const dismissedSet = new Set(dismissed.map((d) => canonicalPair(d.affairIdA, d.affairIdB).key));
 
-  // Group by politician
-  const byPolitician = new Map<string, typeof affairs>();
+  const byId = new Map(affairs.map((a) => [a.id, a as DetectedAffair]));
+
+  const byPolitician = new Map<string, DetectedAffair[]>();
   for (const affair of affairs) {
     const list = byPolitician.get(affair.politicianId) ?? [];
-    list.push(affair);
+    list.push(affair as DetectedAffair);
     byPolitician.set(affair.politicianId, list);
   }
 
-  const duplicates: PotentialDuplicate[] = [];
+  // Best result per pair. Both sides of a pair can produce a match, and they can
+  // disagree, so the winner is picked on score then on matchedBy — never on which
+  // side was queried first, which would make the output order-dependent.
+  const best = new Map<string, PotentialDuplicate>();
+
+  function record(a: DetectedAffair, b: DetectedAffair, match: MatchResult) {
+    const { a: idA, key } = canonicalPair(a.id, b.id);
+    if (dismissedSet.has(key)) return;
+
+    const first = idA === a.id ? a : b;
+    const second = idA === a.id ? b : a;
+    const candidate: PotentialDuplicate = {
+      affairA: toSummary(first),
+      affairB: toSummary(second),
+      confidence: match.confidence,
+      matchedBy: match.matchedBy,
+      score: match.score,
+      contradictions: findContradictions(first, second),
+      unpropagatableDifferences: findUnpropagatableDifferences(first, second),
+    };
+
+    const existing = best.get(key);
+    if (
+      !existing ||
+      candidate.score > existing.score ||
+      (candidate.score === existing.score && candidate.matchedBy < existing.matchedBy)
+    ) {
+      best.set(key, candidate);
+    }
+  }
 
   for (const group of byPolitician.values()) {
     if (group.length < 2) continue;
 
-    // Compare each pair within the same politician
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        const a = group[i];
-        const b = group[j];
+    for (const affair of group) {
+      const matches = await findMatchingAffairs({
+        politicianId: affair.politicianId,
+        title: affair.title,
+        ecli: affair.ecli,
+        pourvoiNumber: affair.pourvoiNumber,
+        caseNumbers: affair.caseNumbers,
+        category: affair.category as AffairCategory,
+        verdictDate: affair.verdictDate,
+        // Without this the affair matches itself, and the ECLI branch would
+        // return that self-match alone and hide every other signal.
+        excludeAffairId: affair.id,
+      });
 
-        // Skip if already dismissed
-        const pairKey = [a!.id, b!.id].sort().join(":");
-        if (dismissedSet.has(pairKey)) continue;
-
-        // Use affair B as a candidate to match against A
-        const matches = await findMatchingAffairs({
-          politicianId: b!.politicianId,
-          title: b!.title,
-          ecli: b!.ecli,
-          pourvoiNumber: b!.pourvoiNumber,
-          caseNumbers: b!.caseNumbers,
-          category: b!.category,
-          verdictDate: b!.verdictDate,
-        });
-
-        // Check if affair A appears in the matches
-        const matchForA = matches.find((m) => m.affairId === a!.id);
-        if (matchForA) {
-          duplicates.push({
-            affairA: {
-              id: a!.id,
-              title: a!.title,
-              sources: [...new Set(a!.sources.map((s) => s.sourceType))],
-            },
-            affairB: {
-              id: b!.id,
-              title: b!.title,
-              sources: [...new Set(b!.sources.map((s) => s.sourceType))],
-            },
-            confidence: matchForA.confidence,
-            matchedBy: matchForA.matchedBy,
-            score: matchForA.score,
-          });
-        }
+      for (const match of matches) {
+        // Belt and braces: excludeAffairId already prevents this, but a self-pair
+        // must never reach the queue if a matcher path ever stops honouring it.
+        if (match.affairId === affair.id) continue;
+        const other = byId.get(match.affairId);
+        // Outside the detected scope, e.g. a rejected affair.
+        if (!other) continue;
+        record(affair, other, match);
       }
     }
   }
@@ -139,8 +256,6 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
   // cannot catch. Pair drafts of the same politician created within
   // DRAFT_CLUSTER_WINDOW_DAYS when their categories share a family.
   // POSSIBLE only (score 0.45): never auto-merged, surfaced for human review.
-  const foundPairs = new Set(duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join(":")));
-
   for (const group of byPolitician.values()) {
     const draftGroup = group.filter((a) => a.publicationStatus === "DRAFT");
     if (draftGroup.length < 2) continue;
@@ -150,37 +265,26 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
         const a = draftGroup[i]!;
         const b = draftGroup[j]!;
 
-        const pairKey = [a.id, b.id].sort().join(":");
-        if (dismissedSet.has(pairKey) || foundPairs.has(pairKey)) continue;
+        const { key } = canonicalPair(a.id, b.id);
+        if (dismissedSet.has(key) || best.has(key)) continue;
+        if (!sameCategoryFamily(a.category, b.category)) continue;
 
         const daysApart =
           Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);
         if (daysApart > DRAFT_CLUSTER_WINDOW_DAYS) continue;
-        if (!sameCategoryFamily(a.category, b.category)) continue;
 
-        foundPairs.add(pairKey);
-        duplicates.push({
-          affairA: {
-            id: a.id,
-            title: a.title,
-            sources: [...new Set(a.sources.map((s) => s.sourceType))],
-          },
-          affairB: {
-            id: b.id,
-            title: b.title,
-            sources: [...new Set(b.sources.map((s) => s.sourceType))],
-          },
+        record(a, b, {
+          affairId: b.id,
           confidence: "POSSIBLE",
-          matchedBy: "politician+category+window",
           score: 0.45,
+          matchedBy: "politician+category+window",
         });
       }
     }
   }
 
-  // Sort by score descending (most confident first)
-  duplicates.sort((a, b) => b.score - a.score);
-  return duplicates;
+  // Most confident first.
+  return [...best.values()].sort((a, b) => b.score - a.score);
 }
 
 // ============================================
@@ -194,9 +298,37 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
  */
 const ADDITIVE_MERGE_FIELDS = ["ecli", "pourvoiNumber", "court", "chamber", "caseNumber"] as const;
 
+export type AdditiveMergeField = (typeof ADDITIVE_MERGE_FIELDS)[number];
+
+/**
+ * What an automatic absorption into a published affair may fill: court-assigned
+ * identifiers only.
+ *
+ * `court` and `chamber` are left out although they would only fill a gap, because
+ * they describe the jurisdiction rather than identify the decision. Both are in
+ * the proposal whitelist, so the draft's value reaches the published fiche
+ * through review instead of a cron write (issue #525, §4).
+ */
+export const ABSORPTION_ADDITIVE_FIELDS: readonly AdditiveMergeField[] = [
+  "ecli",
+  "pourvoiNumber",
+  "caseNumber",
+];
+
 export interface MergeAffairsOptions {
   /** Request context, when the merge is human-initiated from the admin. */
   audit?: { ipAddress?: string | null; userAgent?: string | null };
+  /**
+   * Restricts which fields the survivor may have filled from the absorbed affair.
+   * Defaults to the full additive set, which is right for a human-initiated merge
+   * and for two drafts. Absorption into a published affair narrows it.
+   */
+  additiveFields?: readonly AdditiveMergeField[];
+  /**
+   * Recorded verbatim in the merge audit trail, to keep what the absorbed affair
+   * stated and could not be carried over. Nothing is dropped silently.
+   */
+  auditNotes?: Prisma.InputJsonValue;
 }
 
 export interface MergeAffairsResult {
@@ -342,7 +474,7 @@ export async function mergeAffairs(
     // --- Additive field fill, plus the absorbed affair's URLs.
     const updates: Prisma.AffairUpdateInput = {};
     const identifiersMerged: string[] = [];
-    for (const field of ADDITIVE_MERGE_FIELDS) {
+    for (const field of options.additiveFields ?? ADDITIVE_MERGE_FIELDS) {
       if (!keep[field] && remove[field]) {
         updates[field] = remove[field];
         identifiersMerged.push(field);
@@ -404,6 +536,7 @@ export async function mergeAffairs(
           articlesMoved,
           identifiersMerged,
           slugsPreserved,
+          ...(options.auditNotes ? { notes: options.auditNotes } : {}),
         },
         ipAddress: options.audit?.ipAddress ?? null,
         userAgent: options.audit?.userAgent ?? null,

--- a/src/services/sync/reconcile-affairs.ts
+++ b/src/services/sync/reconcile-affairs.ts
@@ -1,11 +1,21 @@
 /**
  * Affair reconciliation service.
  *
- * Detects potential duplicate affairs from different sources
- * and auto-merges high-confidence duplicates.
+ * Detects potential duplicate affairs and folds the ones automation is allowed to
+ * fold. Since detection was widened to published affairs (issue #525), the queue
+ * mixes pairs a cron may merge with pairs that must never move without a human, so
+ * every pair goes through decideMergeAction() first.
  */
 
-import { findPotentialDuplicates, mergeAffairs } from "@/services/affairs/reconciliation";
+import {
+  findPotentialDuplicates,
+  mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS,
+  type PotentialDuplicate,
+} from "@/services/affairs/reconciliation";
+import { decideMergeAction, type MergeDecision } from "@/services/affairs/merge-decision";
+import { absorbDraftIntoPublished } from "@/services/affairs/absorb-draft";
+import { withImportRun, IMPORTER_RECONCILE } from "@/services/affairs/import-run";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,9 +28,25 @@ export interface ReconcileAffairsOptions {
 
 export interface ReconcileAffairsStats {
   duplicatesFound: number;
+  /** Draft pairs folded together. */
   merged: number;
+  /** Drafts absorbed by a published affair on a court-assigned identifier. */
+  absorbed: number;
+  /** Pairs left for a human, by reason. */
+  reviewRequired: number;
+  notEligible: number;
+  /** Proposals opened because a draft stated something the published fiche did not. */
+  proposalsCreated: number;
   errors: number;
   remainingPossible: number;
+}
+
+interface PlannedPair {
+  pair: PotentialDuplicate;
+  decision: MergeDecision;
+  keepId?: string;
+  removeId?: string;
+  reason: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,43 +60,78 @@ export async function reconcileAffairs(
 
   const duplicates = await findPotentialDuplicates();
 
-  if (duplicates.length === 0) {
-    return { duplicatesFound: 0, merged: 0, errors: 0, remainingPossible: 0 };
-  }
+  const empty: ReconcileAffairsStats = {
+    duplicatesFound: 0,
+    merged: 0,
+    absorbed: 0,
+    reviewRequired: 0,
+    notEligible: 0,
+    proposalsCreated: 0,
+    errors: 0,
+    remainingPossible: 0,
+  };
+  if (duplicates.length === 0) return empty;
 
-  let merged = 0;
-  let errors = 0;
+  const planned: PlannedPair[] = duplicates.map((pair) => {
+    const plan = decideMergeAction(pair);
+    return { pair, ...plan };
+  });
 
-  if (autoMerge) {
-    const mergeable = duplicates.filter(
-      (d) => d.confidence === "CERTAIN" || d.confidence === "HIGH"
-    );
+  const stats: ReconcileAffairsStats = {
+    ...empty,
+    duplicatesFound: duplicates.length,
+    reviewRequired: planned.filter((p) => p.decision === "REVIEW_REQUIRED").length,
+    notEligible: planned.filter((p) => p.decision === "NOT_ELIGIBLE").length,
+    remainingPossible: duplicates.filter((d) => d.confidence === "POSSIBLE").length,
+  };
 
-    for (const dup of mergeable) {
-      const keepId =
-        dup.affairA.sources.length >= dup.affairB.sources.length ? dup.affairA.id : dup.affairB.id;
-      const removeId = keepId === dup.affairA.id ? dup.affairB.id : dup.affairA.id;
+  if (!autoMerge) return stats;
 
-      if (dryRun) {
-        merged++;
-        continue;
-      }
+  const draftMerges = planned.filter((p) => p.decision === "AUTO_MERGE_DRAFTS");
+  const absorptions = planned.filter((p) => p.decision === "AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
 
-      try {
-        await mergeAffairs(keepId, removeId);
-        merged++;
-      } catch {
-        errors++;
-      }
+  for (const plan of draftMerges) {
+    if (dryRun) {
+      stats.merged++;
+      continue;
+    }
+    try {
+      await mergeAffairs(plan.keepId!, plan.removeId!, {
+        auditNotes: { decision: plan.decision, reason: plan.reason },
+      });
+      stats.merged++;
+    } catch {
+      stats.errors++;
     }
   }
 
-  const remainingPossible = duplicates.filter((d) => d.confidence === "POSSIBLE").length;
+  if (absorptions.length === 0) return stats;
 
-  return {
-    duplicatesFound: duplicates.length,
-    merged,
-    errors,
-    remainingPossible,
-  };
+  if (dryRun) {
+    stats.absorbed += absorptions.length;
+    return stats;
+  }
+
+  // Proposals must belong to a run, so one is opened only when an absorption
+  // actually has to write something (issue #513 invariant).
+  await withImportRun(IMPORTER_RECONCILE, async ({ importRunId, setStats }) => {
+    for (const plan of absorptions) {
+      try {
+        const result = await absorbDraftIntoPublished({
+          publishedId: plan.keepId!,
+          draftId: plan.removeId!,
+          importRunId,
+          reason: plan.reason,
+          additiveFields: ABSORPTION_ADDITIVE_FIELDS,
+        });
+        stats.absorbed++;
+        stats.proposalsCreated += result.proposalsCreated;
+      } catch {
+        stats.errors++;
+      }
+    }
+    setStats({ absorbed: stats.absorbed, proposalsCreated: stats.proposalsCreated });
+  });
+
+  return stats;
 }


### PR DESCRIPTION
## Description

Part of #525. **PR 2 sur 3**. Remplace #527, fermée automatiquement lorsque sa branche de base a été supprimée au merge de #526 ; le contenu est identique, rebasé sur `main`.

Corrige l'angle mort de la détection sans exposer les affaires publiées à des fusions heuristiques.

### L'angle mort

`findPotentialDuplicates()` ne chargeait que `verifiedAt: null`, et une paire n'est comparée que si **les deux** côtés sont dans l'ensemble chargé. Valider une affaire la retirait donc définitivement de la détection : **426 affaires sur 466 étaient hors du champ, dont 327 publiées**. L'angle mort grandissait à chaque session de modération.

Le périmètre est désormais le statut de publication, pas l'état de relecture :

```ts
where: { publicationStatus: { in: ["DRAFT", "PUBLISHED"] } }
```

Énuméré explicitement, et non exprimé comme « tout sauf rejeté », pour qu'ajouter une valeur à l'enum n'élargisse pas la file en silence. `REJECTED`, `EXCLUDED` et `ARCHIVED` restent dehors : auditer ces états demande de lire le motif du retrait, c'est une passe historique distincte.

### Élargir imposait de corriger deux défauts d'abord

**Le self-match ECLI.** `findMatchingAffairs` faisait `return matches` dès qu'un ECLI correspondait. Appelée avec les données d'une affaire existante, elle se retrouvait elle-même et retournait ce seul self-match, masquant tous les autres signaux. `MatchCandidate` reçoit un `excludeAffairId`, appliqué aux cinq priorités et non à la seule branche ECLI. Les importeurs ne le passent pas : ils rapprochent un candidat qui n'a pas encore de ligne.

**Un appel par paire au lieu d'un par affaire.** `findMatchingAffairs(b)` était appelée dans la boucle interne alors qu'elle ne dépend pas de `a`.

| | Paires candidates | Appels |
| --- | --- | --- |
| avant | 25 | 25 |
| élargi, forme précédente | 929 | 929 |
| élargi, appel hissé | 929 | **356** |

### La décision de fusion, isolée et pure

`decideMergeAction()` (`merge-decision.ts`) tranche par paire. La même file mêle maintenant des brouillons qu'un cron peut replier et des fiches publiques qu'aucune heuristique ne doit supprimer.

| Paire | Automatique ? | Condition |
| --- | --- | --- |
| `DRAFT + DRAFT` | oui | `CERTAIN` ou `HIGH`, survivant déterministe |
| `DRAFT + PUBLISHED` | absorption dirigée | **identifiant judiciaire commun** exigé |
| `PUBLISHED + PUBLISHED` | **jamais** | toujours en revue, même en `CERTAIN` |
| affaire vérifiée | jamais supprimée | peut rester survivante si publiée |

Sont déterministes `ecli`, `pourvoiNumber` et `caseNumbers` : des numéros attribués par une juridiction. Titre, catégorie, date et proximité de personnalité sont de la ressemblance, jamais une preuve.

Toute contradiction judiciaire (dates de verdict écartées, identifiants divergents) envoie la paire en revue quelle que soit la confiance.

**Le sens de la fusion ne dépend jamais du nombre de sources** quand une affaire publiée est concernée : elle survit toujours. Entre deux brouillons, le survivant est le plus riche, puis le plus petit id, pour que le plan ne dépende pas de l'ordre des lignes.

### L'absorption propose, elle ne réécrit pas

`absorbDraftIntoPublished()` transfère l'additif et **rien d'autre** : sources, événements, liens d'articles, et les seuls identifiants attribués par une juridiction (`ABSORPTION_ADDITIVE_FIELDS`).

`court` et `chamber` en sont exclus, bien qu'ils ne feraient que combler un vide : ils décrivent la juridiction sans identifier la décision. Ils sont dans le whitelist de propositions, donc la valeur du brouillon atteint la fiche publiée par la revue, pas par un cron.

Tout ce que le brouillon affirme sur l'issue judiciaire part dans une `AffairUpdateProposal` : `status`, `verdictDate`, `court`, `sentence`, peines structurées.

### Ce qui ne peut être ni transféré ni proposé

`involvement` et `factsDate` sont hors du whitelist de #513. Une divergence sur ces champs **bloque** l'absorption et passe en revue : `involvement` dit ce dont la personne est accusée d'être, le perdre en silence serait grave.

`title`, `description` et `category` ne bloquent pas, parce que la fiche publiée est la formulation de référence une fois la paire prouvée. Leur valeur absorbée part dans la piste d'audit de la fusion, pour qu'elle reste consultable après suppression de la ligne.

### Effet mesuré sur la base réelle

Essai à blanc, `autoMerge` activé :

```
paires détectées : 12   (12,7 s)
  DRAFT + DRAFT           9
  PUBLISHED + PUBLISHED   3   ← nouvellement visibles

par décision :
  REVIEW_REQUIRED        12
  AUTO_MERGE_DRAFTS       0
  AUTO_ABSORB…            0
```

**Aucune action automatique.** Les 3 paires nouvellement visibles sont réelles et concernent des pages publiques :

- deux condamnations définitives d'une même personne **partageant un numéro de pourvoi** (`HIGH`), donc deux chefs d'une même décision. C'est le seul identifiant déterministe présent dans la base, et la paire passe malgré tout en revue puisque les deux fiches sont publiées : la frontière tient.
- « Affaire Sarkozy-Kadhafi » et sa fiche « Rétractation de Ziad Takieddine », probablement deux volets d'un même dossier.
- deux fiches d'une même affaire de corruption, l'une descriptive et l'autre laconique, avec des dates de verdict contradictoires — signalées comme telles.

Ces trois paires étaient structurellement invisibles avant cette PR.

**Correction d'un chiffre que j'avais avancé dans l'issue** : j'estimais 117 paires candidates à examiner. C'était un signal bon marché de mon cru (famille de catégories plus vocabulaire partagé), bien plus permissif que `findMatchingAffairs`. Le vrai matcher en retient 12.

### Identifiants déterministes : quasi absents de la base

| Signal | Affaires |
| --- | --- |
| `ecli` | 0 |
| `caseNumbers` | 0 |
| `pourvoiNumber` | 3, dont 1 groupe partagé |

`ecli` est par ailleurs `@unique` : deux lignes ne peuvent pas porter le même. L'absorption automatique ne se déclenchera donc jamais sur les données actuelles. Le chemin est construit pour une réactivation de Judilibre, et pour l'instant l'effet de l'élargissement est de **remplir la file de revue**, ce qui est l'intention.

## Type de changement

- [x] Bug fix

## Issue liée

Part of #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre
- **2301 tests** passés, 0 échec (2270 sur `main` après #526)
- 31 tests ajoutés, couvrant les 12 cas demandés dans l'issue
- Comportement vérifié à blanc sur la base réelle : 12 paires, 0 fusion automatique

## Points de revue

**Un défaut trouvé par un test existant.** Le garde `excludeAffairId` suffit en production, mais un matcher qui cesserait de l'honorer aurait fait entrer une paire d'une affaire avec elle-même dans la file. La boucle de détection écarte désormais le self-match indépendamment du matcher.

**La détection prend 12,7 s** contre un temps négligeable avant, pour environ 1800 requêtes. Acceptable dans un cron quotidien, à surveiller si la base grossit. Sans le hissage de l'appel ce serait le triple.

**Les deux fonctions d'analyse de paire restent volontairement étroites.** Les contradictions se limitent aux dates de verdict et aux identifiants divergents ; les divergences bloquantes à `involvement` et `factsDate`. Élargir ces listes bloquerait des absorptions légitimes sans preuve que ça évite une erreur.

**`PotentialDuplicate` gagne quatre champs.** `publicationStatus` et `verifiedAt` sur chaque côté, plus `contradictions` et `unpropagatableDifferences`. Ajout seulement : les consommateurs existants (préflight, scripts) ne changent pas.

## Ordre de fusion

#524 (issue #521) touche aussi le second passage de `findPotentialDuplicates`, sur une région distincte. L'une ou l'autre en premier, mais pas en parallèle.

## Suite

PR 3 : file de revue groupée par personnalité, classification `DUPLICATE` / `LINKED` / `DISTINCT` / `UNCERTAIN` via `AffairPairDecision`, et mesure de précision sur échantillon stratifié.
