### PR TITLE
Corriger le SQL brut du tableau de bord admin

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -49,7 +49,12 @@ async function getDashboardData() {
       COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED' AND "biography" IS NULL)  AS without_bio,
       (SELECT COUNT(*) FROM "Affair")                                                    AS total_affairs,
       (SELECT COUNT(*) FROM "Affair" WHERE "publicationStatus" = 'DRAFT')                AS draft_affairs,
-      (SELECT COUNT(*) FROM "Affair" WHERE "publicationStatus" = 'PUBLISHED' AND "ecli" IS NULL) AS without_ecli
+      -- « Sans référence judiciaire » se mesure sur les décisions rattachées : la
+      -- colonne ecli a été retirée d'Affair (#545).
+      (SELECT COUNT(*) FROM "Affair" a
+        WHERE a."publicationStatus" = 'PUBLISHED'
+          AND NOT EXISTS (SELECT 1 FROM "AffairCourtDecision" acd WHERE acd."affairId" = a.id)
+      ) AS without_ecli
     FROM "Politician"
   `;
 

--- a/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
+++ b/src/services/affairs/__tests__/no-decision-identifier-writes.test.ts
@@ -149,6 +149,30 @@ describe("garde : aucune écriture d'identifiant de décision sur Affair (#545)"
     expect(offenders).toEqual([]);
   });
 
+  it("aucun SQL brut ne référence une colonne retirée", () => {
+    // Le trou que ce garde n'avait pas vu : un `$queryRaw` cite les colonnes en
+    // chaîne SQL, pas en syntaxe objet Prisma, donc le motif d'assignation passe à
+    // côté. Un `COUNT(*) … WHERE "ecli" IS NULL` sur Affair a cassé le build.
+    // `chamber` est exclu : le nom est partagé avec Scrutin, Amendment et Vote, où
+    // il désigne une chambre parlementaire. Le client Prisma généré aussi.
+    const unambiguous = DECISION_IDENTIFIERS.filter((f) => f !== "chamber");
+    const offenders: string[] = [];
+    const files = [...collect("src"), ...collect("scripts")].filter(
+      (f) => !f.includes("/generated/")
+    );
+
+    for (const file of files) {
+      const source = stripComments(readFileSync(file, "utf8"));
+      if (!/\$(?:query|execute)Raw/.test(source)) continue;
+      for (const field of unambiguous) {
+        // La colonne citée entre guillemets doubles, comme Postgres l'exige.
+        if (new RegExp(`"${field}"`).test(source)) offenders.push(`${relative(file)} → "${field}"`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it("ne prétend pas couvrir les champs éditoriaux", () => {
     // Rend explicite ce que ce garde ne dit pas, pour qu'on ne le lise pas comme
     // une interdiction d'écrire court ou verdictDate.


### PR DESCRIPTION
Part of #545. Correctif de build après #561.

## Ce qui cassait

Le build échouait au prérendu de `/admin` :

```
Raw query failed. Code: 42703. Message: column "ecli" does not exist
Export encountered an error on /admin/page: /admin, exiting the build.
```

`src/app/admin/page.tsx` comptait les affaires publiées sans ECLI en **SQL brut** :

```sql
(SELECT COUNT(*) FROM "Affair" WHERE "publicationStatus" = 'PUBLISHED' AND "ecli" IS NULL)
```

La colonne a été retirée en #561. Le compteur mesure désormais l'absence de **décision rattachée**, ce qui est la question qu'un modérateur se pose réellement.

## Pourquoi mon garde ne l'a pas vu

Il cherchait une assignation en syntaxe objet Prisma (`ecli: …`). Une chaîne SQL cite la colonne entre guillemets doubles, donc le motif passait à côté.

Un test est ajouté : aucun fichier contenant `$queryRaw` ou `$executeRaw` ne peut citer `"ecli"`, `"pourvoiNumber"` ou `"caseNumbers"`. Vérifié qu'il attrape bien la régression exacte qui a cassé le build.

`chamber` est exclu de ce balayage, son nom étant partagé avec `Scrutin`, `Amendment` et `Vote` où il désigne une chambre parlementaire ; il reste vérifié nommément sur les surfaces d'écriture d'affaire. Le client Prisma généré est exclu aussi.

## Pourquoi ma vérification locale avait « réussi »

Mon `npm run build` filtrait la sortie sur `Compiled successfully`, une ligne qui apparaît **avant** la collecte des pages, là où l'erreur survient. Le build est désormais vérifié sur son code de sortie : **0**, et 780/780 pages générées.

## Vérifications

**2583 tests**, 0 échec. `tsc` propre. Build complet vert.