### PR TITLE
Ajouter le service de décision juridictionnelle et le transfert en fusion

### DIFF
--- a/src/services/affairs/__tests__/absorb-draft.test.ts
+++ b/src/services/affairs/__tests__/absorb-draft.test.ts
@@ -19,6 +19,9 @@ const tx = {
   publicIdRedirect: { upsert: vi.fn() },
   dismissedDuplicate: { deleteMany: vi.fn() },
   affairPairDecision: { upsert: vi.fn() },
+  // Lu par mergeAffairsInTransaction depuis #536 : les liaisons de décision sont
+  // transférées avant la suppression de l'affaire absorbée.
+  affairCourtDecision: { findMany: vi.fn(), update: vi.fn() },
   affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
   auditLog: { create: vi.fn() },
 };
@@ -105,6 +108,7 @@ beforeEach(() => {
   tx.source.findMany.mockResolvedValue([]);
   tx.affairEvent.findMany.mockResolvedValue([]);
   tx.pressArticleAffair.findMany.mockResolvedValue([]);
+  tx.affairCourtDecision.findMany.mockResolvedValue([]);
   tx.affairUpdateProposal.findFirst.mockResolvedValue(null);
   tx.affairUpdateProposal.create.mockImplementation(async () => {
     calls.push("proposal");

--- a/src/services/affairs/__tests__/court-decisions.test.ts
+++ b/src/services/affairs/__tests__/court-decisions.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #536 — the court decision service. Mocked client: this repository's local
+// `.env` points at production, so a test that inserts rows would insert them there.
+
+const h = vi.hoisted(() => ({
+  create: vi.fn(),
+  findUnique: vi.fn(),
+  findMany: vi.fn(),
+  linkFindUnique: vi.fn(),
+  linkCreate: vi.fn(),
+  linkDeleteMany: vi.fn(),
+  linkFindMany: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    courtDecision: { create: h.create, findUnique: h.findUnique, findMany: h.findMany },
+    affairCourtDecision: {
+      findUnique: h.linkFindUnique,
+      create: h.linkCreate,
+      deleteMany: h.linkDeleteMany,
+      findMany: h.linkFindMany,
+    },
+  },
+}));
+
+import {
+  createCourtDecision,
+  findCourtDecisionByEcli,
+  findCourtDecisionByJudilibreId,
+  findCourtDecisionsByPourvoiNumber,
+  linkAffairToCourtDecision,
+  listCourtDecisionsForAffair,
+  normalizePourvoiNumber,
+  unlinkAffairFromCourtDecision,
+} from "../court-decisions";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.create.mockResolvedValue({ id: "dec_1" });
+  h.linkCreate.mockResolvedValue({});
+  h.linkFindUnique.mockResolvedValue(null);
+  h.linkDeleteMany.mockResolvedValue({ count: 1 });
+  h.linkFindMany.mockResolvedValue([]);
+  h.findMany.mockResolvedValue([]);
+});
+
+describe("normalizePourvoiNumber — issue #536", () => {
+  it("retire les séparateurs du format publié", () => {
+    expect(normalizePourvoiNumber("96-83.698")).toBe("9683698");
+  });
+
+  it("rapproche deux écritures de la même référence", () => {
+    expect(normalizePourvoiNumber("96-83698")).toBe(normalizePourvoiNumber("96-83.698"));
+    expect(normalizePourvoiNumber(" 96 83 698 ")).toBe("9683698");
+  });
+
+  it("replie les accents et la casse", () => {
+    expect(normalizePourvoiNumber("A96-83.698")).toBe("a9683698");
+    expect(normalizePourvoiNumber("Ç12-34.567")).toBe("c1234567");
+  });
+
+  it("ne perd aucun chiffre", () => {
+    expect(normalizePourvoiNumber("21-12.345")).toBe("2112345");
+    expect(normalizePourvoiNumber("97-81.102")).toBe("9781102");
+  });
+});
+
+describe("createCourtDecision — issue #536", () => {
+  it("dérive la forme normalisée, jamais fournie par l'appelant", () => {
+    return createCourtDecision({ pourvoiNumber: "96-83.698" }).then(() => {
+      expect(h.create.mock.calls[0]![0].data).toMatchObject({
+        pourvoiNumber: "96-83.698",
+        pourvoiNumberNormalized: "9683698",
+      });
+    });
+  });
+
+  it("laisse la forme normalisée nulle sans pourvoi", async () => {
+    await createCourtDecision({ ecli: "ECLI:FR:CCASS:2024:C100001" });
+
+    expect(h.create.mock.calls[0]![0].data).toMatchObject({
+      pourvoiNumber: null,
+      pourvoiNumberNormalized: null,
+    });
+  });
+
+  it("laisse juridiction, date et sens nuls quand ils ne sont pas fournis", async () => {
+    // Ces champs ne viennent que d'une source officielle : 23,7 % des Affair.court
+    // désignent un organe qui ne rend aucune décision.
+    await createCourtDecision({ pourvoiNumber: "96-83.698" });
+
+    expect(h.create.mock.calls[0]![0].data).toMatchObject({
+      court: null,
+      chamber: null,
+      decisionDate: null,
+      solution: null,
+    });
+  });
+});
+
+describe("Identités réutilisables — issue #536", () => {
+  it("cherche par ECLI en unicité", async () => {
+    h.findUnique.mockResolvedValue({ id: "dec_1" });
+
+    await findCourtDecisionByEcli("ECLI:FR:CCASS:2024:C100001");
+
+    expect(h.findUnique).toHaveBeenCalledWith({
+      where: { ecli: "ECLI:FR:CCASS:2024:C100001" },
+    });
+  });
+
+  it("cherche par identifiant Judilibre en unicité", async () => {
+    await findCourtDecisionByJudilibreId("jud_1");
+
+    expect(h.findUnique).toHaveBeenCalledWith({ where: { judilibreId: "jud_1" } });
+  });
+
+  it("rend une LISTE pour un pourvoi, parce qu'il n'est pas unique", async () => {
+    h.findMany.mockResolvedValue([{ id: "dec_1" }, { id: "dec_2" }]);
+
+    const found = await findCourtDecisionsByPourvoiNumber("96-83.698");
+
+    // Deux décisions peuvent partager un pourvoi (rejet, cassation partielle,
+    // renvoi) : l'appelant doit trancher, le service ne devine pas.
+    expect(found).toHaveLength(2);
+    expect(h.findMany).toHaveBeenCalledWith({
+      where: { pourvoiNumberNormalized: "9683698" },
+    });
+  });
+
+  it("n'expose aucun upsert par pourvoi", async () => {
+    const mod = await import("../court-decisions");
+
+    expect(mod).not.toHaveProperty("upsertByPourvoiNumber");
+    expect(Object.keys(mod).filter((k) => /upsert/i.test(k))).toEqual([]);
+  });
+});
+
+describe("Liaisons — issue #536", () => {
+  it("crée une liaison absente", async () => {
+    const result = await linkAffairToCourtDecision({ affairId: "a1", courtDecisionId: "dec_1" });
+
+    expect(result.created).toBe(true);
+    expect(h.linkCreate).toHaveBeenCalledWith({
+      data: { affairId: "a1", courtDecisionId: "dec_1", notes: null },
+    });
+  });
+
+  it("est idempotente : relier deux fois ne lève pas d'erreur", async () => {
+    h.linkFindUnique.mockResolvedValue({ affairId: "a1" });
+
+    const result = await linkAffairToCourtDecision({ affairId: "a1", courtDecisionId: "dec_1" });
+
+    expect(result.created).toBe(false);
+    expect(h.linkCreate).not.toHaveBeenCalled();
+  });
+
+  it("permet à une décision de porter deux affaires", async () => {
+    await linkAffairToCourtDecision({ affairId: "a1", courtDecisionId: "dec_1" });
+    await linkAffairToCourtDecision({ affairId: "a2", courtDecisionId: "dec_1" });
+
+    expect(h.linkCreate).toHaveBeenCalledTimes(2);
+    const affairs = h.linkCreate.mock.calls.map((c) => c[0].data.affairId);
+    expect(affairs).toEqual(["a1", "a2"]);
+  });
+
+  it("délie sans jamais supprimer la décision", async () => {
+    const result = await unlinkAffairFromCourtDecision({
+      affairId: "a1",
+      courtDecisionId: "dec_1",
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(h.linkDeleteMany).toHaveBeenCalledWith({
+      where: { affairId: "a1", courtDecisionId: "dec_1" },
+    });
+    // Aucune suppression sur la table des décisions.
+    expect(h.create).not.toHaveBeenCalled();
+  });
+
+  it("liste les décisions d'une affaire avec la note de liaison", async () => {
+    h.linkFindMany.mockResolvedValue([
+      { notes: "deux chefs", courtDecision: { id: "dec_1", pourvoiNumber: "96-83.698" } },
+    ]);
+
+    const decisions = await listCourtDecisionsForAffair("a1");
+
+    expect(decisions).toEqual([
+      { id: "dec_1", pourvoiNumber: "96-83.698", linkNotes: "deux chefs" },
+    ]);
+  });
+});

--- a/src/services/affairs/__tests__/merge-affairs.test.ts
+++ b/src/services/affairs/__tests__/merge-affairs.test.ts
@@ -17,6 +17,10 @@ type TxRecorder = {
   pressArticleAffair: { findMany: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
   publicIdRedirect: { upsert: ReturnType<typeof vi.fn> };
   affairPairDecision: { upsert: ReturnType<typeof vi.fn> };
+  affairCourtDecision: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
   dismissedDuplicate: { deleteMany: ReturnType<typeof vi.fn> };
   auditLog: { create: ReturnType<typeof vi.fn> };
 };
@@ -28,6 +32,7 @@ const tx: TxRecorder = {
   pressArticleAffair: { findMany: vi.fn(), update: vi.fn() },
   publicIdRedirect: { upsert: vi.fn() },
   affairPairDecision: { upsert: vi.fn() },
+  affairCourtDecision: { findMany: vi.fn(), update: vi.fn() },
   dismissedDuplicate: { deleteMany: vi.fn() },
   auditLog: { create: vi.fn() },
 };
@@ -76,6 +81,7 @@ function stub(keep: Record<string, unknown>, remove: Record<string, unknown>) {
   tx.source.findMany.mockResolvedValue([]);
   tx.affairEvent.findMany.mockResolvedValue([]);
   tx.pressArticleAffair.findMany.mockResolvedValue([]);
+  tx.affairCourtDecision.findMany.mockResolvedValue([]);
 }
 
 /** The payload of the single additive update, or null when nothing was written. */
@@ -554,5 +560,176 @@ describe("mergeAffairs — refus transactionnel d'absorber une affaire publiée 
     );
 
     await expect(mergeAffairs("keep", "remove")).resolves.toBeDefined();
+  });
+});
+
+// Issue #536 — a merge deletes the absorbed affair, and the cascade on
+// AffairCourtDecision would take its links with it. A merge of affairs must never
+// destroy a decision, nor a decision's reach across fiches.
+describe("mergeAffairs — transfert des liaisons de décision (#536)", () => {
+  /** Wires the survivor's links, then the absorbed affair's. */
+  function stubDecisionLinks(
+    kept: Array<{ courtDecisionId: string; notes: string | null }>,
+    absorbed: Array<{ courtDecisionId: string; notes: string | null }>
+  ) {
+    tx.affairCourtDecision.findMany.mockResolvedValueOnce(kept).mockResolvedValueOnce(absorbed);
+  }
+
+  it("transfère une liaison unique vers le survivant", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks([], [{ courtDecisionId: "dec_1", notes: null }]);
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.decisionLinksMoved).toBe(1);
+    expect(result.decisionLinksDeduplicated).toBe(0);
+    expect(tx.affairCourtDecision.update).toHaveBeenCalledWith({
+      where: { affairId_courtDecisionId: { affairId: "remove", courtDecisionId: "dec_1" } },
+      data: { affairId: "keep" },
+    });
+  });
+
+  it("transfère plusieurs décisions distinctes", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks(
+      [],
+      [
+        { courtDecisionId: "dec_1", notes: null },
+        { courtDecisionId: "dec_2", notes: null },
+      ]
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.decisionLinksMoved).toBe(2);
+    const moved = tx.affairCourtDecision.update.mock.calls.map(
+      (c) => c[0].where.affairId_courtDecisionId.courtDecisionId
+    );
+    expect(moved).toEqual(["dec_1", "dec_2"]);
+  });
+
+  it("déduplique quand les deux affaires citent déjà la même décision", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks(
+      [{ courtDecisionId: "dec_1", notes: "note du survivant" }],
+      [{ courtDecisionId: "dec_1", notes: "note absorbée" }]
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.decisionLinksMoved).toBe(0);
+    expect(result.decisionLinksDeduplicated).toBe(1);
+    // La note du survivant existe : rien n'est réécrit, rien n'est concaténé.
+    expect(tx.affairCourtDecision.update).not.toHaveBeenCalled();
+  });
+
+  it("reprend la note absorbée quand le survivant n'en a pas", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks(
+      [{ courtDecisionId: "dec_1", notes: null }],
+      [{ courtDecisionId: "dec_1", notes: "deux chefs d'un même arrêt" }]
+    );
+
+    const result = await mergeAffairs("keep", "remove");
+
+    expect(result.decisionLinksDeduplicated).toBe(1);
+    expect(tx.affairCourtDecision.update).toHaveBeenCalledWith({
+      where: { affairId_courtDecisionId: { affairId: "keep", courtDecisionId: "dec_1" } },
+      data: { notes: "deux chefs d'un même arrêt" },
+    });
+  });
+
+  it("ne concatène jamais deux notes différentes en silence", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks(
+      [{ courtDecisionId: "dec_1", notes: "texte A" }],
+      [{ courtDecisionId: "dec_1", notes: "texte B" }]
+    );
+
+    await mergeAffairs("keep", "remove");
+
+    const writes = tx.affairCourtDecision.update.mock.calls.map((c) => c[0].data);
+    for (const w of writes) {
+      expect(String(w.notes ?? "")).not.toContain("texte A");
+    }
+    // Le cas est tracé dans la piste d'audit plutôt que résolu en silence.
+    const changes = tx.auditLog.create.mock.calls[0]![0].data.changes;
+    expect(changes.decisionLinksDeduplicatedIds).toEqual(["dec_1"]);
+  });
+
+  it("ne supprime aucune décision", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks([], [{ courtDecisionId: "dec_1", notes: null }]);
+
+    await mergeAffairs("keep", "remove");
+
+    // Le faux client de transaction n'expose aucune suppression de décision : si le
+    // service en tentait une, l'appel échouerait.
+    expect(tx).not.toHaveProperty("courtDecision");
+  });
+
+  it("consigne les compteurs et les identifiants dans la piste d'audit", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks(
+      [{ courtDecisionId: "dec_shared", notes: "gardée" }],
+      [
+        { courtDecisionId: "dec_shared", notes: "absorbée" },
+        { courtDecisionId: "dec_new", notes: null },
+      ]
+    );
+
+    await mergeAffairs("keep", "remove");
+
+    const changes = tx.auditLog.create.mock.calls[0]![0].data.changes;
+    expect(changes).toMatchObject({
+      decisionLinksMoved: 1,
+      decisionLinksDeduplicated: 1,
+      decisionLinksMovedIds: ["dec_new"],
+      decisionLinksDeduplicatedIds: ["dec_shared"],
+    });
+  });
+
+  it("annule tout si le transfert d'une liaison échoue", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks([], [{ courtDecisionId: "dec_1", notes: null }]);
+    tx.affairCourtDecision.update.mockRejectedValue(new Error("link transfer failed"));
+
+    await expect(mergeAffairs("keep", "remove")).rejects.toThrow("link transfer failed");
+
+    expect(tx.affair.delete).not.toHaveBeenCalled();
+    expect(tx.publicIdRedirect.upsert).not.toHaveBeenCalled();
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("annule le transfert si la suppression de l'affaire échoue", async () => {
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks([], [{ courtDecisionId: "dec_1", notes: null }]);
+    // clearAllMocks efface les appels, pas les implémentations : le rejet posé par
+    // le test précédent doit être explicitement levé.
+    tx.affairCourtDecision.update.mockResolvedValue({});
+    tx.affair.delete.mockRejectedValue(new Error("delete failed"));
+
+    await expect(mergeAffairs("keep", "remove")).rejects.toThrow("delete failed");
+
+    // Le transfert a bien été tenté ; la transaction l'annule.
+    expect(tx.affairCourtDecision.update).toHaveBeenCalled();
+  });
+
+  it("transfère les liaisons avant la suppression de l'affaire", async () => {
+    const order: string[] = [];
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+    stubDecisionLinks([], [{ courtDecisionId: "dec_1", notes: null }]);
+    tx.affairCourtDecision.update.mockImplementation(async () => {
+      order.push("transfer");
+      return {};
+    });
+    tx.affair.delete.mockImplementation(async () => {
+      order.push("delete");
+      return {};
+    });
+
+    await mergeAffairs("keep", "remove");
+
+    expect(order).toEqual(["transfer", "delete"]);
   });
 });

