### PR TITLE
Enrichir les deux décisions existantes depuis Judilibre

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "sync:factchecks": "tsx scripts/sync-factchecks.ts",
     "sync:factchecks:stats": "tsx scripts/sync-factchecks.ts --stats",
     "judilibre:diagnostics": "tsx scripts/judilibre-diagnostics.ts",
+    "enrich:court-decisions": "tsx scripts/enrich-court-decisions-judilibre.ts",
     "sync:press-analysis": "tsx scripts/sync-press-analysis.ts",
     "reconcile:affairs": "tsx scripts/reconcile-affairs.ts",
     "discover:affairs": "tsx scripts/discover-affairs.ts",

--- a/scripts/enrich-court-decisions-judilibre.ts
+++ b/scripts/enrich-court-decisions-judilibre.ts
@@ -1,0 +1,213 @@
+/**
+ * Targeted Judilibre enrichment of the decisions already in the base (#337).
+ *
+ * Usage:
+ *   npm run enrich:court-decisions              # report only, writes nothing
+ *   npm run enrich:court-decisions -- --apply   # writes, after the same checks
+ *
+ * Explicitly invoked, never scheduled. It works from the pourvoi numbers already
+ * stored on `CourtDecision`, so its input is a reference, never a name.
+ *
+ * It refuses to run if the base no longer looks like what it was designed against:
+ * a backfill that adapts to unexpected data is a backfill nobody can review.
+ */
+
+import "dotenv/config";
+import { db } from "../src/lib/db";
+import { enrichCourtDecisionFromJudilibre } from "../src/services/affairs/enrich-court-decision";
+import { createJudilibreClient } from "../src/lib/api/judilibre";
+
+/** What the base looked like when this run was designed. */
+const EXPECTED = {
+  affairs: 463,
+  courtDecisions: 2,
+  links: 3,
+  pairDecisions: 8,
+  proposals: 0,
+  pourvois: ["96-83.698", "97-81.102"],
+} as const;
+
+class PreconditionError extends Error {}
+
+async function readState() {
+  const [affairs, courtDecisions, links, pairDecisions, proposals, decisions] = await Promise.all([
+    db.affair.count(),
+    db.courtDecision.count(),
+    db.affairCourtDecision.count(),
+    db.affairPairDecision.count(),
+    db.affairUpdateProposal.count(),
+    db.courtDecision.findMany({
+      select: {
+        id: true,
+        judilibreId: true,
+        ecli: true,
+        pourvoiNumber: true,
+        decisionDate: true,
+        court: true,
+        chamber: true,
+        solution: true,
+        sourceUrl: true,
+      },
+      orderBy: { pourvoiNumber: "asc" },
+    }),
+  ]);
+  return { affairs, courtDecisions, links, pairDecisions, proposals, decisions };
+}
+
+type State = Awaited<ReturnType<typeof readState>>;
+
+function assertPreconditions(state: State): void {
+  const checks: Array<[string, number, number]> = [
+    ["affaires", state.affairs, EXPECTED.affairs],
+    ["décisions", state.courtDecisions, EXPECTED.courtDecisions],
+    ["liaisons", state.links, EXPECTED.links],
+    ["jugements de paires", state.pairDecisions, EXPECTED.pairDecisions],
+    ["propositions", state.proposals, EXPECTED.proposals],
+  ];
+
+  console.log("Préconditions :");
+  const failures: string[] = [];
+  for (const [label, actual, expected] of checks) {
+    const ok = actual === expected;
+    if (!ok) failures.push(`${label} ${actual} au lieu de ${expected}`);
+    console.log(`  ${ok ? "OK  " : "ÉCART"} ${label.padEnd(24)} ${actual} (attendu ${expected})`);
+  }
+
+  const pourvois = state.decisions.map((d) => d.pourvoiNumber).filter(Boolean);
+  for (const expected of EXPECTED.pourvois) {
+    const present = pourvois.includes(expected);
+    if (!present) failures.push(`pourvoi ${expected} absent`);
+    console.log(`  ${present ? "OK  " : "ÉCART"} pourvoi ${expected}`);
+  }
+
+  // An already-enriched decision is not an error: re-running must be possible, and
+  // must write nothing. A row pointing at a *different* decision than the one its
+  // pourvoi resolves to is caught inside the service, which refuses rather than
+  // silently rewriting which decision a published fiche cites.
+  const alreadyEnriched = state.decisions.filter((d) => d.judilibreId).length;
+  console.log(`  info  déjà enrichies             ${alreadyEnriched}/${state.decisions.length}`);
+
+  if (failures.length > 0) {
+    throw new PreconditionError(
+      `La base ne correspond plus aux mesures de conception : ${failures.join(" ; ")}. Aucune écriture.`
+    );
+  }
+}
+
+function describe(decision: State["decisions"][number]): string {
+  const parts = [
+    `judilibreId=${decision.judilibreId ?? "—"}`,
+    `ecli=${decision.ecli ?? "—"}`,
+    `date=${decision.decisionDate?.toISOString().slice(0, 10) ?? "—"}`,
+    `juridiction=${decision.court ?? "—"}`,
+    `chambre=${decision.chamber ?? "—"}`,
+    `sens=${decision.solution ?? "—"}`,
+  ];
+  return parts.join(" | ");
+}
+
+/** Confirms the built URL actually resolves, rather than assuming the pattern holds. */
+async function checkUrl(url: string): Promise<string> {
+  try {
+    const response = await fetch(url, { redirect: "follow" });
+    return `HTTP ${response.status}`;
+  } catch (error) {
+    return `injoignable (${error instanceof Error ? error.message : String(error)})`;
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  if (apply && args.includes("--dry-run")) {
+    throw new Error("--dry-run et --apply sont exclusifs.");
+  }
+
+  console.log(`Enrichissement Judilibre — ${apply ? "APPLICATION" : "essai à blanc"}\n`);
+
+  if (!createJudilibreClient()) {
+    throw new Error("Judilibre n'est pas configuré dans cet environnement. Aucune écriture.");
+  }
+
+  const before = await readState();
+  assertPreconditions(before);
+
+  console.log("\nAVANT :");
+  for (const decision of before.decisions) {
+    console.log(`  ${decision.pourvoiNumber} → ${describe(decision)}`);
+  }
+
+  if (!apply) {
+    console.log("\nAucune écriture. Relancer avec --apply pour appliquer.");
+    return;
+  }
+
+  console.log("\nEnrichissement :");
+  for (const decision of before.decisions) {
+    if (!decision.pourvoiNumber) continue;
+    const result = await enrichCourtDecisionFromJudilibre({
+      courtDecisionId: decision.id,
+      pourvoiNumber: decision.pourvoiNumber,
+      triggeredBy: "cli",
+    });
+
+    if (result.status === "UPDATED") {
+      console.log(
+        `  ${decision.pourvoiNumber} → ${result.changes.length} champ(s), ${result.judilibreId}`
+      );
+    } else if (result.status === "UNCHANGED") {
+      console.log(`  ${decision.pourvoiNumber} → déjà à jour (${result.judilibreId})`);
+    } else {
+      throw new Error(
+        `${decision.pourvoiNumber} → ${result.status}. Aucune suite : ` +
+          `l'enrichissement doit résoudre exactement une décision.`
+      );
+    }
+  }
+
+  const after = await readState();
+
+  console.log("\nAPRÈS :");
+  for (const decision of after.decisions) {
+    console.log(`  ${decision.pourvoiNumber} → ${describe(decision)}`);
+  }
+
+  console.log("\nURLs publiques :");
+  for (const decision of after.decisions) {
+    if (!decision.sourceUrl) {
+      console.log(`  ${decision.pourvoiNumber} → aucune URL`);
+      continue;
+    }
+    console.log(
+      `  ${decision.pourvoiNumber} → ${decision.sourceUrl} (${await checkUrl(decision.sourceUrl)})`
+    );
+  }
+
+  const failures: string[] = [];
+  if (after.affairs !== EXPECTED.affairs) failures.push(`affaires ${after.affairs}`);
+  if (after.courtDecisions !== EXPECTED.courtDecisions)
+    failures.push(`décisions ${after.courtDecisions}`);
+  if (after.links !== EXPECTED.links) failures.push(`liaisons ${after.links}`);
+  if (after.pairDecisions !== EXPECTED.pairDecisions)
+    failures.push(`jugements ${after.pairDecisions}`);
+  if (after.proposals !== EXPECTED.proposals) failures.push(`propositions ${after.proposals}`);
+  const missing = after.decisions.filter((d) => !d.judilibreId);
+  if (missing.length > 0) failures.push(`${missing.length} décision(s) sans identifiant Judilibre`);
+
+  if (failures.length > 0) {
+    throw new Error(`État final inattendu : ${failures.join(" ; ")}`);
+  }
+
+  console.log(
+    `\nÉtat final conforme : ${after.affairs} affaires, ${after.courtDecisions} décisions, ` +
+      `${after.links} liaisons, ${after.pairDecisions} jugements, ${after.proposals} propositions.`
+  );
+}
+
+main()
+  .then(() => db.$disconnect())
+  .catch(async (error) => {
+    console.error(`\n${error instanceof Error ? error.message : String(error)}`);
+    await db.$disconnect();
+    process.exit(1);
+  });

--- a/src/services/sync/__tests__/no-judilibre-discovery.test.ts
+++ b/src/services/sync/__tests__/no-judilibre-discovery.test.ts
@@ -118,12 +118,17 @@ describe("garde : pas de découverte Judilibre par nom (#337)", () => {
   });
 
   it("aucun script npm ne lance de synchronisation Judilibre", () => {
+    // Ce qui est interdit, c'est une *synchronisation* nominale, pas toute mention de
+    // Judilibre : un script d'enrichissement ciblé ou de diagnostic est légitime, et
+    // c'est précisément ce que #337 livre. La règle porte donc sur un nom en `sync:`
+    // et sur les fichiers supprimés, pas sur le mot.
     const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
       scripts: Record<string, string>;
     };
-    const offenders = Object.entries(pkg.scripts)
-      .filter(([name, cmd]) => /judilibre/i.test(`${name} ${cmd}`))
-      .filter(([name]) => !name.includes("diagnostics"));
+    const offenders = Object.entries(pkg.scripts).filter(
+      ([name, cmd]) =>
+        /^sync:.*judilibre/i.test(name) || REMOVED_FILES.some((removed) => cmd.includes(removed))
+    );
 
     expect(offenders).toEqual([]);
   });


