### PR TITLE
Distinguer preuve officielle et ligne Source officielle

### DIFF
--- a/scripts/audit-convictions.ts
+++ b/scripts/audit-convictions.ts
@@ -16,7 +16,15 @@ import "dotenv/config";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { db } from "../src/lib/db.js";
-import type { AffairStatus, Involvement } from "../src/generated/prisma";
+import type { AffairStatus } from "../src/generated/prisma";
+import {
+  ADVERSE_INVOLVEMENTS,
+  assess,
+  hasPreciseSentence,
+  parseLedger,
+  type EvidenceLevel,
+  type Ledger,
+} from "../src/lib/affairs/audit-evidence.js";
 
 const LEDGER = path.join(process.cwd(), "data", "audit-convictions.json");
 const DEFAULT_BATCH_SIZE = 20;
@@ -32,75 +40,10 @@ const CONVICTION_STATUSES: AffairStatus[] = [
   "CONDAMNATION_DEFINITIVE",
 ];
 
-/** Rôles pour lesquels le résultat judiciaire de l'affaire est celui de la personne. */
-const ADVERSE_INVOLVEMENTS: Involvement[] = ["DIRECT", "INDIRECT"];
-
-/** Hôtes de juridictions et d'institutions compétentes. Niveau B. */
-const OFFICIAL_HOSTS = [
-  "courdecassation.fr",
-  "cours-appel.justice.fr",
-  "justice.fr",
-  "conseil-etat.fr",
-  "ccomptes.fr",
-  "legifrance.gouv.fr",
-  "conseil-constitutionnel.fr",
-  "juricaf.org",
-];
-
-/** Éditeurs correspondant à une juridiction ou institution compétente. Niveau B. */
-const OFFICIAL_PUBLISHER =
-  /cour d.appel|cour de cassation|conseil d.[ée]tat|cour des comptes|tribunal|parquet|minist[èe]re de la justice|conseil constitutionnel|ordre des/i;
-
-/** Types de source qui ne comptent jamais comme secondaire indépendante.
- *  Wikipedia est exclu délibérément : c'est la source qui a induit en erreur sur
- *  l'arrêt du 7 juillet 2026, et une encyclopédie n'atteste pas un dispositif. */
-const NOT_INDEPENDENT_TYPES = new Set(["WIKIPEDIA", "WIKIDATA"]);
-
-/**
- * Recours encore ouvert, énoncé explicitement.
- *
- * La première version cherchait « pourvoi », « en appel » ou « non définitive »
- * n'importe où, et flaguait 15 affaires à tort : une condamnation définitive raconte
- * normalement son historique (« condamné en appel », « rejet du pourvoi, donnant un
- * caractère définitif »). Mentionner un recours passé n'est pas une contradiction.
- */
-const PENDING_RECOURSE = [
-  /pourvoi[^.]{0,60}?(reste possible|est possible|en cours|pendant|a [ée]t[ée] form[ée])/i,
-  /(se sont pourvus|s'est pourvu|se pourvoit)[^.]{0,40}cassation/i,
-  /appel en cours/i,
-  /n['’]est pas d[ée]finitive/i,
-];
-
-/**
- * Recours épuisés, énoncé explicitement. Annule le signal de pendance.
- *
- * La forme simple « la condamnation est définitive » a été ajoutée après un faux
- * signalement : le motif ne reconnaissait que l'adverbe « définitivement » et
- * « caractère définitif ». La négation « n'est pas définitive » ne peut pas matcher,
- * le « n'est pas » s'intercalant entre les deux mots recherchés.
- */
-const RECOURSE_EXHAUSTED =
-  /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis|condamnation est (aujourd'hui )?d[ée]finitive|devenue d[ée]finitive|rendant la condamnation d[ée]finitive/i;
-
-function describesPendingRecourse(description: string): boolean {
-  if (RECOURSE_EXHAUSTED.test(description)) return false;
-  return PENDING_RECOURSE.some((re) => re.test(description));
-}
-
-type EvidenceLevel = "A" | "B" | "C" | "D";
-
-interface Ledger {
-  /** Identifiants d'affaires déjà examinées, dans l'ordre de traitement. */
-  done: string[];
-  /** Répartition A/B/C/D au premier passage, point de comparaison figé. */
-  baseline?: Record<EvidenceLevel, number> & { withoutOfficialSource: number; capturedAt: string };
-}
-
 function readLedger(): Ledger {
   if (!fs.existsSync(LEDGER)) return { done: [] };
   try {
-    const parsed = JSON.parse(fs.readFileSync(LEDGER, "utf8")) as Ledger;
-    return { done: parsed.done ?? [], baseline: parsed.baseline };
+    return parseLedger(JSON.parse(fs.readFileSync(LEDGER, "utf8")));
   } catch {
     console.error(`Registre illisible (${LEDGER}), il faut le corriger à la main.`);
     process.exit(1);
@@ -110,134 +53,6 @@ function readLedger(): Ledger {
 function writeLedger(ledger: Ledger): void {
   fs.mkdirSync(path.dirname(LEDGER), { recursive: true });
   fs.writeFileSync(LEDGER, JSON.stringify(ledger, null, 2) + "\n");
-}
-
-function hostOf(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "").toLowerCase();
-  } catch {
-    return "";
-  }
-}
-
-/** Titre réduit à sa substance, pour repérer une même dépêche reprise ailleurs. */
-function normaliseTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/\p{Mn}/gu, "")
-    .replace(/[^a-z0-9 ]/g, " ")
-    .split(/\s+/)
-    .filter((w) => w.length > 3)
-    .sort()
-    .join(" ");
-}
-
-interface SourceRow {
-  url: string;
-  title: string;
-  publisher: string;
-  publishedAt: Date;
-  sourceType: string;
-}
-
-interface Assessment {
-  level: EvidenceLevel;
-  hasOfficialSource: boolean;
-  independentCount: number;
-  /** Sources écartées du compte parce qu'elles reprennent le même titre. */
-  duplicateReprints: number;
-  contradictions: string[];
-}
-
-function assess(affair: {
-  status: AffairStatus;
-  involvement: Involvement;
-  verdictDate: Date | null;
-  description: string | null;
-  prisonMonths: number | null;
-  fineAmount: unknown;
-  ineligibilityMonths: number | null;
-  sources: SourceRow[];
-  decisionCount: number;
-}): Assessment {
-  const hasOfficialSource = affair.sources.some(
-    (s) =>
-      s.sourceType === "JUDILIBRE" ||
-      s.sourceType === "LEGIFRANCE" ||
-      OFFICIAL_PUBLISHER.test(s.publisher) ||
-      OFFICIAL_HOSTS.some((h) => hostOf(s.url) === h || hostOf(s.url).endsWith("." + h))
-  );
-
-  // Indépendance : éditeurs distincts, hors encyclopédies, et une seule fois par
-  // titre normalisé (une dépêche reprise ne vaut pas deux attestations).
-  const seenPublishers = new Set<string>();
-  const seenTitles = new Set<string>();
-  let independentCount = 0;
-  let duplicateReprints = 0;
-  for (const s of affair.sources) {
-    if (NOT_INDEPENDENT_TYPES.has(s.sourceType)) continue;
-    const publisher = s.publisher.trim().toLowerCase();
-    const title = normaliseTitle(s.title);
-    if (seenPublishers.has(publisher)) continue;
-    if (title && seenTitles.has(title)) {
-      duplicateReprints++;
-      continue;
-    }
-    seenPublishers.add(publisher);
-    if (title) seenTitles.add(title);
-    independentCount++;
-  }
-
-  const contradictions: string[] = [];
-  if (!ADVERSE_INVOLVEMENTS.includes(affair.involvement)) {
-    contradictions.push(`statut de condamnation avec implication ${affair.involvement}`);
-  }
-  if (!affair.verdictDate) {
-    contradictions.push("statut de condamnation sans date de verdict");
-  } else if (affair.verdictDate.getTime() > Date.now()) {
-    contradictions.push("date de verdict dans le futur");
-  } else {
-    const latest = affair.sources.reduce<number>(
-      (max, s) => Math.max(max, s.publishedAt.getTime()),
-      0
-    );
-    if (latest > 0 && latest < affair.verdictDate.getTime()) {
-      contradictions.push("toutes les sources précèdent la date du verdict");
-    }
-  }
-
-  const description = affair.description ?? "";
-  if (affair.status === "CONDAMNATION_DEFINITIVE" && describesPendingRecourse(description)) {
-    contradictions.push("statut définitif mais la description décrit un recours pendant");
-  }
-  if (affair.status !== "CONDAMNATION_DEFINITIVE" && RECOURSE_EXHAUSTED.test(description)) {
-    contradictions.push(
-      "statut non définitif mais la description dit les voies de recours épuisées"
-    );
-  }
-
-  let level: EvidenceLevel;
-  if (contradictions.length > 0) level = "D";
-  else if (affair.decisionCount > 0) level = "A";
-  else if (hasOfficialSource) level = "B";
-  else if (independentCount >= 2) level = "C";
-  else level = "D";
-
-  return { level, hasOfficialSource, independentCount, duplicateReprints, contradictions };
-}
-
-/** Peine chiffrée renseignée, donc vérifiable et à vérifier. */
-function hasPreciseSentence(a: {
-  prisonMonths: number | null;
-  fineAmount: unknown;
-  ineligibilityMonths: number | null;
-}): boolean {
-  return Boolean(
-    (a.prisonMonths ?? 0) > 0 ||
-    (a.fineAmount != null && Number(a.fineAmount) > 0) ||
-    (a.ineligibilityMonths ?? 0) > 0
-  );
 }
 
 async function main() {
@@ -328,31 +143,66 @@ async function main() {
     } as Record<EvidenceLevel, number>);
 
   const dist = distribution(rows);
-  const withoutOfficialSource = rows.filter((r) => !r.hasOfficialSource).length;
+  // Two different questions, deliberately kept apart. The first asks whether a
+  // reader can click an official source on the page; the second asks whether
+  // anything official backs the affair at all, a linked decision included.
+  const withoutOfficialSourceRow = rows.filter((r) => !r.hasOfficialSource).length;
+  const withoutOfficialEvidence = rows.filter((r) => !r.hasOfficialEvidence).length;
 
   console.log(`\n${rows.length} condamnations publiées examinées.\n`);
   console.log("Niveau de preuve :");
   for (const level of ["A", "B", "C", "D"] as const) {
     console.log(`  ${level} : ${dist[level]}`);
   }
-  console.log(`\nMétrique secondaire — sans source officielle : ${withoutOfficialSource}`);
+  console.log(`\nSans preuve officielle (métrique principale) : ${withoutOfficialEvidence}`);
+  console.log(`Sans ligne Source officielle (complétude éditoriale) : ${withoutOfficialSourceRow}`);
 
   // Point de comparaison figé au premier passage.
   if (!ledger.baseline) {
-    ledger.baseline = { ...dist, withoutOfficialSource, capturedAt: new Date().toISOString() };
+    ledger.baseline = {
+      ...dist,
+      withoutOfficialSource: withoutOfficialSourceRow,
+      capturedAt: new Date().toISOString(),
+    };
     writeLedger(ledger);
     console.log("Référence enregistrée dans le registre (premier passage).");
-  } else if (wantReport) {
+  }
+
+  // Capture séparée : un registre antérieur à cette métrique n'a pas d'historique
+  // pour elle, et lui en fabriquer un rétroactivement serait une invention.
+  const evidenceBaselineIsNew = !ledger.evidenceBaseline;
+  if (evidenceBaselineIsNew) {
+    ledger.evidenceBaseline = {
+      withoutOfficialEvidence,
+      capturedAt: new Date().toISOString(),
+    };
+    writeLedger(ledger);
+  }
+
+  if (wantReport && ledger.baseline) {
     const b = ledger.baseline;
     console.log(`\nAvant / après (référence du ${b.capturedAt.slice(0, 10)}) :`);
     for (const level of ["A", "B", "C", "D"] as const) {
       const delta = dist[level] - b[level];
       console.log(`  ${level} : ${b[level]} → ${dist[level]} (${delta >= 0 ? "+" : ""}${delta})`);
     }
-    const deltaOfficial = withoutOfficialSource - b.withoutOfficialSource;
+    const deltaSourceRow = withoutOfficialSourceRow - b.withoutOfficialSource;
     console.log(
-      `  sans source officielle : ${b.withoutOfficialSource} → ${withoutOfficialSource} (${deltaOfficial >= 0 ? "+" : ""}${deltaOfficial})`
+      `  sans ligne Source officielle : ${b.withoutOfficialSource} → ${withoutOfficialSourceRow} (${deltaSourceRow >= 0 ? "+" : ""}${deltaSourceRow})`
     );
+
+    const eb = ledger.evidenceBaseline!;
+    if (evidenceBaselineIsNew) {
+      console.log(
+        `  sans preuve officielle : ${withoutOfficialEvidence} (référence prise aujourd'hui, pas d'historique)`
+      );
+    } else {
+      const deltaEvidence = withoutOfficialEvidence - eb.withoutOfficialEvidence;
+      console.log(
+        `  sans preuve officielle : ${eb.withoutOfficialEvidence} → ${withoutOfficialEvidence} (${deltaEvidence >= 0 ? "+" : ""}${deltaEvidence}, référence du ${eb.capturedAt.slice(0, 10)})`
+      );
+    }
+
     console.log(
       `\nCritère de succès : ${dist.D === 0 ? "ATTEINT" : `${dist.D} affaire(s) en niveau D`}`
     );

--- a/src/lib/affairs/__tests__/audit-evidence.test.ts
+++ b/src/lib/affairs/__tests__/audit-evidence.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { assess, parseLedger, type SourceRow } from "@/lib/affairs/audit-evidence";
+
+// #566 counted two different things under one name. `hasOfficialSource` only
+// looks at Source rows, while level A is granted on a linked CourtDecision, so
+// an affair backed by an identified decision was still reported as "unsourced".
+// The two questions are now separate metrics and must stay separate.
+
+const VERDICT = new Date("2023-05-31");
+const AFTER_VERDICT = new Date("2023-06-01");
+
+function source(overrides: Partial<SourceRow> = {}): SourceRow {
+  return {
+    url: "https://www.lemonde.fr/article",
+    title: "Un titre de presse",
+    publisher: "Le Monde",
+    publishedAt: AFTER_VERDICT,
+    sourceType: "PRESSE",
+    ...overrides,
+  };
+}
+
+const OFFICIAL_SOURCE = source({
+  url: "https://www.legifrance.gouv.fr/jufi/id/JUFITEXT000048493146",
+  title: "Arrêt du 31 mai 2023",
+  publisher: "Legifrance",
+});
+
+function affair(overrides: Partial<Parameters<typeof assess>[0]> = {}) {
+  return assess({
+    status: "CONDAMNATION_PREMIERE_INSTANCE",
+    involvement: "DIRECT",
+    verdictDate: VERDICT,
+    description: "Une description neutre, sans mention de recours.",
+    prisonMonths: null,
+    fineAmount: null,
+    ineligibilityMonths: null,
+    sources: [source()],
+    decisionCount: 0,
+    ...overrides,
+  });
+}
+
+describe("the two official-backing metrics are distinct", () => {
+  it("a linked decision without an official Source row: evidence yes, source row no", () => {
+    const a = affair({ decisionCount: 1, sources: [source()] });
+
+    expect(a.hasOfficialSource).toBe(false);
+    expect(a.hasOfficialEvidence).toBe(true);
+    expect(a.level).toBe("A");
+  });
+
+  it("an official Source row without a linked decision: both yes", () => {
+    const a = affair({ decisionCount: 0, sources: [OFFICIAL_SOURCE] });
+
+    expect(a.hasOfficialSource).toBe(true);
+    expect(a.hasOfficialEvidence).toBe(true);
+    expect(a.level).toBe("B");
+  });
+
+  it("both at once: both yes, and the decision wins the level", () => {
+    const a = affair({ decisionCount: 1, sources: [OFFICIAL_SOURCE] });
+
+    expect(a.hasOfficialSource).toBe(true);
+    expect(a.hasOfficialEvidence).toBe(true);
+    expect(a.level).toBe("A");
+  });
+
+  it("no official backing at all: both no", () => {
+    const a = affair({
+      decisionCount: 0,
+      sources: [source(), source({ publisher: "Libération", title: "Un autre titre" })],
+    });
+
+    expect(a.hasOfficialSource).toBe(false);
+    expect(a.hasOfficialEvidence).toBe(false);
+    expect(a.level).toBe("C");
+  });
+
+  it("no source at all: both no, and the affair falls to D", () => {
+    const a = affair({ decisionCount: 0, sources: [] });
+
+    expect(a.hasOfficialSource).toBe(false);
+    expect(a.hasOfficialEvidence).toBe(false);
+    expect(a.level).toBe("D");
+  });
+
+  // A contradiction sends the affair to D whatever backs it, but it does not
+  // erase the fact that the backing exists: the two metrics stay truthful.
+  it("keeps reporting the backing of a contradictory affair", () => {
+    const a = affair({
+      decisionCount: 1,
+      sources: [OFFICIAL_SOURCE],
+      status: "CONDAMNATION_PREMIERE_INSTANCE",
+      description: "La condamnation est définitive.",
+    });
+
+    expect(a.level).toBe("D");
+    expect(a.contradictions.length).toBeGreaterThan(0);
+    expect(a.hasOfficialEvidence).toBe(true);
+    expect(a.hasOfficialSource).toBe(true);
+  });
+});
+
+describe("the ledger stays readable across generations", () => {
+  it("reads a ledger written before the stricter metric existed", () => {
+    const old = {
+      done: ["aff-1", "aff-2"],
+      baseline: {
+        A: 3,
+        B: 12,
+        C: 64,
+        D: 53,
+        withoutOfficialSource: 120,
+        capturedAt: "2026-07-26T00:00:00.000Z",
+      },
+    };
+
+    const ledger = parseLedger(old);
+
+    expect(ledger.done).toEqual(["aff-1", "aff-2"]);
+    // The historical figure keeps its original meaning: Source rows only.
+    expect(ledger.baseline?.withoutOfficialSource).toBe(120);
+    expect(ledger.baseline?.capturedAt).toBe("2026-07-26T00:00:00.000Z");
+    // No history is invented for the metric that did not exist yet.
+    expect(ledger.evidenceBaseline).toBeUndefined();
+  });
+
+  it("reads a ledger holding both baselines, each with its own date", () => {
+    const ledger = parseLedger({
+      done: [],
+      baseline: {
+        A: 3,
+        B: 11,
+        C: 66,
+        D: 51,
+        withoutOfficialSource: 119,
+        capturedAt: "2026-07-26T00:00:00.000Z",
+      },
+      evidenceBaseline: {
+        withoutOfficialEvidence: 116,
+        capturedAt: "2026-07-27T00:00:00.000Z",
+      },
+    });
+
+    expect(ledger.baseline?.capturedAt).toBe("2026-07-26T00:00:00.000Z");
+    expect(ledger.evidenceBaseline?.capturedAt).toBe("2026-07-27T00:00:00.000Z");
+    expect(ledger.evidenceBaseline?.withoutOfficialEvidence).toBe(116);
+  });
+
+  it("tolerates an empty or malformed ledger without inventing entries", () => {
+    expect(parseLedger({}).done).toEqual([]);
+    expect(parseLedger(null).done).toEqual([]);
+    expect(parseLedger({ done: "not-an-array" }).done).toEqual([]);
+  });
+});

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -1,0 +1,259 @@
+/**
+ * Evidence grading for published convictions (#566).
+ *
+ * Pure logic, extracted from `scripts/audit-convictions.ts` so it can be unit
+ * tested: the script calls `main()` at import time and connects to the
+ * production database, so importing it from a test is not an option.
+ *
+ * The script keeps the file I/O and the console output; everything that decides
+ * a level or reads a ledger lives here.
+ */
+import type { AffairStatus, Involvement } from "@/generated/prisma";
+
+/** Roles for which the judicial outcome of the affair is the person's own. */
+export const ADVERSE_INVOLVEMENTS: Involvement[] = ["DIRECT", "INDIRECT"];
+
+/** Hôtes de juridictions et d'institutions compétentes. Niveau B. */
+export const OFFICIAL_HOSTS = [
+  "courdecassation.fr",
+  "cours-appel.justice.fr",
+  "justice.fr",
+  "conseil-etat.fr",
+  "ccomptes.fr",
+  "legifrance.gouv.fr",
+  "conseil-constitutionnel.fr",
+  "juricaf.org",
+];
+
+/** Éditeurs correspondant à une juridiction ou institution compétente. Niveau B. */
+export const OFFICIAL_PUBLISHER =
+  /cour d.appel|cour de cassation|conseil d.[ée]tat|cour des comptes|tribunal|parquet|minist[èe]re de la justice|conseil constitutionnel|ordre des/i;
+
+/** Types de source qui ne comptent jamais comme secondaire indépendante.
+ *  Wikipedia est exclu délibérément : c'est la source qui a induit en erreur sur
+ *  l'arrêt du 7 juillet 2026, et une encyclopédie n'atteste pas un dispositif. */
+export const NOT_INDEPENDENT_TYPES = new Set(["WIKIPEDIA", "WIKIDATA"]);
+
+/**
+ * Recours encore ouvert, énoncé explicitement.
+ *
+ * La première version cherchait « pourvoi », « en appel » ou « non définitive »
+ * n'importe où, et flaguait 15 affaires à tort : une condamnation définitive raconte
+ * normalement son historique (« condamné en appel », « rejet du pourvoi, donnant un
+ * caractère définitif »). Mentionner un recours passé n'est pas une contradiction.
+ */
+export const PENDING_RECOURSE = [
+  /pourvoi[^.]{0,60}?(reste possible|est possible|en cours|pendant|a [ée]t[ée] form[ée])/i,
+  /(se sont pourvus|s'est pourvu|se pourvoit)[^.]{0,40}cassation/i,
+  /appel en cours/i,
+  /n['’]est pas d[ée]finitive/i,
+];
+
+/**
+ * Recours épuisés, énoncé explicitement. Annule le signal de pendance.
+ *
+ * La forme simple « la condamnation est définitive » a été ajoutée après un faux
+ * signalement : le motif ne reconnaissait que l'adverbe « définitivement » et
+ * « caractère définitif ». La négation « n'est pas définitive » ne peut pas matcher,
+ * le « n'est pas » s'intercalant entre les deux mots recherchés.
+ */
+export const RECOURSE_EXHAUSTED =
+  /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis|condamnation est (aujourd'hui )?d[ée]finitive|devenue d[ée]finitive|rendant la condamnation d[ée]finitive/i;
+
+export function describesPendingRecourse(description: string): boolean {
+  if (RECOURSE_EXHAUSTED.test(description)) return false;
+  return PENDING_RECOURSE.some((re) => re.test(description));
+}
+
+export type EvidenceLevel = "A" | "B" | "C" | "D";
+
+/**
+ * Distribution captured on a first pass, the frozen point of comparison.
+ *
+ * `withoutOfficialSource` keeps its original name and its original meaning:
+ * affairs carrying no official `Source` row. Renaming it would silently
+ * reinterpret the figure already published on #566.
+ */
+export interface Baseline extends Record<EvidenceLevel, number> {
+  withoutOfficialSource: number;
+  capturedAt: string;
+}
+
+/**
+ * Baseline for the stricter metric, added after `Baseline` and therefore
+ * carrying its own capture date: a ledger written before this existed has no
+ * historical figure to compare against, and inventing one would be a fiction.
+ */
+export interface EvidenceBaseline {
+  withoutOfficialEvidence: number;
+  capturedAt: string;
+}
+
+export interface Ledger {
+  /** Identifiants d'affaires déjà examinées, dans l'ordre de traitement. */
+  done: string[];
+  /** Affaires sans ligne Source officielle, au premier passage. */
+  baseline?: Baseline;
+  /** Affaires sans aucune preuve officielle, à sa propre date de capture. */
+  evidenceBaseline?: EvidenceBaseline;
+}
+
+/**
+ * Read a ledger of any generation. An older file has no `evidenceBaseline`;
+ * that absence is preserved rather than filled in, so the report can say the
+ * metric has no history yet instead of pretending it was measured.
+ */
+export function parseLedger(raw: unknown): Ledger {
+  const source = (raw ?? {}) as Partial<Ledger>;
+  return {
+    done: Array.isArray(source.done) ? source.done : [],
+    baseline: source.baseline,
+    evidenceBaseline: source.evidenceBaseline,
+  };
+}
+
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/** Titre réduit à sa substance, pour repérer une même dépêche reprise ailleurs. */
+export function normaliseTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Mn}/gu, "")
+    .replace(/[^a-z0-9 ]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 3)
+    .sort()
+    .join(" ");
+}
+
+export interface SourceRow {
+  url: string;
+  title: string;
+  publisher: string;
+  publishedAt: Date;
+  sourceType: string;
+}
+
+export interface Assessment {
+  level: EvidenceLevel;
+  /**
+   * An official `Source` row is attached. Measures editorial completeness of
+   * the visible sourcing: what a reader can click on the page.
+   */
+  hasOfficialSource: boolean;
+  /**
+   * Something official backs the affair, whether a `Source` row or a linked
+   * `CourtDecision`. The two are not the same thing, and conflating them was
+   * understating the corpus: a level A affair holds an identified decision but
+   * may carry no official Source row, so it counted as "unsourced".
+   */
+  hasOfficialEvidence: boolean;
+  independentCount: number;
+  /** Sources écartées du compte parce qu'elles reprennent le même titre. */
+  duplicateReprints: number;
+  contradictions: string[];
+}
+
+export function assess(affair: {
+  status: AffairStatus;
+  involvement: Involvement;
+  verdictDate: Date | null;
+  description: string | null;
+  prisonMonths: number | null;
+  fineAmount: unknown;
+  ineligibilityMonths: number | null;
+  sources: SourceRow[];
+  decisionCount: number;
+}): Assessment {
+  const hasOfficialSource = affair.sources.some(
+    (s) =>
+      s.sourceType === "JUDILIBRE" ||
+      s.sourceType === "LEGIFRANCE" ||
+      OFFICIAL_PUBLISHER.test(s.publisher) ||
+      OFFICIAL_HOSTS.some((h) => hostOf(s.url) === h || hostOf(s.url).endsWith("." + h))
+  );
+
+  // Indépendance : éditeurs distincts, hors encyclopédies, et une seule fois par
+  // titre normalisé (une dépêche reprise ne vaut pas deux attestations).
+  const seenPublishers = new Set<string>();
+  const seenTitles = new Set<string>();
+  let independentCount = 0;
+  let duplicateReprints = 0;
+  for (const s of affair.sources) {
+    if (NOT_INDEPENDENT_TYPES.has(s.sourceType)) continue;
+    const publisher = s.publisher.trim().toLowerCase();
+    const title = normaliseTitle(s.title);
+    if (seenPublishers.has(publisher)) continue;
+    if (title && seenTitles.has(title)) {
+      duplicateReprints++;
+      continue;
+    }
+    seenPublishers.add(publisher);
+    if (title) seenTitles.add(title);
+    independentCount++;
+  }
+
+  const contradictions: string[] = [];
+  if (!ADVERSE_INVOLVEMENTS.includes(affair.involvement)) {
+    contradictions.push(`statut de condamnation avec implication ${affair.involvement}`);
+  }
+  if (!affair.verdictDate) {
+    contradictions.push("statut de condamnation sans date de verdict");
+  } else if (affair.verdictDate.getTime() > Date.now()) {
+    contradictions.push("date de verdict dans le futur");
+  } else {
+    const latest = affair.sources.reduce<number>(
+      (max, s) => Math.max(max, s.publishedAt.getTime()),
+      0
+    );
+    if (latest > 0 && latest < affair.verdictDate.getTime()) {
+      contradictions.push("toutes les sources précèdent la date du verdict");
+    }
+  }
+
+  const description = affair.description ?? "";
+  if (affair.status === "CONDAMNATION_DEFINITIVE" && describesPendingRecourse(description)) {
+    contradictions.push("statut définitif mais la description décrit un recours pendant");
+  }
+  if (affair.status !== "CONDAMNATION_DEFINITIVE" && RECOURSE_EXHAUSTED.test(description)) {
+    contradictions.push(
+      "statut non définitif mais la description dit les voies de recours épuisées"
+    );
+  }
+
+  let level: EvidenceLevel;
+  if (contradictions.length > 0) level = "D";
+  else if (affair.decisionCount > 0) level = "A";
+  else if (hasOfficialSource) level = "B";
+  else if (independentCount >= 2) level = "C";
+  else level = "D";
+
+  return {
+    level,
+    hasOfficialSource,
+    hasOfficialEvidence: hasOfficialSource || affair.decisionCount > 0,
+    independentCount,
+    duplicateReprints,
+    contradictions,
+  };
+}
+
+/** Peine chiffrée renseignée, donc vérifiable et à vérifier. */
+export function hasPreciseSentence(a: {
+  prisonMonths: number | null;
+  fineAmount: unknown;
+  ineligibilityMonths: number | null;
+}): boolean {
+  return Boolean(
+    (a.prisonMonths ?? 0) > 0 ||
+    (a.fineAmount != null && Number(a.fineAmount) > 0) ||
+    (a.ineligibilityMonths ?? 0) > 0
+  );
+}


### PR DESCRIPTION
Part of #566.

## Le défaut de mesure

Le script mélangeait deux notions sous un seul chiffre. `hasOfficialSource` ne regarde que les lignes `Source`, alors que le niveau A s'obtient sur une `CourtDecision` liée. Conséquence : une affaire adossée à une décision juridictionnelle identifiée, sans ligne `Source` officielle, était comptée comme non sourcée. Trois affaires étaient dans ce cas, soit exactement l'écart entre les deux chiffres ci-dessous.

## Les deux métriques

```
withoutOfficialSourceRow = !hasOfficialSource
withoutOfficialEvidence  = !hasOfficialSource && decisionCount === 0
```

Elles répondent à deux questions différentes, et les garder séparées est le point de cette PR :

- **Sans preuve officielle** : quelque chose d'officiel adosse-t-il l'affaire, ligne `Source` ou décision liée ? C'est la métrique opérationnelle.
- **Sans ligne Source officielle** : un lecteur peut-il cliquer une source officielle sur la page ? C'est de la complétude éditoriale, utile mais distincte.

Mesure actuelle sur les 131 condamnations publiées :

```
Sans preuve officielle (métrique principale)          : 116
Sans ligne Source officielle (complétude éditoriale)  : 119
```

## Registre étendu, pas réécrit

`baseline.withoutOfficialSource` garde son nom et son sens d'origine. Le renommer aurait réinterprété en silence le chiffre déjà publié sur #566.

La nouvelle référence est ajoutée à côté, avec sa propre date de capture, parce qu'un registre écrit avant l'existence de cette métrique n'a pas d'historique pour elle. Le rapport le dit explicitement au premier passage plutôt que d'afficher un delta fabriqué :

```
sans ligne Source officielle : 120 → 119 (-1)
sans preuve officielle : 116 (référence prise aujourd'hui, pas d'historique)
```

Vérifié sur le registre réel : l'ancienne référence ressort identique au bit près après passage du nouveau script.

## Extraction

La logique d'évaluation part dans `src/lib/affairs/audit-evidence.ts`. Le script appelle `main()` à l'import et se connecte à la base de production, donc l'importer depuis un test n'était pas envisageable. Le script garde ses entrées-sorties et son affichage ; tout ce qui décide d'un niveau ou lit un registre est désormais testable.

Aucun changement de comportement dans le classement : la répartition A/B/C/D et la file priorisée sont identiques avant et après.

## Tests

9 tests dans `src/lib/affairs/__tests__/audit-evidence.test.ts` :

- décision liée sans ligne `Source` : preuve oui, ligne source non, niveau A ;
- source officielle sans décision liée : les deux oui, niveau B ;
- les deux à la fois : la décision l'emporte pour le niveau ;
- aucune preuve officielle, et le cas sans aucune source ;
- une affaire contradictoire tombe en D sans que cela efface ce qui l'adosse : les deux métriques restent sincères ;
- lecture d'un registre antérieur à la métrique, sans historique inventé ;
- lecture d'un registre portant les deux références, chacune à sa date ;
- registre vide ou malformé.

Suite complète : 2628 passants, 130 ignorés. `tsc` propre.
