### PR TITLE
Durcir la garde de cohérence de l'impact citoyen

### DIFF
--- a/src/services/sync/__tests__/generate-scrutin-citizen-impacts.test.ts
+++ b/src/services/sync/__tests__/generate-scrutin-citizen-impacts.test.ts
@@ -176,3 +176,154 @@ describeIfDb("generateScrutinCitizenImpacts — amendment substance contract", (
     expect(row?.citizenImpact).toBeNull();
   });
 });
+
+// Regression: an amendment-linked scrutin whose substance did NOT resolve
+// (empty blocks) must still be guarded. Historically the guard was gated on
+// `substanceBlocks.length > 0`, so these slipped through and a dossier-drifted
+// impact was persisted unchecked (the SC-012903 failure mode).
+const PFX2 = "TEST_CIG_";
+
+const NEONIC_TITLE = "Interdire les néonicotinoïdes pour protéger les abeilles";
+const NEONIC_SUBTITLE =
+  "Rétablir l'interdiction des pesticides néonicotinoïdes tueurs d'abeilles, sans dérogation possible.";
+// Impact coherent with the néonicotinoïdes policy title.
+const NEONIC_IMPACT =
+  "**Ce qui était proposé**\n\nUn amendement proposait d'interdire les néonicotinoïdes, ces pesticides accusés de tuer les abeilles, sans aucune dérogation.";
+// Dossier-drift impact (cooperatives) — shares no salient term with the title.
+const DRIFT_IMPACT =
+  "**Ce qui était proposé**\n\nIl proposait d'obliger les coopératives agricoles à publier la répartition de leurs revenus entre filiales et associés.";
+
+describeIfDb("generateScrutinCitizenImpacts — guard without resolved substance", () => {
+  let noRefScrutinId: string;
+  let ptDriftScrutinId: string;
+  let ptOkScrutinId: string;
+
+  async function cleanup() {
+    await db.scrutinAmendment.deleteMany({
+      where: { amendment: { externalId: { startsWith: PFX2 } } },
+    });
+    await db.scrutinPolicyTitle.deleteMany({
+      where: { scrutin: { externalId: { startsWith: PFX2 } } },
+    });
+    await db.scrutin.deleteMany({ where: { externalId: { startsWith: PFX2 } } });
+    await db.amendment.deleteMany({ where: { externalId: { startsWith: PFX2 } } });
+    await db.legislativeDossier.deleteMany({ where: { externalId: `${PFX2}DLR` } });
+  }
+
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ generateScrutinCitizenImpacts } =
+      await import("@/services/sync/generate-scrutin-citizen-impacts"));
+    await cleanup();
+
+    // No exposeDesMotifs on the dossier -> an amendment with empty content/summary
+    // resolves to ZERO substance blocks (see substance-resolver fallback).
+    const dossier = await db.legislativeDossier.create({
+      data: {
+        externalId: `${PFX2}DLR`,
+        slug: `${PFX2}dossier`,
+        title: "Projet de loi sur l'agriculture",
+        summary: "Résumé générique du dossier agricole.",
+        status: "EN_COURS",
+      },
+    });
+
+    async function makeScrutin(suffix: string, withPolicyTitle: boolean): Promise<string> {
+      const amd = await db.amendment.create({
+        data: {
+          externalId: `${PFX2}A${suffix}`,
+          number: `A${suffix}`,
+          dossierId: dossier.id,
+          status: "DEPOSE",
+          legislature: 17,
+          chamber: "AN",
+          article: "ARTICLE 1",
+          content: null,
+          summary: null,
+        },
+      });
+      const scrutin = await db.scrutin.create({
+        data: {
+          externalId: `${PFX2}S${suffix}`,
+          slug: `${PFX2}s${suffix}`,
+          title: `l'amendement n° ${suffix} du projet de loi sur l'agriculture`,
+          sourceUrl: `https://www.assemblee-nationale.fr/dyn/17/scrutins/test-cig-${suffix}`,
+          votingDate: new Date("2026-06-01"),
+          legislature: 17,
+          chamber: "AN",
+          votesFor: 30,
+          votesAgainst: 40,
+          votesAbstain: 1,
+          result: "REJECTED",
+          summary: "Résumé générique du scrutin.",
+          dossierLegislatifId: dossier.id,
+          amendmentLinks: {
+            create: [{ amendmentId: amd.id, role: "PRINCIPAL", source: "TITLE_REGEX" }],
+          },
+        },
+      });
+      if (withPolicyTitle) {
+        await db.scrutinPolicyTitle.create({
+          data: {
+            scrutinId: scrutin.id,
+            officialTitleSnapshot: scrutin.title,
+            inputHash: "test-hash",
+            policyTitle: NEONIC_TITLE,
+            policySubtitle: NEONIC_SUBTITLE,
+            proceduralLabel: `Amendement n°${suffix}`,
+            confidence: "HIGH",
+            qualitySignals: {},
+            generationSource: "LLM",
+            status: "APPROVED",
+          },
+        });
+      }
+      return scrutin.id;
+    }
+
+    noRefScrutinId = await makeScrutin("NOREF", false);
+    ptDriftScrutinId = await makeScrutin("DRIFT", true);
+    ptOkScrutinId = await makeScrutin("OK", true);
+  });
+
+  afterAll(cleanup);
+
+  beforeEach(() => {
+    mockCall.mockReset();
+  });
+
+  it("does NOT persist when there is no reference (no substance AND no policy title)", async () => {
+    mockCall.mockResolvedValue(mistralImpact(DRIFT_IMPACT));
+    const stats = await generateScrutinCitizenImpacts({
+      scrutinIds: [noRefScrutinId],
+      force: true,
+    });
+
+    expect(stats.generated).toBe(0);
+    expect(stats.skippedIncoherent).toBe(1);
+    const row = await db.scrutin.findUnique({ where: { id: noRefScrutinId } });
+    expect(row?.citizenImpact).toBeNull();
+  });
+
+  it("guards against the policy title even when substance did not resolve", async () => {
+    mockCall.mockResolvedValue(mistralImpact(DRIFT_IMPACT));
+    const stats = await generateScrutinCitizenImpacts({
+      scrutinIds: [ptDriftScrutinId],
+      force: true,
+    });
+
+    expect(stats.generated).toBe(0);
+    expect(stats.skippedIncoherent).toBe(1);
+    const row = await db.scrutin.findUnique({ where: { id: ptDriftScrutinId } });
+    expect(row?.citizenImpact).toBeNull();
+  });
+
+  it("still persists an impact coherent with the policy title (no over-blocking)", async () => {
+    mockCall.mockResolvedValue(mistralImpact(NEONIC_IMPACT));
+    const stats = await generateScrutinCitizenImpacts({ scrutinIds: [ptOkScrutinId], force: true });
+
+    expect(stats.generated).toBe(1);
+    const row = await db.scrutin.findUnique({ where: { id: ptOkScrutinId } });
+    expect(row?.citizenImpact).toContain("néonicotinoïdes");
+  });
+});

