### PR TITLE
Lire les identifiants de décision depuis CourtDecision

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -155,21 +155,10 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
             </div>
           </div>
 
-          {/* Judicial identifiers */}
-          {(affair.ecli || affair.pourvoiNumber || affair.caseNumber) && (
+          {/* Références éditoriales. Les identifiants de décision (ECLI, pourvoi)
+              se lisent sur les décisions rattachées, plus bas sur cette page (#545). */}
+          {affair.caseNumber && (
             <div className="grid grid-cols-2 gap-4 pt-2 border-t">
-              {affair.ecli && (
-                <div>
-                  <p className="text-sm text-muted-foreground">ECLI</p>
-                  <p className="font-mono text-sm">{affair.ecli}</p>
-                </div>
-              )}
-              {affair.pourvoiNumber && (
-                <div>
-                  <p className="text-sm text-muted-foreground">N° de pourvoi</p>
-                  <p className="font-mono text-sm">{affair.pourvoiNumber}</p>
-                </div>
-              )}
               {affair.caseNumber && (
                 <div>
                   <p className="text-sm text-muted-foreground">N° de dossier</p>

--- a/src/app/admin/affaires/page.tsx
+++ b/src/app/admin/affaires/page.tsx
@@ -38,7 +38,6 @@ interface AffairItem {
   status: string;
   category: string;
   publicationStatus: PublicationStatus;
-  ecli: string | null;
   createdAt: string;
   politician: {
     id: string;

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -207,12 +207,12 @@ export default async function AffairDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // Double lecture des identifiants déplacés vers la décision (#536). `court` et
+  // Identifiants lus depuis les décisions rattachées (#545). `court` et
   // `verdictDate` restent lus depuis l'affaire : ils sont éditoriaux.
   const linkedDecisions = sortCourtDecisionsForDisplay(
     affair.courtDecisions.map((link) => link.courtDecision)
   );
-  const resolvedDecisionFields = resolveDecisionFields(affair, linkedDecisions);
+  const resolvedDecisionFields = resolveDecisionFields(linkedDecisions);
 
   const superCategory = CATEGORY_TO_SUPER[affair.category as AffairCategory];
   const certainty = getCertaintyLevel(affair.status);

--- a/src/app/api/admin/affaires/route.ts
+++ b/src/app/api/admin/affaires/route.ts
@@ -32,8 +32,16 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   if (pubStatus) where.publicationStatus = pubStatus;
   if (category) where.category = category;
   if (status) where.status = status;
-  if (hasEcli === "true") where.ecli = { not: null };
-  if (hasEcli === "false") where.ecli = null;
+  // Filtre sur les décisions rattachées, plus sur la colonne de l'affaire, qui n'est
+  // plus alimentée (#545). « sans ECLI » signifie désormais « aucune décision
+  // rattachée n'en porte », ce qui est la question que se pose réellement un
+  // modérateur.
+  if (hasEcli === "true") {
+    where.courtDecisions = { some: { courtDecision: { ecli: { not: null } } } };
+  }
+  if (hasEcli === "false") {
+    where.courtDecisions = { none: { courtDecision: { ecli: { not: null } } } };
+  }
   if (search) {
     where.OR = [
       { title: { contains: search, mode: "insensitive" } },

--- a/src/app/api/admin/politiques/[id]/detect-duplicates/route.ts
+++ b/src/app/api/admin/politiques/[id]/detect-duplicates/route.ts
@@ -34,6 +34,18 @@ const STOPWORDS = new Set([
   "l",
 ]);
 
+/** Références qu'au moins une décision de chaque côté porte en commun. */
+function sharedDecisionRefs(a: AffairForComparison, b: AffairForComparison): string[] {
+  const refsOf = (affair: AffairForComparison) =>
+    new Set(
+      affair.courtDecisions.flatMap((l) =>
+        [l.courtDecision.ecli, l.courtDecision.pourvoiNumber].filter((v): v is string => Boolean(v))
+      )
+    );
+  const refsB = refsOf(b);
+  return [...refsOf(a)].filter((ref) => refsB.has(ref));
+}
+
 function normalizeTitle(title: string): string[] {
   return title
     .toLowerCase()
@@ -55,9 +67,10 @@ interface AffairForComparison {
   category: string;
   involvement: string;
   publicationStatus: string;
-  ecli: string | null;
-  pourvoiNumber: string | null;
-  caseNumbers: string[];
+  /** Décisions rattachées (#545), et non des colonnes de l'affaire. */
+  courtDecisions: Array<{
+    courtDecision: { ecli: string | null; pourvoiNumber: string | null };
+  }>;
   factsDate: Date | null;
   startDate: Date | null;
   verdictDate: Date | null;
@@ -76,8 +89,7 @@ export interface DuplicateGroup {
     category: string;
     involvement: string;
     publicationStatus: string;
-    ecli: string | null;
-    pourvoiNumber: string | null;
+    decisionRefs: Array<{ ecli: string | null; pourvoiNumber: string | null }>;
     factsDate: string | null;
     startDate: string | null;
     verdictDate: string | null;
@@ -93,22 +105,16 @@ function calculatePairScore(
   const reasons: string[] = [];
   let score = 0;
 
-  // Exact identifiers — definite match
-  if (a.ecli && b.ecli && a.ecli === b.ecli) {
-    return { score: 100, reasons: ["ECLI identique"] };
-  }
-
-  if (a.pourvoiNumber && b.pourvoiNumber && a.pourvoiNumber === b.pourvoiNumber) {
-    return { score: 95, reasons: ["Numéro de pourvoi identique"] };
-  }
-
-  // Case number overlap
-  if (a.caseNumbers.length > 0 && b.caseNumbers.length > 0) {
-    const overlap = a.caseNumbers.filter((n) => b.caseNumbers.includes(n));
-    if (overlap.length > 0) {
-      score += 40;
-      reasons.push(`Numéro(s) de dossier commun(s) : ${overlap.join(", ")}`);
-    }
+  // Une décision commune est la meilleure raison de LIRE la paire, jamais la preuve
+  // qu'elle est un doublon : une décision porte plusieurs chefs, donc plusieurs
+  // fiches (#557). Le rang reste élevé, l'affirmation ne l'est plus, et le score ne
+  // déclenche aucune action : il filtre et il trie, un humain tranche.
+  const shared = sharedDecisionRefs(a, b);
+  if (shared.length > 0) {
+    score += 60;
+    reasons.push(
+      `Décision commune (${shared.join(", ")}) : à départager, chefs distincts possibles`
+    );
   }
 
   // Title similarity — normalized word overlap
@@ -171,9 +177,9 @@ export const GET = withAdminAuth(async (_request: NextRequest, context) => {
       category: true,
       involvement: true,
       publicationStatus: true,
-      ecli: true,
-      pourvoiNumber: true,
-      caseNumbers: true,
+      courtDecisions: {
+        select: { courtDecision: { select: { ecli: true, pourvoiNumber: true } } },
+      },
       factsDate: true,
       startDate: true,
       verdictDate: true,
@@ -211,8 +217,7 @@ export const GET = withAdminAuth(async (_request: NextRequest, context) => {
         category: a.category,
         involvement: a.involvement,
         publicationStatus: a.publicationStatus,
-        ecli: a.ecli,
-        pourvoiNumber: a.pourvoiNumber,
+        decisionRefs: a.courtDecisions.map((l) => l.courtDecision),
         factsDate: a.factsDate?.toISOString() || null,
         startDate: a.startDate?.toISOString() || null,
         verdictDate: a.verdictDate?.toISOString() || null,

--- a/src/app/api/export/affaires/route.ts
+++ b/src/app/api/export/affaires/route.ts
@@ -158,11 +158,7 @@ export const GET = withPublicRoute(async (request) => {
     sentence: a.sentence ?? "",
     otherSentence: a.otherSentence ?? "",
     court: a.court ?? "",
-    ecli:
-      resolveDecisionField(
-        a.ecli,
-        a.courtDecisions.map((l) => l.courtDecision.ecli)
-      ).value ?? "",
+    ecli: resolveDecisionField(a.courtDecisions.map((l) => l.courtDecision.ecli)).value ?? "",
     descriptionPlain: stripMarkdownForCSV(a.description),
     sourceCount: a._count.sources,
     sourceUrl: a.sources[0]?.url ?? "",

--- a/src/components/admin/DuplicateDetector.tsx
+++ b/src/components/admin/DuplicateDetector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { Fragment, useCallback, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { formatDateShort } from "@/lib/utils";
@@ -34,8 +34,7 @@ interface DuplicateAffair {
   category: string;
   involvement: string;
   publicationStatus: string;
-  ecli: string | null;
-  pourvoiNumber: string | null;
+  decisionRefs?: Array<{ ecli: string | null; pourvoiNumber: string | null }>;
   factsDate: string | null;
   startDate: string | null;
   verdictDate: string | null;
@@ -146,19 +145,14 @@ function AffairCard({
         <dt className="text-muted-foreground">Sources</dt>
         <dd className="font-medium">{affair.sourceCount}</dd>
 
-        {affair.ecli && (
-          <>
-            <dt className="text-muted-foreground">ECLI</dt>
-            <dd className="font-mono text-[10px] break-all">{affair.ecli}</dd>
-          </>
-        )}
-
-        {affair.pourvoiNumber && (
-          <>
-            <dt className="text-muted-foreground">Pourvoi</dt>
-            <dd className="font-mono text-[10px]">{affair.pourvoiNumber}</dd>
-          </>
-        )}
+        {(affair.decisionRefs ?? []).map((ref, index) => (
+          <Fragment key={`${ref.ecli ?? ""}-${ref.pourvoiNumber ?? ""}-${index}`}>
+            <dt className="text-muted-foreground">Décision</dt>
+            <dd className="font-mono text-[10px] break-all">
+              {[ref.pourvoiNumber, ref.ecli].filter(Boolean).join(" · ") || "sans référence"}
+            </dd>
+          </Fragment>
+        ))}
       </dl>
 
       {/* Sources list */}

--- a/src/lib/affairs/__tests__/decision-fields.test.ts
+++ b/src/lib/affairs/__tests__/decision-fields.test.ts
@@ -1,39 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { resolveDecisionField, resolveDecisionFields } from "../decision-fields";
 
-// Issue #536 — the transition rule. An affair's own value is the editorial record and
-// wins; a single linked decision fills a gap; several linked decisions yield no flat
+// Issue #545 — the linked decisions are the only source. The affair side is gone:
+// nothing writes those columns any more, so preferring them would freeze whatever a
+// backfill happened to leave there. Several linked decisions still yield no flat
 // value at all, because choosing one would be an implicit editorial decision.
 
-describe("resolveDecisionField — priorité à la valeur historique (#536)", () => {
-  it("garde la valeur de l'affaire quand elle existe", () => {
-    const r = resolveDecisionField("ECLI:AFFAIRE", ["ECLI:DECISION"]);
-
-    expect(r).toEqual({ value: "ECLI:AFFAIRE", source: "affair" });
-  });
-
-  it("garde la valeur de l'affaire même face à plusieurs décisions", () => {
-    const r = resolveDecisionField("96-83.698", ["11-11.111", "22-22.222"]);
-
-    expect(r.value).toBe("96-83.698");
-    expect(r.source).toBe("affair");
-  });
-
-  it("reprend la décision unique quand l'affaire ne dit rien", () => {
-    const r = resolveDecisionField(null, ["ECLI:DECISION"]);
+describe("resolveDecisionField — la décision est la seule source (#545)", () => {
+  it("reprend la valeur de la décision unique", () => {
+    const r = resolveDecisionField(["ECLI:DECISION"]);
 
     expect(r).toEqual({ value: "ECLI:DECISION", source: "decision" });
   });
 
   it("ne rend AUCUNE valeur plate avec plusieurs décisions liées", () => {
-    const r = resolveDecisionField(null, ["11-11.111", "22-22.222"]);
+    const r = resolveDecisionField(["11-11.111", "22-22.222"]);
 
     expect(r).toEqual({ value: null, source: "ambiguous" });
   });
 
   it("ne choisit pas la seule décision porteuse parmi plusieurs", () => {
     // Ce serait exactement le choix implicite que cette fonction refuse.
-    const r = resolveDecisionField(null, [null, "22-22.222"]);
+    const r = resolveDecisionField([null, "22-22.222"]);
 
     expect(r.value).toBeNull();
     expect(r.source).toBe("ambiguous");
@@ -42,49 +30,55 @@ describe("resolveDecisionField — priorité à la valeur historique (#536)", ()
   it("ne choisit jamais la décision la plus récente", () => {
     // Sur une affaire couvrant première instance, appel puis cassation, la plus
     // récente est souvent un rejet de forme, pas le résultat attendu du lecteur.
-    const r = resolveDecisionField(null, ["ancienne", "récente"]);
+    const r = resolveDecisionField(["ancienne", "récente"]);
 
     expect(r.value).toBeNull();
   });
 
-  it("rend absent quand ni l'affaire ni la décision unique ne portent la valeur", () => {
-    expect(resolveDecisionField(null, [null])).toEqual({ value: null, source: "absent" });
-    expect(resolveDecisionField(null, [])).toEqual({ value: null, source: "absent" });
+  it("rend absent sans décision, ou quand la décision unique ne porte rien", () => {
+    expect(resolveDecisionField([])).toEqual({ value: null, source: "absent" });
+    expect(resolveDecisionField([null])).toEqual({ value: null, source: "absent" });
+    expect(resolveDecisionField([undefined])).toEqual({ value: null, source: "absent" });
   });
 
-  it("traite la chaîne vide comme absente, des deux côtés", () => {
-    expect(resolveDecisionField("", ["ECLI:DECISION"]).source).toBe("decision");
-    expect(resolveDecisionField("", [""]).source).toBe("absent");
+  it("traite la chaîne vide comme absente", () => {
+    expect(resolveDecisionField([""])).toEqual({ value: null, source: "absent" });
+  });
+
+  it("ne rend jamais la provenance « affair »", () => {
+    // Le type la conserve pour qu'une valeur journalisée avant #545 se relise, mais
+    // plus aucun chemin ne la produit.
+    for (const decisions of [[], [null], ["x"], ["a", "b"]]) {
+      expect(resolveDecisionField(decisions).source).not.toBe("affair");
+    }
   });
 });
 
-describe("resolveDecisionFields — vue complète (#536)", () => {
-  it("rend le comportement historique quand l'affaire porte tout", () => {
-    const r = resolveDecisionFields(
-      { ecli: "ECLI:A", pourvoiNumber: "96-83.698", chamber: "11e chambre" },
-      []
-    );
+describe("resolveDecisionFields — vue complète (#545)", () => {
+  it("rend tout absent sans décision rattachée", () => {
+    const r = resolveDecisionFields([]);
 
-    expect(r.ecli.value).toBe("ECLI:A");
-    expect(r.pourvoiNumber.value).toBe("96-83.698");
-    expect(r.chamber.value).toBe("11e chambre");
+    expect(r.ecli.value).toBeNull();
+    expect(r.pourvoiNumber.value).toBeNull();
+    expect(r.chamber.value).toBeNull();
     expect(r.hasMultipleDecisions).toBe(false);
     expect(r.decisionCount).toBe(0);
   });
 
-  it("comble les vides depuis une décision unique", () => {
-    const r = resolveDecisionFields({ ecli: null, pourvoiNumber: null, chamber: null }, [
-      { ecli: "ECLI:D", pourvoiNumber: "97-81.102", chamber: "2e chambre" },
+  it("lit les trois champs depuis une décision unique", () => {
+    const r = resolveDecisionFields([
+      { ecli: "ECLI:D", pourvoiNumber: "97-81.102", chamber: "Chambre criminelle" },
     ]);
 
     expect(r.ecli).toEqual({ value: "ECLI:D", source: "decision" });
     expect(r.pourvoiNumber.value).toBe("97-81.102");
+    expect(r.chamber.value).toBe("Chambre criminelle");
     expect(r.decisionCount).toBe(1);
     expect(r.hasMultipleDecisions).toBe(false);
   });
 
   it("n'offre aucune valeur plate quand deux décisions sont liées", () => {
-    const r = resolveDecisionFields({}, [
+    const r = resolveDecisionFields([
       { pourvoiNumber: "11-11.111" },
       { pourvoiNumber: "22-22.222" },
     ]);
@@ -95,30 +89,28 @@ describe("resolveDecisionFields — vue complète (#536)", () => {
     expect(r.decisionCount).toBe(2);
   });
 
-  it("mélange les provenances champ par champ", () => {
-    const r = resolveDecisionFields({ ecli: "ECLI:AFFAIRE", chamber: null }, [
-      { ecli: "ECLI:DECISION", chamber: "3e chambre" },
-    ]);
+  it("champ par champ : un vide reste vide, un renseigné se lit", () => {
+    const r = resolveDecisionFields([{ ecli: null, chamber: "Chambre criminelle" }]);
 
-    expect(r.ecli.source).toBe("affair");
+    expect(r.ecli.source).toBe("absent");
     expect(r.chamber.source).toBe("decision");
   });
 
   it("ne couvre ni court ni verdictDate : ils restent éditoriaux", () => {
-    const resolved = resolveDecisionFields({}, [{}]);
+    const resolved = resolveDecisionFields([{}]);
 
     expect(resolved).not.toHaveProperty("court");
     expect(resolved).not.toHaveProperty("verdictDate");
   });
 
   it("reproduit le cas réel de la décision partagée", () => {
-    // Une décision, deux fiches. Chaque fiche porte déjà son pourvoi, donc chacune
-    // continue d'afficher exactement ce qu'elle affichait avant : le rattachement
-    // n'introduit aucune suggestion de doublon.
-    const shared = { pourvoiNumber: "96-83.698", ecli: null, chamber: null };
-    for (const affair of [{ pourvoiNumber: "96-83.698" }, { pourvoiNumber: "96-83.698" }]) {
-      const r = resolveDecisionFields(affair, [shared]);
-      expect(r.pourvoiNumber).toEqual({ value: "96-83.698", source: "affair" });
+    // Une décision, deux fiches. Chacune affiche la même référence, et le
+    // rattachement n'introduit aucune suggestion de doublon.
+    const shared = { pourvoiNumber: "96-83.698", ecli: null, chamber: "Chambre criminelle" };
+
+    for (let fiche = 0; fiche < 2; fiche++) {
+      const r = resolveDecisionFields([shared]);
+      expect(r.pourvoiNumber).toEqual({ value: "96-83.698", source: "decision" });
       expect(r.hasMultipleDecisions).toBe(false);
       expect(r.decisionCount).toBe(1);
     }

--- a/src/lib/affairs/decision-fields.ts
+++ b/src/lib/affairs/decision-fields.ts
@@ -1,9 +1,14 @@
 /**
- * Dual read of the identifiers that moved to `CourtDecision` (#536).
+ * Read of the identifiers that live on `CourtDecision` (#536, #545).
  *
- * During the transition an affair may carry a historical value, be linked to a
- * decision that carries it, or both. This module decides which one a flat field
- * shows, and refuses to invent one when the answer is genuinely plural.
+ * It used to be a dual read, preferring the affair's own historical value and falling
+ * back to the linked decision. #545 removed the affair side: nothing writes those
+ * columns any more, so keeping them as a preferred source would freeze whatever a
+ * backfill happened to leave there. The linked decisions are now the only source.
+ *
+ * Measured before the switch on the 340 published affairs: 3 carry a pourvoi number,
+ * and each is linked to exactly one decision carrying the same value, so no displayed
+ * value changes. What changes is provenance, from `affair` to `decision`.
  *
  * Two fields are deliberately absent: `court` and `verdictDate` stay editorial and
  * are always read from `Affair`. Measured on the base, 23.7 % of `Affair.court`
@@ -15,6 +20,10 @@
  */
 
 /** Where a displayed value came from, so a caller can label or debug it. */
+/**
+ * `affair` is no longer produced (#545): it survives in the type so a stored or
+ * logged value from before the switch still parses.
+ */
 export type DecisionFieldSource = "affair" | "decision" | "ambiguous" | "absent";
 
 export interface ResolvedDecisionField<T> {
@@ -32,25 +41,15 @@ export interface DecisionFieldCarrier {
 /**
  * Picks the value a flat field should show.
  *
- * Order, and the reasoning behind it:
- *
- * 1. **The affair's own value wins.** It was written or validated by moderation, so
- *    it is the editorial record and must not be overridden by a backfill.
- * 2. **One linked decision** and the affair says nothing: the decision's value fills
- *    the gap.
- * 3. **Several linked decisions**: no flat value at all. Choosing would mean picking
- *    one decision over another, and "the most recent" is the wrong default — on an
- *    affair covering first instance, appeal then cassation, the most recent is often
- *    a procedural rejection rather than the outcome a reader is looking for. The
- *    caller shows the list instead.
+ * **Several linked decisions mean no flat value at all.** Choosing would mean picking
+ * one decision over another, and "the most recent" is the wrong default — on an affair
+ * covering first instance, appeal then cassation, the most recent is often a
+ * procedural rejection rather than the outcome a reader is looking for. The caller
+ * shows the list instead.
  */
 export function resolveDecisionField<T>(
-  affairValue: T | null | undefined,
   decisionValues: Array<T | null | undefined>
 ): ResolvedDecisionField<T> {
-  if (affairValue !== null && affairValue !== undefined && affairValue !== "") {
-    return { value: affairValue, source: "affair" };
-  }
   // Ambiguity is about how many decisions are linked, not how many hold a value:
   // narrowing on the single non-null value would be exactly the implicit choice
   // this function exists to refuse.
@@ -80,22 +79,12 @@ export interface ResolvedDecisionFields {
  * `court` and `verdictDate` are not here on purpose: they remain read from `Affair`.
  */
 export function resolveDecisionFields(
-  affair: DecisionFieldCarrier,
   decisions: readonly DecisionFieldCarrier[]
 ): ResolvedDecisionFields {
   return {
-    ecli: resolveDecisionField(
-      affair.ecli,
-      decisions.map((d) => d.ecli)
-    ),
-    pourvoiNumber: resolveDecisionField(
-      affair.pourvoiNumber,
-      decisions.map((d) => d.pourvoiNumber)
-    ),
-    chamber: resolveDecisionField(
-      affair.chamber,
-      decisions.map((d) => d.chamber)
-    ),
+    ecli: resolveDecisionField(decisions.map((d) => d.ecli)),
+    pourvoiNumber: resolveDecisionField(decisions.map((d) => d.pourvoiNumber)),
+    chamber: resolveDecisionField(decisions.map((d) => d.chamber)),
     hasMultipleDecisions: decisions.length > 1,
     decisionCount: decisions.length,
   };

--- a/src/services/affairs/__tests__/merge-affairs.test.ts
+++ b/src/services/affairs/__tests__/merge-affairs.test.ts
@@ -62,11 +62,7 @@ function affair(overrides: Partial<Record<string, unknown>> = {}) {
     slug: "affaire-conservee",
     publicId: "AF-000001",
     oldSlugs: [],
-    ecli: null,
-    pourvoiNumber: null,
-    caseNumbers: [],
     court: null,
-    chamber: null,
     caseNumber: null,
     publicationStatus: "DRAFT",
     ...overrides,
@@ -200,26 +196,47 @@ describe("mergeAffairs — URLs survive the merge (issue #525)", () => {
 });
 
 describe("mergeAffairs — additive only (issue #525)", () => {
-  it("fills a judicial field the survivor is missing", async () => {
+  it("fills an editorial field the survivor is missing", async () => {
     stub(
-      affair({ id: "keep", court: null, chamber: null }),
-      affair({ id: "remove", slug: "absorbee", court: "Cour d'appel de Paris", chamber: "2e" })
+      affair({ id: "keep", court: null, caseNumber: null }),
+      affair({
+        id: "remove",
+        slug: "absorbee",
+        court: "Cour d'appel de Paris",
+        caseNumber: "2023/12345",
+      })
     );
 
     const result = await mergeAffairs("keep", "remove");
 
-    expect(updatePayload()).toMatchObject({ court: "Cour d'appel de Paris", chamber: "2e" });
-    expect(result.identifiersMerged).toEqual(expect.arrayContaining(["court", "chamber"]));
+    expect(updatePayload()).toMatchObject({
+      court: "Cour d'appel de Paris",
+      caseNumber: "2023/12345",
+    });
+    expect(result.identifiersMerged).toEqual(expect.arrayContaining(["court", "caseNumber"]));
+  });
+
+  it("ne remplit plus aucun identifiant de décision (#545)", async () => {
+    // Ils vivent sur CourtDecision, et les liaisons de l'absorbée sont transférées :
+    // le survivant continue de citer les mêmes décisions, sans copie de colonne.
+    stub(affair({ id: "keep" }), affair({ id: "remove", slug: "absorbee" }));
+
+    await mergeAffairs("keep", "remove");
+
+    const payload = updatePayload() ?? {};
+    for (const field of ["ecli", "pourvoiNumber", "chamber", "caseNumbers"]) {
+      expect(payload).not.toHaveProperty(field);
+    }
   });
 
   it("never overwrites a judicial field the survivor already states", async () => {
     stub(
-      affair({ id: "keep", court: "Tribunal de Paris", ecli: "ECLI:FR:CCASS:2024:C100001" }),
+      affair({ id: "keep", court: "Tribunal de Paris", caseNumber: "2023/111" }),
       affair({
         id: "remove",
         slug: "absorbee",
         court: "Cour d'appel de Lyon",
-        ecli: "ECLI:FR:CCASS:2024:C900009",
+        caseNumber: "2023/999",
       })
     );
 
@@ -229,17 +246,6 @@ describe("mergeAffairs — additive only (issue #525)", () => {
     expect(payload).not.toHaveProperty("court");
     expect(payload).not.toHaveProperty("ecli");
     expect(result.identifiersMerged).toEqual([]);
-  });
-
-  it("unions caseNumbers instead of replacing them", async () => {
-    stub(
-      affair({ id: "keep", caseNumbers: ["A1"] }),
-      affair({ id: "remove", slug: "absorbee", caseNumbers: ["A1", "B2"] })
-    );
-
-    await mergeAffairs("keep", "remove");
-
-    expect(updatePayload()?.caseNumbers).toEqual(["A1", "B2"]);
   });
 
   it("leaves editorial fields alone", async () => {

--- a/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
+++ b/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
@@ -33,19 +33,24 @@ const WRITE_SURFACES = [
   "src/services/affairs/create-draft.ts",
   "src/app/api/admin/affaires/route.ts",
   "src/app/api/admin/affaires/[id]/route.ts",
+  // Ajouté en #545 PR 2 : la fusion remplissait additivement ces champs sur le
+  // survivant, et la première version de ce garde ne regardait pas ce fichier.
+  "src/services/affairs/reconciliation.ts",
 ];
 
 /**
  * An assignment, not a read.
  *
- * `ecli: true` is a Prisma `select`, and `ecli: { not: null }` is a `where`: both
- * read the column. Only a value that is neither a boolean nor an object writes it.
+ * `ecli: true` is a Prisma `select`, `ecli: { not: null }` is a `where`, and
+ * `ecli: string | null` is a type annotation: none of them writes the column. Only a
+ * value that is none of those three shapes does.
  *
  * The whitespace sits *inside* the lookahead on purpose. With `:\s*(?!…)` in front,
  * `\s*` can backtrack to zero characters and the lookahead then passes on the space,
  * so `ecli: { not: null }` would read as a write.
  */
-const ASSIGNMENT_SOURCE = (field: string) => String.raw`\b${field}\s*:(?!\s*(?:true\b|false\b|\{))`;
+const ASSIGNMENT_SOURCE = (field: string) =>
+  String.raw`\b${field}\s*:(?!\s*(?:true\b|false\b|\{|string\b|number\b|boolean\b|Date\b))`;
 
 function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -7,7 +7,8 @@
  */
 
 import { db } from "@/lib/db";
-import type { AffairCategory } from "@/generated/prisma";
+import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
+import type { AffairCategory, Prisma } from "@/generated/prisma";
 
 export type MatchConfidence = "CERTAIN" | "HIGH" | "POSSIBLE";
 
@@ -309,9 +310,15 @@ export function pickConfidentMatch(matches: MatchResult[]): ConfidentMatch {
 export interface MatchCandidate {
   politicianId: string;
   title: string;
-  ecli?: string | null;
-  pourvoiNumber?: string | null;
-  caseNumbers?: string[];
+  /**
+   * References of the decisions the candidate is linked to (#545).
+   *
+   * A list, because an affair can cite several decisions, and because these no
+   * longer come from columns on the affair: `Affair.ecli` and
+   * `Affair.pourvoiNumber` stopped being written, so reading them would only ever
+   * return what a past backfill left behind.
+   */
+  decisionRefs?: Array<{ ecli?: string | null; pourvoiNumber?: string | null }>;
   category?: AffairCategory;
   verdictDate?: Date | null;
   /**
@@ -357,73 +364,67 @@ function normalizeAffairTitle(title: string, politicianName?: string): string {
 }
 
 /**
+ * Affairs linked to a decision matching `where`, optionally scoped to one politician.
+ *
+ * Reads through `AffairCourtDecision` rather than through columns on `Affair`: the
+ * identifiers live on the decision now (#545), and the same decision legitimately
+ * reaches several affairs.
+ */
+async function findAffairsLinkedToDecision(
+  where: Prisma.CourtDecisionWhereInput,
+  politicianId?: string
+): Promise<string[]> {
+  const links = await db.affairCourtDecision.findMany({
+    where: {
+      courtDecision: where,
+      ...(politicianId ? { affair: { politicianId } } : {}),
+    },
+    select: { affairId: true },
+  });
+  return [...new Set(links.map((l) => l.affairId))];
+}
+
+/**
  * Find existing affairs that match a candidate affair.
  * Returns matches ordered by confidence score (highest first).
  */
 export async function findMatchingAffairs(candidate: MatchCandidate): Promise<MatchResult[]> {
   const matches: MatchResult[] = [];
 
-  // Priority 1: ECLI (unique European identifier) — CERTAIN match
-  if (candidate.ecli) {
-    const ecliMatch = await db.affair.findUnique({
-      where: { ecli: candidate.ecli },
-      select: { id: true },
-    });
-    // A self-match proves nothing and must not short-circuit: ecli is unique, so
-    // when the candidate is an existing row this lookup finds that row itself.
-    if (ecliMatch && ecliMatch.id !== candidate.excludeAffairId) {
-      matches.push({
-        affairId: ecliMatch.id,
-        confidence: "CERTAIN",
-        score: 1.0,
-        matchedBy: "ecli",
-      });
-      return matches; // ECLI is definitive, no need to check further
+  const refs = candidate.decisionRefs ?? [];
+  const ecliRefs = refs.map((r) => r.ecli).filter((v): v is string => Boolean(v));
+  const pourvoiRefs = refs.map((r) => r.pourvoiNumber).filter((v): v is string => Boolean(v));
+
+  // Priority 1: shared ECLI, read through the linked decisions.
+  //
+  // It no longer short-circuits. An ECLI identifies a decision, and one decision can
+  // carry several counts, so it is a reason to read the pair rather than the end of
+  // the enquiry — the other signals may say something the reviewer needs (#557).
+  if (ecliRefs.length > 0) {
+    const ecliMatches = await findAffairsLinkedToDecision({ ecli: { in: ecliRefs } });
+    for (const affairId of ecliMatches) {
+      if (affairId === candidate.excludeAffairId) continue;
+      matches.push({ affairId, confidence: "CERTAIN", score: 1.0, matchedBy: "ecli" });
     }
   }
 
-  // Priority 2: Pourvoi number + same politician — HIGH confidence
-  if (candidate.pourvoiNumber) {
-    const pourvoiMatches = await db.affair.findMany({
-      where: {
-        pourvoiNumber: candidate.pourvoiNumber,
-        politicianId: candidate.politicianId,
-      },
-      select: { id: true },
-    });
-    for (const match of pourvoiMatches) {
-      if (match.id === candidate.excludeAffairId) continue;
-      matches.push({
-        affairId: match.id,
-        confidence: "HIGH",
-        score: 0.95,
-        matchedBy: "pourvoiNumber",
-      });
+  // Priority 2: shared pourvoi number, read through the linked decisions, on the
+  // same politician. A pourvoi is not unique, so this is a lead, never an identity.
+  if (pourvoiRefs.length > 0) {
+    const pourvoiMatches = await findAffairsLinkedToDecision(
+      { pourvoiNumberNormalized: { in: pourvoiRefs.map(foldJudicialReference) } },
+      candidate.politicianId
+    );
+    for (const affairId of pourvoiMatches) {
+      if (affairId === candidate.excludeAffairId) continue;
+      if (matches.some((m) => m.affairId === affairId)) continue;
+      matches.push({ affairId, confidence: "HIGH", score: 0.95, matchedBy: "pourvoiNumber" });
     }
   }
 
-  // Priority 3: Case numbers intersection + same politician — HIGH confidence
-  if (candidate.caseNumbers && candidate.caseNumbers.length > 0) {
-    const caseNumberMatches = await db.affair.findMany({
-      where: {
-        politicianId: candidate.politicianId,
-        caseNumbers: { hasSome: candidate.caseNumbers },
-      },
-      select: { id: true },
-    });
-    for (const match of caseNumberMatches) {
-      if (match.id === candidate.excludeAffairId) continue;
-      // Avoid duplicating matches already found by pourvoi
-      if (!matches.some((m) => m.affairId === match.id)) {
-        matches.push({
-          affairId: match.id,
-          confidence: "HIGH",
-          score: 0.8,
-          matchedBy: "caseNumbers",
-        });
-      }
-    }
-  }
+  // No case-number priority any more (#545). It matched on `Affair.caseNumbers`,
+  // which was empty on all 463 affairs and has no equivalent on `CourtDecision`:
+  // matching on a field that exists nowhere is not a capability worth keeping.
 
   // Priority 4: Normalized title matching — bidirectional
   // Strips "[À VÉRIFIER]" prefix, politician name, and common decorators,

--- a/src/services/affairs/reconciliation.test.ts
+++ b/src/services/affairs/reconciliation.test.ts
@@ -37,14 +37,16 @@ function makeDraft(
     involvement: string;
     factsDate: Date | null;
     verdictDate: Date | null;
+    courtDecisions: Array<{
+      courtDecision: { ecli: string | null; pourvoiNumber: string | null };
+    }>;
   }> = {}
 ) {
   return {
     id,
     title: overrides.title ?? `Affaire ${id}`,
-    ecli: null,
-    pourvoiNumber: null,
-    caseNumbers: [],
+    // Références portées par les décisions rattachées (#545), plus par l'affaire.
+    courtDecisions: overrides.courtDecisions ?? [],
     category: overrides.category ?? "AUTRE",
     involvement: overrides.involvement ?? "DIRECT",
     factsDate: overrides.factsDate ?? null,

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -90,9 +90,10 @@ const DETECTED_PUBLICATION_STATUSES = ["DRAFT", "PUBLISHED"] as const;
 type DetectedAffair = {
   id: string;
   title: string;
-  ecli: string | null;
-  pourvoiNumber: string | null;
-  caseNumbers: string[];
+  /** Références des décisions rattachées (#545), et non des colonnes de l'affaire. */
+  courtDecisions: Array<{
+    courtDecision: { ecli: string | null; pourvoiNumber: string | null };
+  }>;
   category: string;
   involvement: string;
   factsDate: Date | null;
@@ -105,14 +106,36 @@ type DetectedAffair = {
   sources: { sourceType: SourceType }[];
 };
 
-/** Judicial values that rule out the two rows being one decision. */
+/** Le jeu de références portées par les décisions rattachées à une affaire. */
+function decisionRefs(affair: DetectedAffair, field: "ecli" | "pourvoiNumber"): Set<string> {
+  const refs = new Set<string>();
+  for (const link of affair.courtDecisions) {
+    const value = link.courtDecision[field];
+    if (value) refs.add(value);
+  }
+  return refs;
+}
+
+/**
+ * Judicial values that rule out the two rows being one decision.
+ *
+ * Lues depuis les décisions rattachées (#545). La contradiction porte sur des
+ * ensembles disjoints : deux fiches citant chacune une décision, et **aucune en
+ * commun**, ne décrivent pas la même décision. Partager une référence n'est en
+ * revanche pas une preuve de doublon, c'est ce que #557 verrouille.
+ */
 function findContradictions(a: DetectedAffair, b: DetectedAffair): string[] {
   const contradictions: string[] = [];
   if (verdictDatesConflict(a.verdictDate, b.verdictDate)) contradictions.push("verdictDate");
-  if (a.ecli && b.ecli && a.ecli !== b.ecli) contradictions.push("ecli");
-  if (a.pourvoiNumber && b.pourvoiNumber && a.pourvoiNumber !== b.pourvoiNumber) {
-    contradictions.push("pourvoiNumber");
+
+  for (const field of ["ecli", "pourvoiNumber"] as const) {
+    const refsA = decisionRefs(a, field);
+    const refsB = decisionRefs(b, field);
+    if (refsA.size === 0 || refsB.size === 0) continue;
+    const shared = [...refsA].some((ref) => refsB.has(ref));
+    if (!shared) contradictions.push(field);
   }
+
   return contradictions;
 }
 
@@ -165,9 +188,11 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
     select: {
       id: true,
       title: true,
-      ecli: true,
-      pourvoiNumber: true,
-      caseNumbers: true,
+      // Les références viennent des décisions rattachées, plus des colonnes de
+      // l'affaire, qui ne sont plus alimentées (#545).
+      courtDecisions: {
+        select: { courtDecision: { select: { ecli: true, pourvoiNumber: true } } },
+      },
       category: true,
       involvement: true,
       factsDate: true,
@@ -234,13 +259,10 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
       const matches = await findMatchingAffairs({
         politicianId: affair.politicianId,
         title: affair.title,
-        ecli: affair.ecli,
-        pourvoiNumber: affair.pourvoiNumber,
-        caseNumbers: affair.caseNumbers,
+        decisionRefs: affair.courtDecisions.map((l) => l.courtDecision),
         category: affair.category as AffairCategory,
         verdictDate: affair.verdictDate,
-        // Without this the affair matches itself, and the ECLI branch would
-        // return that self-match alone and hide every other signal.
+        // Without this the affair matches itself on every identifier branch.
         excludeAffairId: affair.id,
       });
 
@@ -315,25 +337,27 @@ export async function findPotentialDuplicates(): Promise<PotentialDuplicate[]> {
  * Fields filled on the survivor only when it does not already carry a value.
  * Purely additive: a merge must never overwrite what the survivor states, but
  * losing what the absorbed affair stated is data loss, since its row is deleted.
+ *
+ * `ecli`, `pourvoiNumber` and `chamber` left this list in #545: they identify a
+ * decision, not an affair, and nothing writes them on `Affair` any more. What the
+ * absorbed row cited is not lost — its decision links are transferred by the merge,
+ * so the survivor keeps citing the same decisions.
  */
-const ADDITIVE_MERGE_FIELDS = ["ecli", "pourvoiNumber", "court", "chamber", "caseNumber"] as const;
+const ADDITIVE_MERGE_FIELDS = ["court", "caseNumber"] as const;
 
 export type AdditiveMergeField = (typeof ADDITIVE_MERGE_FIELDS)[number];
 
 /**
- * What an automatic absorption into a published affair may fill: court-assigned
- * identifiers only.
+ * What an absorption into a published affair may fill.
  *
- * `court` and `chamber` are left out although they would only fill a gap, because
- * they describe the jurisdiction rather than identify the decision. Both are in
- * the proposal whitelist, so the draft's value reaches the published fiche
- * through review instead of a cron write (issue #525, §4).
+ * Only `caseNumber` remains: it is an editorial reference displayed as text, and
+ * filling a gap on it states nothing new about the person. `court` stays out although
+ * it would only fill a gap, because it describes the jurisdiction; it is in the
+ * proposal whitelist, so the draft's value reaches the published fiche through review
+ * rather than a write (issue #525, §4). The decision identifiers left the list
+ * entirely in #545 — they are carried by the transferred decision links.
  */
-export const ABSORPTION_ADDITIVE_FIELDS: readonly AdditiveMergeField[] = [
-  "ecli",
-  "pourvoiNumber",
-  "caseNumber",
-];
+export const ABSORPTION_ADDITIVE_FIELDS: readonly AdditiveMergeField[] = ["caseNumber"];
 
 export interface MergeAffairsOptions {
   /** Request context, when the merge is human-initiated from the admin. */
@@ -484,11 +508,7 @@ export async function mergeAffairsInTransaction(
       oldSlugs: true,
       politicianId: true,
       publicationStatus: true,
-      ecli: true,
-      pourvoiNumber: true,
-      caseNumbers: true,
       court: true,
-      chamber: true,
       caseNumber: true,
     } as const;
 
@@ -672,13 +692,6 @@ export async function mergeAffairsInTransaction(
       if (!keep[field] && remove[field]) {
         updates[field] = remove[field];
         identifiersMerged.push(field);
-      }
-    }
-    if (remove.caseNumbers.length > 0) {
-      const merged = [...new Set([...keep.caseNumbers, ...remove.caseNumbers])];
-      if (merged.length !== keep.caseNumbers.length) {
-        updates.caseNumbers = merged;
-        identifiersMerged.push("caseNumbers");
       }
     }
 


### PR DESCRIPTION
Part of #545. Deuxième des trois PR. Suite de #559.

## Portée

Les lectures et le matching passent de `Affair` à `CourtDecision`. Aucune colonne n'est retirée : c'est l'objet de la PR 3.

## Diff public nul, mesuré

Les 340 affaires publiées, avant et après, en comparant les **valeurs** :

```text
DIFF NUL sur 340 affaires publiées
```

Le seul écart est la provenance, sur exactement les 3 affaires concernées :

```diff
- AF-000034 | pourvoi=96-83.698/affair   | chambre=Chambre criminelle/decision
+ AF-000034 | pourvoi=96-83.698/decision | chambre=Chambre criminelle/decision
```

C'était prévisible et je l'ai vérifié plutôt que supposé : chacune des 3 affaires est liée à exactement une décision portant **la même** valeur, donc la valeur affichée ne peut pas changer. `chambre` se lisait déjà depuis la décision, l'affaire ne la portant jamais.

## Fin de la double lecture

`resolveDecisionField` ne prend plus la valeur de l'affaire. La conserver comme source préférée aurait figé ce qu'un backfill avait laissé dans une colonne que plus rien n'alimente.

La règle d'ambiguïté est intacte : **plusieurs décisions rattachées donnent zéro valeur plate**. Choisir reviendrait à préférer une décision à une autre, et « la plus récente » est le mauvais défaut, souvent un rejet de forme plutôt que le résultat cherché.

`"affair"` reste dans le type `DecisionFieldSource` pour qu'une valeur journalisée avant cette PR se relise, avec un test qui vérifie qu'aucun chemin ne la produit plus.

## Matching

Les priorités par identifiant lisent à travers `AffairCourtDecision` :

```ts
findAffairsLinkedToDecision({ ecli: { in: ecliRefs } })
findAffairsLinkedToDecision({ pourvoiNumberNormalized: { in: … } }, politicianId)
```

**L'ECLI ne court-circuite plus.** Il terminait l'enquête, ce qui masquait tous les autres signaux. Un ECLI identifie une décision, et une décision porte plusieurs chefs : c'est une raison de lire la paire, pas la fin de l'analyse (#557).

**La priorité par `caseNumbers` disparaît.** Elle lisait un champ vide sur les 463 affaires, sans équivalent sur `CourtDecision` : matcher sur un champ qui n'existe nulle part n'est pas une capacité à préserver.

La détection de contradiction porte maintenant sur des **ensembles disjoints** : deux fiches citant chacune une décision, sans aucune en commun, ne décrivent pas la même décision. Partager une référence n'est en revanche pas une preuve de doublon, ce que #557 verrouille.

## Un manque de la PR 1, corrigé ici

La fusion remplissait additivement `ecli`, `pourvoiNumber`, `chamber` et `caseNumbers` sur le survivant. **Le garde de la PR 1 ne regardait pas `reconciliation.ts`**, donc il ne l'avait pas vu.

`ADDITIVE_MERGE_FIELDS` ne garde que `court` et `caseNumber`, et `ABSORPTION_ADDITIVE_FIELDS` que `caseNumber`. Rien n'est perdu : la fusion transfère les liaisons de l'absorbée, donc le survivant continue de citer les mêmes décisions, sans copie de colonne.

Le garde couvre désormais `reconciliation.ts`, et sa règle a été affinée deux fois. Elle exclut maintenant les annotations de type en plus des `select` et des `where` :

```ts
\becli\s*:(?!\s*(?:true\b|false\b|\{|string\b|number\b|boolean\b|Date\b))
```

Vérifié qu'elle attrape toujours `ecli: data.ecli || null` et `ecli: remove.ecli`, et qu'elle ignore `ecli: true`, `ecli: { not: null }` et `ecli: string | null`.

## Le détecteur admin affirmait ce que #557 a infirmé

`/api/admin/politiques/[id]/detect-duplicates` rendait « ECLI identique » avec un score de **100**, commenté « definite match ». C'est exactement le raisonnement que le cas Carignon a démenti.

Vérifié d'abord que ce score ne déclenche aucune action : il filtre au-dessus de 40 et il trie, un humain tranche. Le rang reste donc élevé, l'affirmation ne l'est plus :

> Décision commune (96-83.698) : à départager, chefs distincts possibles

## File de doublons inchangée

```text
avant  1 paire | title-partial | POSSIBLE | 0.3 | REVIEW_REQUIRED | 0 auto-fusionnable
après  1 paire | title-partial | POSSIBLE | 0.3 | REVIEW_REQUIRED | 0 auto-fusionnable
```

La paire trouvée par pourvoi n'apparaît pas, et j'ai vérifié pourquoi plutôt que de le supposer : `AF-000034 × AF-000035` a été jugée `LINKED` avec `matchedBy=pourvoiNumber` lors du tri de #525, donc elle est filtrée de la file. `AF-000036` a un autre politique et un autre pourvoi.

Aucune donnée modifiée : 463 affaires, 2 décisions, 3 liaisons, 8 jugements, 0 proposition.

## Autres lectures basculées

Export CSV, page publique d'affaire, fiche admin d'affaire, filtre admin « sans ECLI » (qui interroge désormais les décisions rattachées, la question qu'un modérateur se pose réellement), et le rendu du détecteur de doublons, qui liste les références des décisions au lieu de colonnes.

## Vérifications

**2582 tests**, 0 échec. `tsc`, `eslint` et `npm run build` propres.

Aucune migration : `prisma migrate diff` reste vide.
