### PR TITLE
feat(votes): refonte de la carte de scrutin (marge, seuil de majorité, positions de groupes)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,6 +85,9 @@
   --sidebar-accent-foreground: oklch(0.25 0.05 250);
   --sidebar-border: oklch(0.87 0 0);
   --sidebar-ring: oklch(0.25 0.06 255);
+  --vote-pour: #4a8a5c;
+  --vote-contre: #9e5454;
+  --vote-abstention: #8a8e96;
 }
 
 .dark {
@@ -121,6 +124,9 @@
   --sidebar-accent-foreground: oklch(0.85 0.02 250);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.65 0.1 250);
+  --vote-pour: #7ab892;
+  --vote-contre: #c88a8a;
+  --vote-abstention: #6a6e78;
 }
 
 @layer base {

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -12,6 +12,7 @@ import {
   getTypeCounts,
   type ScrutinSort,
 } from "@/lib/data/scrutins";
+import { getScrutinGroupPositionsBatch } from "@/lib/data/groupes";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import type { VotingResult, Chamber, ThemeCategory, ScrutinType } from "@/types";
@@ -70,6 +71,10 @@ export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsLi
       getThemeCounts(),
       getTypeCounts(),
     ]);
+
+  // Group positions for the whole page in ONE batched query (anti-N+1), keyed by
+  // scrutin id. getScrutins stays untouched; this is the only extra query per page.
+  const positionsByScrutin = await getScrutinGroupPositionsBatch(scrutins.map((s) => s.id));
 
   const buildUrl = (newParams: Record<string, string | undefined>) => {
     const current = new URLSearchParams();
@@ -224,6 +229,7 @@ export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsLi
                 type={scrutin.type}
                 dossier={scrutin.dossierLegislatif}
                 policy={scrutin.policyTitle}
+                groupPositions={positionsByScrutin.get(scrutin.id) ?? []}
               />
             ))}
           </div>

--- a/src/components/votes/CardGroupPositions.tsx
+++ b/src/components/votes/CardGroupPositions.tsx
@@ -15,6 +15,12 @@ const HEADER_DOT_VAR: Record<GroupPosition, string> = {
   ABSTENTION: "var(--vote-abstention)",
 };
 
