### PR TITLE
Aligner la documentation sur le flux Judilibre réel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Full list in `package.json` under `scripts`. Most have a `:stats` dry-run varian
 - **Enrichment**: `sync:hatvp`, `sync:photos`, `sync:deceased`, `sync:birthdates`, `sync:careers`, `sync:partis`
 - **Votes**: `sync:scrutins-an`, `sync:scrutins-senat`
 - **Legislation**: `sync:legislation`, `sync:legislation:content`
-- **Content**: `sync:press`, `sync:factchecks`, `sync:judilibre:deprecated`, `sync:moderate`, `sync:enrich`
+- **Content**: `sync:press`, `sync:factchecks`, `sync:moderate`, `sync:enrich`
 - **Elections**: `sync:rne:maires`, `sync:elections:municipales`, `sync:resultats-csv`
 - **Orchestration**: `sync:daily`, `sync:full`
 
@@ -168,7 +168,7 @@ Pages import and render. Data modules query and cache. Business logic sits in se
 Two distinct resolver systems:
 
 - **Identity v2** (`src/lib/identity/`) — resolves a structured person description to a Politician row. Composable signal evaluators (birthdate, department, first-name, gender, external-id) feed a log-LR combiner. Auto-links only on `SAME` (>=0.95). `UNDECIDED` requires manual review.
-- **Affair-to-Politician** (`src/lib/affair-matching/`) — decides which politician a candidate affair mentions. Nine signal evaluators, log-LR combiner, three-tier judgment (SAME / UNDECIDED / NO_MATCH). Every import pipeline (Judilibre, press analysis, discover-affairs, manual admin) calls the resolver. Every decision writes an `AffairPoliticianDecision` audit row. Admin review: `/admin/affair-matching/`.
+- **Affair-to-Politician** (`src/lib/affair-matching/`) — decides which politician a candidate affair mentions. Nine signal evaluators, log-LR combiner, three-tier judgment (SAME / UNDECIDED / NO_MATCH). Every import pipeline (press analysis, discover-affairs, manual admin) calls the resolver. Every decision writes an `AffairPoliticianDecision` audit row. Admin review: `/admin/affair-matching/`.
 
 ### Caching strategy
 
@@ -281,7 +281,8 @@ These rules apply to AI assistants specifically when generating code, queries, o
 - **Escalate `Affair.involvement` automatically.** The default `MENTIONED_ONLY` exists to protect the presumption of innocence. Only human moderators can upgrade involvement.
 - **Auto-link politicians to affairs below threshold.** The resolver returns `SAME / UNDECIDED / NO_MATCH`. Only `SAME` (>= 0.95 for identity, above `SAME_THRESHOLD` for affair-matching) auto-links. `UNDECIDED` requires manual review.
 - **Publish a judicial affair outside the guard (RGPD art. 10).** Never write `publicationStatus: "PUBLISHED"` on `Affair` directly. The only path to publication is `assertPublishable()` in `src/lib/affairs/publish-guard.ts`, which requires a source, requires every automated matching decision to be human-validated, and writes `verifiedAt` + `verifiedBy` atomically. A CI guard rejects direct `PUBLISHED` literals; variable-based writes are caught in review.
-- **Let an automated pipeline create a non-DRAFT affair.** Press, Wikidata, Wikipedia, Judilibre and any future source create affairs in `DRAFT` only. Publication is always a separate, explicit human action.
+- **Let an automated pipeline create a non-DRAFT affair.** Press, Wikidata, Wikipedia and any future source create affairs in `DRAFT` only. Publication is always a separate, explicit human action.
+- **Search Judilibre by a person's name.** Removed in #337: the corpus is pseudonymised, and name-based discovery produced 0 affairs over 156 decisions. Judilibre is reached only from a known reference (Judilibre id, ECLI, pourvoi number), it fills a `CourtDecision`, and it never creates or modifies an `Affair`. An architecture test blocks reintroduction.
 - **Import data from unverified sources.** Blogs, forums, social media, unverified aggregators are not allowed as primary sources.
 - **Add feature flags or compatibility shims** when the code can be changed directly.
 - **Use em dashes (—) in any generated content.** Commas, colons, and parentheses do the job.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Poligraph centralise les informations publiques sur les responsables politiques 
 
 ### Affaires judiciaires
 
