### PR TITLE
Ne pas dater un verdict avec une ligne Wikidata

### DIFF
--- a/src/lib/affairs/__tests__/audit-evidence.test.ts
+++ b/src/lib/affairs/__tests__/audit-evidence.test.ts
@@ -236,3 +236,52 @@ describe("detects a total shown as firm over a partly suspended sentence", () =>
     expect(a.contradictions).toEqual([]);
   });
 });
+
+// The "all sources predate the verdict" check was defeated by its own corpus:
+// a Wikidata row is stamped with its import date, so it always postdates the
+// verdict and pushed the maximum past it. Seven published convictions whose
+// only real source was written before the decision they assert went unflagged.
+describe("dating a verdict against sources that can actually attest it", () => {
+  const VERDICT_2024 = new Date("2024-06-19");
+  const PRESS_2020 = source({ publishedAt: new Date("2020-06-16") });
+  const WIKIDATA_2026 = source({
+    publisher: "Wikidata",
+    sourceType: "WIKIDATA",
+    title: "Wikidata — une personne",
+    publishedAt: new Date("2026-01-18"),
+  });
+  const MESSAGE = "toutes les sources précèdent la date du verdict";
+
+  it("flags a verdict whose only press source predates it, despite a later Wikidata row", () => {
+    const a = affair({
+      verdictDate: VERDICT_2024,
+      sources: [PRESS_2020, WIKIDATA_2026],
+    });
+
+    expect(a.contradictions).toContain(MESSAGE);
+    expect(a.level).toBe("D");
+  });
+
+  it("flags it just the same without the encyclopedia row", () => {
+    const a = affair({ verdictDate: VERDICT_2024, sources: [PRESS_2020] });
+
+    expect(a.contradictions).toContain(MESSAGE);
+  });
+
+  it("says nothing when a press source postdates the verdict", () => {
+    const a = affair({
+      verdictDate: VERDICT_2024,
+      sources: [source({ publishedAt: new Date("2024-06-20") }), WIKIDATA_2026],
+    });
+
+    expect(a.contradictions).not.toContain(MESSAGE);
+  });
+
+  it("says nothing when only encyclopedias are attached, the level already sanctioning it", () => {
+    const a = affair({ verdictDate: VERDICT_2024, sources: [WIKIDATA_2026] });
+
+    expect(a.contradictions).not.toContain(MESSAGE);
+    expect(a.independentCount).toBe(0);
+    expect(a.level).toBe("D");
+  });
+});

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -236,10 +236,15 @@ export function assess(affair: {
   } else if (affair.verdictDate.getTime() > Date.now()) {
     contradictions.push("date de verdict dans le futur");
   } else {
-    const latest = affair.sources.reduce<number>(
-      (max, s) => Math.max(max, s.publishedAt.getTime()),
-      0
-    );
+    // Encyclopedias are excluded here for the same reason they are excluded from
+    // the independence count: they attest nothing about a dispositif. Leaving
+    // them in defeated the check outright, since a Wikidata row is stamped with
+    // its import date and therefore always postdates the verdict. Jalkh carried
+    // a 2024 verdict whose only press source was written in 2020, and nothing
+    // fired.
+    const latest = affair.sources
+      .filter((s) => !NOT_INDEPENDENT_TYPES.has(s.sourceType))
+      .reduce<number>((max, s) => Math.max(max, s.publishedAt.getTime()), 0);
     if (latest > 0 && latest < affair.verdictDate.getTime()) {
       contradictions.push("toutes les sources précèdent la date du verdict");
     }


### PR DESCRIPTION
Part of #566.

## Le contrôle se neutralisait lui-même

`assess()` signale une affaire dont toutes les sources précèdent la date du verdict : le dispositif affirmé n'est alors attesté par rien. Le contrôle prenait le maximum des dates de publication, **encyclopédies comprises**.

Or une ligne Wikidata porte sa date d'import, pas celle d'un fait. Elle postdate donc systématiquement le verdict et poussait le maximum au-delà. Le contrôle ne pouvait se déclencher que sur une fiche sans Wikidata.

Cas type, la fiche Jalkh :

```
verdictDate  2024-06-19   « Cour de cassation (confirmation) »
source 1     2020-06-16   France 24
source 2     2026-01-18   Wikidata
```

Maximum retenu : 2026. Aucun signalement. Pourtant la seule source réelle est écrite quatre ans avant la décision qu'elle est censée établir.

## La correction

Les types déjà exclus du compte d'indépendance, `WIKIPEDIA` et `WIKIDATA`, le sont aussi du calcul de date. Une encyclopédie n'atteste pas un dispositif ; elle ne peut pas davantage en dater un.

## Effet mesuré sur le corpus

```
avant   A 4   B 11   C 66   D 50    0 en revue urgente
après   A 4   B 11   C 61   D 56    8 en revue urgente
```

Sept condamnations publiées remontent, chacune affirmant un verdict qu'aucune de ses sources ne peut attester : Fillon, Cambadélis, Kerbrat, Dussopt, Piednoir, Jalkh, Jean-Marie Le Pen. La huitième, Marine Le Pen, était déjà signalée pour absence de date de verdict.

Le `D 50` publié dans le rapport du lot 2 était donc sous-évalué de six. La mesure corrigée est `D 56`.

## Tests

Quatre cas ajoutés :

- source de presse antérieure au verdict **avec** ligne Wikidata postérieure : signalé ;
- même cas sans l'encyclopédie : signalé, comportement inchangé ;
- source de presse postérieure au verdict avec Wikidata : rien ;
- encyclopédie seule : rien, le niveau sanctionnant déjà l'absence de source indépendante.

Suite complète : 2659 passants, 130 ignorés. `tsc` propre.
