### PR TITLE
Ajouter le modèle de décision juridictionnelle, en additif

### DIFF
--- a/docs/judicial-decision-model.md
+++ b/docs/judicial-decision-model.md
@@ -200,8 +200,8 @@ champ, pas la fréquence du phénomène.
 | --------------- | ---------------------------------------------------- | ------------------------------------------------------- | --------------------------- | ---------------------------------------------- |
 | `ecli`          | export CSV, propositions, matching, fusion additive  | `IDENTITÉ_DE_DÉCISION`                                  | **oui**                     | colonne CSV « ECLI »                           |
 | `pourvoiNumber` | matching, propositions, fusion additive              | `IDENTITÉ_DE_DÉCISION`                                  | **oui**                     | aucune surface publique                        |
-| `caseNumbers`   | matching (`hasSome`), propositions                   | `IDENTITÉ_DE_DÉCISION`                                  | **oui**                     | aucune, champ vide                             |
-| `caseNumber`    | page publique, fusion additive                       | `IDENTITÉ_DE_DÉCISION`                                  | **oui**                     | bloc « N° dossier » sur la fiche               |
+| `caseNumbers`   | matching (`hasSome`), propositions, jamais affiché   | `IDENTITÉ_DE_DÉCISION`                                  | **différé**, voir §6 bis    | aucune, champ vide                             |
+| `caseNumber`    | page publique, carte, formulaire admin, fusion       | `CONTENU_ÉDITORIAL_D_AFFAIRE` en l'état                 | **différé**, voir §6 bis    | bloc « N° dossier » sur la fiche               |
 | `chamber`       | page publique, `AffairCard`, admin                   | `IDENTITÉ_DE_DÉCISION`                                  | **oui**, coût nul (0 ligne) | bloc « Chambre » sur la fiche                  |
 | `court`         | page publique, export CSV, admin, fusion             | **`À_CLARIFIER`** : 23,7 % ne sont pas des juridictions | **non en l'état**           | bloc « Tribunal », colonne CSV « Juridiction » |
 | `verdictDate`   | **clé de tri**, API publique, MCP, export, affichage | `CONTENU_ÉDITORIAL_D_AFFAIRE`                           | **non**                     | tri, API, MCP, export                          |
@@ -306,9 +306,8 @@ L'intégration Judilibre ne tranche pas, `judilibreId` se lit aussi bien dans le
 deux. La convention du dépôt non plus : le code est en anglais, les deux formes
 l'étant également.
 
-Le reste de ce document conserve `JudicialDecision` dans les extraits de schéma,
-pour rester lisible à côté de l'issue. **Le nom à retenir pour la PR de schéma est
-`CourtDecision`**, avec `AffairCourtDecision` pour la table de liaison.
+Les extraits de schéma de ce document portent désormais les noms actés :
+**`CourtDecision`** et **`AffairCourtDecision`**.
 
 ---
 
@@ -334,7 +333,7 @@ Trois raisons, dont deux mesurées :
    un déplacement casserait le classement de toutes les listes.
 3. Elle est exposée par l'API publique, le MCP et l'export.
 
-`JudicialDecision.decisionDate` portera la date **de la décision**.
+`CourtDecision.decisionDate` porte la date **de la décision**.
 `Affair.verdictDate` reste la date éditoriale du **dernier résultat connu**. Les
 deux coexistent et ne disent pas la même chose : il faut le documenter, pas le
 fusionner.
@@ -367,7 +366,7 @@ Ils sont consignés ici, pas modélisés.
 ## 6. Modèle recommandé
 
 ```prisma
-model JudicialDecision {
+model CourtDecision {
   id String @id @default(cuid())
 
   /// Clé externe Judilibre, quand la décision en vient.
@@ -402,20 +401,20 @@ model JudicialDecision {
   @@index([decisionDate])
 }
 
-model AffairJudicialDecision {
-  affairId           String
-  judicialDecisionId String
+model AffairCourtDecision {
+  affairId        String
+  courtDecisionId String
 
   /// Texte libre en attendant d'avoir assez de cas pour un enum honnête.
   notes String?
 
-  affair           Affair           @relation(fields: [affairId], references: [id], onDelete: Cascade)
-  judicialDecision JudicialDecision @relation(fields: [judicialDecisionId], references: [id], onDelete: Cascade)
+  affair        Affair        @relation(fields: [affairId], references: [id], onDelete: Cascade)
+  courtDecision CourtDecision @relation(fields: [courtDecisionId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
 
-  @@id([affairId, judicialDecisionId])
-  @@index([judicialDecisionId])
+  @@id([affairId, courtDecisionId])
+  @@index([courtDecisionId])
 }
 ```
 
