### PR TITLE
Supprimer toute fusion automatique traversant la frontière du publié

### DIFF
--- a/src/app/admin/affaires/doublons/page.tsx
+++ b/src/app/admin/affaires/doublons/page.tsx
@@ -42,6 +42,7 @@ interface PairRow {
   score: number;
   contradictions: string[];
   unpropagatableDifferences: string[];
+  sharesOfficialIdentifier: boolean;
   previousClassification: Classification | null;
   rulingStale: boolean;
   plan: { decision: MergeDecision; reason: string; keepId?: string; removeId?: string };
@@ -57,8 +58,11 @@ interface Group {
 interface Metrics {
   candidatePairs: number;
   ruled: number;
+  decided: number;
   byClassification: Record<Classification, number>;
-  precision: number | null;
+  duplicateRate: number | null;
+  usefulMatchRate: number | null;
+  falsePositiveRate: number | null;
 }
 
 const CLASSIFICATION_LABELS: Record<Classification, string> = {
@@ -192,23 +196,45 @@ export default function DuplicatesReviewPage() {
 
       {metrics && (
         <Card>
-          <CardContent className="flex flex-wrap gap-x-8 gap-y-2 p-4 text-sm">
-            <span>
-              Paires jugées : <strong>{metrics.ruled}</strong>
-            </span>
-            <span>
-              Précision du signal :{" "}
-              <strong>
-                {metrics.precision === null
-                  ? "pas encore mesurable"
-                  : `${Math.round(metrics.precision * 100)} %`}
-              </strong>
-            </span>
-            {(Object.keys(CLASSIFICATION_LABELS) as Classification[]).map((key) => (
-              <span key={key} className="text-muted-foreground">
-                {CLASSIFICATION_LABELS[key]} : {metrics.byClassification[key]}
+          <CardContent className="space-y-3 p-4 text-sm">
+            <div className="flex flex-wrap gap-x-8 gap-y-1">
+              <span>
+                Paires tranchées : <strong>{metrics.decided}</strong>
+                {metrics.byClassification.UNCERTAIN > 0 && (
+                  <span className="text-muted-foreground">
+                    {" "}
+                    (+ {metrics.byClassification.UNCERTAIN} différée
+                    {metrics.byClassification.UNCERTAIN > 1 ? "s" : ""})
+                  </span>
+                )}
               </span>
-            ))}
+              {(
+                [
+                  ["Vrais doublons", metrics.duplicateRate],
+                  ["Rapprochements utiles", metrics.usefulMatchRate],
+                  ["Faux positifs francs", metrics.falsePositiveRate],
+                ] as const
+              ).map(([label, rate]) => (
+                <span key={label}>
+                  {label} :{" "}
+                  <strong>
+                    {rate === null ? "pas encore mesurable" : `${Math.round(rate * 100)} %`}
+                  </strong>
+                </span>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-x-6 gap-y-1 text-muted-foreground">
+              {(Object.keys(CLASSIFICATION_LABELS) as Classification[]).map((key) => (
+                <span key={key}>
+                  {CLASSIFICATION_LABELS[key]} : {metrics.byClassification[key]}
+                </span>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Une paire différée n&apos;entre dans aucun taux : elle ne tranche rien. Un
+              rapprochement utile n&apos;est pas forcément un doublon : deux chefs d&apos;une même
+              décision se lient, ils ne se fusionnent pas.
+            </p>
           </CardContent>
         </Card>
       )}
@@ -258,6 +284,9 @@ export default function DuplicatesReviewPage() {
                     <Badge variant="outline">{pair.confidence}</Badge>
                     <Badge variant="outline">{pair.matchedBy}</Badge>
                     <span className="text-muted-foreground">score {pair.score}</span>
+                    {pair.sharesOfficialIdentifier && (
+                      <Badge variant="secondary">identifiant judiciaire commun</Badge>
+                    )}
                     {pair.previousClassification && (
                       <Badge variant="secondary">
                         déjà jugé : {CLASSIFICATION_LABELS[pair.previousClassification]}

--- a/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
+++ b/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
@@ -12,6 +12,8 @@ const h = vi.hoisted(() => ({
   affairUpdate: vi.fn(),
   auditCreate: vi.fn(),
   decisionFindUnique: vi.fn(),
+  absorbDraftIntoPublished: vi.fn(),
+  withImportRun: vi.fn(),
   mergeAffairs: vi.fn(),
   recordPairDecision: vi.fn(),
   invalidateEntity: vi.fn(),
@@ -32,6 +34,13 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 vi.mock("@/services/affairs/reconciliation", () => ({ mergeAffairs: h.mergeAffairs }));
+vi.mock("@/services/affairs/absorb-draft", () => ({
+  absorbDraftIntoPublished: h.absorbDraftIntoPublished,
+}));
+vi.mock("@/services/affairs/import-run", () => ({
+  withImportRun: h.withImportRun,
+  IMPORTER_MANUAL_ADMIN: "manual-admin",
+}));
 vi.mock("@/services/affairs/pair-decision", () => ({
   recordPairDecision: h.recordPairDecision,
 }));
@@ -88,6 +97,14 @@ beforeEach(() => {
     order.push("invalidate");
   });
   h.decisionFindUnique.mockResolvedValue({ classification: "LINKED" });
+  h.absorbDraftIntoPublished.mockImplementation(async () => {
+    order.push("absorb");
+    return { proposalsCreated: 1, proposedFields: ["court"], recordedDifferences: [] };
+  });
+  h.withImportRun.mockImplementation(
+    async (_i: string, fn: (ctx: { importRunId: string }) => unknown) =>
+      fn({ importRunId: "run_1" })
+  );
   h.auditCreate.mockImplementation(async () => {
     order.push("audit");
     return {};
@@ -155,7 +172,12 @@ describe("POST /doublons/decision — classer sans rien déplacer (#525)", () =>
 describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525)", () => {
   it("refuse de supprimer une affaire publiée", async () => {
     h.affairFindUnique
-      .mockResolvedValueOnce({ id: "keep", updatedAt: new Date(), politician: { slug: "x" } })
+      .mockResolvedValueOnce({
+        id: "keep",
+        updatedAt: new Date(),
+        publicationStatus: "PUBLISHED",
+        politician: { slug: "x" },
+      })
       .mockResolvedValueOnce({
         id: "remove",
         updatedAt: new Date(),
@@ -168,11 +190,15 @@ describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525
     expect(h.mergeAffairs).not.toHaveBeenCalled();
   });
 
-  it("absorbe un brouillon et écrit le jugement dans la même transaction", async () => {
+  it("emprunte le chemin d'absorption quand le survivant est publié", async () => {
+    // Absorber dans une fiche publiée ne doit pas écrire court/chamber en direct :
+    // seuls les identifiants attribués par une juridiction passent, le reste va en
+    // proposition (#525 §4).
     h.affairFindUnique
       .mockResolvedValueOnce({
         id: "keep",
         updatedAt: new Date("2026-07-01"),
+        publicationStatus: "PUBLISHED",
         politician: { slug: "jean-dupont" },
       })
       .mockResolvedValueOnce({
@@ -184,12 +210,41 @@ describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525
     const res = await mergePOST(req({ keepId: "keep", removeId: "remove", signal }), ctx);
 
     expect(res.status).toBe(200);
-    // Le jugement part dans les options de la fusion, donc dans sa transaction.
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(h.absorbDraftIntoPublished).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publishedId: "keep",
+        draftId: "remove",
+        pairDecision: expect.objectContaining({ reviewedBy: "admin" }),
+      })
+    );
+    await expect(res.json()).resolves.toMatchObject({ proposalsCreated: 1 });
+  });
+
+  it("fusionne normalement entre deux brouillons, avec son jugement", async () => {
+    h.affairFindUnique
+      .mockResolvedValueOnce({
+        id: "keep",
+        updatedAt: new Date("2026-07-01"),
+        publicationStatus: "DRAFT",
+        politician: { slug: "jean-dupont" },
+      })
+      .mockResolvedValueOnce({
+        id: "remove",
+        updatedAt: new Date("2026-07-02"),
+        publicationStatus: "DRAFT",
+      });
+
+    const res = await mergePOST(req({ keepId: "keep", removeId: "remove", signal }), ctx);
+
+    expect(res.status).toBe(200);
+    expect(h.absorbDraftIntoPublished).not.toHaveBeenCalled();
     expect(h.mergeAffairs).toHaveBeenCalledWith(
       "keep",
       "remove",
       expect.objectContaining({
-        pairDecision: expect.objectContaining({ otherAffairId: "remove", reviewedBy: "admin" }),
+        removeMustNotBePublished: true,
+        pairDecision: expect.objectContaining({ otherAffairId: "remove" }),
       })
     );
   });
@@ -199,6 +254,7 @@ describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525
       .mockResolvedValueOnce({
         id: "keep",
         updatedAt: new Date(),
+        publicationStatus: "DRAFT",
         politician: { slug: "jean-dupont" },
       })
       .mockResolvedValueOnce({ id: "remove", updatedAt: new Date(), publicationStatus: "DRAFT" });

--- a/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
+++ b/src/app/api/admin/affaires/__tests__/pair-routes.test.ts
@@ -218,6 +218,10 @@ describe("POST /doublons/fusionner — jamais supprimer une fiche publiée (#525
         pairDecision: expect.objectContaining({ reviewedBy: "admin" }),
       })
     );
+    // Le run et la proposition doivent être attribuables au même acteur.
+    expect(h.withImportRun.mock.calls[0]![0]).toBe("manual-admin");
+    expect(h.absorbDraftIntoPublished.mock.calls[0]![0].importer).toBe("manual-admin");
+    expect(h.absorbDraftIntoPublished.mock.calls[0]![0].importRunId).toBe("run_1");
     await expect(res.json()).resolves.toMatchObject({ proposalsCreated: 1 });
   });
 

--- a/src/app/api/admin/affaires/doublons/fusionner/route.ts
+++ b/src/app/api/admin/affaires/doublons/fusionner/route.ts
@@ -60,18 +60,21 @@ export const POST = withAdminAuth(
     }
 
     const meta = getRequestMeta(request);
+    // The plain merge needs the timestamps here; the absorption path re-reads them
+    // inside its own transaction, so it takes only the reviewer and the signal.
     const ruling = {
       reviewedBy: "admin",
       notes: body.notes ?? null,
       signal: body.signal,
-      keepUpdatedAt: keep.updatedAt,
-      removeUpdatedAt: remove.updatedAt,
     };
+    const timestamps = { keepUpdatedAt: keep.updatedAt, removeUpdatedAt: remove.updatedAt };
 
     let result;
     let proposalsCreated = 0;
     if (keep.publicationStatus === "PUBLISHED") {
-      // Proposals belong to a run (issue #513 invariant).
+      // The run is opened around the transaction, not inside it: its own state is
+      // bookkeeping, and withImportRun() guarantees it never stays RUNNING. The
+      // business atomicity is the transaction inside absorbDraftIntoPublished().
       const absorbed = await withImportRun(IMPORTER_MANUAL_ADMIN, ({ importRunId }) =>
         absorbDraftIntoPublished({
           publishedId: keepId,
@@ -79,17 +82,21 @@ export const POST = withAdminAuth(
           importRunId,
           reason: `Fusion confirmée en revue des doublons (${body.signal.matchedBy}/${body.signal.confidence})`,
           pairDecision: ruling,
+          audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
         })
       );
       proposalsCreated = absorbed.proposalsCreated;
-      result = { proposedFields: absorbed.proposedFields };
+      result = {
+        proposedFields: absorbed.proposedFields,
+        slugsPreserved: absorbed.slugsPreserved,
+      };
     } else {
       result = await mergeAffairs(keepId, removeId, {
         // The precheck above answers 409; this makes the service enforce it too,
         // in case the row is published between that read and the write.
         removeMustNotBePublished: true,
         audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
-        pairDecision: { otherAffairId: removeId, ...ruling },
+        pairDecision: { otherAffairId: removeId, ...ruling, ...timestamps },
       });
     }
 

--- a/src/app/api/admin/affaires/doublons/fusionner/route.ts
+++ b/src/app/api/admin/affaires/doublons/fusionner/route.ts
@@ -80,6 +80,9 @@ export const POST = withAdminAuth(
           publishedId: keepId,
           draftId: removeId,
           importRunId,
+          // Same importer as the run above: the proposal must be attributable to
+          // the confirmed admin action, not to an automatic pipeline.
+          importer: IMPORTER_MANUAL_ADMIN,
           reason: `Fusion confirmée en revue des doublons (${body.signal.matchedBy}/${body.signal.confidence})`,
           pairDecision: ruling,
           audit: { ipAddress: meta.ip, userAgent: meta.userAgent },

--- a/src/app/api/admin/affaires/doublons/fusionner/route.ts
+++ b/src/app/api/admin/affaires/doublons/fusionner/route.ts
@@ -4,6 +4,8 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
 import { pairMergeSchema, type PairMergeBody } from "@/lib/security/schemas/affair-pair";
 import { mergeAffairs } from "@/services/affairs/reconciliation";
+import { absorbDraftIntoPublished } from "@/services/affairs/absorb-draft";
+import { withImportRun, IMPORTER_MANUAL_ADMIN } from "@/services/affairs/import-run";
 import { invalidateEntity } from "@/lib/cache";
 
 /**
@@ -14,6 +16,11 @@ import { invalidateEntity } from "@/lib/cache";
  * into a published fiche is supported, the reverse retires a page a reader can
  * reach. Two published affairs need a moderator to unpublish one first, so the
  * removal is a deliberate editorial act rather than a side effect of a merge.
+ *
+ * When the survivor is published, the absorption path runs instead of a plain
+ * merge: it fills court-assigned identifiers only and turns everything the draft
+ * states about the judicial outcome into proposals, so confirming a merge cannot
+ * silently rewrite a published record (issue #525, §4).
  */
 export const POST = withAdminAuth(
   withValidation(pairMergeSchema, async (request, _context, body: PairMergeBody) => {
@@ -26,7 +33,12 @@ export const POST = withAdminAuth(
     const [keep, remove] = await Promise.all([
       db.affair.findUnique({
         where: { id: keepId },
-        select: { id: true, updatedAt: true, politician: { select: { slug: true } } },
+        select: {
+          id: true,
+          updatedAt: true,
+          publicationStatus: true,
+          politician: { select: { slug: true } },
+        },
       }),
       db.affair.findUnique({
         where: { id: removeId },
@@ -48,25 +60,43 @@ export const POST = withAdminAuth(
     }
 
     const meta = getRequestMeta(request);
-    const result = await mergeAffairs(keepId, removeId, {
-      // The precheck above answers 409; this makes the service enforce it too,
-      // in case the row is published between that read and the write.
-      removeMustNotBePublished: true,
-      audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
-      pairDecision: {
-        otherAffairId: removeId,
-        reviewedBy: "admin",
-        notes: body.notes ?? null,
-        signal: body.signal,
-        keepUpdatedAt: keep.updatedAt,
-        removeUpdatedAt: remove.updatedAt,
-      },
-    });
+    const ruling = {
+      reviewedBy: "admin",
+      notes: body.notes ?? null,
+      signal: body.signal,
+      keepUpdatedAt: keep.updatedAt,
+      removeUpdatedAt: remove.updatedAt,
+    };
+
+    let result;
+    let proposalsCreated = 0;
+    if (keep.publicationStatus === "PUBLISHED") {
+      // Proposals belong to a run (issue #513 invariant).
+      const absorbed = await withImportRun(IMPORTER_MANUAL_ADMIN, ({ importRunId }) =>
+        absorbDraftIntoPublished({
+          publishedId: keepId,
+          draftId: removeId,
+          importRunId,
+          reason: `Fusion confirmée en revue des doublons (${body.signal.matchedBy}/${body.signal.confidence})`,
+          pairDecision: ruling,
+        })
+      );
+      proposalsCreated = absorbed.proposalsCreated;
+      result = { proposedFields: absorbed.proposedFields };
+    } else {
+      result = await mergeAffairs(keepId, removeId, {
+        // The precheck above answers 409; this makes the service enforce it too,
+        // in case the row is published between that read and the write.
+        removeMustNotBePublished: true,
+        audit: { ipAddress: meta.ip, userAgent: meta.userAgent },
+        pairDecision: { otherAffairId: removeId, ...ruling },
+      });
+    }
 
     // After the transaction commits, never before.
     invalidateEntity("affair");
     if (keep.politician?.slug) invalidateEntity("politician", keep.politician.slug);
 
-    return NextResponse.json({ success: true, ...result });
+    return NextResponse.json({ success: true, proposalsCreated, ...result });
   })
 );

--- a/src/app/api/admin/affaires/doublons/route.ts
+++ b/src/app/api/admin/affaires/doublons/route.ts
@@ -3,8 +3,9 @@ import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
 import { decideMergeAction } from "@/services/affairs/merge-decision";
-import { computePairPrecision } from "@/services/affairs/pair-decision";
+import { computePairMetrics } from "@/services/affairs/pair-decision";
 import { canonicalPair } from "@/services/affairs/affair-pair";
+import { isOfficialJudicialIdentifierMatch } from "@/services/affairs/matching";
 
 /**
  * The duplicate review queue, grouped by politician (issue #525).
@@ -57,6 +58,9 @@ export const GET = withAdminAuth(async () => {
       confidence: pair.confidence,
       matchedBy: pair.matchedBy,
       score: pair.score,
+      // Surfaced as a reason to read the pair, never as a reason to merge it: the
+      // Carignon case shares a pourvoi number and is two counts (issue #525).
+      sharesOfficialIdentifier: isOfficialJudicialIdentifierMatch(pair.matchedBy),
       contradictions: pair.contradictions,
       unpropagatableDifferences: pair.unpropagatableDifferences,
       previousClassification: pair.previousClassification,
@@ -68,7 +72,7 @@ export const GET = withAdminAuth(async () => {
     groups.set(politicianId, group);
   }
 
-  const metrics = await computePairPrecision(pairs.length);
+  const metrics = await computePairMetrics(pairs.length);
 
   return NextResponse.json({
     total: pairs.length,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -52,6 +52,19 @@ function buildExtendedClient() {
 
 export const db = globalForPrisma.prisma ?? buildExtendedClient();
 
+/**
+ * The client handed to a `db.$transaction(async (tx) => …)` callback.
+ *
+ * Derived from `db` rather than written as `Prisma.TransactionClient`: this client
+ * is extended, so its transaction client is not assignable to the vanilla type.
+ * Exported so a service can hand its transaction to another service and keep one
+ * atomic unit across module boundaries.
+ */
+export type DbTransactionClient = Omit<
+  typeof db,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+
 // Cache in all environments — prevents duplicate pools in serverless (Vercel)
 // and avoids hot-reload duplication in dev
 globalForPrisma.prisma = db;

--- a/src/services/affairs/__tests__/absorb-draft.test.ts
+++ b/src/services/affairs/__tests__/absorb-draft.test.ts
@@ -1,24 +1,49 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Issue #525 §4 — absorbing a draft into a published affair may add, never rewrite.
-// Anything the draft states about the judicial outcome goes to the proposal queue.
+/**
+ * Issue #525 §4 and the atomicity review of #533.
+ *
+ * The path used to merge first and propose afterwards: a proposal failing after
+ * that commit left the draft already deleted, and what it stated about status,
+ * verdict date, court or sentence was lost with no proposal to show for it.
+ * Everything below is about one transaction, all-or-nothing.
+ */
 
-const h = vi.hoisted(() => ({
-  findUnique: vi.fn(),
-  mergeAffairs: vi.fn(),
-  proposeAffairUpdate: vi.fn(),
+const calls: string[] = [];
+
+const tx = {
+  affair: { findUnique: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  source: { findMany: vi.fn(), update: vi.fn() },
+  affairEvent: { findMany: vi.fn(), update: vi.fn() },
+  pressArticleAffair: { findMany: vi.fn(), update: vi.fn() },
+  publicIdRedirect: { upsert: vi.fn() },
+  dismissedDuplicate: { deleteMany: vi.fn() },
+  affairPairDecision: { upsert: vi.fn() },
+  affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+  auditLog: { create: vi.fn() },
+};
+
+/** A real transaction rolls back on throw; the fake records that it did. */
+let rolledBack = false;
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    $transaction: async (fn: (t: unknown) => unknown) => {
+      try {
+        return await fn(tx);
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    },
+  },
 }));
 
-vi.mock("@/lib/db", () => ({ db: { affair: { findUnique: h.findUnique } } }));
-vi.mock("../reconciliation", () => ({
-  mergeAffairs: h.mergeAffairs,
-  ABSORPTION_ADDITIVE_FIELDS: ["ecli", "pourvoiNumber", "caseNumber"],
-}));
-vi.mock("../proposals", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../proposals")>();
+vi.mock("../reconciliation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../reconciliation")>();
   return {
-    normalizeForCompare: actual.normalizeForCompare,
-    proposeAffairUpdate: h.proposeAffairUpdate,
+    ABSORPTION_ADDITIVE_FIELDS: ["ecli", "pourvoiNumber", "caseNumber"],
+    mergeAffairsInTransaction: actual.mergeAffairsInTransaction,
   };
 });
 
@@ -27,12 +52,21 @@ import { absorbDraftIntoPublished } from "../absorb-draft";
 function affair(overrides: Record<string, unknown> = {}) {
   return {
     id: "x",
+    slug: "fiche",
+    publicId: "AF-000001",
+    oldSlugs: [],
+    politicianId: "p1",
     title: "Titre",
     description: "Description",
     category: "AUTRE",
     status: null,
     verdictDate: null,
     court: null,
+    chamber: null,
+    caseNumber: null,
+    ecli: null,
+    pourvoiNumber: null,
+    caseNumbers: [],
     sentence: null,
     prisonMonths: null,
     prisonSuspended: null,
@@ -41,94 +75,248 @@ function affair(overrides: Record<string, unknown> = {}) {
     communityService: null,
     otherSentence: null,
     publicationStatus: "DRAFT",
+    updatedAt: new Date("2026-07-01"),
+    politician: { slug: "jean-dupont", fullName: "Jean Dupont" },
     sources: [],
     ...overrides,
   };
 }
 
 function stub(published: Record<string, unknown>, draft: Record<string, unknown>) {
-  h.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
+  tx.affair.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
     Promise.resolve(where.id === published.id ? published : draft)
   );
 }
 
-/** The patch handed to the proposal queue, or null when nothing was proposed. */
-function proposedPatch(): Record<string, unknown> | null {
-  const call = h.proposeAffairUpdate.mock.calls[0];
-  return call ? (call[0].patch as Record<string, unknown>) : null;
-}
+const base = {
+  importRunId: "run_1",
+  reason: "Fusion confirmée en revue",
+  pairDecision: {
+    reviewedBy: "admin",
+    signal: { confidence: "HIGH", matchedBy: "pourvoiNumber", score: 0.95 },
+  },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.mergeAffairs.mockResolvedValue({
-    sourcesMoved: 0,
-    eventsMoved: 0,
-    articlesMoved: 0,
-    identifiersMerged: [],
-    slugsPreserved: [],
+  calls.length = 0;
+  rolledBack = false;
+  tx.source.findMany.mockResolvedValue([]);
+  tx.affairEvent.findMany.mockResolvedValue([]);
+  tx.pressArticleAffair.findMany.mockResolvedValue([]);
+  tx.affairUpdateProposal.findFirst.mockResolvedValue(null);
+  tx.affairUpdateProposal.create.mockImplementation(async () => {
+    calls.push("proposal");
+    return { id: "prop_1" };
   });
-  h.proposeAffairUpdate.mockResolvedValue({
-    autoApplied: [],
-    autoProposalId: null,
-    pendingProposalId: "prop_1",
-    conflictProposalId: null,
-    deduped: false,
+  tx.affair.delete.mockImplementation(async () => {
+    calls.push("delete");
+    return {};
+  });
+  tx.affairPairDecision.upsert.mockImplementation(async () => {
+    calls.push("ruling");
+    return { id: "dec_1" };
+  });
+  tx.auditLog.create.mockImplementation(async () => {
+    calls.push("audit");
+    return {};
+  });
+  tx.source.update.mockImplementation(async () => {
+    calls.push("source");
+    return {};
+  });
+  tx.affairEvent.update.mockImplementation(async () => {
+    calls.push("event");
+    return {};
+  });
+  tx.pressArticleAffair.update.mockImplementation(async () => {
+    calls.push("article");
+    return {};
   });
 });
 
-const base = {
-  importRunId: "run_1",
-  reason: "Identifiant judiciaire commun (pourvoiNumber)",
-};
+const publishedAffair = () =>
+  affair({ id: "pub", slug: "publiee", publicId: "AF-000001", publicationStatus: "PUBLISHED" });
+const draftAffair = (overrides: Record<string, unknown> = {}) =>
+  affair({
+    id: "draft",
+    slug: "brouillon",
+    publicId: "AF-000002",
+    publicationStatus: "DRAFT",
+    status: "PROCES_EN_COURS",
+    court: "Tribunal correctionnel de Paris",
+    ...overrides,
+  });
 
-describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (#525)", () => {
-  it("n'écrase aucun champ sensible non nul de l'affaire publiée", async () => {
+describe("absorbDraftIntoPublished — tout ou rien (#525)", () => {
+  it("valide proposition, fusion, jugement et audit ensemble", async () => {
+    stub(publishedAffair(), draftAffair());
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(result.proposalsCreated).toBe(1);
+    expect(result.proposedFields).toEqual(expect.arrayContaining(["status", "court"]));
+    // La proposition est écrite AVANT la suppression : si elle échoue, rien n'a bougé.
+    expect(calls.indexOf("proposal")).toBeLessThan(calls.indexOf("delete"));
+    expect(calls).toEqual(expect.arrayContaining(["proposal", "delete", "ruling", "audit"]));
+    expect(rolledBack).toBe(false);
+  });
+
+  it("ne supprime pas le brouillon si la proposition échoue", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.affairUpdateProposal.create.mockRejectedValue(new Error("proposal write failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("proposal write failed");
+
+    expect(rolledBack).toBe(true);
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+  });
+
+  it("ne déplace aucune relation si la proposition échoue", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.source.findMany.mockResolvedValue([{ id: "s1", url: "https://example.org/a" }]);
+    tx.affairUpdateProposal.create.mockRejectedValue(new Error("proposal write failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow();
+
+    expect(tx.source.update).not.toHaveBeenCalled();
+    expect(tx.affairEvent.update).not.toHaveBeenCalled();
+    expect(tx.pressArticleAffair.update).not.toHaveBeenCalled();
+  });
+
+  it("n'écrit ni jugement ni audit si la proposition échoue", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.affairUpdateProposal.create.mockRejectedValue(new Error("proposal write failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow();
+
+    expect(tx.affairPairDecision.upsert).not.toHaveBeenCalled();
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+    expect(tx.publicIdRedirect.upsert).not.toHaveBeenCalled();
+  });
+
+  it("annule la proposition si la fusion échoue", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.affair.delete.mockRejectedValue(new Error("delete failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("delete failed");
+
+    // La proposition a bien été tentée, mais la transaction est annulée : rien ne
+    // subsiste, ce que prouve le rollback de la transaction qui la portait.
+    expect(tx.affairUpdateProposal.create).toHaveBeenCalled();
+    expect(rolledBack).toBe(true);
+  });
+
+  it("annule tout si le jugement de paire échoue", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.affairPairDecision.upsert.mockRejectedValue(new Error("ruling failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("ruling failed");
+
+    expect(rolledBack).toBe(true);
+  });
+});
+
+describe("absorbDraftIntoPublished — ce qui est écrit, et ce qui ne l'est pas (#525)", () => {
+  it("n'écrase aucun champ sensible de la fiche publiée", async () => {
+    stub(publishedAffair(), draftAffair({ court: "Cour d'appel de Lyon", sentence: "12 mois" }));
+
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+
+    const payload = (tx.affair.update.mock.calls[0]?.[0]?.data ?? {}) as Record<string, unknown>;
+    for (const field of [
+      "status",
+      "verdictDate",
+      "court",
+      "chamber",
+      "sentence",
+      "title",
+      "description",
+      "category",
+      "involvement",
+      "publicationStatus",
+    ]) {
+      expect(payload).not.toHaveProperty(field);
+    }
+  });
+
+  it("transfère les identifiants additifs autorisés", async () => {
+    stub(
+      publishedAffair(),
+      draftAffair({ ecli: "ECLI:FR:CCASS:2024:C900009", caseNumber: "24-90009" })
+    );
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    const payload = (tx.affair.update.mock.calls[0]?.[0]?.data ?? {}) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      ecli: "ECLI:FR:CCASS:2024:C900009",
+      caseNumber: "24-90009",
+    });
+    expect(result.slugsPreserved).toEqual(["brouillon"]);
+  });
+
+  it("préserve le slug absorbé et la redirection du publicId", async () => {
+    stub(publishedAffair(), draftAffair({ oldSlugs: ["brouillon-v1"] }));
+
+    const result = await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+    });
+
+    expect(result.slugsPreserved).toEqual(["brouillon", "brouillon-v1"]);
+    expect(tx.publicIdRedirect.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { fromPublicId: "AF-000002" },
+        create: expect.objectContaining({ toPublicId: "AF-000001", reason: "merged" }),
+      })
+    );
+  });
+
+  it("juge la paire contre les lignes relues dans la transaction", async () => {
+    const readInTx = new Date("2026-07-24T12:00:00Z");
     stub(
       affair({
         id: "pub",
+        slug: "publiee",
         publicationStatus: "PUBLISHED",
-        status: "CONDAMNATION_DEFINITIVE",
-        court: "Cour de cassation",
-        sentence: "6 mois avec sursis",
-        verdictDate: new Date("2024-01-15"),
+        updatedAt: readInTx,
       }),
-      affair({
-        id: "draft",
-        status: "PROCES_EN_COURS",
-        court: "Tribunal correctionnel de Paris",
-        sentence: "réquisitions de 12 mois",
-        verdictDate: new Date("2024-01-20"),
-      })
+      draftAffair({ updatedAt: readInTx })
     );
 
     await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
 
-    // Le service de fusion est appelé avec la seule liste additive restreinte :
-    // ni court ni chamber ne peuvent y être remplis.
-    const mergeOptions = h.mergeAffairs.mock.calls[0]![2];
-    expect(mergeOptions.additiveFields).toEqual(["ecli", "pourvoiNumber", "caseNumber"]);
-    expect(mergeOptions.additiveFields).not.toContain("court");
-    expect(mergeOptions.additiveFields).not.toContain("chamber");
-
-    // Et le survivant est bien l'affaire publiée.
-    expect(h.mergeAffairs).toHaveBeenCalledWith("pub", "draft", expect.anything());
+    const args = tx.affairPairDecision.upsert.mock.calls[0]![0];
+    expect(args.create).toMatchObject({
+      classification: "DUPLICATE",
+      affairAUpdatedAt: readInTx,
+      affairBUpdatedAt: readInTx,
+      mergedIntoAffairId: "pub",
+    });
   });
 
-  it("crée une proposition pour chaque donnée sensible divergente", async () => {
-    stub(
-      affair({
-        id: "pub",
-        publicationStatus: "PUBLISHED",
-        status: "CONDAMNATION_DEFINITIVE",
-        court: null,
-      }),
-      affair({
-        id: "draft",
-        status: "PROCES_EN_COURS",
-        court: "Tribunal correctionnel de Paris",
-        prisonMonths: 6,
-      })
-    );
+  it("ne propose rien quand le brouillon n'ajoute aucune valeur", async () => {
+    stub(publishedAffair(), draftAffair({ status: null, court: null }));
 
     const result = await absorbDraftIntoPublished({
       publishedId: "pub",
@@ -136,43 +324,13 @@ describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (
       ...base,
     });
 
-    expect(proposedPatch()).toEqual({
-      status: "PROCES_EN_COURS",
-      court: "Tribunal correctionnel de Paris",
-      prisonMonths: 6,
-    });
-    expect(result.proposalsCreated).toBe(1);
-    expect(h.proposeAffairUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ affairId: "pub", importRunId: "run_1" })
-    );
-  });
-
-  it("ne propose pas un champ que l'affaire publiée porte déjà à l'identique", async () => {
-    stub(
-      affair({ id: "pub", publicationStatus: "PUBLISHED", court: "Cour de cassation" }),
-      affair({ id: "draft", court: "Cour de cassation" })
-    );
-
-    const result = await absorbDraftIntoPublished({
-      publishedId: "pub",
-      draftId: "draft",
-      ...base,
-    });
-
-    expect(h.proposeAffairUpdate).not.toHaveBeenCalled();
     expect(result.proposalsCreated).toBe(0);
+    expect(tx.affairUpdateProposal.create).not.toHaveBeenCalled();
+    expect(tx.affair.delete).toHaveBeenCalled();
   });
 
   it("garde trace des différences ni transférées ni proposables", async () => {
-    stub(
-      affair({
-        id: "pub",
-        publicationStatus: "PUBLISHED",
-        category: "AUTRE",
-        title: "Titre publié",
-      }),
-      affair({ id: "draft", category: "RECEL", title: "Titre du brouillon" })
-    );
+    stub(publishedAffair(), draftAffair({ category: "RECEL", title: "Titre du brouillon" }));
 
     const result = await absorbDraftIntoPublished({
       publishedId: "pub",
@@ -181,8 +339,7 @@ describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (
     });
 
     expect(result.recordedDifferences).toEqual(expect.arrayContaining(["title", "category"]));
-    // Rien n'est perdu en silence : la valeur absorbée part dans la piste d'audit.
-    const notes = h.mergeAffairs.mock.calls[0]![2].auditNotes;
+    const notes = tx.auditLog.create.mock.calls[0]![0].data.changes.notes;
     expect(notes.recordedDifferences).toEqual(
       expect.arrayContaining([{ field: "category", absorbedValue: "RECEL" }])
     );
@@ -191,32 +348,30 @@ describe("absorbDraftIntoPublished — l'affaire publiée n'est pas réécrite (
 
 describe("absorbDraftIntoPublished — refuse de se tromper de sens (#525)", () => {
   it("refuse si le survivant n'est pas publié", async () => {
-    stub(affair({ id: "pub", publicationStatus: "DRAFT" }), affair({ id: "draft" }));
+    stub(affair({ id: "pub", publicationStatus: "DRAFT" }), draftAffair());
 
     await expect(
       absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
     ).rejects.toThrow("n'est pas publiée");
-    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+    expect(tx.affairUpdateProposal.create).not.toHaveBeenCalled();
   });
 
-  it("refuse si l'affaire absorbée n'est pas un brouillon", async () => {
-    stub(
-      affair({ id: "pub", publicationStatus: "PUBLISHED" }),
-      affair({ id: "draft", publicationStatus: "PUBLISHED" })
-    );
+  it("refuse si l'affaire absorbée est publiée", async () => {
+    stub(publishedAffair(), draftAffair({ publicationStatus: "PUBLISHED" }));
 
     await expect(
       absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
     ).rejects.toThrow("n'est pas un brouillon");
-    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(tx.affair.delete).not.toHaveBeenCalled();
   });
 
   it("refuse si une des deux affaires a disparu", async () => {
-    h.findUnique.mockResolvedValue(null);
+    tx.affair.findUnique.mockResolvedValue(null);
 
     await expect(
       absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
     ).rejects.toThrow("introuvable");
-    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(tx.affair.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/services/affairs/__tests__/absorb-draft.test.ts
+++ b/src/services/affairs/__tests__/absorb-draft.test.ts
@@ -90,6 +90,7 @@ function stub(published: Record<string, unknown>, draft: Record<string, unknown>
 
 const base = {
   importRunId: "run_1",
+  importer: "manual-admin",
   reason: "Fusion confirmée en revue",
   pairDecision: {
     reviewedBy: "admin",
@@ -373,5 +374,90 @@ describe("absorbDraftIntoPublished — refuse de se tromper de sens (#525)", () 
       absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
     ).rejects.toThrow("introuvable");
     expect(tx.affair.delete).not.toHaveBeenCalled();
+  });
+});
+
+// Review of #533 — the service hard-coded `importer: "reconcile-affairs"` while the
+// route opened its run as `manual-admin`. A confirmed admin merge was therefore
+// filed under an automatic importer, and since the importer is part of payloadHash,
+// it could also dedupe against an old automatic proposal.
+describe("absorbDraftIntoPublished — provenance de la proposition (#525)", () => {
+  it("enregistre la proposition sous l'importer fourni", async () => {
+    stub(publishedAffair(), draftAffair());
+
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+
+    const data = tx.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(data.importer).toBe("manual-admin");
+    expect(data.importer).not.toBe("reconcile-affairs");
+  });
+
+  it("porte le même importer que le run qui l'entoure", async () => {
+    // La route ouvre withImportRun(IMPORTER_MANUAL_ADMIN) et passe le même ici :
+    // le run et la proposition doivent être attribuables au même acteur.
+    stub(publishedAffair(), draftAffair());
+
+    await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+      importRunId: "run_manual",
+      importer: "manual-admin",
+    });
+
+    const data = tx.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(data.importRunId).toBe("run_manual");
+    expect(data.importer).toBe("manual-admin");
+  });
+
+  it("cherche un doublon de proposition dans le périmètre du seul importer courant", async () => {
+    stub(publishedAffair(), draftAffair());
+
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+
+    expect(tx.affairUpdateProposal.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ importer: "manual-admin" }),
+      })
+    );
+  });
+
+  it("ne se déduplique pas avec une proposition automatique antérieure", async () => {
+    // L'importer entre dans payloadHash : deux acteurs différents ne peuvent pas
+    // produire la même empreinte, donc une proposition manuelle ne peut pas être
+    // absorbée par une ancienne proposition automatique.
+    stub(publishedAffair(), draftAffair());
+    await absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base });
+    const manualHash = tx.affairUpdateProposal.create.mock.calls[0]![0].data.payloadHash;
+
+    vi.clearAllMocks();
+    tx.affairUpdateProposal.findFirst.mockResolvedValue(null);
+    tx.affairUpdateProposal.create.mockResolvedValue({ id: "prop_2" });
+    tx.source.findMany.mockResolvedValue([]);
+    tx.affairEvent.findMany.mockResolvedValue([]);
+    tx.pressArticleAffair.findMany.mockResolvedValue([]);
+    stub(publishedAffair(), draftAffair());
+    await absorbDraftIntoPublished({
+      publishedId: "pub",
+      draftId: "draft",
+      ...base,
+      importer: "reconcile-affairs",
+    });
+    const autoHash = tx.affairUpdateProposal.create.mock.calls[0]![0].data.payloadHash;
+
+    expect(manualHash).not.toBe(autoHash);
+  });
+
+  it("ne change ni l'atomicité ni le rollback", async () => {
+    stub(publishedAffair(), draftAffair());
+    tx.affairUpdateProposal.create.mockRejectedValue(new Error("proposal write failed"));
+
+    await expect(
+      absorbDraftIntoPublished({ publishedId: "pub", draftId: "draft", ...base })
+    ).rejects.toThrow("proposal write failed");
+
+    expect(rolledBack).toBe(true);
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+    expect(tx.affairPairDecision.upsert).not.toHaveBeenCalled();
   });
 });

--- a/src/services/affairs/__tests__/merge-decision.test.ts
+++ b/src/services/affairs/__tests__/merge-decision.test.ts
@@ -57,36 +57,62 @@ describe("decideMergeAction — deux brouillons (#525)", () => {
   });
 });
 
+// Issue #525 — automation used to cross the published boundary when a
+// court-assigned identifier was shared. The first real triage killed that: two
+// Carignon convictions share a pourvoi number, the facts date, the verdict date and
+// one cassation ruling, and they are still two separate counts, so two affairs.
 describe("decideMergeAction — brouillon face à une affaire publiée (#525)", () => {
   const published = side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus });
   const draft = side({ id: "draft" });
 
-  it("absorbe toujours le brouillon dans l'affaire publiée sur identifiant judiciaire", () => {
+  it("exige une revue même sur un identifiant judiciaire officiel commun", () => {
     for (const matchedBy of ["ecli", "pourvoiNumber", "caseNumbers"]) {
       const plan = decideMergeAction({
         affairA: published,
         affairB: draft,
-        confidence: "HIGH",
+        confidence: "CERTAIN",
         matchedBy,
       });
 
-      expect(plan.decision).toBe("AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
-      expect(plan.keepId).toBe("pub");
-      expect(plan.removeId).toBe("draft");
+      expect(plan.decision).toBe("REVIEW_REQUIRED");
+      expect(plan.keepId).toBeUndefined();
+      expect(plan.removeId).toBeUndefined();
     }
   });
 
-  it("garde l'affaire publiée même quand le brouillon a plus de sources", () => {
-    // Le sens de la fusion ne dépend jamais du nombre de sources ici.
+  it("dit dans le motif qu'un identifiant commun ne prouve pas un doublon", () => {
     const plan = decideMergeAction({
-      affairA: side({ id: "pub", publicationStatus: "PUBLISHED" as PublicationStatus }),
-      affairB: side({ id: "draft", sources: ["PRESSE", "OFFICIEL"] as SourceType[] }),
+      affairA: published,
+      affairB: draft,
       confidence: "CERTAIN",
-      matchedBy: "ecli",
+      matchedBy: "pourvoiNumber",
     });
 
-    expect(plan.keepId).toBe("pub");
-    expect(plan.removeId).toBe("draft");
+    expect(plan.reason).toContain("pourvoiNumber");
+    expect(plan.reason).toContain("plusieurs chefs");
+  });
+
+  it("exige une revue en CERTAIN comme en HIGH", () => {
+    for (const confidence of ["CERTAIN", "HIGH"] as const) {
+      for (const matchedBy of ["ecli", "pourvoiNumber", "caseNumbers", "title+category"]) {
+        expect(
+          decideMergeAction({ affairA: published, affairB: draft, confidence, matchedBy }).decision
+        ).toBe("REVIEW_REQUIRED");
+      }
+    }
+  });
+
+  it("exige une revue même sans contradiction et sur un brouillon jamais vérifié", () => {
+    const plan = decideMergeAction({
+      affairA: published,
+      affairB: side({ id: "draft", verifiedAt: null }),
+      confidence: "CERTAIN",
+      matchedBy: "ecli",
+      contradictions: [],
+      unpropagatableDifferences: [],
+    });
+
+    expect(plan.decision).toBe("REVIEW_REQUIRED");
   });
 
   it("exige une revue quand seul le titre rapproche", () => {
@@ -98,31 +124,23 @@ describe("decideMergeAction — brouillon face à une affaire publiée (#525)", 
     });
 
     expect(plan.decision).toBe("REVIEW_REQUIRED");
-    expect(plan.reason).toContain("heuristique");
   });
 
-  it("exige une revue quand le brouillon affirme autre chose sur un champ non transférable", () => {
-    const plan = decideMergeAction({
+  it("ne dépend pas du sens de la paire", () => {
+    const forward = decideMergeAction({
       affairA: published,
       affairB: draft,
       confidence: "CERTAIN",
       matchedBy: "ecli",
-      unpropagatableDifferences: ["involvement"],
     });
-
-    expect(plan.decision).toBe("REVIEW_REQUIRED");
-    expect(plan.reason).toContain("involvement");
-  });
-
-  it("ne supprime jamais automatiquement un brouillon validé humainement", () => {
-    const plan = decideMergeAction({
-      affairA: published,
-      affairB: side({ id: "draft", verifiedAt: new Date("2026-01-01") }),
+    const backward = decideMergeAction({
+      affairA: draft,
+      affairB: published,
       confidence: "CERTAIN",
       matchedBy: "ecli",
     });
 
-    expect(plan.decision).toBe("REVIEW_REQUIRED");
+    expect(forward).toEqual(backward);
   });
 });
 

--- a/src/services/affairs/__tests__/pair-decision.test.ts
+++ b/src/services/affairs/__tests__/pair-decision.test.ts
@@ -21,11 +21,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import {
-  buildPairDecisionUpsert,
-  computePairPrecision,
-  loadPairExclusions,
-} from "../pair-decision";
+import { buildPairDecisionUpsert, computePairMetrics, loadPairExclusions } from "../pair-decision";
 import { canonicalPair } from "../affair-pair";
 
 const signal = { confidence: "HIGH", matchedBy: "pourvoiNumber", score: 0.95 };
@@ -183,38 +179,78 @@ describe("loadPairExclusions — ce qui exclut, ce qui revient (#525)", () => {
   });
 });
 
-describe("computePairPrecision — mesure sur tous les jugements (#525)", () => {
-  it("ne rend rien avant le premier jugement", async () => {
-    const metrics = await computePairPrecision(12);
+describe("computePairMetrics — trois taux, pas un (#525)", () => {
+  it("ne rend aucun taux avant le premier jugement", async () => {
+    const m = await computePairMetrics(12);
 
-    expect(metrics.precision).toBeNull();
-    expect(metrics.candidatePairs).toBe(12);
+    expect(m.duplicateRate).toBeNull();
+    expect(m.usefulMatchRate).toBeNull();
+    expect(m.falsePositiveRate).toBeNull();
+    expect(m.candidatePairs).toBe(12);
+    expect(m.decided).toBe(0);
   });
 
-  it("rapporte les doublons aux paires réellement tranchées", async () => {
+  it("reproduit les chiffres du premier tri réel", async () => {
+    // 3 DUPLICATE, 3 LINKED, 1 DISTINCT, 1 UNCERTAIN : 7 paires tranchées.
     h.decisionGroupBy.mockResolvedValue([
       { classification: "DUPLICATE", _count: { _all: 3 } },
+      { classification: "LINKED", _count: { _all: 3 } },
       { classification: "DISTINCT", _count: { _all: 1 } },
-      { classification: "LINKED", _count: { _all: 0 } },
+      { classification: "UNCERTAIN", _count: { _all: 1 } },
     ]);
 
-    const metrics = await computePairPrecision(10);
+    const m = await computePairMetrics(1);
 
-    expect(metrics.precision).toBe(0.75);
-    expect(metrics.byClassification.DUPLICATE).toBe(3);
+    expect(m.decided).toBe(7);
+    expect(m.ruled).toBe(8);
+    expect(m.duplicateRate).toBeCloseTo(3 / 7);
+    expect(m.usefulMatchRate).toBeCloseTo(6 / 7);
+    expect(m.falsePositiveRate).toBeCloseTo(1 / 7);
   });
 
-  it("laisse UNCERTAIN hors du calcul, des deux côtés", async () => {
+  it("distingue un doublon d'un rapprochement utile", async () => {
+    // Le point de la mesure : 43 % de doublons, mais 86 % de rapprochements utiles.
+    h.decisionGroupBy.mockResolvedValue([
+      { classification: "DUPLICATE", _count: { _all: 1 } },
+      { classification: "LINKED", _count: { _all: 3 } },
+      { classification: "DISTINCT", _count: { _all: 0 } },
+    ]);
+
+    const m = await computePairMetrics(4);
+
+    expect(m.duplicateRate).toBe(0.25);
+    expect(m.usefulMatchRate).toBe(1);
+    expect(m.falsePositiveRate).toBe(0);
+  });
+
+  it("laisse UNCERTAIN hors de tous les dénominateurs", async () => {
     h.decisionGroupBy.mockResolvedValue([
       { classification: "DUPLICATE", _count: { _all: 1 } },
       { classification: "DISTINCT", _count: { _all: 1 } },
       { classification: "UNCERTAIN", _count: { _all: 8 } },
     ]);
 
-    const metrics = await computePairPrecision(10);
+    const m = await computePairMetrics(10);
 
     // 1 / 2, pas 1 / 10 : différer n'est pas juger.
-    expect(metrics.precision).toBe(0.5);
-    expect(metrics.ruled).toBe(10);
+    expect(m.decided).toBe(2);
+    expect(m.duplicateRate).toBe(0.5);
+    expect(m.ruled).toBe(10);
+  });
+
+  it("conserve les nombres bruts par classification", async () => {
+    h.decisionGroupBy.mockResolvedValue([
+      { classification: "DUPLICATE", _count: { _all: 3 } },
+      { classification: "UNCERTAIN", _count: { _all: 1 } },
+    ]);
+
+    const m = await computePairMetrics(1);
+
+    expect(m.byClassification).toEqual({
+      DUPLICATE: 3,
+      LINKED: 0,
+      DISTINCT: 0,
+      UNCERTAIN: 1,
+    });
   });
 });

--- a/src/services/affairs/absorb-draft.ts
+++ b/src/services/affairs/absorb-draft.ts
@@ -1,34 +1,46 @@
 /**
  * Absorbing a draft into a published affair.
  *
- * The published fiche always survives and is never rewritten by this path. A
- * merge is allowed to carry over what the absorbed row held in addition — its
- * sources, its events, the court-assigned identifiers the published fiche lacks —
- * but everything the draft *states* about the judicial outcome goes through the
+ * The published fiche always survives and is never rewritten by this path. A merge
+ * is allowed to carry over what the absorbed row held in addition — its sources,
+ * its events, the court-assigned identifiers the published fiche lacks — but
+ * everything the draft *states* about the judicial outcome goes through the
  * proposal queue instead, so a human decides whether a published record changes
  * (issue #525, §4).
  *
  * Only reached from a confirmed admin action. The automatic planner never chooses
  * this path: a shared court identifier means a shared decision, not a shared
- * editorial affair, so nothing crosses the published boundary without a person
- * (issue #525).
+ * editorial affair, so nothing crosses the published boundary without a person.
+ *
+ * Everything runs in one transaction. An earlier version merged first and proposed
+ * afterwards: a proposal failing after that commit left the draft already deleted,
+ * and whatever it stated about status, verdict date, court or sentence was lost
+ * with no proposal to show for it. `withImportRun()` did not help — it tracks a
+ * run, it does not span a transaction.
  */
 
 import { db } from "@/lib/db";
 import type { SourceType } from "@/generated/prisma";
 import {
-  mergeAffairs,
+  mergeAffairsInTransaction,
   ABSORPTION_ADDITIVE_FIELDS,
   type AdditiveMergeField,
 } from "./reconciliation";
-import { normalizeForCompare, proposeAffairUpdate } from "./proposals";
+import {
+  normalizeForCompare,
+  recordPendingProposalInTransaction,
+  type LiveAffair,
+} from "./proposals";
 
 /**
  * Fields a draft may contribute to a published fiche, through review only.
  *
- * The proposal whitelist minus the identifiers the merge already carried over
- * directly. `court` sits here rather than in the merge: it names the jurisdiction
- * rather than identifying the decision, so even filling a gap is a review call.
+ * The proposal whitelist minus the identifiers the merge carries over directly.
+ * `court` sits here rather than in the merge: it names the jurisdiction rather than
+ * identifying the decision, so even filling a gap is a review call.
+ *
+ * None of these is auto-applicable, so this path only ever needs the PENDING
+ * write, never the auto-apply branch of proposeAffairUpdate().
  */
 const PROPOSABLE_FROM_DRAFT = [
   "status",
@@ -47,8 +59,8 @@ const PROPOSABLE_FROM_DRAFT = [
  * Differences that survive the merge without being carried or proposed.
  *
  * The published wording is authoritative once the pair is proven to be one
- * decision, so these are not blockers. They are written to the merge audit trail
- * rather than dropped, because the absorbed row is deleted.
+ * decision, so these are not blockers. They go to the merge audit trail rather
+ * than being dropped, because the absorbed row is deleted.
  */
 const RECORDED_ONLY_FIELDS = ["title", "description", "category"] as const;
 
@@ -59,24 +71,26 @@ export interface AbsorbDraftInput {
   /** The merge plan's reason, kept verbatim in the audit trail and rationale. */
   reason: string;
   additiveFields?: readonly AdditiveMergeField[];
-  /** Forwarded to the merge so the ruling commits with it. */
+  /** Recorded with the merge so the ruling commits with it. */
   pairDecision?: {
     reviewedBy: string;
     notes?: string | null;
     signal: { confidence: string; matchedBy: string; score: number };
-    keepUpdatedAt: Date;
-    removeUpdatedAt: Date;
   };
+  audit?: { ipAddress?: string | null; userAgent?: string | null };
 }
 
 export interface AbsorbDraftResult {
   proposalsCreated: number;
   proposedFields: string[];
   recordedDifferences: string[];
+  slugsPreserved: string[];
 }
 
 const AFFAIR_ABSORB_SELECT = {
   id: true,
+  slug: true,
+  publicId: true,
   title: true,
   description: true,
   category: true,
@@ -91,97 +105,109 @@ const AFFAIR_ABSORB_SELECT = {
   communityService: true,
   otherSentence: true,
   publicationStatus: true,
+  updatedAt: true,
+  politician: { select: { slug: true, fullName: true } },
   sources: { select: { sourceType: true, url: true }, take: 1 },
 } as const;
 
 export async function absorbDraftIntoPublished(
   input: AbsorbDraftInput
 ): Promise<AbsorbDraftResult> {
-  const [published, draft] = await Promise.all([
-    db.affair.findUnique({ where: { id: input.publishedId }, select: AFFAIR_ABSORB_SELECT }),
-    db.affair.findUnique({ where: { id: input.draftId }, select: AFFAIR_ABSORB_SELECT }),
-  ]);
-  if (!published) throw new Error(`Affaire publiée introuvable : ${input.publishedId}`);
-  if (!draft) throw new Error(`Brouillon introuvable : ${input.draftId}`);
+  return db.$transaction(async (tx) => {
+    // Read inside the transaction. A caller's precheck can be stale, and the two
+    // updatedAt below become the reference the ruling is judged against.
+    const [published, draft] = await Promise.all([
+      tx.affair.findUnique({ where: { id: input.publishedId }, select: AFFAIR_ABSORB_SELECT }),
+      tx.affair.findUnique({ where: { id: input.draftId }, select: AFFAIR_ABSORB_SELECT }),
+    ]);
+    if (!published) throw new Error(`Affaire publiée introuvable : ${input.publishedId}`);
+    if (!draft) throw new Error(`Brouillon introuvable : ${input.draftId}`);
 
-  // Re-checked here rather than trusted from the plan: the rows can move between
-  // detection and this call, and absorbing the wrong way deletes a public page.
-  if (published.publicationStatus !== "PUBLISHED") {
-    throw new Error(`L'affaire survivante n'est pas publiée : ${input.publishedId}`);
-  }
-  if (draft.publicationStatus !== "DRAFT") {
-    throw new Error(`L'affaire absorbée n'est pas un brouillon : ${input.draftId}`);
-  }
+    // Re-checked here rather than trusted from the caller: absorbing the wrong way
+    // deletes a public page.
+    if (published.publicationStatus !== "PUBLISHED") {
+      throw new Error(`L'affaire survivante n'est pas publiée : ${input.publishedId}`);
+    }
+    if (draft.publicationStatus !== "DRAFT") {
+      throw new Error(`L'affaire absorbée n'est pas un brouillon : ${input.draftId}`);
+    }
 
-  const live = published as unknown as Record<string, unknown>;
-  const incoming = draft as unknown as Record<string, unknown>;
+    const live = published as unknown as Record<string, unknown>;
+    const incoming = draft as unknown as Record<string, unknown>;
 
-  // What the draft states that the published fiche does not.
-  const patch: Record<string, unknown> = {};
-  for (const field of PROPOSABLE_FROM_DRAFT) {
-    const value = incoming[field];
-    if (value === null || value === undefined) continue;
-    if (normalizeForCompare(value) === normalizeForCompare(live[field])) continue;
-    patch[field] = value;
-  }
+    // What the draft states that the published fiche does not.
+    const patch: Record<string, unknown> = {};
+    for (const field of PROPOSABLE_FROM_DRAFT) {
+      const value = incoming[field];
+      if (value === null || value === undefined) continue;
+      if (normalizeForCompare(value) === normalizeForCompare(live[field])) continue;
+      patch[field] = value;
+    }
 
-  const recordedDifferences = RECORDED_ONLY_FIELDS.filter(
-    (field) => normalizeForCompare(incoming[field]) !== normalizeForCompare(live[field])
-  );
+    const recordedDifferences = RECORDED_ONLY_FIELDS.filter(
+      (field) => normalizeForCompare(incoming[field]) !== normalizeForCompare(live[field])
+    );
 
-  // The merge is what deletes the draft, so it runs before proposing: a proposal
-  // on a pair that failed to merge would be unactionable.
-  await mergeAffairs(input.publishedId, input.draftId, {
-    additiveFields: input.additiveFields ?? ABSORPTION_ADDITIVE_FIELDS,
-    removeMustNotBePublished: true,
-    ...(input.pairDecision
-      ? {
-          pairDecision: {
-            otherAffairId: input.draftId,
-            reviewedBy: input.pairDecision.reviewedBy,
-            notes: input.pairDecision.notes,
-            signal: input.pairDecision.signal,
-            keepUpdatedAt: input.pairDecision.keepUpdatedAt,
-            removeUpdatedAt: input.pairDecision.removeUpdatedAt,
-          },
-        }
-      : {}),
-    auditNotes: {
-      absorbedDraft: input.draftId,
-      reason: input.reason,
+    // Proposals first, deliberately: if this write fails, the draft is still there
+    // and nothing has moved. The reverse order is what made the old path lossy.
+    let proposalsCreated = 0;
+    if (Object.keys(patch).length > 0) {
+      const source = draft.sources[0];
+      const outcome = await recordPendingProposalInTransaction(
+        tx,
+        {
+          affairId: input.publishedId,
+          importer: "reconcile-affairs",
+          importRunId: input.importRunId,
+          patch,
+          source: (source?.sourceType ?? "PRESSE") as SourceType,
+          sourceUrl: source?.url ?? null,
+          confidence: 70,
+          rationale:
+            `Absorption d'un brouillon dans cette affaire publiée. ${input.reason}. ` +
+            `Le brouillon renseignait ces champs différemment ; l'affaire publiée n'a pas ` +
+            `été modifiée automatiquement.`,
+        },
+        patch,
+        published as unknown as LiveAffair
+      );
+      proposalsCreated = outcome.deduped ? 0 : 1;
+    }
+
+    const merge = await mergeAffairsInTransaction(tx, input.publishedId, input.draftId, {
+      additiveFields: input.additiveFields ?? ABSORPTION_ADDITIVE_FIELDS,
+      removeMustNotBePublished: true,
+      audit: input.audit,
+      auditNotes: {
+        absorbedDraft: input.draftId,
+        reason: input.reason,
+        proposedFields: Object.keys(patch),
+        // Kept because the absorbed row no longer exists to be consulted.
+        recordedDifferences: recordedDifferences.map((field) => ({
+          field,
+          absorbedValue: String(incoming[field] ?? ""),
+        })),
+      },
+      ...(input.pairDecision
+        ? {
+            pairDecision: {
+              otherAffairId: input.draftId,
+              reviewedBy: input.pairDecision.reviewedBy,
+              notes: input.pairDecision.notes,
+              signal: input.pairDecision.signal,
+              // From the rows read in this transaction, not from the precheck.
+              keepUpdatedAt: published.updatedAt,
+              removeUpdatedAt: draft.updatedAt,
+            },
+          }
+        : {}),
+    });
+
+    return {
+      proposalsCreated,
       proposedFields: Object.keys(patch),
-      // Kept because the absorbed row no longer exists to be consulted.
-      recordedDifferences: recordedDifferences.map((field) => ({
-        field,
-        absorbedValue: String(incoming[field] ?? ""),
-      })),
-    },
+      recordedDifferences,
+      slugsPreserved: merge.slugsPreserved,
+    };
   });
-
-  if (Object.keys(patch).length === 0) {
-    return { proposalsCreated: 0, proposedFields: [], recordedDifferences };
-  }
-
-  const source = draft.sources[0];
-  const result = await proposeAffairUpdate({
-    affairId: input.publishedId,
-    importer: "reconcile-affairs",
-    importRunId: input.importRunId,
-    patch,
-    source: (source?.sourceType ?? "PRESSE") as SourceType,
-    sourceUrl: source?.url ?? null,
-    confidence: 70,
-    rationale:
-      `Absorption d'un brouillon dans cette affaire publiée. ${input.reason}. ` +
-      `Le brouillon renseignait ces champs différemment ; l'affaire publiée n'a pas été ` +
-      `modifiée automatiquement.`,
-  });
-
-  const proposalsCreated = [
-    result.autoProposalId,
-    result.pendingProposalId,
-    result.conflictProposalId,
-  ].filter(Boolean).length;
-
-  return { proposalsCreated, proposedFields: Object.keys(patch), recordedDifferences };
 }

--- a/src/services/affairs/absorb-draft.ts
+++ b/src/services/affairs/absorb-draft.ts
@@ -68,6 +68,15 @@ export interface AbsorbDraftInput {
   publishedId: string;
   draftId: string;
   importRunId: string;
+  /**
+   * Who is absorbing. Recorded on the proposal, and it must match the importer the
+   * surrounding ImportRun was opened with: a confirmed admin merge filed under an
+   * automatic importer would misattribute the write and, worse, could dedupe
+   * against an old automatic proposal, since the importer is part of payloadHash.
+   *
+   * Required rather than defaulted: the previous hard-coded value was the bug.
+   */
+  importer: string;
   /** The merge plan's reason, kept verbatim in the audit trail and rationale. */
   reason: string;
   additiveFields?: readonly AdditiveMergeField[];
@@ -157,7 +166,7 @@ export async function absorbDraftIntoPublished(
         tx,
         {
           affairId: input.publishedId,
-          importer: "reconcile-affairs",
+          importer: input.importer,
           importRunId: input.importRunId,
           patch,
           source: (source?.sourceType ?? "PRESSE") as SourceType,

--- a/src/services/affairs/absorb-draft.ts
+++ b/src/services/affairs/absorb-draft.ts
@@ -8,8 +8,10 @@
  * proposal queue instead, so a human decides whether a published record changes
  * (issue #525, §4).
  *
- * Only reached when an official identifier already proved the two rows describe
- * one decision. See decideMergeAction().
+ * Only reached from a confirmed admin action. The automatic planner never chooses
+ * this path: a shared court identifier means a shared decision, not a shared
+ * editorial affair, so nothing crosses the published boundary without a person
+ * (issue #525).
  */
 
 import { db } from "@/lib/db";
@@ -57,6 +59,14 @@ export interface AbsorbDraftInput {
   /** The merge plan's reason, kept verbatim in the audit trail and rationale. */
   reason: string;
   additiveFields?: readonly AdditiveMergeField[];
+  /** Forwarded to the merge so the ruling commits with it. */
+  pairDecision?: {
+    reviewedBy: string;
+    notes?: string | null;
+    signal: { confidence: string; matchedBy: string; score: number };
+    keepUpdatedAt: Date;
+    removeUpdatedAt: Date;
+  };
 }
 
 export interface AbsorbDraftResult {
@@ -123,6 +133,19 @@ export async function absorbDraftIntoPublished(
   // on a pair that failed to merge would be unactionable.
   await mergeAffairs(input.publishedId, input.draftId, {
     additiveFields: input.additiveFields ?? ABSORPTION_ADDITIVE_FIELDS,
+    removeMustNotBePublished: true,
+    ...(input.pairDecision
+      ? {
+          pairDecision: {
+            otherAffairId: input.draftId,
+            reviewedBy: input.pairDecision.reviewedBy,
+            notes: input.pairDecision.notes,
+            signal: input.pairDecision.signal,
+            keepUpdatedAt: input.pairDecision.keepUpdatedAt,
+            removeUpdatedAt: input.pairDecision.removeUpdatedAt,
+          },
+        }
+      : {}),
     auditNotes: {
       absorbedDraft: input.draftId,
       reason: input.reason,

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -18,8 +18,6 @@ export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
 export const IMPORTER_JUDILIBRE = "judilibre";
 /** Reserved for admin-initiated proposals, so they never end up run-less. */
 export const IMPORTER_MANUAL_ADMIN = "manual-admin";
-/** Absorbing a draft into a published affair proposes rather than writes (#525). */
-export const IMPORTER_RECONCILE = "reconcile-affairs";
 
 export async function startImportRun(importer: string): Promise<string> {
   const run = await db.importRun.create({

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -192,22 +192,31 @@ export interface MatchResult {
 }
 
 /**
- * Signals that identify a decision rather than resemble one: official numbers
+ * Signals that identify a shared court decision or proceeding: official numbers
  * assigned by a court, not words a title happens to share.
  *
- * Only these may carry a merge across the published boundary automatically
- * (issue #525). Title, category, date and politician proximity are resemblance:
- * they can be right, but they cannot prove two rows describe one decision.
+ * What they prove is narrower than it looks. Measured on real data (issue #525):
+ * two Carignon convictions share a pourvoi number, a facts date, a verdict date
+ * and one cassation ruling, yet they are two separate counts — subornation of a
+ * witness and misuse of company assets — and therefore two Poligraph affairs.
+ *
+ * So a shared identifier says "same decision or same proceeding". It does NOT say
+ * "same editorial affair", and on its own it may never authorise a merge.
  */
-export const DETERMINISTIC_MATCH_SIGNALS: ReadonlySet<string> = new Set([
+export const OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS: ReadonlySet<string> = new Set([
   "ecli",
   "pourvoiNumber",
   "caseNumbers",
 ]);
 
-/** Whether a match rests on an official identifier rather than on resemblance. */
-export function isDeterministicMatch(matchedBy: string): boolean {
-  return DETERMINISTIC_MATCH_SIGNALS.has(matchedBy);
+/**
+ * Whether a match rests on a court-assigned identifier rather than resemblance.
+ *
+ * Useful to tell a reviewer why a pair is worth reading — the two fiches cite the
+ * same decision — never to conclude that they are duplicates.
+ */
+export function isOfficialJudicialIdentifierMatch(matchedBy: string): boolean {
+  return OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS.has(matchedBy);
 }
 
 /**

--- a/src/services/affairs/merge-decision.ts
+++ b/src/services/affairs/merge-decision.ts
@@ -9,12 +9,18 @@
  * The asymmetry is deliberate: a wrong merge between drafts costs a re-split of
  * material nobody has read, while a wrong merge involving a published affair
  * deletes a page, mixes two sets of judicial facts about a named person, and
- * retires a URL. So automation stops at the published boundary unless an official
- * identifier proves the two rows describe one decision.
+ * retires a URL. So automation stops at the published boundary, full stop.
+ *
+ * It used to stop there *unless* a court-assigned identifier was shared. The first
+ * real triage killed that exception (issue #525): two Carignon convictions share a
+ * pourvoi number, the facts date, the verdict date and one cassation ruling, and
+ * they are still two separate counts, so two affairs. A shared identifier means a
+ * shared decision or proceeding, never a shared editorial affair. Nothing crosses
+ * the published boundary without a person now.
  */
 
 import type { PublicationStatus, SourceType } from "@/generated/prisma";
-import { isDeterministicMatch, type MatchConfidence } from "./matching";
+import { isOfficialJudicialIdentifierMatch, type MatchConfidence } from "./matching";
 
 /** Statuses this lot handles. See the issue for ARCHIVED/EXCLUDED/REJECTED. */
 const MERGEABLE_STATUSES: ReadonlySet<PublicationStatus> = new Set([
@@ -22,11 +28,14 @@ const MERGEABLE_STATUSES: ReadonlySet<PublicationStatus> = new Set([
   "PUBLISHED",
 ] as PublicationStatus[]);
 
-export type MergeDecision =
-  | "AUTO_MERGE_DRAFTS"
-  | "AUTO_ABSORB_DRAFT_INTO_PUBLISHED"
-  | "REVIEW_REQUIRED"
-  | "NOT_ELIGIBLE";
+/**
+ * What the automatic planner may conclude.
+ *
+ * There is no automatic absorption into a published affair: that path exists as a
+ * service (`absorbDraftIntoPublished`) but is only reachable from a confirmed
+ * admin action, never from a cron (issue #525).
+ */
+export type MergeDecision = "AUTO_MERGE_DRAFTS" | "REVIEW_REQUIRED" | "NOT_ELIGIBLE";
 
 export interface MergeDecisionAffair {
   id: string;
@@ -47,7 +56,11 @@ export interface MergeDecisionInput {
   contradictions?: string[];
   /**
    * Sensitive fields the two rows state differently that a merge could neither
-   * write nor turn into a proposal, so absorbing would drop a claim in silence.
+   * write nor turn into a proposal.
+   *
+   * Informational since automation stopped crossing the published boundary: it is
+   * shown to the reviewer rather than gating a decision. Draft merges keep their
+   * previous behaviour and do not consult it.
    */
   unpropagatableDifferences?: string[];
 }
@@ -81,7 +94,6 @@ function pickDraftSurvivor(
 export function decideMergeAction(input: MergeDecisionInput): MergePlan {
   const { affairA: a, affairB: b, confidence, matchedBy } = input;
   const contradictions = input.contradictions ?? [];
-  const unpropagatable = input.unpropagatableDifferences ?? [];
 
   if (a.id === b.id) {
     return { decision: "NOT_ELIGIBLE", reason: "Une affaire ne peut pas fusionner avec elle-même" };
@@ -117,42 +129,21 @@ export function decideMergeAction(input: MergeDecisionInput): MergePlan {
     };
   }
 
-  // One of each: absorption is directed, the published affair always survives.
+  // One draft, one published: never automatic, whatever the evidence.
+  //
+  // A shared identifier is reported in the reason rather than acted on: it is the
+  // strongest reason to *read* the pair, and the Carignon case is exactly why it
+  // cannot be a reason to merge it.
   if (aPublished !== bPublished) {
-    const published = aPublished ? a : b;
-    const draft = aPublished ? b : a;
-
-    if (!confident) {
+    if (isOfficialJudicialIdentifierMatch(matchedBy)) {
       return {
         decision: "REVIEW_REQUIRED",
-        reason: `Rapprochement non concluant (${confidence}) face à une affaire publiée`,
+        reason: `Identifiant de décision commun (${matchedBy}) entre un brouillon et une affaire publiée : une même décision peut porter plusieurs chefs, donc plusieurs fiches`,
       };
     }
-    if (!isDeterministicMatch(matchedBy)) {
-      return {
-        decision: "REVIEW_REQUIRED",
-        reason: `Rapprochement heuristique (${matchedBy}) : pas d'identifiant judiciaire commun`,
-      };
-    }
-    if (unpropagatable.length > 0) {
-      return {
-        decision: "REVIEW_REQUIRED",
-        reason: `Le brouillon affirme autre chose sur : ${unpropagatable.join(", ")}`,
-      };
-    }
-    // A human already validated this draft; deciding it is a duplicate is theirs.
-    if (draft.verifiedAt !== null) {
-      return {
-        decision: "REVIEW_REQUIRED",
-        reason: "Le brouillon a déjà été validé par une relecture humaine",
-      };
-    }
-
     return {
-      decision: "AUTO_ABSORB_DRAFT_INTO_PUBLISHED",
-      keepId: published.id,
-      removeId: draft.id,
-      reason: `Identifiant judiciaire commun (${matchedBy}) : le brouillon est absorbé par l'affaire publiée`,
+      decision: "REVIEW_REQUIRED",
+      reason: `Brouillon rapproché d'une affaire publiée (${matchedBy}/${confidence}) : la fusion retire une page publique`,
     };
   }
 

--- a/src/services/affairs/pair-decision.ts
+++ b/src/services/affairs/pair-decision.ts
@@ -157,23 +157,38 @@ export async function loadPairExclusions(
   return { excluded, stale, uncertain, classifications };
 }
 
-export interface PairPrecisionMetrics {
+export interface PairMetrics {
   /** Pairs a run proposed, whatever the ruling. */
   candidatePairs: number;
+  /** Every ruling stored, UNCERTAIN included. */
   ruled: number;
+  /** Rulings that settled something. The denominator of every rate below. */
+  decided: number;
   byClassification: Record<AffairPairClassification, number>;
-  /** Share of ruled pairs that were real duplicates. Null before any ruling. */
-  precision: number | null;
+  /** Share of settled pairs that were one affair recorded twice. */
+  duplicateRate: number | null;
+  /** Share worth surfacing at all: duplicates plus genuinely related affairs. */
+  usefulMatchRate: number | null;
+  /** Share that turned out to relate nothing. */
+  falsePositiveRate: number | null;
 }
 
 /**
- * Precision of the detection signal, from rulings alone.
+ * How the detection signal actually performs, from rulings alone.
  *
- * Deliberately computed over every ruling rather than over the top of the ranking:
- * scoring only the most confident pairs would measure the ranking, not the signal
- * (issue #525, §7).
+ * Three rates rather than one "precision", because the first real triage showed a
+ * single number hides the answer (issue #525). Of 7 settled pairs, 3 were
+ * duplicates and 3 were correct but misnamed — two counts of one decision, two
+ * strands of one case, two episodes of one campaign. Reporting 43 % and calling it
+ * precision would suggest the other 57 % was noise; only 1 pair related nothing.
+ *
+ * Computed over every ruling rather than over the top of the ranking: scoring only
+ * the most confident pairs would measure the ranking, not the signal (§7).
+ *
+ * UNCERTAIN is excluded from the denominator. Deferring is not deciding, and
+ * counting it either way would move the numbers without new information.
  */
-export async function computePairPrecision(candidatePairs: number): Promise<PairPrecisionMetrics> {
+export async function computePairMetrics(candidatePairs: number): Promise<PairMetrics> {
   const grouped = await db.affairPairDecision.groupBy({
     by: ["classification"],
     _count: { _all: true },
@@ -189,15 +204,16 @@ export async function computePairPrecision(candidatePairs: number): Promise<Pair
     byClassification[row.classification] = row._count._all;
   }
 
-  // UNCERTAIN is excluded from both sides: it is an absence of judgement, and
-  // counting it either way would move the number without new information.
   const decided = byClassification.DUPLICATE + byClassification.LINKED + byClassification.DISTINCT;
-  const ruled = decided + byClassification.UNCERTAIN;
+  const rate = (numerator: number) => (decided === 0 ? null : numerator / decided);
 
   return {
     candidatePairs,
-    ruled,
+    ruled: decided + byClassification.UNCERTAIN,
+    decided,
     byClassification,
-    precision: decided === 0 ? null : byClassification.DUPLICATE / decided,
+    duplicateRate: rate(byClassification.DUPLICATE),
+    usefulMatchRate: rate(byClassification.DUPLICATE + byClassification.LINKED),
+    falsePositiveRate: rate(byClassification.DISTINCT),
   };
 }

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { db } from "@/lib/db";
+import { db, type DbTransactionClient } from "@/lib/db";
 import { Prisma } from "@/generated/prisma";
 import type { ProposalRisk, SourceType } from "@/generated/prisma";
 import {
@@ -283,7 +283,7 @@ export interface ProposeAffairUpdateResult {
   deduped: boolean;
 }
 
-type LiveAffair = Record<string, unknown> & {
+export type LiveAffair = Record<string, unknown> & {
   publicId: string | null;
   slug: string;
   title: string;
@@ -429,22 +429,95 @@ async function findExisting(
   });
 }
 
+/**
+ * Everything a PENDING proposal write needs, computed without touching the DB.
+ *
+ * Pure so the same payload can be written by the plain path or inside a caller's
+ * transaction, with no risk of the two drifting (issue #525).
+ */
+export function buildPendingProposalPayload(args: {
+  input: ProposeAffairUpdateInput;
+  extractorVersion: string;
+  patch: Record<string, unknown>;
+  live: LiveAffair;
+}): { payloadHash: string; data: Prisma.AffairUpdateProposalUncheckedCreateInput } {
+  const observedValues = pickObserved(args.patch, args.live);
+  const payloadHash = computePayloadHash({
+    importer: args.input.importer,
+    extractorVersion: args.extractorVersion,
+    source: args.input.source,
+    sourceUrl: args.input.sourceUrl,
+    officialId: args.input.officialId,
+    sourceContentHash: args.input.sourceContentHash,
+    proposedPatch: args.patch,
+    observedValues,
+  });
+
+  return {
+    payloadHash,
+    data: buildProposalData(
+      {
+        input: args.input,
+        extractorVersion: args.extractorVersion,
+        patch: args.patch,
+        observedValues,
+        snapshot: buildAffairSnapshot(args.live),
+        payloadHash,
+      },
+      "PENDING"
+    ),
+  };
+}
+
+/**
+ * Records a PENDING proposal on a caller-supplied transaction.
+ *
+ * Mirrors the plain path below, including the rule that a terminal state is never
+ * resurrected: a rejected patch replayed later stays rejected.
+ */
+export async function recordPendingProposalInTransaction(
+  tx: DbTransactionClient,
+  input: ProposeAffairUpdateInput,
+  patch: Record<string, unknown>,
+  live: LiveAffair,
+  extractorVersion = "v1"
+): Promise<{ proposalId: string; deduped: boolean }> {
+  const { payloadHash, data } = buildPendingProposalPayload({
+    input,
+    extractorVersion,
+    patch,
+    live,
+  });
+
+  const existing = await tx.affairUpdateProposal.findFirst({
+    where: { affairId: input.affairId, importer: input.importer, payloadHash },
+    select: { id: true, status: true },
+  });
+  if (existing) {
+    if (existing.status === "PENDING") {
+      await tx.affairUpdateProposal.update({
+        where: { id: existing.id },
+        data: { updatedAt: new Date() },
+      });
+    }
+    return { proposalId: existing.id, deduped: true };
+  }
+
+  const created = await tx.affairUpdateProposal.create({ data, select: { id: true } });
+  return { proposalId: created.id, deduped: false };
+}
+
 async function recordPendingProposal(
   input: ProposeAffairUpdateInput,
   extractorVersion: string,
   patch: Record<string, unknown>,
   live: LiveAffair
 ): Promise<{ proposalId: string; deduped: boolean }> {
-  const observedValues = pickObserved(patch, live);
-  const payloadHash = computePayloadHash({
-    importer: input.importer,
+  const { payloadHash, data } = buildPendingProposalPayload({
+    input,
     extractorVersion,
-    source: input.source,
-    sourceUrl: input.sourceUrl,
-    officialId: input.officialId,
-    sourceContentHash: input.sourceContentHash,
-    proposedPatch: patch,
-    observedValues,
+    patch,
+    live,
   });
 
   const existing = await findExisting(input.affairId, input.importer, payloadHash);
@@ -460,20 +533,7 @@ async function recordPendingProposal(
     return { proposalId: existing.id, deduped: true };
   }
 
-  const created = await db.affairUpdateProposal.create({
-    data: buildProposalData(
-      {
-        input,
-        extractorVersion,
-        patch,
-        observedValues,
-        snapshot: buildAffairSnapshot(live),
-        payloadHash,
-      },
-      "PENDING"
-    ),
-    select: { id: true },
-  });
+  const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
   return { proposalId: created.id, deduped: false };
 }
 

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -5,7 +5,7 @@
  * allows merging them, and tracks dismissed false positives.
  */
 
-import { db } from "@/lib/db";
+import { db, type DbTransactionClient } from "@/lib/db";
 import { canonicalPair } from "./affair-pair";
 import { buildPairDecisionUpsert, loadPairExclusions } from "./pair-decision";
 import {
@@ -453,7 +453,24 @@ export async function mergeAffairs(
   removeId: string,
   options: MergeAffairsOptions = {}
 ): Promise<MergeAffairsResult> {
-  return db.$transaction(async (tx) => {
+  return db.$transaction((tx) => mergeAffairsInTransaction(tx, keepId, removeId, options));
+}
+
+/**
+ * The merge itself, on a caller-supplied transaction.
+ *
+ * Exists so a caller can widen the atomic unit. Absorbing a draft into a published
+ * affair has to create its proposals in the *same* transaction as the deletion:
+ * otherwise a failing proposal leaves the draft already gone, and whatever it
+ * stated about the judicial outcome is lost with no trace (issue #525).
+ */
+export async function mergeAffairsInTransaction(
+  tx: DbTransactionClient,
+  keepId: string,
+  removeId: string,
+  options: MergeAffairsOptions = {}
+): Promise<MergeAffairsResult> {
+  {
     const affairSelect = {
       id: true,
       title: true,
@@ -690,7 +707,7 @@ export async function mergeAffairs(
       identifiersMerged,
       slugsPreserved,
     };
-  });
+  }
 }
 
 // ============================================

--- a/src/services/sync/__tests__/reconcile-affairs.test.ts
+++ b/src/services/sync/__tests__/reconcile-affairs.test.ts
@@ -24,10 +24,8 @@ vi.mock("@/services/affairs/reconciliation", () => ({
 vi.mock("@/services/affairs/absorb-draft", () => ({
   absorbDraftIntoPublished: h.absorbDraftIntoPublished,
 }));
-vi.mock("@/services/affairs/import-run", () => ({
-  withImportRun: h.withImportRun,
-  IMPORTER_RECONCILE: "reconcile-affairs",
-}));
+// Mocked only to prove the cron never opens a run: the service no longer imports it.
+vi.mock("@/services/affairs/import-run", () => ({ withImportRun: h.withImportRun }));
 vi.mock("@/lib/db", () => ({ db: { affair: { findMany: h.affairFindMany } } }));
 vi.mock("@/lib/cache", () => ({
   invalidateEntity: h.invalidateEntity,

--- a/src/services/sync/__tests__/reconcile-affairs.test.ts
+++ b/src/services/sync/__tests__/reconcile-affairs.test.ts
@@ -104,19 +104,111 @@ describe("reconcileAffairs — invalidation du chemin cron (#525)", () => {
     expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["jean-dupont"]);
   });
 
-  it("invalide aussi après une absorption dans une affaire publiée", async () => {
+  it("n'appelle jamais l'absorption sur une paire traversant le publié", async () => {
+    // Le chemin automatique s'arrête à la frontière du publié, quelle que soit la
+    // force du signal : un identifiant judiciaire commun désigne une décision
+    // partagée, pas une même affaire éditoriale (#525).
     h.findPotentialDuplicates.mockResolvedValue([
-      pair({ id: "pub", publicationStatus: "PUBLISHED" }, { id: "draft" }),
+      pair(
+        { id: "pub", publicationStatus: "PUBLISHED" },
+        { id: "draft" },
+        {
+          confidence: "CERTAIN",
+          matchedBy: "ecli",
+          score: 1,
+        }
+      ),
     ]);
-    h.absorbDraftIntoPublished.mockImplementation(async () => {
-      order.push("absorb");
-      return { proposalsCreated: 1, proposedFields: ["court"], recordedDifferences: [] };
-    });
 
     const stats = await reconcileAffairs({ autoMerge: true });
 
-    expect(stats.absorbed).toBe(1);
-    expect(order).toEqual(["absorb", "invalidate", "invalidate-politicians"]);
+    expect(h.absorbDraftIntoPublished).not.toHaveBeenCalled();
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(stats.reviewRequired).toBe(1);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("n'ouvre aucun run d'import quand rien n'est à absorber", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair(
+        { id: "pub", publicationStatus: "PUBLISHED" },
+        { id: "draft" },
+        {
+          matchedBy: "pourvoiNumber",
+        }
+      ),
+    ]);
+
+    await reconcileAffairs({ autoMerge: true });
+
+    expect(h.withImportRun).not.toHaveBeenCalled();
+  });
+
+  it("ne rapporte aucune absorption : la statistique n'existe plus", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair({ id: "pub", publicationStatus: "PUBLISHED" }, { id: "draft" }),
+    ]);
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats).not.toHaveProperty("absorbed");
+  });
+
+  it("ne compte aucune absorption en essai à blanc", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair(
+        { id: "pub", publicationStatus: "PUBLISHED" },
+        { id: "draft" },
+        {
+          confidence: "CERTAIN",
+          matchedBy: "ecli",
+        }
+      ),
+      pair({ id: "d1" }, { id: "d2" }),
+    ]);
+
+    const stats = await reconcileAffairs({ autoMerge: true, dryRun: true });
+
+    expect(stats).not.toHaveProperty("absorbed");
+    // Seule la paire de brouillons est planifiée comme fusionnable.
+    expect(stats.merged).toBe(1);
+    expect(stats.reviewRequired).toBe(1);
+    expect(h.absorbDraftIntoPublished).not.toHaveBeenCalled();
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("laisse une paire publiée + publiée en revue", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair(
+        { id: "a", publicationStatus: "PUBLISHED" },
+        { id: "b", publicationStatus: "PUBLISHED" },
+        { confidence: "CERTAIN", matchedBy: "ecli" }
+      ),
+    ]);
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.reviewRequired).toBe(1);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
+  });
+
+  it("ne supprime jamais automatiquement un brouillon vérifié", async () => {
+    h.findPotentialDuplicates.mockResolvedValue([
+      pair(
+        { id: "a" },
+        { id: "b", verifiedAt: new Date("2026-01-01") },
+        {
+          confidence: "CERTAIN",
+          matchedBy: "ecli",
+        }
+      ),
+    ]);
+
+    const stats = await reconcileAffairs({ autoMerge: true });
+
+    expect(stats.reviewRequired).toBe(1);
+    expect(h.mergeAffairs).not.toHaveBeenCalled();
   });
 
   it("n'invalide rien quand aucune fusion n'a eu lieu", async () => {

--- a/src/services/sync/reconcile-affairs.ts
+++ b/src/services/sync/reconcile-affairs.ts
@@ -2,20 +2,21 @@
  * Affair reconciliation service.
  *
  * Detects potential duplicate affairs and folds the ones automation is allowed to
- * fold. Since detection was widened to published affairs (issue #525), the queue
- * mixes pairs a cron may merge with pairs that must never move without a human, so
- * every pair goes through decideMergeAction() first.
+ * fold: draft pairs, and nothing else. Since detection was widened to published
+ * affairs (issue #525), the queue mixes those with pairs that must never move
+ * without a human, so every pair goes through decideMergeAction() first.
+ *
+ * Nothing crosses the published boundary here. Absorbing a draft into a published
+ * fiche is still supported, by `absorbDraftIntoPublished()`, but only from a
+ * confirmed admin action.
  */
 
 import {
   findPotentialDuplicates,
   mergeAffairs,
-  ABSORPTION_ADDITIVE_FIELDS,
   type PotentialDuplicate,
 } from "@/services/affairs/reconciliation";
 import { decideMergeAction, type MergeDecision } from "@/services/affairs/merge-decision";
-import { absorbDraftIntoPublished } from "@/services/affairs/absorb-draft";
-import { withImportRun, IMPORTER_RECONCILE } from "@/services/affairs/import-run";
 import { db } from "@/lib/db";
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 
@@ -30,10 +31,8 @@ export interface ReconcileAffairsOptions {
 
 export interface ReconcileAffairsStats {
   duplicatesFound: number;
-  /** Draft pairs folded together. */
+  /** Draft pairs folded together. The only merge this path performs. */
   merged: number;
-  /** Drafts absorbed by a published affair on a court-assigned identifier. */
-  absorbed: number;
   /** Pairs left for a human, by reason. */
   reviewRequired: number;
   notEligible: number;
@@ -85,7 +84,6 @@ export async function reconcileAffairs(
   const empty: ReconcileAffairsStats = {
     duplicatesFound: 0,
     merged: 0,
-    absorbed: 0,
     reviewRequired: 0,
     notEligible: 0,
     proposalsCreated: 0,
@@ -110,7 +108,6 @@ export async function reconcileAffairs(
   if (!autoMerge) return stats;
 
   const draftMerges = planned.filter((p) => p.decision === "AUTO_MERGE_DRAFTS");
-  const absorptions = planned.filter((p) => p.decision === "AUTO_ABSORB_DRAFT_INTO_PUBLISHED");
 
   // Survivors of every merge that actually landed, for one invalidation pass.
   const survivors: string[] = [];
@@ -131,40 +128,8 @@ export async function reconcileAffairs(
     }
   }
 
-  if (absorptions.length === 0) {
-    await invalidateAfterMerges(survivors);
-    return stats;
-  }
-
-  if (dryRun) {
-    stats.absorbed += absorptions.length;
-    return stats;
-  }
-
-  // Proposals must belong to a run, so one is opened only when an absorption
-  // actually has to write something (issue #513 invariant).
-  await withImportRun(IMPORTER_RECONCILE, async ({ importRunId, setStats }) => {
-    for (const plan of absorptions) {
-      try {
-        const result = await absorbDraftIntoPublished({
-          publishedId: plan.keepId!,
-          draftId: plan.removeId!,
-          importRunId,
-          reason: plan.reason,
-          additiveFields: ABSORPTION_ADDITIVE_FIELDS,
-        });
-        stats.absorbed++;
-        stats.proposalsCreated += result.proposalsCreated;
-        survivors.push(plan.keepId!);
-      } catch {
-        stats.errors++;
-      }
-    }
-    setStats({ absorbed: stats.absorbed, proposalsCreated: stats.proposalsCreated });
-  });
-
-  // After the run committed, never during it.
-  await invalidateAfterMerges(survivors);
+  // After every merge committed, never during.
+  if (!dryRun) await invalidateAfterMerges(survivors);
 
   return stats;
 }


### PR DESCRIPTION
## Description

Part of #525. Supprime toute fusion automatique traversant la frontière du publié.

**Remplace #533**, rebasée sur `main` après le merge de #532. Contenu identique, plus la correction de provenance ci-dessous. La branche précédente ne pouvait pas être mise à jour : un rebase exige une poussée forcée, refusée dans ma session.

### Le risque découvert au premier tri réel

Deux condamnations d'Alain Carignon partagent **le même numéro de pourvoi, la même date de faits, la même date de verdict et le même arrêt de cassation**. Elles sont pourtant deux chefs distincts : subornation de témoin et abus de biens sociaux. Le tri les a classées `LINKED`, pas `DUPLICATE`.

> Un ECLI, un numéro de pourvoi ou un numéro de dossier commun identifie une décision ou une procédure judiciaire commune. Il ne prouve pas que deux fiches représentent la même affaire éditoriale.

Or `AUTO_ABSORB_DRAFT_INTO_PUBLISHED` autorisait exactement cela : un identifiant commun suffisait à faire absorber un brouillon par une fiche publiée, sans relecture. Sur la paire Carignon, si l'un des deux côtés avait été un brouillon, le cron aurait fusionné deux chefs distincts et supprimé une ligne. Seule la frontière du publié l'a arrêté, par accident de configuration des données.

### Avant / après

| Paire | Avant | Après |
| --- | --- | --- |
| `DRAFT + DRAFT`, `CERTAIN`/`HIGH` | auto-fusion | **inchangé** |
| `DRAFT + PUBLISHED`, identifiant judiciaire commun | **absorption automatique** | **revue** |
| `DRAFT + PUBLISHED`, rapprochement heuristique | revue | revue |
| `PUBLISHED + PUBLISHED` | revue | revue |
| brouillon vérifié à absorber | revue | revue |

L'interface continue de proposer la fiche publiée comme survivante recommandée. L'action reste humaine, explicite et confirmée.

### Branches mortes supprimées

- **`AUTO_ABSORB_DRAFT_INTO_PUBLISHED` retiré du type `MergeDecision`.** Il ne représentait plus aucune décision automatique réelle, et le garder aurait laissé une branche que rien ne peut atteindre. Le type devient `AUTO_MERGE_DRAFTS | REVIEW_REQUIRED | NOT_ELIGIBLE`. Une action humaine d'absorption n'a pas à être représentée comme une décision du détecteur.
- **La phase d'absorption retirée de `reconcileAffairs()`**, avec ses imports (`absorbDraftIntoPublished`, `withImportRun`, `IMPORTER_RECONCILE`, `ABSORPTION_ADDITIVE_FIELDS`).
- **La statistique `absorbed` supprimée**, plutôt que laissée à zéro : elle ne décrivait plus aucun chemin réel, et un compteur qui ne peut plus bouger induit en erreur.

### `absorbDraftIntoPublished()` conservé, et enfin utilisé au bon endroit

Le service reste, branché sur l'action admin confirmée. Ce n'est pas seulement pour éviter du code mort : la route de fusion appelait `mergeAffairs` avec l'ensemble additif complet, donc **elle écrivait `court` et `chamber` directement sur une fiche publiée**, ce que le §4 de #525 interdit.

Désormais, quand le survivant est publié, la route emprunte le chemin d'absorption : seuls les identifiants attribués par une juridiction sont écrits, et tout ce que le brouillon affirme sur l'issue judiciaire part en `AffairUpdateProposal`. Entre deux brouillons, la fusion ordinaire reste inchangée.

### Vocabulaire technique corrigé

`isDeterministicMatch()` devenait trompeur : il ne désignait rien de déterminant sur l'identité éditoriale.

| Avant | Après |
| --- | --- |
| `DETERMINISTIC_MATCH_SIGNALS` | `OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS` |
| `isDeterministicMatch()` | `isOfficialJudicialIdentifierMatch()` |

La documentation cite désormais le cas Carignon comme contre-exemple, et le signal reste **visible dans la file de revue** : c'est la meilleure raison de lire une paire, jamais une raison de la fusionner. Le motif de mise en revue le dit explicitement.

### Métriques

Un ratio unique appelé « précision » cachait la réponse. Sur les 7 paires tranchées du premier tri : 3 doublons, mais 3 rapprochements **corrects et mal nommés** (chefs d'une même décision, volets d'un dossier, épisodes d'une campagne). Annoncer 43 % suggérait que les 57 % restants étaient du bruit, alors qu'une seule paire ne reliait rien.

`computePairPrecision()` devient `computePairMetrics()` et expose :

```
decided           = DUPLICATE + LINKED + DISTINCT
duplicateRate     = DUPLICATE / decided
usefulMatchRate   = (DUPLICATE + LINKED) / decided
falsePositiveRate = DISTINCT / decided
```

`UNCERTAIN` reste hors de tous les dénominateurs : différer n'est pas juger. Les nombres bruts par classification sont conservés. L'interface affiche « Vrais doublons », « Rapprochements utiles » et « Faux positifs francs », avec une note expliquant qu'un rapprochement utile n'est pas forcément un doublon.

### Mesure sur les décisions existantes

| | Valeur |
| --- | --- |
| paires tranchées | 7 |
| différées | 1 |
| Vrais doublons | **42,9 %** (3/7) |
| Rapprochements utiles | **85,7 %** (6/7) |
| Faux positifs francs | **14,3 %** (1/7) |

Aucune décision en base n'a été réécrite pour améliorer ces chiffres. Ce sont les jugements rendus au premier tri, tels quels.

**Sur la mesure du signal corrigé de #521 :** elle n'est pas disponible sur `main`. #532 n'est pas mergée, donc le garde lexical n'y est pas et le faux positif reste actif dans le détecteur. Mesuré sur la branche de #532, le garde écarte cette paire et ne touche à aucune autre. Ces deux PR modifient toutes deux `matching.ts` et `reconciliation.ts`, sur des régions distinctes : à merger l'une après l'autre, pas en parallèle.

## Invariants maintenus

- Aucune fiche publiée ne peut être supprimée automatiquement.
- Aucun identifiant judiciaire partagé ne suffit seul à fusionner deux affaires.
- Une affaire vérifiée n'est jamais supprimée automatiquement.
- Toute correction sensible sur une fiche publiée passe par une proposition ou une action humaine.
- URL, redirections, sources et piste d'audit préservées.
- Le plan de fusion reste déterministe, indépendant de l'ordre des lignes.

## Type de changement

- [x] Bug fix

## Issue liée

Part of #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts.

**2355 tests** passés, 0 échec. Tests ciblés relancés séparément sur `merge-decision`, `reconcile-affairs`, la file de revue, les métriques de paires et le chemin à blanc : **63 tests**.

Couverture des cas demandés : identifiant commun (ECLI, pourvoi, `caseNumbers`) en revue ; `CERTAIN` et `HIGH` sans absorption ; absence de contradiction et brouillon jamais vérifié toujours en revue ; `reconcileAffairs({autoMerge:true})` n'appelle jamais l'absorption ni n'ouvre de run d'import ; essai à blanc sans absorption ; `DRAFT + DRAFT` inchangé ; brouillon vérifié protégé ; `PUBLISHED + PUBLISHED` en revue ; identifiant commun visible comme signal ; statistique `absorbed` absente ; indépendance au sens de la paire.

**Aucune donnée de production modifiée.** 463 affaires et 8 jugements avant comme après, vérifiés en lecture seule.

## Suites hors périmètre

- Snapshot de l'affaire absorbée lors d'une fusion : issue dédiée.
- Audit séparé de `ARCHIVED` et `EXCLUDED` : issue dédiée.
- Dissociation `JudicialDecision` / affaire éditoriale, qui est la vraie réponse au cas Carignon : issue dédiée.
- Réorientation de Judilibre : #337 mise à jour.
- #516 et #517 restent des chantiers distincts.

---

## Mise à jour : atomicité de l'absorption corrigée

Ajouté après revue. Le chemin d'absorption n'était **pas atomique**, et #533 rendait ce risque directement accessible depuis la route admin.

### Le défaut

```
1. calcul des différences
2. mergeAffairs()            → ouvre SA transaction, déplace, supprime, COMMIT
3. proposeAffairUpdate()     → hors de cette transaction
```

`withImportRun()` ne protégeait rien : il suit l'état d'une exécution, il n'ouvre pas de transaction. Si l'étape 3 échouait, le brouillon était déjà supprimé et ce qu'il portait sur `status`, `verdictDate`, `court`, `sentence` ou les peines disparaissait **sans proposition correspondante**.

### Stratégie transactionnelle retenue

Pas de transaction imbriquée. Deux primitives internes prenant un client de transaction fourni par l'appelant :

- `mergeAffairsInTransaction(tx, keepId, removeId, options)` — `mergeAffairs()` public reste inchangé et se contente d'ouvrir `db.$transaction()` autour d'elle ;
- `recordPendingProposalInTransaction(tx, …)`, adossée à un constructeur pur `buildPendingProposalPayload()` que le chemin ordinaire utilise aussi, pour que les deux ne divergent pas.

Le patch d'absorption ne touche **jamais** un champ auto-applicable (`ecli`, `pourvoiNumber`, `caseNumbers` sont écrits par la fusion, pas proposés), donc seule la branche `PENDING` est nécessaire : inutile de rendre transactionnelle toute la machinerie d'auto-application.

`absorbDraftIntoPublished()` ouvre désormais **une seule** transaction :

```
lecture des deux lignes dans la transaction
→ calcul des différences
→ création des propositions
→ fusion, transferts, préservation des slugs, redirection publicId, suppression
→ jugement AffairPairDecision = DUPLICATE
→ AuditLog
→ commit
```

**L'ordre compte** : les propositions sont écrites **avant** la suppression. Si elles échouent, rien n'a bougé, même sans compter sur le rollback.

Les dates `affairAUpdatedAt` et `affairBUpdatedAt` du jugement viennent des lignes **relues dans la transaction**, plus du précontrôle de la route. La route ne transmet donc plus que le relecteur et le signal.

L'`ImportRun` reste créé avant et finalisé après : son état est de la comptabilité, pas de la logique métier, et `withImportRun()` garantit déjà qu'il ne reste jamais en `RUNNING` si la transaction échoue.

L'invalidation des caches reste après le commit.

### Un type dérivé, pas recopié

Le client Prisma du projet est **étendu**, donc son client de transaction n'est pas assignable à `Prisma.TransactionClient`. `src/lib/db.ts` exporte désormais `DbTransactionClient`, dérivé de `typeof db`, ce qui permet à un service de passer sa transaction à un autre sans contorsion de typage.

### Tests de rollback

**15 tests** sur `absorb-draft`, dont 6 spécifiquement sur l'atomicité. La transaction simulée note explicitement qu'elle a été annulée.

| Scénario | Vérifié |
| --- | --- |
| proposition en échec | brouillon **non supprimé** |
| proposition en échec | aucune source, aucun événement, aucun lien d'article déplacé |
| proposition en échec | aucun jugement, aucun audit, aucune redirection |
| fusion en échec | transaction annulée, la proposition ne subsiste pas |
| jugement en échec | tout annulé |
| succès | proposition, fusion, jugement et audit ensemble, **proposition avant suppression** |

**Régression prouvée.** En replaçant la fusion avant la proposition, comme dans la version précédente, **4 de ces tests échouent**. Avec le correctif, les 15 passent.

Couverture complémentaire : slugs et redirection `publicId` préservés, aucun champ sensible de la fiche publiée écrit, identifiants additifs autorisés transférés, jugement daté sur les lignes relues, invalidation après commit seulement, et le planificateur automatique ne choisit toujours jamais cette absorption.

### Mesures

**#532 n'est pas mergée.** Vérifié via l'API GitHub : `{"state":"open","merged":false,"merged_at":null}`, et la pointe distante de `main` est toujours `f6dfe30a`. Le garde lexical du joker `AUTRE` n'est donc pas sur `main`, et cette PR en descend directement — aucun conflit à résoudre, aucun garde à préserver.

Deux vues distinctes, à ne pas confondre :

**Jugements historiques, inchangés.** Aucune décision réécrite.

| | Valeur |
| --- | --- |
| bruts | `DUPLICATE` 3, `LINKED` 3, `DISTINCT` 1, `UNCERTAIN` 1 |
| tranchées | 7 |
| Vrais doublons | **42,9 %** |
| Rapprochements utiles | **85,7 %** |
| Faux positifs francs | **14,3 %** |

**Signal actuel sur cette branche.** 1 paire proposée, en revue, **0 auto-fusionnable**. Le faux positif du joker `AUTRE` reste proposé, puisque le garde de #532 n'est pas encore mergé. Une fois #532 sur `main`, il disparaîtra du signal ; les taux historiques ci-dessus ne changeront pas, parce qu'ils décrivent des jugements déjà rendus.

463 affaires, 0 proposition, 8 jugements : identiques avant et après. **Aucune donnée de production modifiée.**

### Vérifications relancées

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2363 tests**, 0 échec.

---

## Mise à jour : #532 intégrée, et provenance corrigée

### #532 est dans la base de cette PR

Rebasée sur `bc8dce0d`, le merge de #532. **Aucun conflit** : les deux PR touchaient `matching.ts` et `reconciliation.ts` sur des régions distinctes.

Le garde lexical est intégralement conservé, vérifié par contenu sur la branche : `pairingRestsOnWildcard()`, `significantTitleWords()`, `titlesShareVocabulary()`, et son application bornée au second passage à `POSSIBLE` / 0,45.

### Provenance de la proposition d'absorption manuelle

Défaut relevé en revue. La route ouvrait son run avec `IMPORTER_MANUAL_ADMIN`, mais le service déposait la proposition sous `importer: "reconcile-affairs"` codé en dur.

Deux conséquences : la proposition était **mal attribuée**, et surtout l'importer entre dans `payloadHash`, donc une absorption confirmée par un administrateur pouvait se **dédoublonner avec une ancienne proposition automatique** et disparaître silencieusement.

Solution retenue, la première des deux proposées : `AbsorbDraftInput.importer` devient un champ **requis**, et la route passe `IMPORTER_MANUAL_ADMIN`. Requis plutôt que défauté, parce que la valeur codée en dur était précisément le bug, et le service peut avoir d'autres appelants plus tard.

`IMPORTER_RECONCILE` est **supprimé** : après le retrait de l'auto-absorption, il n'avait plus aucun appelant en production, seulement sa déclaration et un mock de test devenu vestigial. Vérifié aussi en base : 0 proposition et 0 run portent cette valeur, donc rien n'en dépend.

### Tests ajoutés

5 sur la provenance dans `absorb-draft`, 1 sur la route :

- la proposition porte l'importer fourni, et pas `reconcile-affairs` ;
- le run et la proposition portent le **même** importer, `manual-admin` côté route ;
- la recherche de doublon est **scopée** à l'importer courant ;
- une proposition manuelle et une proposition automatique produisent des `payloadHash` **différents**, donc aucune déduplication artificielle ;
- l'atomicité et le rollback sont inchangés par ce changement.

**20 tests** sur `absorb-draft` au total, dont 6 sur l'atomicité et 5 sur la provenance.

### Mesure en lecture seule après #532

| | Valeur |
| --- | --- |
| file actuelle, paires proposées | 1, en revue |
| **auto-fusionnables** | **0** |
| signal brut, paires de la fenêtre | 2 |
| dont dépendant du seul joker `AUTRE` | 1 |
| **écartées par le garde** | **1** |
| **faux positif `AUTRE` encore proposé** | **non** |

Jugements historiques, **inchangés** : `DUPLICATE` 3, `LINKED` 3, `DISTINCT` 1, `UNCERTAIN` 1. Taux **42,9 %**, **85,7 %**, **14,3 %** sur 7 paires tranchées. Aucune décision réécrite.

463 affaires, 0 proposition, 8 jugements : identiques avant et après. **Aucune donnée de production modifiée.**

### Vérifications relancées

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2391 tests**, 0 échec.
