### PR TITLE
Corriger deux pertes de données possibles à la fusion d'affaires

### DIFF
--- a/src/services/affairs/__tests__/merge-affairs.test.ts
+++ b/src/services/affairs/__tests__/merge-affairs.test.ts
@@ -50,10 +50,10 @@ function affair(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: "keep",
     title: "Affaire conservée",
+    politicianId: "p1",
     slug: "affaire-conservee",
     publicId: "AF-000001",
     oldSlugs: [],
-    politicianId: "p1",
     ecli: null,
     pourvoiNumber: null,
     caseNumbers: [],
@@ -353,5 +353,156 @@ describe("mergeAffairs — bookkeeping (issue #525)", () => {
 
     await expect(mergeAffairs("keep", "remove")).rejects.toThrow("Affair to keep not found");
     expect(tx.affair.delete).not.toHaveBeenCalled();
+  });
+});
+
+// Review of #526 — the invariants lived only in the admin routes, but the cron
+// calls the service directly. Both cases below deleted an affair outright.
+describe("mergeAffairs — invariants du service (#525)", () => {
+  it("refuse de fusionner une affaire avec elle-même, sans rien supprimer", async () => {
+    // Sans ce garde : les transferts sont tous ignorés (mêmes URL, mêmes clés),
+    // aucune redirection n'est écrite puisque les publicId sont égaux, puis la
+    // ligne est supprimée. Perte totale.
+    const same = affair({ id: "keep", slug: "gardee", publicId: "AF-000001" });
+    stub(same, same);
+
+    await expect(mergeAffairs("keep", "keep")).rejects.toThrow(/elle-même/i);
+
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+    expect(tx.affair.update).not.toHaveBeenCalled();
+    expect(tx.source.update).not.toHaveBeenCalled();
+    expect(tx.affairEvent.update).not.toHaveBeenCalled();
+    expect(tx.pressArticleAffair.update).not.toHaveBeenCalled();
+    expect(tx.publicIdRedirect.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuse de fusionner deux affaires de personnalités différentes", async () => {
+    // Affair est 1:1 avec Politician : une telle fusion déplacerait les sources
+    // d'une personne vers la fiche d'une autre, puis supprimerait la ligne.
+    stub(
+      affair({ id: "keep", politicianId: "p1" }),
+      affair({ id: "remove", slug: "absorbee", politicianId: "p2" })
+    );
+
+    await expect(mergeAffairs("keep", "remove")).rejects.toThrow(/personnalités différentes/i);
+
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+    expect(tx.affair.update).not.toHaveBeenCalled();
+    expect(tx.source.update).not.toHaveBeenCalled();
+    expect(tx.affairEvent.update).not.toHaveBeenCalled();
+    expect(tx.pressArticleAffair.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("mergeAffairs — la déduplication ne doit rien perdre (#525)", () => {
+  it("transfère deux événements qui ne diffèrent que par leur source", async () => {
+    const date = new Date("2024-03-01T00:00:00Z");
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.affairEvent.findMany
+      .mockResolvedValueOnce([
+        {
+          date,
+          type: "CONDAMNATION",
+          title: "Jugement",
+          description: "Première instance",
+          sourceUrl: "https://example.org/a",
+          sourceTitle: "Le Monde",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "e1",
+          date,
+          type: "CONDAMNATION",
+          title: "Jugement",
+          description: "Première instance",
+          sourceUrl: "https://example.org/b",
+          sourceTitle: "AFP",
+        },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    // Même date, même type, même titre : l'ancienne clé les confondait et
+    // l'événement absorbé disparaissait avec sa source.
+    expect(result.eventsMoved).toBe(1);
+    expect(tx.affairEvent.update).toHaveBeenCalledWith({
+      where: { id: "e1" },
+      data: { affairId: "keep" },
+    });
+  });
+
+  it("ignore un événement identique sur tous ses champs", async () => {
+    const date = new Date("2024-03-01T00:00:00Z");
+    const event = {
+      date,
+      type: "CONDAMNATION",
+      title: "Jugement",
+      description: "Première instance",
+      sourceUrl: "https://example.org/a",
+      sourceTitle: "Le Monde",
+    };
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.affairEvent.findMany
+      .mockResolvedValueOnce([event])
+      .mockResolvedValueOnce([{ id: "e1", ...event }]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.eventsMoved).toBe(0);
+    expect(tx.affairEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("complète l'extrait et l'archive d'une source de même URL", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.source.findMany
+      .mockResolvedValueOnce([
+        { id: "s0", url: "https://example.org/a", excerpt: null, archivedUrl: null },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "s1",
+          url: "https://example.org/a",
+          excerpt: "Extrait clé",
+          archivedUrl: "https://archive.org/x",
+        },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    // La source n'est pas déplacée (l'URL existe déjà) mais ce qu'elle apportait
+    // ne disparaît pas avec la ligne supprimée.
+    expect(result.sourcesMoved).toBe(0);
+    expect(result.sourcesEnriched).toBe(1);
+    expect(tx.source.update).toHaveBeenCalledWith({
+      where: { id: "s0" },
+      data: { excerpt: "Extrait clé", archivedUrl: "https://archive.org/x" },
+    });
+  });
+
+  it("ne remplace pas un extrait déjà présent sur la source conservée", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    tx.source.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "s0",
+          url: "https://example.org/a",
+          excerpt: "Extrait retenu",
+          archivedUrl: "https://archive.org/keep",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "s1",
+          url: "https://example.org/a",
+          excerpt: "Autre extrait",
+          archivedUrl: "https://archive.org/other",
+        },
+      ]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.sourcesEnriched).toBe(0);
+    expect(tx.source.update).not.toHaveBeenCalled();
   });
 });

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -333,6 +333,8 @@ export interface MergeAffairsOptions {
 
 export interface MergeAffairsResult {
   sourcesMoved: number;
+  /** Sources whose URL already existed and whose extra fields were carried over. */
+  sourcesEnriched: number;
   eventsMoved: number;
   articlesMoved: number;
   identifiersMerged: string[];
@@ -340,9 +342,30 @@ export interface MergeAffairsResult {
   slugsPreserved: string[];
 }
 
-/** Semantic identity of an event: it carries no unique constraint in the schema. */
-function eventKey(event: { date: Date; type: string; title: string }): string {
-  return [event.date.toISOString(), event.type, event.title].join("|");
+/**
+ * Semantic identity of an event: it carries no unique constraint in the schema.
+ *
+ * Every field that holds information, not just date/type/title: two events can
+ * share those three and still differ by description or by the source they cite.
+ * Keying on the short triple dropped the absorbed one along with its source.
+ * When anything differs, both are kept — merging their prose is a human call.
+ */
+function eventKey(event: {
+  date: Date;
+  type: string;
+  title: string;
+  description: string | null;
+  sourceUrl: string | null;
+  sourceTitle: string | null;
+}): string {
+  return [
+    event.date.toISOString(),
+    event.type,
+    event.title,
+    event.description ?? "",
+    event.sourceUrl ?? "",
+    event.sourceTitle ?? "",
+  ].join("|");
 }
 
 /**
@@ -410,35 +433,80 @@ export async function mergeAffairs(
     if (!keep) throw new Error(`Affair to keep not found: ${keepId}`);
     if (!remove) throw new Error(`Affair to remove not found: ${removeId}`);
 
+    // Checked here rather than only in the callers: the cron path calls this
+    // service directly. Merging an affair with itself skipped every transfer
+    // (same rows on both sides), wrote no redirect (equal publicIds) and then
+    // deleted the row — an outright loss.
+    if (keepId === removeId) {
+      throw new Error(`Une affaire ne peut pas fusionner avec elle-même : ${keepId}`);
+    }
+    // Affair is 1:1 with Politician, so a cross-person merge would move one
+    // person's sources onto another's fiche and then delete the row.
+    if (keep.politicianId !== remove.politicianId) {
+      throw new Error(
+        `Fusion refusée entre personnalités différentes : ${keep.politicianId} / ${remove.politicianId}`
+      );
+    }
+
     // --- Sources: unique on (affairId, url), so skip URLs already present.
     const existingSources = await tx.source.findMany({
       where: { affairId: keepId },
-      select: { url: true },
+      select: { id: true, url: true, excerpt: true, archivedUrl: true },
     });
-    const existingUrls = new Set(existingSources.map((s) => s.url));
+    const keptByUrl = new Map(existingSources.map((s) => [s.url, s]));
 
     const sourcesToTransfer = await tx.source.findMany({
       where: { affairId: removeId },
-      select: { id: true, url: true },
+      select: { id: true, url: true, excerpt: true, archivedUrl: true },
     });
     let sourcesMoved = 0;
+    let sourcesEnriched = 0;
     for (const source of sourcesToTransfer) {
-      if (existingUrls.has(source.url)) continue;
-      await tx.source.update({ where: { id: source.id }, data: { affairId: keepId } });
-      existingUrls.add(source.url);
-      sourcesMoved++;
+      const kept = keptByUrl.get(source.url);
+      if (!kept) {
+        await tx.source.update({ where: { id: source.id }, data: { affairId: keepId } });
+        keptByUrl.set(source.url, { ...source });
+        sourcesMoved++;
+        continue;
+      }
+      // Same URL on both sides, so the row is not moved and will be cascaded away.
+      // Whatever it documented and the kept row does not must survive that.
+      // Fills only: a value already stated is never replaced.
+      const fill: { excerpt?: string; archivedUrl?: string } = {};
+      if (!kept.excerpt && source.excerpt) fill.excerpt = source.excerpt;
+      if (!kept.archivedUrl && source.archivedUrl) fill.archivedUrl = source.archivedUrl;
+      if (Object.keys(fill).length > 0) {
+        await tx.source.update({ where: { id: kept.id }, data: fill });
+        keptByUrl.set(source.url, { ...kept, ...fill });
+        sourcesEnriched++;
+      }
     }
 
     // --- Events: no unique constraint, so deduplicate on their semantic key.
     const existingEvents = await tx.affairEvent.findMany({
       where: { affairId: keepId },
-      select: { date: true, type: true, title: true },
+      select: {
+        date: true,
+        type: true,
+        title: true,
+        description: true,
+        sourceUrl: true,
+        sourceTitle: true,
+      },
     });
     const existingEventKeys = new Set(existingEvents.map(eventKey));
 
     const eventsToTransfer = await tx.affairEvent.findMany({
       where: { affairId: removeId },
-      select: { id: true, date: true, type: true, title: true },
+      select: {
+        id: true,
+        date: true,
+        type: true,
+        title: true,
+        description: true,
+        sourceUrl: true,
+        sourceTitle: true,
+      },
     });
     let eventsMoved = 0;
     for (const event of eventsToTransfer) {
@@ -532,6 +600,7 @@ export async function mergeAffairs(
           mergedFrom: removeId,
           mergedFromTitle: remove.title,
           sourcesMoved,
+          sourcesEnriched,
           eventsMoved,
           articlesMoved,
           identifiersMerged,
@@ -543,7 +612,14 @@ export async function mergeAffairs(
       },
     });
 
-    return { sourcesMoved, eventsMoved, articlesMoved, identifiersMerged, slugsPreserved };
+    return {
+      sourcesMoved,
+      sourcesEnriched,
+      eventsMoved,
+      articlesMoved,
+      identifiersMerged,
+      slugsPreserved,
+    };
   });
 }
 

--- a/src/services/sync/__tests__/reconcile-affairs.test.ts
+++ b/src/services/sync/__tests__/reconcile-affairs.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Review of #526 — the admin routes invalidated caches after a merge, the cron
+// path did not, so an automatic merge left the deleted affair's page and the
+// person's profile served from cache.
+
+const order: string[] = [];
+
+const h = vi.hoisted(() => ({
+  findPotentialDuplicates: vi.fn(),
+  mergeAffairs: vi.fn(),
+  absorbDraftIntoPublished: vi.fn(),
+  withImportRun: vi.fn(),
+  affairFindMany: vi.fn(),
+  invalidateEntity: vi.fn(),
+  invalidateAffectedPoliticians: vi.fn(),
+}));
+
+vi.mock("@/services/affairs/reconciliation", () => ({
+  findPotentialDuplicates: h.findPotentialDuplicates,
+  mergeAffairs: h.mergeAffairs,
+  ABSORPTION_ADDITIVE_FIELDS: ["ecli", "pourvoiNumber", "caseNumber"],
+}));
+vi.mock("@/services/affairs/absorb-draft", () => ({
+  absorbDraftIntoPublished: h.absorbDraftIntoPublished,
+}));
+vi.mock("@/services/affairs/import-run", () => ({
+  withImportRun: h.withImportRun,
+  IMPORTER_RECONCILE: "reconcile-affairs",
+}));
+vi.mock("@/lib/db", () => ({ db: { affair: { findMany: h.affairFindMany } } }));
+vi.mock("@/lib/cache", () => ({
+  invalidateEntity: h.invalidateEntity,
+  invalidateAffectedPoliticians: h.invalidateAffectedPoliticians,
+}));
+
+import { reconcileAffairs } from "../reconcile-affairs";
+
+function pair(
+  a: Partial<{ id: string; publicationStatus: string; verifiedAt: Date | null }>,
+  b: Partial<{ id: string; publicationStatus: string; verifiedAt: Date | null }>,
+  overrides: Partial<{ confidence: string; matchedBy: string; score: number }> = {}
+) {
+  const side = (s: typeof a, fallbackId: string) => ({
+    id: s.id ?? fallbackId,
+    title: `Affaire ${s.id ?? fallbackId}`,
+    politicianId: "p1",
+    sources: [],
+    updatedAt: new Date("2026-07-01"),
+    publicationStatus: s.publicationStatus ?? "DRAFT",
+    verifiedAt: s.verifiedAt ?? null,
+  });
+  return {
+    affairA: side(a, "a"),
+    affairB: side(b, "b"),
+    confidence: overrides.confidence ?? "HIGH",
+    matchedBy: overrides.matchedBy ?? "pourvoiNumber",
+    score: overrides.score ?? 0.95,
+    contradictions: [],
+    unpropagatableDifferences: [],
+    previousClassification: null,
+    rulingStale: false,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  h.mergeAffairs.mockImplementation(async () => {
+    order.push("merge");
+    return {
+      sourcesMoved: 0,
+      sourcesEnriched: 0,
+      eventsMoved: 0,
+      articlesMoved: 0,
+      identifiersMerged: [],
+      slugsPreserved: [],
+    };
+  });
+  h.affairFindMany.mockResolvedValue([{ politician: { slug: "jean-dupont" } }]);
+  h.invalidateEntity.mockImplementation(() => {
+    order.push("invalidate");
+  });
+  h.invalidateAffectedPoliticians.mockImplementation(() => {
+    order.push("invalidate-politicians");
+  });
+  h.withImportRun.mockImplementation(
+    async (
+      _importer: string,
+      fn: (ctx: { importRunId: string; setStats: () => void }) => unknown
+    ) => fn({ importRunId: "run_1", setStats: () => {} })
+  );
+});
+
+describe("reconcileAffairs — invalidation du chemin cron (#525)", () => {
+  it("invalide les caches après une auto-fusion de brouillons", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([pair({ id: "a" }, { id: "b" })]);
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.merged).toBe(1);
+    expect(order).toEqual(["merge", "invalidate", "invalidate-politicians"]);
+    expect(h.invalidateEntity).toHaveBeenCalledWith("affair");
+    expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["jean-dupont"]);
+  });
+
+  it("invalide aussi après une absorption dans une affaire publiée", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair({ id: "pub", publicationStatus: "PUBLISHED" }, { id: "draft" }),
+    ]);
+    h.absorbDraftIntoPublished.mockImplementation(async () => {
+      order.push("absorb");
+      return { proposalsCreated: 1, proposedFields: ["court"], recordedDifferences: [] };
+    });
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.absorbed).toBe(1);
+    expect(order).toEqual(["absorb", "invalidate", "invalidate-politicians"]);
+  });
+
+  it("n'invalide rien quand aucune fusion n'a eu lieu", async () => {
+    // Deux affaires publiées : revue obligatoire, donc aucune écriture.
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair(
+        { id: "a", publicationStatus: "PUBLISHED" },
+        { id: "b", publicationStatus: "PUBLISHED" }
+      ),
+    ]);
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.merged).toBe(0);
+    expect(stats.reviewRequired).toBe(1);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("n'invalide rien en essai à blanc", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([pair({ id: "a" }, { id: "b" })]);
+
+    await reconcileAffairs({ autoMerge: true, dryRun: true });
+
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("n'invalide pas quand la fusion a échoué", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([pair({ id: "a" }, { id: "b" })]);
+    h.mergeAffairs.mockRejectedValue(new Error("rollback"));
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.errors).toBe(1);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("ne touche à rien sans autoMerge", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([pair({ id: "a" }, { id: "b" })]);
+
+    const stats = await reconcileAffairs({});
+
+    expect(stats.duplicatesFound).toBe(1);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/sync/reconcile-affairs.ts
+++ b/src/services/sync/reconcile-affairs.ts
@@ -16,6 +16,8 @@ import {
 import { decideMergeAction, type MergeDecision } from "@/services/affairs/merge-decision";
 import { absorbDraftIntoPublished } from "@/services/affairs/absorb-draft";
 import { withImportRun, IMPORTER_RECONCILE } from "@/services/affairs/import-run";
+import { db } from "@/lib/db";
+import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,6 +41,26 @@ export interface ReconcileAffairsStats {
   proposalsCreated: number;
   errors: number;
   remainingPossible: number;
+}
+
+/**
+ * Refreshes what a merge made stale.
+ *
+ * The admin routes already do this; the cron path did not, so an automatic merge
+ * left the deleted affair's page and the person's profile served from cache.
+ * Runs once after all merges rather than per merge, and only when at least one
+ * landed.
+ */
+async function invalidateAfterMerges(survivorIds: string[]): Promise<void> {
+  if (survivorIds.length === 0) return;
+
+  invalidateEntity("affair");
+
+  const survivors = await db.affair.findMany({
+    where: { id: { in: [...new Set(survivorIds)] } },
+    select: { politician: { select: { slug: true } } },
+  });
+  invalidateAffectedPoliticians(survivors.map((a) => a.politician?.slug));
 }
 
 interface PlannedPair {
@@ -90,6 +112,9 @@ export async function reconcileAffairs(
   const draftMerges = planned.filter((p) => p.decision === "AUTO_MERGE_DRAFTS");
   const absorptions = planned.filter((p) => p.decision === "AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
 
+  // Survivors of every merge that actually landed, for one invalidation pass.
+  const survivors: string[] = [];
+
   for (const plan of draftMerges) {
     if (dryRun) {
       stats.merged++;
@@ -100,12 +125,16 @@ export async function reconcileAffairs(
         auditNotes: { decision: plan.decision, reason: plan.reason },
       });
       stats.merged++;
+      survivors.push(plan.keepId!);
     } catch {
       stats.errors++;
     }
   }
 
-  if (absorptions.length === 0) return stats;
+  if (absorptions.length === 0) {
+    await invalidateAfterMerges(survivors);
+    return stats;
+  }
 
   if (dryRun) {
     stats.absorbed += absorptions.length;
@@ -126,12 +155,16 @@ export async function reconcileAffairs(
         });
         stats.absorbed++;
         stats.proposalsCreated += result.proposalsCreated;
+        survivors.push(plan.keepId!);
       } catch {
         stats.errors++;
       }
     }
     setStats({ absorbed: stats.absorbed, proposalsCreated: stats.proposalsCreated });
   });
+
+  // After the run committed, never during it.
+  await invalidateAfterMerges(survivors);
 
   return stats;
 }


### PR DESCRIPTION
## Description

Part of #525. Correction issue de la revue de #526, sans revert et sans rouvrir le design.

Les quatre points de la revue sont fondés. Le premier détruisait des données.

### 1. Une fusion pouvait supprimer une affaire sans rien conserver

Les invariants vivaient dans les routes admin, mais `reconcileAffairs()` appelle le service directement. Deux cas passaient donc sans garde.

**Fusion d'une affaire avec elle-même.** Vérifié en traçant l'exécution : tous les transferts sont ignorés (mêmes lignes des deux côtés), le remplissage additif ne s'applique pas (`!keep[field]` est faux dès que le champ est renseigné), `computePreservedSlugs` retourne un tableau vide (le slug est déjà servi), puis `tx.affair.delete` s'exécute. La redirection `publicId` est ensuite sautée puisque les deux identifiants sont égaux.

Résultat : **la ligne disparaît sans redirection et sans qu'aucune donnée soit reprise ailleurs.** Prouvé par un test intermédiaire avant correctif, qui montrait `affair.delete` appelé.

**Fusion entre deux personnalités.** `Affair` est 1:1 avec `Politician` : la fusion déplaçait les sources et les événements d'une personne vers la fiche d'une autre, puis supprimait la ligne.

Les deux contrôles sont désormais **dans la transaction, avant toute mutation**.

### 2. La déduplication d'événements perdait des métadonnées

La clé `(date, type, title)` confondait deux événements qui partagent ces trois champs mais diffèrent par `description`, `sourceUrl` ou `sourceTitle`. L'événement absorbé était ignoré, puis supprimé en cascade avec sa ligne : sa description et sa source disparaissaient.

L'identité porte maintenant sur tous les champs qui portent de l'information. Dès qu'un seul diffère, **les deux événements sont transférés**. Fusionner leurs textes est un arbitrage humain, pas une décision de service.

### 3. Une source de même URL était ignorée avec ce qu'elle apportait

Quand l'URL existait déjà sur l'affaire conservée, la source absorbée était sautée puis supprimée en cascade, avec son `excerpt` et son `archivedUrl`.

Ces deux champs sont désormais **complétés sur la source conservée quand ils y sont absents**, jamais remplacés. Le résultat expose `sourcesEnriched` pour que ce soit visible dans la piste d'audit.

**Un point de ta revue que je n'applique pas, et pourquoi.** Tu mentionnes aussi un « `sourceType` plus précis ». `Source.sourceType` est **non nullable avec un défaut `PRESSE`** : rien ne distingue un défaut jamais renseigné d'une source réellement de presse. Le compléter signifierait écraser `PRESSE`, ce qui contredit ta propre règle « ne pas remplacer une valeur déjà présente ». Je le laisse tel quel. Si tu veux le traiter, il faudrait d'abord rendre le champ nullable ou ajouter un marqueur d'origine, ce qui est un changement de schéma.

### 4. Le chemin cron ne rafraîchissait aucun cache

Les routes admin invalidaient déjà, `reconcileAffairs()` non : après une fusion automatique, la page de l'affaire supprimée et le profil de la personnalité restaient servis depuis le cache.

L'invalidation porte sur le tag et les routes des affaires, puis sur le profil des personnalités concernées. Elle tourne **une fois après toutes les fusions**, et seulement si au moins une a abouti : ni en essai à blanc, ni quand la transaction a échoué.

## Type de changement

- [x] Bug fix

## Issue liée

Part of #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `tsc --noEmit` propre, eslint et Prettier propres
- **2313 tests** passés, 0 échec (2301 sur `main`)
- 12 tests ajoutés, écrits **avant** les correctifs : les 5 qui portent sur les défauts échouaient bien sans eux
- Les tests d'invariants vérifient qu'aucune suppression, aucune mise à jour de relation et aucune redirection n'a lieu dans les deux cas refusés

## Points de revue

**Les gardes sont dans la transaction, pas avant.** Une vérification hors transaction pourrait être invalidée entre la lecture et l'écriture. Les routes admin gardent malgré tout leurs propres contrôles : elles renvoient 400 et 409 plutôt qu'une exception 500.

**La déduplication d'événements devient plus permissive**, donc un même fait peut apparaître deux fois sur la fiche après fusion. C'est l'arbitrage assumé : un doublon visible se corrige à la main, une métadonnée supprimée ne se récupère pas.

**`MergeAffairsResult` gagne `sourcesEnriched`.** Ajout seulement.