@@ -454,6 +453,45 @@ model AffairJudicialDecision {
     valeurs dont trois relèvent d'autres issues. `notes String?` suffit à consigner
     ce qu'un relecteur constate ; l'enum viendra quand cinq cas réels au moins
     auront été observés et classés.
+
+---
+
+## 6 bis. `caseNumber` et `caseNumbers` : différés, et pourquoi
+
+Le modèle ci-dessus n'en contient **aucun des deux**. Une version antérieure de ce
+document les classait tous deux `IDENTITÉ_DE_DÉCISION` et « doit migrer », ce qui
+était incohérent avec le schéma proposé. Position tranchée après audit.
+
+### Ils ne veulent pas dire la même chose
+
+| Champ         | Type       | Où il sert                                                                                                       | Nature réelle                                          |
+| ------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `caseNumber`  | `String?`  | fiche publique (« N° dossier »), `AffairCard`, formulaire admin (« N° d'affaire »), `lib/validations/affairs.ts` | chaîne **saisie à la main et affichée**                |
+| `caseNumbers` | `String[]` | rapprochement machine (`hasSome`), détection de doublons, whitelist auto-applicable des propositions             | identifiant **jamais affiché**, écrit par un importeur |
+
+Ce ne sont donc pas un singulier et son pluriel : l'un est éditorial et visible,
+l'autre est machine et invisible.
+
+### Décision : différer les deux
+
+Trois raisons :
+
+1. **Ils sont à 0 ligne.** Rien à migrer, aucune pression de données.
+2. **Les recopier importerait la confusion** ci-dessus dans un modèle neuf, où elle
+   n'a pas lieu d'être.
+3. **L'identité de la décision n'en a pas besoin** pour les phases 1 à 3 :
+   `judilibreId`, `ecli` et `pourvoiNumber` suffisent.
+
+Les champs historiques **restent sur `Affair`** pendant toute la transition, et
+`caseNumber` continue d'être affiché tel quel.
+
+### Quand les ajouter
+
+Au moment où une source officielle les remplit, c'est-à-dire à la **phase 4**, quand
+Judilibre montrera ce qu'une décision porte réellement et avec quelle cardinalité.
+Un seul champ canonique sera alors ajouté, `caseNumbers String[]` sur la décision, et
+non les deux. Ajouter aujourd'hui un champ qu'on ne peut ni peupler ni justifier
+serait spéculatif.
 
 ---
 
@@ -631,7 +669,7 @@ délibérément plus petit que `AffairProceeding`.
 
 | PR  | Contenu                                                      | Taille  | Bloquée par |
 | --- | ------------------------------------------------------------ | ------- | ----------- |
-| 1   | schéma additif : `JudicialDecision` + liaison, sans enum     | petite  | —           |
+| 1   | schéma additif : `CourtDecision` + liaison, sans enum        | petite  | —           |
 | 2   | service de création et de liaison, tests, **aucun backfill** | moyenne | 1           |
 | 3   | backfill contrôlé des 2 décisions, idempotent, rapport       | petite  | 2           |
 | 4   | double lecture avec repli, fiche publique et export          | moyenne | 3           |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -616,6 +616,11 @@ model Affair {
   // Importer-proposed changes awaiting review (Affaires v2, lot 1)
   updateProposals AffairUpdateProposal[]
 
+  /// Décisions juridictionnelles auxquelles cette fiche est rattachée (#536).
+  /// Optionnel par construction : une affaire portant sur une enquête en cours ou
+  /// une action du parquet n'attend aucune décision.
+  courtDecisions AffairCourtDecision[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -2573,4 +2578,81 @@ enum AffairPairClassification {
 
   /// Deferred, not an exclusion: stays visible in a re-examination filter.
   UNCERTAIN
+}
+
+/// Une décision juridictionnelle rendue par une juridiction identifiée, quel que
+/// soit son ordre ou sa matière (#536).
+///
+/// Existe parce qu'une décision peut concerner plusieurs fiches éditoriales : deux
+/// condamnations mesurées en base partagent un numéro de pourvoi, une date de faits,
+/// une date de verdict et un arrêt de cassation, et sont pourtant deux chefs
+/// distincts. `Affair.ecli @unique` rend ce cas inexprimable.
+///
+/// Ne représente PAS un acte d'une autorité non juridictionnelle : ni réquisition du
+/// ministère public, ni délibération de la HATVP, ni sanction du Bureau du Sénat, ni
+/// travaux d'une commission d'enquête. Voir docs/judicial-decision-model.md §4 bis.
+model CourtDecision {
+  id String @id @default(cuid())
+
+  /// Clé externe Judilibre. Avec `ecli`, la seule identité réutilisable
+  /// automatiquement : le reste exige une procédure contrôlée.
+  judilibreId String? @unique
+  /// Identifiant européen. Identifie exactement une décision, d'où l'unicité — et
+  /// c'est ici son domicile correct, pas sur `Affair`.
+  ecli        String? @unique
+
+  /// Tel que publié, pour l'affichage : « 96-83.698 ».
+  pourvoiNumber           String?
+  /// Sans séparateurs, pour le rapprochement : « 9683698 ».
+  /// Indexé mais NON unique : un même pourvoi peut produire plusieurs décisions
+  /// (rejet, cassation partielle, renvoi), et rien dans les données ne prouve le
+  /// contraire. Ne jamais dédupliquer automatiquement sur ce champ.
+  pourvoiNumberNormalized String?
+
+  decisionDate DateTime?
+  /// La juridiction émettrice, jamais un parquet. Renseigné uniquement depuis une
+  /// source officielle : 23,7 % des `Affair.court` désignent un organe non
+  /// juridictionnel, donc ce champ ne se recopie pas depuis l'affaire.
+  court        String?
+  chamber      String?
+  /// Sens de la décision : rejet, cassation, cassation partielle, non-admission.
+  /// Chaîne libre en attendant d'observer le vocabulaire réel de Judilibre.
+  solution     String?
+  /// URL officielle canonique.
+  sourceUrl    String?
+
+  /// Charge brute d'une source officielle. Non requêtable, non faisant foi, et
+  /// jamais un endroit où ranger un champ modélisable.
+  metadata Json?
+
+  affairs AffairCourtDecision[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([pourvoiNumberNormalized])
+  @@index([decisionDate])
+}
+
+/// Rattachement d'une fiche éditoriale à une décision. Plusieurs-à-plusieurs des
+/// deux côtés : une décision peut porter plusieurs chefs, et une affaire peut
+/// traverser plusieurs décisions (#536).
+///
+/// Pas d'enum de relation : un seul cas réel observé ne peut pas en justifier cinq
+/// valeurs, dont certaines relèvent de #516 ou décrivent une relation entre deux
+/// décisions plutôt qu'entre une décision et une affaire.
+model AffairCourtDecision {
+  affairId        String
+  courtDecisionId String
+
+  /// Ce qu'un relecteur constate, en attendant assez de cas pour un enum honnête.
+  notes String?
+
+  affair        Affair        @relation(fields: [affairId], references: [id], onDelete: Cascade)
+  courtDecision CourtDecision @relation(fields: [courtDecisionId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@id([affairId, courtDecisionId])
+  @@index([courtDecisionId])
 }

--- a/src/services/affairs/__tests__/court-decision-schema.test.ts
+++ b/src/services/affairs/__tests__/court-decision-schema.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Issue #536 — structural guarantees of the CourtDecision model.
+ *
+ * Read from the schema file rather than exercised against a database: this
+ * repository's local `.env` points at production, so a test that writes rows would
+ * write them there. What matters here is not that Prisma can insert — it can — but
+ * that the guarantees the design rests on cannot be removed without a test failing.
+ *
+ * Behavioural tests (create, link, unlink) land with the service in PR 2, where
+ * there is code to exercise.
+ */
+
+const schema = readFileSync(join(process.cwd(), "prisma/schema.prisma"), "utf8");
+
+function modelBlock(name: string): string {
+  const start = schema.indexOf(`model ${name} {`);
+  expect(start, `model ${name} absent du schéma`).toBeGreaterThan(-1);
+  const end = schema.indexOf("\n}", start);
+  return schema.slice(start, end);
+}
+
+describe("CourtDecision — identité de la décision (#536)", () => {
+  const model = modelBlock("CourtDecision");
+
+  it("rend ecli unique : un ECLI identifie exactement une décision", () => {
+    expect(model).toMatch(/ecli\s+String\?\s+@unique/);
+  });
+
+  it("rend judilibreId unique : c'est une clé externe", () => {
+    expect(model).toMatch(/judilibreId\s+String\?\s+@unique/);
+  });
+
+  it("NE rend PAS le pourvoi unique, ni brut ni normalisé", () => {
+    // Un même pourvoi peut produire plusieurs décisions (rejet, cassation
+    // partielle, renvoi). Rendre ce champ unique interdirait de les enregistrer.
+    expect(model).not.toMatch(/pourvoiNumber\s+String\?\s+@unique/);
+    expect(model).not.toMatch(/pourvoiNumberNormalized\s+String\?\s+@unique/);
+  });
+
+  it("indexe la forme normalisée du pourvoi, pour rapprocher sans dédupliquer", () => {
+    expect(model).toMatch(/@@index\(\[pourvoiNumberNormalized\]\)/);
+    expect(model).toMatch(/pourvoiNumberNormalized\s+String\?/);
+  });
+
+  it("garde une forme d'affichage distincte de la forme normalisée", () => {
+    expect(model).toMatch(/pourvoiNumber\s+String\?/);
+  });
+
+  it("porte la juridiction, la chambre, la date et le sens de la décision", () => {
+    for (const field of ["decisionDate", "court", "chamber", "solution", "sourceUrl"]) {
+      expect(model, `${field} absent`).toContain(field);
+    }
+  });
+
+  it("n'ajoute ni caseNumber ni caseNumbers", () => {
+    // Différés : à 0 ligne, et les deux champs d'`Affair` ne veulent pas dire la
+    // même chose (l'un est affiché et saisi à la main, l'autre sert au
+    // rapprochement machine). Les recopier importerait cette confusion.
+    expect(model).not.toContain("caseNumber");
+  });
+});
+
+describe("AffairCourtDecision — la liaison (#536)", () => {
+  const model = modelBlock("AffairCourtDecision");
+
+  it("interdit deux fois la même liaison, par sa clé primaire composite", () => {
+    expect(model).toMatch(/@@id\(\[affairId,\s*courtDecisionId\]\)/);
+  });
+
+  it("est supprimée avec l'affaire, jamais l'inverse", () => {
+    expect(model).toMatch(/affair\s+Affair\s+@relation\([^)]*onDelete: Cascade/);
+  });
+
+  it("est supprimée avec la décision, jamais l'inverse", () => {
+    expect(model).toMatch(/courtDecision\s+CourtDecision\s+@relation\([^)]*onDelete: Cascade/);
+  });
+
+  it("n'a pas d'enum de relation", () => {
+    // Un seul cas réel observé ne peut pas justifier cinq valeurs, dont certaines
+    // relèvent de #516 ou décrivent une relation entre deux décisions.
+    expect(model).not.toContain("relationType");
+    expect(schema).not.toContain("enum CourtDecisionRelation");
+    expect(schema).not.toContain("enum JudicialDecisionRelation");
+  });
+
+  it("garde un champ de notes libre en attendant assez de cas", () => {
+    expect(model).toMatch(/notes\s+String\?/);
+  });
+
+  it("indexe le côté décision, pour lister les affaires d'une décision", () => {
+    expect(model).toMatch(/@@index\(\[courtDecisionId\]\)/);
+  });
+});
+
+describe("Affair — ce que cette PR ne touche pas (#536)", () => {
+  const model = modelBlock("Affair");
+
+  it("expose la relation inverse", () => {
+    expect(model).toMatch(/courtDecisions\s+AffairCourtDecision\[\]/);
+  });
+
+  it("conserve ses identifiants historiques et leur contrainte", () => {
+    // La transition les garde en place ; leur retrait est une PR ultérieure, et
+    // `ecli @unique` ne peut être levée qu'après peuplement et lecture de la
+    // décision.
+    expect(model).toMatch(/ecli\s+String\?\s+@unique/);
+    for (const field of [
+      "pourvoiNumber",
+      "caseNumber",
+      "caseNumbers",
+      "chamber",
+      "court",
+      "verdictDate",
+    ]) {
+      expect(model, `${field} retiré d'Affair`).toContain(field);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Part of #536. **PR 1 sur 4**, strictement additive.

Crée `CourtDecision` et `AffairCourtDecision`. Ne retire rien, ne modifie aucune lecture, ne touche à aucune route ni au service de propositions.

## Le problème

Le modèle actuel pose les identifiants d'une décision sur `Affair` et rend `Affair.ecli` unique, ce qui suppose qu'une décision n'appartient qu'à une fiche. Mesuré faux : deux condamnations partagent un numéro de pourvoi, une date de faits, une date de verdict et un arrêt de cassation, et sont deux chefs distincts.

## Préflight : trois points résolus avant d'écrire la migration

### 1. `caseNumber` et `caseNumbers` : différés

La matrice du document disait que les deux devaient migrer, le modèle proposé n'en contenait aucun. Audit fait, et les deux champs **ne veulent pas dire la même chose** :

| Champ | Où il sert | Nature réelle |
| --- | --- | --- |
| `caseNumber` | fiche publique, `AffairCard`, formulaire admin (« N° d'affaire »), `lib/validations` | chaîne **saisie à la main et affichée** |
| `caseNumbers` | rapprochement `hasSome`, détection de doublons, whitelist auto-applicable | identifiant **jamais affiché**, écrit par un importeur |

Ce ne sont donc pas un singulier et son pluriel. **Position retenue : différer les deux** (option 3). Ils sont à 0 ligne, les recopier importerait cette confusion dans un modèle neuf, et l'identité de la décision n'en a pas besoin pour les phases 1 à 3 : `judilibreId`, `ecli` et `pourvoiNumber` suffisent.

Un champ canonique unique `caseNumbers String[]` sera ajouté en phase 4, quand Judilibre montrera ce qu'une décision porte réellement. Les champs historiques restent sur `Affair` pendant toute la transition. Le document est mis à jour en conséquence (§6 bis), et la matrice reclasse `caseNumber` en `CONTENU_ÉDITORIAL_D_AFFAIRE` **en l'état**, puisqu'il est saisi à la main et affiché.

### 2. Identité sans ECLI

Aucune contrainte unique nouvelle sur le pourvoi. Les seules identités réutilisables automatiquement sont `judilibreId` et `ecli`. Un test vérifie explicitement que ni `pourvoiNumber` ni `pourvoiNumberNormalized` ne sont uniques.

### 3. Transfert des liaisons lors d'une fusion

**Livré en PR 2, avant tout backfill.** Cette PR ne crée aucune liaison, donc aucune ne peut être perdue par une cascade d'ici là.

## SQL vérifié comme strictement additif

| Contrôle | Résultat |
| --- | --- |
| `DROP` | **0** |
| `ALTER TABLE "Affair"` | **0** |
| `DROP CONSTRAINT` | **0** |
| `CREATE TABLE` | 2 |
| `CREATE INDEX` | 5 |
| `ALTER TABLE` | 2, les deux `ADD CONSTRAINT ... FOREIGN KEY` sur la table de liaison neuve |
| tables touchées | `CourtDecision`, `AffairCourtDecision` — aucune autre |

## Schéma appliqué en production avant l'ouverture de la PR

Ordre volontaire : le schéma additif d'abord, le code ensuite. Merger cette PR ne déclenche donc aucune migration.

Sauvegarde `pg_dump -Fc` prise avant (386 Mo). Préconditions vérifiées :

```
table CourtDecision existe        : false
table AffairCourtDecision existe  : false
affaires                          : 463
affaires avec pourvoiNumber       : 3
jugements de paires               : 8
propositions                      : 0
Affair.ecli unique                : true
```

État après application :

```
CourtDecision                     : 0 ligne
AffairCourtDecision               : 0 ligne
affaires                          : 463  (inchangé)
jugements                         : 8    (inchangé)
propositions                      : 0    (inchangé)
Affair.ecli unique                : conservée
colonnes de Affair                : 43   (inchangé)
index CourtDecision               : pkey, ecli_key, judilibreId_key, pourvoiNumberNormalized_idx, decisionDate_idx
liaison                           : pkey composite + index courtDecisionId + 2 clés étrangères
```

## Tests

**15 tests ajoutés**, qui vérifient les garanties structurelles sur lesquelles la conception repose :

- `ecli` et `judilibreId` uniques ;
- **`pourvoiNumber` et sa forme normalisée NON uniques** ;
- forme normalisée indexée, distincte de la forme d'affichage ;
- clé primaire composite sur la liaison, donc une même liaison ne peut pas exister deux fois ;
- `onDelete: Cascade` des deux côtés de la liaison ;
- **aucun enum de relation** ;
- relation inverse présente sur `Affair` ;
- `Affair` conserve ses sept champs historiques **et** sa contrainte `ecli @unique` ;
- `CourtDecision` ne contient ni `caseNumber` ni `caseNumbers`.

**Une réserve à assumer** : ces tests lisent `prisma/schema.prisma`, ils n'exercent pas une base. Mon `.env` local pointe la production, donc un test qui insère des lignes les insérerait là. Les tests de comportement demandés — créer une décision, la lier à deux affaires, refuser une liaison en double, délier sans supprimer l'affaire — arrivent en **PR 2**, où il y aura un service à exercer. Écrire ici des tests qui écrivent en production aurait été le mauvais choix.

Ce que ces tests apportent malgré tout : ils échouent si quelqu'un rend le pourvoi unique, ajoute l'enum, retire un `Cascade`, ou retire un champ d'`Affair`.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Part of #536

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx prisma validate`, `npx prisma migrate diff --script`, `npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2406 tests**, 0 échec.

## Suite

PR 2 : service `court-decisions.ts`, normalisation du pourvoi, et **transfert des liaisons dans `mergeAffairsInTransaction()`**, qui doit précéder tout backfill.
