### PR TITLE
Arrêter toute écriture d'identifiant de décision sur Affair

### DIFF
--- a/scripts/proposals.ts
+++ b/scripts/proposals.ts
@@ -46,9 +46,6 @@ const FIELD_LABELS: Record<string, string> = {
   ineligibilityMonths: "inéligibilité (mois)",
   communityService: "TIG (heures)",
   otherSentence: "autre peine",
-  ecli: "ECLI",
-  pourvoiNumber: "n° de pourvoi",
-  caseNumbers: "n° de dossiers",
 };
 
 function arg(name: string): string | undefined {

--- a/src/app/admin/affaires/[id]/edit/page.tsx
+++ b/src/app/admin/affaires/[id]/edit/page.tsx
@@ -57,8 +57,6 @@ export default async function EditAffairPage({ params }: PageProps) {
     court: affair.court || undefined,
     chamber: affair.chamber || undefined,
     caseNumber: affair.caseNumber || undefined,
-    ecli: affair.ecli || undefined,
-    pourvoiNumber: affair.pourvoiNumber || undefined,
     linkedAffairId: affair.linkedAffairId ?? null,
     sources: affair.sources.map((s) => ({
       id: s.id,

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -99,9 +99,6 @@ const FIELD_LABELS: Record<string, string> = {
   ineligibilityMonths: "Inéligibilité (mois)",
   communityService: "TIG (heures)",
   otherSentence: "Autre peine",
-  ecli: "ECLI",
-  pourvoiNumber: "N° de pourvoi",
-  caseNumbers: "N° de dossiers",
 };
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;

--- a/src/app/api/admin/affaires/[id]/route.ts
+++ b/src/app/api/admin/affaires/[id]/route.ts
@@ -122,12 +122,8 @@ export const PUT = withAdminAuth(async (request: NextRequest, context) => {
       otherSentence: data.otherSentence || null,
       // Jurisdiction
       court: data.court || null,
-      chamber: data.chamber || null,
       caseNumber: data.caseNumber || null,
       // Judicial identifiers
-      ecli: data.ecli || null,
-      pourvoiNumber: data.pourvoiNumber || null,
-      caseNumbers: data.caseNumbers || [],
       linkedAffairId: data.linkedAffairId ?? null,
     },
   });

--- a/src/app/api/admin/affaires/route.ts
+++ b/src/app/api/admin/affaires/route.ts
@@ -191,12 +191,8 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
       otherSentence: data.otherSentence || null,
       // Jurisdiction
       court: data.court || null,
-      chamber: data.chamber || null,
       caseNumber: data.caseNumber || null,
       // Judicial identifiers
-      ecli: data.ecli || null,
-      pourvoiNumber: data.pourvoiNumber || null,
-      caseNumbers: data.caseNumbers || [],
       linkedAffairId: data.linkedAffairId ?? null,
       sources: {
         create: data.sources.map((s) => ({

--- a/src/components/admin/AffairForm.tsx
+++ b/src/components/admin/AffairForm.tsx
@@ -59,11 +59,8 @@ interface AffairFormData {
   otherSentence?: string;
   // Jurisdiction
   court?: string;
-  chamber?: string;
   caseNumber?: string;
   // Judicial identifiers
-  ecli?: string;
-  pourvoiNumber?: string;
   linkedAffairId?: string | null;
   sources: Source[];
 }
@@ -370,15 +367,6 @@ export function AffairForm({ politicians, initialData }: AffairFormProps) {
               />
             </div>
             <div>
-              <Label htmlFor="chamber">Chambre</Label>
-              <Input
-                id="chamber"
-                value={formData.chamber || ""}
-                onChange={(e) => updateField("chamber", e.target.value)}
-                placeholder="Ex: 11ème chambre"
-              />
-            </div>
-            <div>
               <Label htmlFor="caseNumber">N° d&apos;affaire</Label>
               <Input
                 id="caseNumber"
@@ -390,32 +378,11 @@ export function AffairForm({ politicians, initialData }: AffairFormProps) {
           </div>
 
           <hr className="my-4" />
-          <h4 className="font-medium text-sm">Identifiants judiciaires</h4>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="ecli">ECLI</Label>
-              <Input
-                id="ecli"
-                value={formData.ecli || ""}
-                onChange={(e) => updateField("ecli", e.target.value)}
-                placeholder="Ex: ECLI:FR:CCASS:2023:CR00123"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                European Case Law Identifier (identifiant unique européen)
-              </p>
-            </div>
-            <div>
-              <Label htmlFor="pourvoiNumber">N° de pourvoi</Label>
-              <Input
-                id="pourvoiNumber"
-                value={formData.pourvoiNumber || ""}
-                onChange={(e) => updateField("pourvoiNumber", e.target.value)}
-                placeholder="Ex: 22-83.456"
-              />
-              <p className="text-xs text-muted-foreground mt-1">Numéro de pourvoi en cassation</p>
-            </div>
-          </div>
+          <p className="text-xs text-muted-foreground">
+            Les identifiants d&apos;une décision (ECLI, n° de pourvoi) ne se saisissent plus ici :
+            une même décision peut concerner plusieurs affaires. Ils se gèrent en rattachant une
+            décision de justice, plus bas sur cette fiche.
+          </p>
         </CardContent>
       </Card>
 

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -16,7 +16,7 @@ import { AffairStatus, Prisma } from "@/generated/prisma";
  * discover-affairs (Wikidata penalties): verdictDate, court, sentence,
  *   prisonMonths, prisonSuspended, ineligibilityMonths, communityService,
  *   otherSentence.
- * judilibre: status, ecli, pourvoiNumber, caseNumbers.
+ * judilibre: status. Its identifiers moved to `CourtDecision` (#545).
  *
  * fineAmount is allowed but no importer emits it today: Wikidata signals a fine
  * (wikidata-penalties.ts maps Q1243001 to "fineAmount") yet the extractor reduces
@@ -34,6 +34,12 @@ import { AffairStatus, Prisma } from "@/generated/prisma";
  * - politicianId, partyAtTimeId, linkedAffairId: re-attribution is identity
  *   resolution work, handled by AffairPoliticianDecision.
  * - slug, publicId, oldSlugs: public URLs are not importer territory.
+ * - ecli, pourvoiNumber, caseNumbers: decision identifiers, and a decision is not
+ *   an affair (#545). They live on `CourtDecision`, reached through a link, and are
+ *   written by the targeted Judilibre enrichment (#337). Proposing them on an affair
+ *   would put back the "one decision, one affair" assumption the Carignon case
+ *   disproved. `Affair.court`, `Affair.verdictDate` and `Affair.caseNumber` stay:
+ *   they describe the editorial state of an affair, not a decision.
  *
  * Widen this list only together with the importer that needs it.
  */
@@ -70,11 +76,6 @@ export const affairPatchSchema = z
     ineligibilityMonths: monthsLike.nullable().optional(),
     communityService: z.number().int().min(0).max(10000).nullable().optional(),
     otherSentence: z.string().min(1).max(2000).nullable().optional(),
-
-    // Machine identifiers (the only auto-applicable family)
-    ecli: z.string().min(1).max(120).nullable().optional(),
-    pourvoiNumber: z.string().min(1).max(120).nullable().optional(),
-    caseNumbers: z.array(z.string().min(1).max(120)).max(50).optional(),
   })
   .refine((patch) => Object.keys(patch).length > 0, {
     message: "Le patch ne peut pas être vide",
@@ -94,9 +95,6 @@ export const PROPOSABLE_FIELDS = Object.freeze([
   "ineligibilityMonths",
   "communityService",
   "otherSentence",
-  "ecli",
-  "pourvoiNumber",
-  "caseNumbers",
 ] as const);
 
 export type ProposableField = (typeof PROPOSABLE_FIELDS)[number];

--- a/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
+++ b/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { PROPOSABLE_FIELDS } from "@/lib/security/schemas/affair-proposal";
+
+/**
+ * Issue #545 — nothing writes a decision identifier onto an `Affair` any more.
+ *
+ * `ecli`, `pourvoiNumber`, `chamber` and `caseNumbers` identify a decision, and a
+ * decision is not an affair: one decision carries several counts, so it reaches
+ * several fiches. They belong to `CourtDecision`, written by the targeted Judilibre
+ * enrichment (#337) and linked through `AffairCourtDecision` (#536).
+ *
+ * `court`, `verdictDate` and `caseNumber` are NOT covered here: they describe the
+ * editorial state of an affair, and 23.7 % of `Affair.court` values name a body that
+ * renders no decision at all. They stay writable.
+ */
+
+const ROOT = process.cwd();
+
+/** Identifiers that may no longer be written onto an affair. */
+const DECISION_IDENTIFIERS = ["ecli", "pourvoiNumber", "caseNumbers", "chamber"] as const;
+
+/** Fields that stay on `Affair` and must remain writable. */
+const EDITORIAL_FIELDS = ["court", "verdictDate", "caseNumber"] as const;
+
+/**
+ * Where an affair row is actually written. Court-decision code is excluded: it
+ * writes the same field names onto a different table, which is the point.
+ */
+const WRITE_SURFACES = [
+  "src/services/affairs/index.ts",
+  "src/services/affairs/create-draft.ts",
+  "src/app/api/admin/affaires/route.ts",
+  "src/app/api/admin/affaires/[id]/route.ts",
+];
+
+/**
+ * An assignment, not a read.
+ *
+ * `ecli: true` is a Prisma `select`, and `ecli: { not: null }` is a `where`: both
+ * read the column. Only a value that is neither a boolean nor an object writes it.
+ *
+ * The whitespace sits *inside* the lookahead on purpose. With `:\s*(?!…)` in front,
+ * `\s*` can backtrack to zero characters and the lookahead then passes on the space,
+ * so `ecli: { not: null }` would read as a write.
+ */
+const ASSIGNMENT_SOURCE = (field: string) => String.raw`\b${field}\s*:(?!\s*(?:true\b|false\b|\{))`;
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function collect(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current)) {
+      const path = join(current, entry);
+      if (statSync(path).isDirectory()) {
+        if (entry === "__tests__" || entry === "node_modules") continue;
+        walk(path);
+        continue;
+      }
+      if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(path);
+    }
+  };
+  walk(join(ROOT, dir));
+  return out;
+}
+
+const relative = (f: string) => f.replace(ROOT + "/", "");
+
+describe("garde : aucune écriture d'identifiant de décision sur Affair (#545)", () => {
+  it("les surfaces d'écriture d'affaire n'assignent plus ces champs", () => {
+    const offenders: string[] = [];
+
+    for (const rel of WRITE_SURFACES) {
+      const source = stripComments(readFileSync(join(ROOT, rel), "utf8"));
+      for (const field of DECISION_IDENTIFIERS) {
+        const assignment = new RegExp(ASSIGNMENT_SOURCE(field), "g");
+        if (assignment.test(source)) offenders.push(`${rel} → ${field}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("aucun de ces champs n'est proposable", () => {
+    const offenders = DECISION_IDENTIFIERS.filter((field) =>
+      (PROPOSABLE_FIELDS as readonly string[]).includes(field)
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("le chemin d'auto-application a disparu, pas seulement ses champs", () => {
+    // Lu dans la source plutôt qu'importé : `proposals.ts` construit le client
+    // Prisma au chargement, et ce garde doit rester lexical.
+    //
+    // Conséquence directe : « un importeur ne mute jamais une affaire existante »
+    // devient absolu, sans exception. Un chemin que personne ne peut atteindre est
+    // un chemin que personne ne maintient, donc il est supprimé et non désactivé.
+    const source = stripComments(
+      readFileSync(join(ROOT, "src/services/affairs/proposals.ts"), "utf8")
+    );
+
+    for (const symbol of ["AUTO_APPLICABLE_FIELDS", "applyAutoCandidates", "AUTO_APPLIED"]) {
+      expect(source).not.toContain(symbol);
+    }
+    // Et le service n'écrit plus jamais une affaire.
+    expect(source).not.toMatch(/\b(?:db|tx)\.affair\.update\b/);
+  });
+
+  it("les champs éditoriaux restent proposables", () => {
+    // Borne par le bas : sans elle, vider PROPOSABLE_FIELDS rendrait la règle verte.
+    for (const field of ["court", "verdictDate"] as const) {
+      expect(PROPOSABLE_FIELDS as readonly string[]).toContain(field);
+    }
+  });
+
+  it("le formulaire admin ne propose plus de saisir ECLI ni pourvoi", () => {
+    const form = readFileSync(join(ROOT, "src/components/admin/AffairForm.tsx"), "utf8");
+
+    expect(form).not.toContain('htmlFor="ecli"');
+    expect(form).not.toContain('htmlFor="pourvoiNumber"');
+  });
+
+  it("aucun service de synchronisation n'écrit ces identifiants", () => {
+    // `chamber` est exclu de ce balayage : le nom est partagé avec Scrutin et
+    // Amendment, où il désigne une chambre parlementaire. Sur les surfaces
+    // d'écriture d'affaire ci-dessus, il est vérifié nommément.
+    const unambiguous = DECISION_IDENTIFIERS.filter((f) => f !== "chamber");
+    const offenders: string[] = [];
+
+    for (const file of collect("src/services/sync")) {
+      const source = stripComments(readFileSync(file, "utf8"));
+      for (const field of unambiguous) {
+        if (new RegExp(ASSIGNMENT_SOURCE(field)).test(source)) {
+          offenders.push(`${relative(file)} → ${field}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("ne prétend pas couvrir les champs éditoriaux", () => {
+    // Rend explicite ce que ce garde ne dit pas, pour qu'on ne le lise pas comme
+    // une interdiction d'écrire court ou verdictDate.
+    for (const field of EDITORIAL_FIELDS) {
+      expect(DECISION_IDENTIFIERS as readonly string[]).not.toContain(field);
+    }
+  });
+});

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -111,12 +111,6 @@ describe("deriveRiskLevel", () => {
       "MEDIUM"
     );
   });
-
-  it("LOW quand seuls des identifiants machine vides sont remplis", () => {
-    expect(deriveRiskLevel(["ecli", "pourvoiNumber"], { ecli: null, pourvoiNumber: null })).toBe(
-      "LOW"
-    );
-  });
 });
 
 describe("detectDrift", () => {
@@ -241,7 +235,7 @@ describe("validatePatch", () => {
     }
   });
 
-  it("accepte les 13 champs de la whitelist du lot 1", () => {
+  it("accepte les 10 champs de la whitelist", () => {
     expect(() =>
       validatePatch({
         status: "CONDAMNATION_DEFINITIVE",
@@ -254,11 +248,19 @@ describe("validatePatch", () => {
         ineligibilityMonths: 60,
         communityService: 100,
         otherSentence: "interdiction d'exercer",
-        ecli: "ECLI:FR:CCASS:2026:X",
-        pourvoiNumber: "23-80.000",
-        caseNumbers: ["A", "B"],
       })
     ).not.toThrow();
+  });
+
+  it("refuse les identifiants de décision, partis sur CourtDecision (#545)", () => {
+    for (const patch of [
+      { ecli: "ECLI:FR:CCASS:2026:X" },
+      { pourvoiNumber: "23-80.000" },
+      { caseNumbers: ["A", "B"] },
+      { chamber: "Chambre criminelle" },
+    ]) {
+      expect(() => validatePatch(patch)).toThrow(ProposalValidationError);
+    }
   });
 
   it("coerce fineAmount en Decimal, sans passer par un flottant", () => {
@@ -290,46 +292,6 @@ describe("validatePatch", () => {
 });
 
 describe("proposeAffairUpdate", () => {
-  it("auto-applique un ECLI absent et libre, sans revue", async () => {
-    const result = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
-    });
-
-    expect(result.autoApplied).toEqual(["ecli"]);
-    expect(result.pendingProposalId).toBeNull();
-    expect(db.affair.update).toHaveBeenCalledTimes(1);
-    expect(db.affair.update.mock.calls[0]![0].data).toEqual({ ecli: "ECLI:FR:CCASS:2026:X" });
-    expect(db.affairUpdateProposal.create.mock.calls[0]![0].data.status).toBe("AUTO_APPLIED");
-    // The automated write still leaves a trace.
-    expect(db.auditLog.create).toHaveBeenCalledTimes(1);
-    // Proposal row, affair write and audit entry share one transaction.
-    expect(db.$transaction).toHaveBeenCalledTimes(1);
-  });
-
-  it("l'auto-application revérifie l'éligibilité DANS la transaction", async () => {
-    // Field was empty at classification time, filled in by the time we write.
-    db.affair.findUnique
-      .mockResolvedValueOnce(EMPTY_AFFAIR)
-      .mockResolvedValueOnce({ ...EMPTY_AFFAIR, ecli: "ECLI:FR:CCASS:2020:OTHER" });
-
-    const result = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
-    });
-
-    expect(result.autoApplied).toEqual([]);
-    expect(result.conflictProposalId).toBe("prop_new");
-    expect(db.affair.update).not.toHaveBeenCalled();
-    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
-    expect(created.status).toBe("CONFLICT");
-    expect(created.conflictDetail).toEqual({
-      ecli: { expected: EMPTY_VALUE, actual: "ECLI:FR:CCASS:2020:OTHER" },
-    });
-  });
-
   it("enregistre un affairSnapshot pour survivre à la suppression de l'affaire", async () => {
     await proposeAffairUpdate({ ...BASE_INPUT, patch: { verdictDate: "2026-05-13" } });
 
@@ -343,46 +305,14 @@ describe("proposeAffairUpdate", () => {
     });
   });
 
-  it("passe en CONFLICT quand l'ECLI appartient déjà à une autre affaire", async () => {
-    db.affair.findFirst.mockResolvedValue({ id: "aff_other" });
-
-    const result = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { ecli: "ECLI:FR:CCASS:2026:X" },
-    });
-
-    expect(result.conflictProposalId).toBe("prop_new");
-    expect(result.autoApplied).toEqual([]);
-    // No blind write, so no P2002 on the unique index.
-    expect(db.affair.update).not.toHaveBeenCalled();
-    expect(db.affairUpdateProposal.create.mock.calls[0]![0].data.status).toBe("CONFLICT");
-  });
-
-  it("met un ECLI contradictoire en revue au lieu de l'écraser", async () => {
-    db.affair.findUnique.mockResolvedValue({ ...EMPTY_AFFAIR, ecli: "ECLI:FR:CCASS:2020:OLD" });
-
-    const result = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { ecli: "ECLI:FR:CCASS:2026:NEW" },
-    });
-
-    expect(result.autoApplied).toEqual([]);
-    expect(result.pendingProposalId).toBe("prop_new");
-    expect(db.affair.update).not.toHaveBeenCalled();
-    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
-    expect(created.status).toBe("PENDING");
-    expect(created.riskLevel).toBe("HIGH");
-  });
-
-  it("n'auto-applique jamais un statut ou une peine", async () => {
+  it("n'écrit jamais sur l'affaire : tout part en revue", async () => {
+    // Depuis #545 l'invariant est absolu, sans exception : un importeur ne mute
+    // jamais une affaire existante, quel que soit le champ.
     const result = await proposeAffairUpdate({
       ...BASE_INPUT,
       patch: { status: "CONDAMNATION_DEFINITIVE", prisonMonths: 24, verdictDate: "2026-05-13" },
     });
 
-    expect(result.autoApplied).toEqual([]);
     expect(result.pendingProposalId).toBe("prop_new");
     expect(db.affair.update).not.toHaveBeenCalled();
     const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
@@ -392,26 +322,6 @@ describe("proposeAffairUpdate", () => {
       "verdictDate",
     ]);
     expect(created.riskLevel).toBe("HIGH");
-  });
-
-  it("n'ajoute que les numéros de dossier absents, et rien si tout est déjà là", async () => {
-    db.affair.findUnique.mockResolvedValue({ ...EMPTY_AFFAIR, caseNumbers: ["A", "B"] });
-
-    const nothingNew = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { caseNumbers: ["A", "B"] },
-    });
-    expect(nothingNew.autoApplied).toEqual([]);
-    expect(db.affair.update).not.toHaveBeenCalled();
-
-    const withNew = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { caseNumbers: ["B", "C"] },
-    });
-    expect(withNew.autoApplied).toEqual(["caseNumbers"]);
-    expect(db.affair.update.mock.calls[0]![0].data.caseNumbers.sort()).toEqual(["A", "B", "C"]);
   });
 
   it("idempotence : un patch déjà enregistré ne crée pas de doublon", async () => {
@@ -439,21 +349,6 @@ describe("proposeAffairUpdate", () => {
     expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
     // Not even a touch: the row keeps its terminal state.
     expect(db.affairUpdateProposal.update).not.toHaveBeenCalled();
-  });
-
-  it("sépare l'auto-applicable de ce qui doit être revu, en une passe", async () => {
-    const result = await proposeAffairUpdate({
-      ...BASE_INPUT,
-      source: "JUDILIBRE",
-      patch: { ecli: "ECLI:FR:CCASS:2026:X", status: "CONDAMNATION_DEFINITIVE" },
-    });
-
-    expect(result.autoApplied).toEqual(["ecli"]);
-    expect(result.pendingProposalId).toBe("prop_new");
-    expect(db.affair.update.mock.calls[0]![0].data).toEqual({ ecli: "ECLI:FR:CCASS:2026:X" });
-
-    const statuses = db.affairUpdateProposal.create.mock.calls.map((c) => c[0].data.status);
-    expect(statuses).toEqual(["AUTO_APPLIED", "PENDING"]);
   });
 
   it("refuse un patch invalide avant toute écriture", async () => {

--- a/src/services/affairs/create-draft.ts
+++ b/src/services/affairs/create-draft.ts
@@ -47,9 +47,6 @@ export interface CreateDraftAffairInput {
 
   // Jurisdiction and machine identifiers
   court?: string | null;
-  ecli?: string | null;
-  pourvoiNumber?: string | null;
-  caseNumbers?: string[];
 
   // Sentence
   sentence?: string | null;
@@ -89,9 +86,6 @@ export async function createDraftAffairFromDiscovery(
     factsDate: input.factsDate ?? null,
     verdictDate: input.verdictDate ?? null,
     court: input.court ?? null,
-    ecli: input.ecli ?? null,
-    pourvoiNumber: input.pourvoiNumber ?? null,
-    caseNumbers: input.caseNumbers ?? [],
     sentence: input.sentence ?? null,
     prisonMonths: input.prisonMonths ?? null,
     prisonSuspended: input.prisonSuspended ?? null,

--- a/src/services/affairs/index.ts
+++ b/src/services/affairs/index.ts
@@ -115,9 +115,6 @@ export async function createAffair(input: CreateAffairInput): Promise<AffairWith
       startDate: input.startDate,
       verdictDate: input.verdictDate,
       sentence: input.sentence,
-      ecli: input.ecli,
-      pourvoiNumber: input.pourvoiNumber,
-      caseNumbers: input.caseNumbers || [],
       sources: {
         create: input.sources,
       },

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -16,12 +16,21 @@ import {
 // proposeAffairUpdate(), which auto-applies only absent, non-contradictory
 // machine identifiers and files everything else as a reviewable proposal.
 
-/** The only family an importer may write without human review. */
-export const AUTO_APPLICABLE_FIELDS = Object.freeze([
-  "ecli",
-  "pourvoiNumber",
-  "caseNumbers",
-] as const);
+/**
+ * Importers never write an affair. Not "almost never": never (#545).
+ *
+ * There used to be one exception, an auto-apply path that filled the decision
+ * identifiers `ecli`, `pourvoiNumber` and `caseNumbers` when they were empty, on the
+ * grounds that filling a blank machine identifier needed no editorial call.
+ *
+ * Those identifiers moved to `CourtDecision`, written by the targeted Judilibre
+ * enrichment (#337). No importer had anything left to auto-apply, so the exception
+ * and its machinery are gone rather than left inert: a code path nobody can reach is
+ * a code path nobody maintains.
+ *
+ * The `AUTO_APPLIED` and `CONFLICT` proposal statuses stay in the schema, and the
+ * admin still renders them. No new row can carry them; a historical one still reads.
+ */
 
 /**
  * Changing any of these is HIGH risk regardless of the previous value.
@@ -30,7 +39,6 @@ export const AUTO_APPLICABLE_FIELDS = Object.freeze([
  */
 const HIGH_RISK_FIELDS = Object.freeze(["status"] as const);
 
-const AUTO_SET: ReadonlySet<string> = new Set(AUTO_APPLICABLE_FIELDS);
 const HIGH_RISK_SET: ReadonlySet<string> = new Set(HIGH_RISK_FIELDS);
 
 export class ProposalValidationError extends Error {
@@ -62,9 +70,6 @@ export const AFFAIR_PROPOSABLE_SELECT = {
   ineligibilityMonths: true,
   communityService: true,
   otherSentence: true,
-  ecli: true,
-  pourvoiNumber: true,
-  caseNumbers: true,
 } as const;
 
 export interface AffairSnapshot {
@@ -182,7 +187,9 @@ export function deriveRiskLevel(
   const touchesJudicialState = patchKeys.some((k) => HIGH_RISK_SET.has(k));
   const overwrites = patchKeys.some((k) => normalizeForCompare(observedValues[k]) !== EMPTY_VALUE);
   if (touchesJudicialState || overwrites) return "HIGH";
-  return patchKeys.every((k) => AUTO_SET.has(k)) ? "LOW" : "MEDIUM";
+  // LOW is no longer produced: it meant "only auto-applicable identifiers", and no
+  // field is auto-applicable any more. The enum value stays for historical rows.
+  return "MEDIUM";
 }
 
 // ─── Drift detection ─────────────────────────────────────────────
@@ -256,13 +263,8 @@ export interface ProposeAffairUpdateInput {
 }
 
 export interface ProposeAffairUpdateResult {
-  /** Machine identifiers written straight away. */
-  autoApplied: ProposableField[];
-  autoProposalId: string | null;
-  /** Proposal awaiting review, if any field required one. */
+  /** The proposal awaiting review. Always set unless the payload was a duplicate. */
   pendingProposalId: string | null;
-  /** Set when an identifier is contradicted or already taken elsewhere. */
-  conflictProposalId: string | null;
   /** True when an identical payload had already been recorded. */
   deduped: boolean;
 }
@@ -295,60 +297,23 @@ export async function proposeAffairUpdate(
   }
   const live = affair as unknown as LiveAffair;
 
-  // Classification only. The auto path recomputes eligibility inside its own
-  // transaction, because the row can move between this read and the write.
-  const autoCandidates: Record<string, unknown> = {};
   const reviewPatch: Record<string, unknown> = {};
-
   for (const field of fields) {
-    const proposed = (patch as Record<string, unknown>)[field];
-    if (!AUTO_SET.has(field)) {
-      reviewPatch[field] = proposed;
-      continue;
-    }
-    if (field !== "caseNumbers" && normalizeForCompare(live[field]) !== EMPTY_VALUE) {
-      // Contradicts a stored identifier: that is a review decision, not a fill.
-      reviewPatch[field] = proposed;
-      continue;
-    }
-    if (proposed === null || proposed === undefined) continue;
-    autoCandidates[field] = proposed;
+    reviewPatch[field] = (patch as Record<string, unknown>)[field];
   }
 
   const result: ProposeAffairUpdateResult = {
-    autoApplied: [],
-    autoProposalId: null,
     pendingProposalId: null,
-    conflictProposalId: null,
     deduped: false,
   };
-
-  if (Object.keys(autoCandidates).length > 0) {
-    const outcome = await applyAutoCandidates(input, extractorVersion, autoCandidates, live);
-    result.deduped = result.deduped || outcome.deduped;
-    if (outcome.kind === "applied") {
-      result.autoApplied = outcome.appliedFields;
-      result.autoProposalId = outcome.proposalId;
-    } else if (outcome.kind === "conflict") {
-      result.conflictProposalId = outcome.proposalId;
-    }
-  }
 
   if (Object.keys(reviewPatch).length > 0) {
     const outcome = await recordPendingProposal(input, extractorVersion, reviewPatch, live);
     result.pendingProposalId = outcome.proposalId;
-    result.deduped = result.deduped || outcome.deduped;
+    result.deduped = outcome.deduped;
   }
 
   return result;
-}
-
-function mergeCaseNumbers(current: string[], incoming: string[]): string[] {
-  const seen = new Set(current);
-  for (const value of incoming) {
-    if (value) seen.add(value);
-  }
-  return Array.from(seen);
 }
 
 function pickObserved(
@@ -369,9 +334,13 @@ interface ProposalRowArgs {
   payloadHash: string;
 }
 
+/**
+ * Only `PENDING` remains creatable (#545). `AUTO_APPLIED` and `CONFLICT` stay in the
+ * schema so a historical row still reads, but nothing produces them any more.
+ */
 function buildProposalData(
   args: ProposalRowArgs,
-  status: "PENDING" | "AUTO_APPLIED" | "CONFLICT",
+  status: "PENDING",
   extras: { appliedAt?: Date | null; conflictDetail?: ConflictDetail } = {}
 ): Prisma.AffairUpdateProposalUncheckedCreateInput {
   return {
@@ -519,138 +488,6 @@ async function recordPendingProposal(
 
   const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
   return { proposalId: created.id, deduped: false };
-}
-
-type AutoOutcome =
-  | { kind: "applied"; proposalId: string; appliedFields: ProposableField[]; deduped: boolean }
-  | { kind: "conflict"; proposalId: string; deduped: boolean }
-  | { kind: "skipped"; deduped: boolean };
-
-/**
- * Auto-applies absent, non-contradictory machine identifiers.
- *
- * Eligibility is re-checked INSIDE the transaction: between the classification
- * read and this write, another run or an editor may have filled the field or
- * claimed the ECLI. Proposal row, affair write, audit entry and terminal state
- * commit together or not at all.
- */
-async function applyAutoCandidates(
-  input: ProposeAffairUpdateInput,
-  extractorVersion: string,
-  candidates: Record<string, unknown>,
-  liveAtRead: LiveAffair
-): Promise<AutoOutcome> {
-  const payloadHash = computePayloadHash({
-    importer: input.importer,
-    extractorVersion,
-    source: input.source,
-    sourceUrl: input.sourceUrl,
-    officialId: input.officialId,
-    sourceContentHash: input.sourceContentHash,
-    proposedPatch: candidates,
-    observedValues: pickObserved(candidates, liveAtRead),
-  });
-
-  const existing = await findExisting(input.affairId, input.importer, payloadHash);
-  if (existing) return { kind: "skipped", deduped: true };
-
-  return db.$transaction(async (tx) => {
-    const live = (await tx.affair.findUnique({
-      where: { id: input.affairId },
-      select: AFFAIR_PROPOSABLE_SELECT,
-    })) as unknown as LiveAffair | null;
-    if (!live) return { kind: "skipped" as const, deduped: false };
-
-    const writePatch: Record<string, unknown> = {};
-    const conflicts: ConflictDetail = {};
-
-    for (const [field, proposed] of Object.entries(candidates)) {
-      if (field === "caseNumbers") {
-        const current = Array.isArray(live.caseNumbers) ? (live.caseNumbers as string[]) : [];
-        const merged = mergeCaseNumbers(current, Array.isArray(proposed) ? proposed : []);
-        // Additive only: nothing new means nothing to do.
-        if (merged.length > current.length) writePatch.caseNumbers = merged;
-        continue;
-      }
-
-      const actual = normalizeForCompare(live[field]);
-      if (actual !== EMPTY_VALUE) {
-        conflicts[field] = { expected: EMPTY_VALUE, actual };
-        continue;
-      }
-
-      if (field === "ecli") {
-        const taken = await tx.affair.findFirst({
-          where: { ecli: String(proposed), id: { not: input.affairId } },
-          select: { id: true },
-        });
-        if (taken) {
-          // "Absent" but not "non-contradictory": Affair.ecli is @unique, so a
-          // blind write would raise P2002. Surface it instead.
-          conflicts[field] = { expected: EMPTY_VALUE, actual: "déjà rattaché à une autre affaire" };
-          continue;
-        }
-      }
-
-      writePatch[field] = proposed;
-    }
-
-    const rowArgs: ProposalRowArgs = {
-      input,
-      extractorVersion,
-      patch: candidates,
-      observedValues: pickObserved(candidates, live),
-      snapshot: buildAffairSnapshot(live),
-      payloadHash,
-    };
-
-    if (Object.keys(conflicts).length > 0) {
-      const row = await tx.affairUpdateProposal.create({
-        data: buildProposalData(rowArgs, "CONFLICT", { conflictDetail: conflicts }),
-        select: { id: true },
-      });
-      return { kind: "conflict" as const, proposalId: row.id, deduped: false };
-    }
-
-    if (Object.keys(writePatch).length === 0) {
-      return { kind: "skipped" as const, deduped: false };
-    }
-
-    const row = await tx.affairUpdateProposal.create({
-      data: buildProposalData({ ...rowArgs, patch: writePatch }, "AUTO_APPLIED", {
-        appliedAt: new Date(),
-      }),
-      select: { id: true },
-    });
-
-    await tx.affair.update({
-      where: { id: input.affairId },
-      data: buildPrismaData(validatePatch(writePatch)),
-    });
-
-    await tx.auditLog.create({
-      data: {
-        action: "UPDATE",
-        entityType: "Affair",
-        entityId: input.affairId,
-        changes: toJson({
-          action: "PROPOSAL_AUTO_APPLIED",
-          importer: input.importer,
-          extractorVersion,
-          proposalId: row.id,
-          before: pickObserved(writePatch, live),
-          after: writePatch,
-        }),
-      },
-    });
-
-    return {
-      kind: "applied" as const,
-      proposalId: row.id,
-      appliedFields: Object.keys(writePatch) as ProposableField[],
-      deduped: false,
-    };
-  });
 }
 
 function clampConfidence(value: number): number {

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -87,8 +87,6 @@ export interface DiscoverAffairsResult {
   affairsCreated: number;
   /** Affaires v2, lot 1: enrichment of existing affairs is now proposal-based. */
   proposalsPending: number;
-  proposalsAutoApplied: number;
-  proposalsConflicted: number;
   proposalsDeduped: number;
   /** Several affairs tied at HIGH: no enrichment, a draft is created instead. */
   ambiguousMatches: number;
@@ -220,8 +218,6 @@ export async function discoverAffairs(options?: {
     duplicatesSkipped: 0,
     affairsCreated: 0,
     proposalsPending: 0,
-    proposalsAutoApplied: 0,
-    proposalsConflicted: 0,
     proposalsDeduped: 0,
     ambiguousMatches: 0,
     errors: [],
@@ -314,8 +310,6 @@ export async function discoverAffairs(options?: {
         duplicatesSkipped: stats.duplicatesSkipped,
         affairsCreated: stats.affairsCreated,
         proposalsPending: stats.proposalsPending,
-        proposalsAutoApplied: stats.proposalsAutoApplied,
-        proposalsConflicted: stats.proposalsConflicted,
         proposalsDeduped: stats.proposalsDeduped,
         ambiguousMatches: stats.ambiguousMatches,
       });
@@ -660,8 +654,6 @@ async function proposePenaltyEnrichment(
   });
 
   if (result.pendingProposalId) stats.proposalsPending++;
-  if (result.autoProposalId) stats.proposalsAutoApplied++;
-  if (result.conflictProposalId) stats.proposalsConflicted++;
   if (result.deduped) stats.proposalsDeduped++;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -208,9 +208,6 @@ export type CreateAffairInput = {
   verdictDate?: Date;
   sentence?: string;
   // Judicial identifiers (multi-source matching)
-  ecli?: string;
-  pourvoiNumber?: string;
-  caseNumbers?: string[];
   sources: {
     url: string;
     title: string;


### PR DESCRIPTION
Part of #545. Première des trois PR. Suite de #536, #337 et #557.

## Portée

Cette PR arrête les **écritures**. Les lectures et le matching restent inchangés, et aucune colonne n'est retirée : c'est l'objet des deux PR suivantes.

## Mesure préalable

Comptée en lecture seule sur les 463 affaires :

| champ | affaires renseignées |
|---|---|
| `ecli` | **0** |
| `pourvoiNumber` | 3 |
| `chamber` | **0** |
| `caseNumbers` | **0** |
| `caseNumber` | **0** |
| `court` | 275 |
| `verdictDate` | 163 |

Les **trois** pourvois historiques sont tous représentés dans les 2 `CourtDecision` et leurs 3 liaisons :

```text
AF-000034  96-83.698 → COUVERT
AF-000035  96-83.698 → COUVERT
AF-000036  97-81.102 → COUVERT
```

Arrêter les écritures ne coûte donc aucune information : il n'y a presque rien à écrire, et ce qui existe vit déjà sur les décisions.

## Ce qui ne s'écrit plus

`ecli`, `pourvoiNumber`, `caseNumbers` et `chamber` sortent de toutes les surfaces d'écriture d'affaire : le service de création, la création de brouillon depuis une découverte, les routes admin de création et de mise à jour, le type `DiscoveredAffair`, le schéma des propositions, et les champs du formulaire admin.

Le formulaire dit désormais où cela se passe, plutôt que de disparaître sans explication :

> Les identifiants d'une décision (ECLI, n° de pourvoi) ne se saisissent plus ici : une même décision peut concerner plusieurs affaires. Ils se gèrent en rattachant une décision de justice.

`court`, `verdictDate` et `caseNumber` restent écrivables et proposables. Ils décrivent l'état éditorial d'une affaire, et **23,7 %** des valeurs de `Affair.court` désignent un organe qui ne rend aucune décision.

## Une conséquence que je n'avais pas anticipée

`AUTO_APPLICABLE_FIELDS` valait **exactement** ces trois identifiants. C'était la seule famille qu'un importeur pouvait écrire sans revue, au motif que remplir un identifiant machine vide ne demandait pas d'arbitrage éditorial.

Les retirer vidait donc entièrement le chemin d'auto-application.

J'ai d'abord voulu le laisser inerte et documenté, pour garder la PR bornée. Deux signaux m'ont fait changer d'avis. TypeScript a d'abord refusé de compiler une garde `field !== "caseNumbers"` devenue sans objet. Puis huit tests se sont retrouvés à couvrir du code qu'aucun appel ne peut plus atteindre. Garder la machinerie aurait laissé à la fois du code mort et des tests qui testent l'impossible.

Le chemin est donc supprimé : `applyAutoCandidates`, `mergeCaseNumbers`, la branche de classification, et les champs de résultat `autoApplied`, `autoProposalId`, `conflictProposalId`.

**L'invariant de #513 devient absolu** : un importeur ne mute jamais une affaire existante, sans exception. `proposeAffairUpdate()` produit toujours une proposition.

Ce qui reste volontairement : les statuts `AUTO_APPLIED` et `CONFLICT` dans le schéma, et leur affichage admin. Aucune nouvelle ligne ne peut les porter, une ligne historique se lit encore. Toucher à l'enum relèverait d'une migration, hors de cette PR.

`deriveRiskLevel` ne produit plus `LOW`, qui signifiait « uniquement des identifiants auto-applicables ». La valeur reste dans l'enum pour les lignes existantes.

## Tests

**7 tests** de garde. Le plus utile vérifie qu'aucune surface d'écriture n'assigne ces champs, avec une distinction qui a demandé deux essais :

```ts
\becli\s*:(?!\s*(?:true\b|false\b|\{))
```

`ecli: true` est un `select` et `ecli: { not: null }` est un `where` : deux lectures. Ma première version plaçait l'espacement avant l'anticipation, ce qui laissait `\s*` revenir à zéro caractère et faisait passer une lecture pour une écriture. Vérifié que la règle attrape bien `ecli: data.ecli || null` et ignore les deux formes de lecture.

`chamber` est exclu du balayage des services de synchronisation : le nom est partagé avec `Scrutin` et `Amendment`, où il désigne une chambre parlementaire. Sur les surfaces d'écriture d'affaire, il est vérifié nommément — et c'est ce qui a révélé deux vraies écritures de `Affair.chamber` dans les routes admin.

Deux tests bornent la règle par le bas : les champs éditoriaux doivent rester proposables, et le garde énonce explicitement qu'il ne les couvre pas.

Côté suite existante : 7 tests du chemin d'auto-application sont retirés, un est réécrit pour vérifier ce qui compte désormais, à savoir qu'aucune écriture n'atteint l'affaire. La liste blanche passe de 13 à 10 champs, avec un test qui refuse explicitement les trois identifiants retirés.

## Vérifications

Suite complète, environnement sans `DATABASE_URL` : **2583 tests**, 0 échec. `tsc` et `eslint` propres.

`prisma migrate diff` rend « empty migration » : aucune colonne touchée.

Comptes de production inchangés : 463 affaires, 2 décisions, 3 liaisons, 8 jugements, 0 proposition.
