### PR TITLE
Gérer les liaisons entre affaire et décision depuis l'admin

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CourtDecisionLinks } from "@/components/admin/CourtDecisionLinks";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -24,6 +25,12 @@ async function getAffair(id: string) {
     include: {
       politician: { select: { id: true, fullName: true, slug: true } },
       sources: { orderBy: { publishedAt: "desc" } },
+      // Links only: this surface manages the affair ↔ decision relation, never the
+      // decision catalogue itself (#536).
+      courtDecisions: {
+        select: { notes: true, courtDecision: true },
+        orderBy: { createdAt: "asc" },
+      },
     },
   });
 }
@@ -263,6 +270,25 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
               </li>
             ))}
           </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          <CourtDecisionLinks
+            affairId={affair.id}
+            initialLinks={affair.courtDecisions.map((link) => ({
+              id: link.courtDecision.id,
+              ecli: link.courtDecision.ecli,
+              pourvoiNumber: link.courtDecision.pourvoiNumber,
+              court: link.courtDecision.court,
+              chamber: link.courtDecision.chamber,
+              decisionDate: link.courtDecision.decisionDate?.toISOString() ?? null,
+              solution: link.courtDecision.solution,
+              sourceUrl: link.courtDecision.sourceUrl,
+              linkNotes: link.notes,
+            }))}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/api/admin/affaires/[id]/decisions/route.ts
+++ b/src/app/api/admin/affaires/[id]/decisions/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import {
+  linkCourtDecisionSchema,
+  unlinkCourtDecisionSchema,
+  updateCourtDecisionLinkSchema,
+  type LinkCourtDecisionBody,
+  type UnlinkCourtDecisionBody,
+  type UpdateCourtDecisionLinkBody,
+} from "@/lib/security/schemas/court-decision";
+import { invalidateEntity } from "@/lib/cache";
+
+/**
+ * Affair ↔ court decision links, from the admin (#536).
+ *
+ * Manages links only. No route here creates, edits or deletes a `CourtDecision`:
+ * an unlink removes the join row and nothing else, and an orphaned decision is left
+ * in place rather than cleaned up — a decision outlives the fiches citing it.
+ *
+ * None of these routes touches an affair's historical fields (`ecli`,
+ * `pourvoiNumber`, `court`, `verdictDate`, `chamber`, `caseNumber`).
+ */
+
+async function readAffairAndDecision(affairId: string, courtDecisionId: string) {
+  // Re-read both rows before writing: the caller's view can be stale, and linking a
+  // decision that has since been removed would leave a dangling reference.
+  const [affair, decision] = await Promise.all([
+    db.affair.findUnique({
+      where: { id: affairId },
+      select: { id: true, politician: { select: { slug: true } } },
+    }),
+    db.courtDecision.findUnique({ where: { id: courtDecisionId }, select: { id: true } }),
+  ]);
+  return { affair, decision };
+}
+
+/** Links an existing decision to the affair. Idempotent. */
+export const POST = withAdminAuth(
+  withValidation(linkCourtDecisionSchema, async (request, context, body: LinkCourtDecisionBody) => {
+    const { id: affairId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { affair, decision } = await readAffairAndDecision(affairId, body.courtDecisionId);
+
+    if (!affair) return NextResponse.json({ error: "Affaire non trouvée" }, { status: 404 });
+    if (!decision) return NextResponse.json({ error: "Décision non trouvée" }, { status: 404 });
+
+    const meta = getRequestMeta(request);
+    // One transaction: a link without its audit entry would leave no trace of who
+    // attached which decision to which fiche.
+    const created = await db.$transaction(async (tx) => {
+      const existing = await tx.affairCourtDecision.findUnique({
+        where: {
+          affairId_courtDecisionId: { affairId, courtDecisionId: body.courtDecisionId },
+        },
+        select: { affairId: true },
+      });
+      if (existing) return false;
+
+      await tx.affairCourtDecision.create({
+        data: {
+          affairId,
+          courtDecisionId: body.courtDecisionId,
+          notes: body.notes ?? null,
+        },
+      });
+      await tx.auditLog.create({
+        data: {
+          action: "CREATE",
+          entityType: "AffairCourtDecision",
+          entityId: affairId,
+          changes: { courtDecisionId: body.courtDecisionId, notes: body.notes ?? null },
+          ipAddress: meta.ip,
+          userAgent: meta.userAgent,
+        },
+      });
+      return true;
+    });
+
+    // After the transaction commits, never before.
+    invalidateEntity("affair");
+    if (affair.politician?.slug) invalidateEntity("politician", affair.politician.slug);
+
+    return NextResponse.json({ success: true, created });
+  })
+);
+
+/** Adds or clears the link note. Never touches the decision itself. */
+export const PATCH = withAdminAuth(
+  withValidation(
+    updateCourtDecisionLinkSchema,
+    async (request, context, body: UpdateCourtDecisionLinkBody) => {
+      const { id: affairId } = await (context as { params: Promise<{ id: string }> }).params;
+      const { affair, decision } = await readAffairAndDecision(affairId, body.courtDecisionId);
+
+      if (!affair) return NextResponse.json({ error: "Affaire non trouvée" }, { status: 404 });
+      if (!decision) return NextResponse.json({ error: "Décision non trouvée" }, { status: 404 });
+
+      const meta = getRequestMeta(request);
+      const updated = await db.$transaction(async (tx) => {
+        const existing = await tx.affairCourtDecision.findUnique({
+          where: {
+            affairId_courtDecisionId: { affairId, courtDecisionId: body.courtDecisionId },
+          },
+          select: { notes: true },
+        });
+        if (!existing) return null;
+
+        await tx.affairCourtDecision.update({
+          where: {
+            affairId_courtDecisionId: { affairId, courtDecisionId: body.courtDecisionId },
+          },
+          data: { notes: body.notes },
+        });
+        await tx.auditLog.create({
+          data: {
+            action: "UPDATE",
+            entityType: "AffairCourtDecision",
+            entityId: affairId,
+            changes: {
+              courtDecisionId: body.courtDecisionId,
+              notes: body.notes,
+              previousNotes: existing.notes,
+            },
+            ipAddress: meta.ip,
+            userAgent: meta.userAgent,
+          },
+        });
+        return true;
+      });
+
+      if (updated === null) {
+        return NextResponse.json({ error: "Liaison non trouvée" }, { status: 404 });
+      }
+
+      invalidateEntity("affair");
+      if (affair.politician?.slug) invalidateEntity("politician", affair.politician.slug);
+
+      return NextResponse.json({ success: true });
+    }
+  )
+);
+
+/**
+ * Removes the link. Deletes only `AffairCourtDecision`.
+ *
+ * The decision stays in place even if no affair cites it any more: it is an official
+ * record, not a by-product of the fiche.
+ */
+export const DELETE = withAdminAuth(
+  withValidation(
+    unlinkCourtDecisionSchema,
+    async (request, context, body: UnlinkCourtDecisionBody) => {
+      const { id: affairId } = await (context as { params: Promise<{ id: string }> }).params;
+      const { affair } = await readAffairAndDecision(affairId, body.courtDecisionId);
+
+      if (!affair) return NextResponse.json({ error: "Affaire non trouvée" }, { status: 404 });
+
+      const meta = getRequestMeta(request);
+      const deleted = await db.$transaction(async (tx) => {
+        const result = await tx.affairCourtDecision.deleteMany({
+          where: { affairId, courtDecisionId: body.courtDecisionId },
+        });
+        if (result.count === 0) return false;
+
+        await tx.auditLog.create({
+          data: {
+            action: "DELETE",
+            entityType: "AffairCourtDecision",
+            entityId: affairId,
+            changes: {
+              courtDecisionId: body.courtDecisionId,
+              // Said explicitly so an audit reader knows the decision survived.
+              courtDecisionDeleted: false,
+            },
+            ipAddress: meta.ip,
+            userAgent: meta.userAgent,
+          },
+        });
+        return true;
+      });
+
+      invalidateEntity("affair");
+      if (affair.politician?.slug) invalidateEntity("politician", affair.politician.slug);
+
+      return NextResponse.json({ success: true, deleted });
+    }
+  )
+);

--- a/src/app/api/admin/affaires/__tests__/court-decision-link-routes.test.ts
+++ b/src/app/api/admin/affaires/__tests__/court-decision-link-routes.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Issue #536 — admin management of affair ↔ decision links.
+ *
+ * What these tests defend: an unlink removes the join row and nothing else, a link is
+ * idempotent, every write leaves an audit entry in the same transaction, caches are
+ * invalidated only after the commit, and no route can reach a decision's own row.
+ */
+
+const order: string[] = [];
+
+const h = vi.hoisted(() => ({
+  affairFindUnique: vi.fn(),
+  decisionFindUnique: vi.fn(),
+  decisionFindMany: vi.fn(),
+  linkFindUnique: vi.fn(),
+  linkCreate: vi.fn(),
+  linkUpdate: vi.fn(),
+  linkDeleteMany: vi.fn(),
+  auditCreate: vi.fn(),
+  invalidateEntity: vi.fn(),
+  adminGuard: vi.fn(),
+}));
+
+let rolledBack = false;
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    affair: { findUnique: h.affairFindUnique },
+    courtDecision: { findUnique: h.decisionFindUnique, findMany: h.decisionFindMany },
+    $transaction: async (fn: (t: unknown) => unknown) => {
+      try {
+        return await fn({
+          affairCourtDecision: {
+            findUnique: h.linkFindUnique,
+            create: h.linkCreate,
+            update: h.linkUpdate,
+            deleteMany: h.linkDeleteMany,
+          },
+          auditLog: { create: h.auditCreate },
+        });
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    },
+  },
+}));
+vi.mock("@/lib/cache", () => ({ invalidateEntity: h.invalidateEntity }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) => {
+    // Records that the guard wrapped the handler, and lets a test refuse the call.
+    h.adminGuard();
+    return fn(req, ctx);
+  },
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "203.0.113.1", userAgent: "test-agent" }),
+}));
+
+import {
+  POST as linkPOST,
+  PATCH as notePATCH,
+  DELETE as unlinkDELETE,
+} from "@/app/api/admin/affaires/[id]/decisions/route";
+import { GET as searchGET } from "@/app/api/admin/court-decisions/search/route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ctx: any = { params: Promise.resolve({ id: "a1" }) };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function req(body: unknown, method = "POST"): any {
+  return new Request("http://test/api", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function searchReq(q: string): any {
+  return new Request(`http://test/api/admin/court-decisions/search?q=${encodeURIComponent(q)}`);
+}
+
+const AFFAIR = { id: "a1", politician: { slug: "jean-dupont" } };
+const DECISION = { id: "dec_1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  rolledBack = false;
+  h.affairFindUnique.mockResolvedValue(AFFAIR);
+  h.decisionFindUnique.mockResolvedValue(DECISION);
+  h.decisionFindMany.mockResolvedValue([]);
+  h.linkFindUnique.mockResolvedValue(null);
+  h.linkCreate.mockImplementation(async () => {
+    order.push("link");
+    return {};
+  });
+  h.linkUpdate.mockImplementation(async () => {
+    order.push("update");
+    return {};
+  });
+  h.linkDeleteMany.mockImplementation(async () => {
+    order.push("delete");
+    return { count: 1 };
+  });
+  h.auditCreate.mockImplementation(async () => {
+    order.push("audit");
+    return {};
+  });
+  h.invalidateEntity.mockImplementation(() => {
+    order.push("invalidate");
+  });
+});
+
+describe("Recherche de décisions existantes (#536)", () => {
+  it("cherche par ECLI exact", async () => {
+    await searchGET(searchReq("ECLI:FR:CCASS:1997:C100001"), ctx);
+
+    const where = h.decisionFindMany.mock.calls[0]![0].where;
+    expect(where.OR).toEqual(expect.arrayContaining([{ ecli: "ECLI:FR:CCASS:1997:C100001" }]));
+  });
+
+  it("cherche par judilibreId exact", async () => {
+    await searchGET(searchReq("jud_42"), ctx);
+
+    const where = h.decisionFindMany.mock.calls[0]![0].where;
+    expect(where.OR).toEqual(expect.arrayContaining([{ judilibreId: "jud_42" }]));
+  });
+
+  it("cherche par pourvoi normalisé", async () => {
+    await searchGET(searchReq("96-83.698"), ctx);
+
+    const where = h.decisionFindMany.mock.calls[0]![0].where;
+    expect(where.OR).toEqual(
+      expect.arrayContaining([{ pourvoiNumberNormalized: { contains: "9683698" } }])
+    );
+  });
+
+  it("rend toujours une LISTE, même pour un pourvoi partagé", async () => {
+    h.decisionFindMany.mockResolvedValue([
+      { id: "dec_1", pourvoiNumber: "96-83.698", _count: { affairs: 2 } },
+      { id: "dec_2", pourvoiNumber: "96-83.698", _count: { affairs: 1 } },
+    ]);
+
+    const res = await searchGET(searchReq("96-83.698"), ctx);
+    const body = await res.json();
+
+    // Un pourvoi peut produire plusieurs décisions : aucune n'est présentée comme
+    // la bonne.
+    expect(body.results).toHaveLength(2);
+    expect(body.total).toBe(2);
+    expect(body.results[0].linkedAffairCount).toBe(2);
+  });
+
+  it("refuse un terme trop court", async () => {
+    const res = await searchGET(searchReq("a"), ctx);
+
+    expect(res.status).toBe(400);
+    expect(h.decisionFindMany).not.toHaveBeenCalled();
+  });
+
+  it("passe par la garde admin", async () => {
+    await searchGET(searchReq("96-83.698"), ctx);
+
+    expect(h.adminGuard).toHaveBeenCalled();
+  });
+});
+
+describe("Liaison (#536)", () => {
+  it("lie une décision et consigne l'audit dans la même transaction", async () => {
+    const res = await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ created: true });
+    expect(order.slice(0, 2)).toEqual(["link", "audit"]);
+  });
+
+  it("est idempotente : une liaison existante ne crée pas de doublon", async () => {
+    h.linkFindUnique.mockResolvedValue({ affairId: "a1" });
+
+    const res = await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+
+    await expect(res.json()).resolves.toMatchObject({ created: false });
+    expect(h.linkCreate).not.toHaveBeenCalled();
+    expect(h.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it("renvoie 404 sur une affaire inexistante", async () => {
+    h.affairFindUnique.mockResolvedValue(null);
+
+    const res = await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+
+    expect(res.status).toBe(404);
+    expect(h.linkCreate).not.toHaveBeenCalled();
+  });
+
+  it("renvoie 404 sur une décision inexistante", async () => {
+    h.decisionFindUnique.mockResolvedValue(null);
+
+    const res = await linkPOST(req({ courtDecisionId: "absente" }), ctx);
+
+    expect(res.status).toBe(404);
+    expect(h.linkCreate).not.toHaveBeenCalled();
+  });
+
+  it("invalide les caches seulement après le commit", async () => {
+    await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+
+    expect(order).toEqual(["link", "audit", "invalidate", "invalidate"]);
+  });
+
+  it("annule la liaison si l'audit échoue", async () => {
+    h.auditCreate.mockRejectedValue(new Error("audit failed"));
+
+    await expect(linkPOST(req({ courtDecisionId: "dec_1" }), ctx)).rejects.toThrow("audit failed");
+
+    expect(rolledBack).toBe(true);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+});
+
+describe("Note de liaison (#536)", () => {
+  it("met la note à jour et garde l'ancienne valeur en audit", async () => {
+    h.linkFindUnique.mockResolvedValue({ notes: "ancienne" });
+
+    const res = await notePATCH(
+      req({ courtDecisionId: "dec_1", notes: "deux chefs" }, "PATCH"),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(h.linkUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { notes: "deux chefs" } })
+    );
+    expect(h.auditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          changes: expect.objectContaining({ notes: "deux chefs", previousNotes: "ancienne" }),
+        }),
+      })
+    );
+  });
+
+  it("renvoie 404 quand la liaison n'existe pas", async () => {
+    h.linkFindUnique.mockResolvedValue(null);
+
+    const res = await notePATCH(req({ courtDecisionId: "dec_1", notes: null }, "PATCH"), ctx);
+
+    expect(res.status).toBe(404);
+    expect(h.linkUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("Retrait de liaison (#536)", () => {
+  it("supprime la liaison, jamais la décision", async () => {
+    const res = await unlinkDELETE(
+      req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(h.linkDeleteMany).toHaveBeenCalledWith({
+      where: { affairId: "a1", courtDecisionId: "dec_1" },
+    });
+    // Le client de transaction simulé n'expose aucune suppression de décision : si la
+    // route en tentait une, l'appel échouerait.
+    expect(h.auditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entityType: "AffairCourtDecision",
+          changes: expect.objectContaining({ courtDecisionDeleted: false }),
+        }),
+      })
+    );
+  });
+
+  it("laisse une décision orpheline en base", async () => {
+    // Aucun appel de nettoyage : une décision survit aux fiches qui la citaient.
+    await unlinkDELETE(req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"), ctx);
+
+    expect(order.filter((o) => o === "delete")).toHaveLength(1);
+    expect(order).not.toContain("deleteDecision");
+  });
+
+  it("invalide les caches seulement après le commit", async () => {
+    await unlinkDELETE(req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"), ctx);
+
+    expect(order).toEqual(["delete", "audit", "invalidate", "invalidate"]);
+  });
+
+  it("annule le retrait si l'audit échoue", async () => {
+    h.auditCreate.mockRejectedValue(new Error("audit failed"));
+
+    await expect(
+      unlinkDELETE(req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"), ctx)
+    ).rejects.toThrow("audit failed");
+
+    expect(rolledBack).toBe(true);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("renvoie 404 sur une affaire inexistante", async () => {
+    h.affairFindUnique.mockResolvedValue(null);
+
+    const res = await unlinkDELETE(
+      req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"),
+      ctx
+    );
+
+    expect(res.status).toBe(404);
+    expect(h.linkDeleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("Périmètre : la route ne touche pas au catalogue (#536)", () => {
+  it("n'appelle jamais une création ou une suppression de décision", async () => {
+    await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+    await notePATCH(req({ courtDecisionId: "dec_1", notes: "x" }, "PATCH"), ctx);
+    await unlinkDELETE(req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"), ctx);
+
+    // Seule la lecture est exposée sur le modèle de décision.
+    expect(h.decisionFindUnique).toHaveBeenCalled();
+    const decisionMock = h.decisionFindUnique.mock;
+    expect(decisionMock).toBeDefined();
+  });
+
+  it("chaque écriture passe par la garde admin", async () => {
+    await linkPOST(req({ courtDecisionId: "dec_1" }), ctx);
+    await unlinkDELETE(req({ courtDecisionId: "dec_1", confirmed: true }, "DELETE"), ctx);
+
+    expect(h.adminGuard).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/api/admin/court-decisions/search/route.ts
+++ b/src/app/api/admin/court-decisions/search/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { normalizePourvoiNumber } from "@/services/affairs/court-decisions";
+
+/**
+ * Search among decisions that already exist (#536).
+ *
+ * Read-only, and it never creates a decision: the admin surface manages links, not
+ * the decision catalogue. Creation belongs to #337.
+ *
+ * A pourvoi search always returns a list. A pourvoi can produce several decisions
+ * (rejection, partial cassation, remand), so assuming uniqueness here would hand the
+ * administrator one row and hide the others.
+ */
+export const GET = withAdminAuth(async (request) => {
+  const term = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+  if (term.length < 2) {
+    return NextResponse.json({ error: "Terme de recherche trop court" }, { status: 400 });
+  }
+
+  const normalized = normalizePourvoiNumber(term);
+
+  const decisions = await db.courtDecision.findMany({
+    where: {
+      OR: [
+        { ecli: term },
+        { judilibreId: term },
+        // Normalised, so « 96-83.698 » and « 9683698 » find the same rows. `contains`
+        // is for ergonomics on a partial number, not an identity rule.
+        ...(normalized.length >= 2
+          ? [{ pourvoiNumberNormalized: { contains: normalized } as const }]
+          : []),
+      ],
+    },
+    select: {
+      id: true,
+      ecli: true,
+      pourvoiNumber: true,
+      court: true,
+      chamber: true,
+      decisionDate: true,
+      solution: true,
+      sourceUrl: true,
+      _count: { select: { affairs: true } },
+    },
+    orderBy: [{ decisionDate: "asc" }, { pourvoiNumber: "asc" }],
+    take: 25,
+  });
+
+  return NextResponse.json({
+    // Always a list, never a single match: the caller must see every candidate.
+    results: decisions.map((d) => ({ ...d, linkedAffairCount: d._count.affairs })),
+    total: decisions.length,
+  });
+});

--- a/src/components/admin/CourtDecisionLinks.tsx
+++ b/src/components/admin/CourtDecisionLinks.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, ExternalLink, Loader2, Search, Unlink } from "lucide-react";
+
+/**
+ * Manage the links between an affair and existing court decisions (#536).
+ *
+ * Links only. Nothing here creates, edits or deletes a decision: that belongs to
+ * #337, once the identity rules are settled. A search by pourvoi number always shows
+ * every candidate, because a pourvoi can produce several decisions.
+ */
+
+interface DecisionSummary {
+  id: string;
+  ecli: string | null;
+  pourvoiNumber: string | null;
+  court: string | null;
+  chamber: string | null;
+  decisionDate: string | null;
+  solution: string | null;
+  sourceUrl: string | null;
+  linkedAffairCount?: number;
+}
+
+interface LinkedDecision extends DecisionSummary {
+  linkNotes: string | null;
+}
+
+interface Props {
+  affairId: string;
+  initialLinks: LinkedDecision[];
+}
+
+function DecisionFields({ decision }: { decision: DecisionSummary }) {
+  const rows: Array<[string, string | null]> = [
+    ["ECLI", decision.ecli],
+    ["N° de pourvoi", decision.pourvoiNumber],
+    ["Juridiction", decision.court],
+    ["Chambre", decision.chamber],
+    ["Date", decision.decisionDate ? decision.decisionDate.slice(0, 10) : null],
+    ["Sens", decision.solution],
+  ];
+  const filled = rows.filter(([, value]) => value);
+
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+      {filled.length === 0 && (
+        <div className="col-span-2 text-muted-foreground">Aucune référence publique renseignée</div>
+      )}
+      {filled.map(([label, value]) => (
+        <div key={label} className="flex gap-2">
+          <dt className="text-muted-foreground">{label}</dt>
+          <dd className="font-mono text-xs break-all">{value}</dd>
+        </div>
+      ))}
+      {decision.sourceUrl && (
+        <div className="col-span-2">
+          <a
+            href={decision.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 underline underline-offset-4"
+          >
+            Consulter la source officielle
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        </div>
+      )}
+    </dl>
+  );
+}
+
+export function CourtDecisionLinks({ affairId, initialLinks }: Props) {
+  const [links, setLinks] = useState<LinkedDecision[]>(initialLinks);
+  const [term, setTerm] = useState("");
+  const [results, setResults] = useState<DecisionSummary[] | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>(
+    Object.fromEntries(initialLinks.map((l) => [l.id, l.linkNotes ?? ""]))
+  );
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLinks(initialLinks);
+  }, [initialLinks]);
+
+  const call = useCallback(async (url: string, init: RequestInit, key: string) => {
+    setBusy(key);
+    setError(null);
+    try {
+      const res = await fetch(url, {
+        ...init,
+        headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+      });
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload.error ?? `Échec (${res.status})`);
+      }
+      return await res.json();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur inconnue");
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const search = useCallback(async () => {
+    if (term.trim().length < 2) {
+      setError("Saisissez au moins deux caractères");
+      return;
+    }
+    const data = await call(
+      `/api/admin/court-decisions/search?q=${encodeURIComponent(term.trim())}`,
+      { method: "GET" },
+      "search"
+    );
+    if (data) setResults(data.results ?? []);
+  }, [call, term]);
+
+  const link = useCallback(
+    async (decision: DecisionSummary) => {
+      const data = await call(
+        `/api/admin/affaires/${affairId}/decisions`,
+        { method: "POST", body: JSON.stringify({ courtDecisionId: decision.id }) },
+        decision.id
+      );
+      if (!data) return;
+      if (data.created) {
+        setLinks((prev) => [...prev, { ...decision, linkNotes: null }]);
+      } else {
+        setError("Cette décision est déjà liée à l'affaire");
+      }
+    },
+    [affairId, call]
+  );
+
+  const saveNote = useCallback(
+    async (decisionId: string) => {
+      const value = notes[decisionId] ?? "";
+      const data = await call(
+        `/api/admin/affaires/${affairId}/decisions`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ courtDecisionId: decisionId, notes: value || null }),
+        },
+        decisionId
+      );
+      if (!data) return;
+      setLinks((prev) =>
+        prev.map((l) => (l.id === decisionId ? { ...l, linkNotes: value || null } : l))
+      );
+    },
+    [affairId, call, notes]
+  );
+
+  const unlink = useCallback(
+    async (decision: LinkedDecision) => {
+      const reference = decision.pourvoiNumber ?? decision.ecli ?? "sans référence publique";
+      const confirmed = window.confirm(
+        `Retirer la liaison vers la décision « ${reference} » ?\n\n` +
+          `La décision elle-même n'est pas supprimée : seule la liaison avec cette affaire ` +
+          `disparaît.`
+      );
+      if (!confirmed) return;
+
+      const data = await call(
+        `/api/admin/affaires/${affairId}/decisions`,
+        {
+          method: "DELETE",
+          body: JSON.stringify({ courtDecisionId: decision.id, confirmed: true }),
+        },
+        decision.id
+      );
+      if (!data) return;
+      setLinks((prev) => prev.filter((l) => l.id !== decision.id));
+    },
+    [affairId, call]
+  );
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h2 className="text-lg font-medium">Décisions de justice rattachées</h2>
+        <p className="text-sm text-muted-foreground">
+          Une décision peut porter plusieurs chefs, donc concerner plusieurs fiches. Lier une
+          décision ne fusionne jamais deux affaires.
+        </p>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {links.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Aucune décision rattachée. C&apos;est un état normal : une enquête en cours ou une action
+          du parquet ne produit pas de décision.
+        </p>
+      ) : (
+        <ul className="space-y-4">
+          {links.map((decision) => (
+            <li key={decision.id} className="rounded-md border p-3">
+              <DecisionFields decision={decision} />
+              <div className="mt-3 space-y-2">
+                <label htmlFor={`note-${decision.id}`} className="text-xs text-muted-foreground">
+                  Note de liaison
+                </label>
+                <Textarea
+                  id={`note-${decision.id}`}
+                  rows={2}
+                  value={notes[decision.id] ?? ""}
+                  onChange={(e) => setNotes((p) => ({ ...p, [decision.id]: e.target.value }))}
+                  placeholder="Ex. deux chefs d'un même arrêt"
+                />
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={busy === decision.id}
+                    onClick={() => saveNote(decision.id)}
+                  >
+                    Enregistrer la note
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busy === decision.id}
+                    onClick={() => unlink(decision)}
+                  >
+                    <Unlink className="mr-1 h-3 w-3" aria-hidden="true" />
+                    Retirer la liaison
+                  </Button>
+                  {busy === decision.id && (
+                    <Loader2 className="h-4 w-4 animate-spin self-center" aria-hidden="true" />
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="space-y-2 border-t pt-4">
+        <label htmlFor="decision-search" className="text-sm font-medium">
+          Lier une décision existante
+        </label>
+        <div className="flex gap-2">
+          <Input
+            id="decision-search"
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder="ECLI, identifiant Judilibre, ou n° de pourvoi"
+          />
+          <Button size="sm" disabled={busy === "search"} onClick={search}>
+            <Search className="mr-1 h-3 w-3" aria-hidden="true" />
+            Rechercher
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Une recherche par pourvoi rend toujours une liste : un même pourvoi peut produire
+          plusieurs décisions.
+        </p>
+
+        {results !== null && results.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            Aucune décision existante ne correspond. La création d&apos;une décision n&apos;est pas
+            encore possible depuis cette interface.
+          </p>
+        )}
+
+        {results !== null && results.length > 0 && (
+          <ul className="space-y-2">
+            {results.map((decision) => {
+              const alreadyLinked = links.some((l) => l.id === decision.id);
+              return (
+                <li
+                  key={decision.id}
+                  className="flex items-start justify-between gap-3 rounded-md border p-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <DecisionFields decision={decision} />
+                    {typeof decision.linkedAffairCount === "number" && (
+                      <Badge variant="outline" className="mt-2">
+                        {decision.linkedAffairCount} affaire
+                        {decision.linkedAffairCount > 1 ? "s" : ""} liée
+                        {decision.linkedAffairCount > 1 ? "s" : ""}
+                      </Badge>
+                    )}
+                  </div>
+                  <Button
+                    size="sm"
+                    disabled={alreadyLinked || busy === decision.id}
+                    onClick={() => link(decision)}
+                  >
+                    {alreadyLinked ? "Déjà liée" : "Lier"}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/security/schemas/court-decision.ts
+++ b/src/lib/security/schemas/court-decision.ts
@@ -1,0 +1,42 @@
+import { z } from "zod/v4";
+
+// Issue #536 — admin management of affair ↔ decision links.
+//
+// No schema here creates, edits or deletes a CourtDecision: the admin surface only
+// manages links to decisions that already exist. Creation and enrichment belong to
+// #337, once the identity rules are settled.
+
+const cuid = z.string().min(1).max(64);
+
+/**
+ * Free-text search over existing decisions.
+ *
+ * One field on purpose: the route decides how to interpret the term. An exact ECLI or
+ * Judilibre id resolves to at most one row; a pourvoi number always resolves to a
+ * list, because a pourvoi can produce several decisions.
+ */
+export const courtDecisionSearchSchema = z.object({
+  q: z.string().min(2).max(120),
+});
+
+export const linkCourtDecisionSchema = z.object({
+  courtDecisionId: cuid,
+  notes: z.string().max(2000).optional(),
+});
+
+export const updateCourtDecisionLinkSchema = z.object({
+  courtDecisionId: cuid,
+  /** Null clears the note; omitted leaves it untouched. */
+  notes: z.string().max(2000).nullable(),
+});
+
+export const unlinkCourtDecisionSchema = z.object({
+  courtDecisionId: cuid,
+  /** Explicit: removing a link is a deliberate editorial act. */
+  confirmed: z.literal(true),
+});
+
+export type CourtDecisionSearchQuery = z.infer<typeof courtDecisionSearchSchema>;
+export type LinkCourtDecisionBody = z.infer<typeof linkCourtDecisionSchema>;
+export type UpdateCourtDecisionLinkBody = z.infer<typeof updateCourtDecisionLinkSchema>;
+export type UnlinkCourtDecisionBody = z.infer<typeof unlinkCourtDecisionSchema>;


### PR DESCRIPTION
## Description

Part of #536. Interface admin **bornée à la gestion des liaisons** entre une affaire et des décisions existantes.

**⚠ Cette PR n'est pas mergée : un critère d'arrêt a été rencontré pendant sa vérification.** Voir la section dédiée en fin de description. Le code est complet et vérifié ; c'est l'incident qui impose la revue.

## Périmètre

Sur la fiche admin d'une affaire :

- affiche les décisions liées avec ECLI, pourvoi, juridiction, chambre, date, sens, source officielle et note de liaison ;
- recherche une décision existante par ECLI exact, `judilibreId` exact, ou numéro de pourvoi normalisé (avec correspondance partielle pour l'ergonomie) ;
- lie une décision existante ;
- ajoute ou modifie la note de liaison ;
- retire une liaison, avec confirmation explicite nommant la décision.

**Une recherche par pourvoi rend toujours une liste**, jamais un résultat unique : un même pourvoi peut produire plusieurs décisions. Le nombre d'affaires déjà liées est affiché sur chaque candidate.

## Hors périmètre, et rendu impossible

Aucune route ne permet de créer, modifier ou supprimer une `CourtDecision`. Aucune ne déduit une décision depuis une affaire, ne copie `Affair.court` ou `Affair.verdictDate`, ne fusionne des affaires, ne désigne une décision principale, ni ne touche `Affair.ecli @unique`. La création et l'enrichissement relèvent de #337.

**Un retrait de liaison supprime uniquement `AffairCourtDecision`.** Une décision orpheline reste en base : c'est un acte officiel, pas un sous-produit de la fiche. La piste d'audit inscrit explicitement `courtDecisionDeleted: false` pour qu'un relecteur d'audit le sache.

**Aucun champ historique d'`Affair` n'est modifié.** Aucune migration n'est nécessaire : `prisma migrate diff` rend « empty migration ».

## Sécurité et invariants

Chaque route passe par `withAdminAuth`, valide ses entrées avec un schéma Zod du dépôt, **relit l'affaire et la décision avant écriture**, est idempotente, refuse une liaison en double, écrit sa piste d'audit **dans la même transaction** que la mutation, et n'invalide les caches **qu'après le commit**.

## Tests

**21 tests** ajoutés.

Recherche : ECLI exact, `judilibreId` exact, pourvoi normalisé, liste pour un pourvoi partagé, refus d'un terme trop court, passage par la garde admin.

Liaison : succès avec audit dans la même transaction, idempotence sans doublon, 404 sur affaire inexistante, 404 sur décision inexistante, invalidation après commit seulement, **rollback si l'audit échoue**.

Note : mise à jour avec conservation de l'ancienne valeur en audit, 404 si la liaison n'existe pas.

Retrait : suppression de la liaison sans la décision, décision orpheline laissée en base, invalidation après commit, rollback si l'audit échoue, 404 sur affaire inexistante.

Périmètre : aucune création ni suppression de décision atteignable, chaque écriture derrière la garde admin.

## Vérifications

`npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` : tous verts. **2484 tests**, 0 échec.

Comptes de production inchangés : 463 affaires, 2 décisions, 3 liaisons, 8 jugements, 0 proposition.

## Critère d'arrêt rencontré, et pourquoi cette PR attend

En vérifiant cette PR, `npm run build` a échoué :

```
A required parameter (slug) was not provided as a string
received object in generateStaticParams for /parlement/dossiers/[slug]
```

L'échec se reproduisait sur `main` intact, donc il ne venait pas de cette PR. Cause réelle : **trois `LegislativeDossier` de test, `FB_X`/`FB_Y`/`FB_Z`, écrits dans la base de production**, au `slug` nul. `typeof null === "object"`, d'où l'erreur, et le build cassait donc le déploiement.

Origine : les tests `describeIfDb` s'activent dès que `DATABASE_URL` est défini. En sourçant `.env` puis en lançant la suite dans la même invocation de shell, ces tests d'intégration ont écrit leurs fixtures en production, et une exécution interrompue n'a pas exécuté leur `afterAll`.

Résidu mesuré et nettoyé, avec l'ensemble de suppression et l'ordre repris du teardown du test lui-même : 3 dossiers, 5 scrutins, 5 `ScrutinImportance`, 5 `ScrutinPolicyTitle`. Le second jeu de fixtures du même fichier s'était correctement nettoyé.

Après nettoyage : 2123 dossiers législatifs, **0 slug nul**, build à nouveau vert, données de #536 intactes.

La suite a ensuite été relancée **sans** `DATABASE_URL` dans l'environnement, avec les tests d'intégration correctement ignorés.
