### PR TITLE
Audit des condamnations : rendre les chiffres comparables et les contradictions inratables

### DIFF
--- a/scripts/audit-convictions.ts
+++ b/scripts/audit-convictions.ts
@@ -5,31 +5,43 @@
  * en lots ; il n'écrit jamais une affaire. Les corrections passent par
  * `AffairUpdateProposal` ou par la modération, jamais par ici.
  *
+ * Deux axes, délibérément séparés. Le niveau de preuve dit ce que le monde publie
+ * sur cette affaire ; les contradictions disent ce que nous avons mal saisi. Les
+ * confondre sur un seul axe masquait 11 fiches déjà étayées au niveau C.
+ *
  * Usage :
  *   npx tsx --env-file=.env scripts/audit-convictions.ts                 # métrique + file
+ *   npx tsx --env-file=.env scripts/audit-convictions.ts --report        # + comparaison
  *   npx tsx --env-file=.env scripts/audit-convictions.ts --batch         # prochain lot
  *   npx tsx --env-file=.env scripts/audit-convictions.ts --batch --size=25
- *   npx tsx --env-file=.env scripts/audit-convictions.ts --done=id1,id2  # marque traité
- *   npx tsx --env-file=.env scripts/audit-convictions.ts --report        # avant/après
+ *   npx tsx --env-file=.env scripts/audit-convictions.ts --resolved=id1,id2
+ *   npx tsx --env-file=.env scripts/audit-convictions.ts --transferred=id1 --issue=571
+ *   npx tsx --env-file=.env scripts/audit-convictions.ts --recapture     # fige une référence
  */
 import "dotenv/config";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { db } from "../src/lib/db.js";
 import type { AffairStatus } from "../src/generated/prisma";
+import { RULES } from "../src/lib/affairs/grading-rules.js";
 import {
   ADVERSE_INVOLVEMENTS,
   assess,
   hasPreciseSentence,
+  isComparable,
   parseLedger,
+  type ContradictionKind,
   type EvidenceLevel,
   type Ledger,
+  type ReviewEntry,
+  type ReviewOutcome,
 } from "../src/lib/affairs/audit-evidence.js";
 
 const LEDGER = path.join(process.cwd(), "data", "audit-convictions.json");
 const DEFAULT_BATCH_SIZE = 20;
 const MIN_BATCH_SIZE = 15;
 const MAX_BATCH_SIZE = 25;
+const LEVELS = ["A", "B", "C", "D"] as const;
 
 /** Statuts de condamnation. Repris explicitement : une valeur ajoutée à l'enum doit
  *  être arbitrée ici plutôt que d'entrer dans l'audit par surprise. */
