### PR TITLE
Retirer les résumés IA de presse des surfaces publiques

### DIFF
--- a/src/components/recap/RecapView.tsx
+++ b/src/components/recap/RecapView.tsx
@@ -16,7 +16,6 @@ import { PLATFORM_UPDATE_TYPE_LABELS, PLATFORM_UPDATE_TYPE_ICONS } from "@/confi
 import { CERTAINTY_LABELS, CERTAINTY_COLORS, type CertaintyLevel } from "@/config/certainty";
 import { NewsletterCTA } from "@/app/recap/NewsletterCTA";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
-import { PressStoriesGrid } from "./PressStoriesGrid";
 import { RecapShareBlock } from "./RecapShareBlock";
 import { SITE_URL } from "@/config/site";
 
@@ -404,9 +403,8 @@ export function RecapView({ weekStart, data }: RecapViewProps) {
                     semaine.
                   </p>
 
-                  {data.press.storiesOfTheWeek.length > 0 ? (
-                    <PressStoriesGrid stories={data.press.storiesOfTheWeek} />
-                  ) : null}
+                  {/* Press "stories of the week" hidden from the public recap for now
+                      (press-publisher neighbouring rights). We link, we don't reproduce. */}
 
                   <Link
                     href="/presse"

--- a/src/lib/email/__tests__/render-recap-press.test.ts
+++ b/src/lib/email/__tests__/render-recap-press.test.ts
@@ -37,16 +37,13 @@ describe("buildPressStoriesHtml", () => {
     expect(html).toContain("Le Monde");
   });
 
-  it("includes the AI summary when present", () => {
+  it("never renders the AI summary, even when present (press neighbouring rights)", () => {
     const html = buildPressStoriesHtml([baseStory]);
-    expect(html).toContain("Un plan ambitieux annoncé.");
-  });
-
-  it("omits the summary block when aiSummary is null", () => {
-    const story: PressStory = { ...baseStory, aiSummary: null };
-    const html = buildPressStoriesHtml([story]);
-    expect(html).toContain("Le gouvernement annonce un plan");
+    expect(html).not.toContain("Un plan ambitieux annoncé.");
     expect(html).not.toContain("font-style: italic");
+    // We link, we don't reproduce: title and source stay, summary never appears.
+    expect(html).toContain("Le gouvernement annonce un plan");
+    expect(html).toContain('href="https://lemonde.fr/article/1"');
   });
 
   it("escapes HTML in story title", () => {

--- a/src/lib/email/render-recap.ts
+++ b/src/lib/email/render-recap.ts
@@ -201,13 +201,11 @@ export function buildPressStoriesHtml(stories: PressStory[]): string {
       const title = escapeHtml(s.title);
       const feedSource = escapeHtml(s.feedSource);
       const dateLabel = formatDateShort(s.publishedAt);
-      const summary = s.aiSummary
-        ? `<p style="margin: 4px 0 0; font-style: italic; font-size: 13px; color: #374151;">${escapeHtml(s.aiSummary)}</p>`
-        : "";
+      // AI summary intentionally not rendered: link, don't reproduce
+      // (press-publisher neighbouring rights). Title + source + link only.
       return `<div style="padding: 10px 0; border-bottom: 1px solid #f3f4f6;">
         <p style="margin: 0; font-weight: 600;"><a href="${s.url}" style="color: #1e3a5f; text-decoration: none;">${title}</a></p>
         <p style="margin: 2px 0 0; font-size: 12px; color: #6b7280;">${feedSource} · ${dateLabel}</p>
-        ${summary}
       </div>`;
     })
     .join("");


### PR DESCRIPTION
## Description

Retire le texte dérivé des articles de presse (résumés IA) des surfaces publiques. Le principe : on lie, on ne reproduit pas. Titres, sources, dates et liens restent ; seul le résumé disparaît.

- **Newsletter** (`render-recap.ts`) : `buildPressStoriesHtml` ne rend plus l'aiSummary. Les stories gardent titre + source + date + lien. La version texte de l'e-mail ne l'affichait déjà pas.
- **Page recap web** (`RecapView.tsx`) : la grille « stories of the week » est masquée. Le compteur d'articles et le lien « Voir la revue de presse » restent. Retrait réversible (composant `PressStoriesGrid` conservé).

Le chatbot RAG (`embeddings.ts` réinjecte l'aiSummary dans le contexte du LLM) est derrière un toggle actuellement désactivé, donc hors périmètre ici. À traiter le jour d'une réactivation.

## Motivation

Éviter toute réutilisation qui s'apparenterait à de la reproduction de contenu éditorial. Le droit voisin des éditeurs de presse (loi 2019-775) limite la réutilisation à de très courts extraits ; un résumé IA affiché publiquement est une zone grise qu'on écarte.

## Tests

- `render-recap-press.test.ts` : l'assertion « inclut le résumé » devient une garde de non-régression (le résumé ne doit jamais apparaître, même présent en base).
- `npx tsc --noEmit` propre ; tests recap (data + email) verts.
