### PR TITLE
Enrichir une décision depuis Judilibre à partir d'une référence

### DIFF
--- a/src/app/api/admin/court-decisions/[id]/enrich/route.ts
+++ b/src/app/api/admin/court-decisions/[id]/enrich/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import {
+  enrichCourtDecisionSchema,
+  type EnrichCourtDecisionBody,
+} from "@/lib/security/schemas/court-decision";
+import { enrichCourtDecisionFromJudilibre } from "@/services/affairs/enrich-court-decision";
+import { invalidateEntity } from "@/lib/cache";
+
+/**
+ * Targeted Judilibre enrichment of one decision (#337).
+ *
+ * Manual and explicit: nothing here is scheduled, and no cron reaches this route.
+ * The input is a judicial reference, never a name.
+ *
+ * The route writes no affair. It refreshes the decision's own official fields, which
+ * the public fiche then renders through the dual read shipped with #536.
+ */
+
+/** Maps a refusal to a status code, so the admin sees why nothing was written. */
+const REFUSAL_STATUS: Record<string, number> = {
+  NOT_FOUND: 404,
+  AMBIGUOUS: 409,
+  CONFLICT: 409,
+  NO_REFERENCE: 400,
+  UNAVAILABLE: 503,
+};
+
+const REFUSAL_MESSAGE: Record<string, string> = {
+  NOT_FOUND: "Aucune décision Judilibre ne correspond à cette référence.",
+  AMBIGUOUS:
+    "Plusieurs décisions portent ce pourvoi. Un pourvoi n'identifie pas une décision : " +
+    "préciser l'identifiant Judilibre ou l'ECLI.",
+  CONFLICT: "La réponse officielle contredit l'identité de cette décision. Rien n'a été écrit.",
+  NO_REFERENCE: "Fournir une référence : identifiant Judilibre, ECLI ou numéro de pourvoi.",
+  UNAVAILABLE: "L'accès à Judilibre n'est pas configuré sur cet environnement.",
+};
+
+export const POST = withAdminAuth(
+  withValidation(
+    enrichCourtDecisionSchema,
+    async (request, context, body: EnrichCourtDecisionBody) => {
+      const { id } = await (context as { params: Promise<{ id: string }> }).params;
+
+      const decision = await db.courtDecision.findUnique({
+        where: { id },
+        select: { id: true },
+      });
+      if (!decision) {
+        return NextResponse.json({ error: "Décision non trouvée" }, { status: 404 });
+      }
+
+      const meta = getRequestMeta(request);
+      const result = await enrichCourtDecisionFromJudilibre({
+        courtDecisionId: id,
+        judilibreId: body.judilibreId ?? null,
+        ecli: body.ecli ?? null,
+        pourvoiNumber: body.pourvoiNumber ?? null,
+        triggeredBy: "admin",
+        requestMeta: meta,
+      });
+
+      if (result.status === "UPDATED") {
+        // Only after the transaction committed, and only for the fiches that cite it.
+        const links = await db.affairCourtDecision.findMany({
+          where: { courtDecisionId: id },
+          select: { affair: { select: { politician: { select: { slug: true } } } } },
+        });
+        invalidateEntity("affair");
+        for (const link of links) {
+          const slug = link.affair?.politician?.slug;
+          if (slug) invalidateEntity("politician", slug);
+        }
+        return NextResponse.json({
+          status: result.status,
+          judilibreId: result.judilibreId,
+          changes: result.changes,
+        });
+      }
+
+      if (result.status === "UNCHANGED") {
+        return NextResponse.json({ status: result.status, judilibreId: result.judilibreId });
+      }
+
+      return NextResponse.json(
+        { status: result.status, error: REFUSAL_MESSAGE[result.status], details: result },
+        { status: REFUSAL_STATUS[result.status] ?? 400 }
+      );
+    }
+  )
+);