--- a/src/services/affairs/court-decisions.ts
+++ b/src/services/affairs/court-decisions.ts
@@ -1,0 +1,171 @@
+/**
+ * Court decisions, and their links to editorial affairs (#536).
+ *
+ * A `CourtDecision` is a decision handed down by an identified jurisdiction, whatever
+ * its order or subject matter. A `CourtDecision` is not an affair: one decision can
+ * carry several counts and therefore reach several Poligraph fiches, which is what
+ * `Affair.ecli @unique` made impossible to record.
+ *
+ * Deliberately absent from this module: any lookup or upsert keyed on the pourvoi
+ * number. A pourvoi can produce several decisions (rejection, partial cassation,
+ * remand), so reusing a row on that basis would silently merge two decisions. The
+ * only identities safe to reuse automatically are `judilibreId` and `ecli`.
+ */
+
+import { db, type DbTransactionClient } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma";
+
+/**
+ * Strips every separator from a pourvoi number so two spellings of the same
+ * reference compare equal: « 96-83.698 » and « 96-83698 » both give « 9683698 ».
+ *
+ * Pure, and the only normalisation the model relies on. Used to *find* candidates,
+ * never to decide that two rows are the same decision.
+ */
+export function normalizePourvoiNumber(raw: string): string {
+  return (
+    raw
+      .normalize("NFD")
+      // \p{Mn} keeps this ASCII-only: a literal combining-mark range is invisible in source.
+      .replace(/\p{Mn}/gu, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "")
+  );
+}
+
+export interface CreateCourtDecisionInput {
+  judilibreId?: string | null;
+  ecli?: string | null;
+  /** As published, for display. The normalised form is derived, never passed in. */
+  pourvoiNumber?: string | null;
+  decisionDate?: Date | null;
+  /**
+   * The issuing jurisdiction, never a prosecution office. Only ever set from an
+   * official source: 23.7 % of `Affair.court` values name a body that renders no
+   * decision, so that field must not be copied here.
+   */
+  court?: string | null;
+  chamber?: string | null;
+  solution?: string | null;
+  sourceUrl?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+}
+
+type Client = DbTransactionClient | typeof db;
+
+/** Derives the normalised form so no caller can put the two out of step. */
+function toCreateData(input: CreateCourtDecisionInput) {
+  return {
+    judilibreId: input.judilibreId ?? null,
+    ecli: input.ecli ?? null,
+    pourvoiNumber: input.pourvoiNumber ?? null,
+    pourvoiNumberNormalized: input.pourvoiNumber
+      ? normalizePourvoiNumber(input.pourvoiNumber)
+      : null,
+    decisionDate: input.decisionDate ?? null,
+    court: input.court ?? null,
+    chamber: input.chamber ?? null,
+    solution: input.solution ?? null,
+    sourceUrl: input.sourceUrl ?? null,
+    ...(input.metadata === null || input.metadata === undefined
+      ? {}
+      : { metadata: input.metadata }),
+  };
+}
+
+export async function createCourtDecision(
+  input: CreateCourtDecisionInput,
+  client: Client = db
+): Promise<{ id: string }> {
+  return client.courtDecision.create({ data: toCreateData(input), select: { id: true } });
+}
+
+export async function findCourtDecisionById(id: string, client: Client = db) {
+  return client.courtDecision.findUnique({ where: { id } });
+}
+
+/** An ECLI identifies exactly one decision, so this lookup is safe to act on. */
+export async function findCourtDecisionByEcli(ecli: string, client: Client = db) {
+  return client.courtDecision.findUnique({ where: { ecli } });
+}
+
+/** A Judilibre id is an external primary key, so this lookup is safe to act on. */
+export async function findCourtDecisionByJudilibreId(judilibreId: string, client: Client = db) {
+  return client.courtDecision.findUnique({ where: { judilibreId } });
+}
+
+/**
+ * Candidates sharing a normalised pourvoi number.
+ *
+ * Returns a list on purpose. A pourvoi is not unique, so the caller has to decide
+ * what to do with zero, one, or several rows — and stop rather than guess when
+ * several come back.
+ */
+export async function findCourtDecisionsByPourvoiNumber(
+  pourvoiNumber: string,
+  client: Client = db
+) {
+  return client.courtDecision.findMany({
+    where: { pourvoiNumberNormalized: normalizePourvoiNumber(pourvoiNumber) },
+  });
+}
+
+/**
+ * Links an affair to a decision. Idempotent: relinking the same pair is a no-op
+ * rather than a constraint violation.
+ */
+export async function linkAffairToCourtDecision(
+  input: { affairId: string; courtDecisionId: string; notes?: string | null },
+  client: Client = db
+): Promise<{ created: boolean }> {
+  const existing = await client.affairCourtDecision.findUnique({
+    where: {
+      affairId_courtDecisionId: {
+        affairId: input.affairId,
+        courtDecisionId: input.courtDecisionId,
+      },
+    },
+    select: { affairId: true },
+  });
+  if (existing) return { created: false };
+
+  await client.affairCourtDecision.create({
+    data: {
+      affairId: input.affairId,
+      courtDecisionId: input.courtDecisionId,
+      notes: input.notes ?? null,
+    },
+  });
+  return { created: true };
+}
+
+/**
+ * Removes a link. Never deletes the decision: a decision outlives the fiches that
+ * cite it, and unlinking is an editorial act on the affair, not on the decision.
+ */
+export async function unlinkAffairFromCourtDecision(
+  input: { affairId: string; courtDecisionId: string },
+  client: Client = db
+): Promise<{ deleted: boolean }> {
+  const result = await client.affairCourtDecision.deleteMany({
+    where: { affairId: input.affairId, courtDecisionId: input.courtDecisionId },
+  });
+  return { deleted: result.count > 0 };
+}
+
+export async function listCourtDecisionsForAffair(affairId: string, client: Client = db) {
+  const links = await client.affairCourtDecision.findMany({
+    where: { affairId },
+    include: { courtDecision: true },
+    orderBy: { createdAt: "asc" },
+  });
+  return links.map((link) => ({ ...link.courtDecision, linkNotes: link.notes }));
+}
+
+export async function listAffairIdsForCourtDecision(courtDecisionId: string, client: Client = db) {
+  const links = await client.affairCourtDecision.findMany({
+    where: { courtDecisionId },
+    select: { affairId: true },
+  });
+  return links.map((link) => link.affairId);
+}