### PR DESCRIPTION
Part of #337. Quatrième des cinq PR. Suite de #551, #552 et #553.

## Ce que fait le script

`npm run enrich:court-decisions` part des numéros de pourvoi **déjà stockés** sur les `CourtDecision` et récupère la décision officielle correspondante. Son entrée est donc une référence, jamais un nom. Il se déclenche à la main, jamais par un cron.

Essai à blanc par défaut, `--apply` pour écrire.

Il refuse de tourner si la base ne ressemble plus à ce contre quoi il a été conçu : un backfill qui s'adapte à des données inattendues est un backfill que personne ne peut relire.

## Résultat, exécuté en production

Préconditions toutes vérifiées : 463 affaires, 2 décisions, 3 liaisons, 8 jugements de paires, 0 proposition, et les deux pourvois attendus présents.

**AVANT**

```text
96-83.698 → judilibreId=— | ecli=— | date=— | juridiction=— | chambre=— | sens=—
97-81.102 → judilibreId=— | ecli=— | date=— | juridiction=— | chambre=— | sens=—
```

**APRÈS**

```text
96-83.698 → judilibreId=6079a87a9ba5988459c4d674 | ecli=— | date=1997-10-27
            juridiction=Cour de cassation | chambre=Chambre criminelle | sens=Rejet
97-81.102 → judilibreId=6079a86d9ba5988459c4d3a6 | ecli=— | date=1998-05-07
            juridiction=Cour de cassation | chambre=Chambre criminelle | sens=Rejet
```

