### PR TITLE
Ajouter la file de revue des doublons et la mémoire des jugements

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Politician {
   contactTwitter  String?
   contactFacebook String?
   contactWebsite  String?
-  contactOverride Boolean  @default(false) // true = don't overwrite from sync
+  contactOverride Boolean @default(false) // true = don't overwrite from sync
 
   // AI-generated biography
   biography            String?   @db.Text
@@ -73,23 +73,23 @@ model Politician {
   currentPartyId String?
 
   // Relations
-  mandates          Mandate[]
-  affairs           Affair[]
-  declarations      Declaration[]
-  partyHistory      PartyMembership[]
-  externalIds       ExternalId[] // IDs from all external sources
-  votes             Vote[] // Parliamentary votes
-  pressMentions     PressArticleMention[] // Mentions in press articles
-  pressRejections   PressAnalysisRejection[] // Low-confidence press analysis rejections
-  factCheckMentions FactCheckMention[] // Mentions in fact-checks
-  promises          Promise[] // Tracker promesses 2027 (Q4 prototype)
-  candidacies       Candidacy[] // Election candidacies
-  candidates        Candidate[] // Local election candidates linked to this politician
-  participation       PoliticianParticipation? // Pre-computed participation stats
-  identityDecisions   IdentityDecision[] // Identity resolution audit trail
+  mandates                  Mandate[]
+  affairs                   Affair[]
+  declarations              Declaration[]
+  partyHistory              PartyMembership[]
+  externalIds               ExternalId[] // IDs from all external sources
+  votes                     Vote[] // Parliamentary votes
+  pressMentions             PressArticleMention[] // Mentions in press articles
+  pressRejections           PressAnalysisRejection[] // Low-confidence press analysis rejections
+  factCheckMentions         FactCheckMention[] // Mentions in fact-checks
+  promises                  Promise[] // Tracker promesses 2027 (Q4 prototype)
+  candidacies               Candidacy[] // Election candidacies
+  candidates                Candidate[] // Local election candidates linked to this politician
+  participation             PoliticianParticipation? // Pre-computed participation stats
+  identityDecisions         IdentityDecision[] // Identity resolution audit trail
   affairPoliticianDecisions AffairPoliticianDecision[] @relation("AffairDecisionPolitician")
-  newsletterEditions  NewsletterEdition[] // Weeks featured as "politician of the week"
-  dossierAuthors      DossierAuthor[] // Dossiers authored/initiated by this politician
+  newsletterEditions        NewsletterEdition[] // Weeks featured as "politician of the week"
+  dossierAuthors            DossierAuthor[] // Dossiers authored/initiated by this politician
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -121,11 +121,11 @@ model ExternalId {
   url        String? // Direct URL to the source page
 
   // Identity resolution metadata
-  confidence  Float?        // 0.0 to 1.0 matching confidence
-  matchedBy   MatchMethod?  // How the link was established
-  verifiedAt  DateTime?     // Manual validation timestamp
-  verifiedBy  String?       // Who validated ("admin:ldiaby")
-  metadata    Json?         // Free-form context { birthDateMatch, deptMatch, etc. }
+  confidence Float? // 0.0 to 1.0 matching confidence
+  matchedBy  MatchMethod? // How the link was established
+  verifiedAt DateTime? // Manual validation timestamp
+  verifiedBy String? // Who validated ("admin:ldiaby")
+  metadata   Json? // Free-form context { birthDateMatch, deptMatch, etc. }
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -138,19 +138,19 @@ model ExternalId {
 
 // Audit trail for identity matching decisions
 model IdentityDecision {
-  id            String      @id @default(cuid())
-  sourceType    DataSource
-  sourceId      String      // The external ID or source identifier
-  politicianId  String
-  judgement     Judgement
-  confidence    Float       // 0.0 to 1.0
-  method        MatchMethod
-  evidence      Json        // { birthDateMatch: false, deptMatch: true, nameScore: 0.95 }
-  decidedBy     String      // "system:sync-rne" or "admin:ldiaby"
-  decidedAt     DateTime    @default(now())
-  supersededBy  String?     // ID of the decision that replaces this one
+  id           String      @id @default(cuid())
+  sourceType   DataSource
+  sourceId     String // The external ID or source identifier
+  politicianId String
+  judgement    Judgement
+  confidence   Float // 0.0 to 1.0
+  method       MatchMethod
+  evidence     Json // { birthDateMatch: false, deptMatch: true, nameScore: 0.95 }
+  decidedBy    String // "system:sync-rne" or "admin:ldiaby"
+  decidedAt    DateTime    @default(now())
+  supersededBy String? // ID of the decision that replaces this one
 
-  politician    Politician  @relation(fields: [politicianId], references: [id], onDelete: Cascade)
+  politician Politician @relation(fields: [politicianId], references: [id], onDelete: Cascade)
 
   @@index([sourceType, sourceId])
   @@index([politicianId])
@@ -159,19 +159,19 @@ model IdentityDecision {
 
 // Affair-to-politician resolver decisions (deterministic matching, audit trail)
 model AffairPoliticianDecision {
-  id                 String   @id @default(cuid())
+  id String @id @default(cuid())
 
   // Input identity (for idempotency)
-  textHash           String   // SHA256 of the input text
-  candidateText      String   @db.Text // first 2000 chars for audit
-  metadata           Json     // source, refs, dates, court
+  textHash      String // SHA256 of the input text
+  candidateText String @db.Text // first 2000 chars for audit
+  metadata      Json // source, refs, dates, court
 
   // Resolver output
-  judgment           AffairPoliticianJudgment
-  topCandidates      Json     // top 3 with full signal breakdown
-  topScore           Float
-  gap                Float
-  resolverVersion    String   @default("v1")
+  judgment        AffairPoliticianJudgment
+  topCandidates   Json // top 3 with full signal breakdown
+  topScore        Float
+  gap             Float
+  resolverVersion String                   @default("v1")
 
   // Final destination (nullable until linked)
   affairId           String?
@@ -180,17 +180,17 @@ model AffairPoliticianDecision {
   chosenPolitician   Politician? @relation("AffairDecisionPolitician", fields: [chosenPoliticianId], references: [id], onDelete: SetNull)
 
   // Provenance (reuses existing SourceType enum)
-  source             SourceType
-  sourceRef          String   @default("")
+  source    SourceType
+  sourceRef String     @default("")
 
   // Review workflow
-  reviewedAt         DateTime?
-  reviewedBy         String?
-  reviewAction       AffairReviewAction?
-  reviewNotes        String?  @db.Text
+  reviewedAt   DateTime?
+  reviewedBy   String?
+  reviewAction AffairReviewAction?
+  reviewNotes  String?             @db.Text
 
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([textHash, source, sourceRef])
   @@index([judgment, reviewedAt])
@@ -363,6 +363,12 @@ model Mandate {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  // NOTE: a partial UNIQUE index "Mandate_current_type_uq" on
+  // (politicianId, type) WHERE isCurrent = true AND type IN (DEPUTE, SENATEUR)
+  // is applied manually (see
+  // prisma/migrations/manual/add-mandate-current-type-unique.sql). Scoped to
+  // parliamentary types on purpose. Not declared here because partial indexes
+  // require the `partialIndexes` preview feature. db push leaves it untouched.
 
   @@index([politicianId])
   @@index([type])
@@ -371,12 +377,6 @@ model Mandate {
   @@index([isCurrent, type, departmentCode])
   @@index([departmentCode])
   @@index([partyId])
-  // NOTE: a partial UNIQUE index "Mandate_current_type_uq" on
-  // (politicianId, type) WHERE isCurrent = true AND type IN (DEPUTE, SENATEUR)
-  // is applied manually (see
-  // prisma/migrations/manual/add-mandate-current-type-unique.sql). Scoped to
-  // parliamentary types on purpose. Not declared here because partial indexes
-  // require the `partialIndexes` preview feature. db push leaves it untouched.
 }
 
 // Local mandate extension — 1:1 with Mandate for local-specific fields
@@ -404,7 +404,7 @@ model MandateGovernment {
   id             String   @id @default(cuid())
   mandate        Mandate  @relation(fields: [mandateId], references: [id], onDelete: Cascade)
   mandateId      String   @unique
-  governmentName String   // "Gouvernement Borne", etc.
+  governmentName String // "Gouvernement Borne", etc.
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 }
@@ -466,7 +466,7 @@ model EuropeanGroup {
 model ParliamentaryGroup {
   id        String  @id @default(cuid())
   code      String // "SOC", "EPR", "DR", "LR", "RN"...
-  slug      String?  @unique // e.g. "epr-17", "soc-17"
+  slug      String? @unique // e.g. "epr-17", "soc-17"
   publicId  String? @unique // "GP-000042" — stable public identifier (poligraphId, see /docs/api)
   name      String // Full official name
   shortName String? // Display short name if different from code
@@ -535,10 +535,10 @@ model Affair {
   partyAtTime   Party?  @relation(fields: [partyAtTimeId], references: [id])
   partyAtTimeId String?
 
-  title       String // Ex: "Affaire des emplois fictifs du MoDem"
-  slug        String   @unique
-  publicId    String?  @unique // "AF-000542" — stable public identifier (poligraphId, see /docs/api)
-  oldSlugs    String[] @default([])
+  title                 String // Ex: "Affaire des emplois fictifs du MoDem"
+  slug                  String    @unique
+  publicId              String?   @unique // "AF-000542" — stable public identifier (poligraphId, see /docs/api)
+  oldSlugs              String[]  @default([])
   description           String    @db.Text
   originalDescription   String?   @db.Text // Pre-enrichment description (for rollback)
   descriptionEnrichedAt DateTime? // When AI description enrichment was applied
@@ -594,9 +594,9 @@ model Affair {
   confidenceScore Int?
 
   // SLAPP (procédure-bâillon) tagging (orthogonal to AffairCategory)
-  isSlapp           Boolean   @default(false)
-  slappCriteria     Json?     // SlappCriteriaPayload — see src/config/slapp.ts
-  slappQualifiedAt  DateTime? // When qualified as SLAPP (audit trail)
+  isSlapp          Boolean   @default(false)
+  slappCriteria    Json? // SlappCriteriaPayload — see src/config/slapp.ts
+  slappQualifiedAt DateTime? // When qualified as SLAPP (audit trail)
 
   // Publication control (moderation)
   publicationStatus PublicationStatus @default(DRAFT)
@@ -962,8 +962,8 @@ model Vote {
   // sort and chamber filter. Maintained by Postgres trigger
   // sync_vote_denorm_from_scrutin_trigger when Scrutin.votingDate or Scrutin.chamber
   // is updated. See docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md.
-  votingDate DateTime
-  chamber    Chamber
+  votingDate  DateTime
+  chamber     Chamber
   // Also denormalized from Scrutin.type to drop the JOIN on the per-politician votes
   // list/counts filtered by tab (Textes de loi / Amendements). Same trigger and INSERT
   // path as votingDate/chamber. Nullable: mirrors Scrutin.type (which can be null).
@@ -986,9 +986,9 @@ model ScrutinImportance {
   id        String   @id @default(cuid())
   scrutinId String   @unique
   scrutin   Scrutin  @relation(fields: [scrutinId], references: [id], onDelete: Cascade)
-  score     Float    // 0-100
+  score     Float // 0-100
   isKeyVote Boolean  @default(false)
-  signals   Json     // { turnout, margin, pressCoverage, hasDossier, hasCitizenImpact, voteType }
+  signals   Json // { turnout, margin, pressCoverage, hasDossier, hasCitizenImpact, voteType }
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1005,7 +1005,7 @@ model ScrutinGroupPosition {
   forCount     Int
   againstCount Int
   abstainCount Int
-  cohesionPct  Float              // max(for,against,abstain) / total * 100
+  cohesionPct  Float // max(for,against,abstain) / total * 100
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt
 
@@ -1028,22 +1028,22 @@ model ScrutinAnalysis {
 }
 
 model DebateTranscript {
-  id        String   @id @default(cuid())
-  scrutinId String?
-  scrutin   Scrutin? @relation(fields: [scrutinId], references: [id], onDelete: SetNull)
-  seanceRef String
-  date      DateTime
+  id          String    @id @default(cuid())
+  scrutinId   String?
+  scrutin     Scrutin?  @relation(fields: [scrutinId], references: [id], onDelete: SetNull)
+  seanceRef   String
+  date        DateTime
   // Séance start timestamp parsed from AN <dateSeance> (YYYYMMDDHHmmss). Enables
   // ordering same-day sittings; votes carry no time so it is metadata, not a join key.
-  startTime DateTime?
+  startTime   DateTime?
   // Sitting order within the day, from AN <numSeanceJour> (Unique -> 1, else the int).
   seanceOrder Int?
   // Full séance text (NOT truncated). Never index this column and never select it by
   // default — load it explicitly only when a matcher needs it.
-  content   String   @db.Text
-  sourceUrl String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  content     String    @db.Text
+  sourceUrl   String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@index([scrutinId])
   @@index([seanceRef])
@@ -1184,15 +1184,15 @@ model LegislativeDossier {
 }
 
 model DossierAuthor {
-  id           String              @id @default(cuid())
+  id           String             @id @default(cuid())
   dossierId    String
-  dossier      LegislativeDossier  @relation(fields: [dossierId], references: [id], onDelete: Cascade)
+  dossier      LegislativeDossier @relation(fields: [dossierId], references: [id], onDelete: Cascade)
   politicianId String
-  politician   Politician          @relation(fields: [politicianId], references: [id], onDelete: Cascade)
+  politician   Politician         @relation(fields: [politicianId], references: [id], onDelete: Cascade)
   acteurRef    String? // AN acteurRef for traceability
-  role         DossierActorRole    @default(AUTEUR)
-  chamber      Chamber?            // AN or SENAT
-  commission   String?             // For rapporteurs: commission name
+  role         DossierActorRole   @default(AUTEUR)
+  chamber      Chamber? // AN or SENAT
+  commission   String? // For rapporteurs: commission name
 
   @@unique([dossierId, politicianId, role])
   @@index([dossierId])
@@ -1311,44 +1311,44 @@ enum ScrutinAmendmentSource {
 }
 
 model ScrutinPolicyTitle {
-  id                    String                       @id @default(cuid())
-  scrutinId             String                       @unique
-  scrutin               Scrutin                      @relation(fields: [scrutinId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  scrutinId String  @unique
+  scrutin   Scrutin @relation(fields: [scrutinId], references: [id], onDelete: Cascade)
 
-  officialTitleSnapshot String                       @db.Text
+  officialTitleSnapshot String  @db.Text
   officialSourceUrl     String?
-  sources               Json                         @default("[]")
+  sources               Json    @default("[]")
 
-  inputHash             String
+  inputHash String
 
-  policyTitle           String?                      @db.VarChar(140)
-  policySubtitle        String?                      @db.Text
-  proceduralLabel       String
+  policyTitle     String? @db.VarChar(140)
+  policySubtitle  String? @db.Text
+  proceduralLabel String
 
-  confidence            PolicyTitleConfidence
-  qualitySignals        Json
-  generationSource      PolicyTitleSource
-  modelVersion          String?
-  promptVersion         String?
+  confidence       PolicyTitleConfidence
+  qualitySignals   Json
+  generationSource PolicyTitleSource
+  modelVersion     String?
+  promptVersion    String?
 
-  evidenceQuotes        Json                         @default("[]")
-  generationWarnings    Json                         @default("[]")
-  currentWarnings       Json                         @default("[]")
-  inputs                Json                         @default("{}")
+  evidenceQuotes     Json @default("[]")
+  generationWarnings Json @default("[]")
+  currentWarnings    Json @default("[]")
+  inputs             Json @default("{}")
 
-  status                PolicyTitleStatus
-  reviewedAt            DateTime?
-  reviewedBy            String?
-  editedFromGenerated   Boolean                      @default(false)
+  status              PolicyTitleStatus
+  reviewedAt          DateTime?
+  reviewedBy          String?
+  editedFromGenerated Boolean           @default(false)
 
-  regenerationStatus    RegenerationStatus           @default(idle)
-  regenerationError     String?
+  regenerationStatus RegenerationStatus @default(idle)
+  regenerationError  String?
 
-  generatedAt           DateTime                     @default(now())
-  createdAt             DateTime                     @default(now())
-  updatedAt             DateTime                     @updatedAt
+  generatedAt DateTime @default(now())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  history               ScrutinPolicyTitleRevision[]
+  history ScrutinPolicyTitleRevision[]
 
   @@index([status, generatedAt])
   @@index([confidence, status])
@@ -1576,18 +1576,18 @@ model PressAnalysisRejection {
 // ============================================
 
 model FactCheck {
-  id            String          @id @default(cuid())
-  slug          String?         @unique // SEO-friendly URL slug
-  publicId      String?         @unique // "FC-000542" — stable public identifier (poligraphId, see /docs/api)
-  claimText     String          @db.Text // La déclaration vérifiée
-  claimant      String? // Qui a fait la déclaration
-  title         String          @db.Text // Titre de l'article de fact-check
-  verdict       String // Verdict textuel original (ex: "Faux", "Mostly False")
-  verdictRating FactCheckRating // Rating normalisé
-  source        String // "AFP Factuel", "Les Décodeurs", etc.
-  sourceUrl     String          @unique // URL de l'article original
-  publishedAt   DateTime // Date de publication du fact-check
-  claimDate     DateTime? // Date de la déclaration vérifiée
+  id                String            @id @default(cuid())
+  slug              String?           @unique // SEO-friendly URL slug
+  publicId          String?           @unique // "FC-000542" — stable public identifier (poligraphId, see /docs/api)
+  claimText         String            @db.Text // La déclaration vérifiée
+  claimant          String? // Qui a fait la déclaration
+  title             String            @db.Text // Titre de l'article de fact-check
+  verdict           String // Verdict textuel original (ex: "Faux", "Mostly False")
+  verdictRating     FactCheckRating // Rating normalisé
+  source            String // "AFP Factuel", "Les Décodeurs", etc.
+  sourceUrl         String            @unique // URL de l'article original
+  publishedAt       DateTime // Date de publication du fact-check
+  claimDate         DateTime? // Date de la déclaration vérifiée
   languageCode      String? // "fr", "en"
   publicationStatus PublicationStatus @default(DRAFT)
 
@@ -1692,10 +1692,10 @@ enum ElectionStatus {
 }
 
 enum CandidacyStatus {
-  DECLARE      // Candidature officiellement annoncée par l'intéressé
-  PRESSENTI    // Sources crédibles annoncent l'intention, pas d'annonce officielle
-  ENVISAGE     // Hypothèse de presse, pas de signal direct de l'intéressé
-  RETIRE       // Annoncé puis retiré ou écarté
+  DECLARE // Candidature officiellement annoncée par l'intéressé
+  PRESSENTI // Sources crédibles annoncent l'intention, pas d'annonce officielle
+  ENVISAGE // Hypothèse de presse, pas de signal direct de l'intéressé
+  RETIRE // Annoncé puis retiré ou écarté
 }
 
 model Election {
@@ -1843,7 +1843,7 @@ model ElectoralList {
   publicId   String?  @unique // "LM-000542" — stable public identifier (poligraphId, see /docs/api)
   election   Election @relation(fields: [electionId], references: [id], onDelete: Cascade)
   electionId String
-  commune    Commune @relation(fields: [communeId], references: [id])
+  commune    Commune  @relation(fields: [communeId], references: [id])
   communeId  String
 
   listName   String
@@ -2206,19 +2206,19 @@ model SocialPost {
 // ============================================
 
 model Commune {
-  id             String   @id // INSEE code (e.g., "75056")
-  name           String
-  departmentCode String
-  departmentName String
-  regionCode     String?
-  regionName     String?
-  postalCodes    String[]
-  population     Int?
-  latitude       Float?
-  longitude      Float?
-  totalSeats          Int? // Conseil municipal seats (computed from population)
-  constituencyNumber  Int? // Legislative constituency (CIRCO_LEG from INSEE COG)
-  website             String?
+  id                 String   @id // INSEE code (e.g., "75056")
+  name               String
+  departmentCode     String
+  departmentName     String
+  regionCode         String?
+  regionName         String?
+  postalCodes        String[]
+  population         Int?
+  latitude           Float?
+  longitude          Float?
+  totalSeats         Int? // Conseil municipal seats (computed from population)
+  constituencyNumber Int? // Legislative constituency (CIRCO_LEG from INSEE COG)
+  website            String?
 
   candidacies           Candidacy[]
   electoralLists        ElectoralList[]
@@ -2372,7 +2372,7 @@ model PlatformUpdate {
   metadata    Json?
   sourceUrl   String?
 
-  createdAt   DateTime           @default(now())
+  createdAt DateTime @default(now())
 
   @@index([date])
   @@index([sourceUrl])
@@ -2421,13 +2421,13 @@ model Promise {
 // ============================================
 
 model Platform {
-  id         String   @id @default(cuid())
-  party      Party?   @relation(fields: [partyId], references: [id])
-  partyId    String?
+  id              String         @id @default(cuid())
+  party           Party?         @relation(fields: [partyId], references: [id])
+  partyId         String?
   electoralList   ElectoralList? @relation(fields: [electoralListId], references: [id])
   electoralListId String?        @unique
-  election   Election @relation(fields: [electionId], references: [id])
-  electionId String
+  election        Election       @relation(fields: [electionId], references: [id])
+  electionId      String
 
   sourceUrl         String?
   publicationStatus PublicationStatus @default(DRAFT)
@@ -2453,7 +2453,7 @@ model Proposal {
   position Int // -3..+3 scale: negative = Pole A, 0 = neutral, positive = Pole B
 
   summary       String
-  sourceExcerpt String?  @db.Text
+  sourceExcerpt String? @db.Text
   sourceUrl     String?
 
   aiGenerated Boolean @default(false)
@@ -2468,7 +2468,7 @@ model Proposal {
 }
 
 model QuizQuestion {
-  id    String @id @default(cuid())
+  id    String            @id @default(cuid())
   axis  ThematicAxis
   scope QuizElectionScope
 
@@ -2514,4 +2514,60 @@ model PublicIdRedirect {
 
   @@index([toPublicId])
   @@index([entityType])
+}
+
+/// Human ruling on a detected duplicate pair (issue #525).
+///
+/// Detection now covers published affairs, so the same queue holds pairs that a
+/// cron may fold and pairs that need a person. This records what that person
+/// decided, so the pair stops coming back.
+///
+/// Affair references are deliberately plain strings with no relation: a DUPLICATE
+/// ruling must outlive the row it absorbed, and a Cascade or Restrict would either
+/// erase the ruling or block the merge it authorised.
+model AffairPairDecision {
+  id String @id @default(cuid())
+
+  /// Sorted "idA:idB". The single guard against (A,B) and (B,A) both being stored.
+  pairKey   String @unique
+  affairIdA String
+  affairIdB String
+
+  classification AffairPairClassification
+
+  /// Why the pair was proposed, kept so a ruling can be re-read in context.
+  confidence String
+  matchedBy  String
+  score      Float
+
+  /// Both rows as of the ruling. A later edit on either side makes a DISTINCT or
+  /// UNCERTAIN ruling stale, and the pair may be proposed again.
+  affairAUpdatedAt DateTime
+  affairBUpdatedAt DateTime
+
+  /// Survivor of a merge authorised by a DUPLICATE ruling.
+  mergedIntoAffairId String?
+
+  reviewedBy String
+  reviewedAt DateTime @default(now())
+  notes      String?  @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([classification, reviewedAt])
+  @@index([affairIdA])
+  @@index([affairIdB])
+}
+
+enum AffairPairClassification {
+  /// One affair recorded twice: merge authorised.
+  DUPLICATE
+  /// Distinct affairs that belong to the same story. Publishing the link is a
+  /// separate editorial act, never a side effect of this ruling.
+  LINKED
+  /// Not the same affair. Excluded until either row changes.
+  DISTINCT
+  /// Deferred, not an exclusion: stays visible in a re-examination filter.
+  UNCERTAIN
 }

--- a/src/app/admin/affaires/doublons/page.tsx
+++ b/src/app/admin/affaires/doublons/page.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { AlertTriangle, ExternalLink, Link2, Loader2 } from "lucide-react";
+
+// Issue #525: review queue for detected duplicate pairs, grouped by politician.
+// Detection now covers published affairs, so most pairs land here rather than in
+// the cron. Nothing on this page moves data without an explicit click.
+
+type Classification = "DUPLICATE" | "LINKED" | "DISTINCT" | "UNCERTAIN";
+type MergeDecision =
+  | "AUTO_MERGE_DRAFTS"
+  | "AUTO_ABSORB_DRAFT_INTO_PUBLISHED"
+  | "REVIEW_REQUIRED"
+  | "NOT_ELIGIBLE";
+
+interface PairSide {
+  id: string;
+  title: string;
+  publicId: string | null;
+  slug: string;
+  publicationStatus: string;
+  verifiedAt: string | null;
+  category: string;
+  status: string;
+  involvement: string;
+  verdictDate: string | null;
+  factsDate: string | null;
+  linkedAffairId: string | null;
+  sources: string[];
+}
+
+interface PairRow {
+  pairKey: string;
+  confidence: string;
+  matchedBy: string;
+  score: number;
+  contradictions: string[];
+  unpropagatableDifferences: string[];
+  previousClassification: Classification | null;
+  rulingStale: boolean;
+  plan: { decision: MergeDecision; reason: string; keepId?: string; removeId?: string };
+  affairA: PairSide;
+  affairB: PairSide;
+}
+
+interface Group {
+  politician: { id: string; firstName: string; lastName: string; slug: string } | null;
+  pairs: PairRow[];
+}
+
+interface Metrics {
+  candidatePairs: number;
+  ruled: number;
+  byClassification: Record<Classification, number>;
+  precision: number | null;
+}
+
+const CLASSIFICATION_LABELS: Record<Classification, string> = {
+  DUPLICATE: "Doublon à fusionner",
+  LINKED: "Affaires liées",
+  DISTINCT: "Affaires distinctes",
+  UNCERTAIN: "Incertain",
+};
+
+function statusVariant(status: string): "default" | "secondary" | "outline" {
+  if (status === "PUBLISHED") return "default";
+  if (status === "DRAFT") return "secondary";
+  return "outline";
+}
+
+export default function DuplicatesReviewPage() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [busyPair, setBusyPair] = useState<string | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/affaires/doublons");
+      if (!res.ok) throw new Error(`Chargement impossible (${res.status})`);
+      const data = await res.json();
+      setGroups(data.groups ?? []);
+      setMetrics(data.metrics ?? null);
+      setTotal(data.total ?? 0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const act = useCallback(
+    async (pair: PairRow, url: string, body: Record<string, unknown>) => {
+      setBusyPair(pair.pairKey);
+      setError(null);
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          throw new Error(payload.error ?? `Échec (${res.status})`);
+        }
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Erreur inconnue");
+      } finally {
+        setBusyPair(null);
+      }
+    },
+    [load]
+  );
+
+  const classify = (pair: PairRow, classification: Exclude<Classification, "DUPLICATE">) =>
+    act(pair, "/api/admin/affaires/doublons/decision", {
+      affairIdA: pair.affairA.id,
+      affairIdB: pair.affairB.id,
+      classification,
+      notes: notes[pair.pairKey] || undefined,
+      signal: { confidence: pair.confidence, matchedBy: pair.matchedBy, score: pair.score },
+    });
+
+  const merge = (pair: PairRow, keep: PairSide, remove: PairSide) => {
+    const message =
+      `Fusionner « ${remove.title} » dans « ${keep.title} » ?\n\n` +
+      `L'affaire absorbée sera supprimée. Ses anciennes URL continueront de résoudre ` +
+      `vers l'affaire conservée.`;
+    if (!window.confirm(message)) return;
+    return act(pair, "/api/admin/affaires/doublons/fusionner", {
+      keepId: keep.id,
+      removeId: remove.id,
+      notes: notes[pair.pairKey] || undefined,
+      signal: { confidence: pair.confidence, matchedBy: pair.matchedBy, score: pair.score },
+    });
+  };
+
+  const publishLink = (pair: PairRow, from: PairSide, to: PairSide) => {
+    const existing = from.linkedAffairId
+      ? `\n\nAttention : « ${from.title} » est déjà liée à une autre affaire. Ce lien sera remplacé.`
+      : "";
+    const message =
+      `Publier le lien de « ${from.title} » vers « ${to.title} » ?\n\n` +
+      `Le lien est visible sur les fiches publiées.${existing}`;
+    if (!window.confirm(message)) return;
+    return act(pair, "/api/admin/affaires/doublons/lier", {
+      fromAffairId: from.id,
+      toAffairId: to.id,
+      confirmed: true,
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 p-8 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        <span>Chargement de la file…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Doublons d&apos;affaires</h1>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          {total} paire{total > 1 ? "s" : ""} détectée{total > 1 ? "s" : ""}, regroupée
+          {total > 1 ? "s" : ""} par personnalité. Les affaires d&apos;une même personne se lisent
+          ensemble : une paire qui ressemble à un doublon isolément est souvent deux chefs
+          d&apos;une même décision.
+        </p>
+      </header>
+
+      {metrics && (
+        <Card>
+          <CardContent className="flex flex-wrap gap-x-8 gap-y-2 p-4 text-sm">
+            <span>
+              Paires jugées : <strong>{metrics.ruled}</strong>
+            </span>
+            <span>
+              Précision du signal :{" "}
+              <strong>
+                {metrics.precision === null
+                  ? "pas encore mesurable"
+                  : `${Math.round(metrics.precision * 100)} %`}
+              </strong>
+            </span>
+            {(Object.keys(CLASSIFICATION_LABELS) as Classification[]).map((key) => (
+              <span key={key} className="text-muted-foreground">
+                {CLASSIFICATION_LABELS[key]} : {metrics.byClassification[key]}
+              </span>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {groups.length === 0 && (
+        <p className="text-sm text-muted-foreground">Aucune paire en attente de revue.</p>
+      )}
+
+      {groups.map((group) => (
+        <section key={group.politician?.id ?? "inconnu"} className="space-y-3">
+          <h2 className="text-lg font-medium">
+            {group.politician ? (
+              <Link
+                href={`/politiques/${group.politician.slug}`}
+                className="underline-offset-4 hover:underline"
+              >
+                {group.politician.firstName} {group.politician.lastName}
+              </Link>
+            ) : (
+              "Personnalité inconnue"
+            )}{" "}
+            <span className="text-sm font-normal text-muted-foreground">
+              ({group.pairs.length} paire{group.pairs.length > 1 ? "s" : ""})
+            </span>
+          </h2>
+
+          {group.pairs.map((pair) => {
+            const busy = busyPair === pair.pairKey;
+            const sides = [pair.affairA, pair.affairB];
+            const draft = sides.find((s) => s.publicationStatus === "DRAFT");
+            const published = sides.find((s) => s.publicationStatus === "PUBLISHED");
+
+            return (
+              <Card key={pair.pairKey}>
+                <CardContent className="space-y-4 p-4">
+                  <div className="flex flex-wrap items-center gap-2 text-xs">
+                    <Badge variant="outline">{pair.confidence}</Badge>
+                    <Badge variant="outline">{pair.matchedBy}</Badge>
+                    <span className="text-muted-foreground">score {pair.score}</span>
+                    {pair.previousClassification && (
+                      <Badge variant="secondary">
+                        déjà jugé : {CLASSIFICATION_LABELS[pair.previousClassification]}
+                      </Badge>
+                    )}
+                    {pair.rulingStale && (
+                      <Badge variant="destructive">à réexaminer, les fiches ont changé</Badge>
+                    )}
+                  </div>
+
+                  <div className="overflow-x-auto">
+                    <table className="w-full min-w-[40rem] text-sm">
+                      <caption className="sr-only">
+                        Comparaison des deux affaires de la paire
+                      </caption>
+                      <thead>
+                        <tr className="text-left text-xs uppercase text-muted-foreground">
+                          <th scope="col" className="py-1 pr-3 font-medium">
+                            Champ
+                          </th>
+                          {sides.map((s) => (
+                            <th key={s.id} scope="col" className="py-1 pr-3 font-medium">
+                              {s.publicId ?? s.id.slice(0, 8)}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr className="border-t">
+                          <th scope="row" className="py-1 pr-3 text-left font-normal">
+                            Titre
+                          </th>
+                          {sides.map((s) => (
+                            <td key={s.id} className="py-1 pr-3">
+                              <Link
+                                href={`/affaires/${s.slug}`}
+                                className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+                              >
+                                {s.title}
+                                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                              </Link>
+                            </td>
+                          ))}
+                        </tr>
+                        <tr className="border-t">
+                          <th scope="row" className="py-1 pr-3 text-left font-normal">
+                            Publication
+                          </th>
+                          {sides.map((s) => (
+                            <td key={s.id} className="py-1 pr-3">
+                              <Badge variant={statusVariant(s.publicationStatus)}>
+                                {s.publicationStatus}
+                              </Badge>
+                              {s.verifiedAt && (
+                                <span className="ml-2 text-xs text-muted-foreground">vérifiée</span>
+                              )}
+                            </td>
+                          ))}
+                        </tr>
+                        {(
+                          [
+                            ["Catégorie", "category"],
+                            ["État", "status"],
+                            ["Implication", "involvement"],
+                            ["Date de verdict", "verdictDate"],
+                            ["Date des faits", "factsDate"],
+                          ] as const
+                        ).map(([label, field]) => {
+                          const differs = sides[0]![field] !== sides[1]![field];
+                          return (
+                            <tr key={field} className="border-t">
+                              <th scope="row" className="py-1 pr-3 text-left font-normal">
+                                {label}
+                              </th>
+                              {sides.map((s) => (
+                                <td
+                                  key={s.id}
+                                  className={`py-1 pr-3 ${differs ? "font-medium" : "text-muted-foreground"}`}
+                                >
+                                  {String(s[field] ?? "—").slice(0, 30)}
+                                </td>
+                              ))}
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {pair.contradictions.length > 0 && (
+                    <p className="text-sm">
+                      <strong>Données contradictoires :</strong> {pair.contradictions.join(", ")}.
+                      Deux décisions distinctes plutôt qu&apos;un doublon, sauf erreur de saisie.
+                    </p>
+                  )}
+                  {pair.unpropagatableDifferences.length > 0 && (
+                    <p className="text-sm">
+                      <strong>Non transférable automatiquement :</strong>{" "}
+                      {pair.unpropagatableDifferences.join(", ")}.
+                    </p>
+                  )}
+                  <p className="text-sm text-muted-foreground">{pair.plan.reason}</p>
+
+                  <Textarea
+                    aria-label="Note de revue"
+                    placeholder="Note de revue (facultatif)"
+                    value={notes[pair.pairKey] ?? ""}
+                    onChange={(e) =>
+                      setNotes((prev) => ({ ...prev, [pair.pairKey]: e.target.value }))
+                    }
+                    rows={2}
+                  />
+
+                  <div className="flex flex-wrap gap-2">
+                    {draft && published && (
+                      <Button
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => merge(pair, published, draft)}
+                      >
+                        Fusionner le brouillon dans la fiche publiée
+                      </Button>
+                    )}
+                    {!published && (
+                      <Button
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => merge(pair, sides[0]!, sides[1]!)}
+                      >
+                        Fusionner dans {sides[0]!.publicId ?? "la première"}
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      disabled={busy}
+                      onClick={() => classify(pair, "LINKED")}
+                    >
+                      Affaires liées
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => classify(pair, "DISTINCT")}
+                    >
+                      Affaires distinctes
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => classify(pair, "UNCERTAIN")}
+                    >
+                      Incertain
+                    </Button>
+                    {pair.previousClassification === "LINKED" && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={busy}
+                        onClick={() => publishLink(pair, sides[0]!, sides[1]!)}
+                      >
+                        <Link2 className="mr-1 h-3 w-3" aria-hidden="true" />
+                        Publier le lien
+                      </Button>
+                    )}
+                    {busy && (
+                      <Loader2 className="h-4 w-4 animate-spin self-center" aria-hidden="true" />
+                    )}
+                  </div>
+
+                  {pair.previousClassification === "LINKED" && (
+                    <p className="text-xs text-muted-foreground">
+                      Le lien n&apos;est pas publié tant qu&apos;il n&apos;a pas été confirmé : il
+                      apparaît sur les fiches publiées.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
+++ b/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #525 — the review endpoints. What matters: a published affair can never be
+// deleted by a merge, classifying LINKED publishes nothing, and cache invalidation
+// happens only after the write committed.
+
+const order: string[] = [];
+
+const h = vi.hoisted(() => ({
+  affairFindUnique: vi.fn(),
+  affairFindMany: vi.fn(),
+  affairUpdate: vi.fn(),
+  auditCreate: vi.fn(),
+  mergeAffairs: vi.fn(),
+  recordPairDecision: vi.fn(),
+  invalidateEntity: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    affair: {
+      findUnique: h.affairFindUnique,
+      findMany: h.affairFindMany,
+      update: h.affairUpdate,
+    },
+    auditLog: { create: h.auditCreate },
+  },
+}));
+vi.mock("@/services/affairs/reconciliation", () => ({ mergeAffairs: h.mergeAffairs }));
+vi.mock("@/services/affairs/pair-decision", () => ({
+  recordPairDecision: h.recordPairDecision,
+}));
+vi.mock("@/lib/cache", () => ({ invalidateEntity: h.invalidateEntity }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) =>
+    fn(req, ctx),
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "203.0.113.1", userAgent: "test-agent" }),
+}));
+
+import { POST as decisionPOST } from "@/app/api/admin/affaires/doublons/decision/route";
+import { POST as mergePOST } from "@/app/api/admin/affaires/doublons/fusionner/route";
+import { POST as linkPOST } from "@/app/api/admin/affaires/doublons/lier/route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ctx: any = { params: Promise.resolve({}) };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function req(body: unknown): any {
+  return new Request("http://test/api", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const signal = { confidence: "HIGH", matchedBy: "pourvoiNumber", score: 0.95 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  h.recordPairDecision.mockResolvedValue("dec_1");
+  h.mergeAffairs.mockImplementation(async () => {
+    order.push("merge");
+    return {
+      sourcesMoved: 0,
+      eventsMoved: 0,
+      articlesMoved: 0,
+      identifiersMerged: [],
+      slugsPreserved: ["absorbee"],
+    };
+  });
+  h.affairUpdate.mockImplementation(async () => {
+    order.push("update");
+    return {};
+  });
+  h.invalidateEntity.mockImplementation(() => {
+    order.push("invalidate");
+  });
+});
+
+describe("POST /doublons/decision — classer sans rien déplacer (#525)", () => {
+  it("enregistre le jugement avec la fraîcheur des deux fiches", async () => {
+    h.affairFindMany.mockResolvedValue([
+      { id: "a", updatedAt: new Date("2026-07-01") },
+      { id: "b", updatedAt: new Date("2026-07-02") },
+    ]);
+
+    const res = await decisionPOST(
+      req({ affairIdA: "a", affairIdB: "b", classification: "DISTINCT", signal }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(h.recordPairDecision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classification: "DISTINCT",
+        affairAUpdatedAt: new Date("2026-07-01"),
+        affairBUpdatedAt: new Date("2026-07-02"),
+      })
+    );
+  });
+
+  it("classer LINKED ne publie aucun lien", async () => {
+    h.affairFindMany.mockResolvedValue([
+      { id: "a", updatedAt: new Date("2026-07-01") },
+      { id: "b", updatedAt: new Date("2026-07-01") },
+    ]);
+
+    await decisionPOST(
+      req({ affairIdA: "a", affairIdB: "b", classification: "LINKED", signal }),
+      ctx
+    );
+
+    expect(h.affairUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuse une paire d'une affaire avec elle-même", async () => {
+    const res = await decisionPOST(
+      req({ affairIdA: "a", affairIdB: "a", classification: "DISTINCT", signal }),
+      ctx
+    );
+
+    expect(res.status).toBe(400);
+    expect(h.recordPairDecision).not.toHaveBeenCalled();
+  });
+
+  it("renvoie 404 si une affaire a disparu", async () => {
+    h.affairFindMany.mockResolvedValue([{ id: "a", updatedAt: new Date() }]);
+
+    const res = await decisionPOST(
+      req({ affairIdA: "a", affairIdB: "b", classification: "DISTINCT", signal }),
+      ctx
+    );
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525)", () => {
+  it("refuse de supprimer une affaire publiée", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({ id: "keep", updatedAt: new Date(), politician: { slug: "x" } })
+      .mockResolvedValueOnce({
+        id: "remove",
+        updatedAt: new Date(),
+        publicationStatus: "PUBLISHED",
+      });
+
+    const res = await mergePOST(req({ keepId: "keep", removeId: "remove", signal }), ctx);
+
+    expect(res.status).toBe(409);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("absorbe un brouillon et écrit le jugement dans la même transaction", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({
+        id: "keep",
+        updatedAt: new Date("2026-07-01"),
+        politician: { slug: "jean-dupont" },
+      })
+      .mockResolvedValueOnce({
+        id: "remove",
+        updatedAt: new Date("2026-07-02"),
+        publicationStatus: "DRAFT",
+      });
+
+    const res = await mergePOST(req({ keepId: "keep", removeId: "remove", signal }), ctx);
+
+    expect(res.status).toBe(200);
+    // Le jugement part dans les options de la fusion, donc dans sa transaction.
+    expect(h.mergeAffairs).toHaveBeenCalledWith(
+      "keep",
+      "remove",
+      expect.objectContaining({
+        pairDecision: expect.objectContaining({ otherAffairId: "remove", reviewedBy: "admin" }),
+      })
+    );
+  });
+
+  it("invalide les caches seulement après la fusion", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({
+        id: "keep",
+        updatedAt: new Date(),
+        politician: { slug: "jean-dupont" },
+      })
+      .mockResolvedValueOnce({ id: "remove", updatedAt: new Date(), publicationStatus: "DRAFT" });
+
+    await mergePOST(req({ keepId: "keep", removeId: "remove", signal }), ctx);
+
+    expect(order[0]).toBe("merge");
+    expect(order.slice(1)).toEqual(["invalidate", "invalidate"]);
+  });
+});
+
+describe("POST /doublons/lier — publier le lien est un acte séparé (#525)", () => {
+  it("écrit linkedAffairId et signale un remplacement", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({
+        id: "from",
+        linkedAffairId: "autre",
+        politician: { slug: "jean-dupont" },
+      })
+      .mockResolvedValueOnce({ id: "to" });
+
+    const res = await linkPOST(
+      req({ fromAffairId: "from", toAffairId: "to", confirmed: true }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ replaced: true });
+    expect(h.affairUpdate).toHaveBeenCalledWith({
+      where: { id: "from" },
+      data: { linkedAffairId: "to" },
+    });
+  });
+
+  it("garde trace du lien remplacé", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({
+        id: "from",
+        linkedAffairId: "autre",
+        politician: { slug: "jean-dupont" },
+      })
+      .mockResolvedValueOnce({ id: "to" });
+
+    await linkPOST(req({ fromAffairId: "from", toAffairId: "to", confirmed: true }), ctx);
+
+    expect(h.auditCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changes: expect.objectContaining({
+          linkedAffairId: "to",
+          replacedLinkedAffairId: "autre",
+        }),
+      }),
+    });
+  });
+
+  it("renvoie 404 si une affaire a disparu", async () => {
+    h.affairFindUnique.mockResolvedValue(null);
+
+    const res = await linkPOST(
+      req({ fromAffairId: "from", toAffairId: "to", confirmed: true }),
+      ctx
+    );
+
+    expect(res.status).toBe(404);
+    expect(h.affairUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/affaires/doublons/decision/route.ts
+++ b/src/app/api/admin/affaires/doublons/decision/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation } from "@/lib/security";
+import { pairDecisionSchema, type PairDecisionBody } from "@/lib/security/schemas/affair-pair";
+import { recordPairDecision } from "@/services/affairs/pair-decision";
+
+/**
+ * Records a ruling that does not move data: LINKED, DISTINCT or UNCERTAIN.
+ *
+ * LINKED stops here on purpose. It notes that two fiches belong to the same story;
+ * publishing that relation is a separate, confirmed editorial act, because
+ * linkedAffairId is rendered on published pages (issue #525).
+ */
+export const POST = withAdminAuth(
+  withValidation(pairDecisionSchema, async (_request, _context, body: PairDecisionBody) => {
+    if (body.affairIdA === body.affairIdB) {
+      return NextResponse.json({ error: "Les deux affaires sont identiques" }, { status: 400 });
+    }
+
+    const affairs = await db.affair.findMany({
+      where: { id: { in: [body.affairIdA, body.affairIdB] } },
+      select: { id: true, updatedAt: true },
+    });
+    if (affairs.length !== 2) {
+      return NextResponse.json({ error: "Affaire(s) non trouvée(s)" }, { status: 404 });
+    }
+    const updatedAt = new Map(affairs.map((a) => [a.id, a.updatedAt]));
+
+    const id = await recordPairDecision({
+      affairIdA: body.affairIdA,
+      affairIdB: body.affairIdB,
+      classification: body.classification,
+      reviewedBy: "admin",
+      notes: body.notes ?? null,
+      signal: body.signal,
+      affairAUpdatedAt: updatedAt.get(body.affairIdA)!,
+      affairBUpdatedAt: updatedAt.get(body.affairIdB)!,
+    });
+
+    return NextResponse.json({ success: true, decisionId: id });
+  })
+);

--- a/src/app/api/admin/affaires/doublons/fusionner/route.ts
+++ b/src/app/api/admin/affaires/doublons/fusionner/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import { pairMergeSchema, type PairMergeBody } from "@/lib/security/schemas/affair-pair";
+import { mergeAffairs } from "@/services/affairs/reconciliation";
+import { invalidateEntity } from "@/lib/cache";
+
+/**
+ * Human-confirmed merge of a duplicate pair, with its DUPLICATE ruling written in
+ * the same transaction (issue #525).
+ *
+ * Refuses to delete a published affair whatever the caller asks: absorbing a draft
+ * into a published fiche is supported, the reverse retires a page a reader can
+ * reach. Two published affairs need a moderator to unpublish one first, so the
+ * removal is a deliberate editorial act rather than a side effect of a merge.
+ */
+export const POST = withAdminAuth(
+  withValidation(pairMergeSchema, async (request, _context, body: PairMergeBody) => {
+    const { keepId, removeId } = body;
+
+    if (keepId === removeId) {
+      return NextResponse.json({ error: "Les deux affaires sont identiques" }, { status: 400 });
+    }
+
+    const [keep, remove] = await Promise.all([
+      db.affair.findUnique({
+        where: { id: keepId },
+        select: { id: true, updatedAt: true, politician: { select: { slug: true } } },
+      }),
+      db.affair.findUnique({
+        where: { id: removeId },
+        select: { id: true, updatedAt: true, publicationStatus: true },
+      }),
+    ]);
+    if (!keep || !remove) {
+      return NextResponse.json({ error: "Affaire(s) non trouvée(s)" }, { status: 404 });
+    }
+
+    if (remove.publicationStatus === "PUBLISHED") {
+      return NextResponse.json(
+        {
+          error:
+            "Une affaire publiée ne peut pas être supprimée par une fusion. Dépubliez-la d'abord.",
+        },
+        { status: 409 }
+      );
+    }
+
+    const meta = getRequestMeta(request);
+    const result = await mergeAffairs(keepId, removeId, {
+      audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
+      pairDecision: {
+        otherAffairId: removeId,
+        reviewedBy: "admin",
+        notes: body.notes ?? null,
+        signal: body.signal,
+        keepUpdatedAt: keep.updatedAt,
+        removeUpdatedAt: remove.updatedAt,
+      },
+    });
+
+    // After the transaction commits, never before.
+    invalidateEntity("affair");
+    if (keep.politician?.slug) invalidateEntity("politician", keep.politician.slug);
+
+    return NextResponse.json({ success: true, ...result });
+  })
+);

--- a/src/app/api/admin/affaires/doublons/lier/route.ts
+++ b/src/app/api/admin/affaires/doublons/lier/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import { pairLinkSchema, type PairLinkBody } from "@/lib/security/schemas/affair-pair";
+import { invalidateEntity } from "@/lib/cache";
+
+/**
+ * Publishes the relation between two affairs ruled LINKED (issue #525).
+ *
+ * Separate from the ruling and gated on an explicit confirmation, because
+ * linkedAffairId is rendered on published fiches: classifying a pair must not
+ * publish anything by itself. The field is also directional and holds a single
+ * link, so overwriting an existing one has to be a visible choice.
+ */
+export const POST = withAdminAuth(
+  withValidation(pairLinkSchema, async (request, _context, body: PairLinkBody) => {
+    const { fromAffairId, toAffairId } = body;
+
+    if (fromAffairId === toAffairId) {
+      return NextResponse.json({ error: "Les deux affaires sont identiques" }, { status: 400 });
+    }
+
+    const [from, to] = await Promise.all([
+      db.affair.findUnique({
+        where: { id: fromAffairId },
+        select: {
+          id: true,
+          linkedAffairId: true,
+          politician: { select: { slug: true } },
+        },
+      }),
+      db.affair.findUnique({ where: { id: toAffairId }, select: { id: true } }),
+    ]);
+    if (!from || !to) {
+      return NextResponse.json({ error: "Affaire(s) non trouvée(s)" }, { status: 404 });
+    }
+
+    const replaced = from.linkedAffairId && from.linkedAffairId !== toAffairId;
+
+    await db.affair.update({
+      where: { id: fromAffairId },
+      data: { linkedAffairId: toAffairId },
+    });
+
+    const meta = getRequestMeta(request);
+    await db.auditLog.create({
+      data: {
+        action: "UPDATE",
+        entityType: "Affair",
+        entityId: fromAffairId,
+        changes: {
+          linkedAffairId: toAffairId,
+          replacedLinkedAffairId: from.linkedAffairId ?? null,
+        },
+        ipAddress: meta.ip,
+        userAgent: meta.userAgent,
+      },
+    });
+
+    invalidateEntity("affair");
+    if (from.politician?.slug) invalidateEntity("politician", from.politician.slug);
+
+    return NextResponse.json({ success: true, replaced: Boolean(replaced) });
+  })
+);

--- a/src/app/api/admin/affaires/doublons/route.ts
+++ b/src/app/api/admin/affaires/doublons/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
+import { decideMergeAction } from "@/services/affairs/merge-decision";
+import { computePairPrecision } from "@/services/affairs/pair-decision";
+import { canonicalPair } from "@/services/affairs/affair-pair";
+
+/**
+ * The duplicate review queue, grouped by politician (issue #525).
+ *
+ * Grouped because a person's affairs only make sense read together: a pair that
+ * looks like a duplicate in isolation is often two counts of one case, which is
+ * only visible next to the others.
+ */
+export const GET = withAdminAuth(async () => {
+  const pairs = await findPotentialDuplicates();
+
+  const politicianIds = [...new Set(pairs.map((p) => p.affairA.politicianId))];
+  const politicians = await db.politician.findMany({
+    where: { id: { in: politicianIds } },
+    select: { id: true, firstName: true, lastName: true, slug: true },
+  });
+  const byPolitician = new Map(politicians.map((p) => [p.id, p]));
+
+  const affairIds = pairs.flatMap((p) => [p.affairA.id, p.affairB.id]);
+  const affairs = await db.affair.findMany({
+    where: { id: { in: [...new Set(affairIds)] } },
+    select: {
+      id: true,
+      publicId: true,
+      slug: true,
+      category: true,
+      status: true,
+      involvement: true,
+      verdictDate: true,
+      factsDate: true,
+      linkedAffairId: true,
+    },
+  });
+  const detail = new Map(affairs.map((a) => [a.id, a]));
+
+  const groups = new Map<
+    string,
+    { politician: (typeof politicians)[number] | null; pairs: unknown[] }
+  >();
+
+  for (const pair of pairs) {
+    const politicianId = pair.affairA.politicianId;
+    const group = groups.get(politicianId) ?? {
+      politician: byPolitician.get(politicianId) ?? null,
+      pairs: [],
+    };
+    const plan = decideMergeAction(pair);
+    group.pairs.push({
+      pairKey: canonicalPair(pair.affairA.id, pair.affairB.id).key,
+      confidence: pair.confidence,
+      matchedBy: pair.matchedBy,
+      score: pair.score,
+      contradictions: pair.contradictions,
+      unpropagatableDifferences: pair.unpropagatableDifferences,
+      previousClassification: pair.previousClassification,
+      rulingStale: pair.rulingStale,
+      plan,
+      affairA: { ...pair.affairA, ...detail.get(pair.affairA.id) },
+      affairB: { ...pair.affairB, ...detail.get(pair.affairB.id) },
+    });
+    groups.set(politicianId, group);
+  }
+
+  const metrics = await computePairPrecision(pairs.length);
+
+  return NextResponse.json({
+    total: pairs.length,
+    metrics,
+    groups: [...groups.values()].sort((a, b) => b.pairs.length - a.pairs.length),
+  });
+});

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Fingerprint,
   BarChart3,
   Vote,
+  CopyCheck,
   GitPullRequestArrow,
 } from "lucide-react";
 
@@ -43,6 +44,7 @@ const contentItems: NavItem[] = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
   { href: "/admin/affaires", label: "Affaires", icon: Scale },
   { href: "/admin/affaires/propositions", label: "Propositions", icon: GitPullRequestArrow },
+  { href: "/admin/affaires/doublons", label: "Doublons", icon: CopyCheck },
   { href: "/admin/politiques", label: "Politiques", icon: Users },
   { href: "/admin/partis", label: "Partis", icon: Building2 },
   { href: "/admin/maires", label: "Maires", icon: Crown },

--- a/src/lib/security/schemas/affair-pair.ts
+++ b/src/lib/security/schemas/affair-pair.ts
@@ -1,0 +1,49 @@
+import { z } from "zod/v4";
+import { AffairPairClassification } from "@/generated/prisma";
+
+// Issue #525 — the review queue. Classifications are derived from the generated
+// Prisma enum rather than retyped, so the API cannot drift from the database.
+
+const affairId = z.string().min(1).max(64);
+
+/** Rulings the plain decision endpoint accepts. */
+const REVIEW_ONLY = ["LINKED", "DISTINCT", "UNCERTAIN"] as const;
+
+export const pairDecisionSchema = z.object({
+  affairIdA: affairId,
+  affairIdB: affairId,
+  // DUPLICATE is absent on purpose: it authorises a merge, which is a structural
+  // operation with its own endpoint, never a classification write alone.
+  classification: z.enum(REVIEW_ONLY),
+  notes: z.string().max(2000).optional(),
+  signal: z.object({
+    confidence: z.string().min(1).max(20),
+    matchedBy: z.string().min(1).max(60),
+    score: z.number().min(0).max(1),
+  }),
+});
+
+export const pairMergeSchema = z.object({
+  /** Survivor. The endpoint refuses to delete a published affair. */
+  keepId: affairId,
+  removeId: affairId,
+  notes: z.string().max(2000).optional(),
+  signal: z.object({
+    confidence: z.string().min(1).max(20),
+    matchedBy: z.string().min(1).max(60),
+    score: z.number().min(0).max(1),
+  }),
+});
+
+export const pairLinkSchema = z.object({
+  /** The affair that will carry linkedAffairId. */
+  fromAffairId: affairId,
+  toAffairId: affairId,
+  /** Explicit: publishing the link is visible on published pages. */
+  confirmed: z.literal(true),
+});
+
+export type PairDecisionBody = z.infer<typeof pairDecisionSchema>;
+export type PairMergeBody = z.infer<typeof pairMergeSchema>;
+export type PairLinkBody = z.infer<typeof pairLinkSchema>;
+export { AffairPairClassification };

--- a/src/services/affairs/__tests__/absorb-draft.test.ts
+++ b/src/services/affairs/__tests__/absorb-draft.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #525 §4 — absorbing a draft into a published affair may add, never rewrite.
+// Anything the draft states about the judicial outcome goes to the proposal queue.
+
+const h = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  mergeAffairs: vi.fn(),
+  proposeAffairUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: { affair: { findUnique: h.findUnique } } }));
+vi.mock("../reconciliation", () => ({
+  mergeAffairs: h.mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS: ["ecli", "pourvoiNumber", "caseNumber"],
+}));
+vi.mock("../proposals", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proposals")>();
+  return {
+    normalizeForCompare: actual.normalizeForCompare,
+    proposeAffairUpdate: h.proposeAffairUpdate,
+  };
+});
+
+import { absorbDraftIntoPublished } from "../absorb-draft";
+
+function affair(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "x",
+    title: "Titre",
+    description: "Description",
+    category: "AUTRE",
+    status: null,
+    verdictDate: null,
+    court: null,
+    sentence: null,
+    prisonMonths: null,
+    prisonSuspended: null,
+    fineAmount: null,
+    ineligibilityMonths: null,
+    communityService: null,
+    otherSentence: null,
+    publicationStatus: "DRAFT",
+    sources: [],
+    ...overrides,
+  };
+}
+
+function stub(published: Record<string, unknown>, draft: Record<string, unknown>) {
+  h.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
+    Promise.resolve(where.id === published.id ? published : draft)
+  );
+}
+
+/** The patch handed to the proposal queue, or null when nothing was proposed. */
+function proposedPatch(): Record<string, unknown> | null {
+  const call = h.proposeAffairUpdate.mock.calls[0];
+  return call ? (call[0].patch as Record<string, unknown>) : null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.mergeAffairs.mockResolvedValue({
+    sourcesMoved: 0,
+    eventsMoved: 0,
+    articlesMoved: 0,
+    identifiersMerged: [],
+    slugsPreserved: [],
+  });
+  h.proposeAffairUpdate.mockResolvedValue({
+    autoApplied: [],
+    autoProposalId: null,
+    pendingProposalId: "prop_1",
+    conflictProposalId: null,
+    deduped: false,
+  });
+});
+
+const base = {
+  importRunId: "run_1",
+  reason: "Identifiant judiciaire commun (pourvoiNumber)",
+};
+
+describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (#525)", () => {
+  it("n'écrase aucun champ sensible non nul de l'affaire publiée", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        status: "CONDAMNATION_DEFINITIVE",
+        court: "Cour de cassation",
+        sentence: "6 mois avec sursis",
+        verdictDate: new Date("2024-01-15"),
+      }),
+      affair({
+        id: "draft",
+        status: "PROCES_EN_COURS",
+        court: "Tribunal correctionnel de Paris",
+        sentence: "réquisitions de 12 mois",
+        verdictDate: new Date("2024-01-20"),
+      })
+    );
+
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+
+    // Le service de fusion est appelé avec la seule liste additive restreinte :
+    // ni court ni chamber ne peuvent y être remplis.
+    const mergeOptions = h.mergeAffairs.mock.calls[0]![2];
+    expect(mergeOptions.additiveFields).toEqual(["ecli", "pourvoiNumber", "caseNumber"]);
+    expect(mergeOptions.additiveFields).not.toContain("court");
+    expect(mergeOptions.additiveFields).not.toContain("chamber");
+
+    // Et le survivant est bien l'affaire publiée.
+    expect(h.mergeAffairs).toHaveBeenCalledWith("pub", "draft", expect.anything());
+  });
+
+  it("crée une proposition pour chaque donnée sensible divergente", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        status: "CONDAMNATION_DEFINITIVE",
+        court: null,
+      }),
+      affair({
+        id: "draft",
+        status: "PROCES_EN_COURS",
+        court: "Tribunal correctionnel de Paris",
+        prisonMonths: 6,
+      })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(proposedPatch()).toEqual({
+      status: "PROCES_EN_COURS",
+      court: "Tribunal correctionnel de Paris",
+      prisonMonths: 6,
+    });
+    expect(result.proposalsCreated).toBe(1);
+    expect(h.proposeAffairUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ affairId: "pub", importRunId: "run_1" })
+    );
+  });
+
+  it("ne propose pas un champ que l'affaire publiée porte déjà à l'identique", async () => {
+    stub(
+      affair({ id: "pub", publicationStatus: "PUBLISHED", court: "Cour de cassation" }),
+      affair({ id: "draft", court: "Cour de cassation" })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(h.proposeAffairUpdate).not.toHaveBeenCalled();
+    expect(result.proposalsCreated).toBe(0);
+  });
+
+  it("garde trace des différences ni transférées ni proposables", async () => {
+    stub(
+      affair({
+        id: "pub",
+        publicationStatus: "PUBLISHED",
+        category: "AUTRE",
+        title: "Titre publié",
+      }),
+      affair({ id: "draft", category: "RECEL", title: "Titre du brouillon" })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(result.recordedDifferences).toEqual(expect.arrayContaining(["title", "category"]));
+    // Rien n'est perdu en silence : la valeur absorbée part dans la piste d'audit.
+    const notes = h.mergeAffairs.mock.calls[0]![2].auditNotes;
+    expect(notes.recordedDifferences).toEqual(
+      expect.arrayContaining([{ field: "category", absorbedValue: "RECEL" }])
+    );
+  });
+});
+
+describe("absorbDraftIntoPublished — refuse de se tromper de sens (#525)", () => {
+  it("refuse si le survivant n'est pas publié", async () => {
+    stub(affair({ id: "pub", publicationStatus: "DRAFT" }), affair({ id: "draft" }));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("n'est pas publiée");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("refuse si l'affaire absorbée n'est pas un brouillon", async () => {
+    stub(
+      affair({ id: "pub", publicationStatus: "PUBLISHED" }),
+      affair({ id: "draft", publicationStatus: "PUBLISHED" })
+    );
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("n'est pas un brouillon");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("refuse si une des deux affaires a disparu", async () => {
+    h.findUnique.mockResolvedValue(null);
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("introuvable");
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/affairs/__tests__/merge-decision.test.ts
+++ b/src/services/affairs/__tests__/merge-decision.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from "vitest";
+
+// matching.ts imports @/lib/db at module level; decideMergeAction is pure.
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { decideMergeAction, type MergeDecisionAffair } from "../merge-decision";
+import type { PublicationStatus, SourceType } from "@/generated/prisma";
+
+function side(overrides: Partial<MergeDecisionAffair> & { id: string }): MergeDecisionAffair {
+  return {
+    publicationStatus: "DRAFT" as PublicationStatus,
+    verifiedAt: null,
+    sources: [],
+    ...overrides,
+  };
+}
+
+const press = ["PRESSE"] as SourceType[];
+
+describe("decideMergeAction — deux brouillons (#525)", () => {
+  it("auto-fusionne sur une confiance suffisante", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", sources: press }),
+      affairB: side({ id: "b" }),
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(plan.decision).toBe("AUTO_MERGE_DRAFTS");
+    // Le plus riche en sources survit.
+    expect(plan.keepId).toBe("a");
+    expect(plan.removeId).toBe("b");
+  });
+
+  it("exige une revue sur un rapprochement POSSIBLE", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "b" }),
+      confidence: "POSSIBLE",
+      matchedBy: "politician+category+window",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("ne supprime jamais automatiquement un brouillon validé humainement", () => {
+    // « b » serait absorbé sur le critère des sources, mais il a été relu.
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", sources: press }),
+      affairB: side({ id: "b", verifiedAt: new Date("2026-01-01") }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.removeId).toBeUndefined();
+  });
+});
+
+describe("decideMergeAction — brouillon face à une affaire publiée (#525)", () => {
+  const published = side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus });
+  const draft = side({ id: "draft" });
+
+  it("absorbe toujours le brouillon dans l'affaire publiée sur identifiant judiciaire", () => {
+    for (const matchedBy of ["ecli", "pourvoiNumber", "caseNumbers"]) {
+      const plan = decideMergeAction({
+        affairA: published,
+        affairB: draft,
+        confidence: "HIGH",
+        matchedBy,
+      });
+
+      expect(plan.decision).toBe("AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
+      expect(plan.keepId).toBe("pub");
+      expect(plan.removeId).toBe("draft");
+    }
+  });
+
+  it("garde l'affaire publiée même quand le brouillon a plus de sources", () => {
+    // Le sens de la fusion ne dépend jamais du nombre de sources ici.
+    const plan = decideMergeAction({
+      affairA: side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      affairB: side({ id: "draft", sources: ["PRESSE", "OFFICIEL"] as SourceType[] }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.keepId).toBe("pub");
+    expect(plan.removeId).toBe("draft");
+  });
+
+  it("exige une revue quand seul le titre rapproche", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: draft,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("heuristique");
+  });
+
+  it("exige une revue quand le brouillon affirme autre chose sur un champ non transférable", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: draft,
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+      unpropagatableDifferences: ["involvement"],
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("involvement");
+  });
+
+  it("ne supprime jamais automatiquement un brouillon validé humainement", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: side({ id: "draft", verifiedAt: new Date("2026-01-01") }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+});
+
+describe("decideMergeAction — deux affaires publiées (#525)", () => {
+  it("n'auto-fusionne jamais, même en CERTAIN sur identifiant judiciaire", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      affairB: side({ id: "b", publicationStatus: "PUBLISHED" as PublicationStatus }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.keepId).toBeUndefined();
+  });
+
+  it("une affaire publiée vérifiée n'est jamais supprimée automatiquement", () => {
+    const plan = decideMergeAction({
+      affairA: side({
+        id: "a",
+        publicationStatus: "PUBLISHED" as PublicationStatus,
+        verifiedAt: new Date("2026-01-01"),
+      }),
+      affairB: side({
+        id: "b",
+        publicationStatus: "PUBLISHED" as PublicationStatus,
+        verifiedAt: new Date("2026-01-02"),
+      }),
+      confidence: "CERTAIN",
+      matchedBy: "pourvoiNumber",
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+  });
+});
+
+describe("decideMergeAction — garde-fous (#525)", () => {
+  it("toute contradiction judiciaire passe en revue, quelle que soit la confiance", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "b" }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+      contradictions: ["verdictDate"],
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(plan.reason).toContain("verdictDate");
+  });
+
+  it("refuse une affaire hors du périmètre de statuts", () => {
+    for (const status of ["REJECTED", "EXCLUDED", "ARCHIVED"] as PublicationStatus[]) {
+      const plan = decideMergeAction({
+        affairA: side({ id: "a", publicationStatus: status }),
+        affairB: side({ id: "b" }),
+        confidence: "CERTAIN",
+        matchedBy: "ecli",
+      });
+
+      expect(plan.decision).toBe("NOT_ELIGIBLE");
+    }
+  });
+
+  it("refuse une affaire face à elle-même", () => {
+    const plan = decideMergeAction({
+      affairA: side({ id: "a" }),
+      affairB: side({ id: "a" }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+    });
+
+    expect(plan.decision).toBe("NOT_ELIGIBLE");
+  });
+
+  it("est déterministe : l'ordre des deux côtés ne change pas le plan", () => {
+    // À sources égales, le départage se fait sur l'id, pas sur la place dans la paire.
+    const a = side({ id: "zzz" });
+    const b = side({ id: "aaa" });
+
+    const forward = decideMergeAction({
+      affairA: a,
+      affairB: b,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+    const backward = decideMergeAction({
+      affairA: b,
+      affairB: a,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(forward).toEqual(backward);
+    expect(forward.keepId).toBe("aaa");
+  });
+
+  it("reste déterministe quand les sources départagent", () => {
+    const rich = side({ id: "zzz", sources: ["PRESSE", "OFFICIEL"] as SourceType[] });
+    const poor = side({ id: "aaa", sources: press });
+
+    const forward = decideMergeAction({
+      affairA: rich,
+      affairB: poor,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+    const backward = decideMergeAction({
+      affairA: poor,
+      affairB: rich,
+      confidence: "HIGH",
+      matchedBy: "title+category",
+    });
+
+    expect(forward).toEqual(backward);
+    expect(forward.keepId).toBe("zzz");
+  });
+});

--- a/src/services/affairs/__tests__/pair-decision.test.ts
+++ b/src/services/affairs/__tests__/pair-decision.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #525 — a ruling must survive re-runs, and must stop surviving once the
+// rows it was made against have changed.
+
+const h = vi.hoisted(() => ({
+  decisionFindMany: vi.fn(),
+  decisionUpsert: vi.fn(),
+  decisionGroupBy: vi.fn(),
+  dismissedFindMany: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    affairPairDecision: {
+      findMany: h.decisionFindMany,
+      upsert: h.decisionUpsert,
+      groupBy: h.decisionGroupBy,
+    },
+    dismissedDuplicate: { findMany: h.dismissedFindMany },
+  },
+}));
+
+import {
+  buildPairDecisionUpsert,
+  computePairPrecision,
+  loadPairExclusions,
+} from "../pair-decision";
+import { canonicalPair } from "../affair-pair";
+
+const signal = { confidence: "HIGH", matchedBy: "pourvoiNumber", score: 0.95 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.dismissedFindMany.mockResolvedValue([]);
+  h.decisionFindMany.mockResolvedValue([]);
+  h.decisionGroupBy.mockResolvedValue([]);
+});
+
+describe("canonicalPair — une seule identité par paire (#525)", () => {
+  it("donne la même clé dans les deux sens", () => {
+    expect(canonicalPair("b", "a").key).toBe(canonicalPair("a", "b").key);
+    expect(canonicalPair("b", "a").a).toBe("a");
+  });
+});
+
+describe("buildPairDecisionUpsert — ordre canonique (#525)", () => {
+  it("trie les identifiants", () => {
+    const args = buildPairDecisionUpsert({
+      affairIdA: "zzz",
+      affairIdB: "aaa",
+      classification: "DISTINCT",
+      reviewedBy: "admin",
+      signal,
+      affairAUpdatedAt: new Date("2026-07-01"),
+      affairBUpdatedAt: new Date("2026-07-02"),
+    });
+
+    expect(args.where).toEqual({ pairKey: "aaa:zzz" });
+    expect(args.create).toMatchObject({ affairIdA: "aaa", affairIdB: "zzz" });
+  });
+
+  it("fait suivre les dates au tri, sinon la fraîcheur est comparée à la mauvaise fiche", () => {
+    const args = buildPairDecisionUpsert({
+      affairIdA: "zzz",
+      affairIdB: "aaa",
+      classification: "DISTINCT",
+      reviewedBy: "admin",
+      signal,
+      affairAUpdatedAt: new Date("2026-07-01"),
+      affairBUpdatedAt: new Date("2026-07-02"),
+    });
+
+    // "aaa" est passée en second à l'appel : sa date doit devenir affairAUpdatedAt.
+    expect(args.create).toMatchObject({
+      affairAUpdatedAt: new Date("2026-07-02"),
+      affairBUpdatedAt: new Date("2026-07-01"),
+    });
+  });
+
+  it("conserve le survivant d'une fusion", () => {
+    const args = buildPairDecisionUpsert({
+      affairIdA: "a",
+      affairIdB: "b",
+      classification: "DUPLICATE",
+      reviewedBy: "admin",
+      signal,
+      affairAUpdatedAt: new Date("2026-07-01"),
+      affairBUpdatedAt: new Date("2026-07-01"),
+      mergedIntoAffairId: "a",
+    });
+
+    expect(args.create).toMatchObject({ mergedIntoAffairId: "a" });
+  });
+});
+
+describe("loadPairExclusions — ce qui exclut, ce qui revient (#525)", () => {
+  const now = new Date("2026-07-01T00:00:00Z");
+  const later = new Date("2026-07-20T00:00:00Z");
+
+  function ruling(classification: string, updated = now) {
+    return {
+      pairKey: "a:b",
+      affairIdA: "a",
+      affairIdB: "b",
+      classification,
+      affairAUpdatedAt: updated,
+      affairBUpdatedAt: updated,
+    };
+  }
+
+  it("exclut DUPLICATE, LINKED et DISTINCT", async () => {
+    for (const classification of ["DUPLICATE", "LINKED", "DISTINCT"]) {
+      h.decisionFindMany.mockResolvedValue([ruling(classification)]);
+
+      const result = await loadPairExclusions(
+        new Map([
+          ["a", now],
+          ["b", now],
+        ])
+      );
+
+      expect(result.excluded.has("a:b")).toBe(true);
+    }
+  });
+
+  it("n'exclut pas UNCERTAIN, qui diffère au lieu de trancher", async () => {
+    h.decisionFindMany.mockResolvedValue([ruling("UNCERTAIN")]);
+
+    const result = await loadPairExclusions(
+      new Map([
+        ["a", now],
+        ["b", now],
+      ])
+    );
+
+    expect(result.excluded.has("a:b")).toBe(false);
+    expect(result.uncertain.has("a:b")).toBe(true);
+  });
+
+  it("rouvre un DISTINCT quand une des deux fiches a été modifiée depuis", async () => {
+    h.decisionFindMany.mockResolvedValue([ruling("DISTINCT")]);
+
+    const result = await loadPairExclusions(
+      new Map([
+        ["a", later],
+        ["b", now],
+      ])
+    );
+
+    expect(result.stale.has("a:b")).toBe(true);
+    expect(result.excluded.has("a:b")).toBe(false);
+  });
+
+  it("ne rouvre pas un DUPLICATE : la fusion a déjà eu lieu", async () => {
+    h.decisionFindMany.mockResolvedValue([ruling("DUPLICATE")]);
+
+    const result = await loadPairExclusions(
+      new Map([
+        ["a", later],
+        ["b", later],
+      ])
+    );
+
+    expect(result.stale.has("a:b")).toBe(false);
+    expect(result.excluded.has("a:b")).toBe(true);
+  });
+
+  it("honore encore l'ancienne table de faux positifs, dans les deux sens", async () => {
+    h.dismissedFindMany.mockResolvedValue([{ affairIdA: "b", affairIdB: "a" }]);
+
+    const result = await loadPairExclusions(new Map());
+
+    expect(result.excluded.has("a:b")).toBe(true);
+  });
+
+  it("expose la classification pour que la file affiche ce qui a été jugé", async () => {
+    h.decisionFindMany.mockResolvedValue([ruling("UNCERTAIN")]);
+
+    const result = await loadPairExclusions(new Map());
+
+    expect(result.classifications.get("a:b")).toBe("UNCERTAIN");
+  });
+});
+
+describe("computePairPrecision — mesure sur tous les jugements (#525)", () => {
+  it("ne rend rien avant le premier jugement", async () => {
+    const metrics = await computePairPrecision(12);
+
+    expect(metrics.precision).toBeNull();
+    expect(metrics.candidatePairs).toBe(12);
+  });
+
+  it("rapporte les doublons aux paires réellement tranchées", async () => {
+    h.decisionGroupBy.mockResolvedValue([
+      { classification: "DUPLICATE", _count: { _all: 3 } },
+      { classification: "DISTINCT", _count: { _all: 1 } },
+      { classification: "LINKED", _count: { _all: 0 } },
+    ]);
+
+    const metrics = await computePairPrecision(10);
+
+    expect(metrics.precision).toBe(0.75);
+    expect(metrics.byClassification.DUPLICATE).toBe(3);
+  });
+
+  it("laisse UNCERTAIN hors du calcul, des deux côtés", async () => {
+    h.decisionGroupBy.mockResolvedValue([
+      { classification: "DUPLICATE", _count: { _all: 1 } },
+      { classification: "DISTINCT", _count: { _all: 1 } },
+      { classification: "UNCERTAIN", _count: { _all: 8 } },
+    ]);
+
+    const metrics = await computePairPrecision(10);
+
+    // 1 / 2, pas 1 / 10 : différer n'est pas juger.
+    expect(metrics.precision).toBe(0.5);
+    expect(metrics.ruled).toBe(10);
+  });
+});

--- a/src/services/affairs/absorb-draft.ts
+++ b/src/services/affairs/absorb-draft.ts
@@ -1,0 +1,164 @@
+/**
+ * Absorbing a draft into a published affair.
+ *
+ * The published fiche always survives and is never rewritten by this path. A
+ * merge is allowed to carry over what the absorbed row held in addition — its
+ * sources, its events, the court-assigned identifiers the published fiche lacks —
+ * but everything the draft *states* about the judicial outcome goes through the
+ * proposal queue instead, so a human decides whether a published record changes
+ * (issue #525, §4).
+ *
+ * Only reached when an official identifier already proved the two rows describe
+ * one decision. See decideMergeAction().
+ */
+
+import { db } from "@/lib/db";
+import type { SourceType } from "@/generated/prisma";
+import {
+  mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS,
+  type AdditiveMergeField,
+} from "./reconciliation";
+import { normalizeForCompare, proposeAffairUpdate } from "./proposals";
+
+/**
+ * Fields a draft may contribute to a published fiche, through review only.
+ *
+ * The proposal whitelist minus the identifiers the merge already carried over
+ * directly. `court` sits here rather than in the merge: it names the jurisdiction
+ * rather than identifying the decision, so even filling a gap is a review call.
+ */
+const PROPOSABLE_FROM_DRAFT = [
+  "status",
+  "verdictDate",
+  "court",
+  "sentence",
+  "prisonMonths",
+  "prisonSuspended",
+  "fineAmount",
+  "ineligibilityMonths",
+  "communityService",
+  "otherSentence",
+] as const;
+
+/**
+ * Differences that survive the merge without being carried or proposed.
+ *
+ * The published wording is authoritative once the pair is proven to be one
+ * decision, so these are not blockers. They are written to the merge audit trail
+ * rather than dropped, because the absorbed row is deleted.
+ */
+const RECORDED_ONLY_FIELDS = ["title", "description", "category"] as const;
+
+export interface AbsorbDraftInput {
+  publishedId: string;
+  draftId: string;
+  importRunId: string;
+  /** The merge plan's reason, kept verbatim in the audit trail and rationale. */
+  reason: string;
+  additiveFields?: readonly AdditiveMergeField[];
+}
+
+export interface AbsorbDraftResult {
+  proposalsCreated: number;
+  proposedFields: string[];
+  recordedDifferences: string[];
+}
+
+const AFFAIR_ABSORB_SELECT = {
+  id: true,
+  title: true,
+  description: true,
+  category: true,
+  status: true,
+  verdictDate: true,
+  court: true,
+  sentence: true,
+  prisonMonths: true,
+  prisonSuspended: true,
+  fineAmount: true,
+  ineligibilityMonths: true,
+  communityService: true,
+  otherSentence: true,
+  publicationStatus: true,
+  sources: { select: { sourceType: true, url: true }, take: 1 },
+} as const;
+
+export async function absorbDraftIntoPublished(
+  input: AbsorbDraftInput
+): Promise<AbsorbDraftResult> {
+  const [published, draft] = await Promise.all([
+    db.affair.findUnique({ where: { id: input.publishedId }, select: AFFAIR_ABSORB_SELECT }),
+    db.affair.findUnique({ where: { id: input.draftId }, select: AFFAIR_ABSORB_SELECT }),
+  ]);
+  if (!published) throw new Error(`Affaire publiée introuvable : ${input.publishedId}`);
+  if (!draft) throw new Error(`Brouillon introuvable : ${input.draftId}`);
+
+  // Re-checked here rather than trusted from the plan: the rows can move between
+  // detection and this call, and absorbing the wrong way deletes a public page.
+  if (published.publicationStatus !== "PUBLISHED") {
+    throw new Error(`L'affaire survivante n'est pas publiée : ${input.publishedId}`);
+  }
+  if (draft.publicationStatus !== "DRAFT") {
+    throw new Error(`L'affaire absorbée n'est pas un brouillon : ${input.draftId}`);
+  }
+
+  const live = published as unknown as Record<string, unknown>;
+  const incoming = draft as unknown as Record<string, unknown>;
+
+  // What the draft states that the published fiche does not.
+  const patch: Record<string, unknown> = {};
+  for (const field of PROPOSABLE_FROM_DRAFT) {
+    const value = incoming[field];
+    if (value === null || value === undefined) continue;
+    if (normalizeForCompare(value) === normalizeForCompare(live[field])) continue;
+    patch[field] = value;
+  }
+
+  const recordedDifferences = RECORDED_ONLY_FIELDS.filter(
+    (field) => normalizeForCompare(incoming[field]) !== normalizeForCompare(live[field])
+  );
+
+  // The merge is what deletes the draft, so it runs before proposing: a proposal
+  // on a pair that failed to merge would be unactionable.
+  await mergeAffairs(input.publishedId, input.draftId, {
+    additiveFields: input.additiveFields ?? ABSORPTION_ADDITIVE_FIELDS,
+    auditNotes: {
+      absorbedDraft: input.draftId,
+      reason: input.reason,
+      proposedFields: Object.keys(patch),
+      // Kept because the absorbed row no longer exists to be consulted.
+      recordedDifferences: recordedDifferences.map((field) => ({
+        field,
+        absorbedValue: String(incoming[field] ?? ""),
+      })),
+    },
+  });
+
+  if (Object.keys(patch).length === 0) {
+    return { proposalsCreated: 0, proposedFields: [], recordedDifferences };
+  }
+
+  const source = draft.sources[0];
+  const result = await proposeAffairUpdate({
+    affairId: input.publishedId,
+    importer: "reconcile-affairs",
+    importRunId: input.importRunId,
+    patch,
+    source: (source?.sourceType ?? "PRESSE") as SourceType,
+    sourceUrl: source?.url ?? null,
+    confidence: 70,
+    rationale:
+      `Absorption d'un brouillon dans cette affaire publiée. ${input.reason}. ` +
+      `Le brouillon renseignait ces champs différemment ; l'affaire publiée n'a pas été ` +
+      `modifiée automatiquement.`,
+  });
+
+  const proposalsCreated = [
+    result.autoProposalId,
+    result.pendingProposalId,
+    result.conflictProposalId,
+  ].filter(Boolean).length;
+
+  return { proposalsCreated, proposedFields: Object.keys(patch), recordedDifferences };
+}

--- a/src/services/affairs/affair-pair.ts
+++ b/src/services/affairs/affair-pair.ts
@@ -1,0 +1,19 @@
+/**
+ * Identity of an unordered pair of affairs.
+ *
+ * Its own module so both the detector and the decision store can depend on it
+ * without importing each other. Every store and every exclusion goes through
+ * this one function, which is what stops (A, B) and (B, A) from producing two
+ * rows for one pair (issue #525).
+ */
+
+export interface CanonicalPair {
+  a: string;
+  b: string;
+  key: string;
+}
+
+export function canonicalPair(idA: string, idB: string): CanonicalPair {
+  const [a, b] = [idA, idB].sort();
+  return { a: a!, b: b!, key: `${a}:${b}` };
+}

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -18,6 +18,8 @@ export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
 export const IMPORTER_JUDILIBRE = "judilibre";
 /** Reserved for admin-initiated proposals, so they never end up run-less. */
 export const IMPORTER_MANUAL_ADMIN = "manual-admin";
+/** Absorbing a draft into a published affair proposes rather than writes (#525). */
+export const IMPORTER_RECONCILE = "reconcile-affairs";
 
 export async function startImportRun(importer: string): Promise<string> {
   const run = await db.importRun.create({

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -75,6 +75,25 @@ export interface MatchResult {
 }
 
 /**
+ * Signals that identify a decision rather than resemble one: official numbers
+ * assigned by a court, not words a title happens to share.
+ *
+ * Only these may carry a merge across the published boundary automatically
+ * (issue #525). Title, category, date and politician proximity are resemblance:
+ * they can be right, but they cannot prove two rows describe one decision.
+ */
+export const DETERMINISTIC_MATCH_SIGNALS: ReadonlySet<string> = new Set([
+  "ecli",
+  "pourvoiNumber",
+  "caseNumbers",
+]);
+
+/** Whether a match rests on an official identifier rather than on resemblance. */
+export function isDeterministicMatch(matchedBy: string): boolean {
+  return DETERMINISTIC_MATCH_SIGNALS.has(matchedBy);
+}
+
+/**
  * Minimum share of the longer title that the shorter one must cover for
  * containment to count as a duplicate signal.
  *
@@ -184,6 +203,14 @@ export interface MatchCandidate {
   caseNumbers?: string[];
   category?: AffairCategory;
   verdictDate?: Date | null;
+  /**
+   * Set when the candidate IS an existing row, so it cannot match itself.
+   *
+   * Importers leave this empty: they match a candidate that has no row yet.
+   * Duplicate detection must set it, otherwise the ECLI branch below returns the
+   * affair's own id and stops, hiding every other signal (issue #525).
+   */
+  excludeAffairId?: string;
 }
 
 /**
@@ -231,7 +258,9 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       where: { ecli: candidate.ecli },
       select: { id: true },
     });
-    if (ecliMatch) {
+    // A self-match proves nothing and must not short-circuit: ecli is unique, so
+    // when the candidate is an existing row this lookup finds that row itself.
+    if (ecliMatch && ecliMatch.id !== candidate.excludeAffairId) {
       matches.push({
         affairId: ecliMatch.id,
         confidence: "CERTAIN",
@@ -252,6 +281,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of pourvoiMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       matches.push({
         affairId: match.id,
         confidence: "HIGH",
@@ -271,6 +301,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of caseNumberMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       // Avoid duplicating matches already found by pourvoi
       if (!matches.some((m) => m.affairId === match.id)) {
         matches.push({
@@ -306,6 +337,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
     });
 
     for (const existing of samePoliticianAffairs) {
+      if (existing.id === candidate.excludeAffairId) continue;
       if (matches.some((m) => m.affairId === existing.id)) continue;
 
       const normalizedExisting = normalizeAffairTitle(existing.title, politicianName);
@@ -360,6 +392,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       select: { id: true },
     });
     for (const match of categoryDateMatches) {
+      if (match.id === candidate.excludeAffairId) continue;
       if (!matches.some((m) => m.affairId === match.id)) {
         matches.push({
           affairId: match.id,

--- a/src/services/affairs/merge-decision.ts
+++ b/src/services/affairs/merge-decision.ts
@@ -1,0 +1,181 @@
+/**
+ * What may be done with a detected duplicate pair, and by whom.
+ *
+ * Detection was widened to published affairs (issue #525), which means the same
+ * queue now holds pairs that may be folded by a cron and pairs that must never
+ * be touched without a human. Keeping that judgement in one pure function makes
+ * it testable and keeps the rule out of the executor.
+ *
+ * The asymmetry is deliberate: a wrong merge between drafts costs a re-split of
+ * material nobody has read, while a wrong merge involving a published affair
+ * deletes a page, mixes two sets of judicial facts about a named person, and
+ * retires a URL. So automation stops at the published boundary unless an official
+ * identifier proves the two rows describe one decision.
+ */
+
+import type { PublicationStatus, SourceType } from "@/generated/prisma";
+import { isDeterministicMatch, type MatchConfidence } from "./matching";
+
+/** Statuses this lot handles. See the issue for ARCHIVED/EXCLUDED/REJECTED. */
+const MERGEABLE_STATUSES: ReadonlySet<PublicationStatus> = new Set([
+  "DRAFT",
+  "PUBLISHED",
+] as PublicationStatus[]);
+
+export type MergeDecision =
+  | "AUTO_MERGE_DRAFTS"
+  | "AUTO_ABSORB_DRAFT_INTO_PUBLISHED"
+  | "REVIEW_REQUIRED"
+  | "NOT_ELIGIBLE";
+
+export interface MergeDecisionAffair {
+  id: string;
+  publicationStatus: PublicationStatus;
+  verifiedAt: Date | null;
+  sources: SourceType[];
+}
+
+export interface MergeDecisionInput {
+  affairA: MergeDecisionAffair;
+  affairB: MergeDecisionAffair;
+  confidence: MatchConfidence;
+  matchedBy: string;
+  /**
+   * Fields whose values rule out that the two rows describe one decision, such as
+   * verdict dates months apart. Any contradiction sends the pair to review.
+   */
+  contradictions?: string[];
+  /**
+   * Sensitive fields the two rows state differently that a merge could neither
+   * write nor turn into a proposal, so absorbing would drop a claim in silence.
+   */
+  unpropagatableDifferences?: string[];
+}
+
+export interface MergePlan {
+  decision: MergeDecision;
+  /** Survivor and absorbed, set only for the two automatic decisions. */
+  keepId?: string;
+  removeId?: string;
+  /** Why, in French: surfaced in the review queue and in the merge audit trail. */
+  reason: string;
+}
+
+/**
+ * Survivor between two drafts: the richer row, then the lower id.
+ *
+ * The id tie-break is what makes the plan deterministic. Without it the outcome
+ * would depend on which side detection happened to label A, which varies with
+ * row order (requirement 12).
+ */
+function pickDraftSurvivor(
+  a: MergeDecisionAffair,
+  b: MergeDecisionAffair
+): [keep: MergeDecisionAffair, remove: MergeDecisionAffair] {
+  if (a.sources.length !== b.sources.length) {
+    return a.sources.length > b.sources.length ? [a, b] : [b, a];
+  }
+  return a.id < b.id ? [a, b] : [b, a];
+}
+
+export function decideMergeAction(input: MergeDecisionInput): MergePlan {
+  const { affairA: a, affairB: b, confidence, matchedBy } = input;
+  const contradictions = input.contradictions ?? [];
+  const unpropagatable = input.unpropagatableDifferences ?? [];
+
+  if (a.id === b.id) {
+    return { decision: "NOT_ELIGIBLE", reason: "Une affaire ne peut pas fusionner avec elle-même" };
+  }
+
+  for (const affair of [a, b]) {
+    if (!MERGEABLE_STATUSES.has(affair.publicationStatus)) {
+      return {
+        decision: "NOT_ELIGIBLE",
+        reason: `Statut hors périmètre : ${affair.publicationStatus}`,
+      };
+    }
+  }
+
+  // Contradictory judicial data means the pair may not be one affair at all.
+  if (contradictions.length > 0) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: `Données judiciaires contradictoires : ${contradictions.join(", ")}`,
+    };
+  }
+
+  const confident = confidence === "CERTAIN" || confidence === "HIGH";
+  const aPublished = a.publicationStatus === "PUBLISHED";
+  const bPublished = b.publicationStatus === "PUBLISHED";
+
+  // Two published affairs: never automatic, whatever the confidence. Merging
+  // them deletes a page a reader can reach today.
+  if (aPublished && bPublished) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: "Deux affaires publiées : la fusion retire une page publique",
+    };
+  }
+
+  // One of each: absorption is directed, the published affair always survives.
+  if (aPublished !== bPublished) {
+    const published = aPublished ? a : b;
+    const draft = aPublished ? b : a;
+
+    if (!confident) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Rapprochement non concluant (${confidence}) face à une affaire publiée`,
+      };
+    }
+    if (!isDeterministicMatch(matchedBy)) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Rapprochement heuristique (${matchedBy}) : pas d'identifiant judiciaire commun`,
+      };
+    }
+    if (unpropagatable.length > 0) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Le brouillon affirme autre chose sur : ${unpropagatable.join(", ")}`,
+      };
+    }
+    // A human already validated this draft; deciding it is a duplicate is theirs.
+    if (draft.verifiedAt !== null) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: "Le brouillon a déjà été validé par une relecture humaine",
+      };
+    }
+
+    return {
+      decision: "AUTO_ABSORB_DRAFT_INTO_PUBLISHED",
+      keepId: published.id,
+      removeId: draft.id,
+      reason: `Identifiant judiciaire commun (${matchedBy}) : le brouillon est absorbé par l'affaire publiée`,
+    };
+  }
+
+  // Two drafts: nothing public is at stake.
+  if (!confident) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: `Rapprochement non concluant (${confidence})`,
+    };
+  }
+
+  const [keep, remove] = pickDraftSurvivor(a, b);
+  if (remove.verifiedAt !== null) {
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: "Le brouillon à absorber a déjà été validé par une relecture humaine",
+    };
+  }
+
+  return {
+    decision: "AUTO_MERGE_DRAFTS",
+    keepId: keep.id,
+    removeId: remove.id,
+    reason: `Deux brouillons rapprochés en ${confidence} (${matchedBy})`,
+  };
+}

--- a/src/services/affairs/pair-decision.ts
+++ b/src/services/affairs/pair-decision.ts
@@ -1,0 +1,203 @@
+/**
+ * Human rulings on detected duplicate pairs (issue #525).
+ *
+ * Detection was widened to published affairs, so most pairs now need a person
+ * rather than a cron. Without a memory of what that person decided, the same
+ * pairs would be re-proposed at every run and the queue would never drain.
+ *
+ * A ruling is not permanent truth. "Not the same affair" was judged against the
+ * two rows as they stood; if either is later edited, the ruling is stale and the
+ * pair may be worth another look. That is what the two stored `updatedAt` are for.
+ */
+
+import { db } from "@/lib/db";
+import type { AffairPairClassification, Prisma } from "@/generated/prisma";
+import { canonicalPair } from "./affair-pair";
+
+/**
+ * Rulings that keep a pair out of the duplicate queue.
+ *
+ * UNCERTAIN is absent on purpose: it defers a decision, it does not settle one, so
+ * the pair stays visible. DUPLICATE excludes because the merge already happened.
+ */
+const EXCLUDING_CLASSIFICATIONS: readonly AffairPairClassification[] = [
+  "DUPLICATE",
+  "LINKED",
+  "DISTINCT",
+];
+
+/** Rulings a later edit on either affair can reopen. */
+const STALEABLE_CLASSIFICATIONS: readonly AffairPairClassification[] = ["DISTINCT", "UNCERTAIN"];
+
+export interface RecordPairDecisionInput {
+  affairIdA: string;
+  affairIdB: string;
+  classification: AffairPairClassification;
+  reviewedBy: string;
+  notes?: string | null;
+  /** The signal that proposed the pair, kept so the ruling can be re-read. */
+  signal: { confidence: string; matchedBy: string; score: number };
+  /** Both rows as of the ruling; a later edit makes DISTINCT/UNCERTAIN stale. */
+  affairAUpdatedAt: Date;
+  affairBUpdatedAt: Date;
+  mergedIntoAffairId?: string | null;
+}
+
+/**
+ * The upsert a ruling amounts to, canonical ordering included.
+ *
+ * Pure and exported so both callers share one implementation: the standalone path
+ * below, and the merge transaction, which must write a DUPLICATE ruling and the
+ * merge together. Returning args rather than performing the write avoids handing
+ * a transaction client across a module boundary.
+ */
+export function buildPairDecisionUpsert(
+  input: RecordPairDecisionInput
+): Prisma.AffairPairDecisionUpsertArgs {
+  const { a, b, key } = canonicalPair(input.affairIdA, input.affairIdB);
+  // Timestamps follow the ids through the canonical sort, or a later staleness
+  // check would compare affair A against affair B's recorded time.
+  const swapped = a !== input.affairIdA;
+  const affairAUpdatedAt = swapped ? input.affairBUpdatedAt : input.affairAUpdatedAt;
+  const affairBUpdatedAt = swapped ? input.affairAUpdatedAt : input.affairBUpdatedAt;
+
+  const data = {
+    classification: input.classification,
+    confidence: input.signal.confidence,
+    matchedBy: input.signal.matchedBy,
+    score: input.signal.score,
+    affairAUpdatedAt,
+    affairBUpdatedAt,
+    mergedIntoAffairId: input.mergedIntoAffairId ?? null,
+    reviewedBy: input.reviewedBy,
+    reviewedAt: new Date(),
+    notes: input.notes ?? null,
+  };
+
+  return {
+    where: { pairKey: key },
+    create: { pairKey: key, affairIdA: a, affairIdB: b, ...data },
+    update: data,
+  };
+}
+
+/** Store a ruling outside any merge, replacing an earlier one for the same pair. */
+export async function recordPairDecision(input: RecordPairDecisionInput): Promise<string> {
+  const decision = await db.affairPairDecision.upsert(buildPairDecisionUpsert(input));
+  return decision.id;
+}
+
+export interface PairExclusions {
+  /** Canonical keys detection must skip. */
+  excluded: Set<string>;
+  /** Canonical keys ruled DISTINCT or UNCERTAIN whose rows have since changed. */
+  stale: Set<string>;
+  /** Canonical keys deferred as UNCERTAIN, for the re-examination filter. */
+  uncertain: Set<string>;
+  /** Ruling stored per pair, so a re-proposed pair can show what was decided. */
+  classifications: Map<string, AffairPairClassification>;
+}
+
+/**
+ * Which pairs a detection run must skip, and which rulings have gone stale.
+ *
+ * Reads the legacy DismissedDuplicate table as well. Those rows mean exactly
+ * "false positive", so they are honoured as DISTINCT until they are backfilled
+ * into this model and the dual read is removed.
+ */
+export async function loadPairExclusions(
+  affairUpdatedAt: Map<string, Date>
+): Promise<PairExclusions> {
+  const [decisions, dismissed] = await Promise.all([
+    db.affairPairDecision.findMany({
+      select: {
+        pairKey: true,
+        affairIdA: true,
+        affairIdB: true,
+        classification: true,
+        affairAUpdatedAt: true,
+        affairBUpdatedAt: true,
+      },
+    }),
+    db.dismissedDuplicate.findMany({ select: { affairIdA: true, affairIdB: true } }),
+  ]);
+
+  const excluded = new Set<string>();
+  const stale = new Set<string>();
+  const uncertain = new Set<string>();
+  const classifications = new Map<string, AffairPairClassification>();
+
+  for (const decision of decisions) {
+    classifications.set(decision.pairKey, decision.classification);
+    if (decision.classification === "UNCERTAIN") uncertain.add(decision.pairKey);
+
+    if (STALEABLE_CLASSIFICATIONS.includes(decision.classification)) {
+      const liveA = affairUpdatedAt.get(decision.affairIdA);
+      const liveB = affairUpdatedAt.get(decision.affairIdB);
+      const changed =
+        (liveA !== undefined && liveA.getTime() > decision.affairAUpdatedAt.getTime()) ||
+        (liveB !== undefined && liveB.getTime() > decision.affairBUpdatedAt.getTime());
+      if (changed) {
+        stale.add(decision.pairKey);
+        // A stale ruling stops excluding: the pair is worth another look.
+        continue;
+      }
+    }
+
+    if (EXCLUDING_CLASSIFICATIONS.includes(decision.classification)) {
+      excluded.add(decision.pairKey);
+    }
+  }
+
+  // Legacy table, read until the backfill lands.
+  for (const row of dismissed) {
+    excluded.add(canonicalPair(row.affairIdA, row.affairIdB).key);
+  }
+
+  return { excluded, stale, uncertain, classifications };
+}
+
+export interface PairPrecisionMetrics {
+  /** Pairs a run proposed, whatever the ruling. */
+  candidatePairs: number;
+  ruled: number;
+  byClassification: Record<AffairPairClassification, number>;
+  /** Share of ruled pairs that were real duplicates. Null before any ruling. */
+  precision: number | null;
+}
+
+/**
+ * Precision of the detection signal, from rulings alone.
+ *
+ * Deliberately computed over every ruling rather than over the top of the ranking:
+ * scoring only the most confident pairs would measure the ranking, not the signal
+ * (issue #525, §7).
+ */
+export async function computePairPrecision(candidatePairs: number): Promise<PairPrecisionMetrics> {
+  const grouped = await db.affairPairDecision.groupBy({
+    by: ["classification"],
+    _count: { _all: true },
+  });
+
+  const byClassification = {
+    DUPLICATE: 0,
+    LINKED: 0,
+    DISTINCT: 0,
+    UNCERTAIN: 0,
+  } as Record<AffairPairClassification, number>;
+  for (const row of grouped) {
+    byClassification[row.classification] = row._count._all;
+  }
+
+  // UNCERTAIN is excluded from both sides: it is an absence of judgement, and
+  // counting it either way would move the number without new information.
+  const decided = byClassification.DUPLICATE + byClassification.LINKED + byClassification.DISTINCT;
+  const ruled = decided + byClassification.UNCERTAIN;
+
+  return {
+    candidatePairs,
+    ruled,
+    byClassification,
+    precision: decided === 0 ? null : byClassification.DUPLICATE / decided,
+  };
+}

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -28,6 +28,10 @@ function makeDraft(
     createdAt: Date;
     publicationStatus: string;
     politicianId: string;
+    verifiedAt: Date | null;
+    involvement: string;
+    factsDate: Date | null;
+    verdictDate: Date | null;
   }> = {}
 ) {
   return {
@@ -37,10 +41,13 @@ function makeDraft(
     pourvoiNumber: null,
     caseNumbers: [],
     category: overrides.category ?? "AUTRE",
-    verdictDate: null,
+    involvement: overrides.involvement ?? "DIRECT",
+    factsDate: overrides.factsDate ?? null,
+    verdictDate: overrides.verdictDate ?? null,
     politicianId: overrides.politicianId ?? "p1",
     createdAt: overrides.createdAt ?? new Date("2026-05-19T10:00:00Z"),
     publicationStatus: overrides.publicationStatus ?? "DRAFT",
+    verifiedAt: overrides.verifiedAt ?? null,
     sources: [],
   };
 }
@@ -145,5 +152,159 @@ describe("findPotentialDuplicates — draft window clustering", () => {
 
     expect(duplicates).toHaveLength(1);
     expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+  });
+});
+
+// Issue #525 — verifying an affair used to remove it from detection for good,
+// which hid every duplicate involving a published fiche.
+describe("findPotentialDuplicates — périmètre élargi (#525)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([]);
+  });
+
+  it("n'exclut plus les affaires vérifiées de la requête", async () => {
+    mockedAffairFindMany.mockResolvedValue([]);
+
+    await findPotentialDuplicates();
+
+    const where = mockedAffairFindMany.mock.calls[0]![0].where;
+    expect(where).toEqual({ publicationStatus: { in: ["DRAFT", "PUBLISHED"] } });
+    expect(where).not.toHaveProperty("verifiedAt");
+  });
+
+  it("fait participer une affaire publiée et vérifiée à la détection", async () => {
+    const verifiedPublished = makeDraft("pub", {
+      publicationStatus: "PUBLISHED",
+      verifiedAt: new Date("2026-01-01"),
+      title: "Condamnation pour recel",
+    });
+    mockedAffairFindMany.mockResolvedValue([
+      verifiedPublished,
+      makeDraft("draft", { title: "Condamnation pour recel" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "pub", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    const summaries = [duplicates[0]!.affairA, duplicates[0]!.affairB];
+    const published = summaries.find((s) => s.id === "pub")!;
+    expect(published.publicationStatus).toBe("PUBLISHED");
+    expect(published.verifiedAt).toEqual(new Date("2026-01-01"));
+  });
+
+  it("appelle le matcher une fois par affaire, pas une fois par paire", async () => {
+    // 4 affaires d'une même personnalité : 6 paires, mais 4 appels suffisent.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1"),
+      makeDraft("a2"),
+      makeDraft("a3"),
+      makeDraft("a4"),
+    ]);
+
+    await findPotentialDuplicates();
+
+    expect(mockedFindMatchingAffairs).toHaveBeenCalledTimes(4);
+  });
+
+  it("passe excludeAffairId pour qu'une affaire ne se rapproche pas d'elle-même", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+
+    await findPotentialDuplicates();
+
+    for (const call of mockedFindMatchingAffairs.mock.calls) {
+      expect(call[0].excludeAffairId).toBeDefined();
+    }
+  });
+
+  it("ignore un self-match même si le matcher en renvoie un", async () => {
+    // Catégories de familles incompatibles, pour que seul le 1er passage joue.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { category: "MENACE" }),
+      makeDraft("a2", { category: "FRAUDE_FISCALE" }),
+    ]);
+    mockedFindMatchingAffairs.mockImplementation(
+      ({ excludeAffairId }: { excludeAffairId: string }) =>
+        Promise.resolve([
+          { affairId: excludeAffairId, confidence: "CERTAIN", score: 1, matchedBy: "ecli" },
+        ])
+    );
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("ne remonte pas un faux positif déjà écarté", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED" }),
+      makeDraft("a2", { publicationStatus: "PUBLISHED" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+    // Enregistré dans l'autre sens : la clé canonique doit quand même l'exclure.
+    mockedDismissedFindMany.mockResolvedValue([{ affairIdA: "a2", affairIdB: "a1" }]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(0);
+  });
+
+  it("signale une contradiction de date de verdict sur la paire", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        publicationStatus: "PUBLISHED",
+        verdictDate: new Date("2020-01-01"),
+      }),
+      makeDraft("a2", { verdictDate: new Date("2024-06-01") }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates[0]!.contradictions).toContain("verdictDate");
+  });
+
+  it("signale un involvement divergent comme non transférable", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { publicationStatus: "PUBLISHED", involvement: "MENTIONED_ONLY" }),
+      makeDraft("a2", { involvement: "DIRECT" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates[0]!.unpropagatableDifferences).toContain("involvement");
+  });
+
+  it("produit la même paire quel que soit le sens du rapprochement", async () => {
+    mockedAffairFindMany.mockResolvedValue([makeDraft("zzz"), makeDraft("aaa")]);
+    // Chaque côté rapproche l'autre, avec des scores différents : le meilleur gagne.
+    mockedFindMatchingAffairs.mockImplementation(
+      ({ excludeAffairId }: { excludeAffairId: string }) =>
+        Promise.resolve(
+          excludeAffairId === "zzz"
+            ? [{ affairId: "aaa", confidence: "POSSIBLE", score: 0.3, matchedBy: "title-partial" }]
+            : [{ affairId: "zzz", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" }]
+        )
+    );
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.score).toBe(0.95);
+    expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+    // Ordre canonique : le plus petit id en A.
+    expect(duplicates[0]!.affairA.id).toBe("aaa");
+    expect(duplicates[0]!.affairB.id).toBe("zzz");
   });
 });

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -4,6 +4,8 @@ vi.mock("@/lib/db", () => ({
   db: {
     affair: { findMany: vi.fn() },
     dismissedDuplicate: { findMany: vi.fn() },
+    // Read by loadPairExclusions: detection now honours stored rulings (#525).
+    affairPairDecision: { findMany: vi.fn() },
   },
 }));
 
@@ -19,6 +21,7 @@ import { findMatchingAffairs } from "./matching";
 const mockedAffairFindMany = db.affair.findMany as ReturnType<typeof vi.fn>;
 const mockedDismissedFindMany = db.dismissedDuplicate.findMany as ReturnType<typeof vi.fn>;
 const mockedFindMatchingAffairs = findMatchingAffairs as ReturnType<typeof vi.fn>;
+const mockedDecisionFindMany = db.affairPairDecision.findMany as ReturnType<typeof vi.fn>;
 
 function makeDraft(
   id: string,
@@ -29,6 +32,7 @@ function makeDraft(
     publicationStatus: string;
     politicianId: string;
     verifiedAt: Date | null;
+    updatedAt: Date;
     involvement: string;
     factsDate: Date | null;
     verdictDate: Date | null;
@@ -48,6 +52,7 @@ function makeDraft(
     createdAt: overrides.createdAt ?? new Date("2026-05-19T10:00:00Z"),
     publicationStatus: overrides.publicationStatus ?? "DRAFT",
     verifiedAt: overrides.verifiedAt ?? null,
+    updatedAt: overrides.updatedAt ?? new Date("2026-05-19T10:00:00Z"),
     sources: [],
   };
 }
@@ -56,6 +61,7 @@ describe("findPotentialDuplicates — draft window clustering", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedDismissedFindMany.mockResolvedValue([]);
+    mockedDecisionFindMany.mockResolvedValue([]);
     mockedFindMatchingAffairs.mockResolvedValue([]);
   });
 
@@ -161,6 +167,7 @@ describe("findPotentialDuplicates — périmètre élargi (#525)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedDismissedFindMany.mockResolvedValue([]);
+    mockedDecisionFindMany.mockResolvedValue([]);
     mockedFindMatchingAffairs.mockResolvedValue([]);
   });
 
@@ -306,5 +313,103 @@ describe("findPotentialDuplicates — périmètre élargi (#525)", () => {
     // Ordre canonique : le plus petit id en A.
     expect(duplicates[0]!.affairA.id).toBe("aaa");
     expect(duplicates[0]!.affairB.id).toBe("zzz");
+  });
+});
+
+// Issue #525 — a ruled pair must stop coming back, and must start coming back
+// once the rows it was ruled against have changed.
+describe("findPotentialDuplicates — jugements humains (#525)", () => {
+  const ruledAt = new Date("2026-07-01T00:00:00Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedDecisionFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+  });
+
+  function pairOfPublished(updatedAt: Date) {
+    return [
+      { ...makeDraft("a1", { publicationStatus: "PUBLISHED" }), updatedAt },
+      { ...makeDraft("a2", { publicationStatus: "PUBLISHED" }), updatedAt },
+    ];
+  }
+
+  it("ne repropose pas une paire jugée distincte", async () => {
+    mockedAffairFindMany.mockResolvedValue(pairOfPublished(ruledAt));
+    mockedDecisionFindMany.mockResolvedValue([
+      {
+        pairKey: "a1:a2",
+        affairIdA: "a1",
+        affairIdB: "a2",
+        classification: "DISTINCT",
+        affairAUpdatedAt: ruledAt,
+        affairBUpdatedAt: ruledAt,
+      },
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(0);
+  });
+
+  it("repropose une paire jugée distincte dont une fiche a changé depuis", async () => {
+    const edited = new Date("2026-07-20T00:00:00Z");
+    mockedAffairFindMany.mockResolvedValue([
+      { ...makeDraft("a1", { publicationStatus: "PUBLISHED" }), updatedAt: edited },
+      { ...makeDraft("a2", { publicationStatus: "PUBLISHED" }), updatedAt: ruledAt },
+    ]);
+    mockedDecisionFindMany.mockResolvedValue([
+      {
+        pairKey: "a1:a2",
+        affairIdA: "a1",
+        affairIdB: "a2",
+        classification: "DISTINCT",
+        affairAUpdatedAt: ruledAt,
+        affairBUpdatedAt: ruledAt,
+      },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.rulingStale).toBe(true);
+    expect(duplicates[0]!.previousClassification).toBe("DISTINCT");
+  });
+
+  it("garde visible une paire différée en incertain", async () => {
+    mockedAffairFindMany.mockResolvedValue(pairOfPublished(ruledAt));
+    mockedDecisionFindMany.mockResolvedValue([
+      {
+        pairKey: "a1:a2",
+        affairIdA: "a1",
+        affairIdB: "a2",
+        classification: "UNCERTAIN",
+        affairAUpdatedAt: ruledAt,
+        affairBUpdatedAt: ruledAt,
+      },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.previousClassification).toBe("UNCERTAIN");
+  });
+
+  it("ne repropose pas une paire déjà fusionnée, même après modification", async () => {
+    const edited = new Date("2026-07-20T00:00:00Z");
+    mockedAffairFindMany.mockResolvedValue(pairOfPublished(edited));
+    mockedDecisionFindMany.mockResolvedValue([
+      {
+        pairKey: "a1:a2",
+        affairIdA: "a1",
+        affairIdB: "a2",
+        classification: "DUPLICATE",
+        affairAUpdatedAt: ruledAt,
+        affairBUpdatedAt: ruledAt,
+      },
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(0);
   });
 });

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -6,8 +6,19 @@
  */
 
 import { db } from "@/lib/db";
-import { Prisma, type SourceType } from "@/generated/prisma";
-import { findMatchingAffairs, sameCategoryFamily, type MatchConfidence } from "./matching";
+import {
+  Prisma,
+  type AffairCategory,
+  type PublicationStatus,
+  type SourceType,
+} from "@/generated/prisma";
+import {
+  findMatchingAffairs,
+  sameCategoryFamily,
+  verdictDatesConflict,
+  type MatchConfidence,
+  type MatchResult,
+} from "./matching";
 
 // ============================================
 // TYPES
@@ -17,6 +28,10 @@ export interface AffairSummary {
   id: string;
   title: string;
   sources: SourceType[];
+  /** Needed by decideMergeAction: automation stops at the published boundary. */
+  publicationStatus: PublicationStatus;
+  /** A verified affair is never deleted automatically (issue #525). */
+  verifiedAt: Date | null;
 }
 
 export interface PotentialDuplicate {
@@ -25,6 +40,10 @@ export interface PotentialDuplicate {
   confidence: MatchConfidence;
   matchedBy: string;
   score: number;
+  /** Judicial values that rule out the two rows describing one decision. */
+  contradictions: string[];
+  /** Differences a merge could neither write nor turn into a proposal. */
+  unpropagatableDifferences: string[];
 }
 
 export interface ReconciliationStats {
@@ -45,15 +64,99 @@ export interface ReconciliationStats {
 const DRAFT_CLUSTER_WINDOW_DAYS = 14;
 
 /**
- * Find potential duplicate pairs among unverified affairs.
+ * Statuses duplicate detection covers.
  *
- * Groups affairs by politician, then compares each pair using
- * the existing matching algorithm.
+ * Named explicitly rather than expressed as "everything except rejected", so
+ * adding a status to the enum cannot silently widen the queue. Left out for this
+ * lot: REJECTED (a moderator already ruled), EXCLUDED (a wrong exclusion is a
+ * moderation audit, not duplicate detection) and ARCHIVED (needs the reason for
+ * archiving to be read). Auditing those is a separate historical pass.
+ */
+const DETECTED_PUBLICATION_STATUSES = ["DRAFT", "PUBLISHED"] as const;
+
+/**
+ * Canonical key for an unordered pair.
+ *
+ * Every store and every exclusion goes through this, so (A, B) and (B, A) can
+ * never produce two rows for one pair.
+ */
+export function canonicalPair(idA: string, idB: string): { a: string; b: string; key: string } {
+  const [a, b] = [idA, idB].sort();
+  return { a: a!, b: b!, key: `${a}:${b}` };
+}
+
+type DetectedAffair = {
+  id: string;
+  title: string;
+  ecli: string | null;
+  pourvoiNumber: string | null;
+  caseNumbers: string[];
+  category: string;
+  involvement: string;
+  factsDate: Date | null;
+  verdictDate: Date | null;
+  politicianId: string;
+  createdAt: Date;
+  publicationStatus: PublicationStatus;
+  verifiedAt: Date | null;
+  sources: { sourceType: SourceType }[];
+};
+
+/** Judicial values that rule out the two rows being one decision. */
+function findContradictions(a: DetectedAffair, b: DetectedAffair): string[] {
+  const contradictions: string[] = [];
+  if (verdictDatesConflict(a.verdictDate, b.verdictDate)) contradictions.push("verdictDate");
+  if (a.ecli && b.ecli && a.ecli !== b.ecli) contradictions.push("ecli");
+  if (a.pourvoiNumber && b.pourvoiNumber && a.pourvoiNumber !== b.pourvoiNumber) {
+    contradictions.push("pourvoiNumber");
+  }
+  return contradictions;
+}
+
+/**
+ * Differences a merge could neither write nor propose, so absorbing would drop
+ * the claim in silence.
+ *
+ * `involvement` says what the person is accused of being, and `factsDate` says
+ * when: both are outside the proposal whitelist, so a disagreement has to stop
+ * automation. Title, description and category are left out on purpose — the
+ * surviving published fiche is the authoritative wording, and the merge audit
+ * trail records what the absorbed row said.
+ */
+function findUnpropagatableDifferences(a: DetectedAffair, b: DetectedAffair): string[] {
+  const differences: string[] = [];
+  if (a.involvement !== b.involvement) differences.push("involvement");
+  const factsA = a.factsDate?.getTime() ?? null;
+  const factsB = b.factsDate?.getTime() ?? null;
+  if (factsA !== null && factsB !== null && factsA !== factsB) differences.push("factsDate");
+  return differences;
+}
+
+function toSummary(affair: DetectedAffair): AffairSummary {
+  return {
+    id: affair.id,
+    title: affair.title,
+    sources: [...new Set(affair.sources.map((s) => s.sourceType))],
+    publicationStatus: affair.publicationStatus,
+    verifiedAt: affair.verifiedAt,
+  };
+}
+
+/**
+ * Find potential duplicate pairs among drafts and published affairs.
+ *
+ * Verifying an affair used to remove it from detection for good, which hid every
+ * duplicate involving a published fiche — the blind spot of issue #525. Scope is
+ * now publication status, not review state.
+ *
+ * Widening the outer loop made the previous shape untenable: findMatchingAffairs
+ * was called once per pair although it only depends on one side, so a politician
+ * with n affairs cost n(n-1)/2 calls where n suffice. It is now called once per
+ * affair and the results are folded into pairs.
  */
 export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
-  // Load all unverified affairs
   const affairs = await db.affair.findMany({
-    where: { verifiedAt: null },
+    where: { publicationStatus: { in: [...DETECTED_PUBLICATION_STATUSES] } },
     select: {
       id: true,
       title: true,
@@ -61,73 +164,87 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       pourvoiNumber: true,
       caseNumbers: true,
       category: true,
+      involvement: true,
+      factsDate: true,
       verdictDate: true,
       politicianId: true,
       createdAt: true,
       publicationStatus: true,
+      verifiedAt: true,
       sources: { select: { sourceType: true } },
     },
   });
 
-  // Load dismissed pairs to exclude
   const dismissed = await db.dismissedDuplicate.findMany({
     select: { affairIdA: true, affairIdB: true },
   });
-  const dismissedSet = new Set(dismissed.map((d) => [d.affairIdA, d.affairIdB].sort().join(":")));
+  const dismissedSet = new Set(dismissed.map((d) => canonicalPair(d.affairIdA, d.affairIdB).key));
 
-  // Group by politician
-  const byPolitician = new Map<string, typeof affairs>();
+  const byId = new Map(affairs.map((a) => [a.id, a as DetectedAffair]));
+
+  const byPolitician = new Map<string, DetectedAffair[]>();
   for (const affair of affairs) {
     const list = byPolitician.get(affair.politicianId) ?? [];
-    list.push(affair);
+    list.push(affair as DetectedAffair);
     byPolitician.set(affair.politicianId, list);
   }
 
-  const duplicates: PotentialDuplicate[] = [];
+  // Best result per pair. Both sides of a pair can produce a match, and they can
+  // disagree, so the winner is picked on score then on matchedBy — never on which
+  // side was queried first, which would make the output order-dependent.
+  const best = new Map<string, PotentialDuplicate>();
+
+  function record(a: DetectedAffair, b: DetectedAffair, match: MatchResult) {
+    const { a: idA, key } = canonicalPair(a.id, b.id);
+    if (dismissedSet.has(key)) return;
+
+    const first = idA === a.id ? a : b;
+    const second = idA === a.id ? b : a;
+    const candidate: PotentialDuplicate = {
+      affairA: toSummary(first),
+      affairB: toSummary(second),
+      confidence: match.confidence,
+      matchedBy: match.matchedBy,
+      score: match.score,
+      contradictions: findContradictions(first, second),
+      unpropagatableDifferences: findUnpropagatableDifferences(first, second),
+    };
+
+    const existing = best.get(key);
+    if (
+      !existing ||
+      candidate.score > existing.score ||
+      (candidate.score === existing.score && candidate.matchedBy < existing.matchedBy)
+    ) {
+      best.set(key, candidate);
+    }
+  }
 
   for (const group of byPolitician.values()) {
     if (group.length < 2) continue;
 
-    // Compare each pair within the same politician
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        const a = group[i];
-        const b = group[j];
+    for (const affair of group) {
+      const matches = await findMatchingAffairs({
+        politicianId: affair.politicianId,
+        title: affair.title,
+        ecli: affair.ecli,
+        pourvoiNumber: affair.pourvoiNumber,
+        caseNumbers: affair.caseNumbers,
+        category: affair.category as AffairCategory,
+        verdictDate: affair.verdictDate,
+        // Without this the affair matches itself, and the ECLI branch would
+        // return that self-match alone and hide every other signal.
+        excludeAffairId: affair.id,
+      });
 
-        // Skip if already dismissed
-        const pairKey = [a!.id, b!.id].sort().join(":");
-        if (dismissedSet.has(pairKey)) continue;
-
-        // Use affair B as a candidate to match against A
-        const matches = await findMatchingAffairs({
-          politicianId: b!.politicianId,
-          title: b!.title,
-          ecli: b!.ecli,
-          pourvoiNumber: b!.pourvoiNumber,
-          caseNumbers: b!.caseNumbers,
-          category: b!.category,
-          verdictDate: b!.verdictDate,
-        });
-
-        // Check if affair A appears in the matches
-        const matchForA = matches.find((m) => m.affairId === a!.id);
-        if (matchForA) {
-          duplicates.push({
-            affairA: {
-              id: a!.id,
-              title: a!.title,
-              sources: [...new Set(a!.sources.map((s) => s.sourceType))],
-            },
-            affairB: {
-              id: b!.id,
-              title: b!.title,
-              sources: [...new Set(b!.sources.map((s) => s.sourceType))],
-            },
-            confidence: matchForA.confidence,
-            matchedBy: matchForA.matchedBy,
-            score: matchForA.score,
-          });
-        }
+      for (const match of matches) {
+        // Belt and braces: excludeAffairId already prevents this, but a self-pair
+        // must never reach the queue if a matcher path ever stops honouring it.
+        if (match.affairId === affair.id) continue;
+        const other = byId.get(match.affairId);
+        // Outside the detected scope, e.g. a rejected affair.
+        if (!other) continue;
+        record(affair, other, match);
       }
     }
   }
@@ -139,8 +256,6 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
   // cannot catch. Pair drafts of the same politician created within
   // DRAFT_CLUSTER_WINDOW_DAYS when their categories share a family.
   // POSSIBLE only (score 0.45): never auto-merged, surfaced for human review.
-  const foundPairs = new Set(duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join(":")));
-
   for (const group of byPolitician.values()) {
     const draftGroup = group.filter((a) => a.publicationStatus === "DRAFT");
     if (draftGroup.length < 2) continue;
@@ -150,37 +265,26 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
         const a = draftGroup[i]!;
         const b = draftGroup[j]!;
 
-        const pairKey = [a.id, b.id].sort().join(":");
-        if (dismissedSet.has(pairKey) || foundPairs.has(pairKey)) continue;
+        const { key } = canonicalPair(a.id, b.id);
+        if (dismissedSet.has(key) || best.has(key)) continue;
+        if (!sameCategoryFamily(a.category, b.category)) continue;
 
         const daysApart =
           Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);
         if (daysApart > DRAFT_CLUSTER_WINDOW_DAYS) continue;
-        if (!sameCategoryFamily(a.category, b.category)) continue;
 
-        foundPairs.add(pairKey);
-        duplicates.push({
-          affairA: {
-            id: a.id,
-            title: a.title,
-            sources: [...new Set(a.sources.map((s) => s.sourceType))],
-          },
-          affairB: {
-            id: b.id,
-            title: b.title,
-            sources: [...new Set(b.sources.map((s) => s.sourceType))],
-          },
+        record(a, b, {
+          affairId: b.id,
           confidence: "POSSIBLE",
-          matchedBy: "politician+category+window",
           score: 0.45,
+          matchedBy: "politician+category+window",
         });
       }
     }
   }
 
-  // Sort by score descending (most confident first)
-  duplicates.sort((a, b) => b.score - a.score);
-  return duplicates;
+  // Most confident first.
+  return [...best.values()].sort((a, b) => b.score - a.score);
 }
 
 // ============================================
@@ -194,9 +298,37 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
  */
 const ADDITIVE_MERGE_FIELDS = ["ecli", "pourvoiNumber", "court", "chamber", "caseNumber"] as const;
 
+export type AdditiveMergeField = (typeof ADDITIVE_MERGE_FIELDS)[number];
+
+/**
+ * What an automatic absorption into a published affair may fill: court-assigned
+ * identifiers only.
+ *
+ * `court` and `chamber` are left out although they would only fill a gap, because
+ * they describe the jurisdiction rather than identify the decision. Both are in
+ * the proposal whitelist, so the draft's value reaches the published fiche
+ * through review instead of a cron write (issue #525, §4).
+ */
+export const ABSORPTION_ADDITIVE_FIELDS: readonly AdditiveMergeField[] = [
+  "ecli",
+  "pourvoiNumber",
+  "caseNumber",
+];
+
 export interface MergeAffairsOptions {
   /** Request context, when the merge is human-initiated from the admin. */
   audit?: { ipAddress?: string | null; userAgent?: string | null };
+  /**
+   * Restricts which fields the survivor may have filled from the absorbed affair.
+   * Defaults to the full additive set, which is right for a human-initiated merge
+   * and for two drafts. Absorption into a published affair narrows it.
+   */
+  additiveFields?: readonly AdditiveMergeField[];
+  /**
+   * Recorded verbatim in the merge audit trail, to keep what the absorbed affair
+   * stated and could not be carried over. Nothing is dropped silently.
+   */
+  auditNotes?: Prisma.InputJsonValue;
 }
 
 export interface MergeAffairsResult {
@@ -342,7 +474,7 @@ export async function mergeAffairs(
     // --- Additive field fill, plus the absorbed affair's URLs.
     const updates: Prisma.AffairUpdateInput = {};
     const identifiersMerged: string[] = [];
-    for (const field of ADDITIVE_MERGE_FIELDS) {
+    for (const field of options.additiveFields ?? ADDITIVE_MERGE_FIELDS) {
       if (!keep[field] && remove[field]) {
         updates[field] = remove[field];
         identifiersMerged.push(field);
@@ -404,6 +536,7 @@ export async function mergeAffairs(
           articlesMoved,
           identifiersMerged,
           slugsPreserved,
+          ...(options.auditNotes ? { notes: options.auditNotes } : {}),
         },
         ipAddress: options.audit?.ipAddress ?? null,
         userAgent: options.audit?.userAgent ?? null,

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -6,9 +6,12 @@
  */
 
 import { db } from "@/lib/db";
+import { canonicalPair } from "./affair-pair";
+import { buildPairDecisionUpsert, loadPairExclusions } from "./pair-decision";
 import {
   Prisma,
   type AffairCategory,
+  type AffairPairClassification,
   type PublicationStatus,
   type SourceType,
 } from "@/generated/prisma";
@@ -27,7 +30,11 @@ import {
 export interface AffairSummary {
   id: string;
   title: string;
+  /** Both sides always share it; carried so the queue can group by person. */
+  politicianId: string;
   sources: SourceType[];
+  /** Carried so a ruling can record the rows it was made against. */
+  updatedAt: Date;
   /** Needed by decideMergeAction: automation stops at the published boundary. */
   publicationStatus: PublicationStatus;
   /** A verified affair is never deleted automatically (issue #525). */
@@ -44,6 +51,10 @@ export interface PotentialDuplicate {
   contradictions: string[];
   /** Differences a merge could neither write nor turn into a proposal. */
   unpropagatableDifferences: string[];
+  /** An earlier human ruling on this pair, when one no longer excludes it. */
+  previousClassification: AffairPairClassification | null;
+  /** True when that ruling was made against rows that have since been edited. */
+  rulingStale: boolean;
 }
 
 export interface ReconciliationStats {
@@ -74,17 +85,6 @@ const DRAFT_CLUSTER_WINDOW_DAYS = 14;
  */
 const DETECTED_PUBLICATION_STATUSES = ["DRAFT", "PUBLISHED"] as const;
 
-/**
- * Canonical key for an unordered pair.
- *
- * Every store and every exclusion goes through this, so (A, B) and (B, A) can
- * never produce two rows for one pair.
- */
-export function canonicalPair(idA: string, idB: string): { a: string; b: string; key: string } {
-  const [a, b] = [idA, idB].sort();
-  return { a: a!, b: b!, key: `${a}:${b}` };
-}
-
 type DetectedAffair = {
   id: string;
   title: string;
@@ -99,6 +99,7 @@ type DetectedAffair = {
   createdAt: Date;
   publicationStatus: PublicationStatus;
   verifiedAt: Date | null;
+  updatedAt: Date;
   sources: { sourceType: SourceType }[];
 };
 
@@ -136,7 +137,9 @@ function toSummary(affair: DetectedAffair): AffairSummary {
   return {
     id: affair.id,
     title: affair.title,
+    politicianId: affair.politicianId,
     sources: [...new Set(affair.sources.map((s) => s.sourceType))],
+    updatedAt: affair.updatedAt,
     publicationStatus: affair.publicationStatus,
     verifiedAt: affair.verifiedAt,
   };
@@ -171,14 +174,14 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       createdAt: true,
       publicationStatus: true,
       verifiedAt: true,
+      updatedAt: true,
       sources: { select: { sourceType: true } },
     },
   });
 
-  const dismissed = await db.dismissedDuplicate.findMany({
-    select: { affairIdA: true, affairIdB: true },
-  });
-  const dismissedSet = new Set(dismissed.map((d) => canonicalPair(d.affairIdA, d.affairIdB).key));
+  // Rulings are checked against the rows as they stand: a DISTINCT made before an
+  // edit no longer settles anything (issue #525).
+  const exclusions = await loadPairExclusions(new Map(affairs.map((a) => [a.id, a.updatedAt])));
 
   const byId = new Map(affairs.map((a) => [a.id, a as DetectedAffair]));
 
@@ -196,7 +199,7 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
 
   function record(a: DetectedAffair, b: DetectedAffair, match: MatchResult) {
     const { a: idA, key } = canonicalPair(a.id, b.id);
-    if (dismissedSet.has(key)) return;
+    if (exclusions.excluded.has(key)) return;
 
     const first = idA === a.id ? a : b;
     const second = idA === a.id ? b : a;
@@ -208,6 +211,8 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       score: match.score,
       contradictions: findContradictions(first, second),
       unpropagatableDifferences: findUnpropagatableDifferences(first, second),
+      previousClassification: exclusions.classifications.get(key) ?? null,
+      rulingStale: exclusions.stale.has(key),
     };
 
     const existing = best.get(key);
@@ -266,7 +271,7 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
         const b = draftGroup[j]!;
 
         const { key } = canonicalPair(a.id, b.id);
-        if (dismissedSet.has(key) || best.has(key)) continue;
+        if (exclusions.excluded.has(key) || best.has(key)) continue;
         if (!sameCategoryFamily(a.category, b.category)) continue;
 
         const daysApart =
@@ -329,6 +334,20 @@ export interface MergeAffairsOptions {
    * stated and could not be carried over. Nothing is dropped silently.
    */
   auditNotes?: Prisma.InputJsonValue;
+  /**
+   * Ruling to store in the same transaction as the merge.
+   *
+   * A merge without its ruling would be re-proposed at the next run; a ruling
+   * without its merge would claim work that never happened. Both or neither.
+   */
+  pairDecision?: {
+    otherAffairId: string;
+    reviewedBy: string;
+    notes?: string | null;
+    signal: { confidence: string; matchedBy: string; score: number };
+    keepUpdatedAt: Date;
+    removeUpdatedAt: Date;
+  };
 }
 
 export interface MergeAffairsResult {
@@ -542,6 +561,25 @@ export async function mergeAffairs(
         userAgent: options.audit?.userAgent ?? null,
       },
     });
+
+    // Same transaction as the merge: a merge without its ruling would be
+    // re-proposed, a ruling without its merge would claim work never done.
+    if (options.pairDecision) {
+      const ruling = options.pairDecision;
+      await tx.affairPairDecision.upsert(
+        buildPairDecisionUpsert({
+          affairIdA: keepId,
+          affairIdB: ruling.otherAffairId,
+          classification: "DUPLICATE",
+          reviewedBy: ruling.reviewedBy,
+          notes: ruling.notes,
+          signal: ruling.signal,
+          affairAUpdatedAt: ruling.keepUpdatedAt,
+          affairBUpdatedAt: ruling.removeUpdatedAt,
+          mergedIntoAffairId: keepId,
+        })
+      );
+    }
 
     return { sourcesMoved, eventsMoved, articlesMoved, identifiersMerged, slugsPreserved };
   });

--- a/src/services/sync/reconcile-affairs.ts
+++ b/src/services/sync/reconcile-affairs.ts
@@ -1,11 +1,21 @@
 /**
  * Affair reconciliation service.
  *
- * Detects potential duplicate affairs from different sources
- * and auto-merges high-confidence duplicates.
+ * Detects potential duplicate affairs and folds the ones automation is allowed to
+ * fold. Since detection was widened to published affairs (issue #525), the queue
+ * mixes pairs a cron may merge with pairs that must never move without a human, so
+ * every pair goes through decideMergeAction() first.
  */
 
-import { findPotentialDuplicates, mergeAffairs } from "@/services/affairs/reconciliation";
+import {
+  findPotentialDuplicates,
+  mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS,
+  type PotentialDuplicate,
+} from "@/services/affairs/reconciliation";
+import { decideMergeAction, type MergeDecision } from "@/services/affairs/merge-decision";
+import { absorbDraftIntoPublished } from "@/services/affairs/absorb-draft";
+import { withImportRun, IMPORTER_RECONCILE } from "@/services/affairs/import-run";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,9 +28,25 @@ export interface ReconcileAffairsOptions {
 
 export interface ReconcileAffairsStats {
   duplicatesFound: number;
+  /** Draft pairs folded together. */
   merged: number;
+  /** Drafts absorbed by a published affair on a court-assigned identifier. */
+  absorbed: number;
+  /** Pairs left for a human, by reason. */
+  reviewRequired: number;
+  notEligible: number;
+  /** Proposals opened because a draft stated something the published fiche did not. */
+  proposalsCreated: number;
   errors: number;
   remainingPossible: number;
+}
+
+interface PlannedPair {
+  pair: PotentialDuplicate;
+  decision: MergeDecision;
+  keepId?: string;
+  removeId?: string;
+  reason: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,43 +60,78 @@ export async function reconcileAffairs(
 
   const duplicates = await findPotentialDuplicates();
 
-  if (duplicates.length === 0) {
-    return { duplicatesFound: 0, merged: 0, errors: 0, remainingPossible: 0 };
-  }
+  const empty: ReconcileAffairsStats = {
+    duplicatesFound: 0,
+    merged: 0,
+    absorbed: 0,
+    reviewRequired: 0,
+    notEligible: 0,
+    proposalsCreated: 0,
+    errors: 0,
+    remainingPossible: 0,
+  };
+  if (duplicates.length === 0) return empty;
 
-  let merged = 0;
-  let errors = 0;
+  const planned: PlannedPair[] = duplicates.map((pair) => {
+    const plan = decideMergeAction(pair);
+    return { pair, ...plan };
+  });
 
-  if (autoMerge) {
-    const mergeable = duplicates.filter(
-      (d) => d.confidence === "CERTAIN" || d.confidence === "HIGH"
-    );
+  const stats: ReconcileAffairsStats = {
+    ...empty,
+    duplicatesFound: duplicates.length,
+    reviewRequired: planned.filter((p) => p.decision === "REVIEW_REQUIRED").length,
+    notEligible: planned.filter((p) => p.decision === "NOT_ELIGIBLE").length,
+    remainingPossible: duplicates.filter((d) => d.confidence === "POSSIBLE").length,
+  };
 
-    for (const dup of mergeable) {
-      const keepId =
-        dup.affairA.sources.length >= dup.affairB.sources.length ? dup.affairA.id : dup.affairB.id;
-      const removeId = keepId === dup.affairA.id ? dup.affairB.id : dup.affairA.id;
+  if (!autoMerge) return stats;
 
-      if (dryRun) {
-        merged++;
-        continue;
-      }
+  const draftMerges = planned.filter((p) => p.decision === "AUTO_MERGE_DRAFTS");
+  const absorptions = planned.filter((p) => p.decision === "AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
 
-      try {
-        await mergeAffairs(keepId, removeId);
-        merged++;
-      } catch {
-        errors++;
-      }
+  for (const plan of draftMerges) {
+    if (dryRun) {
+      stats.merged++;
+      continue;
+    }
+    try {
+      await mergeAffairs(plan.keepId!, plan.removeId!, {
+        auditNotes: { decision: plan.decision, reason: plan.reason },
+      });
+      stats.merged++;
+    } catch {
+      stats.errors++;
     }
   }
 
-  const remainingPossible = duplicates.filter((d) => d.confidence === "POSSIBLE").length;
+  if (absorptions.length === 0) return stats;
 
-  return {
-    duplicatesFound: duplicates.length,
-    merged,
-    errors,
-    remainingPossible,
-  };
+  if (dryRun) {
+    stats.absorbed += absorptions.length;
+    return stats;
+  }
+
+  // Proposals must belong to a run, so one is opened only when an absorption
+  // actually has to write something (issue #513 invariant).
+  await withImportRun(IMPORTER_RECONCILE, async ({ importRunId, setStats }) => {
+    for (const plan of absorptions) {
+      try {
+        const result = await absorbDraftIntoPublished({
+          publishedId: plan.keepId!,
+          draftId: plan.removeId!,
+          importRunId,
+          reason: plan.reason,
+          additiveFields: ABSORPTION_ADDITIVE_FIELDS,
+        });
+        stats.absorbed++;
+        stats.proposalsCreated += result.proposalsCreated;
+      } catch {
+        stats.errors++;
+      }
+    }
+    setStats({ absorbed: stats.absorbed, proposalsCreated: stats.proposalsCreated });
+  });
+
+  return stats;
 }


### PR DESCRIPTION
## Description

Part of #525. **PR 3 sur 3**, enchaînée sur #528 (base : `fix-525-detection`).

La détection couvre désormais les affaires publiées, et presque toutes les paires demandent une personne plutôt qu'un cron. Sans mémoire de ce que cette personne décide, les mêmes paires reviennent à chaque passage et la file ne se vide jamais.

### Le modèle

`AffairPairDecision`, avec quatre décisions possibles :

| Décision | Effet sur la file | Effet sur les données |
| --- | --- | --- |
| `DUPLICATE` | exclue définitivement | écrite dans la transaction de la fusion |
| `LINKED` | exclue | **aucun** : publier le lien est une action distincte |
| `DISTINCT` | exclue tant que les deux fiches n'ont pas changé | aucun |
| `UNCERTAIN` | **reste visible**, marquée | aucun |

Les références aux affaires sont des colonnes texte, **sans relation Prisma**. Une décision `DUPLICATE` doit survivre à la suppression de la ligne qu'elle a autorisé à absorber : un `Cascade` effacerait la décision, un `Restrict` bloquerait la fusion qu'elle autorise. Le survivant est conservé dans `mergedIntoAffairId`.

### Un jugement n'est pas une vérité définitive

« Ce ne sont pas les mêmes affaires » a été jugé contre les deux fiches telles qu'elles étaient. Si l'une est modifiée ensuite, le jugement ne tranche plus rien. Les deux `updatedAt` sont donc enregistrés au moment de la décision, et un `DISTINCT` ou un `UNCERTAIN` dont une fiche a bougé depuis **remonte dans la file**, marqué « à réexaminer ».

`DUPLICATE` ne se périme pas : la fusion a déjà eu lieu.

### Une seule identité par paire

`canonicalPair()` passe dans son propre module, `affair-pair.ts`, pour que le détecteur et le magasin de décisions en dépendent tous les deux sans s'importer mutuellement. Tout stockage et toute exclusion passent par cette fonction, ce qui est la seule garantie que `(A, B)` et `(B, A)` ne produisent pas deux lignes pour une paire.

Les dates suivent les identifiants dans le tri canonique, sinon une vérification de fraîcheur comparerait l'affaire A à la date enregistrée pour B. C'est testé.

### `LINKED` ne publie rien

`linkedAffairId` est **rendu sur les fiches publiées**, il est directionnel et ne porte qu'un seul lien. Le classer depuis un tri de doublons publierait du contenu et pourrait écraser un lien existant.

La classification note donc le constat. Publier la relation est un second geste, sur un endpoint distinct, avec confirmation explicite, aperçu du remplacement éventuel, et une entrée dans la piste d'audit qui conserve le lien remplacé.

### La fusion humaine refuse de supprimer une page publique

L'endpoint de fusion renvoie **409** si l'affaire à absorber est publiée, quoi que demande l'appelant. Absorber un brouillon dans une fiche publiée est prévu ; l'inverse retire une page qu'un lecteur peut atteindre. Deux fiches publiées exigent d'en dépublier une d'abord, pour que le retrait soit un acte éditorial délibéré et non l'effet de bord d'une fusion.

### Mesure de précision

Calculée sur **tous** les jugements et non sur le haut du classement : ne noter que les paires les plus confiantes mesurerait le classement, pas le signal (§7).

`UNCERTAIN` est exclu des deux côtés du ratio. Différer n'est pas juger, et le compter dans un sens ou dans l'autre déplacerait le chiffre sans information nouvelle.

## Schéma : déjà appliqué en production

`prisma db push` exécuté avant l'ouverture de cette PR, dans cet ordre volontaire : le schéma additif d'abord, le code ensuite. Merger cette PR ne déclenche donc aucune migration.

Diff appliqué, vérifié avec `prisma migrate diff --script` avant l'action : un `CREATE TYPE`, un `CREATE TABLE`, quatre index. **Aucun `ALTER` sur une table existante, aucune clé étrangère ajoutée.**

État après application : table présente et vide, enum dans l'ordre attendu, 5 index, 466 affaires inchangées, 0 clé étrangère.

## `DismissedDuplicate` : lecture double, rien à migrer

L'ancienne table est encore lue et honorée comme `DISTINCT`. Constat en base : **0 ligne**, et `dismissDuplicate()` n'a aucun appelant hors de son propre module. Le backfill décrit dans l'issue n'a donc rien à migrer. La lecture double coûte une requête et reste en place le temps que le modèle soit retiré dans une PR ultérieure.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Part of #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre, eslint et Prettier propres
- **2328 tests** passés, 0 échec (2301 après #528)
- 27 tests ajoutés
- Smoke test en lecture sur la base réelle après application du schéma : 12 paires, 12 en revue, 0 jugement antérieur, précision « pas encore mesurable »

## Réserve à lever avant de merger

**La CI ne tournera pas sur cette PR.** Les workflows sont déclenchés sur `pull_request: branches: [main, staging]`, et celle-ci cible `fix-525-detection`. Il n'y a donc que mes vérifications locales.

Merger #528 d'abord, puis rebaser cette branche sur `main`, fera tourner la CI. Attention à ne pas supprimer la branche de base au merge : c'est ce qui a fermé automatiquement #527.

## Points de revue

**L'accessibilité du tableau de comparaison.** Chaque ligne a un `<th scope="row">`, le tableau une légende en lecteur d'écran, et il défile dans son propre conteneur pour que la page ne défile jamais horizontalement.

**Trois confirmations navigateur** avant toute action destructrice ou publique : fusion, publication de lien, et remplacement d'un lien existant. Le message nomme l'affaire concernée et dit ce qui va se passer.

**Un point que je n'ai pas résolu, volontairement.** `linkedAffairId` ne représente pas correctement un groupe de trois volets ou plus. Hors périmètre de #525, comme convenu.

## Suites

- Backfill `DismissedDuplicate` → `DISTINCT` (rien à migrer aujourd'hui), retrait de la lecture double, suppression du modèle.
- Audit séparé de `ARCHIVED` et `EXCLUDED`, sans auto-fusion et avec affichage du motif de retrait.
