### PR TITLE
Conditionner les tests d'intégration à une base locale

### DIFF
--- a/src/lib/data/__tests__/_seed-explained.ts
+++ b/src/lib/data/__tests__/_seed-explained.ts
@@ -1,4 +1,5 @@
 import type { PolicyTitleConfidence, ScrutinType } from "@/generated/prisma";
+import { assertLocalTestDb } from "@/test/db-guard";
 
 // Shared fixtures for the getExplainedShowcase / getScrutins integration tests.
 //
@@ -23,22 +24,6 @@ const SCRUTIN_FIXTURES: Array<{
   { id: "low1", dossierId: "C", confidence: "LOW", score: 100 },
 ];
 const SCRUTIN_IDS = SCRUTIN_FIXTURES.map((s) => s.id);
-
-/**
- * Allowlist guard: only the disposable local harness DB may be touched by
- * these fixtures. A denylist would silently miss any future non-matching
- * remote host, so we require the URL to look like the local harness instead
- * of merely not looking like a known remote provider.
- */
-function assertLocalTestDb(): void {
-  const url = process.env.DATABASE_URL ?? "";
-  if (!/@(localhost|127\.0\.0\.1)[:/]/.test(url)) {
-    throw new Error(
-      "Explained fixtures refuse to run: DATABASE_URL is not a local test DB. " +
-        "Run explained integration tests only via the disposable harness (npm run test:db:477)."
-    );
-  }
-}
 
 /**
  * Deletes the shared fixtures above, children before parents, using the same

--- a/src/lib/data/__tests__/explained-only.integration.test.ts
+++ b/src/lib/data/__tests__/explained-only.integration.test.ts
@@ -6,11 +6,11 @@ import { vi } from "vitest";
 // data-function tests in this directory do (e.g. explained-showcase).
 vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { it, expect, beforeAll, afterAll } from "vitest";
 
-const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+import { describeIfLocalDb } from "@/test/db-guard";
 
-// Dynamic imports (deferred to beforeAll, inside describeIfDb): both @/lib/db
+// Dynamic imports (deferred to beforeAll, inside describeIfLocalDb): both @/lib/db
 // and @/lib/data/scrutins transitively construct the Prisma client at import
 // time, which throws when DATABASE_URL is unset. Static imports would make
 // this suite fail instead of skip when run without a database.
@@ -19,7 +19,7 @@ let getScrutins: typeof import("@/lib/data/scrutins").getScrutins;
 let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
 let cleanupExplainedFixtures: typeof import("./_seed-explained").cleanupExplainedFixtures;
 
-describeIfDb("getScrutins explainedOnly", () => {
+describeIfLocalDb("getScrutins explainedOnly", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ getScrutins } = await import("@/lib/data/scrutins"));

--- a/src/lib/data/__tests__/explained-showcase.integration.test.ts
+++ b/src/lib/data/__tests__/explained-showcase.integration.test.ts
@@ -5,11 +5,11 @@ import { vi } from "vitest";
 // other data-function tests in this directory do (e.g. condamnations.test.ts).
 vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { it, expect, beforeAll, afterAll } from "vitest";
 
-const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+import { assertLocalTestDb, describeIfLocalDb } from "@/test/db-guard";
 
-// Dynamic imports (deferred to beforeAll, inside describeIfDb): both @/lib/db
+// Dynamic imports (deferred to beforeAll, inside describeIfLocalDb): both @/lib/db
 // and @/lib/data/scrutins transitively construct the Prisma client at import
 // time, which throws when DATABASE_URL is unset. Static imports would make
 // this suite fail instead of skip when run without a database.
@@ -18,12 +18,19 @@ let getExplainedShowcase: typeof import("@/lib/data/scrutins").getExplainedShowc
 let seedExplainedFixtures: typeof import("./_seed-explained").seedExplainedFixtures;
 let cleanupExplainedFixtures: typeof import("./_seed-explained").cleanupExplainedFixtures;
 
-describeIfDb("getExplainedShowcase", () => {
+describeIfLocalDb("getExplainedShowcase", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
     ({ seedExplainedFixtures, cleanupExplainedFixtures } = await import("./_seed-explained"));
     await seedExplainedFixtures(db);
+  });
+
+  // This block seeds the shared fixtures, so this block removes them. They used to
+  // be cleaned up by the *next* block's afterAll, which coupled two independent
+  // fixture sets: anything that stopped that hook early left this set behind.
+  afterAll(async () => {
+    await cleanupExplainedFixtures(db);
   });
 
   it("excludes LOW, caps per dossier, honors count", async () => {
@@ -44,14 +51,17 @@ describeIfDb("getExplainedShowcase", () => {
 // Own fixtures (FB_* ids/dossiers, isolated via excludeScrutinIds) proving the
 // all-time fallback fires when the widest (365-day) window's DIVERSIFIED
 // output is short of `count` — even though the raw fetched row count is not.
-describeIfDb("getExplainedShowcase — all-time fallback", () => {
+describeIfLocalDb("getExplainedShowcase — all-time fallback", () => {
   const FB_DOSSIER_IDS = ["FB_X", "FB_Y", "FB_Z"] as const;
   const FB_SCRUTIN_IDS = ["FB_x1", "FB_x2", "FB_x3", "FB_y1", "FB_z1"];
 
   beforeAll(async () => {
+    // These fixtures are written inline rather than through seedExplainedFixtures(),
+    // so they need the guard the shared helper applies for its own callers.
+    assertLocalTestDb();
+
     ({ db } = await import("@/lib/db"));
     ({ getExplainedShowcase } = await import("@/lib/data/scrutins"));
-    ({ cleanupExplainedFixtures } = await import("./_seed-explained"));
 
     // Idempotent: delete-first by these explicit ids, children before parents.
     await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
@@ -123,7 +133,6 @@ describeIfDb("getExplainedShowcase — all-time fallback", () => {
   });
 
   afterAll(async () => {
-    await cleanupExplainedFixtures(db);
     await db.scrutinImportance.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
     await db.scrutinPolicyTitle.deleteMany({ where: { scrutinId: { in: FB_SCRUTIN_IDS } } });
     await db.scrutin.deleteMany({ where: { id: { in: FB_SCRUTIN_IDS } } });

--- a/src/services/scrutin-policy-title/__tests__/force-regen-fields.integration.test.ts
+++ b/src/services/scrutin-policy-title/__tests__/force-regen-fields.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { it, expect, afterAll, beforeAll, beforeEach, vi } from "vitest";
 
 // Mock BEFORE importing the orchestrator.
 const mockCall = vi.fn();
@@ -7,7 +7,7 @@ vi.mock("@/lib/api/mistral", async (orig) => {
   return { ...actual, callMistral: (...a: unknown[]) => mockCall(...a) };
 });
 
-const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+import { describeIfLocalDb } from "@/test/db-guard";
 
 let db: typeof import("@/lib/db").db;
 let generateScrutinPolicyTitle: typeof import("@/services/scrutin-policy-title").generateScrutinPolicyTitle;
@@ -71,7 +71,7 @@ async function seedOldApprovedTitle(): Promise<string> {
   return row.id;
 }
 
-describeIfDb("forced regeneration resets age/review fields", () => {
+describeIfLocalDb("forced regeneration resets age/review fields", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ generateScrutinPolicyTitle } = await import("@/services/scrutin-policy-title"));

--- a/src/services/scrutin-policy-title/__tests__/generate.integration.test.ts
+++ b/src/services/scrutin-policy-title/__tests__/generate.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { it, expect, afterAll, beforeAll, beforeEach, vi } from "vitest";
 
 // Mock BEFORE importing the orchestrator.
 const mockCall = vi.fn();
@@ -7,7 +7,7 @@ vi.mock("@/lib/api/mistral", async (orig) => {
   return { ...actual, callMistral: (...a: unknown[]) => mockCall(...a) };
 });
 
-const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+import { describeIfLocalDb } from "@/test/db-guard";
 
 let db: typeof import("@/lib/db").db;
 let generateScrutinPolicyTitle: typeof import("@/services/scrutin-policy-title").generateScrutinPolicyTitle;
@@ -37,7 +37,7 @@ function mistralResponse(content: string) {
   return { choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }] };
 }
 
-describeIfDb("generateScrutinPolicyTitle", () => {
+describeIfLocalDb("generateScrutinPolicyTitle", () => {
   beforeAll(async () => {
     ({ db } = await import("@/lib/db"));
     ({ generateScrutinPolicyTitle } = await import("@/services/scrutin-policy-title"));
@@ -304,7 +304,7 @@ describeIfDb("generateScrutinPolicyTitle", () => {
   });
 });
 
-describeIfDb("assertNotApprovedByGenerator", () => {
+describeIfLocalDb("assertNotApprovedByGenerator", () => {
   it("throws if status APPROVED", async () => {
     const { assertNotApprovedByGenerator } = await import("@/services/scrutin-policy-title");
     expect(() => assertNotApprovedByGenerator("APPROVED")).toThrow();

--- a/src/services/sync/reconcile-scrutin-dossier/__tests__/remediate.integration.test.ts
+++ b/src/services/sync/reconcile-scrutin-dossier/__tests__/remediate.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import type { ScrutinDossierTransition } from "../types";
 
 // Mock BEFORE anything imports remediate.ts, which pulls in generateScrutinPolicyTitle,
@@ -10,7 +10,7 @@ vi.mock("@/lib/api/mistral", async (orig) => {
   return { ...actual, callMistral: (...a: unknown[]) => mockCall(...a) };
 });
 
-const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+import { describeIfLocalDb } from "@/test/db-guard";
 
 let db: typeof import("@/lib/db").db;
 let repairScrutinDossier: typeof import("../remediate").repairScrutinDossier;
@@ -151,7 +151,7 @@ function repointTransition(f: RepointFixture, externalId: string): ScrutinDossie
   };
 }
 
-describeIfDb("repairScrutinDossier (Phase A)", () => {
+describeIfLocalDb("repairScrutinDossier (Phase A)", () => {
   let fixtureA: RepointFixture; // happy-path REPOINT
   let fixtureB: RepointFixture; // linkless REPOINT
   let fixtureD: RepointFixture; // idempotent re-run
@@ -432,7 +432,7 @@ describeIfDb("repairScrutinDossier (Phase A)", () => {
   });
 });
 
-describeIfDb("requeueLinklessTitlesWithLinks", () => {
+describeIfLocalDb("requeueLinklessTitlesWithLinks", () => {
   const PFX2 = "TEST_RMD_LATE_";
   let policyTitleId: string;
 
@@ -541,7 +541,7 @@ describeIfDb("requeueLinklessTitlesWithLinks", () => {
  * CLAUDE.local.md, `.env`/`.env.prod` are the same production database). Do
  * not run this file with DATABASE_URL pointed at that database.
  */