Six champs écrits par décision. Les deux pourvois résolvent à **exactement une** décision chacun.

`ecli` reste nul, et c'est correct : l'API ne renvoie aucun ECLI pour ces décisions de 1997 et 1998, l'identifiant ayant été introduit en France une quinzaine d'années plus tard. Rien n'a été fabriqué pour combler le trou.

URLs publiques construites **et vérifiées** par une requête réelle, pas supposées :

```text
https://www.courdecassation.fr/decision/6079a87a9ba5988459c4d674  → HTTP 200
https://www.courdecassation.fr/decision/6079a86d9ba5988459c4d3a6  → HTTP 200
```

## Aucune affaire touchée

Comptes inchangés : 463 affaires, 2 décisions, 3 liaisons, 8 jugements, 0 proposition.

La preuve la plus directe est la date de dernière modification des trois affaires liées, restée **antérieure** à l'exécution :

```text
AF-000034 [PUBLISHED] CONDAMNATION_DEFINITIVE  maj=2026-07-24
AF-000035 [PUBLISHED] CONDAMNATION_DEFINITIVE  maj=2026-03-04
AF-000036 [PUBLISHED] CONDAMNATION_DEFINITIVE  maj=2026-03-04
```

Leurs `court`, `verdictDate` et `ecli` sont inchangés. Aucune liaison modifiée, aucune proposition créée.