--- a/src/app/api/admin/court-decisions/__tests__/enrich-route.test.ts
+++ b/src/app/api/admin/court-decisions/__tests__/enrich-route.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Issue #337 — the admin trigger for targeted Judilibre enrichment.
+ *
+ * What these tests defend: the route is behind the admin guard, requires an explicit
+ * confirmation and at least one reference, refuses a name-based input by having no
+ * field for it, invalidates caches only after a real write, and turns each refusal
+ * into a status code rather than a silent success.
+ */
+
+const h = vi.hoisted(() => ({
+  decisionFindUnique: vi.fn(),
+  linkFindMany: vi.fn(),
+  enrich: vi.fn(),
+  invalidateEntity: vi.fn(),
+  adminGuard: vi.fn(),
+}));
+
+const order: string[] = [];
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    courtDecision: { findUnique: h.decisionFindUnique },
+    affairCourtDecision: { findMany: h.linkFindMany },
+  },
+}));
+vi.mock("@/lib/cache", () => ({
+  invalidateEntity: (...args: unknown[]) => {
+    order.push("invalidate");
+    return h.invalidateEntity(...args);
+  },
+}));
+vi.mock("@/services/affairs/enrich-court-decision", () => ({
+  enrichCourtDecisionFromJudilibre: (...args: unknown[]) => {
+    order.push("enrich");
+    return h.enrich(...args);
+  },
+}));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) => {
+    h.adminGuard();
+    return fn(req, ctx);
+  },
+}));
+
+import { POST } from "../[id]/enrich/route";
+
+function request(body: unknown) {
+  return new Request("https://poligraph.fr/api/admin/court-decisions/dec_1/enrich", {
+    method: "POST",
+    headers: { "content-type": "application/json", "user-agent": "test-agent" },
+    body: JSON.stringify(body),
+  }) as unknown as Parameters<typeof POST>[0];
+}
+
+const context = { params: Promise.resolve({ id: "dec_1" }) } as unknown as Parameters<
+  typeof POST
+>[1];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  h.decisionFindUnique.mockResolvedValue({ id: "dec_1" });
+  h.linkFindMany.mockResolvedValue([{ affair: { politician: { slug: "jean-exemple" } } }]);
+  h.enrich.mockResolvedValue({ status: "UPDATED", judilibreId: "jud_1", changes: [] });
+});
+
+describe("POST enrichissement — succès (#337)", () => {
+  it("passe la référence au service et rend les changements", async () => {
+    const response = await POST(request({ pourvoiNumber: "96-83.698", confirmed: true }), context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "UPDATED",
+      judilibreId: "jud_1",
+    });
+    expect(h.enrich.mock.calls[0]![0]).toMatchObject({
+      courtDecisionId: "dec_1",
+      pourvoiNumber: "96-83.698",
+      triggeredBy: "admin",
+    });
+  });
+
+  it("invalide les caches seulement après l'écriture", async () => {
+    await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(order).toEqual(["enrich", "invalidate", "invalidate"]);
+    expect(h.invalidateEntity).toHaveBeenCalledWith("affair");
+    expect(h.invalidateEntity).toHaveBeenCalledWith("politician", "jean-exemple");
+  });
+
+  it("n'invalide rien quand rien n'a changé", async () => {
+    h.enrich.mockResolvedValue({ status: "UNCHANGED", judilibreId: "jud_1" });
+
+    const response = await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(response.status).toBe(200);
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST enrichissement — refus (#337)", () => {
+  it("exige une confirmation explicite", async () => {
+    const response = await POST(request({ pourvoiNumber: "96-83.698" }), context);
+
+    expect(response.status).toBe(400);
+    expect(h.enrich).not.toHaveBeenCalled();
+  });
+
+  it("exige au moins une référence", async () => {
+    const response = await POST(request({ confirmed: true }), context);
+
+    expect(response.status).toBe(400);
+    expect(h.enrich).not.toHaveBeenCalled();
+  });
+
+  it("n'accepte aucun champ de recherche par nom", async () => {
+    // Le flux abandonné : nom → recherche → affaire. Le schéma ne peut pas l'exprimer.
+    await POST(request({ name: "Jean Exemple", politician: "x", confirmed: true }), context);
+
+    expect(h.enrich).not.toHaveBeenCalled();
+  });
+
+  it("rend 404 sur une décision inexistante, sans appeler le service", async () => {
+    h.decisionFindUnique.mockResolvedValue(null);
+
+    const response = await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(response.status).toBe(404);
+    expect(h.enrich).not.toHaveBeenCalled();
+  });
+
+  it("rend 409 sur un pourvoi ambigu, et n'invalide rien", async () => {
+    h.enrich.mockResolvedValue({
+      status: "AMBIGUOUS",
+      reference: "96-83.698",
+      candidates: ["a", "b"],
+    });
+
+    const response = await POST(request({ pourvoiNumber: "96-83.698", confirmed: true }), context);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ status: "AMBIGUOUS" });
+    expect(h.invalidateEntity).not.toHaveBeenCalled();
+  });
+
+  it("rend 409 sur une identité contradictoire", async () => {
+    h.enrich.mockResolvedValue({ status: "CONFLICT", reason: "identifiant différent" });
+
+    const response = await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(response.status).toBe(409);
+  });
+
+  it("rend 404 quand la référence ne résout pas", async () => {
+    h.enrich.mockResolvedValue({ status: "NOT_FOUND", reference: "00-00.000" });
+
+    const response = await POST(request({ pourvoiNumber: "00-00.000", confirmed: true }), context);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rend 503 quand Judilibre n'est pas configuré", async () => {
+    h.enrich.mockResolvedValue({ status: "UNAVAILABLE" });
+
+    const response = await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(response.status).toBe(503);
+  });
+});
+
+describe("POST enrichissement — périmètre (#337)", () => {
+  it("passe par la garde admin", async () => {
+    await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    expect(h.adminGuard).toHaveBeenCalled();
+  });
+
+  it("n'atteint aucune table d'affaire en écriture", async () => {
+    await POST(request({ judilibreId: "jud_1", confirmed: true }), context);
+
+    // La route ne lit les liaisons que pour invalider ; rien d'autre n'est exposé.
+    expect(h.linkFindMany.mock.calls[0]![0]).toMatchObject({
+      where: { courtDecisionId: "dec_1" },
+    });
+  });
+});

