### PR TITLE
Importer le type de décision de fusion au lieu de le recopier

### DIFF
--- a/src/app/admin/affaires/doublons/page.tsx
+++ b/src/app/admin/affaires/doublons/page.tsx
@@ -7,17 +7,16 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { AlertTriangle, ExternalLink, Link2, Loader2 } from "lucide-react";
+// Type-only, so no service or database code reaches the client bundle. Imported
+// rather than redeclared: the local copy still listed an automatic absorption
+// months after the planner stopped being able to return one (issue #525).
+import type { MergeDecision } from "@/services/affairs/merge-decision";
 
 // Issue #525: review queue for detected duplicate pairs, grouped by politician.
 // Detection now covers published affairs, so most pairs land here rather than in
 // the cron. Nothing on this page moves data without an explicit click.
 
 type Classification = "DUPLICATE" | "LINKED" | "DISTINCT" | "UNCERTAIN";
-type MergeDecision =
-  | "AUTO_MERGE_DRAFTS"
-  | "AUTO_ABSORB_DRAFT_INTO_PUBLISHED"
-  | "REVIEW_REQUIRED"
-  | "NOT_ELIGIBLE";
 
 interface PairSide {
   id: string;

--- a/src/app/admin/affaires/doublons/page.tsx
+++ b/src/app/admin/affaires/doublons/page.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { AlertTriangle, ExternalLink, Link2, Loader2 } from "lucide-react";
 // Type-only, so no service or database code reaches the client bundle. Imported
 // rather than redeclared: the local copy still listed an automatic absorption
-// months after the planner stopped being able to return one (issue #525).
+// while the planner could no longer return that value (issue #525).
 import type { MergeDecision } from "@/services/affairs/merge-decision";
 
 // Issue #525: review queue for detected duplicate pairs, grouped by politician.


### PR DESCRIPTION
## Description

Relevé lors de la vérification post-merge de #537.

`src/app/admin/affaires/doublons/page.tsx` déclarait sa propre copie de `MergeDecision`, et cette copie listait encore `AUTO_ABSORB_DRAFT_INTO_PUBLISHED` alors que #537 a retiré ce membre du type serveur.

Sans effet à l'exécution : l'API ne peut plus renvoyer cette valeur, et rien dans la page ne l'aiguillait. Mais le type client annonçait un état devenu impossible, et rien n'aurait signalé la prochaine dérive.

## Correctif

Le type est **importé** plutôt que recopié :

```ts
import type { MergeDecision } from "@/services/affairs/merge-decision";
```

`import type` est effacé à la compilation, donc aucun code de service ni de base de données n'atteint le bundle client. Vérifié : `npm run build` compile et `/admin/affaires/doublons` reste une route dynamique normale.

C'est ce qui rend la dérive structurellement impossible, plutôt que de supprimer une ligne en attendant la suivante.

`Classification` reste déclaré localement, volontairement : il reflète un enum Prisma, et l'importer depuis le client généré ferait entrer une dépendance nettement plus lourde dans un composant client. Hors périmètre.

## Type de changement

- [x] Bug fix

## Issue liée

Suite de #525

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm run build` : verts. **2391 tests**, 0 échec.

Diff : 1 fichier, 4 insertions, 5 suppressions.
