### PR TITLE
Ne jamais auto-fusionner deux brouillons sur un identifiant judiciaire commun

### DIFF
--- a/src/lib/affairs/match-evidence.ts
+++ b/src/lib/affairs/match-evidence.ts
@@ -1,0 +1,104 @@
+/**
+ * What a duplicate match rests on, told apart by category (#557).
+ *
+ * Lives here rather than next to the matcher because the matcher imports the Prisma
+ * client, and this is a pure classification consumed by a pure decision function.
+ * Shared vocabulary belongs below both.
+ *
+ * The distinction it draws is the whole point:
+ *
+ *   a shared court decision  →  same decision, possibly several affairs
+ *   shared editorial content →  possibly one affair described twice
+ *
+ * Only the second is a reason to merge. Two Carignon convictions share a pourvoi
+ * number, a facts date, a verdict date and one cassation ruling, and are still two
+ * counts — subornation of a witness and misuse of company assets — so two affairs.
+ */
+
+/**
+ * Signals that identify a shared court decision or proceeding: official numbers
+ * assigned by a court, not words a title happens to share.
+ *
+ * A shared identifier says "same decision or same proceeding". It does NOT say
+ * "same editorial affair", and on its own it may never authorise a merge.
+ */
+export const OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS: ReadonlySet<string> = new Set([
+  "ecli",
+  "pourvoiNumber",
+  "caseNumbers",
+  // Not produced by the matcher yet. Declared so that the day a shared
+  // `CourtDecision` becomes a signal, it is classified as a decision identity by
+  // construction rather than by someone remembering to add it here.
+  "courtDecision",
+  "judilibreId",
+]);
+
+/**
+ * Signals that rest on the affair's own editorial content: what a human wrote in
+ * the title, the category, the dates.
+ *
+ * These are the only signals that may authorise an automatic merge. They can be
+ * wrong, but when they are, they are wrong about *the same affair being described
+ * twice*, which is what a merge fixes. A shared decision identifier is not wrong at
+ * all, and still does not mean one affair.
+ */
+export const EDITORIAL_IDENTITY_SIGNALS: ReadonlySet<string> = new Set([
+  "title",
+  "title-exact",
+  "title-exact-date-conflict",
+  "title-partial",
+  "category",
+  "date",
+  // From the draft-clustering pass in `reconciliation.ts`, which pairs on
+  // `politician+category+window`. These rest on the affairs' own attributes, not on
+  // a court identifier, so they belong here. That pass only ever reaches POSSIBLE,
+  // so the confidence gate stops it anyway; the classification still has to be right.
+  "politician",
+  "window",
+]);
+
+export interface MatchEvidence {
+  /** At least one atom names a court-assigned identifier or a shared decision. */
+  officialDecisionIdentity: boolean;
+  /** At least one atom rests on the affair's own editorial content. */
+  editorialIdentityEvidence: boolean;
+  /** Atoms in neither vocabulary. Counted as evidence of nothing, deliberately. */
+  unrecognisedSignals: string[];
+}
+
+/**
+ * Classifies a `matchedBy` value.
+ *
+ * `matchedBy` is a `string`, and `title+category` shows the format already composes
+ * with `+`. A plain equality test against a set of names would therefore go quietly
+ * false the day a composite like `ecli+title-exact` appears — which is exactly the
+ * bug that would let a shared decision authorise a merge again. So the value is
+ * decomposed and each atom classified.
+ */
+export function classifyMatchEvidence(matchedBy: string): MatchEvidence {
+  const atoms = matchedBy
+    .split("+")
+    .map((atom) => atom.trim())
+    .filter(Boolean);
+
+  return {
+    officialDecisionIdentity: atoms.some((atom) => OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS.has(atom)),
+    // An unknown atom must not pass for editorial evidence: a signal nobody has
+    // classified is not a reason to delete a row automatically.
+    editorialIdentityEvidence: atoms.some((atom) => EDITORIAL_IDENTITY_SIGNALS.has(atom)),
+    unrecognisedSignals: atoms.filter(
+      (atom) =>
+        !OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS.has(atom) && !EDITORIAL_IDENTITY_SIGNALS.has(atom)
+    ),
+  };
+}
+
+/**
+ * Whether a match rests on a court-assigned identifier rather than resemblance.
+ *
+ * Useful to tell a reviewer why a pair is worth reading — the two fiches cite the
+ * same decision — never to conclude that they are duplicates.
+ */
+export function isOfficialJudicialIdentifierMatch(matchedBy: string): boolean {
+  return classifyMatchEvidence(matchedBy).officialDecisionIdentity;
+}