@@ -41,7 +53,7 @@ const CONVICTION_STATUSES: AffairStatus[] = [
 ];
 
 function readLedger(): Ledger {
-  if (!fs.existsSync(LEDGER)) return { done: [] };
+  if (!fs.existsSync(LEDGER)) return { reviewed: [] };
   try {
     return parseLedger(JSON.parse(fs.readFileSync(LEDGER, "utf8")));
   } catch {
@@ -55,12 +67,46 @@ function writeLedger(ledger: Ledger): void {
   fs.writeFileSync(LEDGER, JSON.stringify(ledger, null, 2) + "\n");
 }
 
+function idsFrom(arg: string): string[] {
+  return arg
+    .split("=")[1]!
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Ajoute des entrées sans dupliquer : une affaire déjà sortie de la file y reste. */
+function record(ledger: Ledger, ids: string[], outcome: ReviewOutcome): number {
+  const known = new Set(ledger.reviewed.map((e) => e.affairId));
+  const fresh: ReviewEntry[] = ids
+    .filter((affairId) => !known.has(affairId))
+    .map((affairId) => ({ affairId, outcome, at: new Date().toISOString() }));
+  ledger.reviewed = [...ledger.reviewed, ...fresh];
+  return fresh.length;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const wantBatch = args.includes("--batch");
   const wantReport = args.includes("--report");
-  const doneArg = args.find((a) => a.startsWith("--done="));
+  const wantRecapture = args.includes("--recapture");
+  const resolvedArg = args.find((a) => a.startsWith("--resolved="));
+  const transferredArg = args.find((a) => a.startsWith("--transferred="));
+  const issueArg = args.find((a) => a.startsWith("--issue="));
   const sizeArg = args.find((a) => a.startsWith("--size="));
+
+  // `--done=` ne disait pas pourquoi l'affaire sortait de la file, et c'est
+  // exactement ce qui a fait disparaître 10 fiches contradictoires de la revue.
+  // Le faire signifier silencieusement l'un des deux nouveaux motifs rejouerait
+  // la confusion qu'on retire.
+  if (args.some((a) => a.startsWith("--done="))) {
+    console.error(
+      "--done= n'existe plus : il ne disait pas pourquoi l'affaire sortait de la file.\n" +
+        "  --resolved=id1,id2                 affaire corrigée\n" +
+        "  --transferred=id1,id2 --issue=571  affaire confiée à une issue"
+    );
+    process.exit(1);
+  }
 
   const size = Math.min(
     MAX_BATCH_SIZE,
@@ -69,17 +115,24 @@ async function main() {
 
   const ledger = readLedger();
 
-  if (doneArg) {
-    const ids = doneArg
-      .split("=")[1]!
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-    const before = ledger.done.length;
-    // Idempotent : un identifiant déjà présent n'est pas ajouté deux fois.
-    ledger.done = [...new Set([...ledger.done, ...ids])];
+  if (resolvedArg || transferredArg) {
+    if (transferredArg && !issueArg) {
+      console.error("--transferred= exige --issue=N : une affaire confiée sans destinataire");
+      console.error("est une affaire perdue, pas une affaire traitée.");
+      process.exit(1);
+    }
+    let added = 0;
+    if (resolvedArg) added += record(ledger, idsFrom(resolvedArg), { kind: "RESOLVED" });
+    if (transferredArg) {
+      const issue = Number(issueArg!.split("=")[1]);
+      if (!Number.isInteger(issue) || issue <= 0) {
+        console.error(`--issue=${issueArg!.split("=")[1]} n'est pas un numéro d'issue.`);
+        process.exit(1);
+      }
+      added += record(ledger, idsFrom(transferredArg), { kind: "TRANSFERRED", issue });
+    }
     writeLedger(ledger);
-    console.log(`Registre : ${before} → ${ledger.done.length} affaire(s) examinée(s).`);
+    console.log(`Registre : ${added} entrée(s) ajoutée(s), ${ledger.reviewed.length} au total.`);
     return;
   }
 
@@ -139,87 +192,122 @@ async function main() {
       ...assessment,
     };
   });
+  type Row = (typeof rows)[number];
 
-  const distribution = (subset: typeof rows) =>
-    subset.reduce((acc, r) => ({ ...acc, [r.evidenceLevel]: acc[r.evidenceLevel] + 1 }), {
-      A: 0,
-      B: 0,
-      C: 0,
-      D: 0,
-    } as Record<EvidenceLevel, number>);
-
-  const dist = distribution(rows);
+  const evidenceDist = rows.reduce(
+    (acc, r) => ({ ...acc, [r.evidenceLevel]: acc[r.evidenceLevel] + 1 }),
+    { A: 0, B: 0, C: 0, D: 0 } as Record<EvidenceLevel, number>
+  );
+  const contradictory = rows.filter((r) => r.contradictions.length > 0);
   // Two different questions, deliberately kept apart. The first asks whether a
   // reader can click an official source on the page; the second asks whether
   // anything official backs the affair at all, a linked decision included.
   const withoutOfficialSourceRow = rows.filter((r) => !r.hasOfficialSource).length;
   const withoutOfficialEvidence = rows.filter((r) => !r.hasOfficialEvidence).length;
 
+  const sufficient = (r: Row) => r.evidenceLevel !== "D";
+  const cross = (evidenceOk: boolean, coherent: boolean) =>
+    rows.filter((r) => sufficient(r) === evidenceOk && (r.contradictions.length === 0) === coherent)
+      .length;
+
   console.log(`\n${rows.length} condamnations publiées examinées.\n`);
-  console.log("Niveau de preuve :");
-  for (const level of ["A", "B", "C", "D"] as const) {
-    console.log(`  ${level} : ${dist[level]}`);
-  }
-  console.log(`\nSans preuve officielle (métrique principale) : ${withoutOfficialEvidence}`);
-  console.log(`Sans ligne Source officielle (complétude éditoriale) : ${withoutOfficialSourceRow}`);
+  console.log("PREUVE       " + LEVELS.map((l) => `${l}=${evidenceDist[l]}`).join("   "));
+  console.log(`COHÉRENCE    ${contradictory.length} fiche(s) contradictoire(s)`);
 
-  // Point de comparaison figé au premier passage.
-  if (!ledger.baseline) {
+  console.log("\ncroisement :");
+  console.log(`  preuve suffisante   + contradictoire : ${cross(true, false)}   (édition seule)`);
+  console.log(`  preuve insuffisante + contradictoire : ${cross(false, false)}`);
+  console.log(`  preuve insuffisante + cohérente      : ${cross(false, true)}`);
+  console.log(`  preuve suffisante   + cohérente      : ${cross(true, true)}`);
+
+  console.log(`\nsans preuve officielle        : ${withoutOfficialEvidence}`);
+  console.log(`sans ligne Source officielle  : ${withoutOfficialSourceRow}`);
+
+  // Une fiche peut porter deux contradictions, donc ce total ne peut pas égaler le
+  // nombre de fiches. La sortie le dit pour qu'un écart ne se lise pas comme un bug.
+  const perKind = new Map<ContradictionKind, number>();
+  for (const r of rows) {
+    for (const c of r.contradictions) perKind.set(c.kind, (perKind.get(c.kind) ?? 0) + 1);
+  }
+  if (perKind.size) {
+    const occurrences = [...perKind.values()].reduce((a, b) => a + b, 0);
+    console.log(
+      `\nCONTRADICTIONS PAR TYPE — ${occurrences} occurrence(s) sur ${contradictory.length} fiche(s)`
+    );
+    for (const [kind, n] of [...perKind].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${String(n).padStart(3)}  ${kind}`);
+    }
+  }
+
+  if (wantReport) {
+    if (isComparable(ledger.baseline, RULES.version)) {
+      const b = ledger.baseline!;
+      console.log(
+        `\nAvant / après (référence du ${b.capturedAt.slice(0, 10)}, règles v${b.rulesVersion}) :`
+      );
+      for (const level of LEVELS) {
+        const delta = evidenceDist[level] - b.evidence[level];
+        console.log(
+          `  ${level} : ${b.evidence[level]} → ${evidenceDist[level]} (${delta >= 0 ? "+" : ""}${delta})`
+        );
+      }
+      const deltas: Array<[string, number, number]> = [
+        ["contradictions", b.contradictoryCount, contradictory.length],
+        ["sans preuve officielle", b.withoutOfficialEvidence, withoutOfficialEvidence],
+        ["sans ligne Source officielle", b.withoutOfficialSource, withoutOfficialSourceRow],
+      ];
+      for (const [label, before, after] of deltas) {
+        const d = after - before;
+        console.log(`  ${label} : ${before} → ${after} (${d >= 0 ? "+" : ""}${d})`);
+      }
+    } else {
+      console.log("\nRÉFÉRENCE NON COMPARABLE");
+      if (ledger.baseline) {
+        console.log(
+          `  Référence du ${ledger.baseline.capturedAt.slice(0, 10)} prise sous les règles v${ledger.baseline.rulesVersion}, les règles courantes sont v${RULES.version}.`
+        );
+      } else {
+        console.log("  Aucune référence versionnée : la précédente a été prise avant que les");
+        console.log("  règles ne soient versionnées, donc on ne sait pas sous quelles règles.");
+      }
+      console.log("  Aucun delta n'est calculé : les niveaux ne sont pas commensurables.");
+      console.log("  Figer une nouvelle référence : --recapture");
+    }
+
+    console.log("\nCRITÈRES DE #566");
+    console.log(
+      `  cohérence : ${contradictory.length} contradiction(s)         (sous notre contrôle)`
+    );
+    console.log(
+      `  preuve    : ${evidenceDist.D} fiche(s) insuffisante(s)  (dépend des sources publiées)`
+    );
+  }
+
+  if (wantRecapture) {
+    // Archivée, pas écrasée : une référence est un point de comparaison publié, et
+    // la perdre en silence coûte plus cher qu'un objet mort dans un fichier local.
+    const archived = ledger.legacyBaselines ? [ledger.legacyBaselines] : [];
+    if (ledger.baseline) archived.push(ledger.baseline);
+    ledger.legacyBaselines = archived.length ? archived : undefined;
     ledger.baseline = {
-      ...dist,
+      rulesVersion: RULES.version,
+      evidence: evidenceDist,
+      contradictoryCount: contradictory.length,
       withoutOfficialSource: withoutOfficialSourceRow,
-      capturedAt: new Date().toISOString(),
-    };
-    writeLedger(ledger);
-    console.log("Référence enregistrée dans le registre (premier passage).");
-  }
-
-  // Capture séparée : un registre antérieur à cette métrique n'a pas d'historique
-  // pour elle, et lui en fabriquer un rétroactivement serait une invention.
-  const evidenceBaselineIsNew = !ledger.evidenceBaseline;
-  if (evidenceBaselineIsNew) {
-    ledger.evidenceBaseline = {
       withoutOfficialEvidence,
       capturedAt: new Date().toISOString(),
     };
     writeLedger(ledger);
-  }
-
-  if (wantReport && ledger.baseline) {
-    const b = ledger.baseline;
-    console.log(`\nAvant / après (référence du ${b.capturedAt.slice(0, 10)}) :`);
-    for (const level of ["A", "B", "C", "D"] as const) {
-      const delta = dist[level] - b[level];
-      console.log(`  ${level} : ${b[level]} → ${dist[level]} (${delta >= 0 ? "+" : ""}${delta})`);
-    }
-    const deltaSourceRow = withoutOfficialSourceRow - b.withoutOfficialSource;
-    console.log(
-      `  sans ligne Source officielle : ${b.withoutOfficialSource} → ${withoutOfficialSourceRow} (${deltaSourceRow >= 0 ? "+" : ""}${deltaSourceRow})`
-    );
-
-    const eb = ledger.evidenceBaseline!;
-    if (evidenceBaselineIsNew) {
-      console.log(
-        `  sans preuve officielle : ${withoutOfficialEvidence} (référence prise aujourd'hui, pas d'historique)`
-      );
-    } else {
-      const deltaEvidence = withoutOfficialEvidence - eb.withoutOfficialEvidence;
-      console.log(
-        `  sans preuve officielle : ${eb.withoutOfficialEvidence} → ${withoutOfficialEvidence} (${deltaEvidence >= 0 ? "+" : ""}${deltaEvidence}, référence du ${eb.capturedAt.slice(0, 10)})`
-      );
-    }
-
-    console.log(
-      `\nCritère de succès : ${dist.D === 0 ? "ATTEINT" : `${dist.D} affaire(s) en niveau D`}`
-    );
+    console.log(`\nNouvelle référence figée sous les règles v${RULES.version}.`);
+    console.log("La précédente est archivée dans legacyBaselines, pas écrasée.");
   }
 
   // File priorisée. L'ordre des critères est celui de #566.
-  const done = new Set(ledger.done);
+  const reviewedById = new Map(ledger.reviewed.map((e) => [e.affairId, e]));
   const queue = rows
-    .filter((r) => !done.has(r.id))
+    .filter((r) => !reviewedById.has(r.id))
     .sort((x, y) => {
-      const rank = (r: typeof x) => [
+      const rank = (r: Row) => [
         r.contradictions.length > 0 ? 0 : 1,
         ADVERSE_INVOLVEMENTS.includes(r.involvement) ? 1 : 0,
         r.preciseSentence ? 0 : 1,
@@ -234,15 +322,41 @@ async function main() {
       return x.slug.localeCompare(y.slug);
     });
 
-  console.log(`\nFile : ${queue.length} à examiner, ${done.size} déjà examinée(s).`);
   const urgent = queue.filter((r) => r.contradictions.length > 0);
   if (urgent.length) {
-    console.log(`\nREVUE URGENTE — ${urgent.length} affaire(s) contradictoires :`);
+    console.log(`\nREVUE URGENTE — ${urgent.length} affaire(s) dans la file :`);
     for (const r of urgent) {
       console.log(`  [${r.evidenceLevel}] ${r.name} — /affaires/${r.slug}`);
-      for (const c of r.contradictions) console.log(`        ${c.message}`);
+      for (const c of r.contradictions) console.log(`        ${c.kind}  ${c.message}`);
     }
   }
+
+  // La correction du défaut central : `urgent` se calcule sur la file, donc une
+  // affaire sortie de la file disparaissait de l'écran même en restant
+  // contradictoire. 10 fiches étaient dans cet état, et le rapport annonçait
+  // 8 affaires en revue urgente quand il y en avait 18.
+  const outOfQueue = rows.filter((r) => reviewedById.has(r.id) && r.contradictions.length > 0);
+  if (outOfQueue.length) {
+    console.log(`\nENCORE CONTRADICTOIRES HORS FILE — ${outOfQueue.length} affaire(s) :`);
+    for (const r of outOfQueue) {
+      const outcome = reviewedById.get(r.id)!.outcome;
+      const motif =
+        outcome.kind === "TRANSFERRED"
+          ? `transférée #${outcome.issue}`
+          : outcome.kind === "RESOLVED"
+            ? "déclarée résolue"
+            : "motif hérité";
+      console.log(`  [${r.evidenceLevel}] ${r.name} — /affaires/${r.slug}   (${motif})`);
+      for (const c of r.contradictions) console.log(`        ${c.kind}  ${c.message}`);
+    }
+  }
+
+  const byOutcome = (kind: ReviewOutcome["kind"]) =>
+    ledger.reviewed.filter((e) => e.outcome.kind === kind).length;
+  console.log(`\nFILE : ${queue.length} à examiner`);
+  console.log(
+    `EXAMINÉES : ${byOutcome("RESOLVED")} résolue(s) · ${byOutcome("TRANSFERRED")} transférée(s) · ${byOutcome("LEGACY")} héritée(s)`
+  );
 
   if (wantBatch) {
     const batch = queue.slice(0, size);
@@ -267,7 +381,9 @@ async function main() {
       );
     }
     console.log(
-      `\nUne fois le lot traité :\n  npx tsx --env-file=.env scripts/audit-convictions.ts --done=${batch.map((b) => b.id).join(",")}`
+      `\nUne fois le lot traité, selon le motif de sortie :\n` +
+        `  --resolved=${batch.map((b) => b.id).join(",")}\n` +
+        `  --transferred=<sous-ensemble> --issue=<numéro>`
     );
   }
 }

--- a/scripts/audit-convictions.ts
+++ b/scripts/audit-convictions.ts
@@ -26,14 +26,15 @@ import type { AffairStatus } from "../src/generated/prisma";
 import { RULES } from "../src/lib/affairs/grading-rules.js";
 import {
   ADVERSE_INVOLVEMENTS,
+  archiveBaseline,
   assess,
   hasPreciseSentence,
   isComparable,
   parseLedger,
+  recordReview,
   type ContradictionKind,
   type EvidenceLevel,
   type Ledger,
-  type ReviewEntry,
   type ReviewOutcome,
 } from "../src/lib/affairs/audit-evidence.js";
 
@@ -75,16 +76,6 @@ function idsFrom(arg: string): string[] {
     .filter(Boolean);
 }
 
-/** Ajoute des entrées sans dupliquer : une affaire déjà sortie de la file y reste. */
-function record(ledger: Ledger, ids: string[], outcome: ReviewOutcome): number {
-  const known = new Set(ledger.reviewed.map((e) => e.affairId));
-  const fresh: ReviewEntry[] = ids
-    .filter((affairId) => !known.has(affairId))
-    .map((affairId) => ({ affairId, outcome, at: new Date().toISOString() }));
-  ledger.reviewed = [...ledger.reviewed, ...fresh];
-  return fresh.length;
-}
-
 async function main() {
   const args = process.argv.slice(2);
   const wantBatch = args.includes("--batch");
@@ -122,17 +113,28 @@ async function main() {
       process.exit(1);
     }
     let added = 0;
-    if (resolvedArg) added += record(ledger, idsFrom(resolvedArg), { kind: "RESOLVED" });
+    let reclassified = 0;
+    const tally = (counts: { added: number; reclassified: number }) => {
+      added += counts.added;
+      reclassified += counts.reclassified;
+    };
+
+    if (resolvedArg) tally(recordReview(ledger, idsFrom(resolvedArg), { kind: "RESOLVED" }));
     if (transferredArg) {
       const issue = Number(issueArg!.split("=")[1]);
       if (!Number.isInteger(issue) || issue <= 0) {
         console.error(`--issue=${issueArg!.split("=")[1]} n'est pas un numéro d'issue.`);
         process.exit(1);
       }
-      added += record(ledger, idsFrom(transferredArg), { kind: "TRANSFERRED", issue });
+      tally(recordReview(ledger, idsFrom(transferredArg), { kind: "TRANSFERRED", issue }));
     }
     writeLedger(ledger);
-    console.log(`Registre : ${added} entrée(s) ajoutée(s), ${ledger.reviewed.length} au total.`);
+    console.log(
+      `Registre : ${added} ajoutée(s), ${reclassified} reclassée(s), ${ledger.reviewed.length} au total.`
+    );
+    if (added === 0 && reclassified === 0) {
+      console.log("Aucun changement : ces affaires portaient déjà ce motif.");
+    }
     return;
   }
 
@@ -286,9 +288,7 @@ async function main() {
   if (wantRecapture) {
     // Archivée, pas écrasée : une référence est un point de comparaison publié, et
     // la perdre en silence coûte plus cher qu'un objet mort dans un fichier local.
-    const archived = ledger.legacyBaselines ? [ledger.legacyBaselines] : [];
-    if (ledger.baseline) archived.push(ledger.baseline);
-    ledger.legacyBaselines = archived.length ? archived : undefined;
+    ledger.legacyBaselines = archiveBaseline(ledger.legacyBaselines, ledger.baseline);
     ledger.baseline = {
       rulesVersion: RULES.version,
       evidence: evidenceDist,

--- a/scripts/audit-convictions.ts
+++ b/scripts/audit-convictions.ts
@@ -141,7 +141,7 @@ async function main() {
   });
 
   const distribution = (subset: typeof rows) =>
-    subset.reduce((acc, r) => ({ ...acc, [r.level]: acc[r.level] + 1 }), {
+    subset.reduce((acc, r) => ({ ...acc, [r.evidenceLevel]: acc[r.evidenceLevel] + 1 }), {
       A: 0,
       B: 0,
       C: 0,
@@ -239,8 +239,8 @@ async function main() {
   if (urgent.length) {
     console.log(`\nREVUE URGENTE — ${urgent.length} affaire(s) contradictoires :`);
     for (const r of urgent) {
-      console.log(`  [${r.level}] ${r.name} — /affaires/${r.slug}`);
-      for (const c of r.contradictions) console.log(`        ${c}`);
+      console.log(`  [${r.evidenceLevel}] ${r.name} — /affaires/${r.slug}`);
+      for (const c of r.contradictions) console.log(`        ${c.message}`);
     }
   }
 
@@ -250,7 +250,7 @@ async function main() {
     for (const r of batch) {
       console.log(
         [
-          `[${r.level}]`,
+          `[${r.evidenceLevel}]`,
           r.status.padEnd(32),
           r.involvement.padEnd(14),
           `src=${String(r.sourceCount).padStart(2)}`,

--- a/src/lib/affairs/__tests__/audit-evidence.test.ts
+++ b/src/lib/affairs/__tests__/audit-evidence.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
+  archiveBaseline,
   assess,
   isComparable,
   parseLedger,
+  recordReview,
   describesPartlySuspendedSentence,
+  type Baseline,
   type ContradictionKind,
+  type Ledger,
   type SourceRow,
 } from "@/lib/affairs/audit-evidence";
 
@@ -255,6 +259,91 @@ describe("le registre distingue résolue, transférée et héritée", () => {
     expect(parseLedger(null).reviewed).toEqual([]);
     expect(parseLedger({ reviewed: "pas-un-tableau" }).reviewed).toEqual([]);
     expect(parseLedger({ done: "pas-un-tableau" }).reviewed).toEqual([]);
+  });
+});
+
+// The first version of this refused to touch an id already in the ledger, so the
+// 10 entries inherited as LEGACY could never be assigned to #569 or #571 — the
+// very next step this lot is meant to enable. Worse, it reported success while
+// adding nothing.
+describe("une entrée du registre peut être reclassée", () => {
+  const legacy = (): Ledger => ({
+    reviewed: [{ affairId: "aff-1", outcome: { kind: "LEGACY" } }],
+  });
+
+  it("reclasse une entrée héritée vers une issue", () => {
+    const ledger = legacy();
+    const counts = recordReview(ledger, ["aff-1"], { kind: "TRANSFERRED", issue: 571 });
+
+    expect(counts).toEqual({ added: 0, reclassified: 1 });
+    expect(ledger.reviewed).toHaveLength(1);
+    expect(ledger.reviewed[0]!.outcome).toEqual({ kind: "TRANSFERRED", issue: 571 });
+  });
+
+  it("horodate la reclassification", () => {
+    const ledger = legacy();
+    recordReview(ledger, ["aff-1"], { kind: "RESOLVED" });
+
+    expect(ledger.reviewed[0]!.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("ajoute une entrée inconnue", () => {
+    const ledger = legacy();
+    const counts = recordReview(ledger, ["aff-2"], { kind: "RESOLVED" });
+
+    expect(counts).toEqual({ added: 1, reclassified: 0 });
+    expect(ledger.reviewed).toHaveLength(2);
+  });
+
+  it("ne compte pas une reclassification vers le même motif", () => {
+    const ledger: Ledger = {
+      reviewed: [{ affairId: "aff-1", outcome: { kind: "TRANSFERRED", issue: 571 } }],
+    };
+    const counts = recordReview(ledger, ["aff-1"], { kind: "TRANSFERRED", issue: 571 });
+
+    expect(counts).toEqual({ added: 0, reclassified: 0 });
+  });
+
+  it("distingue deux issues de transfert différentes", () => {
+    const ledger: Ledger = {
+      reviewed: [{ affairId: "aff-1", outcome: { kind: "TRANSFERRED", issue: 569 } }],
+    };
+    const counts = recordReview(ledger, ["aff-1"], { kind: "TRANSFERRED", issue: 571 });
+
+    expect(counts).toEqual({ added: 0, reclassified: 1 });
+  });
+});
+
+describe("archiver une référence ne l'imbrique pas", () => {
+  const baseline = (day: string): Baseline => ({
+    rulesVersion: 1,
+    evidence: { A: 4, B: 11, C: 72, D: 45 },
+    contradictoryCount: 18,
+    withoutOfficialSource: 120,
+    withoutOfficialEvidence: 117,
+    capturedAt: `2026-07-${day}T00:00:00.000Z`,
+  });
+
+  it("archive la première référence dans un tableau plat", () => {
+    expect(archiveBaseline(undefined, baseline("30"))).toEqual([baseline("30")]);
+  });
+
+  // Two successive recaptures used to produce [[old], new]: an array whose first
+  // element was an array, gaining a level of nesting on every call.
+  it("reste plat après deux archivages", () => {
+    const once = archiveBaseline(undefined, baseline("30"));
+
+    expect(archiveBaseline(once, baseline("31"))).toEqual([baseline("30"), baseline("31")]);
+  });
+
+  it("absorbe la paire non versionnée héritée sans l'aplatir de force", () => {
+    const inherited = { baseline: { A: 3 }, evidenceBaseline: { withoutOfficialEvidence: 116 } };
+
+    expect(archiveBaseline(inherited, baseline("30"))).toEqual([inherited, baseline("30")]);
+  });
+
+  it("n'archive rien quand il n'y a pas de référence à remplacer", () => {
+    expect(archiveBaseline(undefined, undefined)).toBeUndefined();
   });
 });
 

--- a/src/lib/affairs/__tests__/audit-evidence.test.ts
+++ b/src/lib/affairs/__tests__/audit-evidence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assess,
+  isComparable,
   parseLedger,
   describesPartlySuspendedSentence,
   type ContradictionKind,
@@ -191,56 +192,94 @@ describe("chaque contradiction porte un type stable", () => {
   });
 });
 
-describe("the ledger stays readable across generations", () => {
-  it("reads a ledger written before the stricter metric existed", () => {
-    const old = {
-      done: ["aff-1", "aff-2"],
-      baseline: {
-        A: 3,
-        B: 12,
-        C: 64,
-        D: 53,
-        withoutOfficialSource: 120,
-        capturedAt: "2026-07-26T00:00:00.000Z",
-      },
-    };
+// #566 allows two reasons to mark an affair examined: resolved, or transferred to
+// an issue that has an owner and a closure criterion. A flat array of ids cannot
+// tell them apart, so the report treated them alike and hid both. 10 of the 27
+// entries were still contradictory and appeared nowhere.
+describe("le registre distingue résolue, transférée et héritée", () => {
+  const OLD_GENERATION = {
+    done: ["aff-1", "aff-2"],
+    baseline: {
+      A: 3,
+      B: 12,
+      C: 64,
+      D: 53,
+      withoutOfficialSource: 120,
+      capturedAt: "2026-07-26T00:00:00.000Z",
+    },
+    evidenceBaseline: {
+      withoutOfficialEvidence: 116,
+      capturedAt: "2026-07-27T00:00:00.000Z",
+    },
+  };
 
-    const ledger = parseLedger(old);
+  it("lit une génération ancienne sans inventer de motif", () => {
+    const ledger = parseLedger(OLD_GENERATION);
 
-    expect(ledger.done).toEqual(["aff-1", "aff-2"]);
-    // The historical figure keeps its original meaning: Source rows only.
-    expect(ledger.baseline?.withoutOfficialSource).toBe(120);
-    expect(ledger.baseline?.capturedAt).toBe("2026-07-26T00:00:00.000Z");
-    // No history is invented for the metric that did not exist yet.
-    expect(ledger.evidenceBaseline).toBeUndefined();
+    expect(ledger.reviewed).toHaveLength(2);
+    expect(ledger.reviewed[0]).toEqual({ affairId: "aff-1", outcome: { kind: "LEGACY" } });
   });
 
-  it("reads a ledger holding both baselines, each with its own date", () => {
-    const ledger = parseLedger({
-      done: [],
-      baseline: {
-        A: 3,
-        B: 11,
-        C: 66,
-        D: 51,
-        withoutOfficialSource: 119,
-        capturedAt: "2026-07-26T00:00:00.000Z",
-      },
-      evidenceBaseline: {
-        withoutOfficialEvidence: 116,
-        capturedAt: "2026-07-27T00:00:00.000Z",
-      },
+  // The old format recorded no timestamp, so none is invented.
+  it("ne fabrique pas d'horodatage pour une entrée héritée", () => {
+    expect(parseLedger(OLD_GENERATION).reviewed[0]!.at).toBeUndefined();
+  });
+
+  // 120 is the figure published on #566 as the canonical reference. It is archived
+  // rather than differenced: it was measured under rules we cannot identify.
+  it("archive l'ancienne paire de références sans la promouvoir", () => {
+    const ledger = parseLedger(OLD_GENERATION);
+
+    expect(ledger.baseline).toBeUndefined();
+    expect(ledger.legacyBaselines).toEqual({
+      baseline: OLD_GENERATION.baseline,
+      evidenceBaseline: OLD_GENERATION.evidenceBaseline,
     });
-
-    expect(ledger.baseline?.capturedAt).toBe("2026-07-26T00:00:00.000Z");
-    expect(ledger.evidenceBaseline?.capturedAt).toBe("2026-07-27T00:00:00.000Z");
-    expect(ledger.evidenceBaseline?.withoutOfficialEvidence).toBe(116);
   });
 
-  it("tolerates an empty or malformed ledger without inventing entries", () => {
-    expect(parseLedger({}).done).toEqual([]);
-    expect(parseLedger(null).done).toEqual([]);
-    expect(parseLedger({ done: "not-an-array" }).done).toEqual([]);
+  it("relit une génération typée à l'identique", () => {
+    const reviewed = [
+      { affairId: "aff-1", outcome: { kind: "RESOLVED" as const }, at: "2026-07-30T10:00:00.000Z" },
+      {
+        affairId: "aff-2",
+        outcome: { kind: "TRANSFERRED" as const, issue: 571 },
+        at: "2026-07-30T10:00:00.000Z",
+      },
+    ];
+
+    expect(parseLedger({ reviewed }).reviewed).toEqual(reviewed);
+  });
+
+  it("tolère un registre vide ou abîmé sans inventer d'entrée", () => {
+    expect(parseLedger({}).reviewed).toEqual([]);
+    expect(parseLedger(null).reviewed).toEqual([]);
+    expect(parseLedger({ reviewed: "pas-un-tableau" }).reviewed).toEqual([]);
+    expect(parseLedger({ done: "pas-un-tableau" }).reviewed).toEqual([]);
+  });
+});
+
+describe("une référence n'est comparable que sous les mêmes règles", () => {
+  const baseline = {
+    rulesVersion: 1,
+    evidence: { A: 4, B: 11, C: 72, D: 45 },
+    contradictoryCount: 18,
+    withoutOfficialSource: 120,
+    withoutOfficialEvidence: 117,
+    capturedAt: "2026-07-30T00:00:00.000Z",
+  };
+
+  it("comparable à version égale", () => {
+    expect(isComparable(baseline, 1)).toBe(true);
+  });
+
+  // This is the defect that produced a false regression diagnosis: the report
+  // printed « D : 53 → 56 (+3) » across a rule change, on an unchanged corpus.
+  it("non comparable à version différente", () => {
+    expect(isComparable(baseline, 2)).toBe(false);
+  });
+
+  it("non comparable en l'absence de référence", () => {
+    expect(isComparable(undefined, 1)).toBe(false);
   });
 });
 

--- a/src/lib/affairs/__tests__/audit-evidence.test.ts
+++ b/src/lib/affairs/__tests__/audit-evidence.test.ts
@@ -3,6 +3,7 @@ import {
   assess,
   parseLedger,
   describesPartlySuspendedSentence,
+  type ContradictionKind,
   type SourceRow,
 } from "@/lib/affairs/audit-evidence";
 
@@ -52,7 +53,7 @@ describe("the two official-backing metrics are distinct", () => {
 
     expect(a.hasOfficialSource).toBe(false);
     expect(a.hasOfficialEvidence).toBe(true);
-    expect(a.level).toBe("A");
+    expect(a.evidenceLevel).toBe("A");
   });
 
   it("an official Source row without a linked decision: both yes", () => {
@@ -60,7 +61,7 @@ describe("the two official-backing metrics are distinct", () => {
 
     expect(a.hasOfficialSource).toBe(true);
     expect(a.hasOfficialEvidence).toBe(true);
-    expect(a.level).toBe("B");
+    expect(a.evidenceLevel).toBe("B");
   });
 
   it("both at once: both yes, and the decision wins the level", () => {
@@ -68,7 +69,7 @@ describe("the two official-backing metrics are distinct", () => {
 
     expect(a.hasOfficialSource).toBe(true);
     expect(a.hasOfficialEvidence).toBe(true);
-    expect(a.level).toBe("A");
+    expect(a.evidenceLevel).toBe("A");
   });
 
   it("no official backing at all: both no", () => {
@@ -79,7 +80,7 @@ describe("the two official-backing metrics are distinct", () => {
 
     expect(a.hasOfficialSource).toBe(false);
     expect(a.hasOfficialEvidence).toBe(false);
-    expect(a.level).toBe("C");
+    expect(a.evidenceLevel).toBe("C");
   });
 
   it("no source at all: both no, and the affair falls to D", () => {
@@ -87,11 +88,12 @@ describe("the two official-backing metrics are distinct", () => {
 
     expect(a.hasOfficialSource).toBe(false);
     expect(a.hasOfficialEvidence).toBe(false);
-    expect(a.level).toBe("D");
+    expect(a.evidenceLevel).toBe("D");
   });
 
-  // A contradiction sends the affair to D whatever backs it, but it does not
-  // erase the fact that the backing exists: the two metrics stay truthful.
+  // This affair is backed by an identified ruling AND contradicts itself. It used
+  // to report level D, which said the evidence was insufficient when it was the
+  // best available. Both facts are now reported side by side.
   it("keeps reporting the backing of a contradictory affair", () => {
     const a = affair({
       decisionCount: 1,
@@ -100,10 +102,92 @@ describe("the two official-backing metrics are distinct", () => {
       description: "La condamnation est définitive.",
     });
 
-    expect(a.level).toBe("D");
-    expect(a.contradictions.length).toBeGreaterThan(0);
+    expect(a.evidenceLevel).toBe("A");
+    expect(a.contradictions.map((c) => c.kind)).toEqual(["NON_DEFINITIF_MAIS_RECOURS_EPUISE"]);
     expect(a.hasOfficialEvidence).toBe(true);
     expect(a.hasOfficialSource).toBe(true);
+  });
+});
+
+// Evidence quality is a property of the world: the documents exist or they do
+// not. Internal coherence is a property of our own data entry. Collapsing both
+// onto one axis hid 11 published fiches whose evidence was already at C and
+// whose only problem was a field we had written wrong ourselves.
+describe("preuve et cohérence sont deux axes indépendants", () => {
+  it("une fiche contradictoire garde le niveau de preuve qu'elle mérite", () => {
+    const contradictory = affair({
+      involvement: "VICTIM",
+      sources: [source(), source({ publisher: "Libération", title: "Un autre titre" })],
+    });
+
+    expect(contradictory.evidenceLevel).toBe("C");
+    expect(contradictory.contradictions).toHaveLength(1);
+    expect(contradictory.contradictions[0]!.kind).toBe("IMPLICATION_NON_ADVERSE");
+  });
+
+  it("le niveau de preuve est le même avec et sans contradiction", () => {
+    const sources = [OFFICIAL_SOURCE];
+    const clean = affair({ sources, involvement: "DIRECT" });
+    const dirty = affair({ sources, involvement: "VICTIM" });
+
+    expect(dirty.evidenceLevel).toBe(clean.evidenceLevel);
+    expect(clean.contradictions).toEqual([]);
+    expect(dirty.contradictions).not.toEqual([]);
+  });
+
+  it("une preuve absente reste en D, contradiction ou pas", () => {
+    expect(affair({ sources: [] }).evidenceLevel).toBe("D");
+    expect(affair({ sources: [], involvement: "VICTIM" }).evidenceLevel).toBe("D");
+  });
+});
+
+// The closure criteria of #566, #569, #571 and #580 quote these strings word for
+// word. A criterion anchored on a display string breaks at the first rewording,
+// so the kind is what issues should cite and the message stays free to change.
+describe("chaque contradiction porte un type stable", () => {
+  const cases: Array<[ContradictionKind, Partial<Parameters<typeof assess>[0]>]> = [
+    ["IMPLICATION_NON_ADVERSE", { involvement: "MENTIONED_ONLY" }],
+    ["VERDICT_SANS_DATE", { verdictDate: null }],
+    ["VERDICT_DANS_LE_FUTUR", { verdictDate: new Date("2099-01-01") }],
+    [
+      "SOURCES_ANTERIEURES_AU_VERDICT",
+      {
+        verdictDate: new Date("2024-06-19"),
+        sources: [source({ publishedAt: new Date("2020-01-01") })],
+      },
+    ],
+    [
+      "PEINE_FERME_MAIS_PARTIELLEMENT_SURSIS",
+      {
+        prisonMonths: 48,
+        prisonSuspended: false,
+        otherSentence: "4 ans dont 2 ans ferme et 2 avec sursis",
+      },
+    ],
+    [
+      "DEFINITIF_MAIS_RECOURS_PENDANT",
+      { status: "CONDAMNATION_DEFINITIVE", description: "Le pourvoi est en cours." },
+    ],
+    [
+      "NON_DEFINITIF_MAIS_RECOURS_EPUISE",
+      { status: "APPEL_EN_COURS", description: "La condamnation est définitive." },
+    ],
+  ];
+
+  it.each(cases)("%s", (kind, overrides) => {
+    expect(affair(overrides).contradictions.map((c) => c.kind)).toContain(kind);
+  });
+
+  it("garde une phrase française lisible à côté du type", () => {
+    const [first] = affair({ verdictDate: null }).contradictions;
+
+    expect(first!.message).toBe("statut de condamnation sans date de verdict");
+  });
+
+  it("nomme l'implication fautive dans le message", () => {
+    const [first] = affair({ involvement: "PLAINTIFF" }).contradictions;
+
+    expect(first!.message).toBe("statut de condamnation avec implication PLAINTIFF");
   });
 });
 
@@ -202,10 +286,13 @@ describe("detects a total shown as firm over a partly suspended sentence", () =>
         prisonSuspended: false,
         [field]: "4 ans dont 2 ans ferme et 2 ans avec sursis",
       });
-      expect(a.contradictions, `via ${field}`).toContain(
-        "peine affichée entièrement ferme alors que le texte décrit une part avec sursis"
-      );
-      expect(a.level).toBe("D");
+      expect(
+        a.contradictions.map((c) => c.kind),
+        `via ${field}`
+      ).toContain("PEINE_FERME_MAIS_PARTIELLEMENT_SURSIS");
+      // A single press source, so the evidence axis is at D on its own merits,
+      // not because of the contradiction.
+      expect(a.evidenceLevel).toBe("D");
     }
   });
 
@@ -250,7 +337,7 @@ describe("dating a verdict against sources that can actually attest it", () => {
     title: "Wikidata — une personne",
     publishedAt: new Date("2026-01-18"),
   });
-  const MESSAGE = "toutes les sources précèdent la date du verdict";
+  const KIND = "SOURCES_ANTERIEURES_AU_VERDICT";
 
   it("flags a verdict whose only press source predates it, despite a later Wikidata row", () => {
     const a = affair({
@@ -258,14 +345,14 @@ describe("dating a verdict against sources that can actually attest it", () => {
       sources: [PRESS_2020, WIKIDATA_2026],
     });
 
-    expect(a.contradictions).toContain(MESSAGE);
-    expect(a.level).toBe("D");
+    expect(a.contradictions.map((c) => c.kind)).toContain(KIND);
+    expect(a.evidenceLevel).toBe("D");
   });
 
   it("flags it just the same without the encyclopedia row", () => {
     const a = affair({ verdictDate: VERDICT_2024, sources: [PRESS_2020] });
 
-    expect(a.contradictions).toContain(MESSAGE);
+    expect(a.contradictions.map((c) => c.kind)).toContain(KIND);
   });
 
   it("says nothing when a press source postdates the verdict", () => {
@@ -274,14 +361,14 @@ describe("dating a verdict against sources that can actually attest it", () => {
       sources: [source({ publishedAt: new Date("2024-06-20") }), WIKIDATA_2026],
     });
 
-    expect(a.contradictions).not.toContain(MESSAGE);
+    expect(a.contradictions.map((c) => c.kind)).not.toContain(KIND);
   });
 
   it("says nothing when only encyclopedias are attached, the level already sanctioning it", () => {
     const a = affair({ verdictDate: VERDICT_2024, sources: [WIKIDATA_2026] });
 
-    expect(a.contradictions).not.toContain(MESSAGE);
+    expect(a.contradictions.map((c) => c.kind)).not.toContain(KIND);
     expect(a.independentCount).toBe(0);
-    expect(a.level).toBe("D");
+    expect(a.evidenceLevel).toBe("D");
   });
 });

--- a/src/lib/affairs/__tests__/grading-rules.test.ts
+++ b/src/lib/affairs/__tests__/grading-rules.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { RULES, fingerprintOf, rulesFingerprint } from "@/lib/affairs/grading-rules";
+
+/**
+ * The fingerprint pins the rule VALUES, not the file text, so reformatting or
+ * rewording a comment leaves it alone.
+ *
+ * Adding a version means adding an entry here. Editing an existing entry in
+ * place is possible, and no test can prevent it: the guard turns a forgotten
+ * bump into a CI failure, it does not protect against a deliberate change.
+ */
+const KNOWN_FINGERPRINTS: Record<number, string> = {
+  1: "a5f8154c1a1bed8a",
+};
+
+describe("les règles de notation sont versionnées", () => {
+  it("l'empreinte correspond à la version déclarée", () => {
+    expect(rulesFingerprint()).toBe(KNOWN_FINGERPRINTS[RULES.version]);
+  });
+
+  it("chaque version connue a une empreinte", () => {
+    expect(Object.keys(KNOWN_FINGERPRINTS)).toContain(String(RULES.version));
+  });
+
+  // Folding the version into the hash would make the guard circular: bumping it
+  // would move the fingerprint on its own, so the test would pass without anyone
+  // checking whether the rules actually changed.
+  it("l'empreinte ignore la version", () => {
+    expect(fingerprintOf({ ...RULES, version: RULES.version + 1 })).toBe(rulesFingerprint());
+  });
+
+  it("l'empreinte bouge si une règle de preuve bouge", () => {
+    const altered = { ...RULES, evidence: { ...RULES.evidence, officialHosts: ["exemple.test"] } };
+
+    expect(fingerprintOf(altered)).not.toBe(rulesFingerprint());
+  });
+
+  it("l'empreinte bouge si une règle de cohérence bouge", () => {
+    const altered = {
+      ...RULES,
+      coherence: { ...RULES.coherence, adverseInvolvements: ["DIRECT"] as const },
+    };
+
+    expect(fingerprintOf(altered)).not.toBe(rulesFingerprint());
+  });
+
+  // Declaration order is not a rule change, so it must not read as one.
+  it("l'empreinte ignore l'ordre de déclaration des clés", () => {
+    const reordered = {
+      version: RULES.version,
+      coherence: RULES.coherence,
+      evidence: RULES.evidence,
+    };
+
+    expect(fingerprintOf(reordered)).toBe(rulesFingerprint());
+  });
+});

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -9,84 +9,29 @@
  * a level or reads a ledger lives here.
  */
 import type { AffairStatus, Involvement } from "@/generated/prisma";
-
-/** Roles for which the judicial outcome of the affair is the person's own. */
-export const ADVERSE_INVOLVEMENTS: Involvement[] = ["DIRECT", "INDIRECT"];
-
-/** Hôtes de juridictions et d'institutions compétentes. Niveau B. */
-export const OFFICIAL_HOSTS = [
-  "courdecassation.fr",
-  "cours-appel.justice.fr",
-  "justice.fr",
-  "conseil-etat.fr",
-  "ccomptes.fr",
-  "legifrance.gouv.fr",
-  "conseil-constitutionnel.fr",
-  "juricaf.org",
-];
-
-/** Éditeurs correspondant à une juridiction ou institution compétente. Niveau B. */
-export const OFFICIAL_PUBLISHER =
-  /cour d.appel|cour de cassation|conseil d.[ée]tat|cour des comptes|tribunal|parquet|minist[èe]re de la justice|conseil constitutionnel|ordre des/i;
-
-/** Types de source qui ne comptent jamais comme secondaire indépendante.
- *  Wikipedia est exclu délibérément : c'est la source qui a induit en erreur sur
- *  l'arrêt du 7 juillet 2026, et une encyclopédie n'atteste pas un dispositif. */
-export const NOT_INDEPENDENT_TYPES = new Set(["WIKIPEDIA", "WIKIDATA"]);
+import { RULES } from "@/lib/affairs/grading-rules";
 
 /**
- * Recours encore ouvert, énoncé explicitement.
- *
- * La première version cherchait « pourvoi », « en appel » ou « non définitive »
- * n'importe où, et flaguait 15 affaires à tort : une condamnation définitive raconte
- * normalement son historique (« condamné en appel », « rejet du pourvoi, donnant un
- * caractère définitif »). Mentionner un recours passé n'est pas une contradiction.
+ * The rules themselves live in `grading-rules.ts`, where they can be fingerprinted
+ * as a whole. These are the names this module and the audit script already used;
+ * they are now derived rather than declared, so they cannot drift from the
+ * fingerprinted set.
  */
-export const PENDING_RECOURSE = [
-  /pourvoi[^.]{0,60}?(reste possible|est possible|en cours|pendant|a [ée]t[ée] form[ée])/i,
-  /(se sont pourvus|s'est pourvu|se pourvoit)[^.]{0,40}cassation/i,
-  /appel en cours/i,
-  /n['’]est pas d[ée]finitive/i,
-];
-
-/**
- * Recours épuisés, énoncé explicitement. Annule le signal de pendance.
- *
- * La forme simple « la condamnation est définitive » a été ajoutée après un faux
- * signalement : le motif ne reconnaissait que l'adverbe « définitivement » et
- * « caractère définitif ». La négation « n'est pas définitive » ne peut pas matcher,
- * le « n'est pas » s'intercalant entre les deux mots recherchés.
- */
-export const RECOURSE_EXHAUSTED =
-  /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis|condamnation est (aujourd'hui )?d[ée]finitive|devenue d[ée]finitive|rendant la condamnation d[ée]finitive/i;
-
-/**
- * A sentence split between a firm part and a suspended part.
- *
- * `SentenceDetails` renders « (ferme) » as soon as `prisonSuspended` is not
- * true, so a partly-suspended sentence stored as a plain total is published as
- * if the whole term were firm. 15 fiches were in that state, some tripling the
- * firm term of a named person, and none of them was flagged: the audit only
- * compared the status against the recourse wording.
- *
- * Two shapes, because the corpus writes it both ways: « 4 ans dont 2 ferme »
- * and « 4 ans ferme, 1 an avec sursis ». Kept close-range so an unrelated
- * « dont » further down a description does not fire.
- */
-const PARTLY_SUSPENDED = [
-  /\bdont\b[^.|]{0,60}(sursis|ferme)/i,
-  /\bferme\b[^.|]{0,60}sursis/i,
-  /\bsursis\b[^.|]{0,60}ferme/i,
-];
+export const ADVERSE_INVOLVEMENTS = RULES.coherence.adverseInvolvements as readonly Involvement[];
+export const OFFICIAL_HOSTS: readonly string[] = RULES.evidence.officialHosts;
+export const OFFICIAL_PUBLISHER = RULES.evidence.officialPublisher;
+export const NOT_INDEPENDENT_TYPES = new Set<string>(RULES.evidence.notIndependentTypes);
+export const PENDING_RECOURSE: readonly RegExp[] = RULES.coherence.pendingRecourse;
+export const RECOURSE_EXHAUSTED = RULES.coherence.recourseExhausted;
 
 /** True when the text describes a sentence that is not entirely firm. */
 export function describesPartlySuspendedSentence(text: string): boolean {
-  return PARTLY_SUSPENDED.some((re) => re.test(text));
+  return RULES.coherence.partlySuspended.some((re) => re.test(text));
 }
 
 export function describesPendingRecourse(description: string): boolean {
-  if (RECOURSE_EXHAUSTED.test(description)) return false;
-  return PENDING_RECOURSE.some((re) => re.test(description));
+  if (RULES.coherence.recourseExhausted.test(description)) return false;
+  return RULES.coherence.pendingRecourse.some((re) => re.test(description));
 }
 
 export type EvidenceLevel = "A" | "B" | "C" | "D";

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -110,8 +110,45 @@ export interface SourceRow {
   sourceType: string;
 }
 
+/**
+ * Stable identifiers for the coherence checks.
+ *
+ * The closure criteria of #566, #569, #571 and #580 used to quote the French
+ * display strings word for word, so rewording a message broke a criterion. Issues
+ * cite the kind; the message is free to change.
+ */
+export type ContradictionKind =
+  | "IMPLICATION_NON_ADVERSE"
+  | "VERDICT_SANS_DATE"
+  | "VERDICT_DANS_LE_FUTUR"
+  | "SOURCES_ANTERIEURES_AU_VERDICT"
+  | "PEINE_FERME_MAIS_PARTIELLEMENT_SURSIS"
+  | "DEFINITIF_MAIS_RECOURS_PENDANT"
+  | "NON_DEFINITIF_MAIS_RECOURS_EPUISE";
+
+export interface Contradiction {
+  kind: ContradictionKind;
+  /** Phrase affichée, en français. */
+  message: string;
+}
+
 export interface Assessment {
-  level: EvidenceLevel;
+  /**
+   * Evidence axis, on its own. A property of the world: the documents exist or
+   * they do not, and their absence can be permanent.
+   *
+   * A contradiction no longer collapses this. It used to: `if (contradictions
+   * .length > 0) level = "D"` short-circuited the whole cascade, so a fiche backed
+   * by an identified ruling whose `involvement` was wrong fell to D exactly like a
+   * single-source fiche. 11 published fiches were in that state and the breakdown
+   * had to be re-derived by hand to see it.
+   */
+  evidenceLevel: EvidenceLevel;
+  /**
+   * Coherence axis. A property of our own data entry, therefore always ours to
+   * fix. Empty means the fiche does not contradict itself.
+   */
+  contradictions: Contradiction[];
   /**
    * An official `Source` row is attached. Measures editorial completeness of
    * the visible sourcing: what a reader can click on the page.
@@ -127,7 +164,6 @@ export interface Assessment {
   independentCount: number;
   /** Sources écartées du compte parce qu'elles reprennent le même titre. */
   duplicateReprints: number;
-  contradictions: string[];
 }
 
 export function assess(affair: {
@@ -172,14 +208,19 @@ export function assess(affair: {
     independentCount++;
   }
 
-  const contradictions: string[] = [];
+  const contradictions: Contradiction[] = [];
+  const flag = (kind: ContradictionKind, message: string) => contradictions.push({ kind, message });
+
   if (!ADVERSE_INVOLVEMENTS.includes(affair.involvement)) {
-    contradictions.push(`statut de condamnation avec implication ${affair.involvement}`);
+    flag(
+      "IMPLICATION_NON_ADVERSE",
+      `statut de condamnation avec implication ${affair.involvement}`
+    );
   }
   if (!affair.verdictDate) {
-    contradictions.push("statut de condamnation sans date de verdict");
+    flag("VERDICT_SANS_DATE", "statut de condamnation sans date de verdict");
   } else if (affair.verdictDate.getTime() > Date.now()) {
-    contradictions.push("date de verdict dans le futur");
+    flag("VERDICT_DANS_LE_FUTUR", "date de verdict dans le futur");
   } else {
     // Encyclopedias are excluded here for the same reason they are excluded from
     // the independence count: they attest nothing about a dispositif. Leaving
@@ -191,7 +232,7 @@ export function assess(affair: {
       .filter((s) => !NOT_INDEPENDENT_TYPES.has(s.sourceType))
       .reduce<number>((max, s) => Math.max(max, s.publishedAt.getTime()), 0);
     if (latest > 0 && latest < affair.verdictDate.getTime()) {
-      contradictions.push("toutes les sources précèdent la date du verdict");
+      flag("SOURCES_ANTERIEURES_AU_VERDICT", "toutes les sources précèdent la date du verdict");
     }
   }
 
@@ -204,35 +245,42 @@ export function assess(affair: {
       [affair.otherSentence, affair.sentence, affair.description].filter(Boolean).join(" | ")
     )
   ) {
-    contradictions.push(
+    flag(
+      "PEINE_FERME_MAIS_PARTIELLEMENT_SURSIS",
       "peine affichée entièrement ferme alors que le texte décrit une part avec sursis"
     );
   }
 
   const description = affair.description ?? "";
   if (affair.status === "CONDAMNATION_DEFINITIVE" && describesPendingRecourse(description)) {
-    contradictions.push("statut définitif mais la description décrit un recours pendant");
+    flag(
+      "DEFINITIF_MAIS_RECOURS_PENDANT",
+      "statut définitif mais la description décrit un recours pendant"
+    );
   }
   if (affair.status !== "CONDAMNATION_DEFINITIVE" && RECOURSE_EXHAUSTED.test(description)) {
-    contradictions.push(
+    flag(
+      "NON_DEFINITIF_MAIS_RECOURS_EPUISE",
       "statut non définitif mais la description dit les voies de recours épuisées"
     );
   }
 
-  let level: EvidenceLevel;
-  if (contradictions.length > 0) level = "D";
-  else if (affair.decisionCount > 0) level = "A";
-  else if (hasOfficialSource) level = "B";
-  else if (independentCount >= 2) level = "C";
-  else level = "D";
+  // The cascade lost its first rung. A contradiction no longer decides the
+  // evidence level, so a well-backed fiche that contradicts itself now reports
+  // both facts instead of only the worse one.
+  let evidenceLevel: EvidenceLevel;
+  if (affair.decisionCount > 0) evidenceLevel = "A";
+  else if (hasOfficialSource) evidenceLevel = "B";
+  else if (independentCount >= 2) evidenceLevel = "C";
+  else evidenceLevel = "D";
 
   return {
-    level,
+    evidenceLevel,
+    contradictions,
     hasOfficialSource,
     hasOfficialEvidence: hasOfficialSource || affair.decisionCount > 0,
     independentCount,
     duplicateReprints,
-    contradictions,
   };
 }
 

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -37,47 +37,101 @@ export function describesPendingRecourse(description: string): boolean {
 export type EvidenceLevel = "A" | "B" | "C" | "D";
 
 /**
- * Distribution captured on a first pass, the frozen point of comparison.
+ * Why an affair left the queue.
  *
- * `withoutOfficialSource` keeps its original name and its original meaning:
- * affairs carrying no official `Source` row. Renaming it would silently
- * reinterpret the figure already published on #566.
+ * #566 allows two reasons to mark one examined: resolved, or transferred to an
+ * issue that has an owner and a closure criterion. They do not mean the same
+ * thing at all — the first asks nothing more, the second asks everything, just
+ * elsewhere — and a flat array of ids could not tell them apart.
  */
-export interface Baseline extends Record<EvidenceLevel, number> {
-  withoutOfficialSource: number;
-  capturedAt: string;
+export type ReviewOutcome =
+  | { kind: "RESOLVED" }
+  | { kind: "TRANSFERRED"; issue: number }
+  /**
+   * Marked examined under the string-array format, motive unrecorded. We know by
+   * measurement that 10 of the 27 such entries are in fact transferred to #569
+   * and #571, and that 17 are no longer contradictory hence probably resolved.
+   * "Probably" is not data, so the unknown stays explicit.
+   */
+  | { kind: "LEGACY" };
+
+export interface ReviewEntry {
+  affairId: string;
+  outcome: ReviewOutcome;
+  /** Absent on legacy entries: the old format recorded no timestamp. */
+  at?: string;
 }
 
 /**
- * Baseline for the stricter metric, added after `Baseline` and therefore
- * carrying its own capture date: a ledger written before this existed has no
- * historical figure to compare against, and inventing one would be a fiction.
+ * Frozen point of comparison, valid only under the rules that produced it.
+ *
+ * `rulesVersion` is what the previous shape lacked. Without it the report
+ * differenced measurements taken under different grading rules and printed
+ * « D : 53 → 56 (+3) » on a corpus that had not changed by a single affair.
  */
-export interface EvidenceBaseline {
+export interface Baseline {
+  rulesVersion: number;
+  evidence: Record<EvidenceLevel, number>;
+  contradictoryCount: number;
+  /** Affaires sans ligne Source officielle. Complétude éditoriale. */
+  withoutOfficialSource: number;
+  /** Affaires sans aucune preuve officielle, décision rattachée incluse. */
   withoutOfficialEvidence: number;
   capturedAt: string;
 }
 
 export interface Ledger {
-  /** Identifiants d'affaires déjà examinées, dans l'ordre de traitement. */
-  done: string[];
-  /** Affaires sans ligne Source officielle, au premier passage. */
+  /** Affaires sorties de la file, avec le motif de leur sortie. */
+  reviewed: ReviewEntry[];
   baseline?: Baseline;
-  /** Affaires sans aucune preuve officielle, à sa propre date de capture. */
-  evidenceBaseline?: EvidenceBaseline;
+  /**
+   * Untyped on purpose. This is an archive, not live data: nobody should read it
+   * to decide anything, and giving it a type would invite exactly that. It holds
+   * the pre-versioning baselines, one of which is the figure published on #566.
+   */
+  legacyBaselines?: unknown;
 }
 
 /**
- * Read a ledger of any generation. An older file has no `evidenceBaseline`;
- * that absence is preserved rather than filled in, so the report can say the
- * metric has no history yet instead of pretending it was measured.
+ * A baseline can only be differenced against the rules it was captured under.
+ *
+ * Returning false is the honest answer, not a degraded one: « référence non
+ * comparable » tells the reader something true, where a delta across a rule
+ * change tells them something false.
+ */
+export function isComparable(baseline: Baseline | undefined, rulesVersion: number): boolean {
+  return baseline?.rulesVersion === rulesVersion;
+}
+
+/**
+ * Read a ledger of any generation.
+ *
+ * An older file carries `done: string[]` and a pair of unversioned baselines.
+ * Those ids become `LEGACY` entries and the baselines are archived rather than
+ * promoted: they were measured under rules that cannot be identified, so
+ * treating them as a comparison point would reproduce the defect being fixed.
  */
 export function parseLedger(raw: unknown): Ledger {
-  const source = (raw ?? {}) as Partial<Ledger>;
+  const source = (raw ?? {}) as Record<string, unknown>;
+
+  if (Array.isArray(source.reviewed)) {
+    return {
+      reviewed: source.reviewed as ReviewEntry[],
+      baseline: source.baseline as Baseline | undefined,
+      legacyBaselines: source.legacyBaselines,
+    };
+  }
+
+  const done = Array.isArray(source.done) ? (source.done as string[]) : [];
+  const unversioned =
+    source.baseline || source.evidenceBaseline
+      ? { baseline: source.baseline, evidenceBaseline: source.evidenceBaseline }
+      : undefined;
+
   return {
-    done: Array.isArray(source.done) ? source.done : [],
-    baseline: source.baseline,
-    evidenceBaseline: source.evidenceBaseline,
+    reviewed: done.map((affairId) => ({ affairId, outcome: { kind: "LEGACY" } })),
+    baseline: undefined,
+    legacyBaselines: source.legacyBaselines ?? unversioned,
   };
 }
 

--- a/src/lib/affairs/audit-evidence.ts
+++ b/src/lib/affairs/audit-evidence.ts
@@ -17,7 +17,7 @@ import { RULES } from "@/lib/affairs/grading-rules";
  * they are now derived rather than declared, so they cannot drift from the
  * fingerprinted set.
  */
-export const ADVERSE_INVOLVEMENTS = RULES.coherence.adverseInvolvements as readonly Involvement[];
+export const ADVERSE_INVOLVEMENTS: readonly Involvement[] = RULES.coherence.adverseInvolvements;
 export const OFFICIAL_HOSTS: readonly string[] = RULES.evidence.officialHosts;
 export const OFFICIAL_PUBLISHER = RULES.evidence.officialPublisher;
 export const NOT_INDEPENDENT_TYPES = new Set<string>(RULES.evidence.notIndependentTypes);
@@ -101,6 +101,60 @@ export interface Ledger {
  */
 export function isComparable(baseline: Baseline | undefined, rulesVersion: number): boolean {
   return baseline?.rulesVersion === rulesVersion;
+}
+
+/** Deux motifs de transfert diffèrent s'ils ne visent pas la même issue. */
+function sameOutcome(a: ReviewOutcome, b: ReviewOutcome): boolean {
+  if (a.kind !== b.kind) return false;
+  return a.kind === "TRANSFERRED" && b.kind === "TRANSFERRED" ? a.issue === b.issue : true;
+}
+
+/**
+ * Record why affairs left the queue, reclassifying entries that are already there.
+ *
+ * Reclassification is not an edge case: the 27 entries inherited from the old
+ * format are all `LEGACY`, and assigning them to #569 or #571 is the next step
+ * this instrument is meant to enable. A version of this that skipped known ids
+ * made that impossible while reporting success.
+ */
+export function recordReview(
+  ledger: Ledger,
+  ids: string[],
+  outcome: ReviewOutcome
+): { added: number; reclassified: number } {
+  const at = new Date().toISOString();
+  const byId = new Map(ledger.reviewed.map((e) => [e.affairId, e]));
+  let added = 0;
+  let reclassified = 0;
+
+  for (const affairId of ids) {
+    const existing = byId.get(affairId);
+    if (!existing) {
+      byId.set(affairId, { affairId, outcome, at });
+      added++;
+      continue;
+    }
+    if (sameOutcome(existing.outcome, outcome)) continue;
+    byId.set(affairId, { affairId, outcome, at });
+    reclassified++;
+  }
+
+  ledger.reviewed = [...byId.values()];
+  return { added, reclassified };
+}
+
+/**
+ * Push a superseded baseline onto the archive, flat.
+ *
+ * A baseline is a comparison point that has been published, so losing one in
+ * silence costs more than keeping a dead object in a local file. Kept flat
+ * because wrapping the archive in itself on each call produced `[[old], new]`,
+ * gaining a level of nesting every time.
+ */
+export function archiveBaseline(archive: unknown, superseded: Baseline | undefined): unknown {
+  const existing = Array.isArray(archive) ? archive : archive ? [archive] : [];
+  const next = superseded ? [...existing, superseded] : existing;
+  return next.length ? next : undefined;
 }
 
 /**

--- a/src/lib/affairs/grading-rules.ts
+++ b/src/lib/affairs/grading-rules.ts
@@ -11,6 +11,7 @@
  * Anything that decides a level or reads a ledger belongs in `audit-evidence.ts`.
  */
 import { createHash } from "node:crypto";
+import type { Involvement } from "@/generated/prisma";
 
 export const RULES = {
   /**
@@ -52,8 +53,16 @@ export const RULES = {
   },
 
   coherence: {
-    /** Roles for which the judicial outcome of the affair is the person's own. */
-    adverseInvolvements: ["DIRECT", "INDIRECT"],
+    /**
+     * Roles for which the judicial outcome of the affair is the person's own.
+     *
+     * `satisfies` rather than a cast at the point of use: it checks every value
+     * against the Prisma enum while keeping the literal types the fingerprint
+     * needs. A cast would silence a typo here, and a typo here is not benign —
+     * `includes()` would match no involvement at all, so every conviction in the
+     * corpus would be reported as describing a third party's outcome.
+     */
+    adverseInvolvements: ["DIRECT", "INDIRECT"] satisfies readonly Involvement[],
 
     /**
      * A recourse still open, stated explicitly.

--- a/src/lib/affairs/grading-rules.ts
+++ b/src/lib/affairs/grading-rules.ts
@@ -1,0 +1,142 @@
+/**
+ * Grading rules for the published-conviction audit (#566), and nothing else.
+ *
+ * This file exists so the version guard has a referent that cannot drift. The
+ * alternative was hand-listing the rules inside the test, which is the exact
+ * defect #583 reports: `AFFAIR_STATUSES` was hand-copied and diverged from the
+ * Prisma enum. A hand-kept list of "what counts as a rule" would diverge the
+ * same way, and the symptom would be worse — a baseline declared comparable
+ * when the rules behind it had moved.
+ *
+ * Anything that decides a level or reads a ledger belongs in `audit-evidence.ts`.
+ */
+import { createHash } from "node:crypto";
+
+export const RULES = {
+  /**
+   * Bump whenever any value below changes. `grading-rules.test.ts` fails until
+   * the new version is given its fingerprint, which turns a silent rule change
+   * into a CI failure.
+   *
+   * Starts at 1 rather than 3: three commits changed the rules after the
+   * 2026-07-26 baseline was frozen (584ba9e7, b732ebc2, bcce13ce), but which
+   * rules were in force that day cannot be reconstructed honestly. That baseline
+   * therefore carries no version and is reported as incomparable.
+   */
+  version: 1,
+
+  evidence: {
+    /** Court and competent-institution hosts. Level B. */
+    officialHosts: [
+      "courdecassation.fr",
+      "cours-appel.justice.fr",
+      "justice.fr",
+      "conseil-etat.fr",
+      "ccomptes.fr",
+      "legifrance.gouv.fr",
+      "conseil-constitutionnel.fr",
+      "juricaf.org",
+    ],
+
+    /** Publishers that are themselves a court or a competent institution. Level B. */
+    officialPublisher:
+      /cour d.appel|cour de cassation|conseil d.[ée]tat|cour des comptes|tribunal|parquet|minist[èe]re de la justice|conseil constitutionnel|ordre des/i,
+
+    /**
+     * Source types that never count as an independent secondary source.
+     *
+     * Wikipedia is excluded deliberately: it is the source that misled the fiches
+     * on the 7 July 2026 ruling, and an encyclopedia attests no dispositif.
+     */
+    notIndependentTypes: ["WIKIPEDIA", "WIKIDATA"],
+  },
+
+  coherence: {
+    /** Roles for which the judicial outcome of the affair is the person's own. */
+    adverseInvolvements: ["DIRECT", "INDIRECT"],
+
+    /**
+     * A recourse still open, stated explicitly.
+     *
+     * The first version searched for "pourvoi", "en appel" or "non définitive"
+     * anywhere and flagged 15 affairs wrongly: a final conviction normally
+     * recounts its own history ("condamné en appel", "rejet du pourvoi, donnant
+     * un caractère définitif"). Mentioning a past recourse is not a contradiction.
+     */
+    pendingRecourse: [
+      /pourvoi[^.]{0,60}?(reste possible|est possible|en cours|pendant|a [ée]t[ée] form[ée])/i,
+      /(se sont pourvus|s'est pourvu|se pourvoit)[^.]{0,40}cassation/i,
+      /appel en cours/i,
+      /n['’]est pas d[ée]finitive/i,
+    ],
+
+    /**
+     * Recourses exhausted, stated explicitly. Cancels the pendency signal.
+     *
+     * The plain "la condamnation est définitive" was added after a false flag:
+     * the pattern only recognised the adverb and "caractère définitif". The
+     * negation "n'est pas définitive" cannot match, "n'est pas" sitting between
+     * the two words sought.
+     */
+    recourseExhausted:
+      /rejet[^.]{0,40}pourvoi|pourvoi[^.]{0,40}(rejet|a [ée]t[ée] rejet)|d[ée]finitivement|caract[èe]re d[ée]finitif|voies de recours [ée]puis|condamnation est (aujourd'hui )?d[ée]finitive|devenue d[ée]finitive|rendant la condamnation d[ée]finitive/i,
+
+    /**
+     * A sentence split between a firm part and a suspended part.
+     *
+     * `SentenceDetails` renders « (ferme) » as soon as `prisonSuspended` is not
+     * true, so a partly-suspended sentence stored as a plain total is published
+     * as if the whole term were firm. 15 fiches were in that state, some tripling
+     * the firm term of a named person.
+     *
+     * Two shapes, because the corpus writes it both ways: « 4 ans dont 2 ferme »
+     * and « 4 ans ferme, 1 an avec sursis ». Kept close-range so an unrelated
+     * « dont » further down a description does not fire.
+     */
+    partlySuspended: [
+      /\bdont\b[^.|]{0,60}(sursis|ferme)/i,
+      /\bferme\b[^.|]{0,60}sursis/i,
+      /\bsursis\b[^.|]{0,60}ferme/i,
+    ],
+  },
+} as const;
+
+/**
+ * Canonical form used for hashing: RegExp reduced to source + flags, object keys
+ * sorted, so neither declaration order nor formatting shifts the fingerprint.
+ */
+function canonicalise(value: unknown): unknown {
+  if (value instanceof RegExp) return { __re: value.source, __flags: value.flags };
+  if (Array.isArray(value)) return value.map(canonicalise);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, nested]) => [key, canonicalise(nested)])
+    );
+  }
+  return value;
+}
+
+/**
+ * Fingerprint of a rule set, version excluded.
+ *
+ * Excluding `version` is what makes the guard meaningful: were the version
+ * hashed, bumping it would change the fingerprint on its own and the test would
+ * pass without anyone checking whether the rules actually moved.
+ *
+ * Exported separately from `rulesFingerprint` so the guard can be tested against
+ * a deliberately altered rule set.
+ */
+export function fingerprintOf(rules: { version: number }): string {
+  const { version: _ignored, ...values } = rules;
+
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalise(values)))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function rulesFingerprint(): string {
+  return fingerprintOf(RULES);
+}


### PR DESCRIPTION
L'audit de #566 décide quelles condamnations publiées sont étayées. Trois défauts le rendaient trompeur, et chacun avait déjà produit une conclusion fausse. Aucune fiche n'est corrigée ici : ce lot répare l'instrument, pas les données.

## 1. Le rapport soustrayait des mesures non commensurables

La référence figée le 26 juillet a été prise avant trois commits qui ont ajouté des contrôles de contradiction (`584ba9e7`, `b732ebc2`, `bcce13ce`). Le rapport imprimait « D : 53 → 56 (+3) » avec l'autorité d'un delta réel. Or le corpus est passé de 132 à 132 affaires, zéro condamnation publiée depuis la référence : ce +3 mesurait le durcissement du détecteur.

Les règles vivent maintenant dans un objet unique, `RULES`, dont on hache les valeurs. La référence porte la version des règles qui l'a produite, et le rapport refuse de calculer un delta entre deux versions différentes. Un test échoue si une règle bouge sans que la version soit incrémentée.

## 2. La revue urgente cachait les affaires transférées

`urgent` se calculait depuis la file, et la file excluait les affaires marquées examinées. Le rapport annonçait 8 affaires en revue urgente alors que 18 le sont : 10 avaient été transférées vers #569 et #571, ce que #566 autorise explicitement, et avaient disparu de l'écran en restant fausses en ligne.

Le registre passe d'un tableau de chaînes à des entrées typées : résolue, transférée vers une issue, ou héritée quand le motif n'a pas été enregistré. Une contradiction reste affichée quel que soit son motif de sortie de file, dans une section dédiée.

## 3. Le niveau D confondait deux problèmes opposés

`if (contradictions.length > 0) level = "D"` court-circuitait toute la cascade de preuve, donc une fiche adossée à un arrêt officiel dont un champ était faux tombait en D comme une fiche à source unique.

La qualité de la preuve est une propriété du monde : les documents existent ou non, et leur absence peut être définitive. La cohérence interne est une propriété de notre saisie, donc toujours réparable de notre côté. Les deux axes sont désormais séparés, et les contradictions portent un type stable plutôt qu'une phrase d'affichage, que les critères de clôture des issues citaient mot pour mot.

## Effet mesuré

Aucun seuil de détection ne change dans ce lot.

```
avant (axe unique)   A=4   B=11   C=61   D=56
après (axe preuve)   A=4   B=11   C=72   D=45
axe cohérence        18 fiches contradictoires

  preuve suffisante   + contradictoire : 11   (édition seule)
  preuve insuffisante + contradictoire :  7
  preuve insuffisante + cohérente      : 38
  preuve suffisante   + cohérente      : 76
```

**D passe de 56 à 45 sans qu'aucune fiche soit corrigée.** Les 11 qui remontent étaient déjà au niveau C sur la preuve. Le rapport le dit explicitement pour que ce mouvement ne se lise pas comme un progrès.

Le critère de succès de #566 se scinde en deux, puisqu'il en mélangeait deux : `0 contradiction`, qui ne dépend que de nous, et `0 preuve insuffisante`, qui dépend des sources publiées. Sur ces 45, 37 ont exactement une source indépendante : il en manque une par fiche.

## Interface

`--done=` est retiré au profit de `--resolved=` et `--transferred= --issue=N`, et échoue avec un message qui renvoie vers les deux. Ajout de `--recapture`, qui archive la référence courante avant d'en figer une nouvelle. La capture automatique au premier passage est supprimée : c'est elle qui avait figé la référence incomparable sans que personne ne le demande.

## Plan de test

- Suite complète : 2800 tests verts. 26 tests ajoutés sur les deux axes, les 7 types de contradiction, les deux générations de registre, le reclassement, l'archivage et la garde d'empreinte.
- `tsc --noEmit`, `eslint`, `format:check` : verts, codes de sortie vérifiés.
- Gardes de `code-quality.yml` qui touchent ce diff (écritures `PUBLISHED` directes, `any` non justifié) reproduites à la main : vertes.
- Vérifié de bout en bout sur la base de production, en lecture seule : bascule de la version des règles pour voir le rapport refuser de soustraire et la garde CI échouer, puis reclassement d'une entrée réelle et rejeu pour l'idempotence. Registre restauré après chaque essai.
- Invariants contrôlés sur les 132 fiches : somme des quatre cases du croisement égale à 132, et 19 occurrences de contradiction sur 18 fiches, une fiche en portant deux.

## Suites connues

- Un identifiant du registre ne correspond à aucune condamnation publiée, probablement une fiche dépubliée. `FILE : 106` et `EXAMINÉES : 27` font donc 133 pour 132 fiches, et le rapport ne l'explique pas.
- Six exports de `audit-evidence.ts` ne servent plus qu'en interne. Ils étaient déjà morts avant ce lot, donc laissés en place.
- La garde d'empreinte rend un oubli visible, pas un changement délibéré impossible : rien n'empêche d'éditer une empreinte connue en place.

Part of #566.
