### PR TITLE
Dire que le garde de badge d'AffairCard est inatteignable

### DIFF
--- a/src/components/politicians/AffairCard.tsx
+++ b/src/components/politicians/AffairCard.tsx
@@ -64,9 +64,14 @@ export function AffairCard({ affair, variant }: AffairCardProps) {
             </div>
           </div>
           <div className="flex items-center gap-2 self-start">
-            {/* Same rule as the affair detail page (#383) : quand la personne n'est
-                pas mise en cause, le rôle mène et le statut passe en couleur neutre,
-                pour que l'affaire ne se lise pas comme sa condamnation (#511). */}
+            {/* Same rule as the affair detail page (#383): when the politician is not
+                the one prosecuted, the role leads and the status turns neutral, so the
+                affair does not read as their own conviction.
+                Currently unreachable in practice: `AffairsSection` routes
+                MENTIONED_ONLY, VICTIM and PLAINTIFF affairs to their own blocks, which
+                already do this. Kept because `affair` is typed `any` here, so nothing
+                stops a future call site from passing one — but the fiche is protected
+                by that routing, not by this branch (#511). */}
             {!accused && (
               <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
                 {INVOLVEMENT_LABELS[affair.involvement as Involvement]}


### PR DESCRIPTION
Vérification en production après le déploiement de #565.

Le garde de peine fonctionne : sur `/affaires/emmanuel-macron-benalla`, le bloc « Peine prononcée » a disparu, l'encart « Résultat judiciaire d'un tiers » s'affiche, et le badge de statut est en `bg-muted`.

Mais la fiche politique révèle que j'avais modifié le mauvais endroit. `AffairsSection` répartit les affaires en trois groupes et ne passe à `AffairCard` que les `DIRECT`/`INDIRECT` ; les mentions et les victimes ont leur propre rendu, déjà correct depuis #383 (badge de rôle en tête, statut neutre, aucune peine).

La branche ajoutée dans `AffairCard` est donc inatteignable. Elle est conservée, `affair` y étant typé `any`, mais le commentaire dit maintenant que la protection vient de la répartition et non d'elle. Un garde inatteignable qui se lit comme le mécanisme de protection est pire qu'aucun garde.