--- a/src/services/affairs/__tests__/merge-decision-official-identity.test.ts
+++ b/src/services/affairs/__tests__/merge-decision-official-identity.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import { decideMergeAction, type MergeDecisionAffair } from "../merge-decision";
+import { classifyMatchEvidence } from "@/lib/affairs/match-evidence";
+import type { MatchConfidence } from "../matching";
+
+/**
+ * Issue #557 — sharing a decision is not being the same affair, whatever the
+ * publication status.
+ *
+ * Two Carignon convictions share a pourvoi number, a facts date, a verdict date and
+ * one cassation ruling, and are still two counts: subornation of a witness and misuse
+ * of company assets. #537 drew that conclusion only at the published boundary; the
+ * reasoning never depended on it.
+ */
+
+function draft(id: string, overrides: Partial<MergeDecisionAffair> = {}): MergeDecisionAffair {
+  return {
+    id,
+    publicationStatus: "DRAFT",
+    verifiedAt: null,
+    sources: ["PRESSE"],
+    ...overrides,
+  };
+}
+
+function plan(matchedBy: string, confidence: MatchConfidence = "CERTAIN") {
+  return decideMergeAction({
+    affairA: draft("aaa"),
+    affairB: draft("bbb"),
+    confidence,
+    matchedBy,
+  });
+}
+
+describe("classifyMatchEvidence — la distinction est explicite (#557)", () => {
+  it("classe les identités de décision officielles", () => {
+    for (const signal of ["ecli", "pourvoiNumber", "caseNumbers"]) {
+      expect(classifyMatchEvidence(signal)).toMatchObject({
+        officialDecisionIdentity: true,
+        editorialIdentityEvidence: false,
+      });
+    }
+  });
+
+  it("classe déjà une décision partagée, avant qu'elle ne devienne un signal", () => {
+    // Déclaré à l'avance : le jour où le matcher produira ce signal, il sera classé
+    // par construction, pas parce que quelqu'un aura pensé à l'ajouter.
+    for (const signal of ["courtDecision", "judilibreId"]) {
+      expect(classifyMatchEvidence(signal).officialDecisionIdentity).toBe(true);
+    }
+  });
+
+  it("classe les preuves éditoriales", () => {
+    for (const signal of ["title-exact", "title-partial", "title+category", "category+date"]) {
+      expect(classifyMatchEvidence(signal)).toMatchObject({
+        officialDecisionIdentity: false,
+        editorialIdentityEvidence: true,
+      });
+    }
+  });
+
+  it("décompose un signal composite au lieu de le comparer en entier", () => {
+    // Le piège que corrige #557 : un `Set.has()` sur la chaîne entière rendrait
+    // false ici, et la paire repasserait en auto-fusion sur un ECLI.
+    const evidence = classifyMatchEvidence("ecli+title-exact");
+
+    expect(evidence.officialDecisionIdentity).toBe(true);
+    expect(evidence.editorialIdentityEvidence).toBe(true);
+  });
+
+  it("ne compte un signal inconnu dans aucune catégorie", () => {
+    const evidence = classifyMatchEvidence("signal-inedit");
+
+    expect(evidence.officialDecisionIdentity).toBe(false);
+    expect(evidence.editorialIdentityEvidence).toBe(false);
+    expect(evidence.unrecognisedSignals).toEqual(["signal-inedit"]);
+  });
+
+  it("signale l'atome inconnu d'un composite sans perdre les autres", () => {
+    const evidence = classifyMatchEvidence("ecli+quelque-chose");
+
+    expect(evidence.officialDecisionIdentity).toBe(true);
+    expect(evidence.editorialIdentityEvidence).toBe(false);
+    expect(evidence.unrecognisedSignals).toEqual(["quelque-chose"]);
+  });
+
+  it("tolère les espaces et une chaîne vide", () => {
+    expect(classifyMatchEvidence(" ecli + title-exact ").officialDecisionIdentity).toBe(true);
+    expect(classifyMatchEvidence("")).toMatchObject({
+      officialDecisionIdentity: false,
+      editorialIdentityEvidence: false,
+      unrecognisedSignals: [],
+    });
+  });
+});
+
+describe("Deux brouillons : identité de décision seule → revue (#557)", () => {
+  it("refuse l'auto-fusion sur un ECLI commun, même en CERTAIN", () => {
+    const result = plan("ecli", "CERTAIN");
+
+    expect(result.decision).toBe("REVIEW_REQUIRED");
+    expect(result.reason).toContain("plusieurs chefs");
+    expect(result.keepId).toBeUndefined();
+    expect(result.removeId).toBeUndefined();
+  });
+
+  it("refuse l'auto-fusion sur un pourvoi commun en HIGH", () => {
+    expect(plan("pourvoiNumber", "HIGH").decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("refuse l'auto-fusion sur des caseNumbers communs en HIGH", () => {
+    expect(plan("caseNumbers", "HIGH").decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("refuse l'auto-fusion sur une même CourtDecision liée", () => {
+    expect(plan("courtDecision", "CERTAIN").decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("refuse l'auto-fusion sur un signal non reconnu", () => {
+    const result = plan("signal-inedit", "CERTAIN");
+
+    expect(result.decision).toBe("REVIEW_REQUIRED");
+    expect(result.reason).toContain("sans preuve d'identité éditoriale");
+  });
+
+  it("nomme le signal dans la raison, pour que le relecteur sache quoi lire", () => {
+    expect(plan("pourvoiNumber").reason).toContain("pourvoiNumber");
+  });
+});
+
+describe("Deux brouillons : preuve éditoriale → auto-fusion préservée (#557)", () => {
+  it("auto-fusionne sur un titre exact en HIGH", () => {
+    const result = plan("title-exact", "HIGH");
+
+    expect(result.decision).toBe("AUTO_MERGE_DRAFTS");
+    expect(result.keepId).toBe("aaa");
+    expect(result.removeId).toBe("bbb");
+  });
+
+  it("auto-fusionne sur titre + catégorie", () => {
+    expect(plan("title+category", "HIGH").decision).toBe("AUTO_MERGE_DRAFTS");
+  });
+
+  it("auto-fusionne quand un identifiant judiciaire accompagne une preuve éditoriale", () => {
+    // Autorisé parce que le moteur distingue désormais les deux catégories : c'est la
+    // preuve éditoriale qui fonde la fusion, l'identifiant ne fait que s'y ajouter.
+    expect(plan("ecli+title-exact", "CERTAIN").decision).toBe("AUTO_MERGE_DRAFTS");
+  });
+
+  it("laisse une preuve éditoriale faible partir en revue par la confiance", () => {
+    expect(plan("title-partial", "POSSIBLE").decision).toBe("REVIEW_REQUIRED");
+    expect(plan("category+date", "POSSIBLE").decision).toBe("REVIEW_REQUIRED");
+  });
+});
+
+describe("La règle vaut pour toutes les combinaisons de statuts (#557)", () => {
+  const cases: Array<[string, MergeDecisionAffair, MergeDecisionAffair]> = [
+    ["brouillon + brouillon", draft("aaa"), draft("bbb")],
+    [
+      "brouillon + publiée",
+      draft("aaa"),
+      draft("bbb", { publicationStatus: "PUBLISHED", verifiedAt: new Date() }),
+    ],
+    [
+      "publiée + publiée",
+      draft("aaa", { publicationStatus: "PUBLISHED", verifiedAt: new Date() }),
+      draft("bbb", { publicationStatus: "PUBLISHED", verifiedAt: new Date() }),
+    ],
+  ];
+
+  for (const [label, affairA, affairB] of cases) {
+    it(`${label} sur un ECLI commun → revue`, () => {
+      const result = decideMergeAction({
+        affairA,
+        affairB,
+        confidence: "CERTAIN",
+        matchedBy: "ecli",
+      });
+
+      expect(result.decision).toBe("REVIEW_REQUIRED");
+    });
+  }
+});
+
+describe("Ce que #557 ne change pas (#557)", () => {
+  it("une contradiction judiciaire reste prioritaire sur tout", () => {
+    const result = decideMergeAction({
+      affairA: draft("aaa"),
+      affairB: draft("bbb"),
+      confidence: "CERTAIN",
+      matchedBy: "title-exact",
+      contradictions: ["verdictDate"],
+    });
+
+    expect(result.reason).toContain("contradictoires");
+  });
+
+  it("un brouillon déjà relu par un humain n'est pas absorbé", () => {
+    const result = decideMergeAction({
+      affairA: draft("aaa"),
+      affairB: draft("bbb", { verifiedAt: new Date() }),
+      confidence: "HIGH",
+      matchedBy: "title-exact",
+    });
+
+    expect(result.decision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("un statut hors périmètre reste non éligible", () => {
+    const result = decideMergeAction({
+      affairA: draft("aaa", { publicationStatus: "ARCHIVED" }),
+      affairB: draft("bbb"),
+      confidence: "CERTAIN",
+      matchedBy: "title-exact",
+    });
+
+    expect(result.decision).toBe("NOT_ELIGIBLE");
+  });
+
+  it("une affaire ne fusionne pas avec elle-même", () => {
+    const result = decideMergeAction({
+      affairA: draft("aaa"),
+      affairB: draft("aaa"),
+      confidence: "CERTAIN",
+      matchedBy: "title-exact",
+    });
+
+    expect(result.decision).toBe("NOT_ELIGIBLE");
+  });
+});

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -192,32 +192,17 @@ export interface MatchResult {
 }
 
 /**
- * Signals that identify a shared court decision or proceeding: official numbers
- * assigned by a court, not words a title happens to share.
- *
- * What they prove is narrower than it looks. Measured on real data (issue #525):
- * two Carignon convictions share a pourvoi number, a facts date, a verdict date
- * and one cassation ruling, yet they are two separate counts — subornation of a
- * witness and misuse of company assets — and therefore two Poligraph affairs.
- *
- * So a shared identifier says "same decision or same proceeding". It does NOT say
- * "same editorial affair", and on its own it may never authorise a merge.
+ * Re-exported so callers keep importing the match vocabulary from the matcher, next
+ * to the code that produces the signals. The definitions live in a database-free
+ * module because the merge planner that consumes them is pure (#557).
  */
-export const OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS: ReadonlySet<string> = new Set([
-  "ecli",
-  "pourvoiNumber",
-  "caseNumbers",
-]);
-
-/**
- * Whether a match rests on a court-assigned identifier rather than resemblance.
- *
- * Useful to tell a reviewer why a pair is worth reading — the two fiches cite the
- * same decision — never to conclude that they are duplicates.
- */
-export function isOfficialJudicialIdentifierMatch(matchedBy: string): boolean {
-  return OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS.has(matchedBy);
-}
+export {
+  classifyMatchEvidence,
+  isOfficialJudicialIdentifierMatch,
+  EDITORIAL_IDENTITY_SIGNALS,
+  OFFICIAL_JUDICIAL_IDENTIFIER_SIGNALS,
+  type MatchEvidence,
+} from "@/lib/affairs/match-evidence";
 
 /**
  * Minimum share of the longer title that the shorter one must cover for

--- a/src/services/affairs/merge-decision.ts
+++ b/src/services/affairs/merge-decision.ts
@@ -17,10 +17,21 @@
  * they are still two separate counts, so two affairs. A shared identifier means a
  * shared decision or proceeding, never a shared editorial affair. Nothing crosses
  * the published boundary without a person now.
+ *
+ * That fix stopped at the published boundary, and the reasoning does not (issue
+ * #557). Two *drafts* sharing an ECLI were still merged automatically, although the
+ * Carignon case says nothing about publication status: one decision carries several
+ * counts, whatever the status of the fiches describing them. So automatic merging
+ * now requires evidence drawn from the affairs' own editorial content, and a shared
+ * decision identity sends the pair to a reader instead — see `classifyMatchEvidence`.
  */
 
 import type { PublicationStatus, SourceType } from "@/generated/prisma";
-import { isOfficialJudicialIdentifierMatch, type MatchConfidence } from "./matching";
+import type { MatchConfidence } from "./matching";
+import {
+  classifyMatchEvidence,
+  isOfficialJudicialIdentifierMatch,
+} from "@/lib/affairs/match-evidence";
 
 /** Statuses this lot handles. See the issue for ARCHIVED/EXCLUDED/REJECTED. */
 const MERGEABLE_STATUSES: ReadonlySet<PublicationStatus> = new Set([
@@ -147,7 +158,24 @@ export function decideMergeAction(input: MergeDecisionInput): MergePlan {
     };
   }
 
-  // Two drafts: nothing public is at stake.
+  // Two drafts: nothing public is at stake, but a shared decision still is not a
+  // shared affair. This check sits before the confidence one on purpose: CERTAIN on
+  // an ECLI is exactly the case that used to merge, and the confidence was never the
+  // problem — what the confidence rested on was.
+  const evidence = classifyMatchEvidence(matchedBy);
+  if (!evidence.editorialIdentityEvidence) {
+    if (evidence.officialDecisionIdentity) {
+      return {
+        decision: "REVIEW_REQUIRED",
+        reason: `Identité de décision commune (${matchedBy}) : une même décision peut porter plusieurs chefs, donc plusieurs fiches`,
+      };
+    }
+    return {
+      decision: "REVIEW_REQUIRED",
+      reason: `Rapprochement sans preuve d'identité éditoriale (${matchedBy})`,
+    };
+  }
+
   if (!confident) {
     return {
       decision: "REVIEW_REQUIRED",

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -533,10 +533,12 @@ describe("findPotentialDuplicates — garde lexical du joker AUTRE (#521)", () =
   });
 
   it("ne change pas une décision AUTO_MERGE_DRAFTS existante", async () => {
-    // Deux brouillons rapprochés en HIGH par un identifiant : le plan reste le même.
+    // Deux brouillons rapprochés en HIGH par une preuve éditoriale : le plan reste le
+    // même. Le signal n'est pas un identifiant de décision, qui partirait en revue
+    // depuis #557 ; ce test porte sur le garde du joker AUTRE, pas sur cette règle.
     mockedAffairFindMany.mockResolvedValue([makeDraft("a1"), makeDraft("a2")]);
     mockedFindMatchingAffairs.mockResolvedValue([
-      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" },
+      { affairId: "a1", confidence: "HIGH", score: 0.95, matchedBy: "title-exact" },
     ]);
 
     const duplicates = await findPotentialDuplicates();

--- a/src/services/sync/__tests__/reconcile-affairs.test.ts
+++ b/src/services/sync/__tests__/reconcile-affairs.test.ts
@@ -52,7 +52,9 @@ function pair(
     affairA: side(a, "a"),
     affairB: side(b, "b"),
     confidence: overrides.confidence ?? "HIGH",
-    matchedBy: overrides.matchedBy ?? "pourvoiNumber",
+    // Preuve éditoriale : depuis #557, un identifiant de décision seul part en revue,
+    // et ces tests portent sur l'invalidation du cache après fusion, pas sur la règle.
+    matchedBy: overrides.matchedBy ?? "title-exact",
     score: overrides.score ?? 0.95,
     contradictions: [],
     unpropagatableDifferences: [],


### PR DESCRIPTION
Closes #557. Part of #514.

## Le défaut

`decideMergeAction()` protégeait la frontière du publié, mais pour `DRAFT + DRAFT` toute paire `CERTAIN` ou `HIGH` restait auto-fusionnable **sans jamais examiner sur quoi reposait la confiance**. Deux brouillons partageant un ECLI étaient donc fusionnés par le cron.

Le cas Carignon ne dépend pas du statut de publication :

```text
même décision judiciaire  ≠  même affaire éditoriale
```

Deux condamnations partagent un pourvoi, une date de faits, une date de verdict et un arrêt de cassation, et restent deux chefs distincts. #537 avait tiré cette conclusion uniquement à la frontière du publié ; le raisonnement, lui, n'en dépendait jamais.

## Pourquoi un test sur chaîne ne suffisait pas

`isOfficialJudicialIdentifierMatch()` faisait `Set.has(matchedBy)`, une égalité exacte. Or `matchedBy` est typé `string`, et une valeur existante, `title+category`, montre que le format compose déjà avec `+`. Une valeur du genre `ecli+title-exact` aurait donc rendu `false` et laissé la paire repartir en auto-fusion, silencieusement.

## Audit du signal réel

Recensé **tous** les producteurs de `matchedBy`, pas seulement le matcher :

| signal | confiance | catégorie |
|---|---|---|
| `ecli` | CERTAIN | identité de décision |
| `pourvoiNumber` | HIGH | identité de décision |
| `caseNumbers` | HIGH | identité de décision |
| `title-exact` | HIGH | preuve éditoriale |
| `title+category` | HIGH | preuve éditoriale |
| `title-exact-date-conflict` | POSSIBLE | preuve éditoriale |
| `title-partial` | POSSIBLE | preuve éditoriale |
| `category+date` | POSSIBLE | preuve éditoriale |
| `politician+category+window` | POSSIBLE | preuve éditoriale |

Ce dernier m'avait échappé au premier passage : il naît dans `reconciliation.ts`, pas dans `matching.ts`. Ses atomes `politician` et `window` reposent sur les attributs des affaires, pas sur un identifiant de justice, donc ils sont classés éditoriaux.

Les paires réellement auto-fusionnables sur identité officielle étaient donc exactement : `ecli` en CERTAIN, `pourvoiNumber` et `caseNumbers` en HIGH.

## La distinction, explicite et typée

```ts
interface MatchEvidence {
  officialDecisionIdentity: boolean;
  editorialIdentityEvidence: boolean;
  unrecognisedSignals: string[];
}
```

`classifyMatchEvidence()` **décompose** la valeur sur `+` et classe chaque atome. Un atome inconnu ne compte dans aucune catégorie : un signal que personne n'a classé n'est pas une raison de supprimer une ligne automatiquement.

`courtDecision` et `judilibreId` sont déjà déclarés côté identité officielle, alors que le matcher ne les produit pas encore. Le jour où une `CourtDecision` partagée devient un signal, elle sera classée par construction, pas parce que quelqu'un y aura pensé.

## La règle

```text
si la confiance ne repose pas sur une preuve d'identité éditoriale
→ REVIEW_REQUIRED
```

Placée **avant** le contrôle de confiance, délibérément : `CERTAIN` sur un ECLI est précisément le cas qui fusionnait, et la confiance n'a jamais été le problème — ce sur quoi elle reposait l'était.

Une combinaison identifiant + preuve éditoriale reste auto-fusionnable, justement parce que le moteur sait maintenant les distinguer : c'est la preuve éditoriale qui fonde la fusion.

## Une extraction rendue nécessaire

`matching.ts` importe le client Prisma, donc tester une règle **pure** exigeait une base de données. Le vocabulaire et la classification vivent désormais dans `src/lib/affairs/match-evidence.ts`, sans dépendance, et `matching.ts` les réexporte pour que les appelants existants ne bougent pas.

## Mesure de la file, en lecture seule

```text
paires proposées                        : 1
auto-fusionnables AVANT                 : 0
auto-fusionnables APRÈS                 : 0
paires affectées par la nouvelle règle  : 0
```

**Aucune donnée modifiée**, confirmé par comparaison avant/après : 463 affaires, 2 décisions, 3 liaisons, 8 jugements, 0 proposition.

À dire tel quel : **ce correctif ne change rien à la file d'aujourd'hui.** Il est préventif, pas correctif. La seule paire en attente était déjà en revue pour un autre motif. Le trou était néanmoins réel — l'ancien chemin `DRAFT + DRAFT` ne consultait aucune preuve — et il se serait déclenché au premier ECLI partagé entre deux brouillons, ce qui devient plus probable maintenant que #337 alimente les décisions.

## Tests

**24 tests** couvrant chaque critère de l'issue : ECLI, pourvoi, `caseNumbers`, `CourtDecision` partagée, `CERTAIN`, `HIGH`, preuve éditoriale seule préservée, combinaison des deux autorisée, signal inconnu refusé, composite décomposé, et la règle vérifiée sur les trois combinaisons de statuts.

Quatre tests existants encodaient l'ancienne règle dans leurs fixtures : ils portent sur l'invalidation du cache et sur le garde du joker `AUTRE`, pas sur la règle de fusion. Leur signal passe donc de `pourvoiNumber` à `title-exact`, ce qui leur rend leur objet.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2582 tests**, 0 échec. `tsc` et `eslint` propres. Aucune migration.
