### PR TITLE
Couverture Storybook des primitives du design system

### DIFF
--- a/src/components/ui/Breadcrumb.stories.tsx
+++ b/src/components/ui/Breadcrumb.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Breadcrumb } from "./Breadcrumb";
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: "UI/Breadcrumb",
+  component: Breadcrumb,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Default: Story = {
+  args: {
+    items: [{ label: "Députés", href: "/deputes" }, { label: "Jean Dupont" }],
+  },
+};
+
+export const DeepPath: Story = {
+  args: {
+    items: [
+      { label: "Parlement", href: "/parlement" },
+      { label: "Votes", href: "/parlement/votes" },
+      { label: "Scrutin n° 1234" },
+    ],
+  },
+};

--- a/src/components/ui/CiteAnchor.stories.tsx
+++ b/src/components/ui/CiteAnchor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CiteAnchor } from "./CiteAnchor";
+import { Toaster } from "./sonner";
+
+const meta: Meta<typeof CiteAnchor> = {
+  title: "UI/CiteAnchor",
+  component: CiteAnchor,
+};
+
+export default meta;
+type Story = StoryObj<typeof CiteAnchor>;
+
+// Revealed on hover / focus of the parent `group` (always visible on touch).
+export const OnHover: Story = {
+  render: () => (
+    <div className="group flex items-center gap-2">
+      <span className="font-medium">Scrutin n° 1234</span>
+      <CiteAnchor anchorId="scrutin-1234" label="le scrutin n° 1234" />
+      <span className="text-xs text-muted-foreground">(survole ou tabule)</span>
+      <Toaster />
+    </div>
+  ),
+};
+
+export const AlwaysVisible: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <span className="font-medium">Affaire AF-000167</span>
+      <CiteAnchor
+        permalink="https://poligraph.fr/affaires/af-000167"
+        label="l'affaire AF-000167"
+        className="opacity-100"
+      />
+      <Toaster />
+    </div>
+  ),
+};

--- a/src/components/ui/HexPattern.stories.tsx
+++ b/src/components/ui/HexPattern.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { HexPattern } from "./HexPattern";
+
+const meta: Meta<typeof HexPattern> = {
+  title: "UI/HexPattern",
+  component: HexPattern,
+};
+
+export default meta;
+type Story = StoryObj<typeof HexPattern>;
+
+export const OnNavy: Story = {
+  render: () => (
+    <div className="relative h-48 w-80 overflow-hidden rounded-lg bg-primary text-primary-foreground">
+      <HexPattern className="absolute inset-0 text-white/15" />
+      <div className="relative p-4 font-display text-lg">Motif hexagonal</div>
+    </div>
+  ),
+};
+
+export const Subtle: Story = {
+  render: () => (
+    <div className="relative h-48 w-80 overflow-hidden rounded-lg border bg-background">
+      <HexPattern className="absolute inset-0 text-muted-foreground/10" />
+      <div className="relative p-4 text-sm text-muted-foreground">Fond discret (hero / footer)</div>
+    </div>
+  ),
+};

