### PR TITLE
Ne plus rapprocher deux brouillons sur la seule absence de qualification

### DIFF
--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -5,9 +5,12 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/lib/db", () => ({ db: {} }));
 
 import {
+  pairingRestsOnWildcard,
   pickConfidentMatch,
   sameCategoryFamily,
+  significantTitleWords,
   titleContainmentMatch,
+  titlesShareVocabulary,
   verdictDatesConflict,
 } from "./matching";
 
@@ -251,5 +254,107 @@ describe("pickConfidentMatch — issue #520", () => {
 
   it("plusieurs CERTAIN : ambigu aussi, on ne devine pas", () => {
     expect(pickConfidentMatch([m("a", "CERTAIN", 1), m("b", "CERTAIN", 1)]).kind).toBe("ambiguous");
+  });
+});
+
+// Issue #521 — AUTRE pairs with every family, so on its own it carries no
+// information about the facts. Fixtures use generic legal phrasings rather than
+// real titles: the pair that motivated this guard is a pair of unpublished drafts.
+describe("pairingRestsOnWildcard — issue #521", () => {
+  it("est vrai quand seul AUTRE rapproche les deux catégories", () => {
+    expect(pairingRestsOnWildcard("AUTRE", "AGRESSION_SEXUELLE")).toBe(true);
+    expect(pairingRestsOnWildcard("RECEL", "AUTRE")).toBe(true);
+  });
+
+  it("est faux pour AUTRE contre AUTRE : l'égalité suffit", () => {
+    expect(pairingRestsOnWildcard("AUTRE", "AUTRE")).toBe(false);
+  });
+
+  it("est faux pour deux catégories identiques", () => {
+    expect(pairingRestsOnWildcard("MENACE", "MENACE")).toBe(false);
+  });
+
+  it("est faux quand une famille nommée les rapproche déjà", () => {
+    expect(pairingRestsOnWildcard("DETOURNEMENT_FONDS_PUBLICS", "FAVORITISME")).toBe(false);
+    expect(pairingRestsOnWildcard("VIOLENCE", "MENACE")).toBe(false);
+    expect(pairingRestsOnWildcard("DIFFAMATION", "INJURE")).toBe(false);
+  });
+
+  it("est faux quand rien ne les rapproche", () => {
+    expect(pairingRestsOnWildcard("MENACE", "FRAUDE_FISCALE")).toBe(false);
+  });
+});
+
+describe("significantTitleWords — issue #521", () => {
+  it("replie les accents", () => {
+    expect(significantTitleWords("Étouffement")).toEqual(new Set(["etouffement"]));
+    expect(significantTitleWords("referes")).toEqual(significantTitleWords("référés"));
+    expect(significantTitleWords("Détention")).toEqual(significantTitleWords("detention"));
+  });
+
+  it("écarte les mots trop courts pour identifier quoi que ce soit", () => {
+    expect(significantTitleWords("Vol de la clé")).toEqual(new Set([]));
+  });
+
+  it("écarte le vocabulaire judiciaire et éditorial générique", () => {
+    for (const filler of ["Affaire", "Enquête", "Procédure", "Plainte", "Soupçons", "Accusation"]) {
+      expect(significantTitleWords(`${filler} Untel`)).toEqual(new Set(["untel"]));
+    }
+  });
+
+  it("garde les mots qui nomment les faits", () => {
+    expect(significantTitleWords("Tentative d'étouffement judiciaire")).toEqual(
+      new Set(["tentative", "etouffement", "judiciaire"])
+    );
+  });
+});
+
+describe("titlesShareVocabulary — issue #521", () => {
+  it("reconnaît deux formulations des mêmes faits", () => {
+    expect(
+      titlesShareVocabulary(
+        "Soupçons de tentative d'étouffement d'une procédure",
+        "Tentative présumée d'étouffement d'une procédure"
+      )
+    ).toBe(true);
+  });
+
+  it("rejette deux faits qui ne partagent aucun vocabulaire", () => {
+    // Forme du faux positif relevé au tri de #525 : une ordonnance de référé sur
+    // des conditions de détention face à une affaire criminelle sans rapport.
+    expect(
+      titlesShareVocabulary(
+        "Ordonnance du juge des référés sur les conditions de détention",
+        "Enlèvement suivi de meurtre"
+      )
+    ).toBe(false);
+  });
+
+  it("ne se laisse pas prendre par le seul mot « affaire »", () => {
+    expect(titlesShareVocabulary("Affaire Untel", "Affaire Machin")).toBe(false);
+  });
+
+  it("ne se laisse pas prendre par une accumulation de mots génériques", () => {
+    expect(
+      titlesShareVocabulary(
+        "Enquête préliminaire ouverte dans une procédure",
+        "Plainte déposée dans une procédure, enquête en cours"
+      )
+    ).toBe(false);
+  });
+
+  it("accepte un seul nom partagé, qui suffit comme piste de relecture", () => {
+    expect(
+      titlesShareVocabulary(
+        "Gestion présumée illégale au Havre",
+        "Soupçons de favoritisme au Havre"
+      )
+    ).toBe(true);
+  });
+
+  it("rapproche malgré une orthographe accentuée différente", () => {
+    expect(
+      titlesShareVocabulary("Ordonnance de référé", "Décision rendue en refere sur le fond")
+    ).toBe(true);
   });
 });

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -59,12 +59,129 @@ function categoryFamily(category: string): string | null {
  * AUTRE matches any family (imports frequently fall back to AUTRE
  * when the legal qualification is unclear).
  */
-export function sameCategoryFamily(a: string, b: string): boolean {
-  if (a === b) return true;
-  if (a === "AUTRE" || b === "AUTRE") return true;
+/** Whether a named family pairs these two categories, wildcard aside. */
+function sameNamedFamily(a: string, b: string): boolean {
   const familyA = categoryFamily(a);
   const familyB = categoryFamily(b);
   return familyA !== null && familyA === familyB;
+}
+
+export function sameCategoryFamily(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a === "AUTRE" || b === "AUTRE") return true;
+  return sameNamedFamily(a, b);
+}
+
+/**
+ * Whether the AUTRE wildcard is the only reason these categories pair up.
+ *
+ * A shared family is evidence about the facts; the wildcard is not, since AUTRE
+ * means "no legal qualification was established". Callers ask for a second signal
+ * before pairing on it (issue #521). Two AUTRE categories are equal, not paired by
+ * the wildcard, so they are excluded here.
+ */
+export function pairingRestsOnWildcard(a: string, b: string): boolean {
+  if (a === b) return false;
+  if (a !== "AUTRE" && b !== "AUTRE") return false;
+  return !sameNamedFamily(a, b);
+}
+
+/**
+ * Words that appear in affair titles regardless of which facts they describe:
+ * French function words of four letters or more (shorter ones are already dropped
+ * by the length filter) and judicial or editorial boilerplate.
+ *
+ * They must not count as shared vocabulary. "Affaire X" and "Affaire Y" have
+ * nothing in common but the word "affaire", and the procedural stage is carried by
+ * the status field, not by the title.
+ */
+const TITLE_NOISE_WORDS = new Set([
+  // Function words
+  "pour",
+  "dans",
+  "avec",
+  "sans",
+  "sous",
+  "mais",
+  "leur",
+  "leurs",
+  "cette",
+  "entre",
+  "contre",
+  "apres",
+  "avant",
+  "chez",
+  "meme",
+  "aussi",
+  "donc",
+  "ainsi",
+  "plus",
+  "tout",
+  "tous",
+  "toute",
+  "toutes",
+  // Judicial and editorial boilerplate
+  "affaire",
+  "affaires",
+  "dossier",
+  "dossiers",
+  "enquete",
+  "enquetes",
+  "preliminaire",
+  "procedure",
+  "procedures",
+  "plainte",
+  "plaintes",
+  "plainte",
+  "proces",
+  "examen",
+  "soupcon",
+  "soupcons",
+  "suspicion",
+  "suspicions",
+  "accusation",
+  "accusations",
+  "presume",
+  "presumee",
+  "presumes",
+  "presumees",
+  "ouverte",
+  "cours",
+  "deposee",
+  "rendue",
+]);
+
+/**
+ * The words of a title that can identify which facts it describes.
+ *
+ * Accents are folded so the same word matches across import spellings.
+ */
+export function significantTitleWords(title: string): Set<string> {
+  return new Set(
+    title
+      .normalize("NFD")
+      // \p{Mn} keeps this ASCII-only: a literal combining-mark range is invisible in source.
+      .replace(/\p{Mn}/gu, "")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((word) => word.length >= 4 && !TITLE_NOISE_WORDS.has(word))
+  );
+}
+
+/**
+ * Whether two titles share at least one word that names the facts.
+ *
+ * Deliberately a single shared word rather than a ratio: measured on production
+ * data, the pairs worth keeping shared several words and the ones worth dropping
+ * shared none, so any threshold in between would be an unmeasurable knob. One
+ * shared word is a lead a reviewer can follow; zero is not.
+ */
+export function titlesShareVocabulary(a: string, b: string): boolean {
+  const wordsA = significantTitleWords(a);
+  for (const word of significantTitleWords(b)) {
+    if (wordsA.has(word)) return true;
+  }
+  return false;
 }
 
 export interface MatchResult {

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -17,6 +17,7 @@ vi.mock("./matching", async (importOriginal) => {
 import { findPotentialDuplicates } from "./reconciliation";
 import { db } from "@/lib/db";
 import { findMatchingAffairs } from "./matching";
+import { decideMergeAction } from "./merge-decision";
 
 const mockedAffairFindMany = db.affair.findMany as ReturnType<typeof vi.fn>;
 const mockedDismissedFindMany = db.dismissedDuplicate.findMany as ReturnType<typeof vi.fn>;
@@ -87,7 +88,12 @@ describe("findPotentialDuplicates — draft window clustering", () => {
 
     const duplicates = await findPotentialDuplicates();
 
-    expect(duplicates).toHaveLength(3); // a1-a2, a1-a3, a2-a3
+    // a1-a2 pair on the probity family. a1-a3 rests on the AUTRE wildcard but both
+    // titles name Le Havre. a2-a3 rests on the wildcard and shares no vocabulary,
+    // so it is dropped (issue #521) — the cluster stays reachable because a3 is
+    // still connected through a1.
+    const pairs = duplicates.map((d) => [d.affairA.id, d.affairB.id].sort().join("-")).sort();
+    expect(pairs).toEqual(["a1-a2", "a1-a3"]);
     for (const pair of duplicates) {
       expect(pair.matchedBy).toBe("politician+category+window");
       expect(pair.confidence).toBe("POSSIBLE");
@@ -411,5 +417,131 @@ describe("findPotentialDuplicates — jugements humains (#525)", () => {
     ]);
 
     expect(await findPotentialDuplicates()).toHaveLength(0);
+  });
+});
+
+// Issue #521 — the AUTRE wildcard pairs categories that share no family, so on its
+// own it says nothing about the facts. The guard is scoped to the second pass:
+// POSSIBLE only, no automatic merge, no data touched.
+describe("findPotentialDuplicates — garde lexical du joker AUTRE (#521)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDismissedFindMany.mockResolvedValue([]);
+    mockedDecisionFindMany.mockResolvedValue([]);
+    mockedFindMatchingAffairs.mockResolvedValue([]);
+  });
+
+  it("écarte une paire joker dont les titres ne partagent rien", async () => {
+    // Forme du faux positif relevé au tri de #525 : une personnalité citée dans
+    // deux couvertures sans rapport, dont l'une n'a pas de qualification.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Ordonnance du juge des référés sur les conditions de détention",
+        category: "AUTRE",
+      }),
+      makeDraft("a2", { title: "Enlèvement suivi de meurtre", category: "AGRESSION_SEXUELLE" }),
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(0);
+  });
+
+  it("garde une paire joker dont les titres partagent un mot porteur", async () => {
+    // Ce que rien d'autre n'attrape : catégories de familles différentes, mêmes
+    // faits, donc ni identifiant ni inclusion de titre ne les rapprochent.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Soupçons de tentative d'étouffement d'une procédure",
+        category: "RECEL",
+      }),
+      makeDraft("a2", {
+        title: "Tentative présumée d'étouffement d'une procédure",
+        category: "AUTRE",
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.confidence).toBe("POSSIBLE");
+    expect(duplicates[0]!.score).toBe(0.45);
+    expect(duplicates[0]!.matchedBy).toBe("politician+category+window");
+  });
+
+  it("ne demande rien aux titres quand les catégories sont identiques", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { title: "Menaces reçues au domicile", category: "MENACE" }),
+      makeDraft("a2", { title: "Colis suspect découvert au bureau", category: "MENACE" }),
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(1);
+  });
+
+  it("ne demande rien aux titres quand une famille nommée les rapproche", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { title: "Emplois familiaux au Parlement", category: "EMPLOI_FICTIF" }),
+      makeDraft("a2", {
+        title: "Marché public attribué sans mise en concurrence",
+        category: "FAVORITISME",
+      }),
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(1);
+  });
+
+  it("conserve le comportement de AUTRE contre AUTRE", async () => {
+    // Catégories égales : le joker n'est pas la raison du rapprochement.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { title: "Cyberattaques contre un parti", category: "AUTRE" }),
+      makeDraft("a2", { title: "Signalement de violences psychologiques", category: "AUTRE" }),
+    ]);
+
+    expect(await findPotentialDuplicates()).toHaveLength(1);
+  });
+
+  it("n'écarte rien sur un rapprochement du premier passage", async () => {
+    // Le garde est borné au 2e passage : un identifiant partagé n'est pas concerné.
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", { title: "Ordonnance de référé", category: "AUTRE" }),
+      makeDraft("a2", { title: "Enlèvement suivi de meurtre", category: "AGRESSION_SEXUELLE" }),
+    ]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0]!.matchedBy).toBe("pourvoiNumber");
+  });
+
+  it("n'introduit aucune paire auto-fusionnable", async () => {
+    mockedAffairFindMany.mockResolvedValue([
+      makeDraft("a1", {
+        title: "Soupçons de tentative d'étouffement d'une procédure",
+        category: "RECEL",
+      }),
+      makeDraft("a2", {
+        title: "Tentative présumée d'étouffement d'une procédure",
+        category: "AUTRE",
+      }),
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+    const plans = duplicates.map((d) => decideMergeAction(d).decision);
+
+    expect(plans).toEqual(["REVIEW_REQUIRED"]);
+  });
+
+  it("ne change pas une décision AUTO_MERGE_DRAFTS existante", async () => {
+    // Deux brouillons rapprochés en HIGH par un identifiant : le plan reste le même.
+    mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
+    mockedFindMatchingAffairs.mockResolvedValue([
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+    ]);
+
+    const duplicates = await findPotentialDuplicates();
+
+    expect(duplicates).toHaveLength(1);
+    expect(decideMergeAction(duplicates[0]!).decision).toBe("AUTO_MERGE_DRAFTS");
   });
 });

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -17,7 +17,9 @@ import {
 } from "@/generated/prisma";
 import {
   findMatchingAffairs,
+  pairingRestsOnWildcard,
   sameCategoryFamily,
+  titlesShareVocabulary,
   verdictDatesConflict,
   type MatchConfidence,
   type MatchResult,
@@ -273,6 +275,19 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
         const { key } = canonicalPair(a.id, b.id);
         if (exclusions.excluded.has(key) || best.has(key)) continue;
         if (!sameCategoryFamily(a.category, b.category)) continue;
+
+        // When only the AUTRE wildcard brings the categories together, the pair
+        // rests on the absence of a qualification rather than on evidence. Ask the
+        // titles for a second signal (issue #521): a person cited in unrelated
+        // coverage otherwise pairs with every other draft about them. Measured on
+        // the real base, this is exactly the one false positive the #525 triage
+        // found. Downgrade only — the result stays POSSIBLE and nothing is merged.
+        if (
+          pairingRestsOnWildcard(a.category, b.category) &&
+          !titlesShareVocabulary(a.title, b.title)
+        ) {
+          continue;
+        }
 
         const daysApart =
           Math.abs(a.createdAt.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60 * 24);


### PR DESCRIPTION
## Description

Closes #521. **Remplace #524**, ouverte avant #526, #528, #530 et #531 et qui ne se fusionne plus proprement. Le correctif est reporté depuis la pointe actuelle de `main`, adapté au code de détection tel qu'il est aujourd'hui.

### Le problème, confirmé par une mesure réelle

`sameCategoryFamily()` traite `AUTRE` comme un joker compatible avec toutes les familles. Quand c'est la **seule** raison pour laquelle deux catégories sont jugées compatibles, cette compatibilité ne dit rien des faits : `AUTRE` signifie qu'aucune qualification juridique n'a été établie.

Le premier tri réel de la file de doublons (#525) a tranché la question. Sur les 7 paires jugées, **une seule était un faux positif franc**, et c'était précisément une paire dépendant du joker : une personnalité citée dans deux couvertures de presse sans aucun rapport, dont l'une des deux fiches n'a pas de qualification.

### Le correctif

Le joker reste. Quand il est la **seule** raison du rapprochement, les titres doivent partager au moins un mot porteur de sens.

Trois ajouts dans `matching.ts` :

- `pairingRestsOnWildcard()` sépare « seul `AUTRE` les rapproche » de « une famille nommée les rapproche déjà ». `AUTRE` contre `AUTRE` n'en fait pas partie : ces catégories sont égales, le joker n'est pas la raison du rapprochement.
- `significantTitleWords()` replie les accents et écarte les mots qu'un titre porte quelle que soit l'affaire : mots grammaticaux de quatre lettres ou plus, et boilerplate judiciaire ou éditorial. Sans cette liste, deux dossiers sans rapport se rapprocheraient sur le seul mot « affaire ».
- `titlesShareVocabulary()` demande un mot en commun.

**Un mot en commun plutôt qu'un ratio, délibérément.** Les paires à conserver en partageaient plusieurs, celles à écarter aucune. Tout seuil intermédiaire aurait été un réglage sans mesure pour le justifier. Un mot partagé est une piste qu'un relecteur peut suivre, zéro n'en est pas une.

### Périmètre du garde

Borné au second passage de `findPotentialDuplicates()`, celui qui regroupe les brouillons d'une même personnalité créés à moins de 14 jours d'écart :

- deux brouillons uniquement ;
- résultat `POSSIBLE` à 0,45, inchangé ;
- **aucun chemin d'auto-fusion modifié** ;
- **aucune donnée écrite**.

Rétrogradation seulement : rien n'est promu, et le premier passage (identifiants, inclusion de titre) n'est pas touché.

## Comportement avant / après, mesuré sur la base réelle

463 affaires, 8 jugements déjà enregistrés. Les décisions persistées masquant la plupart des paires dans la file courante, la mesure présente deux vues : la file réelle, et le signal brut du second passage exclusions ignorées.

| | Avant | Après |
| --- | --- | --- |
| file réelle, paires proposées | 1 | **1** |
| file réelle, paires auto-fusionnables | 0 | **0** |
| signal brut, paires de la fenêtre | 2 | 2 |
| signal brut, dépendant du **seul** joker | 1 | 1 |
| **écartées par le garde** | 0 | **1** |
| paires joker conservées | 1 | 0 |
| faux positif présent | **oui** | **non** |

**La paire écartée est exactement le faux positif franc du tri de #525.** Elle avait déjà été classée `DISTINCT` à la main : le correctif fait maintenant ce travail tout seul.

**Aucun rapprochement utile perdu.** L'autre paire de la fenêtre porte deux fois la même catégorie nommée, donc le garde ne la concerne pas. Elle reste proposée, et son jugement `LINKED` est intact.

**Aucun jugement enregistré touché**, aucune écriture, aucune fusion. La mesure est en lecture seule.

## Invariants de sécurité

- Le garde ne peut qu'**empêcher** un rapprochement, jamais en créer un.
- Le résultat du second passage reste `POSSIBLE` à 0,45, donc hors du filtre `CERTAIN | HIGH` de l'auto-fusion.
- Les protections ajoutées depuis #524 sont préservées : périmètre de détection élargi, `excludeAffairId`, exclusions persistées via `AffairPairDecision`, garde transactionnel de fusion, invalidation du cron.
- Un test vérifie explicitement qu'une décision `AUTO_MERGE_DRAFTS` existante n'est pas modifiée.

## Type de changement

- [x] Bug fix

## Issue liée

Closes #521

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts.

**2369 tests** passés, 0 échec (2346 sur `main`). **23 tests ajoutés**, écrits avant le correctif : les 15 premiers échouaient bien sans lui.

Couverture des cas demandés : joker sans vocabulaire commun (aucune paire), joker avec vocabulaire commun (paire `POSSIBLE`), catégories identiques (garde inactif), même famille nommée (garde inactif), `AUTRE` contre `AUTRE` (comportement conservé), mots génériques seuls (aucune paire), normalisation des accents, `AUTO_MERGE_DRAFTS` inchangé, aucun nouveau chemin d'auto-fusion, et la forme du faux positif du tri.

## Écarts avec le correctif d'origine de #524

- **Le point d'insertion a changé.** Le second passage compare désormais la fenêtre temporelle après la vérification de famille, et consulte les exclusions persistées avant tout. Le garde s'insère entre les deux, sans toucher à ces protections.
- **La liste de mots écartés est étendue** de quatre entrées (`ouverte`, `cours`, `deposee`, `rendue`), pour couvrir le cas « plusieurs mots génériques partagés » demandé en test.
- **La justification est maintenant mesurée, plus supposée.** #524 s'appuyait sur 5 paires dépendant du joker sur 9 ; la base a changé depuis, il n'en reste qu'une, et le tri réel a confirmé qu'elle était le faux positif.
- **Les fixtures de test n'utilisent aucun titre réel.** Les fiches concernées sont des brouillons non publiés : recopier leurs titres dans un fichier suivi par git publierait des allégations judiciaires non modérées sur des personnes nommées. Les fixtures reproduisent la forme avec des tournures juridiques génériques.

## Un test existant change d'attente, volontairement

Le cluster à trois brouillons passe de 3 paires à 2 : celle dont les deux titres ne partagent aucun mot disparaît. Le groupe reste **entièrement connexe** par le troisième brouillon, donc rien ne sort de la file. Le test assère maintenant les paires nommées plutôt qu'un simple compte, pour que ce soit lisible.

## Limites, hors périmètre

- **La liste de mots écartés est une liste, donc une dette.** Elle est courte, justifiée en deux groupes dans le code, et son effet est borné : elle ne peut qu'empêcher un rapprochement, jamais en créer un.
- Le garde n'écarte que les paires à vocabulaire **nul**. C'est volontairement permissif : sur ce projet, une suggestion de trop coûte un rejet, alors qu'un doublon manqué laisse deux fiches dans la base.
- 128 affaires sans qualification juridique restent un problème de données en soi, indépendant du rapprochement.