+const COLUMN_ARIA_LABEL: Record<GroupPosition, string> = {
+  POUR: "Groupes ayant voté pour",
+  CONTRE: "Groupes ayant voté contre",
+  ABSTENTION: "Groupes s'étant abstenus",
+};
+
 function MiniPill({ gp }: { gp: ScrutinGroupPositionData }) {
   const color = gp.group.color ?? getPartyColor(gp.group.code);
   return (
@@ -51,11 +57,7 @@ function PositionColumn({
           {GROUP_POSITION_LABELS[pos]}
         </span>
       </div>
-      <div
-        className="flex flex-wrap gap-1"
-        role="list"
-        aria-label={`Groupes ayant voté ${GROUP_POSITION_LABELS[pos].toLowerCase()}`}
-      >
+      <div className="flex flex-wrap gap-1" role="list" aria-label={COLUMN_ARIA_LABEL[pos]}>
         {groups.map((gp) => (
           <div key={gp.id} role="listitem">
             <MiniPill gp={gp} />

--- a/src/components/votes/CardGroupPositions.tsx
+++ b/src/components/votes/CardGroupPositions.tsx
@@ -1,0 +1,98 @@
+import { GROUP_POSITION_LABELS } from "@/config/labels";
+import { getPartyColor } from "@/config/party-colors";
+import type { ScrutinGroupPositionData } from "@/lib/data/groupes";
+import type { GroupPosition } from "@/types";
+
+interface CardGroupPositionsProps {
+  positions: ScrutinGroupPositionData[];
+}
+
+const POSITION_ORDER: GroupPosition[] = ["POUR", "CONTRE", "ABSTENTION"];
+
+const HEADER_DOT_VAR: Record<GroupPosition, string> = {
+  POUR: "var(--vote-pour)",
+  CONTRE: "var(--vote-contre)",
+  ABSTENTION: "var(--vote-abstention)",
+};
+
+function MiniPill({ gp }: { gp: ScrutinGroupPositionData }) {
+  const color = gp.group.color ?? getPartyColor(gp.group.code);
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border bg-card text-xs"
+      title={`${gp.group.name} (${Math.round(gp.cohesionPct)}% de cohésion)`}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="font-medium">{gp.group.shortName || gp.group.code}</span>
+    </span>
+  );
+}
+
+function PositionColumn({
+  pos,
+  groups,
+}: {
+  pos: GroupPosition;
+  groups: ScrutinGroupPositionData[];
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-1">
+        <span
+          className="w-1.5 h-1.5 rounded-full shrink-0"
+          style={{ backgroundColor: HEADER_DOT_VAR[pos] }}
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          {GROUP_POSITION_LABELS[pos]}
+        </span>
+      </div>
+      <div
+        className="flex flex-wrap gap-1"
+        role="list"
+        aria-label={`Groupes ayant voté ${GROUP_POSITION_LABELS[pos].toLowerCase()}`}
+      >
+        {groups.map((gp) => (
+          <div key={gp.id} role="listitem">
+            <MiniPill gp={gp} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CardGroupPositions({ positions }: CardGroupPositionsProps) {
+  if (positions.length === 0) return null;
+
+  const byPosition = new Map<GroupPosition, ScrutinGroupPositionData[]>();
+  for (const pos of POSITION_ORDER) {
+    byPosition.set(
+      pos,
+      positions.filter((gp) => gp.position === pos)
+    );
+  }
+  const nonEmpty = POSITION_ORDER.filter((pos) => (byPosition.get(pos) ?? []).length > 0);
+
+  return (
+    <div>
+      {/* Desktop: 3 columns, empty columns omitted */}
+      <div className="hidden md:grid md:grid-cols-3 gap-3">
+        {nonEmpty.map((pos) => (
+          <PositionColumn key={pos} pos={pos} groups={byPosition.get(pos) ?? []} />
+        ))}
+      </div>
+
+      {/* Mobile: stacked */}
+      <div className="md:hidden space-y-2">
+        {nonEmpty.map((pos) => (
+          <PositionColumn key={pos} pos={pos} groups={byPosition.get(pos) ?? []} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -96,6 +96,16 @@ export function VoteCard({
   const total = votesFor + votesAgainst + votesAbstain;
   const margin = formatVoteMargin(votesFor, votesAgainst);
   const marginLabelBase = margin.isClose ? margin.label.replace(" · vote serré", "") : margin.label;
+  // Motions (censure/rejet/renvoi) follow an absolute-majority rule and record only
+  // "pour" votes, so the simple pour-vs-contre majority bar does not apply to them.
+  const isMotion = type === "MOTION";
+  // Safety net: never claim a simple majority when the pour/contre reading would
+  // contradict the official result (e.g. a qualified-majority vote passing or failing
+  // against the raw count). In that case we drop the 50% marker and the margin label.
+  const majorityContradicts =
+    (result === "REJECTED" && votesFor > votesAgainst) ||
+    (result === "ADOPTED" && votesFor < votesAgainst);
+  const showMajorityFraming = !isMotion && !majorityContradicts;
   const metaLine = [
     formatDate(new Date(votingDate)),
     ...(compact ? [] : [`${total} votants`]),
@@ -179,57 +189,73 @@ export function VoteCard({
 
         {!compact && (
           <>
-            {/* Suffrage bar: pour vs contre, relative to expressed votes, with
-                a 50% majority marker. Abstention is shown separately below. */}
-            <div className="space-y-1.5">
-              {margin.hasExpressed ? (
-                <>
-                  <div className="relative flex h-2 rounded-full overflow-hidden bg-muted">
-                    <div
-                      className="transition-all"
-                      style={{ width: `${margin.forPercent}%`, background: "var(--vote-pour)" }}
-                      title={`Pour: ${votesFor}`}
-                    />
-                    <div
-                      className="transition-all"
-                      style={{
-                        width: `${margin.againstPercent}%`,
-                        background: "var(--vote-contre)",
-                      }}
-                      title={`Contre: ${votesAgainst}`}
-                    />
-                    <span
-                      className="absolute left-1/2 top-0 bottom-0 w-px bg-foreground"
-                      aria-hidden="true"
-                    />
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs">
-                    <span className="flex items-center gap-3 text-muted-foreground">
-                      <span>Pour: {votesFor}</span>
-                      <span>Contre: {votesAgainst}</span>
-                    </span>
-                    <span className="font-medium">
-                      {marginLabelBase}
-                      {margin.isClose && (
-                        <Badge variant="outline" className="ml-1.5 align-middle text-xs">
-                          vote serré
-                        </Badge>
-                      )}
-                    </span>
-                  </div>
-                </>
-              ) : (
-                <p className="text-xs text-muted-foreground">{margin.label}</p>
-              )}
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <span
-                  className="h-2 w-2 shrink-0 rounded-full"
-                  style={{ background: "var(--vote-abstention)" }}
-                  aria-hidden="true"
-                />
-                <span>Abstention: {votesAbstain}</span>
+            {isMotion ? (
+              /* Motion: absolute-majority rule, only "pour" votes recorded. No
+                 simple-majority bar; the result badge above carries the outcome. */
+              <div className="space-y-1 text-xs">
+                <p className="font-medium">{votesFor} voix pour</p>
+                <p className="text-muted-foreground">
+                  Adoption à la majorité absolue des membres ; seuls les votes pour sont décomptés.
+                </p>
               </div>
-            </div>
+            ) : (
+              /* Suffrage bar: pour vs contre, relative to expressed votes. The 50%
+                 majority marker and margin label appear only when the pour/contre
+                 reading agrees with the official result. Abstention shown separately. */
+              <div className="space-y-1.5">
+                {margin.hasExpressed ? (
+                  <>
+                    <div className="relative flex h-2 rounded-full overflow-hidden bg-muted">
+                      <div
+                        className="transition-all"
+                        style={{ width: `${margin.forPercent}%`, background: "var(--vote-pour)" }}
+                        title={`Pour: ${votesFor}`}
+                      />
+                      <div
+                        className="transition-all"
+                        style={{
+                          width: `${margin.againstPercent}%`,
+                          background: "var(--vote-contre)",
+                        }}
+                        title={`Contre: ${votesAgainst}`}
+                      />
+                      {showMajorityFraming && (
+                        <span
+                          className="absolute left-1/2 top-0 bottom-0 w-px bg-foreground"
+                          aria-hidden="true"
+                        />
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs">
+                      <span className="flex items-center gap-3 text-muted-foreground">
+                        <span>Pour: {votesFor}</span>
+                        <span>Contre: {votesAgainst}</span>
+                      </span>
+                      {showMajorityFraming && (
+                        <span className="font-medium">
+                          {marginLabelBase}
+                          {margin.isClose && (
+                            <Badge variant="outline" className="ml-1.5 align-middle text-xs">
+                              vote serré
+                            </Badge>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-xs text-muted-foreground">{margin.label}</p>
+                )}
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ background: "var(--vote-abstention)" }}
+                    aria-hidden="true"
+                  />
+                  <span>Abstention: {votesAbstain}</span>
+                </div>
+              </div>
+            )}
             {groupPositions && groupPositions.length > 0 && (
               <div className="mt-3">
                 <CardGroupPositions positions={groupPositions} />

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { VotingResultBadge } from "./VoteBadge";
+import { CardGroupPositions } from "./CardGroupPositions";
 import {
   toPublicTitleView,
   displayTitleOf,
@@ -9,6 +10,8 @@ import {
 } from "@/lib/votes/to-public-title-view";
 import { formatDate } from "@/lib/utils";
 import { formatLegislature } from "@/lib/votes/legislature";
+import { formatVoteMargin } from "@/lib/votes/vote-margin";
+import type { ScrutinGroupPositionData } from "@/lib/data/groupes";
 import type { VotingResult, Chamber, ThemeCategory, ScrutinType } from "@/types";
 import {
   CHAMBER_SHORT_LABELS,
@@ -18,7 +21,7 @@ import {
   SCRUTIN_TYPE_LABELS,
   SCRUTIN_TYPE_COLORS,
 } from "@/config/labels";
-import { Calendar, Users, ExternalLink, Building2, FileText } from "lucide-react";
+import { ExternalLink, Building2, FileText } from "lucide-react";
 
 interface VoteCardProps {
   id: string;
@@ -40,6 +43,9 @@ interface VoteCardProps {
   /** Plan 6: the joined policy-title row. When APPROVED + valid, the card shows
    *  the policy title + "Titre explicatif" badge; otherwise the official title. */
   policy?: PolicyForView | null;
+  /** Group positions for this scrutin (batch-loaded by the listing). Rendered
+   *  below the suffrage bar in non-compact mode; omitted entirely when empty. */
+  groupPositions?: ScrutinGroupPositionData[];
   compact?: boolean;
 }
 
@@ -69,6 +75,7 @@ export function VoteCard({
   type,
   dossier,
   policy,
+  groupPositions,
   compact = false,
 }: VoteCardProps) {
   // Use slug for URL if available, fallback to id
@@ -87,9 +94,13 @@ export function VoteCard({
   const isPolicy = view.mode === "policy";
   const scrutinNumber = extractScrutinNumber(externalId);
   const total = votesFor + votesAgainst + votesAbstain;
-  const forPercent = total > 0 ? (votesFor / total) * 100 : 0;
-  const againstPercent = total > 0 ? (votesAgainst / total) * 100 : 0;
-  const abstainPercent = total > 0 ? (votesAbstain / total) * 100 : 0;
+  const margin = formatVoteMargin(votesFor, votesAgainst);
+  const marginLabelBase = margin.isClose ? margin.label.replace(" · vote serré", "") : margin.label;
+  const metaLine = [
+    formatDate(new Date(votingDate)),
+    ...(compact ? [] : [`${total} votants`]),
+    formatLegislature(legislature),
+  ].join(" · ");
 
   return (
     <Card className="hover:shadow-md transition-shadow">
@@ -136,18 +147,8 @@ export function VoteCard({
                   {THEME_CATEGORY_ICONS[theme]} {THEME_CATEGORY_LABELS[theme]}
                 </span>
               )}
-              <span className="flex items-center gap-1">
-                <Calendar className="h-3 w-3" />
-                {formatDate(new Date(votingDate))}
-              </span>
-              {!compact && (
-                <span className="flex items-center gap-1">
-                  <Users className="h-3 w-3" />
-                  {total} votants
-                </span>
-              )}
-              <span className="text-muted-foreground">{formatLegislature(legislature)}</span>
             </div>
+            <p className="mt-1 text-xs text-muted-foreground">{metaLine}</p>
             {dossier?.slug && (
               <Link
                 href={`/parlement/dossiers/${dossier.slug}`}
@@ -178,31 +179,62 @@ export function VoteCard({
 
         {!compact && (
           <>
-            {/* Vote bar */}
-            <div className="space-y-1">
-              <div className="flex h-2 rounded-full overflow-hidden bg-gray-100">
-                <div
-                  className="bg-green-500 transition-all"
-                  style={{ width: `${forPercent}%` }}
-                  title={`Pour: ${votesFor}`}
+            {/* Suffrage bar: pour vs contre, relative to expressed votes, with
+                a 50% majority marker. Abstention is shown separately below. */}
+            <div className="space-y-1.5">
+              {margin.hasExpressed ? (
+                <>
+                  <div className="relative flex h-2 rounded-full overflow-hidden bg-muted">
+                    <div
+                      className="transition-all"
+                      style={{ width: `${margin.forPercent}%`, background: "var(--vote-pour)" }}
+                      title={`Pour: ${votesFor}`}
+                    />
+                    <div
+                      className="transition-all"
+                      style={{
+                        width: `${margin.againstPercent}%`,
+                        background: "var(--vote-contre)",
+                      }}
+                      title={`Contre: ${votesAgainst}`}
+                    />
+                    <span
+                      className="absolute left-1/2 top-0 bottom-0 w-px bg-foreground"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs">
+                    <span className="flex items-center gap-3 text-muted-foreground">
+                      <span>Pour: {votesFor}</span>
+                      <span>Contre: {votesAgainst}</span>
+                    </span>
+                    <span className="font-medium">
+                      {marginLabelBase}
+                      {margin.isClose && (
+                        <Badge variant="outline" className="ml-1.5 align-middle text-xs">
+                          vote serré
+                        </Badge>
+                      )}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <p className="text-xs text-muted-foreground">{margin.label}</p>
+              )}
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ background: "var(--vote-abstention)" }}
+                  aria-hidden="true"
                 />
-                <div
-                  className="bg-red-500 transition-all"
-                  style={{ width: `${againstPercent}%` }}
-                  title={`Contre: ${votesAgainst}`}
-                />
-                <div
-                  className="bg-yellow-500 transition-all"
-                  style={{ width: `${abstainPercent}%` }}
-                  title={`Abstention: ${votesAbstain}`}
-                />
-              </div>
-              <div className="flex justify-between text-xs text-muted-foreground">
-                <span className="text-green-600">Pour: {votesFor}</span>
-                <span className="text-red-600">Contre: {votesAgainst}</span>
-                <span className="text-yellow-600">Abstention: {votesAbstain}</span>
+                <span>Abstention: {votesAbstain}</span>
               </div>
             </div>
+            {groupPositions && groupPositions.length > 0 && (
+              <div className="mt-3">
+                <CardGroupPositions positions={groupPositions} />
+              </div>
+            )}
           </>
         )}
       </CardContent>

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -96,16 +96,18 @@ export function VoteCard({
   const total = votesFor + votesAgainst + votesAbstain;
   const margin = formatVoteMargin(votesFor, votesAgainst);
   const marginLabelBase = margin.isClose ? margin.label.replace(" · vote serré", "") : margin.label;
-  // Motions (censure/rejet/renvoi) follow an absolute-majority rule and record only
-  // "pour" votes, so the simple pour-vs-contre majority bar does not apply to them.
-  const isMotion = type === "MOTION";
+  // A motion de censure records only "pour" votes and passes by absolute majority of
+  // members, so the pour-vs-contre bar does not apply. Other motions (rejet préalable,
+  // renvoi) are ordinary simple-majority ballots with "contre" recorded and keep the
+  // normal bar; the data signal for a censure is votesAgainst === 0.
+  const isCensureStyle = type === "MOTION" && votesAgainst === 0;
   // Safety net: never claim a simple majority when the pour/contre reading would
   // contradict the official result (e.g. a qualified-majority vote passing or failing
   // against the raw count). In that case we drop the 50% marker and the margin label.
   const majorityContradicts =
     (result === "REJECTED" && votesFor > votesAgainst) ||
     (result === "ADOPTED" && votesFor < votesAgainst);
-  const showMajorityFraming = !isMotion && !majorityContradicts;
+  const showMajorityFraming = !isCensureStyle && !majorityContradicts;
   const metaLine = [
     formatDate(new Date(votingDate)),
     ...(compact ? [] : [`${total} votants`]),
@@ -189,9 +191,9 @@ export function VoteCard({
 
         {!compact && (
           <>
-            {isMotion ? (
-              /* Motion: absolute-majority rule, only "pour" votes recorded. No
-                 simple-majority bar; the result badge above carries the outcome. */
+            {isCensureStyle ? (
+              /* Motion de censure: absolute-majority rule, only "pour" votes recorded.
+                 No simple-majority bar; the result badge above carries the outcome. */
               <div className="space-y-1 text-xs">
                 <p className="font-medium">{votesFor} voix pour</p>
                 <p className="text-muted-foreground">

--- a/src/components/votes/__tests__/CardGroupPositions.test.tsx
+++ b/src/components/votes/__tests__/CardGroupPositions.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CardGroupPositions } from "../CardGroupPositions";
+import type { ScrutinGroupPositionData } from "@/lib/data/groupes";
+
+const gp = (
+  id: string,
+  position: "POUR" | "CONTRE" | "ABSTENTION",
+  code: string
+): ScrutinGroupPositionData => ({
+  id,
+  position,
+  forCount: 1,
+  againstCount: 0,
+  abstainCount: 0,
+  cohesionPct: 90,
+  group: {
+    id: "g" + id,
+    code,
+    name: code + " nom",
+    shortName: code,
+    color: "#123456",
+    slug: code.toLowerCase(),
+  },
+});
+
+describe("CardGroupPositions", () => {
+  it("rend le sigle des groupes (info en texte, pas seulement couleur)", () => {
+    render(<CardGroupPositions positions={[gp("1", "POUR", "RE"), gp("2", "CONTRE", "RN")]} />);
+    expect(screen.getAllByText("RE").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("RN").length).toBeGreaterThan(0);
+  });
+
+  it("expose des colonnes de position accessibles", () => {
+    render(<CardGroupPositions positions={[gp("1", "POUR", "RE")]} />);
+    expect(screen.getAllByRole("list", { name: /pour/i }).length).toBeGreaterThan(0);
+  });
+
+  it("rien si aucune position", () => {
+    const { container } = render(<CardGroupPositions positions={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/votes/__tests__/VoteCard.test.tsx
+++ b/src/components/votes/__tests__/VoteCard.test.tsx
@@ -88,4 +88,39 @@ describe("VoteCard", () => {
     render(<VoteCard {...base} compact groupPositions={[groupPosition("1", "POUR", "RE")]} />);
     expect(screen.queryByText("RE")).not.toBeInTheDocument();
   });
+
+  it("motion de censure : pas de cadrage majorité simple, voix pour + note de règle", () => {
+    render(
+      <VoteCard
+        {...base}
+        type="MOTION"
+        votesFor={239}
+        votesAgainst={0}
+        votesAbstain={0}
+        result="REJECTED"
+      />
+    );
+    expect(screen.queryByText(/majorité \+/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/vote serré/)).not.toBeInTheDocument();
+    expect(screen.getByText(/239 voix pour/)).toBeInTheDocument();
+    expect(screen.getByText(/majorité absolue des membres/)).toBeInTheDocument();
+  });
+
+  it("garde-fou : pour > contre mais rejeté (hors motion) masque le libellé de majorité", () => {
+    render(
+      <VoteCard
+        {...base}
+        type="ARTICLE"
+        votesFor={100}
+        votesAgainst={50}
+        votesAbstain={0}
+        result="REJECTED"
+      />
+    );
+    expect(screen.queryByText(/majorité \+/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/vote serré/)).not.toBeInTheDocument();
+    // Les comptes bruts restent affichés, sans revendication de majorité.
+    expect(screen.getByText(/Pour: 100/)).toBeInTheDocument();
+    expect(screen.getByText(/Contre: 50/)).toBeInTheDocument();
+  });
 });

--- a/src/components/votes/__tests__/VoteCard.test.tsx
+++ b/src/components/votes/__tests__/VoteCard.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { VoteCard } from "../VoteCard";
+import type { ScrutinGroupPositionData } from "@/lib/data/groupes";
+
+const base = {
+  id: "1",
+  externalId: "V123",
+  slug: "s",
+  title: "Titre",
+  votingDate: new Date("2024-03-12"),
+  legislature: 17,
+  chamber: "AN" as const,
+  votesFor: 100,
+  votesAgainst: 96,
+  votesAbstain: 12,
+  result: "ADOPTED" as const,
+};
+
+function groupPosition(
+  id: string,
+  position: "POUR" | "CONTRE" | "ABSTENTION",
+  code: string
+): ScrutinGroupPositionData {
+  return {
+    id,
+    position,
+    forCount: 1,
+    againstCount: 0,
+    abstainCount: 0,
+    cohesionPct: 90,
+    group: {
+      id: `g${id}`,
+      code,
+      name: `${code} nom`,
+      shortName: code,
+      color: "#123456",
+      slug: code.toLowerCase(),
+    },
+  };
+}
+
+describe("VoteCard", () => {
+  it("affiche le libellé de marge (vote serré)", () => {
+    render(<VoteCard {...base} />);
+    expect(screen.getByText(/vote serré/)).toBeInTheDocument();
+    expect(screen.getByText(/majorité \+4/)).toBeInTheDocument();
+  });
+
+  it("affiche l'abstention séparément de la barre", () => {
+    render(<VoteCard {...base} />);
+    expect(screen.getByText(/Abstention: 12/)).toBeInTheDocument();
+  });
+
+  it("conserve les comptes Pour et Contre en texte", () => {
+    render(<VoteCard {...base} />);
+    expect(screen.getByText(/Pour: 100/)).toBeInTheDocument();
+    expect(screen.getByText(/Contre: 96/)).toBeInTheDocument();
+  });
+
+  it("aucun suffrage exprimé : pas de barre, libellé dédié", () => {
+    render(<VoteCard {...base} votesFor={0} votesAgainst={0} votesAbstain={0} />);
+    expect(screen.getByText(/Aucun suffrage exprimé/)).toBeInTheDocument();
+  });
+
+  it("regroupe date, votants et législature en une ligne calme", () => {
+    render(<VoteCard {...base} />);
+    expect(screen.getByText(/12 mars 2024 · 208 votants · 17ᵉ législature/)).toBeInTheDocument();
+  });
+
+  it("mode compact : pas de barre de suffrages", () => {
+    render(<VoteCard {...base} compact />);
+    expect(screen.queryByText(/vote serré/)).not.toBeInTheDocument();
+  });
+
+  it("affiche les positions de groupes quand fournies", () => {
+    render(
+      <VoteCard
+        {...base}
+        groupPositions={[groupPosition("1", "POUR", "RE"), groupPosition("2", "CONTRE", "RN")]}
+      />
+    );
+    expect(screen.getAllByText("RE").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("RN").length).toBeGreaterThan(0);
+  });
+
+  it("mode compact : pas de positions de groupes", () => {
+    render(<VoteCard {...base} compact groupPositions={[groupPosition("1", "POUR", "RE")]} />);
+    expect(screen.queryByText("RE")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/votes/__tests__/VoteCard.test.tsx
+++ b/src/components/votes/__tests__/VoteCard.test.tsx
@@ -106,6 +106,23 @@ describe("VoteCard", () => {
     expect(screen.getByText(/majorité absolue des membres/)).toBeInTheDocument();
   });
 
+  it("motion ordinaire (contre > 0) : barre normale, contre visible, pas de note de censure", () => {
+    render(
+      <VoteCard
+        {...base}
+        type="MOTION"
+        votesFor={174}
+        votesAgainst={192}
+        votesAbstain={0}
+        result="REJECTED"
+      />
+    );
+    // Motion de rejet préalable : scrutin ordinaire à la majorité simple.
+    expect(screen.queryByText(/majorité absolue des membres/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Contre: 192/)).toBeInTheDocument();
+    expect(screen.getByText(/manque 18 voix/)).toBeInTheDocument();
+  });
+
   it("garde-fou : pour > contre mais rejeté (hors motion) masque le libellé de majorité", () => {
     render(
       <VoteCard

--- a/src/lib/data/__tests__/group-positions-batch.test.ts
+++ b/src/lib/data/__tests__/group-positions-batch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+
+// groupes.ts imports @/lib/db at module load; this pure helper test needs no DB.
+// Mock it file-scoped (never load real .env globally — that would run describeIfDb
+// integration tests against the production database).
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { groupPositionsByScrutinId } from "../groupes";
+
+const row = (scrutinId: string, id: string) => ({
+  scrutinId,
+  id,
+  position: "POUR" as const,
+  forCount: 1,
+  againstCount: 0,
+  abstainCount: 0,
+  cohesionPct: 100,
+  group: {
+    id: "g" + id,
+    code: "RE",
+    name: "Renaissance",
+    shortName: "RE",
+    color: "#FFD966",
+    slug: "re",
+  },
+});
+
+describe("groupPositionsByScrutinId", () => {
+  it("regroupe par scrutinId", () => {
+    const m = groupPositionsByScrutinId([row("s1", "a"), row("s1", "b"), row("s2", "c")]);
+    expect(m.get("s1")).toHaveLength(2);
+    expect(m.get("s2")).toHaveLength(1);
+  });
+  it("id absent → clé absente", () => {
+    const m = groupPositionsByScrutinId([row("s1", "a")]);
+    expect(m.has("s2")).toBe(false);
+  });
+  it("liste vide → map vide", () => {
+    expect(groupPositionsByScrutinId([]).size).toBe(0);
+  });
+});

--- a/src/lib/data/__tests__/group-positions-batch.test.ts
+++ b/src/lib/data/__tests__/group-positions-batch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 
 // groupes.ts imports @/lib/db at module load; this pure helper test needs no DB.
-// Mock it file-scoped (never load real .env globally — that would run describeIfDb
+// Mock it file-scoped (never load real .env globally, which would run describeIfDb
 // integration tests against the production database).
 vi.mock("@/lib/db", () => ({ db: {} }));
 

--- a/src/lib/data/groupes.ts
+++ b/src/lib/data/groupes.ts
@@ -44,6 +44,47 @@ export async function getScrutinGroupPositions(
   });
 }
 
+export function groupPositionsByScrutinId(
+  rows: (ScrutinGroupPositionData & { scrutinId: string })[]
+): Map<string, ScrutinGroupPositionData[]> {
+  const map = new Map<string, ScrutinGroupPositionData[]>();
+  for (const row of rows) {
+    const { scrutinId, ...rest } = row;
+    const bucket = map.get(scrutinId);
+    if (bucket) bucket.push(rest);
+    else map.set(scrutinId, [rest]);
+  }
+  return map;
+}
+
+export async function getScrutinGroupPositionsBatch(
+  scrutinIds: string[]
+): Promise<Map<string, ScrutinGroupPositionData[]>> {
+  "use cache";
+  cacheTag("votes");
+  cacheLife("synced");
+
+  if (scrutinIds.length === 0) return new Map();
+
+  const rows = await db.scrutinGroupPosition.findMany({
+    where: { scrutinId: { in: scrutinIds } },
+    include: {
+      group: {
+        select: {
+          id: true,
+          code: true,
+          name: true,
+          shortName: true,
+          color: true,
+          slug: true,
+        },
+      },
+    },
+    orderBy: [{ position: "asc" }, { forCount: "desc" }],
+  });
+  return groupPositionsByScrutinId(rows);
+}
+
 export interface ScrutinAnalysisData {
   argumentsFor: string;
   argumentsAgainst: string;

--- a/src/lib/votes/__tests__/vote-margin.test.ts
+++ b/src/lib/votes/__tests__/vote-margin.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { formatVoteMargin } from "../vote-margin";
+
+describe("formatVoteMargin", () => {
+  it("majorité large", () => {
+    const r = formatVoteMargin(400, 29);
+    expect(r.label).toBe("majorité +371");
+    expect(r.isClose).toBe(false);
+    expect(r.hasExpressed).toBe(true);
+  });
+  it("vote serré adopté (|marge| <= 10)", () => {
+    const r = formatVoteMargin(100, 96);
+    expect(r.label).toBe("majorité +4 · vote serré");
+    expect(r.isClose).toBe(true);
+  });
+  it("rejeté", () => {
+    const r = formatVoteMargin(96, 100);
+    expect(r.label).toBe("manque 4 voix · vote serré");
+    expect(r.isClose).toBe(true);
+  });
+  it("rejeté large", () => {
+    expect(formatVoteMargin(20, 300).label).toBe("manque 280 voix");
+  });
+  it("égalité", () => {
+    expect(formatVoteMargin(50, 50).label).toBe("égalité · vote serré");
+  });
+  it("aucun suffrage exprimé", () => {
+    const r = formatVoteMargin(0, 0);
+    expect(r.hasExpressed).toBe(false);
+    expect(r.label).toBe("Aucun suffrage exprimé");
+    expect(r.forPercent).toBe(0);
+  });
+});

--- a/src/lib/votes/vote-margin.ts
+++ b/src/lib/votes/vote-margin.ts
@@ -1,0 +1,37 @@
+// Pure helper: majority reading of a scrutin's expressed votes (pour vs contre).
+// Abstention is intentionally excluded: it does not count toward the majority.
+const CLOSE_THRESHOLD = 10;
+
+export interface VoteMargin {
+  label: string;
+  isClose: boolean;
+  hasExpressed: boolean;
+  forPercent: number;
+  againstPercent: number;
+}
+
+export function formatVoteMargin(votesFor: number, votesAgainst: number): VoteMargin {
+  const expressed = votesFor + votesAgainst;
+  if (expressed <= 0) {
+    return {
+      label: "Aucun suffrage exprimé",
+      isClose: false,
+      hasExpressed: false,
+      forPercent: 0,
+      againstPercent: 0,
+    };
+  }
+  const margin = votesFor - votesAgainst;
+  const isClose = Math.abs(margin) <= CLOSE_THRESHOLD;
+  let base: string;
+  if (margin > 0) base = `majorité +${margin}`;
+  else if (margin < 0) base = `manque ${Math.abs(margin)} voix`;
+  else base = "égalité";
+  return {
+    label: isClose ? `${base} · vote serré` : base,
+    isClose,
+    hasExpressed: true,
+    forPercent: (votesFor / expressed) * 100,
+    againstPercent: (votesAgainst / expressed) * 100,
+  };
+}


### PR DESCRIPTION
Dernière des trois PRs de la refonte #484, après la barre de filtres (#591) et la page thèmes (#592). Elle reconstruit la carte de scrutin autour du sens du vote.

## Changements

- **Barre des suffrages exprimés** : pour (vert) contre contre (rouge), avec une ligne de majorité à 50 %. L'abstention est affichée à part (gris), car elle ne compte pas dans la majorité.
- **Libellé de marge** en clair : « majorité +371 », « manque 4 voix », avec un badge « vote serré » quand l'écart est de 10 voix ou moins.
- **Positions des groupes sur la carte de liste** : puces colorées par groupe, réparties en colonnes Pour / Contre / Abstention (empilées sur mobile), avec le sigle en toutes lettres et le détail au survol.
- **Méta allégée** : date, votants et législature regroupés sur une ligne calme ; les puces catégorielles (type, chambre, thème) sont conservées.
- **Tokens de vote** `--vote-pour` / `--vote-contre` / `--vote-abstention` (clair + sombre).

## Motions de censure

Une motion de censure ne recense que les voix « pour » et s'adopte à la majorité absolue des membres (289). La lecture pour/contre à 50 % ne s'y applique pas : 58 motions apparaîtraient sinon en « majorité +239 », barre pleine, tout en étant rejetées. Ces scrutins (repérés par `type = MOTION` et zéro voix contre) reçoivent un affichage dédié : le nombre de voix pour et une note de règle, sans barre de majorité simple. Les autres motions (rejet préalable, renvoi), qui sont des scrutins ordinaires avec des voix contre, gardent la barre normale. Un garde-fou générique masque en plus le marqueur et la marge dès que la lecture pour/contre contredirait le résultat officiel.

## Performance

Les positions des groupes sont chargées en **une seule requête par page** (clé `scrutinId in pageIds`, environ 200 lignes pour 20 cartes), pas une requête par carte. `getScrutins` n'est pas touchée.

## Accessibilité

Information jamais portée par la seule couleur (comptes, libellé de marge et sigles de groupe en texte) ; le marqueur de majorité a son équivalent textuel ; colonnes de groupes en `role="list"` avec intitulés explicites ; contraste vérifié en clair et en sombre.

## Vérification

`tsc` (cache non incrémental) propre, ESLint et Prettier propres, suite de tests votes verte (122), `npm run build` OK. Revue de branche dédiée sur la fidélité de la représentation du vote.

Part of #484.
