### PR TITLE
Exposer des tags de cache étroits (votes-key, homepage)

### DIFF
--- a/src/__tests__/lib/cache-tags.test.ts
+++ b/src/__tests__/lib/cache-tags.test.ts
@@ -13,12 +13,15 @@ import { SELECTABLE_TAGS } from "@/lib/cache-tags";
 import { SITEMAP_SHARD_TAGS, AFFAIR_BEARING_SHARDS } from "@/lib/seo/sitemap-tags";
 import { revalidateCacheSchema } from "@/lib/security/schemas/admin";
 
-describe("cache invalidation scopes", () => {
-  beforeEach(() => {
-    revalidateTagSpy.mockClear();
-    revalidatePathSpy.mockClear();
-  });
+// Clear the spies before EVERY test (all describes), so a test that fires a
+// broad purge (e.g. revalidateAll) can't leak its tag calls into a later
+// describe that reads the accumulated spy state.
+beforeEach(() => {
+  revalidateTagSpy.mockClear();
+  revalidatePathSpy.mockClear();
+});
 
+describe("cache invalidation scopes", () => {
   it("invalidateEntity('election') updates only the global elections tag", () => {
     invalidateEntity("election");
     const tags = revalidateTagSpy.mock.calls.map((c) => c[0]);
@@ -76,6 +79,24 @@ describe("selective invalidation allow-list", () => {
     expect(revalidateCacheSchema.safeParse({ tags: ["nope"] }).success).toBe(false);
     expect(revalidateCacheSchema.safeParse({ tags: ["affairs", "nope"] }).success).toBe(false);
     expect(revalidateCacheSchema.safeParse({ tags: [] }).success).toBe(false);
+  });
+});
+
+// Narrow sub-tags let an operator refresh the key-votes hub / homepage without
+// firing the global "votes" purge (which spans the whole site and once tripped
+// the Vercel spend cap).
+describe("narrow sub-tags (targeted hub/homepage refresh)", () => {
+  it("are operator-selectable via the cache endpoint", () => {
+    for (const tag of ["votes-key", "homepage"]) {
+      expect(revalidateCacheSchema.safeParse({ tags: [tag] }).success).toBe(true);
+    }
+  });
+
+  it("are NOT purged by revalidateAll — their parent tag covers them there", () => {
+    revalidateAll();
+    const tags = revalidateTagSpy.mock.calls.map((c) => c[0]);
+    expect(tags).not.toContain("votes-key");
+    expect(tags).not.toContain("homepage");
   });
 });
 

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -30,9 +30,20 @@ export const ALL_TAGS = [
  */
 export const FROZEN_TAGS = ["elections-municipales-2026"] as const;
 
+/**
+ * Narrow sub-tags applied ALONGSIDE a broad tag on specific data functions
+ * (e.g. `getKeyVotes` is tagged both "votes" and "votes-key"). Selectable so an
+ * operator can refresh just that surface (the key-votes hub, the homepage)
+ * without purging the whole "votes" tag, which spans the entire site and is
+ * expensive to regenerate. Held out of `revalidateAll()`: a full purge already
+ * covers them through their parent tag.
+ */
+export const NARROW_TAGS = ["votes-key", "homepage"] as const;
+
 /** Every tag an operator may name explicitly (admin endpoint, cron endpoint). */
-export const SELECTABLE_TAGS = [...ALL_TAGS, ...FROZEN_TAGS] as const;
+export const SELECTABLE_TAGS = [...ALL_TAGS, ...FROZEN_TAGS, ...NARROW_TAGS] as const;
 
 export type CacheTag = (typeof ALL_TAGS)[number];
+export type NarrowCacheTag = (typeof NARROW_TAGS)[number];
 export type FrozenCacheTag = (typeof FROZEN_TAGS)[number];
 export type SelectableCacheTag = (typeof SELECTABLE_TAGS)[number];


### PR DESCRIPTION
## Pourquoi

L'endpoint `/api/admin/votes/revalidate` (et le levier `{tags:["votes"]}`) purge le tag `"votes"`, posé sur **tout le site** (home, listings, fiches politiques, `/statistiques`, `/comparer`, récap, groupes, pages de détail). Une remédiation de masse a ainsi régénéré l'ensemble du site en rafale et **saturé le plafond Vercel Spend Management** (503 `DEPLOYMENT_PAUSED`).

Il n'existait aucun levier pour rafraîchir une surface **étroite** (ex. le hub key-votes de `/parlement`, ou la home) sans ce marteau.

## Changement

Ajout d'un groupe `NARROW_TAGS` = `["votes-key", "homepage"]` : des sous-tags déjà posés à côté de `"votes"` sur des fonctions précises (`getKeyVotes`, home). Ils deviennent **sélectionnables** par l'endpoint d'invalidation, mais restent **exclus de `revalidateAll()`** (leur tag parent les couvre déjà lors d'une purge complète).

On peut alors faire `POST /api/admin/cache/revalidate {tags:["votes-key"]}` pour rafraîchir uniquement les cartes key-votes, sans toucher au reste.

## Tests

- `votes-key` / `homepage` acceptés par le schéma de l'endpoint.
- Non purgés par `revalidateAll`.
- `beforeEach` remonté au niveau fichier pour isoler les tests (une purge large ne fuit plus vers un describe suivant).
