### PR TITLE
Passe responsive : titres non tronqués + lisibilité mobile (votes & recherche)

### DIFF
--- a/src/app/recherche/SearchClient.tsx
+++ b/src/app/recherche/SearchClient.tsx
@@ -539,7 +539,7 @@ function AffairRow({ result }: { result: AffairResult }) {
     >
       <Scale className="h-4 w-4 text-amber-500/60 shrink-0" aria-hidden="true" />
       <div className="flex-1 min-w-0">
-        <span className="font-medium text-sm leading-snug">{result.title}</span>
+        <span className="font-medium text-base leading-snug">{result.title}</span>
         <span className="block text-xs text-muted-foreground">{result.politicianName}</span>
       </div>
       <span className="text-[11px] px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 shrink-0 hidden sm:inline">
@@ -556,11 +556,11 @@ function ScrutinRow({ result }: { result: ScrutinResult }) {
       className="flex items-start gap-3 py-3 hover:bg-accent/40 rounded-lg transition-colors px-3 -mx-3"
       prefetch={false}
     >
-      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0 mt-0.5">
+      <span className="text-xs font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0 mt-0.5">
         {CHAMBER_SHORT_LABELS[result.chamber]}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="font-medium text-sm leading-snug">{result.title}</span>
+        <span className="font-medium text-base leading-snug">{result.title}</span>
         <span className="block text-xs text-muted-foreground mt-0.5">
           {formatDateShort(result.votingDate)}
         </span>
@@ -584,7 +584,7 @@ function FactCheckRow({ result }: { result: FactCheckResult }) {
         aria-hidden="true"
       />
       <div className="flex-1 min-w-0">
-        <span className="font-medium text-sm leading-snug">{result.title}</span>
+        <span className="font-medium text-base leading-snug">{result.title}</span>
         <span className="block text-xs text-muted-foreground">
           {result.source}
           {result.politicianName && ` · ${result.politicianName}`}
@@ -614,7 +614,7 @@ function DossierRow({ result }: { result: DossierResult }) {
     >
       <FileText className="h-4 w-4 text-muted-foreground/60 shrink-0" aria-hidden="true" />
       <div className="flex-1 min-w-0">
-        <span className="font-medium text-sm leading-snug">
+        <span className="font-medium text-base leading-snug">
           {result.shortTitle || result.title}
         </span>
         {result.filingDate && (

--- a/src/components/filters/DebouncedSearchInput.tsx
+++ b/src/components/filters/DebouncedSearchInput.tsx
@@ -97,7 +97,7 @@ export function DebouncedSearchInput({
         placeholder={placeholder}
         onChange={(e) => handleChange(e.target.value)}
         onKeyDown={handleKeyDown}
-        className="h-9 w-full rounded-md border border-input bg-background pl-9 pr-8 py-1 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 placeholder:text-muted-foreground"
+        className="h-9 w-full rounded-md border border-input bg-background pl-9 pr-8 py-1 text-base md:text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 placeholder:text-muted-foreground"
       />
       {value && (
         <button

--- a/src/components/search/CommandPalette.tsx
+++ b/src/components/search/CommandPalette.tsx
@@ -374,16 +374,16 @@ export function CommandPalette() {
                             <CategoryIcon categoryKey={category.key} />
                           )}
                           <div className="min-w-0 flex-1">
-                            <div className="truncate text-sm font-medium">{result.primary}</div>
+                            <div className="text-base font-medium">{result.primary}</div>
                             {result.secondary && (
-                              <div className="truncate text-xs text-muted-foreground">
+                              <div className="text-xs text-muted-foreground">
                                 {result.secondary}
                               </div>
                             )}
                           </div>
                           {result.badge && (
                             <span
-                              className="ml-auto shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
+                              className="ml-auto shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
                               style={
                                 result.badgeColor
                                   ? {

--- a/src/components/search/search-results.tsx
+++ b/src/components/search/search-results.tsx
@@ -68,11 +68,6 @@ export interface GlobalSearchResponse {
   }>;
 }
 
-function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max) + "...";
-}
-
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("fr-FR", {
     day: "numeric",
@@ -102,7 +97,7 @@ export function categorizeResults(data: GlobalSearchResponse): SearchResultCateg
       label: "Votes",
       results: data.scrutins.map((s) => ({
         href: `/parlement/votes/${s.slug ?? s.id}`,
-        primary: truncate(s.title, 80),
+        primary: s.title,
         secondary: [
           CHAMBER_LABELS[s.chamber as keyof typeof CHAMBER_LABELS] ?? s.chamber,
           formatDate(s.votingDate),
@@ -134,7 +129,7 @@ export function categorizeResults(data: GlobalSearchResponse): SearchResultCateg
       label: "Dossiers",
       results: data.dossiers.map((d) => ({
         href: `/parlement/dossiers/${d.slug}`,
-        primary: truncate(d.shortTitle ?? d.title, 80),
+        primary: d.shortTitle ?? d.title,
         secondary: d.status,
       })),
     },
@@ -143,7 +138,7 @@ export function categorizeResults(data: GlobalSearchResponse): SearchResultCateg
       label: "Fact-checks",
       results: data.factchecks.map((f) => ({
         href: `/factchecks/${f.slug}`,
-        primary: truncate(f.title, 80),
+        primary: f.title,
         secondary: f.source,
       })),
     },

--- a/src/components/votes/KeyVoteCard.tsx
+++ b/src/components/votes/KeyVoteCard.tsx
@@ -72,10 +72,10 @@ export function KeyVoteCard({
         )}
 
         <Link href={href} prefetch={false} className="hover:underline">
-          <p className="font-medium text-sm line-clamp-2 mb-2">
+          <p className="font-medium text-base mb-2">
             {heading}
             {isPolicy && (
-              <Badge variant="accent" className="ml-1.5 align-middle text-[10px] font-medium">
+              <Badge variant="accent" className="ml-1.5 align-middle text-xs font-medium">
                 Titre explicatif
               </Badge>
             )}

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -96,7 +96,7 @@ export function VoteCard({
         <div className="flex items-start justify-between gap-4 mb-3">
           <div className="flex-1 min-w-0">
             <Link href={href} prefetch={false} className="hover:underline">
-              <p className="font-medium text-sm line-clamp-2">
+              <p className="font-medium text-base">
                 {scrutinNumber && (
                   <span className="font-mono text-xs text-muted-foreground mr-1.5">
                     Scrutin n°{scrutinNumber}
@@ -104,7 +104,7 @@ export function VoteCard({
                 )}
                 {heading}
                 {isPolicy && (
-                  <Badge variant="accent" className="ml-1.5 align-middle text-[10px] font-medium">
+                  <Badge variant="accent" className="ml-1.5 align-middle text-xs font-medium">
                     Titre explicatif
                   </Badge>
                 )}
@@ -145,7 +145,7 @@ export function VoteCard({
                   {total} votants
                 </span>
               )}
-              <span className="text-muted-foreground/60">{legislature}e législature</span>
+              <span className="text-muted-foreground">{legislature}e législature</span>
             </div>
             {dossier?.slug && (
               <Link
@@ -167,6 +167,7 @@ export function VoteCard({
                 rel="noopener noreferrer"
                 className="text-muted-foreground hover:text-foreground"
                 title="Voir sur NosDéputés.fr"
+                aria-label="Voir le scrutin sur NosDéputés.fr (nouvelle fenêtre)"
               >
                 <ExternalLink className="h-4 w-4" />
               </a>


### PR DESCRIPTION
## Contexte

Sur mobile, les titres de scrutins et surtout d'amendements (souvent très longs) étaient tronqués et illisibles, principalement dans les listes de votes et la recherche. Deux règles fixes appliquées à toutes les largeurs en étaient la cause : le `line-clamp-2` des cartes de vote et le `truncate` (une ligne) de la palette de recherche, doublé d'une coupe JS à 80 caractères.

## Changements

- Titres en wrap complet (plus de `line-clamp`/`truncate`) sur `VoteCard`, `KeyVoteCard`, l'omnibox (`CommandPalette`) et la page `/recherche`.
- Suppression de la coupe JS à 80 caractères dans les résultats de recherche.
- Lisibilité : titres primaires à 16px, micro-badges passés à 12px, contraste d'un label corrigé, `aria-label` explicite sur le lien externe des cartes de vote.
- Input de recherche partagé (`DebouncedSearchInput`) aligné sur `text-base md:text-sm` : 16px sur mobile, ce qui stoppe le zoom iOS au focus sur toutes les barres de filtres.

## Vérification

- `tsc` propre, suite complète verte (2679 tests, 130 skips).
- Markup confirmé sur la page servie `/parlement/votes` : `text-base` présent, zéro `line-clamp-2`.
- Vérif visuelle Playwright non réalisable dans l'environnement d'exécution (pas de bridge navigateur) : à confirmer d'un coup d'œil sur mobile.

## À noter

Le build local échoue sur `/affaires/[slug]` (erreur Prisma sur le modèle Affair, liée à la refonte Affaires v2 et au build contre la base de prod). C'est sans rapport avec ce diff, qui ne touche ni les affaires ni Prisma ; à trier séparément.

Part of #483 (brique « passe responsive »). Ne ferme pas #483 : les foundations Storybook restent à faire.
