### PR TITLE
Reconnaître « la condamnation est définitive » comme recours épuisé

### DIFF
--- a/scripts/audit-convictions.ts
+++ b/scripts/audit-convictions.ts
@@ -71,9 +71,16 @@ const PENDING_RECOURSE = [
   /n['’]est pas d[ée]finitive/i,
 ];
 
-/** Recours épuisés, énoncé explicitement. Annule le signal de pendance. */
+/**
+ * Recours épuisés, énoncé explicitement. Annule le signal de pendance.
+ *
+ * La forme simple « la condamnation est définitive » a été ajoutée après un faux
+ * signalement : le motif ne reconnaissait que l'adverbe « définitivement » et
+ * « caractère définitif ». La négation « n'est pas définitive » ne peut pas matcher,
+ * le « n'est pas » s'intercalant entre les deux mots recherchés.
+ */
 const RECOURSE_EXHAUSTED =
-  /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis/i;
+  /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis|condamnation est (aujourd'hui )?d[ée]finitive|devenue d[ée]finitive|rendant la condamnation d[ée]finitive/i;
 
 function describesPendingRecourse(description: string): boolean {
   if (RECOURSE_EXHAUSTED.test(description)) return false;


### PR DESCRIPTION
Suite du lot 1 de #566.

Le détecteur de contradiction de `scripts/audit-convictions.ts` reconnaissait « définitivement » et « caractère définitif » comme marques de recours épuisés, mais pas la forme simple « la condamnation est définitive ». Il signalait donc la fiche Fanget alors que sa description venait d'être corrigée pour dire exactement cela.

Corriger la prose pour satisfaire la regex aurait été prendre le problème à l'envers.

La négation ne peut pas produire de faux négatif : « n'est pas définitive » n'apparie pas « condamnation est définitive », le « n'est pas » s'intercalant entre les deux mots recherchés. Ce motif reste par ailleurs dans la liste des signaux de pendance.

**Effet mesuré :** Fanget sort de la revue urgente, et une vraie contradiction jusque-là invisible apparaît. La fiche Marcangeli porte `CONDAMNATION_PREMIERE_INSTANCE` alors que sa description écrit « Cette condamnation est devenue définitive, sans recours possible ». Elle passe de B à D et prend la tête de la file du lot 2.