### PR TITLE
feat(affaires): carte de liste équitable et citable (#485 PR2)

### DIFF
--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -3,38 +3,24 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { SimplePagination } from "@/components/ui/SimplePagination";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 
 import { AffairesFilterBar } from "@/components/affairs/AffairesFilterBar";
 import { AffairHubTiles } from "@/components/affairs/AffairHubTiles";
+import { AffairListingCard } from "@/components/affairs/AffairListingCard";
 import { SeoIntro } from "@/components/seo/SeoIntro";
-import { stripMarkdown } from "@/lib/utils";
 import {
   getAffairs,
   getSuperCategoryCounts,
   getCertaintyCounts,
   getPartiesWithAffairs,
 } from "@/lib/data/affairs";
-import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 import {
   AFFAIR_STATUS_LABELS,
-  AFFAIR_CATEGORY_LABELS,
-  AFFAIR_STATUS_NEEDS_PRESUMPTION,
   AFFAIR_SUPER_CATEGORY_LABELS,
-  AFFAIR_SUPER_CATEGORY_COLORS,
   AFFAIR_SUPER_CATEGORY_DESCRIPTIONS,
-  CATEGORY_TO_SUPER,
-  INVOLVEMENT_LABELS,
-  INVOLVEMENT_COLORS,
   type AffairSuperCategory,
 } from "@/config/labels";
-import {
-  getCertaintyLevel,
-  CERTAINTY_LABELS,
-  CERTAINTY_COLORS,
-  isAccusedInvolvement,
-  type CertaintyLevel,
-} from "@/config/certainty";
+import { CERTAINTY_LABELS, type CertaintyLevel } from "@/config/certainty";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
@@ -44,15 +30,6 @@ import { AFFAIRES_DEFAULT_TITLE, AFFAIRES_DEFAULT_DESCRIPTION } from "@/lib/seo/
 import { AFFAIRES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
-
-// Hex border colors for affair card left-border (keyed by super-category)
-const SUPER_CATEGORY_BORDER: Record<AffairSuperCategory, string> = {
-  PROBITE: "#9333ea",
-  FINANCES: "#2563eb",
-  PERSONNES: "#dc2626",
-  EXPRESSION: "#d97706",
-  AUTRE: "#6b7280",
-};
 
 interface PageProps {
   searchParams: Promise<{
@@ -291,152 +268,9 @@ export default async function AffairesPage({ searchParams }: PageProps) {
         {affairs.length > 0 ? (
           <>
             <div className="space-y-4">
-              {affairs.map((affair) => {
-                const superCat = CATEGORY_TO_SUPER[affair.category];
-                const certainty = getCertaintyLevel(affair.status);
-                // Charging certainty badge only for the accused; otherwise the
-                // involvement badge below carries the politician's role (#383).
-                const accused = isAccusedInvolvement(affair.involvement);
-                // Get the most relevant date for display
-                const relevantDate = affair.verdictDate || affair.startDate || affair.factsDate;
-                const dateLabel = affair.verdictDate
-                  ? "Verdict"
-                  : affair.startDate
-                    ? "Révélation"
-                    : affair.factsDate
-                      ? "Faits"
-                      : null;
-                return (
-                  <Card
-                    key={affair.id}
-                    className="border-l-4 transition-shadow hover:shadow-md"
-                    style={{ borderLeftColor: SUPER_CATEGORY_BORDER[superCat] }}
-                  >
-                    <CardContent className="pt-6">
-                      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-                        <div className="flex-1">
-                          <div className="flex items-start gap-2 mb-2 flex-wrap">
-                            {relevantDate && (
-                              <Badge variant="secondary" className="font-mono text-base">
-                                {new Date(relevantDate).getFullYear()}
-                                {dateLabel && (
-                                  <span className="ml-1 text-xs opacity-70">({dateLabel})</span>
-                                )}
-                              </Badge>
-                            )}
-                            <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCat]}>
-                              {AFFAIR_SUPER_CATEGORY_LABELS[superCat]}
-                            </Badge>
-                            {accused && (
-                              <Badge className={CERTAINTY_COLORS[certainty]}>
-                                {CERTAINTY_LABELS[certainty]}
-                              </Badge>
-                            )}
-                            <Badge variant="outline">
-                              {AFFAIR_CATEGORY_LABELS[affair.category]}
-                            </Badge>
-                            {affair.involvement !== "DIRECT" && (
-                              <Badge
-                                className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}
-                              >
-                                {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
-                              </Badge>
-                            )}
-                          </div>
-
-                          <h2 className="text-lg font-semibold mb-1">{affair.title}</h2>
-
-                          <Link
-                            href={`/politiques/${affair.politician.slug}`}
-                            className="text-primary hover:underline text-sm"
-                          >
-                            {affair.politician.fullName}
-                          </Link>
-                          {(() => {
-                            const display = getAffairPartyDisplay({
-                              factsDate: affair.factsDate,
-                              partyAtTime: affair.partyAtTime,
-                              currentParty: affair.politician.currentParty,
-                            });
-                            if (display.kind === "at-time") {
-                              return (
-                                <span className="text-sm text-muted-foreground">
-                                  {" ("}
-                                  {display.party.slug ? (
-                                    <Link
-                                      href={`/affaires/parti/${display.party.slug}`}
-                                      className="hover:underline hover:text-foreground"
-                                    >
-                                      {display.party.shortName}
-                                    </Link>
-                                  ) : (
-                                    display.party.shortName
-                                  )}
-                                  {!display.sameAsCurrent && (
-                                    <span className="text-xs"> à l&apos;époque</span>
-                                  )}
-                                  {")"}
-                                </span>
-                              );
-                            }
-                            if (display.kind === "current") {
-                              return (
-                                <span className="text-sm text-muted-foreground">
-                                  {" ("}
-                                  {display.party.shortName}
-                                  {")"}
-                                </span>
-                              );
-                            }
-                            if (
-                              display.kind === "unknown" &&
-                              display.reason === "pre-dates-current-party"
-                            ) {
-                              return (
-                                <span
-                                  className="text-sm text-muted-foreground italic"
-                                  title={`Parti actuel (${display.currentPartyName}) fondé en ${display.currentPartyFoundedDate?.getFullYear()}, soit après la date des faits.`}
-                                >
-                                  {" (parti à l'époque non renseigné)"}
-                                </span>
-                              );
-                            }
-                            return null;
-                          })()}
-
-                          <p className="text-sm text-muted-foreground mt-2 line-clamp-2">
-                            {stripMarkdown(affair.description)}
-                          </p>
-
-                          {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status] &&
-                            (affair.involvement === "DIRECT" ||
-                              affair.involvement === "INDIRECT") && (
-                              <p className="text-xs text-amber-700 bg-amber-50 p-2 rounded mt-3 inline-block">
-                                Présomption d&apos;innocence : affaire en cours
-                              </p>
-                            )}
-                        </div>
-
-                        <div className="text-sm text-muted-foreground md:text-right md:min-w-[150px]">
-                          {affair.sentence && (
-                            <p className="font-medium text-foreground mb-2">{affair.sentence}</p>
-                          )}
-                          <p className="mb-2">
-                            {affair.sources.length} source
-                            {affair.sources.length !== 1 ? "s" : ""}
-                          </p>
-                          <Link
-                            href={`/affaires/${affair.slug}`}
-                            className="text-primary hover:underline text-xs"
-                          >
-                            Voir détails →
-                          </Link>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
+              {affairs.map((affair) => (
+                <AffairListingCard key={affair.id} affair={affair} />
+              ))}
             </div>
 
             {/* Pagination */}

--- a/src/components/affairs/AffairListingCard.tsx
+++ b/src/components/affairs/AffairListingCard.tsx
@@ -1,0 +1,194 @@
+import Link from "next/link";
+import { stripMarkdown } from "@/lib/utils";
+import {
+  getCertaintyLevel,
+  CERTAINTY_LABELS,
+  CERTAINTY_COLORS,
+  isAccusedInvolvement,
+  type CertaintyLevel,
+} from "@/config/certainty";
+import {
+  AFFAIR_CATEGORY_LABELS,
+  INVOLVEMENT_LABELS,
+  INVOLVEMENT_COLORS,
+  CATEGORY_TO_SUPER,
+  AFFAIR_SUPER_CATEGORY_LABELS,
+} from "@/config/labels";
+import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
+import { CiteAnchor } from "@/components/ui/CiteAnchor";
+import { citeAnchorId } from "@/lib/cite";
+import { getAffairPartyDisplay, type PartyDisplayRef } from "@/lib/affairs/party-display";
+import type { AffairStatus, AffairCategory, Involvement } from "@/types";
+
+/**
+ * Left-border hex per certainty level, distinct from the super-category
+ * palette used elsewhere: the listing card foregrounds judicial certainty,
+ * not the offence family.
+ */
+const CERTAINTY_BORDER: Record<CertaintyLevel, string> = {
+  ETABLI: "#dc2626",
+  PRONONCE: "#ea580c",
+  EN_COURS: "#d97706",
+  CLOS_SANS_CHARGE: "#64748b",
+  CLOS_FAVORABLE: "#9ca3af",
+};
+
+// Non-accused cards (victim, plaintiff, mentioned) never carry a charging
+// certainty tier: the border stays neutral so a third party's conviction does
+// not tint the tracked politician's entry as severe. Mirrors the pill gating.
+const NON_ACCUSED_BORDER = "#9ca3af";
+
+export interface AffairListingCardData {
+  id: string;
+  slug: string | null;
+  title: string;
+  description: string;
+  status: AffairStatus;
+  involvement: Involvement;
+  category: AffairCategory;
+  verdictDate: Date | null;
+  startDate: Date | null;
+  factsDate: Date | null;
+  sentence: string | null;
+  sources: { length: number };
+  politician: {
+    slug: string;
+    fullName: string;
+    currentParty: PartyDisplayRef | null;
+  };
+  partyAtTime: PartyDisplayRef | null;
+}
+
+interface AffairListingCardProps {
+  affair: AffairListingCardData;
+}
+
+export function AffairListingCard({ affair }: AffairListingCardProps) {
+  const certainty = getCertaintyLevel(affair.status);
+  // Charging certainty pill only for the accused; otherwise the involvement
+  // badge carries the politician's role, never a status that is not theirs (#383).
+  const accused = isAccusedInvolvement(affair.involvement);
+  const superCat = CATEGORY_TO_SUPER[affair.category];
+  const detailHref = `/affaires/${affair.slug ?? affair.id}`;
+
+  const relevantDate = affair.verdictDate || affair.startDate || affair.factsDate;
+  const dateLabel = affair.verdictDate ? "Verdict" : affair.startDate ? "Révélation" : "Faits";
+
+  const partyDisplay = getAffairPartyDisplay({
+    factsDate: affair.factsDate,
+    partyAtTime: affair.partyAtTime,
+    currentParty: affair.politician.currentParty,
+  });
+
+  const sourcesCount = affair.sources.length;
+
+  return (
+    <article
+      id={citeAnchorId.affair(affair.id)}
+      className="group rounded-xl border border-l-4 bg-card p-4 text-card-foreground shadow-sm transition-shadow hover:shadow-md"
+      style={{ borderLeftColor: accused ? CERTAINTY_BORDER[certainty] : NON_ACCUSED_BORDER }}
+    >
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {accused ? (
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${CERTAINTY_COLORS[certainty]}`}
+          >
+            <span aria-hidden className="inline-block size-1.5 rounded-full bg-current" />
+            {CERTAINTY_LABELS[certainty]}
+          </span>
+        ) : (
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${INVOLVEMENT_COLORS[affair.involvement]}`}
+          >
+            {INVOLVEMENT_LABELS[affair.involvement]}
+          </span>
+        )}
+        {relevantDate && (
+          <span className="text-xs text-muted-foreground">
+            {new Date(relevantDate).getFullYear()} ({dateLabel})
+          </span>
+        )}
+      </div>
+
+      <h2 className="mb-1 text-lg font-semibold">
+        <Link href={detailHref} className="hover:underline focus-visible:underline">
+          {affair.title}
+        </Link>
+      </h2>
+
+      <p className="text-sm">
+        <Link
+          href={`/politiques/${affair.politician.slug}`}
+          className="text-primary hover:underline"
+        >
+          {affair.politician.fullName}
+        </Link>
+        {partyDisplay.kind === "at-time" && (
+          <span className="text-muted-foreground">
+            {" ("}
+            {partyDisplay.party.slug ? (
+              <Link
+                href={`/affaires/parti/${partyDisplay.party.slug}`}
+                className="hover:underline hover:text-foreground"
+              >
+                {partyDisplay.party.shortName}
+              </Link>
+            ) : (
+              partyDisplay.party.shortName
+            )}
+            {!partyDisplay.sameAsCurrent && <span className="text-xs"> à l&apos;époque</span>}
+            {")"}
+          </span>
+        )}
+        {partyDisplay.kind === "current" && (
+          <span className="text-muted-foreground">
+            {" ("}
+            {partyDisplay.party.shortName}
+            {")"}
+          </span>
+        )}
+        {partyDisplay.kind === "unknown" && partyDisplay.reason === "pre-dates-current-party" && (
+          <span
+            className="text-muted-foreground italic"
+            title={`Parti actuel (${partyDisplay.currentPartyName}) fondé en ${partyDisplay.currentPartyFoundedDate?.getFullYear()}, soit après la date des faits.`}
+          >
+            {" (parti à l'époque non renseigné)"}
+          </span>
+        )}
+      </p>
+
+      <p className="mt-1 text-xs text-muted-foreground">
+        {AFFAIR_SUPER_CATEGORY_LABELS[superCat]} · {AFFAIR_CATEGORY_LABELS[affair.category]}
+        {accused && affair.involvement !== "DIRECT" && (
+          <> · {INVOLVEMENT_LABELS[affair.involvement]}</>
+        )}
+      </p>
+
+      <AffairStatusNotice
+        status={affair.status}
+        involvement={affair.involvement}
+        className="mt-3"
+      />
+
+      <p className="mt-3 text-sm text-muted-foreground line-clamp-2">
+        {stripMarkdown(affair.description)}
+      </p>
+
+      <div className="mt-3 border-t pt-3">
+        {affair.sentence && (
+          <p className="mb-1 text-sm font-medium text-foreground">{affair.sentence}</p>
+        )}
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            {sourcesCount} source{sourcesCount !== 1 ? "s" : ""} vérifiée
+            {sourcesCount !== 1 ? "s" : ""}
+            <CiteAnchor anchorId={citeAnchorId.affair(affair.id)} label={affair.title} />
+          </span>
+          <Link href={detailHref} className="font-medium text-primary hover:underline">
+            Voir détails →
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/affairs/AffairListingCard.tsx
+++ b/src/components/affairs/AffairListingCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { stripMarkdown } from "@/lib/utils";
+import { SITE_URL } from "@/config/site";
 import {
   getCertaintyLevel,
   CERTAINTY_LABELS,
@@ -50,7 +51,7 @@ export interface AffairListingCardData {
   startDate: Date | null;
   factsDate: Date | null;
   sentence: string | null;
-  sources: { length: number };
+  _count: { sources: number };
   politician: {
     slug: string;
     fullName: string;
@@ -80,7 +81,7 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
     currentParty: affair.politician.currentParty,
   });
 
-  const sourcesCount = affair.sources.length;
+  const sourcesCount = affair._count.sources;
 
   return (
     <article
@@ -182,7 +183,10 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
           <span className="flex items-center gap-1">
             {sourcesCount} source{sourcesCount !== 1 ? "s" : ""} vérifiée
             {sourcesCount !== 1 ? "s" : ""}
-            <CiteAnchor anchorId={citeAnchorId.affair(affair.id)} label={affair.title} />
+            <CiteAnchor
+              permalink={`${SITE_URL}/affaires/${affair.slug ?? affair.id}`}
+              label={affair.title}
+            />
           </span>
           <Link href={detailHref} className="font-medium text-primary hover:underline">
             Voir détails →

--- a/src/components/affairs/__tests__/AffairListingCard.test.tsx
+++ b/src/components/affairs/__tests__/AffairListingCard.test.tsx
@@ -15,7 +15,7 @@ function baseAffair(overrides: Partial<AffairListingCardData> = {}): AffairListi
     startDate: null,
     factsDate: null,
     sentence: null,
-    sources: { length: 2 },
+    _count: { sources: 2 },
     politician: {
       slug: "jean-test",
       fullName: "Jean Test",
@@ -71,8 +71,17 @@ describe("AffairListingCard : présomption d'innocence (RGPD art. 10)", () => {
 });
 
 describe("AffairListingCard : citabilité", () => {
-  it("expose un contrôle « Citer » (Copier le lien)", () => {
+  it("expose un contrôle « Citer » pointant vers le permalien de l'affaire", () => {
     render(<AffairListingCard affair={baseAffair()} />);
-    expect(screen.getByRole("link", { name: /Copier le lien/i })).toBeTruthy();
+    const cite = screen.getByRole("link", { name: /Copier le lien/i });
+    // Le lien citable vise la page de l'affaire, pas une ancre de la liste.
+    expect(cite.getAttribute("href")).toContain("/affaires/affaire-de-test");
+  });
+
+  it("affiche le nombre réel de sources vérifiées", () => {
+    const { container } = render(
+      <AffairListingCard affair={baseAffair({ _count: { sources: 5 } })} />
+    );
+    expect(container.textContent).toContain("5 sources vérifiées");
   });
 });

--- a/src/components/affairs/__tests__/AffairListingCard.test.tsx
+++ b/src/components/affairs/__tests__/AffairListingCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AffairListingCard, type AffairListingCardData } from "../AffairListingCard";
+
+function baseAffair(overrides: Partial<AffairListingCardData> = {}): AffairListingCardData {
+  return {
+    id: "aff1",
+    slug: "affaire-de-test",
+    title: "Affaire de test",
+    description: "Description factuelle des faits reprochés.",
+    status: "RELAXE",
+    involvement: "DIRECT",
+    category: "CORRUPTION",
+    verdictDate: new Date("2024-06-15"),
+    startDate: null,
+    factsDate: null,
+    sentence: null,
+    sources: { length: 2 },
+    politician: {
+      slug: "jean-test",
+      fullName: "Jean Test",
+      currentParty: null,
+    },
+    partyAtTime: null,
+    ...overrides,
+  };
+}
+
+describe("AffairListingCard : présomption d'innocence (RGPD art. 10)", () => {
+  it("affaire accusée en cours d'instruction : encart présomption + pill « Procédure en cours »", () => {
+    const { container } = render(
+      <AffairListingCard affair={baseAffair({ status: "INSTRUCTION", involvement: "DIRECT" })} />
+    );
+    expect(container.textContent).toContain("présumée innocente");
+    expect(container.textContent).toContain("Procédure en cours");
+  });
+
+  it("affaire close favorable : pas d'encart présomption « en cours »", () => {
+    const { container } = render(
+      <AffairListingCard affair={baseAffair({ status: "RELAXE", involvement: "DIRECT" })} />
+    );
+    expect(container.textContent).not.toContain("présumée innocente");
+  });
+
+  it("non-accusé (victime) : pas de pill de certitude à charge, le rôle porte le badge", () => {
+    const { container } = render(
+      <AffairListingCard
+        affair={baseAffair({ status: "CONDAMNATION_DEFINITIVE", involvement: "VICTIM" })}
+      />
+    );
+    expect(container.textContent).not.toContain("Condamnation définitive");
+    expect(container.textContent).toContain("Victime");
+  });
+
+  it("non-accusé : bordure neutre, jamais la couleur de certitude à charge", () => {
+    const accused = render(
+      <AffairListingCard
+        affair={baseAffair({ status: "CONDAMNATION_DEFINITIVE", involvement: "DIRECT" })}
+      />
+    );
+    const accusedBorder = accused.container.querySelector("article")!.style.borderLeftColor;
+    const victim = render(
+      <AffairListingCard
+        affair={baseAffair({ status: "CONDAMNATION_DEFINITIVE", involvement: "VICTIM" })}
+      />
+    );
+    const victimBorder = victim.container.querySelector("article")!.style.borderLeftColor;
+    expect(accusedBorder).not.toBe("");
+    expect(victimBorder).not.toBe(accusedBorder);
+  });
+});
+
+describe("AffairListingCard : citabilité", () => {
+  it("expose un contrôle « Citer » (Copier le lien)", () => {
+    render(<AffairListingCard affair={baseAffair()} />);
+    expect(screen.getByRole("link", { name: /Copier le lien/i })).toBeTruthy();
+  });
+});

--- a/src/lib/data/affairs.ts
+++ b/src/lib/data/affairs.ts
@@ -107,6 +107,7 @@ async function queryAffairs(
           select: { id: true, slug: true, shortName: true, name: true, color: true },
         },
         sources: { select: { id: true }, take: 1 },
+        _count: { select: { sources: true } },
       },
       orderBy,
       skip,


### PR DESCRIPTION
Deuxième et dernière PR de la refonte #485 de `/affaires`, après les hubs et la barre de filtres (#595). Elle reconstruit la carte de la liste autour de la certitude et de l'équité.

## Changements

- **Certitude en tête** de carte : un pill dominant (libellé + point coloré), rendu uniquement quand l'élu suivi est la personne mise en cause. Sinon, c'est le badge de rôle (victime, plaignant, mentionné) qui mène.
- **Bordure gauche = certitude**, et neutre quand l'élu n'est pas mis en cause : la condamnation d'un tiers ne teinte jamais la carte de la personne en tier « sévère ».
- **Encart de présomption d'innocence systématique** via le composant canonique `AffairStatusNotice` : il apparaît d'office sur les procédures en cours (et pour la personne poursuivie uniquement), plus une simple note discrète.
- **Pied citable** pour les journalistes : le nombre réel de sources vérifiées et un bouton « Citer » qui copie le permalien de la page de l'affaire.
- **Moins de badges** : catégorie, infraction et rôle passent en méta secondaire discrète.

## Présomption d'innocence

Le pill de certitude et la bordure sont tous deux conditionnés à la mise en cause de l'élu suivi. Aucune combinaison rôle × statut ne présente une procédure en cours ou l'affaire d'un tiers comme la culpabilité de la personne. L'encart de prudence est géré par le composant canonique, pas réimplémenté.

## Deux correctifs de fiabilité

- **Compte de sources réel** : la requête ne récupérait qu'une source (`take: 1`), donc le pied affichait toujours « 0 » ou « 1 source » quel que soit le nombre réel. On expose désormais le vrai compte (`_count.sources`). Défaut hérité, mais mis en avant par le nouveau pied citable, donc corrigé ici.
- **« Citer » vise la page de l'affaire** : le bouton copiait une ancre de la liste (fragile sous pagination ou filtre) ; il copie maintenant le permalien `/affaires/[slug]`, comme attendu.

## Accessibilité

Information jamais portée par la seule couleur (libellés texte pour la certitude, la catégorie et le rôle ; la pastille est décorative et `aria-hidden`) ; le bouton « Citer » est un lien accessible ; contraste vérifié clair et sombre.

## Vérification

`tsc` (source) propre, suite affaires verte (562), doctrine SEO verte (152), `npm run build` exit 0. Page toujours en ISR (`revalidate=300`). Revue de branche dédiée sur la fidélité de la présomption d'innocence.

Part of #485.