## Idempotence

Deux entrées d'audit `CourtDecision` au total, une par décision, après trois exécutions successives de `--apply`. Les exécutions suivantes rendent :

```text
96-83.698 → déjà à jour (6079a87a9ba5988459c4d674)
97-81.102 → déjà à jour (6079a86d9ba5988459c4d3a6)
```

## Une précondition corrigée par l'exécution

La première version refusait toute décision portant déjà un `judilibreId`. La seconde exécution s'arrêtait donc en erreur au lieu de se terminer proprement à zéro modification.

C'était plus strict que la règle voulue, qui vise un identifiant **différent**. La précondition devient informative, et le cas dangereux reste couvert là où il doit l'être : le service refuse d'écrire quand la réponse contredit l'identité déjà portée par la ligne. Rien n'est perdu, et le script redevient rejouable.

## Le garde de #553 a fait son travail sur moi

En ajoutant `enrich:court-decisions`, mon propre test d'architecture a échoué : il interdisait tout script npm mentionnant Judilibre, avec pour seule exception un nom contenant « diagnostics ».

L'intention était d'interdire une **synchronisation** nominale, pas toute mention. La règle porte désormais sur un nom en `sync:…judilibre` ou sur une commande référençant un fichier supprimé. Vérifié qu'elle attrape toujours une vraie régression : réintroduire un script `sync:judilibre` est détecté.

## Effet public

Les fiches rendent maintenant une ligne de décision complète, là où elles n'affichaient qu'un numéro de pourvoi :

```text
AF-000034 : Pourvoi n° 96-83.698 · Cour de cassation · Chambre criminelle · 27 octobre 1997 · Rejet
AF-000035 : Pourvoi n° 96-83.698 · Cour de cassation · Chambre criminelle · 27 octobre 1997 · Rejet
AF-000036 : Pourvoi n° 97-81.102 · Cour de cassation · Chambre criminelle · 7 mai 1998 · Rejet
```

`AF-000034` et `AF-000035` citent la **même** décision et le **même** lien officiel, tout en restant deux affaires distinctes. C'est le cas qui a invalidé l'hypothèse « une décision, une affaire » et motivé tout le modèle de #536.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2558 tests**, 0 échec. `tsc` propre.

Aucune migration : le script n'écrit que dans des colonnes livrées par #536.
