### PR TITLE
feat(affaires): hubs + barre de filtres certitude-first (#485 PR1)

### DIFF
--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 import { AffairesFilterBar } from "@/components/affairs/AffairesFilterBar";
+import { AffairHubTiles } from "@/components/affairs/AffairHubTiles";
 import { SeoIntro } from "@/components/seo/SeoIntro";
 import { stripMarkdown } from "@/lib/utils";
 import {
@@ -34,7 +35,6 @@ import {
   isAccusedInvolvement,
   type CertaintyLevel,
 } from "@/config/certainty";
-import { AffairModeToggle } from "@/components/affairs/AffairModeToggle";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
@@ -204,29 +204,12 @@ export default async function AffairesPage({ searchParams }: PageProps) {
                 text={`${totalAffairs} affaires judiciaires impliquant des responsables politiques, documentées avec sources vérifiables. Mises en examen, procès, condamnations et relaxes.`}
               />
             </div>
-            {/* Route the strong judicial/statistics intents from the bare listing */}
-            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
-              <Link
-                href="/affaires/condamnations"
-                className="font-medium text-primary hover:underline"
-                prefetch={false}
-              >
-                Condamnations définitives et en cours →
-              </Link>
-              <Link
-                href="/statistiques"
-                className="font-medium text-primary hover:underline"
-                prefetch={false}
-              >
-                Statistiques : taux de condamnation par parti →
-              </Link>
-            </div>
           </div>
         </div>
 
-        {/* Mode toggle */}
+        {/* Hub tiles: route the strong judicial/statistics/victim intents from the bare listing */}
         <div className="mb-4">
-          <AffairModeToggle mode={mode} />
+          <AffairHubTiles etabliCount={certaintyCounts.ETABLI ?? 0} />
         </div>
 
         {/* Victim mode methodology note */}
@@ -239,31 +222,6 @@ export default async function AffairesPage({ searchParams }: PageProps) {
                 En savoir plus
               </a>
             </p>
-          </div>
-        )}
-
-        {/* Party quick-links */}
-        {partiesWithAffairs.length > 0 && (
-          <div className="mb-4">
-            <p className="text-xs font-medium text-muted-foreground mb-2">Explorer par parti</p>
-            <div className="flex flex-wrap gap-2">
-              {partiesWithAffairs
-                .sort((a, b) => b._count.affairsAtTime - a._count.affairsAtTime)
-                .slice(0, 12)
-                .map((p) => (
-                  <Link
-                    key={p.slug}
-                    href={`/affaires/parti/${p.slug}`}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border hover:bg-muted transition-colors"
-                    prefetch={false}
-                  >
-                    <span className="font-medium">{p.shortName}</span>
-                    <span className="text-xs text-muted-foreground tabular-nums">
-                      {p._count.affairsAtTime}
-                    </span>
-                  </Link>
-                ))}
-            </div>
           </div>
         )}
 
@@ -288,6 +246,7 @@ export default async function AffairesPage({ searchParams }: PageProps) {
 
         {/* Compact filter bar */}
         <AffairesFilterBar
+          mode={mode}
           currentFilters={{
             search: searchFilter,
             sort: sortFilter,

--- a/src/components/affairs/AffairHubTiles.tsx
+++ b/src/components/affairs/AffairHubTiles.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+
+interface AffairHubTilesProps {
+  etabliCount: number;
+}
+
+interface HubTile {
+  href: string;
+  title: string;
+  subtitle: string;
+  accent: boolean;
+  count?: number;
+}
+
+/**
+ * Entry band above the /affaires listing: 3 tiles routing strong intents
+ * (condamnations, statistics, victim-mode) away from the bare list.
+ * Replaces the two easily-missed inline text links.
+ */
+export function AffairHubTiles({ etabliCount }: AffairHubTilesProps) {
+  const tiles: HubTile[] = [
+    {
+      href: "/affaires/condamnations",
+      title: "Condamnations définitives",
+      subtitle: "Vue par mandat et par peine",
+      accent: true,
+      count: etabliCount,
+    },
+    {
+      href: "/statistiques",
+      title: "Taux de condamnation par parti",
+      subtitle: "Comparer les partis politiques",
+      accent: false,
+    },
+    {
+      href: "/affaires?mode=victime",
+      title: "Violences contre les élus",
+      subtitle: "Affaires où l'élu est victime",
+      accent: false,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      {tiles.map((tile) => (
+        <Link
+          key={tile.href}
+          href={tile.href}
+          prefetch={false}
+          className="flex min-h-[44px] flex-col justify-center gap-0.5 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            {tile.accent && (
+              <span
+                aria-hidden="true"
+                className="inline-block h-2 w-2 shrink-0 rounded-full bg-red-700 dark:bg-red-400"
+              />
+            )}
+            {tile.title}
+            {tile.count !== undefined && (
+              <span className="text-red-700 dark:text-red-400">({tile.count})</span>
+            )}
+          </span>
+          <span className="text-xs text-muted-foreground">{tile.subtitle}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/affairs/AffairesFilterBar.tsx
+++ b/src/components/affairs/AffairesFilterBar.tsx
@@ -1,9 +1,18 @@
 "use client";
 
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { SlidersHorizontal, X } from "lucide-react";
 import { useFilterParams } from "@/hooks/useFilterParams";
-import { DebouncedSearchInput, SelectFilter, ActiveFilterChips } from "@/components/filters";
-import type { ActiveFilter } from "@/components/filters";
-import { FilterBarShell } from "@/components/filters/FilterBarShell";
+import { ToggleGroup, type ToggleGroupOption } from "@/components/ui/ToggleGroup";
+import {
+  DebouncedSearchInput,
+  SelectFilter,
+  ActiveFilterChips,
+  FilterBarShell,
+  type ActiveFilter,
+} from "@/components/filters";
+import { AffairModeToggle } from "@/components/affairs/AffairModeToggle";
 import {
   AFFAIR_CATEGORY_LABELS,
   AFFAIR_SUPER_CATEGORY_LABELS,
@@ -11,10 +20,14 @@ import {
   getCategoriesForSuper,
   type AffairSuperCategory,
 } from "@/config/labels";
-import { CERTAINTY_LABELS, type CertaintyLevel } from "@/config/certainty";
+import { CERTAINTY_LABELS, CERTAINTY_SORT_ORDER, type CertaintyLevel } from "@/config/certainty";
 import type { AffairCategory } from "@/types";
+import { cn } from "@/lib/utils";
+
+type AffairMode = "mise-en-cause" | "victime";
 
 interface AffairesFilterBarProps {
+  mode: AffairMode;
   currentFilters: {
     search: string;
     sort: string;
@@ -49,13 +62,38 @@ const SUPER_CATEGORIES: AffairSuperCategory[] = [
   "AUTRE",
 ];
 
+const CERTAINTY_LEVELS_ORDERED = (Object.keys(CERTAINTY_LABELS) as CertaintyLevel[]).sort(
+  (a, b) => CERTAINTY_SORT_ORDER[a] - CERTAINTY_SORT_ORDER[b]
+);
+
+// Dot colour family per level, mirroring CERTAINTY_COLORS. Supplementary only:
+// the text label + count remain the primary signal (never colour-alone).
+const CERTAINTY_DOT_COLORS: Record<CertaintyLevel, string> = {
+  ETABLI: "bg-red-500",
+  PRONONCE: "bg-orange-500",
+  EN_COURS: "bg-amber-500",
+  CLOS_SANS_CHARGE: "bg-slate-500",
+  CLOS_FAVORABLE: "bg-gray-500",
+};
+
+function certaintyDot(level: CertaintyLevel) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("inline-block h-2 w-2 shrink-0 rounded-full", CERTAINTY_DOT_COLORS[level])}
+    />
+  );
+}
+
 export function AffairesFilterBar({
+  mode,
   currentFilters,
   parties,
   certaintyCounts,
   superCounts,
 }: AffairesFilterBarProps) {
   const { isPending, updateParams } = useFilterParams();
+  const [sheetOpen, setSheetOpen] = React.useState(false);
   // Utility filters use replace so they do not stack browser history.
   const set = (updates: Record<string, string>) => updateParams(updates, { mode: "replace" });
 
@@ -66,25 +104,27 @@ export function AffairesFilterBar({
     ? CATEGORY_TO_SUPER[currentFilters.category as AffairCategory]
     : currentFilters.supercat) || "") as AffairSuperCategory | "";
 
-  const certaintyOptions = [
-    { value: "", label: "Toutes les certitudes" },
-    ...(Object.keys(CERTAINTY_LABELS) as CertaintyLevel[])
-      .filter((level) => (certaintyCounts[level] || 0) > 0)
-      .map((level) => ({
+  const certaintyOptions: ToggleGroupOption[] = [
+    { value: "", label: "Toutes" },
+    ...CERTAINTY_LEVELS_ORDERED.filter((level) => (certaintyCounts[level] ?? 0) > 0).map(
+      (level) => ({
         value: level,
-        label: `${CERTAINTY_LABELS[level]} (${certaintyCounts[level] || 0})`,
-      })),
+        label: `${CERTAINTY_LABELS[level]} (${certaintyCounts[level] ?? 0})`,
+        icon: certaintyDot(level),
+      })
+    ),
   ];
 
-  const superCatOptions = [
-    { value: "", label: "Toutes les catégories" },
+  const superCatOptions: ToggleGroupOption[] = [
+    { value: "", label: "Toutes" },
     ...SUPER_CATEGORIES.map((superCat) => ({
       value: superCat,
-      label: `${AFFAIR_SUPER_CATEGORY_LABELS[superCat]} (${superCounts[superCat] || 0})`,
+      label: `${AFFAIR_SUPER_CATEGORY_LABELS[superCat]} (${superCounts[superCat] ?? 0})`,
     })),
   ];
 
-  // Infraction options are scoped to the effective family (no separators).
+  // Infraction options are scoped to the effective family (no separators). The
+  // select itself is only rendered once a family is active (see JSX below).
   const categoryOptions = effectiveSupercat
     ? [
         { value: "", label: "Toutes les infractions" },
@@ -93,12 +133,17 @@ export function AffairesFilterBar({
           label: AFFAIR_CATEGORY_LABELS[cat],
         })),
       ]
-    : [{ value: "", label: "Choisir d'abord une catégorie" }];
+    : [];
+
+  const partyOptions = [
+    { value: "", label: "Tous les partis" },
+    ...parties.map((p) => ({ value: p.slug, label: `${p.shortName} (${p.count})` })),
+  ];
 
   const sortOptions = Object.entries(SORT_OPTIONS).map(([value, label]) => ({ value, label }));
 
-  // Active filter chips. `mode` is a perimeter tab (not a chip); `sort` IS shown
-  // so that "Tout effacer" never resets an invisible state.
+  // Active filter chips. `mode` is a perimeter tab (not a chip); `sort` is a
+  // display preference, not a filter, so it never becomes a chip (mirrors #484).
   const activeFilters: ActiveFilter[] = [];
   if (currentFilters.search) {
     activeFilters.push({ key: "search", label: `Recherche : ${currentFilters.search}` });
@@ -140,68 +185,214 @@ export function AffairesFilterBar({
         currentFilters.category,
     });
   }
-  if (currentFilters.sort) {
-    activeFilters.push({
-      key: "sort",
-      label: `Tri : ${SORT_OPTIONS[currentFilters.sort] ?? currentFilters.sort}`,
-    });
-  }
 
   const removeFilter = (key: string) =>
     key === "supercat" ? set({ supercat: "", category: "" }) : set({ [key]: "" });
 
-  const clearAll = () =>
-    set({ search: "", supercat: "", category: "", certainty: "", parti: "", sort: "" });
+  // Clears every filter EXCEPT sort, which is a display preference, not a
+  // filter: it stays untouched, matching ActiveFilterChips (sort has no chip).
+  const clearAll = () => set({ search: "", supercat: "", category: "", certainty: "", parti: "" });
 
   return (
-    <FilterBarShell isPending={isPending} className="space-y-3">
-      {/* Search input — manual: applies on submit (button/Enter), not while typing */}
-      <DebouncedSearchInput
-        id="search-affairs"
-        value={currentFilters.search}
-        onSearch={(v) => set({ search: v })}
-        manual
-        placeholder="Rechercher une affaire..."
-        label="Recherche"
-      />
+    <FilterBarShell isPending={isPending} className="space-y-4">
+      <AffairModeToggle mode={mode} />
 
-      {/* Dropdowns grid: 2 cols mobile, 4 cols desktop */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <SelectFilter
-          id="supercat-affairs"
-          label="Catégorie d'infraction"
+      {/* Desktop / tablet layout */}
+      <div className="hidden md:block space-y-4">
+        <div className="overflow-x-auto pb-1">
+          <ToggleGroup
+            label="Certitude"
+            value={currentFilters.certainty}
+            options={certaintyOptions}
+            onChange={(v) => set({ certainty: v })}
+            className="flex-nowrap"
+          />
+        </div>
+
+        <ToggleGroup
+          label="Catégorie"
           value={effectiveSupercat}
-          onChange={(v) => set({ supercat: v, category: "" })}
           options={superCatOptions}
+          onChange={(v) => set({ supercat: v, category: "" })}
+          className="flex-wrap"
         />
 
-        <SelectFilter
-          id="category-affairs"
-          label="Infraction précise"
-          value={currentFilters.category}
-          onChange={(v) => set({ supercat: effectiveSupercat, category: v })}
-          options={categoryOptions}
-          disabled={!effectiveSupercat}
-        />
+        <div className="flex flex-wrap items-end gap-3">
+          {effectiveSupercat && (
+            <SelectFilter
+              id="category-affairs"
+              label="Infraction précise"
+              value={currentFilters.category}
+              onChange={(v) => set({ supercat: effectiveSupercat, category: v })}
+              options={categoryOptions}
+              className="min-w-[220px]"
+            />
+          )}
+          <SelectFilter
+            id="parti-affairs"
+            label="Parti"
+            value={currentFilters.parti}
+            onChange={(v) => set({ parti: v })}
+            options={partyOptions}
+            className="min-w-[200px]"
+          />
+          <DebouncedSearchInput
+            id="search-affairs"
+            value={currentFilters.search}
+            onSearch={(v) => set({ search: v })}
+            manual
+            placeholder="Rechercher une affaire..."
+            label="Recherche"
+            className="min-w-[260px] flex-1"
+          />
+        </div>
 
-        <SelectFilter
-          id="certainty-affairs"
-          label="Certitude"
-          value={currentFilters.certainty}
-          onChange={(v) => set({ certainty: v })}
-          options={certaintyOptions}
-        />
-
-        <SelectFilter
-          id="sort-affairs"
-          label="Trier par"
-          value={currentFilters.sort}
-          onChange={(v) => set({ sort: v })}
-          options={sortOptions}
-        />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex-1">
+            <ActiveFilterChips
+              filters={activeFilters}
+              onRemove={removeFilter}
+              onClearAll={clearAll}
+            />
+          </div>
+          <SelectFilter
+            id="sort-affairs"
+            label="Trier"
+            value={currentFilters.sort}
+            onChange={(v) => set({ sort: v })}
+            options={sortOptions}
+            className="min-w-[200px]"
+          />
+        </div>
       </div>
 
-      <ActiveFilterChips filters={activeFilters} onRemove={removeFilter} onClearAll={clearAll} />
+      {/* Mobile layout: "Filtres" bottom-sheet */}
+      <div className="md:hidden space-y-3">
+        <Dialog.Root open={sheetOpen} onOpenChange={setSheetOpen}>
+          <Dialog.Trigger asChild>
+            <button
+              type="button"
+              className="relative inline-flex min-h-11 items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            >
+              <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+              Filtres
+              {activeFilters.length > 0 && (
+                <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-xs font-semibold text-primary-foreground">
+                  {activeFilters.length}
+                </span>
+              )}
+            </button>
+          </Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay
+              className={cn(
+                "fixed inset-0 z-50 bg-black/50",
+                "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+                "motion-reduce:animate-none"
+              )}
+            />
+            <Dialog.Content
+              className={cn(
+                "fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-xl border-t bg-background p-4 shadow-2xl",
+                "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                "data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+                "motion-reduce:animate-none"
+              )}
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <Dialog.Title className="text-base font-semibold">Filtres</Dialog.Title>
+                <Dialog.Close
+                  aria-label="Fermer"
+                  className="flex min-h-11 min-w-11 items-center justify-center rounded-full text-muted-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <X className="h-5 w-5" aria-hidden="true" />
+                </Dialog.Close>
+              </div>
+              <Dialog.Description className="sr-only">
+                Filtrer les affaires par certitude, catégorie, parti et recherche.
+              </Dialog.Description>
+
+              <div className="space-y-5">
+                <AffairModeToggle mode={mode} />
+
+                <div className="overflow-x-auto pb-1">
+                  <ToggleGroup
+                    label="Certitude"
+                    value={currentFilters.certainty}
+                    options={certaintyOptions}
+                    onChange={(v) => set({ certainty: v })}
+                    className="flex-nowrap"
+                  />
+                </div>
+
+                <ToggleGroup
+                  label="Catégorie"
+                  value={effectiveSupercat}
+                  options={superCatOptions}
+                  onChange={(v) => set({ supercat: v, category: "" })}
+                  className="flex-wrap"
+                />
+
+                {effectiveSupercat && (
+                  <SelectFilter
+                    id="category-affairs-sheet"
+                    label="Infraction précise"
+                    value={currentFilters.category}
+                    onChange={(v) => set({ supercat: effectiveSupercat, category: v })}
+                    options={categoryOptions}
+                  />
+                )}
+
+                <SelectFilter
+                  id="parti-affairs-sheet"
+                  label="Parti"
+                  value={currentFilters.parti}
+                  onChange={(v) => set({ parti: v })}
+                  options={partyOptions}
+                />
+
+                <SelectFilter
+                  id="sort-affairs-sheet"
+                  label="Trier"
+                  value={currentFilters.sort}
+                  onChange={(v) => set({ sort: v })}
+                  options={sortOptions}
+                />
+
+                <DebouncedSearchInput
+                  id="search-affairs-sheet"
+                  value={currentFilters.search}
+                  onSearch={(v) => set({ search: v })}
+                  manual
+                  placeholder="Rechercher une affaire..."
+                  label="Recherche"
+                />
+
+                {activeFilters.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={clearAll}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Tout effacer
+                  </button>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setSheetOpen(false)}
+                className="mt-5 inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+              >
+                Appliquer
+              </button>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+
+        <ActiveFilterChips filters={activeFilters} onRemove={removeFilter} onClearAll={clearAll} />
+      </div>
     </FilterBarShell>
   );
 }

--- a/src/components/affairs/__tests__/AffairHubTiles.test.tsx
+++ b/src/components/affairs/__tests__/AffairHubTiles.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AffairHubTiles } from "../AffairHubTiles";
+
+describe("AffairHubTiles", () => {
+  it("rend les 3 tuiles d'entrée vers les bonnes destinations", () => {
+    render(<AffairHubTiles etabliCount={42} />);
+    expect(screen.getByRole("link", { name: /Condamnations définitives/i })).toHaveAttribute(
+      "href",
+      "/affaires/condamnations"
+    );
+    expect(screen.getByRole("link", { name: /par parti/i })).toHaveAttribute(
+      "href",
+      "/statistiques"
+    );
+    expect(screen.getByRole("link", { name: /Violences contre les élus/i })).toHaveAttribute(
+      "href",
+      "/affaires?mode=victime"
+    );
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+  });
+});

--- a/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
+++ b/src/components/affairs/__tests__/AffairesFilterBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 
 const { updateParams } = vi.hoisted(() => ({ updateParams: vi.fn() }));
 
@@ -23,6 +23,7 @@ const emptyFilters = {
   supercat: "",
 };
 const baseProps = {
+  mode: "mise-en-cause" as const,
   currentFilters: emptyFilters,
   parties,
   certaintyCounts: {},
@@ -32,80 +33,104 @@ const baseProps = {
 describe("AffairesFilterBar", () => {
   beforeEach(() => updateParams.mockClear());
 
-  it("does not render a Parti select in the panel", () => {
-    render(<AffairesFilterBar {...baseProps} />);
-    expect(screen.queryByLabelText("Parti")).toBeNull();
-    // The editorial axes remain
-    expect(screen.getByLabelText("Catégorie d'infraction")).toBeInTheDocument();
-    expect(screen.getByLabelText("Infraction précise")).toBeInTheDocument();
+  it("renders certainty as a radiogroup with per-level counts", () => {
+    render(<AffairesFilterBar {...baseProps} certaintyCounts={{ ETABLI: 3, EN_COURS: 7 }} />);
+    const group = screen.getByRole("radiogroup", { name: "Certitude" });
+    expect(
+      within(group).getByRole("radio", { name: "Condamnation définitive (3)" })
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("radio", { name: "Procédure en cours (7)" })
+    ).toBeInTheDocument();
   });
 
-  it("disables the Infraction select until a Famille is chosen", () => {
-    render(<AffairesFilterBar {...baseProps} />);
-    expect(screen.getByLabelText("Infraction précise")).toBeDisabled();
+  it("hides a certainty level with a zero count", () => {
+    render(<AffairesFilterBar {...baseProps} certaintyCounts={{ ETABLI: 3 }} />);
+    expect(screen.queryByRole("radio", { name: /Procédure en cours/ })).toBeNull();
   });
 
-  it("enables the Infraction select when a Famille is selected", () => {
+  it("calls updateParams with the certainty level when a level is clicked", () => {
+    render(<AffairesFilterBar {...baseProps} certaintyCounts={{ ETABLI: 3 }} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Condamnation définitive (3)" }));
+    expect(updateParams).toHaveBeenCalledWith({ certainty: "ETABLI" }, { mode: "replace" });
+  });
+
+  it("does not render the 'infraction précise' select until a super-category is active", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    expect(screen.queryByLabelText("Infraction précise")).toBeNull();
+  });
+
+  it("reveals the 'infraction précise' select once a super-category is selected", () => {
     render(
       <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, supercat: "PROBITE" }} />
     );
-    expect(screen.getByLabelText("Infraction précise")).toBeEnabled();
+    expect(screen.getByLabelText("Infraction précise")).toBeInTheDocument();
   });
 
-  it("keeps a legacy ?category= (no supercat) infraction visible and removable", () => {
+  it("keeps the infraction select usable for a legacy ?category= URL (no supercat)", () => {
     render(
       <AffairesFilterBar
         {...baseProps}
         currentFilters={{ ...emptyFilters, category: "CORRUPTION" }}
       />
     );
-    // Family inferred from the category -> infraction select is usable
-    expect(screen.getByLabelText("Infraction précise")).toBeEnabled();
-    // The infraction chip is present and removable
-    fireEvent.click(screen.getByRole("button", { name: /^Retirer le filtre/ }));
-    expect(updateParams).toHaveBeenCalledWith({ category: "" }, { mode: "replace" });
+    expect(screen.getByLabelText("Infraction précise")).toBeInTheDocument();
   });
 
-  it("applies the manual search only on submit, never while typing", () => {
+  it("calls updateParams with the family code and clears category when a family is clicked", () => {
     render(<AffairesFilterBar {...baseProps} />);
-    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "dupont" } });
-    expect(updateParams).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: "Rechercher" }));
-    expect(updateParams).toHaveBeenCalledWith({ search: "dupont" }, { mode: "replace" });
-  });
-
-  it("removing the Famille chip also clears the category", () => {
-    render(
-      <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, supercat: "PROBITE" }} />
-    );
-    fireEvent.click(screen.getByRole("button", { name: /^Retirer le filtre/ }));
-    expect(updateParams).toHaveBeenCalledWith({ supercat: "", category: "" }, { mode: "replace" });
-  });
-
-  it("renders a removable Parti chip for a legacy ?parti= URL", () => {
-    render(<AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, parti: "rn" }} />);
-    fireEvent.click(screen.getByRole("button", { name: "Retirer le filtre Parti : RN" }));
-    expect(updateParams).toHaveBeenCalledWith({ parti: "" }, { mode: "replace" });
-  });
-
-  it("'Tout effacer' clears every filter but leaves mode untouched", () => {
-    render(<AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, parti: "rn" }} />);
-    fireEvent.click(screen.getByRole("button", { name: "Tout effacer" }));
+    const group = screen.getByRole("radiogroup", { name: "Catégorie" });
+    fireEvent.click(within(group).getByRole("radio", { name: /Atteintes à la probité/ }));
     expect(updateParams).toHaveBeenCalledWith(
-      { search: "", supercat: "", category: "", certainty: "", parti: "", sort: "" },
+      { supercat: "PROBITE", category: "" },
       { mode: "replace" }
     );
   });
 
-  it("shows a Tri chip when a non-default sort is active", () => {
+  it("renders a Parti select in the panel and calls updateParams on selection", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    fireEvent.change(screen.getByLabelText("Parti"), { target: { value: "rn" } });
+    expect(updateParams).toHaveBeenCalledWith({ parti: "rn" }, { mode: "replace" });
+  });
+
+  it("'Tout effacer' resets search/supercat/category/certainty/parti but never sort", () => {
+    render(
+      <AffairesFilterBar
+        {...baseProps}
+        currentFilters={{
+          search: "dupont",
+          sort: "certainty",
+          certainty: "ETABLI",
+          parti: "rn",
+          category: "CORRUPTION",
+          supercat: "PROBITE",
+        }}
+        certaintyCounts={{ ETABLI: 1 }}
+      />
+    );
+    const clearButtons = screen.getAllByRole("button", { name: "Tout effacer" });
+    fireEvent.click(clearButtons[0]!);
+    expect(updateParams).toHaveBeenCalledTimes(1);
+    const [updates, options] = updateParams.mock.calls[0]!;
+    expect(updates).toEqual({
+      search: "",
+      supercat: "",
+      category: "",
+      certainty: "",
+      parti: "",
+    });
+    expect(updates).not.toHaveProperty("sort");
+    expect(options).toEqual({ mode: "replace" });
+  });
+
+  it("does not show a sort chip (sort is excluded from active filter chips)", () => {
     render(
       <AffairesFilterBar {...baseProps} currentFilters={{ ...emptyFilters, sort: "certainty" }} />
     );
-    expect(screen.getByText("Tri : Par certitude")).toBeInTheDocument();
+    expect(screen.queryByText(/Tri :/)).toBeNull();
   });
 
   it("does not show a stale Famille chip when supercat contradicts the category", () => {
-    // category CORRUPTION belongs to PROBITE; supercat=FINANCES is incoherent
     render(
       <AffairesFilterBar
         {...baseProps}
@@ -115,12 +140,16 @@ describe("AffairesFilterBar", () => {
     expect(screen.queryByText("Infractions financières")).toBeNull();
   });
 
-  it("does not offer a certainty option with a zero count", () => {
-    render(<AffairesFilterBar {...baseProps} certaintyCounts={{ ETABLI: 3 }} />);
-    expect(screen.getByText("Condamnation définitive (3)")).toBeInTheDocument();
-    // EN_COURS, CLOS_SANS_CHARGE etc. all have a zero count here and must not
-    // appear as selectable options, whatever level they belong to.
-    expect(screen.queryByText(/Procédure en cours \(0\)/)).toBeNull();
-    expect(screen.queryByText(/Instruction close, sans mise en examen \(0\)/)).toBeNull();
+  it("renders the perimeter toggle (AffairModeToggle) inside the panel", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    expect(screen.getByRole("group", { name: "Type d'affaires" })).toBeInTheDocument();
+  });
+
+  it("applies the manual search only on submit, never while typing", () => {
+    render(<AffairesFilterBar {...baseProps} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "dupont" } });
+    expect(updateParams).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Rechercher" }));
+    expect(updateParams).toHaveBeenCalledWith({ search: "dupont" }, { mode: "replace" });
   });
 });


### PR DESCRIPTION
Première des deux PRs de la refonte #485 de `/affaires`. Elle promeut les hubs et refond la barre de filtres autour de la certitude. La carte équitable et citable suivra (PR2).

## Changements

- **Trois tuiles d'entrée** en tête, à la place des deux liens texte discrets : Condamnations définitives (compteur, accent rouge sobre), Taux de condamnation par parti, Violences contre les élus.
- **Certitude en axe premier** : segmented control (radiogroup) avec compteurs par niveau, ordonné du plus établi au plus favorable. Les niveaux à zéro sont masqués.
- **Catégorie d'infraction** en segmented ; l'affinage « infraction précise » n'apparaît qu'après le choix d'une famille (fini le menu grisé opaque).
- **Filtre parti en place** (menu), avec un lien discret « voir la page du parti » quand un parti est actif ; la pile de puces « Explorer par parti » est retirée.
- **Tri séparé** des filtres, dans son propre groupe.
- **Périmètre** (mis en cause / victime) intégré au panneau de filtres.
- **Mobile** : bottom-sheet accessible (Radix Dialog) déclenché par un bouton « Filtres » portant le nombre de filtres actifs.

## Présomption d'innocence

L'état par défaut n'applique aucun filtre. Les compteurs de certitude rendent visible la part des affaires « en cours » plutôt que de mettre la culpabilité en avant. Le rouge est réservé aux condamnations définitives (recours épuisés) et ne touche jamais une procédure en cours.

## Accessibilité

Radiogroups au clavier ; l'information n'est jamais portée par la seule couleur (chaque option a un libellé texte et un compteur ; la pastille colorée est décorative et `aria-hidden`) ; bottom-sheet accessible ; cibles >= 44px ; contraste vérifié clair et sombre.

## SEO

Aucune régression : les variantes filtrées et le périmètre non défaut restent en `noindex,follow` ; le canonical exclut le tri et la recherche. Aucun nouveau facette indexable.

## Vérification

`tsc` (source) propre, suite affaires verte (556), doctrine SEO verte (152), `npm run build` exit 0. Page toujours en ISR (`revalidate=300`).

Part of #485. Carte équitable et citable : PR2.
