### PR TITLE
Lire les identifiants depuis la décision en repli, sans jamais en choisir une

### DIFF
--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -40,6 +40,7 @@ import { SITE_URL } from "@/config/site";
 import { ShareBar } from "@/components/ui/ShareBar";
 import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 import { buildPublicAffairLookupWheres, pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
+import { resolveDecisionFields } from "@/lib/affairs/decision-fields";
 import { SlappBadge } from "@/components/slapp/SlappBadge";
 import { CriteriaList } from "@/components/slapp/CriteriaList";
 import type { SlappCriteriaPayload } from "@/config/slapp";
@@ -104,6 +105,26 @@ const affairInclude = {
       publicationStatus: true,
       politician: { select: { fullName: true, slug: true } },
     },
+  },
+  // Double lecture (#536) : la fiche sert la valeur historique de l'affaire, et ne
+  // se rabat sur la décision que si l'affaire n'en porte pas et qu'une seule est
+  // liée. Plusieurs décisions liées n'affichent aucune valeur plate.
+  courtDecisions: {
+    select: {
+      courtDecision: {
+        select: {
+          id: true,
+          ecli: true,
+          pourvoiNumber: true,
+          chamber: true,
+          decisionDate: true,
+          court: true,
+          solution: true,
+          sourceUrl: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "asc" as const },
   },
   linkedBy: {
     where: { publicationStatus: "PUBLISHED" as const },
@@ -181,6 +202,11 @@ export default async function AffairDetailPage({ params }: PageProps) {
   if (!affair) {
     notFound();
   }
+
+  // Double lecture des identifiants déplacés vers la décision (#536). `court` et
+  // `verdictDate` restent lus depuis l'affaire : ils sont éditoriaux.
+  const linkedDecisions = affair.courtDecisions.map((link) => link.courtDecision);
+  const resolvedDecisionFields = resolveDecisionFields(affair, linkedDecisions);
 
   const superCategory = CATEGORY_TO_SUPER[affair.category as AffairCategory];
   const certainty = getCertaintyLevel(affair.status);
@@ -397,7 +423,7 @@ export default async function AffairDetailPage({ params }: PageProps) {
               <h2 className="text-lg font-semibold">Juridiction</h2>
             </CardHeader>
             <CardContent>
-              {affair.court || affair.chamber || affair.caseNumber ? (
+              {affair.court || resolvedDecisionFields.chamber.value || affair.caseNumber ? (
                 <dl className="space-y-3">
                   {affair.court && (
                     <div className="flex justify-between">
@@ -405,10 +431,10 @@ export default async function AffairDetailPage({ params }: PageProps) {
                       <dd className="font-medium text-right">{affair.court}</dd>
                     </div>
                   )}
-                  {affair.chamber && (
+                  {resolvedDecisionFields.chamber.value && (
                     <div className="flex justify-between">
                       <dt className="text-muted-foreground">Chambre</dt>
-                      <dd className="font-medium">{affair.chamber}</dd>
+                      <dd className="font-medium">{resolvedDecisionFields.chamber.value}</dd>
                     </div>
                   )}
                   {affair.caseNumber && (
@@ -420,6 +446,35 @@ export default async function AffairDetailPage({ params }: PageProps) {
                 </dl>
               ) : (
                 <p className="text-muted-foreground text-sm">Informations non renseignées</p>
+              )}
+
+              {linkedDecisions.length > 0 && (
+                <div className="mt-4 border-t pt-4">
+                  <h3 className="mb-2 text-sm font-medium">
+                    Décision{linkedDecisions.length > 1 ? "s" : ""} de justice rattachée
+                    {linkedDecisions.length > 1 ? "s" : ""}
+                  </h3>
+                  <ul className="space-y-2 text-sm">
+                    {linkedDecisions.map((decision) => (
+                      <li key={decision.id} className="text-muted-foreground">
+                        {decision.pourvoiNumber && (
+                          <span className="font-mono">{decision.pourvoiNumber}</span>
+                        )}
+                        {decision.court && <span> — {decision.court}</span>}
+                        {decision.decisionDate && (
+                          <span> — {formatDate(decision.decisionDate)}</span>
+                        )}
+                        {decision.solution && <span> — {decision.solution}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                  {resolvedDecisionFields.hasMultipleDecisions && (
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Cette affaire est rattachée à plusieurs décisions. Les références sont listées
+                      séparément plutôt que résumées en une seule valeur.
+                    </p>
+                  )}
+                </div>
               )}
             </CardContent>
           </Card>

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -41,6 +41,10 @@ import { ShareBar } from "@/components/ui/ShareBar";
 import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 import { buildPublicAffairLookupWheres, pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
 import { resolveDecisionFields } from "@/lib/affairs/decision-fields";
+import {
+  buildCourtDecisionDisplay,
+  sortCourtDecisionsForDisplay,
+} from "@/lib/affairs/court-decision-display";
 import { SlappBadge } from "@/components/slapp/SlappBadge";
 import { CriteriaList } from "@/components/slapp/CriteriaList";
 import type { SlappCriteriaPayload } from "@/config/slapp";
@@ -205,7 +209,9 @@ export default async function AffairDetailPage({ params }: PageProps) {
 
   // Double lecture des identifiants déplacés vers la décision (#536). `court` et
   // `verdictDate` restent lus depuis l'affaire : ils sont éditoriaux.
-  const linkedDecisions = affair.courtDecisions.map((link) => link.courtDecision);
+  const linkedDecisions = sortCourtDecisionsForDisplay(
+    affair.courtDecisions.map((link) => link.courtDecision)
+  );
   const resolvedDecisionFields = resolveDecisionFields(affair, linkedDecisions);
 
   const superCategory = CATEGORY_TO_SUPER[affair.category as AffairCategory];
@@ -455,18 +461,27 @@ export default async function AffairDetailPage({ params }: PageProps) {
                     {linkedDecisions.length > 1 ? "s" : ""}
                   </h3>
                   <ul className="space-y-2 text-sm">
-                    {linkedDecisions.map((decision) => (
-                      <li key={decision.id} className="text-muted-foreground">
-                        {decision.pourvoiNumber && (
-                          <span className="font-mono">{decision.pourvoiNumber}</span>
-                        )}
-                        {decision.court && <span> — {decision.court}</span>}
-                        {decision.decisionDate && (
-                          <span> — {formatDate(decision.decisionDate)}</span>
-                        )}
-                        {decision.solution && <span> — {decision.solution}</span>}
-                      </li>
-                    ))}
+                    {linkedDecisions.map((decision) => {
+                      const display = buildCourtDecisionDisplay(decision, formatDate);
+                      return (
+                        <li key={decision.id} className="text-muted-foreground">
+                          <span>{display.parts.join(" — ")}</span>
+                          {display.link && (
+                            <>
+                              {" "}
+                              <a
+                                href={display.link.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline underline-offset-4 hover:text-foreground"
+                              >
+                                {display.link.label}
+                              </a>
+                            </>
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                   {resolvedDecisionFields.hasMultipleDecisions && (
                     <p className="mt-2 text-xs text-muted-foreground">

--- a/src/app/api/export/affaires/route.ts
+++ b/src/app/api/export/affaires/route.ts
@@ -17,6 +17,7 @@ import { parsePagination } from "@/lib/api/pagination";
 import type { AffairStatus, AffairCategory } from "@/types";
 import { SITE_URL } from "@/config/site";
 import { withPublicRoute } from "@/lib/api/with-public-route";
+import { resolveDecisionField } from "@/lib/affairs/decision-fields";
 
 export const dynamic = "force-dynamic";
 
@@ -111,6 +112,12 @@ export const GET = withPublicRoute(async (request) => {
       _count: {
         select: { sources: true },
       },
+      // Double lecture (#536) : l'export sert la valeur historique de l'affaire, et
+      // ne se rabat sur la décision que si l'affaire n'en porte pas et qu'une seule
+      // décision est liée.
+      courtDecisions: {
+        select: { courtDecision: { select: { ecli: true } } },
+      },
     },
     orderBy: { createdAt: "desc" },
     take: limit,
@@ -151,7 +158,11 @@ export const GET = withPublicRoute(async (request) => {
     sentence: a.sentence ?? "",
     otherSentence: a.otherSentence ?? "",
     court: a.court ?? "",
-    ecli: a.ecli ?? "",
+    ecli:
+      resolveDecisionField(
+        a.ecli,
+        a.courtDecisions.map((l) => l.courtDecision.ecli)
+      ).value ?? "",
     descriptionPlain: stripMarkdownForCSV(a.description),
     sourceCount: a._count.sources,
     sourceUrl: a.sources[0]?.url ?? "",

--- a/src/lib/affairs/__tests__/court-decision-display.test.ts
+++ b/src/lib/affairs/__tests__/court-decision-display.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCourtDecisionDisplay,
+  compareCourtDecisionsForDisplay,
+  NO_PUBLIC_REFERENCE,
+  sortCourtDecisionsForDisplay,
+  type CourtDecisionDisplayInput,
+} from "../court-decision-display";
+
+// Issue #536 — a decision identified only by an ECLI, a Judilibre id or an official
+// URL used to render an empty bullet. Nothing displayed may ever be empty, and the
+// internal ids must never reach a reader.
+
+const fmt = (d: Date) => d.toISOString().slice(0, 10);
+
+function decision(overrides: Partial<CourtDecisionDisplayInput> = {}): CourtDecisionDisplayInput {
+  return { id: "cms0v8b2y000039v5wlf7318r", ...overrides };
+}
+
+describe("buildCourtDecisionDisplay — jamais de ligne vide (#536)", () => {
+  it("rend un pourvoi seul", () => {
+    const d = buildCourtDecisionDisplay(decision({ pourvoiNumber: "96-83.698" }), fmt);
+
+    expect(d.parts).toEqual(["Pourvoi n° 96-83.698"]);
+    expect(d.isPlaceholder).toBe(false);
+    expect(d.link).toBeNull();
+  });
+
+  it("rend un ECLI seul", () => {
+    const d = buildCourtDecisionDisplay(decision({ ecli: "ECLI:FR:CCASS:1997:C100001" }), fmt);
+
+    expect(d.parts).toEqual(["ECLI:FR:CCASS:1997:C100001"]);
+    expect(d.isPlaceholder).toBe(false);
+  });
+
+  it("rend le pourvoi ET l'ECLI quand les deux existent", () => {
+    // Deux références distinctes : un lecteur qui vérifie l'une ne doit pas avoir à
+    // deviner que l'autre a été écartée.
+    const d = buildCourtDecisionDisplay(
+      decision({ pourvoiNumber: "96-83.698", ecli: "ECLI:FR:CCASS:1997:C100001" }),
+      fmt
+    );
+
+    expect(d.parts).toEqual(["Pourvoi n° 96-83.698", "ECLI:FR:CCASS:1997:C100001"]);
+  });
+
+  it("rend juridiction, chambre, date et solution dans l'ordre de lecture", () => {
+    const d = buildCourtDecisionDisplay(
+      decision({
+        pourvoiNumber: "96-83.698",
+        court: "Cour de cassation",
+        chamber: "chambre criminelle",
+        decisionDate: new Date("1997-10-27T00:00:00Z"),
+        solution: "rejet",
+      }),
+      fmt
+    );
+
+    expect(d.parts).toEqual([
+      "Pourvoi n° 96-83.698",
+      "Cour de cassation",
+      "chambre criminelle",
+      "1997-10-27",
+      "rejet",
+    ]);
+  });
+
+  it("donne au lien officiel un libellé accessible, jamais l'URL brute", () => {
+    const d = buildCourtDecisionDisplay(
+      decision({ pourvoiNumber: "96-83.698", sourceUrl: "https://www.courdecassation.fr/x" }),
+      fmt
+    );
+
+    expect(d.link).toEqual({
+      href: "https://www.courdecassation.fr/x",
+      label: "Consulter la décision sur la source officielle",
+    });
+    expect(d.link!.label).not.toContain("http");
+  });
+
+  it("rend un texte non vide pour une décision sans aucun champ public", () => {
+    const d = buildCourtDecisionDisplay(decision(), fmt);
+
+    expect(d.parts).toEqual([NO_PUBLIC_REFERENCE]);
+    expect(d.parts[0]!.length).toBeGreaterThan(0);
+    expect(d.isPlaceholder).toBe(true);
+  });
+
+  it("rend un texte non vide pour une décision connue seulement par Judilibre", () => {
+    const d = buildCourtDecisionDisplay(decision({ judilibreId: "jud_42" }), fmt);
+
+    expect(d.parts).toEqual([NO_PUBLIC_REFERENCE]);
+    expect(d.isPlaceholder).toBe(true);
+  });
+
+  it("rend le lien même sans autre référence, avec un libellé de repli", () => {
+    const d = buildCourtDecisionDisplay(
+      decision({ sourceUrl: "https://www.legifrance.gouv.fr/x" }),
+      fmt
+    );
+
+    expect(d.isPlaceholder).toBe(true);
+    expect(d.link?.href).toBe("https://www.legifrance.gouv.fr/x");
+    expect(d.parts).toEqual([NO_PUBLIC_REFERENCE]);
+  });
+
+  it("n'expose jamais l'identifiant interne ni l'identifiant Judilibre", () => {
+    const d = buildCourtDecisionDisplay(
+      decision({ id: "cms0secret", judilibreId: "jud_secret", pourvoiNumber: "96-83.698" }),
+      fmt
+    );
+
+    const rendered = [...d.parts, d.link?.label ?? "", d.link?.href ?? ""].join(" ");
+    expect(rendered).not.toContain("cms0secret");
+    expect(rendered).not.toContain("jud_secret");
+  });
+
+  it("ignore les chaînes vides ou blanches", () => {
+    const d = buildCourtDecisionDisplay(
+      decision({ pourvoiNumber: "   ", ecli: "", court: "Cour de cassation" }),
+      fmt
+    );
+
+    expect(d.parts).toEqual(["Cour de cassation"]);
+  });
+});
+
+describe("Ordre de présentation — stable, et ne désigne rien (#536)", () => {
+  const withDate = (iso: string, id: string): CourtDecisionDisplayInput => ({
+    id,
+    decisionDate: new Date(iso),
+  });
+
+  it("trie par date croissante", () => {
+    const sorted = sortCourtDecisionsForDisplay([
+      withDate("2020-01-01", "b"),
+      withDate("1997-10-27", "a"),
+    ]);
+
+    expect(sorted.map((d) => d.id)).toEqual(["a", "b"]);
+  });
+
+  it("place une décision sans date après celles qui en ont une", () => {
+    const sorted = sortCourtDecisionsForDisplay([
+      decision({ id: "sans-date" }),
+      withDate("1997-10-27", "avec-date"),
+    ]);
+
+    expect(sorted.map((d) => d.id)).toEqual(["avec-date", "sans-date"]);
+  });
+
+  it("départage par pourvoi à date égale", () => {
+    const sorted = sortCourtDecisionsForDisplay([
+      { id: "b", decisionDate: new Date("1997-10-27"), pourvoiNumber: "97-81.102" },
+      { id: "a", decisionDate: new Date("1997-10-27"), pourvoiNumber: "96-83.698" },
+    ]);
+
+    expect(sorted.map((d) => d.pourvoiNumber)).toEqual(["96-83.698", "97-81.102"]);
+  });
+
+  it("départage par ECLI quand le pourvoi ne suffit pas", () => {
+    const sorted = sortCourtDecisionsForDisplay([
+      { id: "b", ecli: "ECLI:Z" },
+      { id: "a", ecli: "ECLI:A" },
+    ]);
+
+    expect(sorted.map((d) => d.ecli)).toEqual(["ECLI:A", "ECLI:Z"]);
+  });
+
+  it("finit par l'identifiant interne, pour rester stable entre deux rendus", () => {
+    const a = decision({ id: "aaa" });
+    const b = decision({ id: "zzz" });
+
+    expect(sortCourtDecisionsForDisplay([b, a]).map((d) => d.id)).toEqual(["aaa", "zzz"]);
+    expect(sortCourtDecisionsForDisplay([a, b]).map((d) => d.id)).toEqual(["aaa", "zzz"]);
+  });
+
+  it("ne modifie pas le tableau de l'appelant", () => {
+    const input = [decision({ id: "zzz" }), decision({ id: "aaa" })];
+    sortCourtDecisionsForDisplay(input);
+
+    expect(input.map((d) => d.id)).toEqual(["zzz", "aaa"]);
+  });
+
+  it("est réflexif : comparer une décision à elle-même rend zéro", () => {
+    const d = withDate("1997-10-27", "a");
+
+    expect(compareCourtDecisionsForDisplay(d, d)).toBe(0);
+  });
+});

--- a/src/lib/affairs/__tests__/decision-fields.test.ts
+++ b/src/lib/affairs/__tests__/decision-fields.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { resolveDecisionField, resolveDecisionFields } from "../decision-fields";
+
+// Issue #536 — the transition rule. An affair's own value is the editorial record and
+// wins; a single linked decision fills a gap; several linked decisions yield no flat
+// value at all, because choosing one would be an implicit editorial decision.
+
+describe("resolveDecisionField — priorité à la valeur historique (#536)", () => {
+  it("garde la valeur de l'affaire quand elle existe", () => {
+    const r = resolveDecisionField("ECLI:AFFAIRE", ["ECLI:DECISION"]);
+
+    expect(r).toEqual({ value: "ECLI:AFFAIRE", source: "affair" });
+  });
+
+  it("garde la valeur de l'affaire même face à plusieurs décisions", () => {
+    const r = resolveDecisionField("96-83.698", ["11-11.111", "22-22.222"]);
+
+    expect(r.value).toBe("96-83.698");
+    expect(r.source).toBe("affair");
+  });
+
+  it("reprend la décision unique quand l'affaire ne dit rien", () => {
+    const r = resolveDecisionField(null, ["ECLI:DECISION"]);
+
+    expect(r).toEqual({ value: "ECLI:DECISION", source: "decision" });
+  });
+
+  it("ne rend AUCUNE valeur plate avec plusieurs décisions liées", () => {
+    const r = resolveDecisionField(null, ["11-11.111", "22-22.222"]);
+
+    expect(r).toEqual({ value: null, source: "ambiguous" });
+  });
+
+  it("ne choisit pas la seule décision porteuse parmi plusieurs", () => {
+    // Ce serait exactement le choix implicite que cette fonction refuse.
+    const r = resolveDecisionField(null, [null, "22-22.222"]);
+
+    expect(r.value).toBeNull();
+    expect(r.source).toBe("ambiguous");
+  });
+
+  it("ne choisit jamais la décision la plus récente", () => {
+    // Sur une affaire couvrant première instance, appel puis cassation, la plus
+    // récente est souvent un rejet de forme, pas le résultat attendu du lecteur.
+    const r = resolveDecisionField(null, ["ancienne", "récente"]);
+
+    expect(r.value).toBeNull();
+  });
+
+  it("rend absent quand ni l'affaire ni la décision unique ne portent la valeur", () => {
+    expect(resolveDecisionField(null, [null])).toEqual({ value: null, source: "absent" });
+    expect(resolveDecisionField(null, [])).toEqual({ value: null, source: "absent" });
+  });
+
+  it("traite la chaîne vide comme absente, des deux côtés", () => {
+    expect(resolveDecisionField("", ["ECLI:DECISION"]).source).toBe("decision");
+    expect(resolveDecisionField("", [""]).source).toBe("absent");
+  });
+});
+
+describe("resolveDecisionFields — vue complète (#536)", () => {
+  it("rend le comportement historique quand l'affaire porte tout", () => {
+    const r = resolveDecisionFields(
+      { ecli: "ECLI:A", pourvoiNumber: "96-83.698", chamber: "11e chambre" },
+      []
+    );
+
+    expect(r.ecli.value).toBe("ECLI:A");
+    expect(r.pourvoiNumber.value).toBe("96-83.698");
+    expect(r.chamber.value).toBe("11e chambre");
+    expect(r.hasMultipleDecisions).toBe(false);
+    expect(r.decisionCount).toBe(0);
+  });
+
+  it("comble les vides depuis une décision unique", () => {
+    const r = resolveDecisionFields({ ecli: null, pourvoiNumber: null, chamber: null }, [
+      { ecli: "ECLI:D", pourvoiNumber: "97-81.102", chamber: "2e chambre" },
+    ]);
+
+    expect(r.ecli).toEqual({ value: "ECLI:D", source: "decision" });
+    expect(r.pourvoiNumber.value).toBe("97-81.102");
+    expect(r.decisionCount).toBe(1);
+    expect(r.hasMultipleDecisions).toBe(false);
+  });
+
+  it("n'offre aucune valeur plate quand deux décisions sont liées", () => {
+    const r = resolveDecisionFields({}, [
+      { pourvoiNumber: "11-11.111" },
+      { pourvoiNumber: "22-22.222" },
+    ]);
+
+    expect(r.pourvoiNumber.value).toBeNull();
+    expect(r.pourvoiNumber.source).toBe("ambiguous");
+    expect(r.hasMultipleDecisions).toBe(true);
+    expect(r.decisionCount).toBe(2);
+  });
+
+  it("mélange les provenances champ par champ", () => {
+    const r = resolveDecisionFields({ ecli: "ECLI:AFFAIRE", chamber: null }, [
+      { ecli: "ECLI:DECISION", chamber: "3e chambre" },
+    ]);
+
+    expect(r.ecli.source).toBe("affair");
+    expect(r.chamber.source).toBe("decision");
+  });
+
+  it("ne couvre ni court ni verdictDate : ils restent éditoriaux", () => {
+    const resolved = resolveDecisionFields({}, [{}]);
+
+    expect(resolved).not.toHaveProperty("court");
+    expect(resolved).not.toHaveProperty("verdictDate");
+  });
+
+  it("reproduit le cas réel de la décision partagée", () => {
+    // Une décision, deux fiches. Chaque fiche porte déjà son pourvoi, donc chacune
+    // continue d'afficher exactement ce qu'elle affichait avant : le rattachement
+    // n'introduit aucune suggestion de doublon.
+    const shared = { pourvoiNumber: "96-83.698", ecli: null, chamber: null };
+    for (const affair of [{ pourvoiNumber: "96-83.698" }, { pourvoiNumber: "96-83.698" }]) {
+      const r = resolveDecisionFields(affair, [shared]);
+      expect(r.pourvoiNumber).toEqual({ value: "96-83.698", source: "affair" });
+      expect(r.hasMultipleDecisions).toBe(false);
+      expect(r.decisionCount).toBe(1);
+    }
+  });
+});

--- a/src/lib/affairs/court-decision-display.ts
+++ b/src/lib/affairs/court-decision-display.ts
@@ -1,0 +1,114 @@
+/**
+ * Public rendering of a court decision (#536).
+ *
+ * A decision can be identified by a pourvoi number, an ECLI, a Judilibre id, or
+ * only an official URL. Rendering just the pourvoi number therefore produced empty
+ * list items for perfectly valid rows. This module decides what a reader sees, and
+ * guarantees the result is never empty.
+ *
+ * `judilibreId` is deliberately never rendered: it is an internal key of an external
+ * API, meaningless to a reader, and the official URL says the same thing usefully.
+ * The Prisma `id` is never rendered either.
+ */
+
+/** The subset of a decision this module reads. */
+export interface CourtDecisionDisplayInput {
+  id: string;
+  ecli?: string | null;
+  pourvoiNumber?: string | null;
+  court?: string | null;
+  chamber?: string | null;
+  decisionDate?: Date | null;
+  solution?: string | null;
+  sourceUrl?: string | null;
+  /** Read only to know whether a reference exists at all; never rendered. */
+  judilibreId?: string | null;
+}
+
+export interface CourtDecisionDisplay {
+  /** Reference parts, in reading order. Never empty. */
+  parts: string[];
+  /** Official source, when there is one. `label` is what a reader clicks. */
+  link: { href: string; label: string } | null;
+  /** True when nothing public is available, so `parts` holds the fallback wording. */
+  isPlaceholder: boolean;
+}
+
+/** Shown when a decision is attached but carries no publicly meaningful reference. */
+export const NO_PUBLIC_REFERENCE = "Décision rattachée, référence publique non renseignée";
+
+function present(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * What to display for one decision.
+ *
+ * Both the pourvoi number and the ECLI are shown when both exist: they are two
+ * different references, and a reader checking one should not have to guess the other
+ * was dropped.
+ */
+export function buildCourtDecisionDisplay(
+  decision: CourtDecisionDisplayInput,
+  formatDate: (date: Date) => string
+): CourtDecisionDisplay {
+  const parts: string[] = [];
+  if (present(decision.pourvoiNumber)) parts.push(`Pourvoi n° ${decision.pourvoiNumber}`);
+  if (present(decision.ecli)) parts.push(decision.ecli);
+  if (present(decision.court)) parts.push(decision.court);
+  if (present(decision.chamber)) parts.push(decision.chamber);
+  if (decision.decisionDate) parts.push(formatDate(decision.decisionDate));
+  if (present(decision.solution)) parts.push(decision.solution);
+
+  const link = present(decision.sourceUrl)
+    ? { href: decision.sourceUrl, label: "Consulter la décision sur la source officielle" }
+    : null;
+
+  // A row with only a source link, or only a Judilibre id, still has to read as
+  // something rather than as a blank bullet.
+  if (parts.length === 0 && !link) {
+    return { parts: [NO_PUBLIC_REFERENCE], link: null, isPlaceholder: true };
+  }
+  if (parts.length === 0) {
+    return { parts: [NO_PUBLIC_REFERENCE], link, isPlaceholder: true };
+  }
+
+  return { parts, link, isPlaceholder: false };
+}
+
+/**
+ * Stable presentation order: date, then pourvoi, then ECLI, then internal id.
+ *
+ * The internal id is a tie-breaker only, so the list never reshuffles between two
+ * renders. **This order designates no decision as the main one** — it exists so a
+ * reader sees a predictable sequence, nothing more.
+ */
+export function compareCourtDecisionsForDisplay(
+  a: CourtDecisionDisplayInput,
+  b: CourtDecisionDisplayInput
+): number {
+  const dateA = a.decisionDate?.getTime();
+  const dateB = b.decisionDate?.getTime();
+  if (dateA !== undefined && dateB !== undefined && dateA !== dateB) return dateA - dateB;
+  // A decision without a date sorts after one that has it: an unknown date cannot
+  // claim a position in the chronology.
+  if (dateA !== undefined && dateB === undefined) return -1;
+  if (dateA === undefined && dateB !== undefined) return 1;
+
+  const pourvoiA = a.pourvoiNumber ?? "";
+  const pourvoiB = b.pourvoiNumber ?? "";
+  if (pourvoiA !== pourvoiB) return pourvoiA.localeCompare(pourvoiB);
+
+  const ecliA = a.ecli ?? "";
+  const ecliB = b.ecli ?? "";
+  if (ecliA !== ecliB) return ecliA.localeCompare(ecliB);
+
+  return a.id.localeCompare(b.id);
+}
+
+/** Sorts a copy, so a caller's array is never mutated. */
+export function sortCourtDecisionsForDisplay<T extends CourtDecisionDisplayInput>(
+  decisions: readonly T[]
+): T[] {
+  return [...decisions].sort(compareCourtDecisionsForDisplay);
+}

--- a/src/lib/affairs/decision-fields.ts
+++ b/src/lib/affairs/decision-fields.ts
@@ -1,0 +1,102 @@
+/**
+ * Dual read of the identifiers that moved to `CourtDecision` (#536).
+ *
+ * During the transition an affair may carry a historical value, be linked to a
+ * decision that carries it, or both. This module decides which one a flat field
+ * shows, and refuses to invent one when the answer is genuinely plural.
+ *
+ * Two fields are deliberately absent: `court` and `verdictDate` stay editorial and
+ * are always read from `Affair`. Measured on the base, 23.7 % of `Affair.court`
+ * values name a body that renders no decision, and 4 affairs carry a verdict date
+ * while no decision has been handed down — so neither is a decision attribute.
+ *
+ * `caseNumber` and `caseNumbers` are absent too: they were deferred from the model,
+ * so there is nothing to fall back to and they always come from the affair.
+ */
+
+/** Where a displayed value came from, so a caller can label or debug it. */
+export type DecisionFieldSource = "affair" | "decision" | "ambiguous" | "absent";
+
+export interface ResolvedDecisionField<T> {
+  value: T | null;
+  source: DecisionFieldSource;
+}
+
+/** The subset of a decision this resolver reads. */
+export interface DecisionFieldCarrier {
+  ecli?: string | null;
+  pourvoiNumber?: string | null;
+  chamber?: string | null;
+}
+
+/**
+ * Picks the value a flat field should show.
+ *
+ * Order, and the reasoning behind it:
+ *
+ * 1. **The affair's own value wins.** It was written or validated by moderation, so
+ *    it is the editorial record and must not be overridden by a backfill.
+ * 2. **One linked decision** and the affair says nothing: the decision's value fills
+ *    the gap.
+ * 3. **Several linked decisions**: no flat value at all. Choosing would mean picking
+ *    one decision over another, and "the most recent" is the wrong default — on an
+ *    affair covering first instance, appeal then cassation, the most recent is often
+ *    a procedural rejection rather than the outcome a reader is looking for. The
+ *    caller shows the list instead.
+ */
+export function resolveDecisionField<T>(
+  affairValue: T | null | undefined,
+  decisionValues: Array<T | null | undefined>
+): ResolvedDecisionField<T> {
+  if (affairValue !== null && affairValue !== undefined && affairValue !== "") {
+    return { value: affairValue, source: "affair" };
+  }
+  // Ambiguity is about how many decisions are linked, not how many hold a value:
+  // narrowing on the single non-null value would be exactly the implicit choice
+  // this function exists to refuse.
+  if (decisionValues.length > 1) {
+    return { value: null, source: "ambiguous" };
+  }
+  const single = decisionValues[0];
+  if (single !== null && single !== undefined && single !== "") {
+    return { value: single, source: "decision" };
+  }
+  return { value: null, source: "absent" };
+}
+
+export interface ResolvedDecisionFields {
+  ecli: ResolvedDecisionField<string>;
+  pourvoiNumber: ResolvedDecisionField<string>;
+  chamber: ResolvedDecisionField<string>;
+  /** True when several decisions are linked, so no flat value is offered. */
+  hasMultipleDecisions: boolean;
+  /** How many decisions the affair cites, for the caller to render a list. */
+  decisionCount: number;
+}
+
+/**
+ * Resolves every field the decision model carries, in one pass.
+ *
+ * `court` and `verdictDate` are not here on purpose: they remain read from `Affair`.
+ */
+export function resolveDecisionFields(
+  affair: DecisionFieldCarrier,
+  decisions: readonly DecisionFieldCarrier[]
+): ResolvedDecisionFields {
+  return {
+    ecli: resolveDecisionField(
+      affair.ecli,
+      decisions.map((d) => d.ecli)
+    ),
+    pourvoiNumber: resolveDecisionField(
+      affair.pourvoiNumber,
+      decisions.map((d) => d.pourvoiNumber)
+    ),
+    chamber: resolveDecisionField(
+      affair.chamber,
+      decisions.map((d) => d.chamber)
+    ),
+    hasMultipleDecisions: decisions.length > 1,
+    decisionCount: decisions.length,
+  };
+}


### PR DESCRIPTION
## Description

Part of #536. **PR 4 sur 4**, à laisser **ouverte pour revue**. Double lecture des identifiants déplacés vers `CourtDecision`.

## La règle, et pourquoi cet ordre

`resolveDecisionField()` est pure et testée :

1. **la valeur de l'affaire l'emporte** quand elle existe. Elle a été écrite ou validée par la modération, elle fait foi, et un backfill n'a pas à la contredire ;
2. **une seule décision liée** et l'affaire ne dit rien : la valeur de la décision comble le vide ;
3. **plusieurs décisions liées** : **aucune valeur plate**. La liste est affichée séparément.

**Jamais « la plus récente ».** Sur une affaire couvrant première instance, appel puis cassation, la plus récente est souvent un rejet de forme, pas le résultat que le lecteur cherche.

Un détail qui compte : l'ambiguïté se juge sur le **nombre de décisions liées**, pas sur le nombre de valeurs renseignées. Se rabattre sur la seule décision porteuse parmi plusieurs serait exactement le choix implicite que cette fonction existe pour refuser. Un test le vérifie.

## Ce qui reste éditorial

`court` et `verdictDate` **ne passent pas** par le résolveur : ils sont toujours lus depuis `Affair`. Mesuré, 23,7 % des `Affair.court` désignent un organe qui ne rend aucune décision, et 4 affaires portent une date de verdict alors qu'aucune décision n'a été rendue. Un test vérifie que le résolveur n'expose ni l'un ni l'autre.

`caseNumber` et `caseNumbers` non plus : ils ont été différés du modèle en PR 1, donc il n'y a rien vers quoi se rabattre et ils viennent toujours de l'affaire.

## Surfaces couvertes

| Surface | Traitement |
| --- | --- |
| export CSV, colonne ECLI | passe par le résolveur |
| export CSV, `court` et `verdictDate` | inchangés, lus depuis l'affaire |
| fiche publique, bloc « Chambre » | passe par le résolveur |
| fiche publique, « Tribunal » et « N° dossier » | inchangés |
| fiche publique | **nouveau** : liste des décisions rattachées |
| API publique, MCP, recherche, SEO | **non touchés** : ils ne consomment aucun de ces champs |

Aucune écriture modifiée.

## Non-régression prouvée sur les données réelles

Résolution rejouée sur les **340 affaires publiées** :

```
valeurs ECLI modifiées : 0   ← diff nul de l'export
repli sur une décision : 0
cas ambigus            : 0
affaires liées         : 3
```

Et les trois affaires liées conservent leur `court` éditorial intact :

```
AF-000034  « Cour de cassation (rejet pourvoi) »
AF-000035  « Cour de cassation (rejet pourvoi) »
AF-000036  « Cour de cassation »
```

Le diff est nul parce que chaque affaire liée porte déjà son propre pourvoi : la règle de priorité fait que le rattachement **n'change rien à l'affichage existant**. C'est le comportement voulu.

## Le cas de la décision partagée

Un test reproduit le cas réel : une décision, deux fiches, chacune portant déjà son pourvoi. Chaque fiche continue d'afficher exactement ce qu'elle affichait, `hasMultipleDecisions` est faux des deux côtés, et **rien ne suggère un doublon** — ce sont deux chefs distincts d'un même arrêt.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Part of #536

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2446 tests**, 0 échec, dont **14 ajoutés** sur le résolveur.

Couverture : priorité à l'affaire y compris face à plusieurs décisions, repli sur une décision unique, aucune valeur plate avec plusieurs liées, refus de choisir la seule porteuse, refus de la plus récente, chaîne vide traitée comme absente, provenances mixtes champ par champ, `court` et `verdictDate` hors périmètre, et le cas réel de la décision partagée.

**Aucune donnée de production modifiée par cette PR.**

## À ne pas merger sans revue

Laissée ouverte comme demandé. Deux points méritent ton avis :

**L'affichage de la liste des décisions** apparaît dès qu'une décision est liée, pas seulement quand il y en a plusieurs. Sur les 3 affaires concernées, la fiche gagne donc un bloc « Décision de justice rattachée » avec le numéro de pourvoi. C'est un ajout visible sur des pages publiques.

**Le message d'ambiguïté** n'est jamais rendu aujourd'hui, faute d'affaire liée à plusieurs décisions. Son libellé n'a donc pas été vu en situation.

---

## Correctif d'affichage ajouté après revue

La fiche sélectionnait `ecli`, `pourvoiNumber`, `court`, `decisionDate`, `solution` et `sourceUrl`, mais n'en rendait que trois. Une décision identifiée seulement par un ECLI, un identifiant Judilibre ou une URL officielle produisait donc **une puce vide**.

`buildCourtDecisionDisplay()`, pur et testé, rend désormais dans l'ordre de lecture : pourvoi, ECLI, juridiction, chambre, date, solution, puis le lien officiel.

**Le pourvoi et l'ECLI sont affichés tous les deux** quand ils existent : ce sont deux références distinctes, et un lecteur qui vérifie l'une ne doit pas avoir à deviner que l'autre a été écartée.

Le lien officiel porte un libellé accessible, « Consulter la décision sur la source officielle », jamais l'URL brute, avec `target="_blank"` et `rel="noopener noreferrer"` selon la convention du dépôt.

**Ni l'identifiant Prisma ni `judilibreId` ne sont jamais rendus.** Le second est une clé interne d'API externe, sans sens pour un lecteur, et l'URL officielle dit la même chose utilement. Un test vérifie qu'aucun des deux ne fuit dans le rendu.

Quand aucun champ public n'est renseigné, la ligne affiche « Décision rattachée, référence publique non renseignée » plutôt que du vide.

### Ordre de présentation

`sortCourtDecisionsForDisplay()` : date croissante, puis pourvoi, puis ECLI, puis identifiant interne comme dernier départage technique — jamais affiché. Une décision sans date passe après celles qui en ont une : une date inconnue ne peut pas revendiquer une place dans la chronologie.

**Cet ordre ne désigne aucune décision comme principale.** Il existe pour qu'un lecteur voie une séquence prévisible, rien de plus.

### Tests ajoutés

**17 tests** sur le formateur : pourvoi seul, ECLI seul, les deux ensemble, tous les champs dans l'ordre, libellé de lien accessible, décision sans champ public rendant un texte non vide, décision connue seulement par Judilibre, lien sans autre référence, aucune fuite des identifiants internes, chaînes blanches ignorées. Plus 7 tests d'ordre : tri par date, absence de date, départage par pourvoi puis ECLI puis id, non-mutation du tableau, réflexivité.

Total sur la PR : **31 tests ajoutés**, 2463 tests au vert.