-describeIfDb("drainDossierRepointRegen (Phase B)", () => {
+describeIfLocalDb("drainDossierRepointRegen (Phase B)", () => {
   const PFX3 = "TEST_RMD_DRAIN_";
 
   interface DrainFixture {
@@ -810,7 +810,7 @@ describeIfDb("drainDossierRepointRegen (Phase B)", () => {
   });
 });
 
-describeIfDb("reclaimAbandonedRegen", () => {
+describeIfLocalDb("reclaimAbandonedRegen", () => {
   const PFX4 = "TEST_RMD_RECLAIM_";
 
   /** Seeds a bare scrutin + ScrutinPolicyTitle row in the requested state. No

--- a/src/test/__tests__/db-guard.test.ts
+++ b/src/test/__tests__/db-guard.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { assertLocalTestDb, describeIfLocalDb, isLocalTestDb } from "../db-guard";
+
+// Issue #547 — integration fixtures reached production because the gate asked
+// "is there a database?" instead of "which database?". These tests pin the
+// predicate, and scan the tree so the old idiom cannot come back.
+
+describe("isLocalTestDb", () => {
+  it("accepte le harness jetable", () => {
+    expect(
+      isLocalTestDb(
+        "postgresql://poligraph_test:poligraph_test@localhost:55432/poligraph_test?sslmode=disable"
+      )
+    ).toBe(true);
+  });
+
+  it("accepte les formes locales sans identifiants et en IP", () => {
+    expect(isLocalTestDb("postgresql://localhost:5432/poligraph_test")).toBe(true);
+    expect(isLocalTestDb("postgresql://user:pass@127.0.0.1:5432/db")).toBe(true);
+    expect(isLocalTestDb("postgresql://user:pass@[::1]:5432/db")).toBe(true);
+  });
+
+  it("refuse une base distante, même avec un mot de passe contenant « localhost »", () => {
+    expect(isLocalTestDb("postgresql://u:p@db.supabase.co:5432/postgres")).toBe(false);
+    // Le piège d'un test par sous-chaîne : « localhost » apparaît, mais l'hôte est distant.
+    expect(isLocalTestDb("postgresql://u:localhost@db.supabase.co:5432/postgres")).toBe(false);
+    expect(isLocalTestDb("postgresql://u:p@localhost.evil.example:5432/db")).toBe(false);
+  });
+
+  it("refuse une URL vide ou illisible", () => {
+    // Une URL qu'on ne sait pas lire n'est pas une preuve d'innocuité.
+    // Pas de cas `undefined` explicite : il déclencherait le paramètre par
+    // défaut et testerait l'environnement courant, pas le rejet.
+    expect(isLocalTestDb("")).toBe(false);
+    expect(isLocalTestDb("pas-une-url")).toBe(false);
+    expect(isLocalTestDb("postgresql://")).toBe(false);
+  });
+});
+
+describe("assertLocalTestDb", () => {
+  it.skipIf(isLocalTestDb())("lève quand la base n'est pas locale", () => {
+    expect(() => assertLocalTestDb()).toThrow(/base locale/);
+  });
+
+  it.runIf(isLocalTestDb())("ne lève pas sous le harness", () => {
+    expect(() => assertLocalTestDb()).not.toThrow();
+  });
+});
+
+describe("describeIfLocalDb", () => {
+  it.skipIf(isLocalTestDb())("n'est pas le describe ouvert quand la base n'est pas locale", () => {
+    // Ignorer plutôt que lever : un bloc qui ne démarre pas n'écrit rien, donc
+    // il n'y a rien à nettoyer. Un garde qui lève dans un beforeAll laisse
+    // survivre les écritures déjà faites par ce même hook.
+    //
+    // On compare au describe ouvert, pas à describe.skip : vitest reconstruit
+    // un chaînage à chaque accès, donc describe.skip n'a pas d'identité stable.
+    expect(describeIfLocalDb).not.toBe(describe);
+  });
+});
+
+// --- Balayage lexical -------------------------------------------------------
+
+const ROOTS = ["src", "scripts"];
+
+const WRITE_PATTERN =
+  /\b(?:db|tx|prisma|client)\.[a-zA-Z]+\.(?:create|createMany|update|updateMany|upsert|delete|deleteMany)\s*\(/;
+
+/** L'ancien portail, qui s'ouvrait sur n'importe quelle base. */
+const LEGACY_GATE = /process\.env\.DATABASE_URL\s*\?\s*describe/;
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * Only `*.integration.test.ts` is scanned, because only those connect to a real
+ * database. Plenty of unit tests still gate on `process.env.DATABASE_URL` while
+ * mocking the Prisma client, which reaches no database at all; deciding "is this
+ * client mocked?" lexically is unreliable, and rewriting those files is unrelated
+ * to this guard.
+ */
+function collectIntegrationTests(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules") continue;
+      out.push(...collectIntegrationTests(full));
+      continue;
+    }
+    if (entry.endsWith(".integration.test.ts")) out.push(full);
+  }
+  return out;
+}
+
+const relative = (f: string) => f.replace(process.cwd() + "/", "");
+
+describe("garde : aucun test d'intégration n'écrit en base sans portail local (#547)", () => {
+  const files = ROOTS.flatMap((root) => collectIntegrationTests(join(process.cwd(), root)));
+
+  it("trouve bien des fichiers à scanner", () => {
+    expect(files.length).toBeGreaterThan(3);
+  });
+
+  it("n'utilise plus le portail fondé sur la seule présence d'une base", () => {
+    const offenders = files.filter((f) => LEGACY_GATE.test(stripComments(readFileSync(f, "utf8"))));
+
+    expect(offenders.map(relative)).toEqual([]);
+  });
+
+  it("exige describeIfLocalDb dans tout fichier qui écrit en base", () => {
+    const offenders = files.filter((f) => {
+      const source = stripComments(readFileSync(f, "utf8"));
+      return WRITE_PATTERN.test(source) && !source.includes("describeIfLocalDb");
+    });
+
+    expect(offenders.map(relative)).toEqual([]);
+  });
+
+  it("couvre effectivement des fichiers qui écrivent, sinon la règle ne prouve rien", () => {
+    // Sans cette borne, supprimer tous les tests d'intégration rendrait la règle
+    // verte et vide.
+    const writers = files.filter((f) => WRITE_PATTERN.test(stripComments(readFileSync(f, "utf8"))));
+
+    expect(writers.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/test/db-guard.ts
+++ b/src/test/db-guard.ts
@@ -1,0 +1,66 @@
+/**
+ * Gate for integration tests that write to a database (issue #547).
+ *
+ * `.env` and `.env.prod` both point at the same production Supabase: this project
+ * has no separate development database. A gate on "is there a database?" therefore
+ * turns every integration test into a production writer as soon as someone exports
+ * `DATABASE_URL` in their shell. The gate has to be "is this a *local throwaway*
+ * database?" instead.
+ *
+ * Skipping is deliberately preferred over throwing. A guard that throws inside
+ * `beforeAll` still lets earlier writes in that same hook reach the database, and
+ * the residue then outlives the run. A block that never starts writes nothing, so
+ * there is nothing to clean up.
+ *
+ * Run these tests through the disposable harness (`npm run test:db:477`), which
+ * exports a `@localhost` URL and tears the container down on exit.
+ */
+
+import { describe } from "vitest";
+
+/** Hosts that can only be a throwaway database on the machine running the tests. */
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Whether `DATABASE_URL` names a local database.
+ *
+ * Parses rather than pattern-matches, so both credentialed
+ * (`postgresql://user:pass@localhost:5432/db`) and bare (`postgresql://localhost/db`)
+ * forms are recognised. Anything unparseable counts as non-local: an unreadable URL
+ * is not evidence of safety.
+ */
+export function isLocalTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
+  if (!url) return false;
+  try {
+    // IPv6 hostnames come back bracketed ("[::1]"); compare the host itself.
+    const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `describe` for suites that write to a database: runs against a local database,
+ * skips everywhere else, including against production.
+ *
+ * Replaces the `process.env.DATABASE_URL ? describe : describe.skip` idiom, which
+ * gated on the presence of a database rather than on which one.
+ */
+export const describeIfLocalDb = isLocalTestDb() ? describe : describe.skip;
+
+/**
+ * Hard refusal, for shared seed and cleanup helpers.
+ *
+ * Second layer behind {@link describeIfLocalDb}: a helper can be called from a
+ * script or a future test that forgot the gate, and it must not depend on its
+ * caller having been careful.
+ */
+export function assertLocalTestDb(): void {
+  if (!isLocalTestDb()) {
+    throw new Error(
+      "Ces fixtures refusent de s'exécuter : DATABASE_URL ne désigne pas une base locale. " +
+        "Lancer les tests d'intégration via le harness jetable (npm run test:db:477)."
+    );
+  }
+}


### PR DESCRIPTION
Closes #547.

## Le défaut

Les tests d'intégration étaient conditionnés à la **présence** d'une base, pas à son identité :

```ts
const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
```

`.env` et `.env.prod` pointent la même base Supabase de production, et il n'y a pas de base de développement séparée. Ce portail s'ouvrait donc sur la production dès que `DATABASE_URL` existait dans l'environnement, et les fixtures y étaient écrites.

Un garde `assertLocalTestDb()` existait bien, mais seulement dans `_seed-explained.ts`. Sur les **6** fichiers `*.integration.test.ts`, un seul passait par lui. Les **95** écritures directes des autres n'étaient pas couvertes.

Pire, le garde se retournait contre son objectif. Dans `explained-showcase.integration.test.ts`, le bloc `FB_*` écrit ses fixtures en ligne sans passer par le helper, puis son `afterAll` commence par `cleanupExplainedFixtures(db)`, qui lève contre une base distante. Les instructions suivantes du même hook, celles qui suppriment précisément `FB_*`, ne s'exécutaient jamais. Écriture sans garde, puis nettoyage empêché par le garde.

## L'approche : ignorer plutôt que lever

Le portail devient « est-ce une base locale jetable ? ».

```ts
export const describeIfLocalDb = isLocalTestDb() ? describe : describe.skip;
```

Ignorer est délibérément préféré à lever. Un garde qui lève au milieu d'un `beforeAll` laisse survivre les écritures que ce même hook a déjà faites, et le résidu dépasse la durée du run. **Un bloc qui ne démarre pas n'écrit rien, donc il n'y a rien à nettoyer.** L'état dangereux devient inatteignable au lieu d'être seulement détecté.

`assertLocalTestDb()` reste, en seconde couche, pour les helpers de seed et de nettoyage : un helper peut être appelé par un script ou un futur test qui a oublié le portail, et il ne doit pas dépendre de la prudence de son appelant.

## Détail

`src/test/db-guard.ts` rassemble le prédicat, le portail et l'assertion, jusqu'ici enfermés dans `_seed-explained.ts`.

Le prédicat **parse** l'URL au lieu de la filtrer par motif. L'ancienne expression `/@(localhost|127\.0\.0\.1)[:/]/` acceptait un mot de passe contenant `localhost` sur un hôte distant, et refusait une URL locale sans identifiants. `new URL(...).hostname` traite les deux correctement, plus IPv6. Une URL illisible compte comme non locale : ne pas savoir lire une URL n'est pas une preuve d'innocuité.

Les 5 fichiers qui écrivent passent au nouveau portail. `reconcile.integration.test.ts` n'est pas touché : malgré son nom, il teste `computeTransitions` sans aucune écriture, c'est un test unitaire mal nommé. Cela clôt au passage un suivi ouvert de longue date qui le soupçonnait à tort.

Dans `explained-showcase.integration.test.ts`, chaque bloc nettoie désormais ses propres fixtures. Le premier bloc gagne le `afterAll` qui lui manquait, et celui du bloc `FB_*` ne nettoie plus que `FB_*`. Le garde est appelé avant le seed en ligne.

## Tests

**10 tests**, dont un balayage lexical qui empêche le trou de revenir : tout `*.integration.test.ts` qui écrit doit utiliser `describeIfLocalDb`, et l'ancien portail est banni. Un quatrième test borne la règle par le bas, sinon supprimer tous les tests d'intégration la rendrait verte et vide.

Le prédicat est couvert sur ses cas pièges : mot de passe contenant `localhost` sur hôte distant, sous-domaine `localhost.evil.example`, forme sans identifiants, IPv6, URL illisible.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2494 tests**, 0 échec. `tsc` et `eslint` propres.

Portail fermé, prouvé sans toucher à la production. Avec une URL distante factice, la suite est ignorée sans ouvrir de connexion :

```
DATABASE_URL="postgresql://u:p@db.factice-inexistant.supabase.co:5432/postgres" \
  npx vitest run src/lib/data/__tests__/explained-showcase.integration.test.ts

Test Files  1 skipped (1)
      Tests  3 skipped (3)
```

Avant ce correctif, cette même commande écrivait ses fixtures.

Portail ouvert : les 6 fichiers tournent toujours contre le harness jetable (`npm run test:db:477`, `@localhost:55432`), chacun passant lorsqu'il est lancé seul.

## Une course préexistante, laissée en dehors

Lancés **ensemble** contre le harness, `explained-only` et `explained-showcase` échouent. Les deux seedent et suppriment les mêmes identifiants explicites (`A`/`B`/`C`, `dA1`, `dA2`, `dB1`, `low1`), et vitest exécute les fichiers en parallèle.

Vérifié sur `main` intact : l'échec y est déjà présent. Le symptôme change, l'erreur devenant une erreur Prisma dans le seed plutôt qu'une assertion, parce que découpler les deux nettoyages ajoute un point de suppression. La cause, elle, est la même et antérieure : des fixtures mutables partagées entre fichiers concurrents.

Ce n'est pas un problème de garde, et le corriger demanderait d'isoler les fixtures des deux fichiers. Documenté séparément plutôt que traité ici.

## Note sur la CI

La CI ne voit pas et ne verra pas cette classe de défaut : son job de tests unitaires n'a pas de `DATABASE_URL`, donc ces blocs y sont ignorés. Le chemin d'écriture n'est atteignable qu'en local. C'est pourquoi le portail doit être exhaustif plutôt que surveillé, et pourquoi le balayage lexical, lui, tourne bien en CI.
