### PR TITLE
Rendre l'enveloppe du sitemap à la requête

### DIFF
--- a/src/app/__tests__/sitemap-dynamic.test.ts
+++ b/src/app/__tests__/sitemap-dynamic.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #572: the sitemap shards were served as static artefacts that tag invalidation
+// could not reach, so a depublished affair stayed announced to crawlers. The
+// route envelope must therefore render per request, while the builders keep
+// their cached, tagged data. This test guards the pairing, not the wording:
+// it calls the route and watches the order of the calls it makes.
+
+const h = vi.hoisted(() => {
+  const calls: string[] = [];
+  const dbHandler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, model: string) {
+      if (model === "$queryRaw" || model === "$queryRawUnsafe") {
+        return async () => {
+          calls.push(`db.${model}`);
+          return [];
+        };
+      }
+      return new Proxy(
+        {},
+        {
+          get(_m, method: string) {
+            return async () => {
+              calls.push(`db.${model}.${method}`);
+              return method === "findFirst" || method === "findUnique" ? null : [];
+            };
+          },
+        }
+      );
+    },
+  };
+  return {
+    calls,
+    connection: vi.fn(async () => {
+      calls.push("connection");
+    }),
+    cacheTag: vi.fn((...tags: string[]) => {
+      calls.push(`cacheTag(${tags.join(",")})`);
+    }),
+    cacheLife: vi.fn((profile: string) => {
+      calls.push(`cacheLife(${profile})`);
+    }),
+    db: new Proxy({}, dbHandler),
+  };
+});
+
+vi.mock("next/server", () => ({ connection: h.connection }));
+vi.mock("next/cache", () => ({ cacheTag: h.cacheTag, cacheLife: h.cacheLife }));
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import sitemap, { generateSitemaps } from "@/app/sitemap";
+import { SITEMAP_SHARD_TAGS } from "@/lib/seo/sitemap-tags";
+
+beforeEach(() => {
+  h.calls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("the sitemap route renders per request", () => {
+  it("awaits a request-time API before touching the database", async () => {
+    await sitemap({ id: Promise.resolve("1") });
+
+    expect(h.connection).toHaveBeenCalledTimes(1);
+
+    const firstDb = h.calls.findIndex((c) => c.startsWith("db."));
+    const connectionAt = h.calls.indexOf("connection");
+    expect(connectionAt).toBe(0);
+    expect(firstDb).toBeGreaterThan(connectionAt);
+  });
+
+  it("opts out on every shard, not just the affairs one", async () => {
+    for (const { id } of await generateSitemaps()) {
+      h.calls.length = 0;
+      h.connection.mockClear();
+      await sitemap({ id: Promise.resolve(String(id)) });
+      expect(h.connection, `shard ${id}`).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("keeps the data builders cached and tagged", async () => {
+    for (const [shard, tags] of Object.entries(SITEMAP_SHARD_TAGS)) {
+      h.calls.length = 0;
+      await sitemap({ id: Promise.resolve(shard) });
+
+      expect(h.cacheTag, `shard ${shard}`).toHaveBeenCalledWith(...tags);
+      expect(h.cacheLife, `shard ${shard}`).toHaveBeenCalledWith("synced");
+    }
+  });
+
+  it("declares the tags before reading, so the read is what gets cached", async () => {
+    await sitemap({ id: Promise.resolve("1") });
+
+    const tagAt = h.calls.findIndex((c) => c.startsWith("cacheTag("));
+    const firstDb = h.calls.findIndex((c) => c.startsWith("db."));
+    expect(tagAt).toBeGreaterThanOrEqual(0);
+    expect(firstDb).toBeGreaterThan(tagAt);
+  });
+
+  it("still exposes exactly five shards", async () => {
+    expect(await generateSitemaps()).toEqual([
+      { id: 0 },
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+      { id: 4 },
+    ]);
+  });
+
+  it("returns nothing for an unknown shard rather than throwing", async () => {
+    await expect(sitemap({ id: Promise.resolve("9") })).resolves.toEqual([]);
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from "next";
 import { cacheTag, cacheLife } from "next/cache";
+import { connection } from "next/server";
 import { Prisma } from "@/generated/prisma";
 import { SITEMAP_SHARD_TAGS } from "@/lib/seo/sitemap-tags";
 import { db } from "@/lib/db";
@@ -20,6 +21,14 @@ export async function generateSitemaps() {
 export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
+  // Render the envelope per request. Measured in production: the shards were
+  // served as static artefacts (`accept-ranges: bytes`, no `x-nextjs-prerender`,
+  // query string ignored in the cache key), so tag invalidation never reached
+  // them and a depublished affair stayed announced — as did the absence of a
+  // newly published one. The data itself stays cached and tagged in the
+  // builders below, so this costs a serialisation, not a query (#572).
+  await connection();
+
   const id = Number(await props.id);
   switch (id) {
     case 0:


### PR DESCRIPTION
Reprend #572, que la PR #574 n'avait pas résolue.

## Ce que la mesure en production a établi

Les shards du sitemap étaient servis comme **artefacts statiques**, pas comme routes ISR, donc hors du chemin de purge par tag. Comparaison des en-têtes entre une route effectivement purgée et le sitemap :

|                              | page d'affaire | sitemap            |
| ---------------------------- | -------------- | ------------------ |
| `x-nextjs-prerender`         | `1`            | absent             |
| `accept-ranges`              | absent         | `bytes`            |
| query string en cache-buster | nouvelle clé   | ignorée, même etag |

Les tags étaient pourtant bien enregistrés dans `.next/server/app/sitemap/N.xml.meta`. Vercel servait le corps en statique et la purge ne l'atteignait jamais.

Le défaut ne concerne d'ailleurs pas que les dépublications. En comparant l'objet servi à la base, **deux affaires publiées manquaient** au sitemap :

```
/affaires/marine-le-pen-outrage-a-agents-publics-incident-du-16e-arrondissement
/affaires/violette-spillebout-condamnation-...-partie-civile-abusive
```

Une nouvelle fiche n'entrait donc jamais dans le sitemap non plus. Le coût SEO est au moins aussi lourd que celui de la fiche fantôme.

## La correction

L'enveloppe de la Metadata Route est rendue à la requête via `await connection()`. Les builders gardent `"use cache"`, `cacheTag(...)` et `cacheLife("synced")` : les données restent en cache tagué, seule la sérialisation XML est refaite par requête.

Pas de `export const revalidate` : le projet s'appuie sur le cache par tags, une fenêtre de temps ne répondrait pas au besoin et masquerait le problème.

## Ce que change le build

```
avant  ●  /sitemap/[__metadata_id__]   1d   1w     (SSG, prérendu statique)
après  ƒ  /sitemap/[__metadata_id__]              (Dynamic, rendu à la demande)
```

Plus aucun corps prérendu dans `.next/server/app/sitemap/`.

## Vérification sur le serveur de production local

Cinq shards servis, comparés **URL par URL** aux ensembles issus du build de `main` avant modification :

| shard | HTTP | content-type      | URL avant | URL après | différences |
| ----- | ---- | ----------------- | --------- | --------- | ----------- |
| 0     | 200  | `application/xml` | 2313      | 2313      | **0**       |
| 1     | 200  | `application/xml` | 547       | 547       | **0**       |
| 2     | 200  | `application/xml` | 300       | 300       | **0**       |
| 3     | 200  | `application/xml` | 500       | 500       | **0**       |
| 4     | 200  | `application/xml` | 200       | 200       | **0**       |

XML bien formé sur les cinq, racine `urlset`, nombre d'entrées conforme. Shard inconnu (`/sitemap/9.xml`) en 404.

Les builders servent bien depuis le cache : 18 ms pour le shard 0, 400 Ko et 2313 URL. Une lecture froide de la base serait d'un tout autre ordre.

À noter, `/sitemap.xml` renvoie 404 et n'a jamais servi d'index : les cinq shards sont déclarés directement dans `robots.txt`, ce qui reste inchangé.

## Test

`src/app/__tests__/sitemap-dynamic.test.ts` observe le comportement réel de la route, pas la présence du mot `connection`. Il appelle la route avec `next/server`, `next/cache` et la base simulés, et vérifie l'ordre des appels :

- `connection()` est attendu **avant** toute lecture de base, et sur les cinq shards ;
- `cacheTag(...)` est appelé avec les tags déclarés, `cacheLife("synced")` avec le bon profil ;
- les tags sont posés avant la lecture, donc c'est bien la lecture qui est mise en cache ;
- `generateSitemaps()` expose toujours exactement cinq shards ;
- un shard inconnu renvoie une liste vide plutôt qu'une exception.

Vérifié dans les deux sens : en commentant `await connection()`, deux de ces tests échouent. Le garde n'est pas tautologique.

Suite complète : 2655 passants, 130 ignorés. `tsc` propre, build à zéro.

## Ce qui reste à prouver

Cette PR ne ferme pas #572. Le critère est la mesure HTTP en production après invalidation, et rien d'autre. Le marqueur retenu est la comparaison d'ensembles d'URL contre la base, plus fiable qu'une URL unique.

## Conservé de #574

`affairs` accepté par l'invalidation sélective, dépublication transactionnelle, invalidation seulement après commit, invalidation du slug de l'affaire et du profil politique. Rien de tout cela n'est touché ici.
