### PR TITLE
Simplifier le CTA de dons de l'accueil

### DIFF
--- a/src/components/home/SupportCampaign.tsx
+++ b/src/components/home/SupportCampaign.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { MONTHLY_TIERS } from "@/config/donation";
-import { cn } from "@/lib/utils";
 import {
   DonationDialogProvider,
   useDonationDialog,
@@ -22,25 +20,11 @@ function CampaignInner() {
         Indépendant et sans publicité. Vos dons mensuels nous aident à tenir les données à jour et à
         faire avancer le projet.
       </p>
-      <div className="mt-6 flex flex-wrap gap-2">
-        {MONTHLY_TIERS.map((tier) => (
-          <div
-            key={tier.monthlyEuros}
-            className={cn(
-              "min-w-[4.5rem] flex-1 rounded-xl border border-primary-foreground/20 bg-primary-foreground/10 px-3 py-3 text-center",
-              tier.recommended && "border-transparent bg-brand text-brand-foreground"
-            )}
-          >
-            <span className="block font-display text-xl font-extrabold">{tier.monthlyEuros}€</span>
-            <span className="text-xs opacity-80">/mois</span>
-          </div>
-        ))}
-      </div>
-      <div className="mt-6 flex flex-wrap items-center gap-4">
+      <div className="mt-8 flex flex-col items-center gap-4">
         <button
           type="button"
           onClick={() => open("monthly")}
-          className="rounded-full bg-brand px-6 py-2.5 font-display font-semibold text-brand-foreground hover:opacity-90"
+          className="w-full rounded-full bg-brand px-10 py-4 font-display text-lg font-bold text-brand-foreground hover:opacity-90 sm:w-auto"
         >
           Je soutiens
         </button>


### PR DESCRIPTION
## Contexte

Sur le bloc « Soutenir Poligraph » de la page d'accueil, les pastilles de montant (5€/10€/15€/20€/50€ par mois) étaient de simples `<div>` décoratifs, donc non cliquables. Elles laissaient penser à une grille de prix sélectionnable alors que le seul point d'entrée réel est le bouton « Je soutiens » (HelloAsso ne pré-remplit pas le montant, cf. `DONATION_PREFILL_MODE`).

## Changements

- Suppression des pastilles de montant non cliquables (`SupportCampaign.tsx`) et des imports `MONTHLY_TIERS` / `cn` devenus inutiles.
- Bouton « Je soutiens » agrandi (`px-10 py-4`, `text-lg font-bold`) et centré. Pleine largeur sur mobile (`w-full sm:w-auto`) pour une meilleure cible tactile.
- Le lien secondaire « Don ponctuel ou autres plateformes » reste, centré sous le bouton.

Aucune modification de la page `/soutenir` (elle n'a pas ce bloc).

## Vérifications

- `eslint` : clean
- `tsc --noEmit` : aucune erreur source
- `vitest` sur `DonationDialogProvider.test.tsx` : 3/3 (le nom accessible « Je soutiens » est conservé)

À valider visuellement sur la preview Vercel (desktop + mobile).