--- a/src/components/ui/ShareBar.stories.tsx
+++ b/src/components/ui/ShareBar.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ShareBar } from "./ShareBar";
+import { Toaster } from "./sonner";
+
+const meta: Meta<typeof ShareBar> = {
+  title: "UI/ShareBar",
+  component: ShareBar,
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShareBar>;
+
+// ShareBar is position:fixed (vertical bar ≥ 2xl, horizontal bar on mobile).
+export const Default: Story = {
+  render: () => (
+    <div className="min-h-[60vh] p-6 text-sm text-muted-foreground">
+      Barre de partage ancrée (bas sur mobile, colonne à gauche en très large).
+      <Toaster />
+      <ShareBar
+        data={{
+          title: "Ma Boussole Parlementaire",
+          text: "Découvre quels élus votent comme toi",
+          url: "https://poligraph.fr",
+        }}
+      />
+    </div>
+  ),
+};

--- a/src/components/ui/ToggleGroup.stories.tsx
+++ b/src/components/ui/ToggleGroup.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ToggleGroup } from "./ToggleGroup";
+
+const meta: Meta<typeof ToggleGroup> = {
+  title: "UI/ToggleGroup",
+  component: ToggleGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleGroup>;
+
+function Demo() {
+  const [value, setValue] = useState("tous");
+  return (
+    <ToggleGroup
+      label="Filtrer par chambre"
+      value={value}
+      onChange={setValue}
+      options={[
+        { value: "tous", label: "Tous" },
+        { value: "an", label: "Assemblée" },
+        { value: "senat", label: "Sénat" },
+      ]}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: () => <Demo />,
+};

--- a/src/components/ui/alert-dialog.stories.tsx
+++ b/src/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "./alert-dialog";
+import { Button } from "./button";
+import { buttonVariants } from "./button";
+
+const meta: Meta<typeof AlertDialog> = {
+  title: "UI/AlertDialog",
+  component: AlertDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Destructive: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">{"Dépublier l'affaire"}</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Dépublier cette affaire ?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {
+              "L'affaire ne sera plus visible publiquement. Cette action est réversible depuis l'espace de modération."
+            }
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Annuler</AlertDialogCancel>
+          <AlertDialogAction className={buttonVariants({ variant: "destructive" })}>
+            Dépublier
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};

--- a/src/components/ui/confirm-dialog.stories.tsx
+++ b/src/components/ui/confirm-dialog.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ConfirmDialog } from "./confirm-dialog";
+import { Button } from "./button";
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: "UI/ConfirmDialog",
+  component: ConfirmDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+function Demo({ variant }: { variant?: "default" | "destructive" }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant={variant === "destructive" ? "destructive" : "default"}
+        onClick={() => setOpen(true)}
+      >
+        {variant === "destructive" ? "Supprimer" : "Confirmer l'action"}
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        onConfirm={() => setOpen(false)}
+        variant={variant}
+        title={variant === "destructive" ? "Supprimer définitivement ?" : "Confirmer ?"}
+        description={
+          variant === "destructive"
+            ? "Cette action est irréversible."
+            : "Merci de confirmer que tu souhaites poursuivre."
+        }
+      />
+    </>
+  );
+}
+
+export const Default: Story = { render: () => <Demo /> };
+export const Destructive: Story = { render: () => <Demo variant="destructive" /> };

--- a/src/components/ui/info-tooltip.stories.tsx
+++ b/src/components/ui/info-tooltip.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InfoTooltip } from "./info-tooltip";
+import { TooltipProvider } from "./tooltip";
+
+const meta: Meta<typeof InfoTooltip> = {
+  title: "UI/InfoTooltip",
+  component: InfoTooltip,
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof InfoTooltip>;
+
+export const FromGlossary: Story = {
+  args: { term: "sursis" },
+};
+
+export const CustomText: Story = {
+  args: { text: "Concordance : part des scrutins où le vote coïncide avec le tien." },
+};
+
+export const Inline: Story = {
+  render: () => (
+    <p className="text-sm">
+      Peine avec sursis
+      <InfoTooltip term="sursis" />
+    </p>
+  ),
+};

--- a/src/components/ui/markdown.stories.tsx
+++ b/src/components/ui/markdown.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MarkdownText } from "./markdown";
+
+const meta: Meta<typeof MarkdownText> = {
+  title: "UI/MarkdownText",
+  component: MarkdownText,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof MarkdownText>;
+
+const SAMPLE = `**Contexte du scrutin**
+
+Le texte porte sur *l'encadrement des dépenses*. Les points clés :
+
+- Plafonnement des niches fiscales
+- Revalorisation du barème
+  - avec indexation sur l'inflation
+- Contrôle renforcé
+
+Plus de détails sur la [méthodologie](/methodologie).
+
+---
+
+Voter POUR soutient la mesure, voter CONTRE la rejette.`;
+
+export const Default: Story = {
+  args: { children: SAMPLE },
+};
+
+export const LinksDisabled: Story = {
+  args: {
+    children: "Voir la [fiche du député](/deputes/jean-dupont) pour le détail.",
+    disableLinks: true,
+  },
+};

--- a/src/components/ui/prompt-dialog.stories.tsx
+++ b/src/components/ui/prompt-dialog.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { PromptDialog } from "./prompt-dialog";
+import { Button } from "./button";
+
+const meta: Meta<typeof PromptDialog> = {
+  title: "UI/PromptDialog",
+  component: PromptDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof PromptDialog>;
+
+function Demo() {
+  const [open, setOpen] = useState(false);
+  const [last, setLast] = useState<string | null>(null);
+  return (
+    <div className="space-y-2">
+      <Button onClick={() => setOpen(true)}>Rejeter avec un motif</Button>
+      {last && <p className="text-sm text-muted-foreground">Motif : {last}</p>}
+      <PromptDialog
+        open={open}
+        onOpenChange={setOpen}
+        onSubmit={(v) => {
+          setLast(v);
+          setOpen(false);
+        }}
+        title="Motif du rejet"
+        description="Explique pourquoi ce brouillon est rejeté."
+        placeholder="Ex : source insuffisante"
+      />
+    </div>
+  );
+}
+
+export const Default: Story = { render: () => <Demo /> };

--- a/src/components/ui/sonner.stories.tsx
+++ b/src/components/ui/sonner.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { toast } from "sonner";
+import { Toaster } from "./sonner";
+import { Button } from "./button";
+
+const meta: Meta<typeof Toaster> = {
+  title: "UI/Toaster (sonner)",
+  component: Toaster,
+};
+
+export default meta;
+type Story = StoryObj<typeof Toaster>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Toaster />
+      <Button variant="outline" onClick={() => toast.success("Lien copié")}>
+        Succès
+      </Button>
+      <Button variant="outline" onClick={() => toast.error("Impossible de copier le lien")}>
+        Erreur
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast("Brouillon enregistré", { description: "À dimanche pour le récap." })}
+      >
+        Avec description
+      </Button>
+    </div>
+  ),
+};