-- Découverte automatique via Wikidata, Judilibre et presse (analyse IA)
+- Découverte automatique via Wikidata et presse (analyse IA)
 - Timeline des procédures (mise en examen, condamnation)
 - Modération éditoriale avec triage IA
 - Fact-checks agrégés (AFP, Les Décodeurs)
@@ -165,7 +165,7 @@ Voir `docs/DATASOURCES.md` pour la liste complète.
 | [data.gouv.fr](https://www.data.gouv.fr)                           | Gouvernement, élections, RNE         | Quotidienne  |
 | [HATVP](https://www.hatvp.fr/open-data/)                           | Déclarations de patrimoine           | Hebdomadaire |
 | [Wikidata](https://www.wikidata.org)                               | Enrichissement, affaires, décès      | Hebdomadaire |
-| [Judilibre](https://www.courdecassation.fr/acces-rapide-judilibre) | Jurisprudence                        | Hebdomadaire |
+| [Judilibre](https://www.courdecassation.fr/acces-rapide-judilibre) | Décisions de justice, par référence  | À la demande |
 | Flux RSS presse                                                    | Mentions médiatiques                 | Horaire      |
 | [Google Fact Check API](https://toolbox.google.com/factcheck/apis) | Fact-checks                          | Quotidienne  |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ graph TB
         GV[Gouvernement]
         WD[Wikidata / Wikipedia]
         HT[HATVP]
-        JD[Judilibre]
+        JD[Judilibre - par référence]
         RSS[Flux RSS presse]
         FC[Google Fact-Check API]
         RNE[RNE maires]

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -168,9 +168,10 @@ Ces garde-fous sont implémentés dans le code et vérifiés par des tests
 automatisés :
 
 - **Aucune publication automatique.** Tout pipeline automatisé (presse,
-  Wikidata, Wikipédia, Judilibre) crée une affaire en brouillon (`DRAFT`),
+  Wikidata, Wikipédia) crée une affaire en brouillon (`DRAFT`),
   jamais publiée directement. Même une condamnation issue d'une source
-  structurée reste en attente de revue.
+  structurée reste en attente de revue. Judilibre ne crée aucune affaire : il
+  alimente une décision de justice rattachée, à partir d'une référence connue.
 - **Validation humaine obligatoire avant publication.** La mise en ligne d'une
   affaire passe par un point de contrôle unique côté serveur qui exige au moins
   une source vérifiable, refuse la publication si un rattachement automatique

--- a/docs/identity-strategy.md
+++ b/docs/identity-strategy.md
@@ -119,7 +119,7 @@ Le poligraphId est le point d'ancrage pour toutes les references externes. Il ap
 | NosDeputes          | Slug ND       | 0.85      | ID institutionnel    | Statistiques parlementaires           |
 | RNE                 | Code INSEE    | 0.7       | Nom + date naissance | Maires (35 000+)                      |
 | Wikipedia           | Titre article | 0.7       | Nom seul             | Biographies                           |
-| Judilibre           | N. decision   | Variable  | Multi-criteres       | Decisions de justice                  |
+| Judilibre           | N. decision   | s.o.      | Aucune               | Decisions rattachees par reference    |
 | Presse              | URL article   | Variable  | Mentions textuelles  | Couverture mediatique                 |
 
 ## Benchmark

--- a/docs/judicial-decision-model.md
+++ b/docs/judicial-decision-model.md
@@ -5,6 +5,14 @@ migration, aucune modification de schéma, aucune implémentation.
 
 Mesures faites en lecture seule le 2026-07-25 sur 463 affaires.
 
+> **État livré.** #536 et #337 sont closes. Le modèle porte le nom `CourtDecision`,
+> avec la table de liaison `AffairCourtDecision`. La phase 4 ci-dessous a été livrée
+> autrement que prévu : l'enrichissement écrit **directement** sur la décision, avec
+> audit de provenance, plutôt que par proposition. Une `CourtDecision` consigne un
+> acte officiel, pas une fiche éditoriale ; les propositions restent réservées aux
+> corrections d'une `Affair`. Ce document reste le compte rendu de la conception,
+> y compris des options écartées.
+
 ---
 
 ## 1. Résumé exécutif
@@ -392,7 +400,7 @@ model CourtDecision {
   /// jamais un endroit où ranger un champ modélisable.
   metadata Json?
 
-  affairs AffairJudicialDecision[]
+  affairs AffairCourtDecision[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -538,7 +546,7 @@ affaires. Volume attendu : **2 décisions, 3 liaisons** (Carignon x2, Balkany x1
 
 ### Phase 3 — double lecture
 
-**Périmètre** : les nouvelles lectures privilégient `JudicialDecision`, avec repli
+**Périmètre** : les nouvelles lectures privilégient `CourtDecision`, avec repli
 sur les champs d'`Affair`.
 
 - Fichiers probables : `lib/data/affairs.ts`, `app/affaires/[slug]/page.tsx`,
@@ -551,7 +559,7 @@ sur les champs d'`Affair`.
 
 ### Phase 4 — alimentation ciblée
 
-**Périmètre** : Judilibre crée ou met à jour une `JudicialDecision` à partir d'une
+**Périmètre** : Judilibre crée ou met à jour une `CourtDecision` à partir d'une
 référence connue, et ne crée jamais d'`Affair`. Les corrections éditoriales passent
 par des propositions.
 
@@ -563,7 +571,7 @@ par des propositions.
 
 **Périmètre** : inventaire des champs encore lus, puis retrait éventuel.
 
-- **`Affair.ecli @unique` ne peut être levée qu'une fois `JudicialDecision.ecli`
+- **`Affair.ecli @unique` ne peut être levée qu'une fois `CourtDecision.ecli`
   peuplée et lue**, sinon on perd la seule garantie d'unicité existante.
 - `chamber` et `caseNumbers` sont à 0 ligne : leur retrait est sans risque de perte,
   mais reste une migration destructive, donc séparée et réversible.
@@ -628,7 +636,7 @@ partagée, un enrichissement Judilibre retomberait dans l'hypothèse « une déc
 une affaire ». Avec elle, le flux devient :
 
 ```
-référence connue → récupération ciblée → JudicialDecision → liaison → propositions
+référence connue → récupération ciblée → CourtDecision → liaison → affichage public
 ```
 
 Judilibre ne décide jamais qu'une affaire est un doublon, qu'une affaire doit être
@@ -646,7 +654,7 @@ créée, ou qu'un statut public doit changer.
 | **#516**      | procédure et ses étapes                                             | reçoit les 9 chaînes `court` multi-étapes et les 55 parquets     |
 | **#517**      | rôle et résultat par participant                                    | reçoit le cas d'une décision visant plusieurs personnes          |
 
-Ces trois chantiers ne doivent pas être fusionnés. `JudicialDecision` est
+Ces trois chantiers ne doivent pas être fusionnés. `CourtDecision` est
 délibérément plus petit que `AffairProceeding`.
 
 ---
@@ -684,7 +692,7 @@ délibérément plus petit que `AffairProceeding`.
 - [ ] Une décision peut être liée à plusieurs affaires, et le cas Carignon est
       enregistré comme tel
 - [ ] Aucun code ne déduit un doublon d'un identifiant partagé
-- [ ] `JudicialDecision.court` n'est jamais renseigné depuis `Affair.court`
+- [x] `CourtDecision.court` n'est jamais renseigné depuis `Affair.court`
 - [ ] `Affair.verdictDate` reste la date éditoriale et continue de trier les listes
 - [ ] L'export CSV rend exactement les mêmes valeurs qu'avant pour les 463 affaires
       actuelles
@@ -692,7 +700,7 @@ délibérément plus petit que `AffairProceeding`.
       synthétique
 - [ ] `Affair.ecli @unique` n'est levée qu'après peuplement et lecture effective
 - [ ] Le backfill est idempotent, prouvé par double exécution
-- [ ] Judilibre ne crée aucune `Affair`
+- [x] Judilibre ne crée aucune `Affair`
 - [ ] Aucune migration destructive dans la même PR qu'un changement de lecture
 - [ ] Une décision de conseil de prud'hommes ou de tribunal administratif peut être
       enregistrée : le modèle n'est pas restreint au pénal ni à l'ordre judiciaire


### PR DESCRIPTION
Part of #337. Dernière des cinq PR. Suite de #551, #552, #553 et #554.

Aucun changement de comportement : uniquement de la documentation, alignée sur ce que le code fait réellement depuis #553 et #554.

## Des affirmations devenues fausses

La plus visible était sur le **README public** :

> Découverte automatique via Wikidata, Judilibre et presse

Judilibre ne découvre plus rien. Le tableau des sources l'annonçait aussi en synchronisation « Hebdomadaire », alors qu'il n'y a plus de synchronisation du tout.

Corrigé également :

- `AGENTS.md` référençait le script npm `sync:judilibre:deprecated`, supprimé ;
- `AGENTS.md` affirmait que « every import pipeline (Judilibre, press analysis, …) calls the resolver » : Judilibre n'appelle plus le résolveur d'identité, puisqu'il ne part plus d'un nom ;
- `AGENTS.md` et `docs/LEGAL.md` listaient Judilibre parmi les pipelines créant des affaires en `DRAFT` : il n'en crée aucune ;
- `docs/identity-strategy.md` le donnait comme source de résolution d'identité « multi-critères » ;
- `docs/ARCHITECTURE.md` le montrait comme une source d'ingestion indifférenciée.

`docs/LEGAL.md` méritait un soin particulier : c'est une page qui engage le projet sur ses garde-fous RGPD. Y laisser écrit que Judilibre crée des affaires aurait décrit un traitement qui n'existe plus.

## Un interdit ajouté là où il sera lu

`AGENTS.md` gagne une entrée dans sa liste des choses à ne pas faire :

> **Search Judilibre by a person's name.** Removed in #337: the corpus is pseudonymised, and name-based discovery produced 0 affairs over 156 decisions.

C'est le fichier que lit quiconque arrive sur le projet. La règle y est plus utile que dans un document d'audit.

## Le document de conception réconcilié

`docs/judicial-decision-model.md` employait encore `JudicialDecision` comme nom du modèle en huit endroits, alors que le nom retenu et livré est `CourtDecision`.

Les quatre occurrences qui **discutent** le nom écarté sont conservées : §4 bis explique pourquoi « judiciaire » désignerait un seul des deux ordres et exclurait les juridictions administratives et financières. Effacer ce raisonnement appauvrirait le document.

Un encadré d'état est ajouté en tête, qui signale aussi un écart assumé avec le plan initial : la phase 4 prévoyait un enrichissement par proposition, il a été livré en **écriture directe** avec audit de provenance. Une `CourtDecision` consigne un acte officiel, pas une fiche éditoriale.

## Le flux, écrit une fois pour toutes

```text
autorisé   référence judiciaire connue → recherche ciblée → CourtDecision → affichage public
interdit   nom de personnalité → recherche → création automatique d'Affair
```

## Vérifications

**2558 tests**, 0 échec. `tsc` propre. `prettier --check` propre sur les fichiers touchés.

Aucun code modifié, aucune migration, aucune écriture en base.
