### PR TITLE
Désindexer les surfaces sans contenu propre repérées dans la Coverage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import { SITE_URL, SITE_HOSTNAME } from "./src/config/site";
 import { OG_IMAGE_NOINDEX_HEADERS } from "./src/lib/seo/og-image-robots";
+import { API_NOINDEX_HEADERS } from "./src/lib/seo/api-robots";
 import { buildSecurityHeaders } from "./src/lib/security-headers";
 
 const nextConfig: NextConfig = {
@@ -73,6 +74,9 @@ const nextConfig: NextConfig = {
       // Keep auto-generated opengraph-image URLs out of the search index (they are
       // assets, not pages) while staying fetchable for social link previews.
       ...OG_IMAGE_NOINDEX_HEADERS,
+      // Same reasoning for /api: machine endpoints, publicly fetchable, never a
+      // search result. The human docs at /docs/api stay indexable.
+      ...API_NOINDEX_HEADERS,
     ];
   },
   async redirects() {

--- a/src/app/parlement/votes/stats/page.tsx
+++ b/src/app/parlement/votes/stats/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { permanentRedirect } from "next/navigation";
 
 interface PageProps {
   searchParams: Promise<{
@@ -10,5 +10,8 @@ export default async function VoteStatsPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const chamber = params.chamber;
   const url = chamber ? `/statistiques?tab=votes&chamber=${chamber}` : "/statistiques?tab=votes";
-  redirect(url);
+  // 308, not 307: the vote stats moved to /statistiques for good. A temporary
+  // redirect tells Google to keep the old URL in the index, which is how these
+  // land in the "Page avec redirection" bucket instead of consolidating.
+  permanentRedirect(url);
 }

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -70,6 +70,10 @@ async function getVoteStats(politicianId: string) {
         scrutin: {
           select: {
             id: true,
+            // Slug drives the link: /parlement/votes/<cuid> only 308s to the
+            // slug URL, so linking by id made every "Derniers votes" row an
+            // internal redirect hop for crawlers.
+            slug: true,
             title: true,
             votingDate: true,
             result: true,

--- a/src/app/politiques/[slug]/relations/page.tsx
+++ b/src/app/politiques/[slug]/relations/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
 import { RelationsClient } from "./RelationsClient";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { politicianRobotsMetadata } from "@/lib/seo/politician-robots";
+import { getPoliticianIndexSignals } from "@/lib/seo/politician-index-signals";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag
 
@@ -37,7 +39,10 @@ const getPoliticianBasic = cache(async function getPoliticianBasic(slug: string)
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const politician = await getPoliticianBasic(slug);
+  const [politician, signals] = await Promise.all([
+    getPoliticianBasic(slug),
+    getPoliticianIndexSignals(slug),
+  ]);
 
   if (!politician) {
     return { title: "Non trouvé" };
@@ -46,6 +51,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `Relations de ${politician.fullName} | Poligraph`,
     description: `Découvrez les relations politiques de ${politician.fullName} : gouvernement, entreprises, département, parcours partisan.`,
+    // Same gate as the profile: a bare RNE-imported mayor has no relations to
+    // show, so the tab must not be a second crawlable URL for a noindexed
+    // profile (issue #385).
+    ...(signals ? politicianRobotsMetadata(signals) : {}),
     alternates: { canonical: `/politiques/${slug}/relations` },
   };
 }

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -15,6 +15,8 @@ import { ArrowLeft, ExternalLink, Info } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { feminizeRole, SCRUTIN_TYPE_LABELS, SCRUTIN_TYPE_COLORS } from "@/config/labels";
 import { getPoliticianVotingStats, getPoliticianVoteTabCounts } from "@/services/voteStats";
+import { politicianRobotsMetadata } from "@/lib/seo/politician-robots";
+import { getPoliticianIndexSignals } from "@/lib/seo/politician-index-signals";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
 
@@ -128,7 +130,10 @@ async function getVotes(
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const politician = await getPolitician(slug);
+  const [politician, signals] = await Promise.all([
+    getPolitician(slug),
+    getPoliticianIndexSignals(slug),
+  ]);
 
   if (!politician) {
     return { title: "Politicien non trouvé" };
@@ -137,6 +142,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `Votes de ${politician.fullName}`,
     description: `Historique complet des votes parlementaires de ${politician.fullName} à l'Assemblée nationale.`,
+    // A sub-tab is never richer than its profile: when the profile is noindexed
+    // for lack of content (issue #385), the votes tab — empty for anyone who
+    // never sat in parliament — must not stay crawlable on its own.
+    ...(signals ? politicianRobotsMetadata(signals) : {}),
     alternates: { canonical: `/politiques/${slug}/votes` },
   };
 }

--- a/src/components/politicians/VotesSection.tsx
+++ b/src/components/politicians/VotesSection.tsx
@@ -26,6 +26,7 @@ interface VotesSectionProps {
       position: VotePosition;
       scrutin: {
         id: string;
+        slug: string | null;
         title: string;
         votingDate: Date | null;
         result: string | null;
@@ -182,13 +183,19 @@ export function VotesSection({
                       sourceUrl: null,
                       policyTitle: vote.scrutin.policyTitle,
                     });
+                    // Link the canonical slug URL, not the cuid: the id form
+                    // exists only as a 308 to the slug, so a whole profile's
+                    // worth of internal links used to point at redirects
+                    // ("Page avec redirection" in Search Console). Falls back
+                    // to the id for the handful of scrutins without a slug.
+                    const scrutinPath = vote.scrutin.slug ?? vote.scrutin.id;
                     return (
                       <div key={vote.id} className="group flex items-start gap-2 text-sm">
                         <span
                           className={`w-2 h-2 mt-1.5 shrink-0 rounded-full ${VOTE_POSITION_DOT_COLORS[vote.position]}`}
                         />
                         <Link
-                          href={`/parlement/votes/${vote.scrutin.id}`}
+                          href={`/parlement/votes/${scrutinPath}`}
                           prefetch={false}
                           className="flex-1 hover:underline"
                         >
@@ -203,7 +210,7 @@ export function VotesSection({
                           )}
                         </Link>
                         <VotePositionBadge position={vote.position} size="sm" />
-                        <CiteAnchor permalink={scrutinPermalink(vote.scrutin.id)} label="ce vote" />
+                        <CiteAnchor permalink={scrutinPermalink(scrutinPath)} label="ce vote" />
                       </div>
                     );
                   })}

--- a/src/components/politicians/__tests__/VotesSection.links.test.tsx
+++ b/src/components/politicians/__tests__/VotesSection.links.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { VotesSection } from "@/components/politicians/VotesSection";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// The @/components/votes barrel reaches src/lib/data/scrutins at import time,
+// which instantiates the Prisma client. Nothing here queries: stub it out so the
+// suite stays a pure render test with no DATABASE_URL.
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+// Minimal shape: only the "Derniers votes" branch is under test, so the stats /
+// parliamentary-card fields stay at their empty values.
+const voteData = (scrutin: { id: string; slug: string | null }) =>
+  ({
+    stats: { total: 1, pour: 1, contre: 0, abstention: 0 },
+    recentVotes: [
+      {
+        id: "vote-1",
+        position: "POUR",
+        scrutin: {
+          ...scrutin,
+          title: "Projet de loi de finances",
+          votingDate: new Date("2026-03-04"),
+          result: "ADOPTED",
+          policyTitle: null,
+        },
+      },
+    ],
+  }) as never;
+
+const renderSection = (scrutin: { id: string; slug: string | null }) =>
+  render(
+    <VotesSection
+      slug="jean-dupont"
+      voteData={voteData(scrutin)}
+      parliamentaryCard={null}
+      currentMandate={null}
+      currentGroup={null}
+    />
+  );
+
+describe("VotesSection : liens des derniers votes", () => {
+  it("pointe sur le slug du scrutin, pas sur le cuid qui ne fait que rediriger", () => {
+    const { container } = renderSection({
+      id: "cmr3vd86j010c04jp8dsdb49o",
+      slug: "2026-03-04-projet-de-loi-de-finances",
+    });
+
+    const hrefs = [...container.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("/parlement/votes/2026-03-04-projet-de-loi-de-finances");
+    expect(hrefs).not.toContain("/parlement/votes/cmr3vd86j010c04jp8dsdb49o");
+  });
+
+  it("retombe sur l'identifiant quand le scrutin n'a pas de slug", () => {
+    const { container } = renderSection({ id: "cmr3vd86j010c04jp8dsdb49o", slug: null });
+
+    const hrefs = [...container.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("/parlement/votes/cmr3vd86j010c04jp8dsdb49o");
+  });
+});

--- a/src/lib/cite.ts
+++ b/src/lib/cite.ts
@@ -16,5 +16,11 @@ export function buildAnchorUrl(anchorId: string): string {
   return `${SITE_URL}${pathname}${query}#${anchorId}`;
 }
 
-/** Absolute permalink to a scrutin detail page (used for recent-vote rows). */
-export const scrutinPermalink = (scrutinId: string) => `${SITE_URL}/parlement/votes/${scrutinId}`;
+/**
+ * Absolute permalink to a scrutin detail page (used for recent-vote rows).
+ * Pass the slug whenever there is one: `/parlement/votes/<cuid>` resolves only
+ * through a 308 to the slug URL, and a cited link should land on the canonical
+ * URL directly.
+ */
+export const scrutinPermalink = (scrutinSlugOrId: string) =>
+  `${SITE_URL}/parlement/votes/${scrutinSlugOrId}`;

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -11,6 +11,7 @@ import { communeRobotsMetadata, COMMUNE_MIN_POPULATION } from "../commune-robots
 import { hasActiveListingFilter, listingRobotsMetadata } from "../listing-robots";
 import { voteDateArchiveRobotsMetadata } from "../parliament-robots";
 import { OG_IMAGE_ROBOTS_SOURCE } from "../og-image-robots";
+import { API_NOINDEX_HEADERS, API_ROBOTS_SOURCE } from "../api-robots";
 import {
   AFFAIRES_LISTING_FILTER_KEYS,
   POLITIQUES_LISTING_FILTER_KEYS,
@@ -173,5 +174,56 @@ describe("doctrine — opengraph-image assets stay noindexed", () => {
   });
   it("leaves the parent page indexable", () => {
     expect(re.test("/parlement/votes/loi")).toBe(false);
+  });
+});
+
+describe("doctrine — /api endpoints stay noindexed", () => {
+  const require = createRequire(import.meta.url);
+  const { pathToRegexp } = require("next/dist/compiled/path-to-regexp") as {
+    pathToRegexp: (path: string, keys?: unknown[], opts?: Record<string, unknown>) => RegExp;
+  };
+  const re = pathToRegexp(API_ROBOTS_SOURCE, [], {
+    delimiter: "/",
+    sensitive: false,
+    strict: false,
+  });
+
+  it("tags every rule with X-Robots-Tag: noindex", () => {
+    expect(API_NOINDEX_HEADERS.length).toBeGreaterThan(0);
+    for (const rule of API_NOINDEX_HEADERS) {
+      expect(rule.headers).toContainEqual({ key: "X-Robots-Tag", value: "noindex" });
+    }
+  });
+
+  it.each(["/api/export/politiques", "/api/export/factchecks", "/api/docs", "/api/chat"])(
+    "noindexes API endpoint %s",
+    (path) => {
+      expect(re.test(path)).toBe(true);
+    }
+  );
+
+  // The human-readable API documentation is a real page and must stay indexable.
+  it.each(["/docs/api", "/statistiques"])("leaves real page %s indexable", (path) => {
+    expect(re.test(path)).toBe(false);
+  });
+});
+
+// The profile sub-tabs reuse the profile's own richness predicate, so a bare
+// RNE-imported mayor cannot leave two extra crawlable URLs behind. Guarded at
+// the source level: the pages must call politicianRobotsMetadata, not hardcode
+// their own rule.
+describe("doctrine — politician sub-tabs inherit the profile's indexability", () => {
+  it.each([
+    "src/app/politiques/[slug]/votes/page.tsx",
+    "src/app/politiques/[slug]/relations/page.tsx",
+  ])("%s applies politicianRobotsMetadata", (file) => {
+    const src = readFileSync(join(process.cwd(), file), "utf8");
+    expect(src).toContain("politicianRobotsMetadata");
+    expect(src).toContain("getPoliticianIndexSignals");
+  });
+
+  it("noindexes the sub-tabs of a bare mayor and leaves a député's indexable", () => {
+    expect(politicianRobotsMetadata(BARE_SMALL_MAYOR)).toEqual(NOINDEX_FOLLOW);
+    expect(politicianRobotsMetadata(RICH_DEPUTE)).toEqual(INDEXABLE);
   });
 });

--- a/src/lib/seo/api-robots.ts
+++ b/src/lib/seo/api-robots.ts
@@ -1,0 +1,30 @@
+/**
+ * Route Handlers under /api are machine endpoints: JSON payloads, CSV exports,
+ * the OpenAPI schema. They are linked from the site (the /docs/api page shows
+ * copy-pastable export URLs), so crawlers follow them and Search Console files
+ * them under "Explorée, actuellement non indexée" — /api/export/politiques and
+ * /api/export/factchecks?limit=10000 both show up in the 2026-07 Coverage
+ * drilldown.
+ *
+ * `X-Robots-Tag: noindex` is the right tool rather than a robots.txt Disallow:
+ * the endpoints must stay fetchable (they are the public data API) while never
+ * competing with a real page in the index.
+ *
+ * The human-readable API documentation lives at /docs/api, outside this prefix,
+ * and stays indexable.
+ */
+
+// Structural subset of Next's custom-route Header type, mirroring og-image-robots.
+type NextHeaderRule = {
+  source: string;
+  headers: Array<{ key: string; value: string }>;
+};
+
+export const API_ROBOTS_SOURCE = "/api/:path*";
+
+export const API_NOINDEX_HEADERS: NextHeaderRule[] = [
+  {
+    source: API_ROBOTS_SOURCE,
+    headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+  },
+];

--- a/src/lib/seo/politician-index-signals.ts
+++ b/src/lib/seo/politician-index-signals.ts
@@ -1,0 +1,57 @@
+import { cache } from "react";
+import { cacheTag, cacheLife } from "next/cache";
+import { db } from "@/lib/db";
+import type { PoliticianIndexSignals } from "./politician-robots";
+
+/**
+ * Loads just the index-richness signals of a politician, for the profile
+ * sub-tabs (/politiques/[slug]/votes, /politiques/[slug]/relations).
+ *
+ * The profile itself already derives these from the full `getPolitician()`
+ * payload, but the sub-tabs only query what they render, so they had no way to
+ * apply `politicianRobotsMetadata()` and stayed indexable for *every* slug —
+ * including the ~34k RNE-imported mayors whose bare profile is already
+ * noindexed. Two extra crawlable URLs per bare profile is the same index bloat
+ * as issue #385, one level down.
+ *
+ * `take: 1` on the relations is deliberate: `isIndexablePolitician()` only ever
+ * tests these counts for `> 0`, so a single row answers the question and the
+ * query stays cheap on politicians with hundreds of votes or declarations.
+ */
+export const getPoliticianIndexSignals = cache(async function getPoliticianIndexSignals(
+  slug: string
+): Promise<PoliticianIndexSignals | null> {
+  "use cache";
+  cacheTag(`politician:${slug}`, "politicians");
+  cacheLife("synced");
+
+  const politician = await db.politician.findUnique({
+    where: { slug },
+    select: {
+      biography: true,
+      mandates: {
+        select: {
+          type: true,
+          // Commune population feeds the MAIRE branch of the richness predicate.
+          localData: { select: { commune: { select: { population: true } } } },
+        },
+      },
+      affairs: { where: { publicationStatus: "PUBLISHED" }, select: { id: true }, take: 1 },
+      factCheckMentions: { select: { id: true }, take: 1 },
+      declarations: { select: { id: true }, take: 1 },
+    },
+  });
+
+  if (!politician) return null;
+
+  return {
+    mandates: politician.mandates.map((m) => ({
+      type: m.type,
+      communePopulation: m.localData?.commune?.population ?? null,
+    })),
+    publishedAffairsCount: politician.affairs.length,
+    factCheckMentionsCount: politician.factCheckMentions.length,
+    declarationsCount: politician.declarations.length,
+    biography: politician.biography,
+  };
+});


### PR DESCRIPTION
## Contexte

Relevé Search Console au 2026-07-10 : le seau « Explorée, actuellement non indexée » gonfle pendant que l'index recule. En dehors des `/opengraph-image` (déjà traités par `X-Robots-Tag` le 2026-07-25), le reste du bloat vient de surfaces qui n'ont pas de contenu à elles. Ce lot les retire de l'index sans casser leur accès.

## Changements

- **Onglets `/politiques/[slug]/votes` et `/relations`** : ils restaient indexables pour tous les slugs, y compris les ~34k maires RNE dont la fiche est déjà `noindex` (#385), soit deux URL explorables de plus par profil vide. Ils réutilisent désormais le même prédicat de richesse que la fiche, via un chargeur de signaux dédié et bon marché (`getPoliticianIndexSignals`). Les filtres du chargeur reproduisent exactement ceux de la fiche (affaires `PUBLISHED`, mandats, bio, factchecks, déclarations), donc les deux surfaces rendent le même verdict.
- **Liens « Derniers votes »** : ils pointaient sur le cuid du scrutin, qui n'existe que sous forme de `308` vers le slug. Tout un profil de liens internes vers des redirections. Ils visent maintenant l'URL canonique, avec repli sur l'id quand le scrutin n'a pas de slug.
- **Endpoints `/api`** : explorés et classés comme des pages dans la Coverage. `X-Robots-Tag: noindex` (pas de `Disallow` robots.txt, l'API publique doit rester récupérable). La doc lisible `/docs/api` reste indexable.
- **`/parlement/votes/stats`** : `308` au lieu de `307`, le déplacement vers `/statistiques` est définitif et doit consolider l'ancienne URL.

## Tests

- `src/lib/seo/__tests__/indexation-doctrine.test.ts` : couvre le `noindex` des `/api`, l'indexabilité de `/docs/api`, et un garde au niveau source qui exige que les sous-onglets appellent bien `politicianRobotsMetadata` + `getPoliticianIndexSignals`.
- `src/components/politicians/__tests__/VotesSection.links.test.tsx` : les liens des derniers votes pointent sur le slug, avec repli sur l'id.

## Suite

Mettre à jour la doctrine `AGENTS.md §5` (règle `/api` + héritage des sous-onglets) pour garder la couche lisible à jour.