--- a/src/components/ui/table.stories.tsx
+++ b/src/components/ui/table.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from "./table";
+import { Badge } from "./badge";
+
+const meta: Meta<typeof Table> = {
+  title: "UI/Table",
+  component: Table,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+const ROWS = [
+  { nom: "Jean Dupont", groupe: "RE", votes: 412, statut: "default" as const },
+  { nom: "Marie Martin", groupe: "LFI", votes: 388, statut: "secondary" as const },
+  { nom: "Paul Bernard", groupe: "LR", votes: 401, statut: "outline" as const },
+];
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>Participation aux scrutins (législature en cours)</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Député</TableHead>
+          <TableHead>Groupe</TableHead>
+          <TableHead className="text-right">Votes</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {ROWS.map((r) => (
+          <TableRow key={r.nom}>
+            <TableCell className="font-medium">{r.nom}</TableCell>
+            <TableCell>
+              <Badge variant={r.statut}>{r.groupe}</Badge>
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {r.votes.toLocaleString("fr-FR")}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};

--- a/src/components/ui/tooltip.stories.tsx
+++ b/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./tooltip";
+import { Button } from "./button";
+
+const meta: Meta<typeof Tooltip> = {
+  title: "UI/Tooltip",
+  component: Tooltip,
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Survole ou tabule</Button>
+      </TooltipTrigger>
+      <TooltipContent>Basé sur les votes réels au Parlement</TooltipContent>
+    </Tooltip>
+  ),
+};


### PR DESCRIPTION
Incrément 2 de la finalisation du design system : **couverture Storybook** des primitives qui n'avaient pas de story. Le design system devient entièrement navigable/documenté.

## Stories ajoutées (13)

Breadcrumb, CiteAnchor, HexPattern, ShareBar, ToggleGroup, AlertDialog, ConfirmDialog, PromptDialog, InfoTooltip, MarkdownText, Toaster (sonner), Table, Tooltip.

Contenu réaliste (français, `fr-FR`), variantes utiles, et wrappers d'état/`TooltipProvider` là où nécessaire. Aucun composant applicatif touché — additif, stories uniquement.

## Vérifié

- `storybook build` : **succès**, toutes les stories (dont les 13 nouvelles) compilent et rendent.
- `tsc --noEmit` : 0 erreur.
- `eslint` : 0 erreur sur les stories.

Basé sur `main` (inclut #601). Travaillé dans un worktree isolé.
