### PR TITLE
feat(votes): mini-barre d'adoption sur la page thèmes

### DIFF
--- a/src/app/parlement/votes/themes/page.tsx
+++ b/src/app/parlement/votes/themes/page.tsx
@@ -90,6 +90,19 @@ export default async function ThemesListingPage() {
                     <span>{total.toLocaleString("fr-FR")} scrutins</span>
                     <span className="text-green-600 font-medium">{adoptedPercent}% adoptés</span>
                   </div>
+                  <div
+                    className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+                    role="progressbar"
+                    aria-valuenow={adoptedPercent}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`Taux d'adoption : ${adoptedPercent}%`}
+                  >
+                    <div
+                      className="h-full rounded-full bg-green-600 dark:bg-green-500"
+                      style={{ width: `${adoptedPercent}%` }}
+                    />
+                  </div>
                 </CardContent>
               </Card>
             </Link>


### PR DESCRIPTION
Dernière brique de la refonte #484, après la barre de filtres (#591). La carte de scrutin suivra.

## Contexte

La page `/parlement/votes/themes` affichait déjà, pour chaque thématique, le volume de scrutins et le taux d'adoption en toutes lettres (« Y% adoptés »). Il manquait la lecture visuelle de ce taux.

## Changement

Une mini-barre d'adoption sous la ligne « X scrutins · Y% adoptés » de chaque carte : piste `bg-muted`, remplissage vert dont la largeur suit le pourcentage.

## Accessibilité

- Piste en `role="progressbar"` avec `aria-valuenow/valuemin/valuemax` et un `aria-label` explicite.
- Le pourcentage en texte reste affiché : l'information n'est jamais portée par la seule barre colorée.
- Aucune animation de largeur (respect de `prefers-reduced-motion`).
- Pleine largeur de la carte, pas de débordement ; contraste vérifié en thème clair et sombre.

## Vérification

`tsc` (cache non incrémental) propre, ESLint et Prettier propres. Page toujours en `revalidate=3600`.

Part of #484.