--- a/src/components/admin/CourtDecisionLinks.tsx
+++ b/src/components/admin/CourtDecisionLinks.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { AlertTriangle, ExternalLink, Loader2, Search, Unlink } from "lucide-react";
+import { AlertTriangle, Download, ExternalLink, Loader2, Search, Unlink } from "lucide-react";
 
 /**
  * Manage the links between an affair and existing court decisions (#536).
  *
- * Links only. Nothing here creates, edits or deletes a decision: that belongs to
- * #337, once the identity rules are settled. A search by pourvoi number always shows
- * every candidate, because a pourvoi can produce several decisions.
+ * Links only. Nothing here creates or deletes a decision. A linked decision can be
+ * refreshed from Judilibre (#337): that rewrites the decision's own official fields,
+ * never the affair. A search by pourvoi number always shows every candidate, because
+ * a pourvoi can produce several decisions.
  */
 
 interface DecisionSummary {
@@ -84,6 +86,8 @@ export function CourtDecisionLinks({ affairId, initialLinks }: Props) {
   );
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     setLinks(initialLinks);
@@ -183,6 +187,43 @@ export function CourtDecisionLinks({ affairId, initialLinks }: Props) {
     [affairId, call]
   );
 
+  const enrich = useCallback(
+    async (decision: LinkedDecision) => {
+      const reference = decision.ecli ?? decision.pourvoiNumber;
+      if (!reference) {
+        setError("Cette décision n'a aucune référence à interroger.");
+        return;
+      }
+      const confirmed = window.confirm(
+        `Récupérer « ${reference} » depuis Judilibre ?\n\n` +
+          `Les champs officiels de la décision (juridiction, chambre, date, sens, ECLI) ` +
+          `seront écrits depuis la réponse de l'API et deviendront visibles sur la fiche ` +
+          `publique. L'affaire elle-même n'est pas modifiée.`
+      );
+      if (!confirmed) return;
+
+      setNotice(null);
+      const body = decision.ecli
+        ? { ecli: decision.ecli, confirmed: true }
+        : { pourvoiNumber: decision.pourvoiNumber, confirmed: true };
+      const data = await call(
+        `/api/admin/court-decisions/${decision.id}/enrich`,
+        { method: "POST", body: JSON.stringify(body) },
+        decision.id
+      );
+      if (!data) return;
+
+      if (data.status === "UNCHANGED") {
+        setNotice("Déjà à jour : la réponse officielle est identique à ce qui est enregistré.");
+        return;
+      }
+      const count = Array.isArray(data.changes) ? data.changes.length : 0;
+      setNotice(`${count} champ(s) mis à jour depuis Judilibre.`);
+      router.refresh();
+    },
+    [call, router]
+  );
+
   return (
     <section className="space-y-4">
       <header>
@@ -201,6 +242,12 @@ export function CourtDecisionLinks({ affairId, initialLinks }: Props) {
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
           <span>{error}</span>
         </div>
+      )}
+
+      {notice && (
+        <p role="status" className="rounded-md border bg-muted/40 p-3 text-sm">
+          {notice}
+        </p>
       )}
 
       {links.length === 0 ? (
@@ -232,6 +279,20 @@ export function CourtDecisionLinks({ affairId, initialLinks }: Props) {
                     onClick={() => saveNote(decision.id)}
                   >
                     Enregistrer la note
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={busy === decision.id || !(decision.ecli || decision.pourvoiNumber)}
+                    onClick={() => enrich(decision)}
+                    title={
+                      decision.ecli || decision.pourvoiNumber
+                        ? undefined
+                        : "Aucune référence à interroger"
+                    }
+                  >
+                    <Download className="mr-1 h-3 w-3" aria-hidden="true" />
+                    Enrichir depuis Judilibre
                   </Button>
                   <Button
                     size="sm"

--- a/src/lib/security/schemas/court-decision.ts
+++ b/src/lib/security/schemas/court-decision.ts
@@ -36,7 +36,27 @@ export const unlinkCourtDecisionSchema = z.object({
   confirmed: z.literal(true),
 });
 
+/**
+ * Targeted Judilibre enrichment of one existing decision (#337).
+ *
+ * The input is a reference, never a person's name: searching the pseudonymised
+ * corpus by name is the retired pipeline, and no field here can express it. At
+ * least one reference is required, checked below rather than left to the route.
+ */
+export const enrichCourtDecisionSchema = z
+  .object({
+    judilibreId: z.string().min(1).max(64).optional(),
+    ecli: z.string().min(1).max(120).optional(),
+    pourvoiNumber: z.string().min(1).max(60).optional(),
+    /** Explicit: enrichment writes official fields onto a publicly rendered decision. */
+    confirmed: z.literal(true),
+  })
+  .refine((v) => Boolean(v.judilibreId || v.ecli || v.pourvoiNumber), {
+    message: "Fournir au moins une référence : identifiant Judilibre, ECLI ou numéro de pourvoi.",
+  });
+
 export type CourtDecisionSearchQuery = z.infer<typeof courtDecisionSearchSchema>;
+export type EnrichCourtDecisionBody = z.infer<typeof enrichCourtDecisionSchema>;
 export type LinkCourtDecisionBody = z.infer<typeof linkCourtDecisionSchema>;
 export type UpdateCourtDecisionLinkBody = z.infer<typeof updateCourtDecisionLinkSchema>;
 export type UnlinkCourtDecisionBody = z.infer<typeof unlinkCourtDecisionSchema>;

--- a/src/services/affairs/__tests__/enrich-court-decision.test.ts
+++ b/src/services/affairs/__tests__/enrich-court-decision.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #337 — targeted enrichment. The tests that matter most are the ones where
+// the service must REFUSE to write: ambiguous pourvoi, contradictory identity, and
+// a response whose nulls must not erase what is already stored.
+
+const h = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  txFindUnique: vi.fn(),
+  update: vi.fn(),
+  auditCreate: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    courtDecision: { findUnique: h.findUnique },
+    $transaction: h.transaction,
+  },
+}));
+
+vi.mock("@/lib/api/judilibre", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/judilibre")>()),
+  createJudilibreClient: () => null,
+}));
+
+import { enrichCourtDecisionFromJudilibre, type JudilibreReader } from "../enrich-court-decision";
+import type { JudilibreDecision } from "@/lib/api/judilibre";
+import { hashJudilibrePayload } from "../judilibre-court-decision";
+
+const TAXONOMY: Record<string, Record<string, string>> = {
+  jurisdiction: { cc: "Cour de cassation" },
+  chamber: { cr: "Chambre criminelle" },
+  solution: { rejet: "Rejet" },
+  type: { arret: "Arrêt" },
+};
+
+function record(overrides: Partial<JudilibreDecision> = {}): JudilibreDecision {
+  return {
+    id: "jud_1",
+    number: "96-83.698",
+    numbers: ["96-83.698"],
+    decision_date: "1997-10-27",
+    jurisdiction: "cc",
+    chamber: "cr",
+    solution: "rejet",
+    type: "arret",
+    themes: [],
+    summary: "",
+    text: "corps",
+    ...overrides,
+  } as JudilibreDecision;
+}
+
+function reader(overrides: Partial<JudilibreReader> = {}): JudilibreReader {
+  return {
+    getDecision: vi.fn().mockResolvedValue(record()),
+    findDecisionByEcli: vi.fn().mockResolvedValue({ id: "jud_1" }),
+    findDecisionsByPourvoiNumber: vi.fn().mockResolvedValue([{ id: "jud_1" }]),
+    getTaxonomy: vi.fn().mockImplementation(async (id: string) => TAXONOMY[id] ?? {}),
+    ...overrides,
+  };
+}
+
+/** A stored row, before enrichment. */
+function stored(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dec_1",
+    judilibreId: null,
+    ecli: null,
+    pourvoiNumber: "96-83.698",
+    pourvoiNumberNormalized: "9683698",
+    decisionDate: null,
+    court: null,
+    chamber: null,
+    solution: null,
+    sourceUrl: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.findUnique.mockResolvedValue(stored());
+  h.txFindUnique.mockResolvedValue(stored());
+  h.update.mockResolvedValue({});
+  h.auditCreate.mockResolvedValue({});
+  h.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn({
+      courtDecision: { findUnique: h.txFindUnique, update: h.update },
+      auditLog: { create: h.auditCreate },
+    })
+  );
+});
+
+describe("Résolution de la référence (#337)", () => {
+  it("écrit les champs officiels depuis un pourvoi résolu", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", pourvoiNumber: "96-83.698" },
+      reader()
+    );
+
+    expect(result.status).toBe("UPDATED");
+    expect(h.update.mock.calls[0]![0].data).toMatchObject({
+      judilibreId: "jud_1",
+      court: "Cour de cassation",
+      chamber: "Chambre criminelle",
+      solution: "Rejet",
+      sourceUrl: "https://www.courdecassation.fr/decision/jud_1",
+    });
+  });
+
+  it("préfère l'identifiant Judilibre à toute autre référence", async () => {
+    const r = reader();
+    await enrichCourtDecisionFromJudilibre(
+      {
+        courtDecisionId: "dec_1",
+        judilibreId: "jud_1",
+        ecli: "ECLI:X",
+        pourvoiNumber: "96-83.698",
+      },
+      r
+    );
+
+    expect(r.findDecisionByEcli).not.toHaveBeenCalled();
+    expect(r.findDecisionsByPourvoiNumber).not.toHaveBeenCalled();
+  });
+
+  it("REFUSE d'écrire quand un pourvoi rend plusieurs décisions", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", pourvoiNumber: "96-83.698" },
+      reader({
+        findDecisionsByPourvoiNumber: vi.fn().mockResolvedValue([{ id: "jud_1" }, { id: "jud_2" }]),
+      })
+    );
+
+    // Un pourvoi peut produire rejet, cassation partielle et renvoi : choisir serait deviner.
+    expect(result).toMatchObject({ status: "AMBIGUOUS", candidates: ["jud_1", "jud_2"] });
+    expect(h.update).not.toHaveBeenCalled();
+    expect(h.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it("rend NOT_FOUND sans écrire quand la référence ne résout pas", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", pourvoiNumber: "00-00.000" },
+      reader({ findDecisionsByPourvoiNumber: vi.fn().mockResolvedValue([]) })
+    );
+
+    expect(result.status).toBe("NOT_FOUND");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("refuse une demande sans aucune référence", async () => {
+    const result = await enrichCourtDecisionFromJudilibre({ courtDecisionId: "dec_1" }, reader());
+
+    expect(result.status).toBe("NO_REFERENCE");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("rend UNAVAILABLE sans client configuré", async () => {
+    const result = await enrichCourtDecisionFromJudilibre({
+      courtDecisionId: "dec_1",
+      judilibreId: "jud_1",
+    });
+
+    expect(result.status).toBe("UNAVAILABLE");
+  });
+});
+
+describe("Vérification d'identité (#337)", () => {
+  it("REFUSE une réponse portant un autre identifiant que celui demandé", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader({ getDecision: vi.fn().mockResolvedValue(record({ id: "jud_autre" })) })
+    );
+
+    expect(result.status).toBe("CONFLICT");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("REFUSE d'enrichir une décision déjà rattachée à un autre identifiant", async () => {
+    h.findUnique.mockResolvedValue(stored({ judilibreId: "jud_deja_la" }));
+    h.txFindUnique.mockResolvedValue(stored({ judilibreId: "jud_deja_la" }));
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    // Sinon on réécrirait en silence quelle décision une fiche publiée cite.
+    expect(result).toMatchObject({ status: "CONFLICT" });
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("REFUSE quand l'ECLI stocké contredit celui de la réponse", async () => {
+    h.findUnique.mockResolvedValue(stored({ ecli: "ECLI:FR:CCASS:2026:CR00001" }));
+    h.txFindUnique.mockResolvedValue(stored({ ecli: "ECLI:FR:CCASS:2026:CR00001" }));
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader({
+        getDecision: vi.fn().mockResolvedValue(record({ ecli: "ECLI:FR:CCASS:2026:CR99999" })),
+      })
+    );
+
+    expect(result.status).toBe("CONFLICT");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("REFUSE une réponse ne portant pas le pourvoi demandé", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", pourvoiNumber: "96-83.698" },
+      reader({
+        getDecision: vi
+          .fn()
+          .mockResolvedValue(record({ number: "12-34.567", numbers: ["12-34.567"] })),
+      })
+    );
+
+    expect(result.status).toBe("CONFLICT");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it("accepte un pourvoi porté par la liste secondaire", async () => {
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", pourvoiNumber: "96-83.698" },
+      reader({
+        getDecision: vi
+          .fn()
+          .mockResolvedValue(record({ number: "97-81.102", numbers: ["97-81.102", "96-83.698"] })),
+      })
+    );
+
+    expect(result.status).toBe("UPDATED");
+  });
+
+  it("REFUSE quand la décision a disparu entre la lecture et la transaction", async () => {
+    h.txFindUnique.mockResolvedValue(null);
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    expect(result.status).toBe("CONFLICT");
+    expect(h.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("Écriture et audit (#337)", () => {
+  it("un null de la réponse n'efface pas une valeur déjà enregistrée", async () => {
+    h.findUnique.mockResolvedValue(stored({ solution: "Rejet", court: "Cour de cassation" }));
+    h.txFindUnique.mockResolvedValue(stored({ solution: "Rejet", court: "Cour de cassation" }));
+
+    await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      // Codes inconnus de la taxonomie → le mappeur rend null.
+      reader({
+        getDecision: vi.fn().mockResolvedValue(record({ solution: "inconnu", jurisdiction: "xx" })),
+      })
+    );
+
+    const written = h.update.mock.calls[0]![0].data;
+    // L'API qui omet un champ ne dit pas que le champ est vide.
+    expect(written).not.toHaveProperty("solution");
+    expect(written).not.toHaveProperty("court");
+  });
+
+  it("applique une valeur officielle différente et garde le diff en audit", async () => {
+    h.findUnique.mockResolvedValue(stored({ solution: "Cassation" }));
+    h.txFindUnique.mockResolvedValue(stored({ solution: "Cassation" }));
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    expect(result).toMatchObject({ status: "UPDATED" });
+    expect(h.update.mock.calls[0]![0].data.solution).toBe("Rejet");
+    const audited = h.auditCreate.mock.calls[0]![0].data.changes.changes;
+    expect(audited).toContainEqual({ field: "solution", before: "Cassation", after: "Rejet" });
+  });
+
+  it("écrit la provenance complète dans l'audit", async () => {
+    await enrichCourtDecisionFromJudilibre(
+      {
+        courtDecisionId: "dec_1",
+        pourvoiNumber: "96-83.698",
+        triggeredBy: "admin",
+        requestMeta: { ip: "203.0.113.7", userAgent: "navigateur" },
+      },
+      reader()
+    );
+
+    const entry = h.auditCreate.mock.calls[0]![0].data;
+    expect(entry).toMatchObject({
+      entityType: "CourtDecision",
+      entityId: "dec_1",
+      ipAddress: "203.0.113.7",
+      userAgent: "navigateur",
+    });
+    expect(entry.changes).toMatchObject({
+      action: "JUDILIBRE_ENRICHMENT",
+      // Le canal, pas l'outil : une seule session admin existe, sans identifiant par personne.
+      triggeredBy: "admin",
+      reference: "pourvoi:96-83.698",
+      judilibreId: "jud_1",
+      mapperVersion: expect.any(String),
+    });
+    expect(entry.changes.sourceContentHash).toHaveLength(64);
+    expect(entry.changes.retrievedAt).toEqual(expect.any(String));
+  });
+
+  it("audit et écriture vivent dans la même transaction", async () => {
+    await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    expect(h.transaction).toHaveBeenCalledTimes(1);
+    expect(h.update).toHaveBeenCalledTimes(1);
+    expect(h.auditCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ne touche ni affaire, ni liaison, ni proposition", async () => {
+    const tx: Record<string, unknown> = {
+      courtDecision: { findUnique: h.txFindUnique, update: h.update },
+      auditLog: { create: h.auditCreate },
+    };
+    h.transaction.mockImplementation(async (fn: (t: unknown) => unknown) => fn(tx));
+
+    await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    // Le client transactionnel n'expose rien d'autre : toucher une affaire lèverait.
+    expect(Object.keys(tx)).toEqual(["courtDecision", "auditLog"]);
+  });
+});
+
+describe("Idempotence (#337)", () => {
+  it("rejouer la même réponse n'écrit rien et ne crée aucun audit", async () => {
+    const same = record();
+    const enriched = stored({
+      judilibreId: "jud_1",
+      pourvoiNumber: "96-83.698",
+      pourvoiNumberNormalized: "9683698",
+      decisionDate: new Date("1997-10-27T00:00:00Z"),
+      court: "Cour de cassation",
+      chamber: "Chambre criminelle",
+      solution: "Rejet",
+      sourceUrl: "https://www.courdecassation.fr/decision/jud_1",
+      metadata: { sourceContentHash: hashJudilibrePayload(same) },
+    });
+    h.findUnique.mockResolvedValue(enriched);
+    h.txFindUnique.mockResolvedValue(enriched);
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader({ getDecision: vi.fn().mockResolvedValue(same) })
+    );
+
+    expect(result).toEqual({ status: "UNCHANGED", judilibreId: "jud_1" });
+    expect(h.update).not.toHaveBeenCalled();
+    expect(h.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it("réécrit quand la charge officielle a changé, même à champs identiques", async () => {
+    const enriched = stored({
+      judilibreId: "jud_1",
+      pourvoiNumber: "96-83.698",
+      pourvoiNumberNormalized: "9683698",
+      decisionDate: new Date("1997-10-27T00:00:00Z"),
+      court: "Cour de cassation",
+      chamber: "Chambre criminelle",
+      solution: "Rejet",
+      sourceUrl: "https://www.courdecassation.fr/decision/jud_1",
+      metadata: { sourceContentHash: "un_hash_anterieur" },
+    });
+    h.findUnique.mockResolvedValue(enriched);
+    h.txFindUnique.mockResolvedValue(enriched);
+
+    const result = await enrichCourtDecisionFromJudilibre(
+      { courtDecisionId: "dec_1", judilibreId: "jud_1" },
+      reader()
+    );
+
+    // Une rectification du texte de la décision doit rester traçable.
+    expect(result.status).toBe("UPDATED");
+    expect(h.auditCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/affairs/enrich-court-decision.ts
+++ b/src/services/affairs/enrich-court-decision.ts
@@ -1,0 +1,328 @@
+/**
+ * Targeted enrichment of a `CourtDecision` from Judilibre (#337).
+ *
+ * The input is always a **reference** — a Judilibre id, an ECLI, a pourvoi number —
+ * never a person's name. Searching the corpus by name produced 0 affairs out of 156
+ * decisions, because the corpus is pseudonymised; that pipeline is retired and this
+ * one deliberately cannot express it.
+ *
+ * The output is a decision, and only a decision. Nothing here creates or modifies an
+ * `Affair`, changes a publication status, touches `Affair.court` or
+ * `Affair.verdictDate`, creates an editorial proposal, merges affairs, or alters a
+ * link. Editorial proposals stay reserved for corrections to an `Affair`.
+ *
+ * Writes are direct rather than proposed: a `CourtDecision` records an official act,
+ * its fields come from an authenticated response, and the editorial fiche is left
+ * untouched. Every write is audited with enough provenance to be re-derived.
+ */
+
+import { db, type DbTransactionClient } from "@/lib/db";
+import { createJudilibreClient, type JudilibreDecision } from "@/lib/api/judilibre";
+import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
+import {
+  hashJudilibrePayload,
+  JUDILIBRE_MAPPER_VERSION,
+  mapJudilibreToCourtDecision,
+  type JudilibreLabels,
+  type MappedCourtDecision,
+} from "./judilibre-court-decision";
+
+/** Fields this service may write. `judilibreId` is the identity, handled apart. */
+const ENRICHABLE_FIELDS = [
+  "ecli",
+  "pourvoiNumber",
+  "pourvoiNumberNormalized",
+  "decisionDate",
+  "court",
+  "chamber",
+  "solution",
+  "sourceUrl",
+] as const;
+
+type EnrichableField = (typeof ENRICHABLE_FIELDS)[number];
+
+export interface EnrichCourtDecisionInput {
+  courtDecisionId: string;
+  /** At least one reference is required; they are tried in this order. */
+  judilibreId?: string | null;
+  ecli?: string | null;
+  pourvoiNumber?: string | null;
+  /** Channel that triggered it — "admin", "cli" — not the tool used. Audited. */
+  triggeredBy?: string | null;
+  requestMeta?: { ip?: string | null; userAgent?: string | null } | null;
+}
+
+export type EnrichCourtDecisionResult =
+  | { status: "UPDATED"; judilibreId: string; changes: FieldChange[] }
+  | { status: "UNCHANGED"; judilibreId: string }
+  | { status: "NOT_FOUND"; reference: string }
+  | { status: "AMBIGUOUS"; reference: string; candidates: string[] }
+  | { status: "CONFLICT"; reason: string }
+  | { status: "NO_REFERENCE" }
+  | { status: "UNAVAILABLE" };
+
+export interface FieldChange {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+/** The narrow slice of the client this service needs, so tests can supply their own. */
+export interface JudilibreReader {
+  getDecision(id: string): Promise<JudilibreDecision>;
+  findDecisionByEcli(ecli: string): Promise<{ id: string } | null>;
+  findDecisionsByPourvoiNumber(pourvoiNumber: string): Promise<{ id: string }[]>;
+  getTaxonomy(
+    id: "jurisdiction" | "chamber" | "solution" | "type"
+  ): Promise<Record<string, string>>;
+}
+
+class EnrichmentStop extends Error {
+  constructor(public readonly result: EnrichCourtDecisionResult) {
+    super("enrichment stopped");
+  }
+}
+
+/**
+ * Resolves the reference to exactly one Judilibre id.
+ *
+ * A pourvoi number is never treated as an identity: several decisions can carry it,
+ * so more than one candidate stops the operation instead of picking the first.
+ */
+async function resolveJudilibreId(
+  reader: JudilibreReader,
+  input: EnrichCourtDecisionInput
+): Promise<{ id: string; reference: string }> {
+  const judilibreId = input.judilibreId?.trim();
+  if (judilibreId) return { id: judilibreId, reference: judilibreId };
+
+  const ecli = input.ecli?.trim();
+  if (ecli) {
+    const found = await reader.findDecisionByEcli(ecli);
+    if (!found) throw new EnrichmentStop({ status: "NOT_FOUND", reference: ecli });
+    return { id: found.id, reference: ecli };
+  }
+
+  const pourvoi = input.pourvoiNumber?.trim();
+  if (pourvoi) {
+    const candidates = await reader.findDecisionsByPourvoiNumber(pourvoi);
+    if (candidates.length === 0)
+      throw new EnrichmentStop({ status: "NOT_FOUND", reference: pourvoi });
+    if (candidates.length > 1) {
+      throw new EnrichmentStop({
+        status: "AMBIGUOUS",
+        reference: pourvoi,
+        candidates: candidates.map((c) => c.id),
+      });
+    }
+    return { id: candidates[0]!.id, reference: pourvoi };
+  }
+
+  throw new EnrichmentStop({ status: "NO_REFERENCE" });
+}
+
+/**
+ * Refuses a response that is not the decision that was asked for.
+ *
+ * Covers both directions: the response must answer the reference used, and it must
+ * not contradict an identity the row already carries. Enriching a row that already
+ * points at another Judilibre decision would silently rewrite which decision a
+ * published fiche cites.
+ */
+function assertIdentityMatches(
+  record: JudilibreDecision,
+  input: EnrichCourtDecisionInput,
+  stored: { judilibreId: string | null; ecli: string | null }
+): void {
+  const stop = (reason: string): never => {
+    throw new EnrichmentStop({ status: "CONFLICT", reason });
+  };
+
+  if (input.judilibreId?.trim() && record.id !== input.judilibreId.trim()) {
+    stop(`la réponse porte l'identifiant ${record.id}, pas ${input.judilibreId.trim()}`);
+  }
+
+  const askedEcli = input.ecli?.trim();
+  if (askedEcli && foldJudicialReference(record.ecli ?? "") !== foldJudicialReference(askedEcli)) {
+    stop(`la réponse porte l'ECLI ${record.ecli ?? "aucun"}, pas ${askedEcli}`);
+  }
+
+  const askedPourvoi = input.pourvoiNumber?.trim();
+  if (askedPourvoi) {
+    const wanted = foldJudicialReference(askedPourvoi);
+    const numbers = record.numbers?.length ? record.numbers : [record.number];
+    if (!numbers.some((n) => n && foldJudicialReference(n) === wanted)) {
+      stop(`la réponse ne porte pas le pourvoi ${askedPourvoi}`);
+    }
+  }
+
+  if (stored.judilibreId && stored.judilibreId !== record.id) {
+    stop(
+      `la décision est déjà rattachée à l'identifiant ${stored.judilibreId}, ` +
+        `la réponse porte ${record.id}`
+    );
+  }
+
+  if (
+    stored.ecli &&
+    record.ecli &&
+    foldJudicialReference(stored.ecli) !== foldJudicialReference(record.ecli)
+  ) {
+    stop(`la décision porte l'ECLI ${stored.ecli}, la réponse porte ${record.ecli}`);
+  }
+}
+
+/** Two stored values compare equal, dates included. */
+function sameValue(a: unknown, b: unknown): boolean {
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  return a === b;
+}
+
+/**
+ * What the official response changes, field by field.
+ *
+ * A null in the response never erases a stored value: the API omitting a field is
+ * not the API stating that the field is empty. A non-null official value that
+ * differs is applied, and the full before/after lands in the audit trail.
+ */
+function computeChanges(
+  stored: Record<string, unknown>,
+  mapped: MappedCourtDecision
+): { data: Record<string, unknown>; changes: FieldChange[] } {
+  const data: Record<string, unknown> = {};
+  const changes: FieldChange[] = [];
+
+  for (const field of ENRICHABLE_FIELDS) {
+    const after = mapped[field as EnrichableField];
+    if (after === null || after === undefined) continue;
+
+    const before = stored[field] ?? null;
+    if (sameValue(before, after)) continue;
+
+    data[field] = after;
+    changes.push({ field, before, after });
+  }
+
+  return { data, changes };
+}
+
+/**
+ * Fetches the official record and writes it onto the decision.
+ *
+ * The network call happens outside the transaction: holding a database connection
+ * open across an HTTP round trip is how a pool runs dry. The row is then re-read
+ * inside the transaction, so a concurrent change is seen before writing.
+ */
+export async function enrichCourtDecisionFromJudilibre(
+  input: EnrichCourtDecisionInput,
+  reader?: JudilibreReader | null,
+  client: typeof db = db
+): Promise<EnrichCourtDecisionResult> {
+  const judilibre = reader ?? (createJudilibreClient() as JudilibreReader | null);
+  if (!judilibre) return { status: "UNAVAILABLE" };
+
+  try {
+    const existing = await client.courtDecision.findUnique({
+      where: { id: input.courtDecisionId },
+      select: { id: true, judilibreId: true, ecli: true },
+    });
+    if (!existing) {
+      return { status: "CONFLICT", reason: "décision introuvable" };
+    }
+
+    const { id: resolvedId } = await resolveJudilibreId(judilibre, input);
+    const record = await judilibre.getDecision(resolvedId);
+    assertIdentityMatches(record, input, existing);
+
+    const [jurisdiction, chamber, solution, type] = await Promise.all([
+      judilibre.getTaxonomy("jurisdiction"),
+      judilibre.getTaxonomy("chamber"),
+      judilibre.getTaxonomy("solution"),
+      judilibre.getTaxonomy("type"),
+    ]);
+    const labels: JudilibreLabels = { jurisdiction, chamber, solution, type };
+    const payloadHash = hashJudilibrePayload(record);
+
+    return await client.$transaction(async (tx) => {
+      const current = await readForUpdate(tx, input.courtDecisionId);
+      if (!current) return { status: "CONFLICT", reason: "décision supprimée entre-temps" };
+
+      assertIdentityMatches(record, input, {
+        judilibreId: current.judilibreId,
+        ecli: current.ecli,
+      });
+
+      const mapped = mapJudilibreToCourtDecision(record, labels, new Date());
+      const { data, changes } = computeChanges(current as Record<string, unknown>, mapped);
+      const identityChanged = current.judilibreId !== record.id;
+      const storedHash = readStoredHash(current.metadata);
+
+      // Replaying the same response must write nothing: no row touched, no audit
+      // entry, and in particular no refreshed `retrievedAt` masquerading as a change.
+      if (!identityChanged && changes.length === 0 && storedHash === payloadHash) {
+        return { status: "UNCHANGED", judilibreId: record.id };
+      }
+
+      if (identityChanged) {
+        changes.unshift({ field: "judilibreId", before: current.judilibreId, after: record.id });
+      }
+
+      await tx.courtDecision.update({
+        where: { id: input.courtDecisionId },
+        data: { ...data, judilibreId: record.id, metadata: mapped.metadata },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: "UPDATE",
+          entityType: "CourtDecision",
+          entityId: input.courtDecisionId,
+          ipAddress: input.requestMeta?.ip ?? null,
+          userAgent: input.requestMeta?.userAgent ?? null,
+          changes: {
+            action: "JUDILIBRE_ENRICHMENT",
+            triggeredBy: input.triggeredBy ?? null,
+            reference: describeReference(input),
+            judilibreId: record.id,
+            sourceContentHash: payloadHash,
+            mapperVersion: JUDILIBRE_MAPPER_VERSION,
+            retrievedAt: mapped.metadata.retrievedAt,
+            changes: changes.map((c) => ({
+              field: c.field,
+              before: serialize(c.before),
+              after: serialize(c.after),
+            })),
+          },
+        },
+      });
+
+      return { status: "UPDATED", judilibreId: record.id, changes };
+    });
+  } catch (error) {
+    if (error instanceof EnrichmentStop) return error.result;
+    throw error;
+  }
+}
+
+async function readForUpdate(tx: DbTransactionClient, id: string) {
+  return tx.courtDecision.findUnique({ where: { id } });
+}
+
+/** The reference actually used, for the audit trail. */
+function describeReference(input: EnrichCourtDecisionInput): string {
+  if (input.judilibreId?.trim()) return `judilibreId:${input.judilibreId.trim()}`;
+  if (input.ecli?.trim()) return `ecli:${input.ecli.trim()}`;
+  if (input.pourvoiNumber?.trim()) return `pourvoi:${input.pourvoiNumber.trim()}`;
+  return "aucune";
+}
+
+/** The hash stored on the previous enrichment, if this row carries one. */
+function readStoredHash(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const hash = (metadata as Record<string, unknown>).sourceContentHash;
+  return typeof hash === "string" ? hash : null;
+}
+
+function serialize(value: unknown): unknown {
+  return value instanceof Date ? value.toISOString() : value;
+}


### PR DESCRIPTION
Part of #337. Deuxième des cinq PR. Suite de #551.

## Ce que fait le service

```ts
enrichCourtDecisionFromJudilibre({ courtDecisionId, judilibreId?, ecli?, pourvoiNumber? })
```

L'entrée est une **référence**, jamais un nom de personne. Le service ne peut pas exprimer le flux abandonné : aucun paramètre ne prend un nom, et le schéma de la route non plus.

La sortie est une décision, et rien d'autre. Aucune `Affair` créée ou modifiée, aucun statut de publication touché, aucun `Affair.court` ni `Affair.verdictDate`, aucune proposition éditoriale, aucune fusion, aucune liaison changée. Un test vérifie que le client transactionnel n'expose que `courtDecision` et `auditLog`, donc qu'atteindre une affaire lèverait.

## Écriture directe, et pourquoi

Une `CourtDecision` consigne un acte officiel, pas une fiche éditoriale. Ses champs viennent d'une réponse authentifiée et vérifiable, donc ils sont écrits directement, avec un audit systématique. Les propositions restent réservées aux corrections éditoriales d'une `Affair`, ce qui laisse l'invariant de #513 intact.

## Résolution de la référence

Dans l'ordre : identifiant Judilibre exact, sinon ECLI exact, sinon pourvoi normalisé.

Pour un pourvoi : zéro résultat donne `NOT_FOUND`, un résultat continue, **plusieurs donnent `AMBIGUOUS` et rien n'est écrit**. Un pourvoi peut produire un rejet, une cassation partielle et un renvoi : choisir serait deviner.

## Vérification d'identité, dans les deux sens

Le service refuse d'écrire quand la réponse ne correspond pas.

Vers l'amont, la réponse doit répondre à la référence utilisée : un autre identifiant, un ECLI qui diffère, un pourvoi absent de la réponse donnent `CONFLICT`.

Vers l'aval, la réponse ne doit pas contredire ce que la ligne porte déjà. **Enrichir une décision déjà rattachée à un autre `judilibreId` réécrirait en silence quelle décision une fiche publiée cite.** C'est refusé.

La vérification est rejouée **dans** la transaction, après relecture de la ligne, donc une modification concurrente est vue avant l'écriture.

## Un null n'efface jamais

Une réponse dont un champ est nul ne remplace pas une valeur déjà enregistrée : l'API qui omet un champ ne dit pas que le champ est vide.

Une valeur officielle non nulle qui change est appliquée directement, et le diff complet part dans l'audit.

## Idempotence

Rejouer exactement la même réponse n'écrit rien : ni ligne touchée, ni audit, ni `retrievedAt` rafraîchi qui passerait pour un changement. La comparaison porte sur le hash de la charge officielle, pas sur les champs seuls, donc une rectification du texte de la décision reste détectée même à champs identiques.

## Audit

Chaque écriture journalise l'identifiant de la décision, le diff champ par champ avant et après, la référence utilisée, le `judilibreId`, le hash du contenu source, la version du mappeur et la date de récupération. Le canal (`admin`, `cli`) est enregistré plutôt que l'outil.

`userId` reste nul : `withAdminAuth` valide une session unique, sans identifiant par personne. L'IP et l'agent sont journalisés à la place.

## Transaction

L'appel réseau a lieu **hors** transaction. Garder une connexion ouverte pendant un aller-retour HTTP est la façon classique d'assécher un pool. La ligne est ensuite relue dans la transaction, où l'écriture et son audit vivent ensemble.

## Route admin

`POST /api/admin/court-decisions/[id]/enrich`, derrière la garde admin, avec `confirmed: true` obligatoire et au moins une référence.

Chaque refus devient un code : 404 introuvable, 409 ambigu ou contradictoire, 400 sans référence, 503 si Judilibre n'est pas configuré. Les caches ne sont invalidés qu'après une écriture réelle, jamais sur `UNCHANGED`.

Un bouton « Enrichir depuis Judilibre » apparaît sur chaque décision liée, désactivé quand la décision n'a aucune référence à interroger, avec une confirmation qui dit ce qui va changer et ce qui ne changera pas.

## Sur les sources officielles

Le critère d'acceptation de #337 mentionne l'attachement idempotent d'une source officielle. Rien n'est attaché ici : une `Source` appartient à une `Affair`, et l'invariant retenu est qu'aucune écriture ne touche `Affair`. Le lien officiel est déjà porté par `CourtDecision.sourceUrl` et rendu par la double lecture de #536, donc le besoin est couvert sans écrire sur la fiche.

## Tests

**32 tests** : 19 sur le service, 13 sur la route.

Les plus utiles sont ceux où le service doit **refuser** : pourvoi ambigu, identité contradictoire en amont comme en aval, décision disparue entre la lecture et la transaction, et le null qui ne doit rien effacer.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2550 tests**, 0 échec. `tsc` et `eslint` propres.

`prisma migrate diff` rend « empty migration » : aucune migration, aucun champ ajouté.

Aucune écriture en production dans cette PR : le service existe, rien ne l'a encore déclenché. C'est #554 qui enrichira les deux décisions réelles.
