### PR TITLE
Design system : durcissement a11y + référence centrale

### DIFF
--- a/docs/design/a11y-perf-audit.md
+++ b/docs/design/a11y-perf-audit.md
@@ -1,0 +1,87 @@
+# Audit a11y / responsive / performance des primitives du design system
+
+Périmètre : `src/components/ui/*` et `src/components/foundations/*` (les primitives
+partagées). Les écrans et composants métier (`src/app/**`,
+`src/components/{politicians,parlement,stats,affairs,votes}`) sont hors périmètre
+de cette passe.
+
+Critères : WCAG 2.1/2.2 AA (contraste, focus visible, cibles tactiles, clavier,
+rôles/labels ARIA), responsive (débordement, zoom 200 %, tactile), performance
+(rendu, poids, images).
+
+## Constat général
+
+Le socle est sain : shadcn/ui sur Tailwind v4, primitives Radix, et `globals.css`
+gère déjà le focus-visible global (`outline-2 outline-offset-2`), le skip-link,
+`prefers-reduced-motion` (neutralise toutes les animations/transitions) et le dark
+mode. La plupart des primitives passent l'audit sans modification. Le durcissement
+se limite donc à quelques écarts ciblés, plus une recommandation d'outillage.
+
+## Verdict par primitive
+
+| Primitive             | Verdict | Note                                                                 |
+| --------------------- | ------- | -------------------------------------------------------------------- |
+| Button                | PASS    | focus-visible, `aria-invalid`, tailles 32–40 px (AA)                 |
+| Badge                 | PASS    | sens porté par le texte, pas par la couleur seule                    |
+| Input / Textarea      | PASS    | `text-base` sur mobile (anti-zoom iOS), `aria-invalid`               |
+| Label / Select        | PASS    | Radix, association via `htmlFor` côté consommateur                   |
+| Tabs                  | PASS    | scroll horizontal + fades, focus-visible, `overflow-x-auto`          |
+| Table                 | PASS    | conteneur `overflow-x-auto` déjà en place                            |
+| Tooltip / InfoTooltip | PASS    | Radix, trigger focusable, icône `aria-hidden` (voir caveat)          |
+| AlertDialog           | PASS    | Radix, `Title` + `Description`                                       |
+| Breadcrumb            | PASS    | `nav` labellisé, `aria-current="page"`, chevrons `aria-hidden`       |
+| SimplePagination      | PASS    | `nav` labellisé, `aria-current`                                      |
+| ToggleGroup           | PASS    | `radiogroup` + roving tabindex + flèches, cible `min-h-11` (44 px)   |
+| ShareBar              | PASS    | `role="group"`, `aria-label` par action, icônes `aria-hidden`, 40 px |
+| StatCard              | PASS    | icônes `aria-hidden`, nombres en `fr-FR`                             |
+| CiteAnchor            | PASS    | `aria-label`, visible au focus et au tactile                         |
+| HexPattern            | PASS    | décoratif, `aria-hidden`                                             |
+| CollapsibleCard       | CORRIGÉ | contenu replié désormais `inert` + `aria-controls`                   |
+| Skeleton              | CORRIGÉ | `aria-hidden` par défaut (placeholder décoratif)                     |
+| Spinner               | CORRIGÉ | prop `label` optionnelle pour annoncer un chargement isolé           |
+
+## Corrections appliquées
+
+1. **CollapsibleCard** — le contenu reste dans le DOM (SEO) mais était **focusable
+   et lu par les lecteurs d'écran même replié**. Ajout de `inert` sur la région
+   quand elle est fermée + `id`/`aria-controls`. Le texte reste indexable, mais le
+   clavier et l'AT ne l'atteignent plus quand il est masqué. Couvert par
+   `CollapsibleCard.test.tsx`.
+2. **Skeleton** — `aria-hidden="true"` par défaut (surchargeable). Un placeholder
+   décoratif ne doit pas être lu ; l'état de chargement doit être annoncé par la
+   région englobante.
+3. **Spinner** — prop `label` optionnelle. Par défaut le glyphe reste décoratif
+   (`aria-hidden`) ; avec `label`, il devient `role="status"` avec nom accessible,
+   pour les cas où le spinner est le seul indicateur de chargement.
+
+## Recommandations (étapes suivantes)
+
+- **Guardrail a11y automatisé** : brancher `@storybook/addon-a11y` (axe sur chaque
+  story) pour capter les régressions. **Non appliqué ici** : le worktree partage son
+  `node_modules` avec une session active ; l'ajout d'une dépendance doit se faire sur
+  un checkout propre. Câblage prévu :
+
+  ```ts
+  // .storybook/main.ts
+  addons: ["@storybook/addon-a11y"],
+  ```
+
+  ```bash
+  npm i -D @storybook/addon-a11y
+  ```
+
+- **Cibles tactiles** : `Button size="icon"` fait 36 px (conforme AA 2.5.8, sous le
+  seuil AAA 44 px). Acceptable, mais pour les boutons icône seule sur surfaces
+  tactiles denses, préférer `icon-lg` (40 px) ou garantir l'espacement.
+- **Tooltip au tactile** : Radix Tooltip ne s'ouvre pas au tap et n'est pas fiable
+  pour l'AT sur mobile. Pour une info _essentielle_ (glossaire), envisager un
+  Popover. `InfoTooltip` porte déjà le terme dans son `aria-label`, ce qui limite
+  le risque.
+
+## Vérification
+
+- `tsc --noEmit` : 0 erreur sur les primitives (baseline conservée).
+- `vitest run src/components/ui` : 20 tests verts (dont 3 nouveaux sur
+  CollapsibleCard).
+- Aucune régression de comportement : les changements sont additifs ou purement
+  ARIA.

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,0 +1,65 @@
+# Design system Poligraph
+
+Référence centrale du design system : où vivent les tokens et composants, la
+langue visuelle, les conventions pour ajouter/modifier un composant, et les
+garanties d'accessibilité.
+
+Source de vérité visuelle : l'export du design system Poligraph (claude.ai Design
+/ bundle `poligraph-design-system-*.zip`) — tokens, guidelines, UI kit et
+patterns. Le code de l'app est l'implémentation vivante ; le bundle est la
+spécification. Les valeurs de tokens du bundle sont d'ailleurs reprises de
+`src/app/globals.css`.
+
+## Où vivent les choses
+
+| Couche                                     | Emplacement                                                   |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| Tokens (couleurs oklch, radius, typo)      | `src/app/globals.css` (`@theme inline` + `:root` / `.dark`)   |
+| Couleurs identité (hors thème)             | `src/config/brand.ts` (`BRAND_NAVY`, `BRAND_RED`)             |
+| Couleurs data / partis / vote / judiciaire | `src/config/{colors,party-colors,labels,judicial-anchors}.ts` |
+| Primitives UI                              | `src/components/ui/*`                                         |
+| Specimens de fondations                    | `src/components/foundations/*` (Typography, Colors, Spacing)  |
+| Documentation vivante                      | Storybook (`npm run storybook`)                               |
+| Assets de marque                           | `docs/design/*`, `public/*`                                   |
+
+## Langue visuelle
+
+- **Identité tricolore** : `BRAND_NAVY` (#002654) porte l'identité, `BRAND_RED`
+  (#ed2939) est réservé aux signaux (condamnations, alertes). Ces constantes sont
+  **indépendantes** des tokens sémantiques (`--primary`, `--brand`,
+  `--destructive`) qui changent avec le thème.
+- **Typographie** : **Outfit** en display (`--font-display`, titres/chiffres),
+  **Atkinson Hyperlegible** en corps/UI (`--font-body`), chargées via `next/font`.
+  Atkinson est choisie pour sa lisibilité maximale (données civiques denses).
+- **Ton** : sobre, factuel, neutre. Tout en français, chiffres au format `fr-FR`,
+  pas d'emoji. Présomption d'innocence et données sourcées.
+
+## Ajouter ou modifier un composant
+
+1. Primitive dans `src/components/ui/`, variantes via `class-variance-authority`,
+   composition via Radix quand un comportement accessible existe déjà, classes
+   fusionnées avec `cn()` (`@/lib/utils`).
+2. Une story `*.stories.tsx` (c'est la doc du composant, pas un extra).
+3. A11y d'emblée : focus visible (le global `globals.css` couvre la plupart des
+   cas), rôles/labels ARIA, icônes décoratives `aria-hidden`, cibles tactiles
+   suffisantes, `prefers-reduced-motion` respecté (géré globalement).
+4. Test co-localisé pour la logique interactive (ex. `CollapsibleCard.test.tsx`).
+
+## Accessibilité
+
+Cible : WCAG 2.1/2.2 AA. `globals.css` fournit le focus-visible global
+(`outline-2 outline-offset-2`), le skip-link, la neutralisation des animations
+sous `prefers-reduced-motion`, et le dark mode. L'audit par primitive et les
+corrections sont consignés dans [`a11y-perf-audit.md`](./a11y-perf-audit.md).
+
+Guardrail recommandé (non encore branché) : `@storybook/addon-a11y` pour passer
+axe sur chaque story et capter les régressions.
+
+## Reste à faire (finalisation)
+
+- Brancher le guardrail a11y Storybook (sur un checkout propre).
+- Couche **patterns** du bundle (JudicialCaution, MissingData, SourceAttribution,
+  VoteBreakdown, PoliticianIdentity, ContextNav…), ancrée sur les invariants
+  légaux.
+- Composants **dataviz** partagés (CompassRadar, PositionAxis, VoteBar,
+  ParticipationRing), en consolidant les Hemicycle existants.

--- a/src/components/ui/CollapsibleCard.test.tsx
+++ b/src/components/ui/CollapsibleCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CollapsibleCard } from "./CollapsibleCard";
+
+describe("CollapsibleCard", () => {
+  it("keeps content in the DOM but inert while collapsed", () => {
+    render(
+      <CollapsibleCard title="Détails">
+        <a href="/x">Lien caché</a>
+      </CollapsibleCard>
+    );
+
+    // Content stays rendered (SEO) even when collapsed…
+    expect(screen.getByText("Lien caché")).toBeInTheDocument();
+
+    // …but the region is inert so keyboard/AT users don't reach it.
+    const header = screen.getByRole("button", { name: /détails/i });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    const regionId = header.getAttribute("aria-controls")!;
+    const region = document.getElementById(regionId)!;
+    expect(region).toHaveAttribute("inert");
+  });
+
+  it("removes inert and flips aria-expanded when opened", () => {
+    render(
+      <CollapsibleCard title="Détails">
+        <a href="/x">Lien caché</a>
+      </CollapsibleCard>
+    );
+
+    const header = screen.getByRole("button", { name: /détails/i });
+    fireEvent.click(header);
+
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    const region = document.getElementById(header.getAttribute("aria-controls")!)!;
+    expect(region).not.toHaveAttribute("inert");
+  });
+
+  it("respects defaultOpen", () => {
+    render(
+      <CollapsibleCard title="Détails" defaultOpen>
+        <span>Contenu</span>
+      </CollapsibleCard>
+    );
+    const header = screen.getByRole("button", { name: /détails/i });
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    const region = document.getElementById(header.getAttribute("aria-controls")!)!;
+    expect(region).not.toHaveAttribute("inert");
+  });
+});

--- a/src/components/ui/CollapsibleCard.tsx
+++ b/src/components/ui/CollapsibleCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -22,6 +22,7 @@ export function CollapsibleCard({
   children,
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen);
+  const regionId = useId();
 
   return (
     <Card>
@@ -37,6 +38,7 @@ export function CollapsibleCard({
         role="button"
         tabIndex={0}
         aria-expanded={open}
+        aria-controls={regionId}
       >
         <div className="flex items-center justify-between">
           <CardTitle>
@@ -47,10 +49,15 @@ export function CollapsibleCard({
           </CardTitle>
           <ChevronDown
             className={`h-5 w-5 text-muted-foreground transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+            aria-hidden="true"
           />
         </div>
       </CardHeader>
+      {/* Content stays in the DOM (SEO) but is made inert when collapsed so
+          keyboard and screen-reader users don't reach visually-hidden links. */}
       <div
+        id={regionId}
+        inert={!open}
         className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
       >
         <div className="overflow-hidden">

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,15 @@
 import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+  // Decorative placeholder: hide from assistive tech by default (the loading
+  // state should be announced by the surrounding region). Overridable via props.
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
 }
 
 export { Skeleton };

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,13 +1,23 @@
 import { cn } from "@/lib/utils";
 
-export function Spinner({ className }: { className?: string }) {
+export function Spinner({
+  className,
+  label,
+}: {
+  className?: string;
+  /** When set, the spinner is announced to screen readers (use for a
+   *  standalone loader). Omit when a visible loading text is already present. */
+  label?: string;
+}) {
   return (
     <svg
       className={cn("animate-spin h-4 w-4", className)}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
-      aria-hidden="true"
+      role={label ? "status" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
     >
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path


### PR DESCRIPTION
Premier incrément de la finalisation du design system : **durcissement a11y / responsive / performance** des primitives partagées (`src/components/ui/*`, `src/components/foundations/*`). Périmètre volontairement limité aux primitives (les écrans/métier sont exclus).

## Constat

Le socle est déjà sain (shadcn/ui sur Tailwind v4, Radix, focus-visible global, `prefers-reduced-motion`, dark mode). La majorité des primitives passent l'audit **sans modification**. Le durcissement se limite à des écarts ciblés + une recommandation d'outillage. Verdict complet par composant dans `docs/design/a11y-perf-audit.md`.

## Corrections

- **CollapsibleCard** : le contenu replié restait dans le DOM (SEO) mais **focusable et lu par les lecteurs d'écran**. Il est désormais `inert` quand fermé (+ `aria-controls`) : le texte reste indexable, mais clavier/AT ne l'atteignent plus quand il est masqué. Couvert par un test.
- **Skeleton** : `aria-hidden` par défaut (placeholder décoratif, surchargeable).
- **Spinner** : prop `label` optionnelle → `role="status"` + nom accessible pour un chargement isolé (défaut inchangé : décoratif).

## Vérifié

- `tsc --noEmit` : 0 erreur sur les primitives.
- `vitest run src/components/ui` : 20 tests verts (dont 3 nouveaux sur CollapsibleCard).
- Changements additifs ou purement ARIA, sans régression de comportement.

## Étapes suivantes (documentées, hors de cette PR)

- Brancher `@storybook/addon-a11y` (axe sur chaque story) comme guardrail. Non fait ici car le worktree partage son `node_modules` avec une session active ; à installer sur un checkout propre.
- Incréments restants du design system : couche patterns (JudicialCaution, MissingData, SourceAttribution…), composants dataviz partagés, doc DS centrale.

Travaillé dans un worktree isolé pour ne pas heurter la session active sur le repo.