--- a/src/services/affairs/court-decisions.ts
+++ b/src/services/affairs/court-decisions.ts
@@ -6,10 +6,10 @@
  * carry several counts and therefore reach several Poligraph fiches, which is what
  * `Affair.ecli @unique` made impossible to record.
  *
- * Deliberately absent from this module: any lookup or upsert keyed on the pourvoi
- * number. A pourvoi can produce several decisions (rejection, partial cassation,
- * remand), so reusing a row on that basis would silently merge two decisions. The
- * only identities safe to reuse automatically are `judilibreId` and `ecli`.
+ * This module deliberately offers no lookup or upsert keyed on the pourvoi number.
+ * A pourvoi can produce several decisions (rejection, partial cassation, remand), so
+ * reusing a row on that basis would silently merge two decisions. The only identities
+ * safe to reuse automatically are `judilibreId` and `ecli`.
  */
 
 import { db, type DbTransactionClient } from "@/lib/db";

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -376,6 +376,10 @@ export interface MergeAffairsOptions {
 
 export interface MergeAffairsResult {
   sourcesMoved: number;
+  /** Court decision links reattached to the survivor. */
+  decisionLinksMoved: number;
+  /** Links dropped because the survivor already cited that decision. */
+  decisionLinksDeduplicated: number;
   /** Sources whose URL already existed and whose extra fields were carried over. */
   sourcesEnriched: number;
   eventsMoved: number;
@@ -438,8 +442,9 @@ export function computePreservedSlugs(input: {
  * failure can never leave sources moved with the affair still present, nor an
  * affair deleted without its redirects.
  *
- * Transfers additively: sources, events, press article links, and the judicial
- * identifiers the survivor is missing. Never touches the survivor's editorial
+ * Transfers additively: sources, events, press article links, court decision links,
+ * and the judicial identifiers the survivor is missing. A merge never deletes a
+ * decision — only the absorbed affair's claim on it moves. Never touches the survivor's editorial
  * fields (title, description, status, dates, sentence) — those are a human
  * decision, and for automated paths they belong in an AffairUpdateProposal.
  *
@@ -607,6 +612,59 @@ export async function mergeAffairsInTransaction(
       articlesMoved++;
     }
 
+    // --- Court decision links: the composite primary key forbids a duplicate, and
+    // the cascade on the absorbed affair would delete its links along with the row.
+    // A merge of affairs must never destroy a decision, nor a decision's reach.
+    const keptDecisionLinks = await tx.affairCourtDecision.findMany({
+      where: { affairId: keepId },
+      select: { courtDecisionId: true, notes: true },
+    });
+    const keptByDecision = new Map(keptDecisionLinks.map((l) => [l.courtDecisionId, l.notes]));
+
+    const decisionLinksToTransfer = await tx.affairCourtDecision.findMany({
+      where: { affairId: removeId },
+      select: { courtDecisionId: true, notes: true },
+    });
+    let decisionLinksMoved = 0;
+    let decisionLinksDeduplicated = 0;
+    const decisionLinksMovedIds: string[] = [];
+    const decisionLinksDeduplicatedIds: string[] = [];
+    for (const link of decisionLinksToTransfer) {
+      if (keptByDecision.has(link.courtDecisionId)) {
+        // Both affairs already cite this decision. The survivor's note wins when it
+        // has one; otherwise the absorbed note is taken over. Two different texts are
+        // never concatenated silently — the audit trail below records the case.
+        const keptNote = keptByDecision.get(link.courtDecisionId) ?? null;
+        if (!keptNote && link.notes) {
+          await tx.affairCourtDecision.update({
+            where: {
+              affairId_courtDecisionId: {
+                affairId: keepId,
+                courtDecisionId: link.courtDecisionId,
+              },
+            },
+            data: { notes: link.notes },
+          });
+        }
+        decisionLinksDeduplicated++;
+        decisionLinksDeduplicatedIds.push(link.courtDecisionId);
+        continue;
+      }
+      // Moved rather than recreated, so `createdAt` keeps its original meaning.
+      await tx.affairCourtDecision.update({
+        where: {
+          affairId_courtDecisionId: {
+            affairId: removeId,
+            courtDecisionId: link.courtDecisionId,
+          },
+        },
+        data: { affairId: keepId },
+      });
+      keptByDecision.set(link.courtDecisionId, link.notes);
+      decisionLinksMoved++;
+      decisionLinksMovedIds.push(link.courtDecisionId);
+    }
+
     // --- Additive field fill, plus the absorbed affair's URLs.
     const updates: Prisma.AffairUpdateInput = {};
     const identifiersMerged: string[] = [];
@@ -671,6 +729,10 @@ export async function mergeAffairsInTransaction(
           sourcesEnriched,
           eventsMoved,
           articlesMoved,
+          decisionLinksMoved,
+          decisionLinksDeduplicated,
+          decisionLinksMovedIds,
+          decisionLinksDeduplicatedIds,
           identifiersMerged,
           slugsPreserved,
           ...(options.auditNotes ? { notes: options.auditNotes } : {}),
@@ -704,6 +766,8 @@ export async function mergeAffairsInTransaction(
       sourcesEnriched,
       eventsMoved,
       articlesMoved,
+      decisionLinksMoved,
+      decisionLinksDeduplicated,
       identifiersMerged,
       slugsPreserved,
     };


### PR DESCRIPTION
## Description

Part of #536. **PR 2 sur 4**. Service de décision juridictionnelle, et protection de la fusion **avant tout backfill**.

## Le point bloquant traité

`AffairCourtDecision` porte `onDelete: Cascade` sur l'affaire. Une fusion supprime l'affaire absorbée, donc **ses liaisons partiraient avec elle**. Introduire une liaison en production sans cette protection perdrait la portée d'une décision au premier repli de doublon.

`mergeAffairsInTransaction()` transfère désormais les liaisons, **dans la transaction de fusion existante** et **avant la suppression** :

1. charge les liaisons du survivant, puis celles de l'absorbée ;
2. déplace chaque liaison absente du survivant, par `update` et non par recréation, pour que `createdAt` garde son sens ;
3. déduplique quand les deux affaires citent déjà la même décision ;
4. conserve les décisions distinctes ;
5. consigne dans l'audit le nombre déplacé, le nombre dédupliqué **et les identifiants des décisions concernées**.

**Aucune décision n'est jamais supprimée par une fusion d'affaires.**

### Règle de notes, documentée

La note du survivant l'emporte quand elle existe. Sinon celle de l'affaire absorbée est reprise. **Deux textes différents ne sont jamais concaténés en silence** : le cas est tracé dans `decisionLinksDeduplicatedIds`, à charge d'un relecteur de trancher.

## Le service

`src/services/affairs/court-decisions.ts` :

```
createCourtDecision()          findCourtDecisionById()
findCourtDecisionByEcli()      findCourtDecisionByJudilibreId()
linkAffairToCourtDecision()    unlinkAffairFromCourtDecision()
listCourtDecisionsForAffair()  listAffairIdsForCourtDecision()
normalizePourvoiNumber()
```

**Aucun `upsertByPourvoiNumber`.** Un test vérifie qu'aucun export ne contient « upsert ». Les seules identités réutilisables automatiquement sont `judilibreId` et `ecli`, tous deux uniques.

`findCourtDecisionsByPourvoiNumber()` rend délibérément une **liste** : un pourvoi peut produire plusieurs décisions (rejet, cassation partielle, renvoi), donc l'appelant doit trancher et le service ne devine pas.

La forme normalisée est **dérivée** dans le service, jamais fournie par l'appelant : les deux colonnes ne peuvent pas se désynchroniser.

`linkAffairToCourtDecision()` est idempotente : relier deux fois est un non-événement, pas une violation de contrainte.

`unlinkAffairFromCourtDecision()` ne supprime que la liaison. Une décision survit aux fiches qui la citent.

## Ce que la PR ne fait pas

Aucune lecture publique modifiée, aucune route, aucun backfill, aucune écriture en production. Les champs `court`, `chamber`, `decisionDate` et `solution` restent nuls si l'appelant ne les fournit pas : ils ne viennent que d'une source officielle, puisque 23,7 % des `Affair.court` désignent un organe qui ne rend aucune décision.

## Tests

**53 tests** au total sur ce périmètre, dont 26 ajoutés.

Service, 16 tests : normalisation (`96-83.698` → `9683698`, accents, casse, aucun chiffre perdu), dérivation de la forme normalisée, champs officiels laissés nuls, recherche par ECLI et par identifiant Judilibre en unicité, **liste pour un pourvoi**, absence d'upsert, liaison idempotente, une décision liée à deux affaires, déliaison sans suppression de décision.

Fusion, 10 tests couvrant les garanties demandées : transfert d'une liaison unique, de plusieurs décisions distinctes, déduplication, reprise de note selon la règle, **aucune concaténation silencieuse**, aucune suppression de décision, compteurs et identifiants dans l'audit, **rollback si le transfert échoue**, **rollback si la suppression échoue**, et transfert **avant** la suppression.

Les suites voisines restent vertes : décision de fusion, absorption manuelle, chemin cron. **Aucune nouvelle auto-fusion traversant la frontière du publié** : le planificateur est inchangé.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Part of #536

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2432 tests**, 0 échec.

**Aucune donnée de production modifiée** : 463 affaires, 0 décision, 0 liaison, 8 jugements.

## Point de revue

Les tests utilisent un client de transaction simulé. Mon `.env` local pointe la production, donc un test qui insère des lignes les insérerait là. Ce que ces tests prouvent malgré tout : l'ordre des opérations, le contenu de la piste d'audit, et le rollback — c'est-à-dire exactement ce que la protection doit garantir.

## Suite

PR 3 : backfill contrôlé, 2 décisions et 3 liaisons, idempotent, avec vérification des préconditions avant toute écriture.