--- a/src/services/sync/generate-scrutin-citizen-impacts.ts
+++ b/src/services/sync/generate-scrutin-citizen-impacts.ts
@@ -241,21 +241,27 @@ export async function generateScrutinCitizenImpacts(options?: {
         continue;
       }
 
-      // Coherence guard: for amendment-linked scrutins, the impact must echo the
-      // official reference (title/amendment). Otherwise the model described a
-      // measure from the broad dossier context — do not persist automatically.
-      if (prepared.hasLinkedAmendment && prepared.input.substanceBlocks.length > 0) {
+      // Coherence guard: for amendment-linked scrutins, the generated impact must
+      // echo the official reference (approved policy title, else resolved amendment
+      // substance). Runs whenever the scrutin is amendment-linked — NOT only when
+      // substance resolved: assessCoherence can check against the policy title even
+      // with empty blocks, and when NO reference exists at all (substance not yet
+      // resolved AND no policy title) we cannot tell whether the model described
+      // THIS amendment or drifted onto the broad dossier — so we refuse to persist.
+      // Better an empty "en bref" than a confident wrong one; a later run
+      // regenerates once a reference exists, since the row stays null.
+      if (prepared.hasLinkedAmendment) {
         const verdict = assessCoherence({
           text: result.citizenImpact,
           policyTitle: prepared.policyTitle?.policyTitle ?? null,
           policySubtitle: prepared.policyTitle?.policySubtitle ?? null,
           blocks: prepared.input.substanceBlocks,
         });
-        if (!verdict.coherent) {
+        if (verdict.referenceUsed === "none" || !verdict.coherent) {
           stats.skippedIncoherent++;
           console.warn(
-            `[citizen-impacts] INCOHERENT impact for ${prepared.slug ?? id} ` +
-              `(coverage ${verdict.coverage.toFixed(2)}, ref=${verdict.referenceUsed}) — not persisted`
+            `[citizen-impacts] NOT PERSISTED for ${prepared.slug ?? id} ` +
+              `(coverage ${verdict.coverage.toFixed(2)}, ref=${verdict.referenceUsed})`
           );
           continue;
         }


### PR DESCRIPTION
## Problème

La garde de cohérence de l'impact citoyen ne se déclenchait que lorsque la substance de l'amendement était résolue :

```js
if (prepared.hasLinkedAmendment && prepared.input.substanceBlocks.length > 0) { ... }
```

Or `assessCoherence` sait aussi vérifier contre le **titre public** (référence `policyTitle`). Résultat : un vote d'amendement dont la substance n'était pas encore résolue au moment de la génération (amendement pas encore rattaché, ou impact généré avant le titre) passait **sans aucun contrôle**, et une description tirée du contexte du dossier était figée en base — le cas SC-012903 (« protection des enfants » raconté comme un placement d'enfants alors que l'amendement portait sur la période de sûreté d'un viol).

Le cron ne réécrivant jamais un impact non-null, ces descriptions restaient en prod.

## Portée constatée

Audit prod avec la métrique de cohérence existante : **1 575 impacts incohérents sur 3 347 votes d'amendement (47 %)**. Ils ont été vidés (retour au résumé générique) et sont régénérés depuis ce pipeline durci.

## Correctif

La garde tourne désormais pour **tout scrutin rattaché à un amendement**, et refuse de persister quand il n'existe **aucune référence** (ni titre public, ni substance) pour vérifier l'impact. Mieux vaut un « en bref » vide qu'une description fausse ; une exécution ultérieure régénère une fois qu'une référence existe (la ligne reste null).

## Tests

3 cas de non-régression ajoutés (amendement rattaché, substance non résolue) :
- aucune référence → non persisté ;
- titre public présent mais impact hors-sujet → non persisté ;
- impact cohérent avec le titre → persisté (pas de sur-blocage).
