### PR TITLE
Récupérer une décision Judilibre par référence et la mapper

### DIFF
--- a/src/lib/affairs/judicial-reference.ts
+++ b/src/lib/affairs/judicial-reference.ts
@@ -1,0 +1,25 @@
+/**
+ * Folding of judicial references, so two spellings of the same reference compare
+ * equal (#536, #337).
+ *
+ * Pure and free of database access: the Judilibre mapper and client both need it,
+ * and neither may drag a `DATABASE_URL` requirement in through an import.
+ */
+
+/**
+ * Strips accents, case and separators: « 96-83.698 », « 96-83698 » and « 9683698 »
+ * all fold to « 9683698 ».
+ *
+ * Used to *find* and to *compare* references. It never decides that two decisions
+ * are the same one — a shared pourvoi number is not an identity.
+ */
+export function foldJudicialReference(raw: string): string {
+  return (
+    raw
+      .normalize("NFD")
+      // \p{Mn} keeps this ASCII-only: a literal combining-mark range is invisible in source.
+      .replace(/\p{Mn}/gu, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "")
+  );
+}

--- a/src/lib/api/__tests__/judilibre-targeted.test.ts
+++ b/src/lib/api/__tests__/judilibre-targeted.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #337 — targeted retrieval by reference. `/search` is full-text, so its hits
+// are candidates: these tests pin the exact-match filter that turns them into an
+// answer, and the refusal to hand back a near miss.
+
+const h = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("../http-client", () => ({
+  HTTPClient: class {
+    get = h.get;
+  },
+  HTTPError: class extends Error {
+    constructor(public status: number) {
+      super(`HTTP ${status}`);
+    }
+  },
+}));
+
+const ENV = {
+  JUDILIBRE_BASE_URL: "https://api.example/judilibre",
+  JUDILIBRE_OAUTH_URL: "https://oauth.example/token",
+  JUDILIBRE_CLIENT_ID: "id",
+  JUDILIBRE_CLIENT_SECRET: "secret",
+  JUDILIBRE_API_KEY: "key",
+};
+
+let JudilibreClient: typeof import("../judilibre").JudilibreClient;
+let buildJudilibreDecisionUrl: typeof import("../judilibre").buildJudilibreDecisionUrl;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  Object.assign(process.env, ENV);
+  ({ JudilibreClient, buildJudilibreDecisionUrl } = await import("../judilibre"));
+
+  // OAuth is a bare fetch, not the mocked HTTP client.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "t", token_type: "Bearer", expires_in: 3600 }),
+    })
+  );
+});
+
+function summary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dec_1",
+    number: "96-83.698",
+    numbers: ["96-83.698"],
+    decision_date: "1997-10-27",
+    jurisdiction: "cc",
+    chamber: "cr",
+    solution: "rejet",
+    type: "arret",
+    themes: [],
+    summary: "",
+    ...overrides,
+  };
+}
+
+describe("findDecisionsByPourvoiNumber (#337)", () => {
+  it("rend la décision dont le pourvoi correspond exactement", async () => {
+    h.get.mockResolvedValue({ data: { results: [summary()], total: 1, page: 0, page_size: 10 } });
+
+    const found = await new JudilibreClient().findDecisionsByPourvoiNumber("96-83.698");
+
+    expect(found).toHaveLength(1);
+    expect(found[0]!.id).toBe("dec_1");
+  });
+
+  it("tolère les variantes d'écriture du pourvoi demandé", async () => {
+    h.get.mockResolvedValue({ data: { results: [summary()], total: 1, page: 0, page_size: 10 } });
+    const client = new JudilibreClient();
+
+    for (const variant of ["96-83.698", "96-83698", "9683698", " 96 83 698 "]) {
+      expect(await client.findDecisionsByPourvoiNumber(variant)).toHaveLength(1);
+    }
+  });
+
+  it("écarte un résultat plein texte dont le pourvoi diffère", async () => {
+    // Le piège : /search répond sur le texte, pas sur la référence.
+    h.get.mockResolvedValue({
+      data: {
+        results: [summary({ id: "bruit", number: "12-34.567", numbers: ["12-34.567"] }), summary()],
+        total: 2,
+        page: 0,
+        page_size: 10,
+      },
+    });
+
+    const found = await new JudilibreClient().findDecisionsByPourvoiNumber("96-83.698");
+
+    expect(found.map((d) => d.id)).toEqual(["dec_1"]);
+  });
+
+  it("reconnaît un pourvoi porté par la liste secondaire", async () => {
+    h.get.mockResolvedValue({
+      data: {
+        results: [summary({ number: "97-81.102", numbers: ["97-81.102", "96-83.698"] })],
+        total: 1,
+        page: 0,
+        page_size: 10,
+      },
+    });
+
+    expect(await new JudilibreClient().findDecisionsByPourvoiNumber("96-83.698")).toHaveLength(1);
+  });
+
+  it("rend une LISTE : un pourvoi peut produire plusieurs décisions", async () => {
+    h.get.mockResolvedValue({
+      data: {
+        results: [summary(), summary({ id: "dec_2", solution: "cassation" })],
+        total: 2,
+        page: 0,
+        page_size: 10,
+      },
+    });
+
+    const found = await new JudilibreClient().findDecisionsByPourvoiNumber("96-83.698");
+
+    expect(found.map((d) => d.id)).toEqual(["dec_1", "dec_2"]);
+  });
+
+  it("rend une liste vide sans appeler l'API sur une référence vide", async () => {
+    expect(await new JudilibreClient().findDecisionsByPourvoiNumber("   ")).toEqual([]);
+    expect(h.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("findDecisionByEcli (#337)", () => {
+  it("rend la décision dont l'ECLI correspond exactement", async () => {
+    h.get.mockResolvedValue({
+      data: {
+        results: [summary({ ecli: "ECLI:FR:CCASS:2026:CR00556" })],
+        total: 1,
+        page: 0,
+        page_size: 10,
+      },
+    });
+
+    const found = await new JudilibreClient().findDecisionByEcli("ECLI:FR:CCASS:2026:CR00556");
+
+    expect(found?.id).toBe("dec_1");
+  });
+
+  it("rend null plutôt qu'un résultat approchant", async () => {
+    h.get.mockResolvedValue({
+      data: {
+        results: [summary({ ecli: "ECLI:FR:CCASS:2026:CR00999" })],
+        total: 1,
+        page: 0,
+        page_size: 10,
+      },
+    });
+
+    expect(await new JudilibreClient().findDecisionByEcli("ECLI:FR:CCASS:2026:CR00556")).toBeNull();
+  });
+
+  it("rend null quand la décision trouvée n'a pas d'ECLI", async () => {
+    h.get.mockResolvedValue({ data: { results: [summary()], total: 1, page: 0, page_size: 10 } });
+
+    expect(await new JudilibreClient().findDecisionByEcli("ECLI:FR:CCASS:1997:CR00001")).toBeNull();
+  });
+});
+
+describe("getTaxonomy (#337)", () => {
+  it("rend la table de libellés officielle", async () => {
+    h.get.mockResolvedValue({ data: { result: { cr: "Chambre criminelle" } } });
+
+    const taxonomy = await new JudilibreClient().getTaxonomy("chamber");
+
+    expect(taxonomy).toEqual({ cr: "Chambre criminelle" });
+    expect(h.get.mock.calls[0]![0]).toContain("/taxonomy?id=chamber");
+  });
+
+  it("ne rappelle pas l'API pour la même taxonomie", async () => {
+    h.get.mockResolvedValue({ data: { result: { cc: "Cour de cassation" } } });
+    const client = new JudilibreClient();
+
+    await client.getTaxonomy("jurisdiction");
+    await client.getTaxonomy("jurisdiction");
+
+    expect(h.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildJudilibreDecisionUrl (#337)", () => {
+  it("construit l'URL publique de la Cour de cassation", () => {
+    expect(buildJudilibreDecisionUrl("6079a87a9ba5988459c4d674")).toBe(
+      "https://www.courdecassation.fr/decision/6079a87a9ba5988459c4d674"
+    );
+  });
+});

--- a/src/lib/api/judilibre.ts
+++ b/src/lib/api/judilibre.ts
@@ -6,6 +6,7 @@
  */
 
 import { HTTPClient, HTTPError } from "./http-client";
+import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
 import { JUDILIBRE_RATE_LIMIT_MS } from "@/config/rate-limits";
 
 // ============================================
@@ -23,19 +24,53 @@ export interface JudilibreSearchResult {
 
 export interface JudilibreDecisionSummary {
   id: string;
-  ecli: string;
+  /**
+   * Absent on historical decisions: ECLI was introduced in France around 2012, and
+   * the API omits the field entirely rather than returning an empty string. Verified
+   * against a 1997 decision (no `ecli` key) and a 2026 one (`ECLI:FR:CCASS:2026:…`).
+   */
+  ecli?: string;
   number: string; // N° pourvoi principal
   numbers: string[]; // Tous les n° pourvoi
   decision_date: string; // YYYY-MM-DD
-  chamber: string;
-  solution: string; // "rejet", "cassation", "irrecevabilité"...
+  /** Taxonomy code, e.g. "cc" for Cour de cassation. */
+  jurisdiction: string;
+  chamber: string; // Taxonomy code, e.g. "cr"
+  solution: string; // Taxonomy code: "rejet", "cassation", "irrecevabilite"...
+  type: string; // Taxonomy code: "arret", "avis"...
   themes: string[];
   summary: string;
 }
 
+/**
+ * A full decision record.
+ *
+ * Field list taken from an actual response, not from the documentation: the API
+ * returns `jurisdiction`, `type`, `publication`, `timeline`, `visa`, `nac`,
+ * `portalis` and others that were previously undeclared, and returns no `zones`.
+ * Extra keys are kept accessible so the raw payload can be stored verbatim.
+ */
 export interface JudilibreDecision extends JudilibreDecisionSummary {
   text: string; // Texte intégral
-  zones: Record<string, { start: number; end: number }[]>;
+  publication?: string[];
+  source?: string;
+  update_date?: string;
+  [key: string]: unknown;
+}
+
+/** A taxonomy maps an API code to its official French label. */
+export type JudilibreTaxonomy = Record<string, string>;
+
+export type JudilibreTaxonomyId = "jurisdiction" | "chamber" | "solution" | "type";
+
+/**
+ * Public URL of a decision on the Cour de cassation site.
+ *
+ * The API returns no URL field, so it is built from the decision id. Verified to
+ * answer 200 for both a 1997 and a 2026 decision.
+ */
+export function buildJudilibreDecisionUrl(judilibreId: string): string {
+  return `https://www.courdecassation.fr/decision/${encodeURIComponent(judilibreId)}`;
 }
 
 interface OAuthTokenResponse {
@@ -69,6 +104,7 @@ export class JudilibreClient {
 
   private accessToken: string | null = null;
   private tokenExpiresAt = 0;
+  private taxonomyCache = new Map<JudilibreTaxonomyId, JudilibreTaxonomy>();
 
   constructor() {
     const baseUrl = process.env.JUDILIBRE_BASE_URL;
@@ -181,6 +217,64 @@ export class JudilibreClient {
       headers,
     });
     return response.data;
+  }
+
+  /**
+   * Official label table for a taxonomy, e.g. `chamber` → `{ cr: "Chambre criminelle" }`.
+   *
+   * Fetched rather than hardcoded so the labels shown to readers are the ones the
+   * Cour de cassation publishes. Cached for the client's lifetime: the taxonomies
+   * change on the scale of institutional reform, not of a sync run.
+   */
+  async getTaxonomy(id: JudilibreTaxonomyId): Promise<JudilibreTaxonomy> {
+    const cached = this.taxonomyCache.get(id);
+    if (cached) return cached;
+
+    const headers = await this.getAuthHeaders();
+    const response = await this.httpClient.get<{ result?: JudilibreTaxonomy }>(
+      `/taxonomy?id=${encodeURIComponent(id)}`,
+      { headers }
+    );
+    const taxonomy = response.data?.result ?? {};
+    this.taxonomyCache.set(id, taxonomy);
+    return taxonomy;
+  }
+
+  /**
+   * Decisions carrying exactly this pourvoi number.
+   *
+   * `/search` is full-text, so its hits are candidates, not answers: the results are
+   * filtered down to those whose own `numbers` contain the requested reference, after
+   * normalisation. Without that filter a near-miss would be handed back as a match.
+   *
+   * Returns a list because a pourvoi is not unique — it can produce a rejection, a
+   * partial cassation and a remand. Deciding between them is the caller's job.
+   */
+  async findDecisionsByPourvoiNumber(pourvoiNumber: string): Promise<JudilibreDecisionSummary[]> {
+    const wanted = foldJudicialReference(pourvoiNumber);
+    if (!wanted) return [];
+
+    const { results } = await this.searchDecisions(pourvoiNumber);
+    return results.filter((decision) => {
+      const numbers = decision.numbers?.length ? decision.numbers : [decision.number];
+      return numbers.some((n) => n && foldJudicialReference(n) === wanted);
+    });
+  }
+
+  /**
+   * The decision carrying exactly this ECLI, or null.
+   *
+   * An ECLI identifies one decision, so a single result is expected; anything that
+   * does not match exactly is discarded rather than returned as a near miss.
+   */
+  async findDecisionByEcli(ecli: string): Promise<JudilibreDecisionSummary | null> {
+    const wanted = foldJudicialReference(ecli);
+    if (!wanted) return null;
+
+    const { results } = await this.searchDecisions(ecli);
+    return (
+      results.find((decision) => foldJudicialReference(decision.ecli ?? "") === wanted) ?? null
+    );
   }
 
   /**

--- a/src/lib/hash/canonical.ts
+++ b/src/lib/hash/canonical.ts
@@ -1,0 +1,30 @@
+/**
+ * Deterministic JSON and content hashing.
+ *
+ * Extracted from `services/affairs/proposals.ts` so callers that must stay free of
+ * database access can hash a payload: that module imports the Prisma client at load
+ * time, which would drag a `DATABASE_URL` requirement into pure mapping code.
+ */
+
+import { createHash } from "node:crypto";
+import { Prisma } from "@/generated/prisma";
+
+/** Deterministic JSON: keys sorted at every depth, so hashing is stable. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Prisma.Decimal.isDecimal(value)) return JSON.stringify(value.toString());
+  if (typeof value === "object") {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonicalJson((value as Record<string, unknown>)[k])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Stable hash of a raw source payload, for sourceContentHash. */
+export function hashSourceContent(payload: unknown): string {
+  return createHash("sha256").update(canonicalJson(payload)).digest("hex");
+}

--- a/src/services/affairs/__tests__/judilibre-court-decision.test.ts
+++ b/src/services/affairs/__tests__/judilibre-court-decision.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import type { JudilibreDecision } from "@/lib/api/judilibre";
+import { buildJudilibreDecisionUrl } from "@/lib/api/judilibre";
+import {
+  buildJudilibreMetadata,
+  hashJudilibrePayload,
+  JUDILIBRE_MAPPER_VERSION,
+  mapJudilibreToCourtDecision,
+  type JudilibreLabels,
+} from "../judilibre-court-decision";
+
+// Issue #337 — payloads copied from real API responses, including the fact that a
+// 1997 decision carries no `ecli` key at all while a 2026 one does.
+
+const LABELS: JudilibreLabels = {
+  jurisdiction: { cc: "Cour de cassation", ca: "Cour d'appel" },
+  chamber: { cr: "Chambre criminelle", soc: "Chambre sociale" },
+  solution: { rejet: "Rejet", cassation: "Cassation" },
+  type: { arret: "Arrêt" },
+};
+
+const RETRIEVED_AT = new Date("2026-07-26T10:00:00Z");
+
+/** 1997 decision: no ECLI key, as the API actually returns it. */
+function historicalDecision(overrides: Partial<JudilibreDecision> = {}): JudilibreDecision {
+  return {
+    id: "6079a87a9ba5988459c4d674",
+    number: "96-83.698",
+    numbers: ["96-83.698"],
+    decision_date: "1997-10-27",
+    jurisdiction: "cc",
+    chamber: "cr",
+    solution: "rejet",
+    type: "arret",
+    publication: ["b"],
+    themes: ["recel", "prescription"],
+    summary: "Les dispositions des articles 203 du Code de procédure pénale…",
+    text: "Sur le moyen unique de cassation…",
+    ...overrides,
+  } as JudilibreDecision;
+}
+
+describe("mapJudilibreToCourtDecision — champs de décision (#337)", () => {
+  it("mappe une décision historique sans ECLI", () => {
+    const mapped = mapJudilibreToCourtDecision(historicalDecision(), LABELS, RETRIEVED_AT);
+
+    expect(mapped.judilibreId).toBe("6079a87a9ba5988459c4d674");
+    expect(mapped.ecli).toBeNull();
+    expect(mapped.pourvoiNumber).toBe("96-83.698");
+    expect(mapped.pourvoiNumberNormalized).toBe("9683698");
+    expect(mapped.decisionDate?.toISOString()).toBe("1997-10-27T00:00:00.000Z");
+    expect(mapped.court).toBe("Cour de cassation");
+    expect(mapped.chamber).toBe("Chambre criminelle");
+    expect(mapped.solution).toBe("Rejet");
+  });
+
+  it("garde l'ECLI d'une décision récente", () => {
+    const mapped = mapJudilibreToCourtDecision(
+      historicalDecision({ ecli: "ECLI:FR:CCASS:2026:CR00556", decision_date: "2026-05-06" }),
+      LABELS,
+      RETRIEVED_AT
+    );
+
+    expect(mapped.ecli).toBe("ECLI:FR:CCASS:2026:CR00556");
+  });
+
+  it("construit l'URL publique depuis l'identifiant", () => {
+    const mapped = mapJudilibreToCourtDecision(historicalDecision(), LABELS, RETRIEVED_AT);
+
+    expect(mapped.sourceUrl).toBe(
+      "https://www.courdecassation.fr/decision/6079a87a9ba5988459c4d674"
+    );
+    expect(buildJudilibreDecisionUrl("a b/c")).toBe(
+      "https://www.courdecassation.fr/decision/a%20b%2Fc"
+    );
+  });
+
+  it("laisse un libellé nul plutôt que d'inventer, sur un code inconnu", () => {
+    const mapped = mapJudilibreToCourtDecision(
+      historicalDecision({ jurisdiction: "xx", chamber: "yy", solution: "zz" }),
+      LABELS,
+      RETRIEVED_AT
+    );
+
+    expect(mapped.court).toBeNull();
+    expect(mapped.chamber).toBeNull();
+    expect(mapped.solution).toBeNull();
+  });
+
+  it("rend une date nulle sur une valeur malformée, jamais un Invalid Date", () => {
+    for (const bad of ["", "27/10/1997", "1997-13-45x", "pas une date"]) {
+      const mapped = mapJudilibreToCourtDecision(
+        historicalDecision({ decision_date: bad }),
+        LABELS,
+        RETRIEVED_AT
+      );
+      expect(mapped.decisionDate).toBeNull();
+    }
+  });
+
+  it("date à minuit UTC, pour qu'un fuseau ne décale pas le jour", () => {
+    const mapped = mapJudilibreToCourtDecision(
+      historicalDecision({ decision_date: "1997-10-27" }),
+      LABELS,
+      RETRIEVED_AT
+    );
+
+    expect(mapped.decisionDate?.getUTCDate()).toBe(27);
+    expect(mapped.decisionDate?.getUTCHours()).toBe(0);
+  });
+
+  it("ne produit aucun champ éditorial", () => {
+    const mapped = mapJudilibreToCourtDecision(
+      historicalDecision({ themes: ["corruption"], summary: "Condamnation confirmée" }),
+      LABELS,
+      RETRIEVED_AT
+    ) as unknown as Record<string, unknown>;
+
+    // Ce qu'un mappeur de décision n'a pas à décider.
+    for (const forbidden of [
+      "title",
+      "category",
+      "status",
+      "politicianId",
+      "verdictDate",
+      "sentence",
+      "publicationStatus",
+      "affairId",
+    ]) {
+      expect(mapped).not.toHaveProperty(forbidden);
+    }
+  });
+});
+
+describe("metadata et hash (#337)", () => {
+  it("retire le corps de la décision, mais garde sa longueur", () => {
+    const record = historicalDecision({ text: "x".repeat(109_681) });
+    const meta = buildJudilibreMetadata(record, RETRIEVED_AT);
+
+    // metadata est chargé à chaque rendu de fiche publique : le corps n'y a pas sa place.
+    expect(meta.judilibre).not.toHaveProperty("text");
+    expect(meta.textLength).toBe(109_681);
+    // Comparé au corps omis, pour rester vrai quels que soient les autres champs.
+    expect(JSON.stringify(meta).length).toBeLessThan(meta.textLength / 10);
+  });
+
+  it("conserve les champs bruts que le mappeur n'utilise pas", () => {
+    const record = historicalDecision({ visa: [{ title: "article 7" }], nac: "12A" });
+    const meta = buildJudilibreMetadata(record, RETRIEVED_AT);
+
+    expect(meta.judilibre).toMatchObject({ visa: [{ title: "article 7" }], nac: "12A" });
+  });
+
+  it("hash stable quel que soit l'ordre des clés", () => {
+    const a = { id: "x", number: "1", text: "t" } as unknown as JudilibreDecision;
+    const b = { text: "t", number: "1", id: "x" } as unknown as JudilibreDecision;
+
+    expect(hashJudilibrePayload(a)).toBe(hashJudilibrePayload(b));
+  });
+
+  it("le hash couvre le corps, même s'il n'est pas stocké", () => {
+    const before = historicalDecision({ text: "version initiale" });
+    const after = historicalDecision({ text: "texte rectifié" });
+
+    // Sinon une rectification du texte passerait pour une absence de changement.
+    expect(hashJudilibrePayload(before)).not.toBe(hashJudilibrePayload(after));
+  });
+
+  it("enregistre la version du mappeur et la date de récupération", () => {
+    const meta = buildJudilibreMetadata(historicalDecision(), RETRIEVED_AT);
+
+    expect(meta.mapperVersion).toBe(JUDILIBRE_MAPPER_VERSION);
+    expect(meta.retrievedAt).toBe("2026-07-26T10:00:00.000Z");
+  });
+});

--- a/src/services/affairs/court-decisions.ts
+++ b/src/services/affairs/court-decisions.ts
@@ -14,6 +14,7 @@
 
 import { db, type DbTransactionClient } from "@/lib/db";
 import type { Prisma } from "@/generated/prisma";
+import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
 
 /**
  * Strips every separator from a pourvoi number so two spellings of the same
@@ -23,14 +24,7 @@ import type { Prisma } from "@/generated/prisma";
  * never to decide that two rows are the same decision.
  */
 export function normalizePourvoiNumber(raw: string): string {
-  return (
-    raw
-      .normalize("NFD")
-      // \p{Mn} keeps this ASCII-only: a literal combining-mark range is invisible in source.
-      .replace(/\p{Mn}/gu, "")
-      .toLowerCase()
-      .replace(/[^a-z0-9]/g, "")
-  );
+  return foldJudicialReference(raw);
 }
 
 export interface CreateCourtDecisionInput {

--- a/src/services/affairs/judilibre-court-decision.ts
+++ b/src/services/affairs/judilibre-court-decision.ts
@@ -1,0 +1,145 @@
+/**
+ * Judilibre record → `CourtDecision` fields (#337).
+ *
+ * Pure mapping, no I/O and no database access, so the translation can be tested
+ * against fixed payloads rather than against a live API.
+ *
+ * This module maps a decision onto a **decision**. It deliberately produces no
+ * affair title, category, status, sentence or person involvement: the discovery
+ * pipeline that inferred those from a pseudonymised corpus produced 0 affairs out
+ * of 156 decisions and was retired. `judilibre-mapping.ts` still holds those
+ * affair-facing helpers and is not reused here.
+ *
+ * Labels are passed in from the API's own taxonomy rather than hardcoded, so a
+ * reader sees the wording the Cour de cassation publishes. An unknown code maps to
+ * null: inventing a label would be asserting something the source did not say.
+ */
+
+import {
+  buildJudilibreDecisionUrl,
+  type JudilibreDecision,
+  type JudilibreTaxonomy,
+} from "@/lib/api/judilibre";
+import { hashSourceContent } from "@/lib/hash/canonical";
+import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
+
+/**
+ * Bumped whenever this mapping changes what it writes for the same payload.
+ * Recorded in the audit trail so a stored value can be traced to the rules that
+ * produced it.
+ */
+export const JUDILIBRE_MAPPER_VERSION = "1.0.0";
+
+/** Official label tables, as returned by `/taxonomy`. */
+export interface JudilibreLabels {
+  jurisdiction: JudilibreTaxonomy;
+  chamber: JudilibreTaxonomy;
+  solution: JudilibreTaxonomy;
+  type: JudilibreTaxonomy;
+}
+
+/** Exactly the `CourtDecision` columns this mapping is allowed to fill. */
+export interface MappedCourtDecision {
+  judilibreId: string;
+  ecli: string | null;
+  pourvoiNumber: string | null;
+  pourvoiNumberNormalized: string | null;
+  decisionDate: Date | null;
+  court: string | null;
+  chamber: string | null;
+  solution: string | null;
+  sourceUrl: string;
+  metadata: JudilibreMetadata;
+}
+
+export interface JudilibreMetadata {
+  /** The raw payload, minus the decision body. See `text` handling below. */
+  judilibre: Record<string, unknown>;
+  /** Length of the omitted body, so its absence is visible rather than silent. */
+  textLength: number;
+  /** Hash over the payload *including* the body, so any change is detectable. */
+  sourceContentHash: string;
+  mapperVersion: string;
+  retrievedAt: string;
+}
+
+/** Reads a taxonomy without ever inventing a label for an unknown code. */
+function label(taxonomy: JudilibreTaxonomy, code: string | undefined): string | null {
+  if (!code) return null;
+  return taxonomy[code] ?? null;
+}
+
+/**
+ * Parses the API's `YYYY-MM-DD` at UTC midnight.
+ *
+ * Without the explicit `Z`, a date-only string is parsed as UTC by the spec but
+ * displayed in local time, which can shift a decision to the previous day west of
+ * Greenwich. A malformed value yields null rather than an Invalid Date.
+ */
+function parseDecisionDate(raw: string | undefined): Date | null {
+  if (!raw || !/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null;
+  const date = new Date(`${raw}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Stable hash of the full payload, body included.
+ *
+ * Exported so callers can compare a fresh response with what was stored without
+ * having to rebuild the metadata.
+ */
+export function hashJudilibrePayload(record: JudilibreDecision): string {
+  return hashSourceContent(record as unknown);
+}
+
+/**
+ * The raw payload as stored, with the decision body removed.
+ *
+ * The body runs to ~110 000 characters, and `metadata` is loaded on every public
+ * affair page through `listCourtDecisionsForAffair`. Keeping it would put a large
+ * unused string on the read path of every fiche. It stays reachable at `sourceUrl`,
+ * its length is recorded, and the hash still covers it, so nothing is silently lost.
+ */
+export function buildJudilibreMetadata(
+  record: JudilibreDecision,
+  retrievedAt: Date
+): JudilibreMetadata {
+  const { text, ...withoutText } = record;
+
+  return {
+    judilibre: withoutText,
+    textLength: typeof text === "string" ? text.length : 0,
+    sourceContentHash: hashJudilibrePayload(record),
+    mapperVersion: JUDILIBRE_MAPPER_VERSION,
+    retrievedAt: retrievedAt.toISOString(),
+  };
+}
+
+/**
+ * Translates one official record into decision fields.
+ *
+ * `pourvoiNumber` keeps the principal number as published; the full `numbers` list
+ * stays in the raw payload. The principal number is not an identity — several
+ * decisions can share it — so it is stored for display and lookup only.
+ */
+export function mapJudilibreToCourtDecision(
+  record: JudilibreDecision,
+  labels: JudilibreLabels,
+  retrievedAt: Date
+): MappedCourtDecision {
+  const pourvoiNumber = record.number?.trim() || null;
+
+  return {
+    judilibreId: record.id,
+    // Absent on decisions predating ECLI in France; null, never fabricated.
+    ecli: record.ecli?.trim() || null,
+    pourvoiNumber,
+    pourvoiNumberNormalized: pourvoiNumber ? foldJudicialReference(pourvoiNumber) : null,
+    decisionDate: parseDecisionDate(record.decision_date),
+    court: label(labels.jurisdiction, record.jurisdiction),
+    chamber: label(labels.chamber, record.chamber),
+    solution: label(labels.solution, record.solution),
+    sourceUrl: buildJudilibreDecisionUrl(record.id),
+    metadata: buildJudilibreMetadata(record, retrievedAt),
+  };
+}

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { canonicalJson, hashSourceContent } from "@/lib/hash/canonical";
 import { db, type DbTransactionClient } from "@/lib/db";
 import { Prisma } from "@/generated/prisma";
 import type { ProposalRisk, SourceType } from "@/generated/prisma";
@@ -119,21 +120,6 @@ export function normalizeForCompare(value: unknown): string {
   return String(value);
 }
 
-/** Deterministic JSON: keys sorted at every depth, so hashing is stable. */
-function canonicalJson(value: unknown): string {
-  if (value === null || value === undefined) return "null";
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (value instanceof Date) return JSON.stringify(value.toISOString());
-  if (Prisma.Decimal.isDecimal(value)) return JSON.stringify(value.toString());
-  if (typeof value === "object") {
-    const entries = Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map((k) => `${JSON.stringify(k)}:${canonicalJson((value as Record<string, unknown>)[k])}`);
-    return `{${entries.join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
-
 function normalizeRecord(record: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const key of Object.keys(record).sort()) {
@@ -142,10 +128,8 @@ function normalizeRecord(record: Record<string, unknown>): Record<string, string
   return out;
 }
 
-/** Stable hash of a raw source payload, for sourceContentHash. */
-export function hashSourceContent(payload: unknown): string {
-  return createHash("sha256").update(canonicalJson(payload)).digest("hex");
-}
+/** Re-exported so existing callers keep importing it from here. */
+export { hashSourceContent };
 
 // ─── Hashing ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Part of #337. Première des cinq PR.

## Pourquoi

Le client Judilibre ne savait chercher qu'en plein texte, et le seul mappeur existant (`judilibre-mapping.ts`) produit une **affaire** : titre, catégorie, statut, détection de condamnation. C'est exactement le flux abandonné après l'audit qui a produit 0 affaire sur 156 décisions.

#337 inverse le sens : on part d'une **référence judiciaire déjà connue** et on vise une **décision**. Cette PR livre les deux briques qui manquaient, la récupération ciblée et le mappeur vers `CourtDecision`.

## Ce que l'API dit vraiment

Tout ce qui suit est mesuré contre l'API, pas repris de la documentation.

Le type `JudilibreDecision` mentait sur deux points. Il déclarait `ecli: string` requis alors que **le champ est entièrement absent** des décisions antérieures à l'ECLI en France, et il déclarait un champ `zones` que l'API ne renvoie pas et que personne ne lisait. À l'inverse, `jurisdiction`, `type`, `publication`, `timeline`, `visa`, `nac` et `portalis` existent sans être déclarés.

Vérifié sur deux décisions réelles :

| | 1997 | 2026 |
|---|---|---|
| `ecli` | absent | `ECLI:FR:CCASS:2026:CR00556` |
| `jurisdiction`, `type`, `themes`, `summary` | présents | présents |

C'est la confirmation après coup que #536 a eu raison de rendre `ecli` optionnel : **l'identité stable d'une décision est `judilibreId`**, pas l'ECLI, qui n'existe que sur la moitié récente du corpus.

L'API ne renvoie aucun champ d'URL. L'URL publique est donc construite, et le motif est vérifié à 200 sur la décision de 1997 comme sur celle de 2026.

## Recherche ciblée

`/search` répond en plein texte : ses résultats sont des candidats, pas des réponses. Les deux recherches filtrent donc sur une correspondance **exacte** après repliement de la référence.

`findDecisionsByPourvoiNumber` rend une **liste**, jamais un résultat unique : un pourvoi peut produire un rejet, une cassation partielle et un renvoi. Trancher est le travail de l'appelant, pas du client. Elle reconnaît aussi un pourvoi porté par la liste secondaire `numbers`.

`findDecisionByEcli` rend la décision ou `null`, jamais un résultat approchant.

`getTaxonomy` récupère les libellés officiels et les met en cache. Ils sont récupérés plutôt qu'écrits en dur pour qu'un lecteur voie le mot de la Cour de cassation : `cc` → Cour de cassation, `cr` → Chambre criminelle, `rejet` → Rejet.

## Mappeur

Pur, sans accès réseau ni base, donc testable sur des charges figées.

Il ne produit **que** des champs de décision. Un test vérifie qu'aucune propriété `title`, `category`, `status`, `politicianId`, `verdictDate`, `sentence`, `publicationStatus` ou `affairId` ne sort de ce mappeur.

Un code de taxonomie inconnu donne `null`, jamais un libellé inventé. Une date malformée donne `null`, jamais un `Invalid Date`. Les dates sont lues à minuit UTC, sinon une décision peut reculer d'un jour à l'ouest de Greenwich.

## Le corps de la décision n'est pas stocké

`metadata` conserve la charge officielle brute, **moins le texte intégral**.

Le corps fait environ 110 000 caractères, et `metadata` est chargé à chaque rendu de fiche publique via `listCourtDecisionsForAffair`, qui fait `include: { courtDecision: true }`. Le garder mettrait une grande chaîne inutilisée sur le chemin de lecture de chaque fiche.

Rien n'est perdu en silence : le texte reste à `sourceUrl`, sa longueur est enregistrée, et **le hash porte sur la charge complète, corps compris**, donc une rectification du texte reste détectable. Un test le vérifie.

Mesure réelle : 2132 et 1382 octets stockés, pour des corps de 109 681 et 11 297 caractères.

## Deux extractions rendues nécessaires

Un mappeur « pur » qui importait `hashSourceContent` depuis `proposals.ts` exigeait en fait une base de données au chargement, ce module important le client Prisma. Même problème avec `normalizePourvoiNumber`, qui vit dans un module de service.

Deux utilitaires sans dépendance sont donc extraits, à comportement inchangé :

- `src/lib/hash/canonical.ts` : `canonicalJson` et `hashSourceContent`, réexporté depuis `proposals.ts` pour que les appelants existants ne bougent pas ;
- `src/lib/affairs/judicial-reference.ts` : `foldJudicialReference`, dont `normalizePourvoiNumber` devient un alias de domaine.

Le client s'en sert aussi, ce qui supprime la troisième copie de ce repliement que j'avais commencé par écrire.

## Tests

**24 tests** : 12 sur le client ciblé, 12 sur le mappeur.

Côté client, le cas qui compte est le faux rapprochement : un résultat plein texte dont le pourvoi diffère doit être écarté, et un ECLI approchant doit rendre `null`.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2518 tests**, 0 échec. `tsc` et `eslint` propres.

Le mappeur a été passé sur les réponses réelles de l'API, en lecture seule, sans aucune écriture :

```
96-83.698 → 1 candidat exact
  judilibreId 6079a87a9ba5988459c4d674 | ecli null | 1997-10-27
  Cour de cassation | Chambre criminelle | Rejet

97-81.102 → 1 candidat exact
  judilibreId 6079a86d9ba5988459c4d3a6 | ecli null | 1998-05-07
  Cour de cassation | Chambre criminelle | Rejet
```

Aucune écriture en base, aucune migration : cette PR n'ajoute que du code de lecture et de transformation.
