### PR TITLE
Documenter la couche patterns et les invariants légaux

### DIFF
--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -20,6 +20,7 @@ spécification. Les valeurs de tokens du bundle sont d'ailleurs reprises de
 | Primitives UI                              | `src/components/ui/*`                                         |
 | Specimens de fondations                    | `src/components/foundations/*` (Typography, Colors, Spacing)  |
 | Documentation vivante                      | Storybook (`npm run storybook`)                               |
+| Patterns et invariants légaux              | `docs/design/patterns/*`, `docs/design/legal-invariants.md`   |
 | Assets de marque                           | `docs/design/*`, `public/*`                                   |
 
 ## Langue visuelle
@@ -52,14 +53,28 @@ Cible : WCAG 2.1/2.2 AA. `globals.css` fournit le focus-visible global
 sous `prefers-reduced-motion`, et le dark mode. L'audit par primitive et les
 corrections sont consignés dans [`a11y-perf-audit.md`](./a11y-perf-audit.md).
 
-Guardrail recommandé (non encore branché) : `@storybook/addon-a11y` pour passer
-axe sur chaque story et capter les régressions.
+Guardrail a11y branché : `@storybook/addon-a11y` passe axe sur chaque story (voir
+[`a11y-perf-audit.md`](./a11y-perf-audit.md) pour le balayage et les écarts de
+contraste restants).
+
+## Patterns et invariants
+
+La couche **patterns** vit dans [`patterns/`](./patterns/README.md) : huit fiches
+(InvolvementBand, JudicialCaution, MissingData, ClickTarget, ContextNav,
+SourceAttribution, VoteBreakdown, PoliticianIdentity) qui documentent comment
+résoudre un problème récurrent du produit, et pourquoi la solution évidente est
+souvent fausse.
+
+Elles s'ancrent sur le chapitre normatif [`legal-invariants.md`](./legal-invariants.md)
+(I1 à I9, vocabulaire imposé, checklist avant publication, cas de refus). Ce
+chapitre décrit des obligations RGPD article 10, pas des préférences : un écran
+qui enfreint un invariant se refuse.
 
 ## Reste à faire (finalisation)
 
-- Brancher le guardrail a11y Storybook (sur un checkout propre).
-- Couche **patterns** du bundle (JudicialCaution, MissingData, SourceAttribution,
-  VoteBreakdown, PoliticianIdentity, ContextNav…), ancrée sur les invariants
-  légaux.
 - Composants **dataviz** partagés (CompassRadar, PositionAxis, VoteBar,
-  ParticipationRing), en consolidant les Hemicycle existants.
+  ParticipationRing) : à extraire des surfaces existantes (`VoteCard`, `Hemicycle`,
+  `RadarChart`), c'est un refactor à cadrer, pas un ajout greenfield.
+- Écarts de contraste en thème sombre relevés par l'addon a11y et les écarts prod
+  catalogués dans les fiches patterns (par exemple la variante `not_accused` de
+  `JudicialCaution`) : correctifs à cadrer séparément.

--- a/docs/design/legal-invariants.md
+++ b/docs/design/legal-invariants.md
@@ -1,0 +1,114 @@
+# Invariants juridiques et éditoriaux
+
+> Chapitre **normatif**. Les autres pages du design system décrivent des intentions esthétiques ; celle-ci décrit des obligations. Un écran qui enfreint un invariant se refuse, il ne s'ajuste pas.
+>
+> Poligraph publie, sur des personnes nommées, des données judiciaires, la catégorie de données la plus encadrée du RGPD (article 10). La conception visuelle **fait partie** de la conformité : une pastille mal placée attribue une infraction à quelqu'un aussi sûrement qu'une phrase.
+
+## Le modèle de données, en deux axes
+
+Toute affaire porte deux informations distinctes. **Confondre les deux est la faute la plus grave** du produit.
+
+| Axe             | Enum                              | Ce qu'il dit                                                     | Ce qu'il ne dit pas           |
+| --------------- | --------------------------------- | ---------------------------------------------------------------- | ----------------------------- |
+| **Statut**      | `AffairStatus` → `CertaintyLevel` | Où en est la procédure, et son issue pour la personne poursuivie | Qui est cette personne        |
+| **Implication** | `Involvement`                     | À quel degré la personne suivie est liée à l'affaire             | Comment, ni à la place de qui |
+
+```
+Involvement          isAccusedInvolvement()   Le statut la décrit ?
+DIRECT               true                     oui
+INDIRECT             true                     oui
+MENTIONED_ONLY       false                    NON
+VICTIM               false                    NON
+PLAINTIFF            false                    NON
+```
+
+**I1. Un badge de certitude ne peut être rendu à côté d'une personne que si `isAccusedInvolvement(involvement)` est vrai.** « Condamnation définitive » sur la fiche d'une victime est une diffamation par mise en page. Source de vérité : `isAccusedInvolvement()` dans `src/config/certainty.ts`, qui garde aussi `AffairStatusNotice`.
+
+**I2. Une catégorie d'infraction qualifie l'affaire, jamais la personne non mise en cause.** « Atteintes à la probité » posé au-dessus d'un portrait se lit comme le sien. Il faut préfixer (« Faits qualifiés : ») et sortir cette information de la ligne de pastilles d'identité.
+
+**I3. Le degré d'implication ne s'énonce pas en pastille, mais en phrase.** Un mot gris de la même taille que trois autres pastilles n'est pas lu. Voir [`patterns/InvolvementBand.md`](./patterns/InvolvementBand.md).
+
+**I4. Aucune escalade automatique d'implication.** Aucun script, aucune heuristique, aucun modèle ne fait passer un `Involvement` vers un degré plus incriminant sans relecture humaine. Les sorties automatiques vont en `DRAFT`.
+
+**I5. Toute affaire publiée porte un encart de prudence.** La qualification procédurale exacte est énoncée avant toute lecture à charge, et les issues favorables sont dominantes. Voir [`patterns/JudicialCaution.md`](./patterns/JudicialCaution.md).
+
+**I6. Toute donnée renvoie à sa source.** Une affirmation sans source est un bug de contenu, pas un manque de finition.
+
+**I7. Ce qui quitte le site est soumis aux mêmes règles.** `<title>`, `og:title`, image OG, texte de partage : hors du site, il ne reste souvent qu'un nom et un titre d'affaire. Voir [`patterns/SourceAttribution.md`](./patterns/SourceAttribution.md).
+
+**I8. Le doute se documente, il ne se comble pas.** Une donnée absente s'affiche comme absente. Ni tiret, ni zéro, ni bloc vide réservé à un procès qui ne concerne pas la personne. Voir [`patterns/MissingData.md`](./patterns/MissingData.md).
+
+**I9. La prudence par défaut n'est pas neutre.** Qualifier de `MENTIONED_ONLY` quelqu'un qui est en réalité **victime** produit une lecture plus défavorable que la réalité : la page montre son visage sous des qualifications d'infraction sans dire que ce n'est pas lui qui est visé. Le degré juste et sourcé protège mieux que le degré le plus faible.
+
+## Vocabulaire imposé
+
+Ces mots ne sont pas interchangeables. Les libellés font foi : `AFFAIR_STATUS_LABELS`, `INVOLVEMENT_LABELS`, `CERTAINTY_LABELS` (dans `src/config/labels.ts`).
+
+| Écrire                                   | Jamais                                      |
+| ---------------------------------------- | ------------------------------------------- |
+| mis en cause, visé par une procédure     | coupable, corrompu, fraudeur                |
+| mise en examen                           | inculpation (terme abandonné en 1993)       |
+| condamnation non définitive              | condamné (sans qualifier), reconnu coupable |
+| condamnation définitive                  | seul cas où « condamné » est exact          |
+| relaxe, acquittement, non-lieu           | blanchi, innocenté, s'en sort               |
+| action publique éteinte par prescription | prescrit (sans plus), échappe à la justice  |
+| classement sans suite                    | affaire enterrée                            |
+| affaire, procédure, dossier              | scandale, casserole, affaire louche         |
+
+- **Vouvoiement** pour le citoyen, « nous » pour Poligraph.
+- **Sentence case** dans les titres.
+- Chiffres en `fr-FR` (`toLocaleString("fr-FR")`), espace insécable pour les milliers.
+- **Pas d'emoji**, jamais, ni en UI ni en copie.
+- Contenus générés : mention explicite (« Certains résumés sont générés automatiquement à partir de sources publiques »).
+
+## Checklist avant publication
+
+À passer sur tout écran qui affiche une affaire, une personne ou un chiffre.
+
+**Attribution**
+
+- [ ] Aucun badge de certitude ni de statut n'est adjacent au nom d'une personne dont `isAccusedInvolvement` est faux.
+- [ ] Aucune catégorie d'infraction n'est rendue comme un attribut de la personne.
+- [ ] Si la personne n'est pas mise en cause, la page dit qui est visé, ou dit explicitement que ce n'est pas elle.
+- [ ] Le degré d'implication est lisible sans défilement, en clair et en mobile.
+
+**Prudence**
+
+- [ ] Un encart de prudence est rendu, quel que soit le couple (statut, implication).
+- [ ] Le wording de l'encart correspond exactement à l'état de la procédure (pas « appel en cours » pour un pourvoi en cassation).
+- [ ] Une issue favorable est rendue comme favorable, pas comme une mise en cause éteinte.
+
+**Sources et données**
+
+- [ ] Chaque affirmation factuelle porte une source consultable.
+- [ ] Les données absentes sont annoncées absentes ; aucun bloc n'est rempli de « non renseigné » pour tenir la grille.
+- [ ] Aucun message contradictoire (« les peines ne concernent pas cette personne » et « pas encore de verdict »).
+- [ ] Les résumés générés sont signalés comme tels.
+
+**Diffusion**
+
+- [ ] `<title>` et `og:title` n'accolent pas le nom d'une personne non mise en cause à un titre d'affaire.
+- [ ] Le texte de partage énonce le rôle quand il n'est pas « mis en cause ».
+- [ ] L'image OG suit la même règle que le titre.
+
+**Accessibilité** (elle fait partie de la mission civique)
+
+- [ ] Cibles tactiles supérieures ou égales à 44 px, y compris les puces de parti et les liens de navigation.
+- [ ] Contraste vérifié sur les fonds colorés (`ensureContrast` / règle BT.601 côté données).
+- [ ] Navigation clavier complète, anneau de focus visible.
+- [ ] `prefers-reduced-motion` respecté.
+- [ ] Aucune information portée par la seule couleur (un parti, un vote, un statut portent toujours un libellé).
+
+## Cas de refus
+
+Un agent ou un contributeur doit **refuser de produire** :
+
+1. Un écran qui range des personnes par gravité supposée sans que le statut judiciaire soit lisible sur chaque ligne (« palmarès des élus les plus véreux »).
+2. Un composant qui affiche un compteur d'affaires sans distinguer condamnations définitives et procédures en cours.
+3. Un visuel de partage qui montre un visage et un chef d'infraction sans le statut de la procédure.
+4. Une carte, un graphe ou un classement qui agrège « nombre d'affaires » toutes implications confondues : additionner un mis en cause et une victime n'a aucun sens et diffame la seconde.
+5. Un ton militant, ironique ou moralisateur, y compris dans un état vide ou un message d'erreur.
+6. Un badge « condamné » dérivé d'autre chose que `CONDAMNATION_DEFINITIVE` + `DIRECT` (voir `CONVICTION_BADGE_WHERE`, source de vérité unique).
+7. Une donnée judiciaire sur une personne qui n'est pas une personnalité publique au sens du produit.
+
+Dans ces cas, le bon comportement est de dire ce qui bloque et de proposer la version conforme, pas de livrer puis d'avertir.

--- a/docs/design/patterns/ClickTarget.md
+++ b/docs/design/patterns/ClickTarget.md
@@ -1,0 +1,67 @@
+# ClickTarget : cible de clic
+
+Une ligne de résultat est une porte. Elle doit s'ouvrir partout où le lecteur appuie.
+
+## Quand l'employer
+
+Toute liste de résultats : affaires, élus, scrutins, dossiers législatifs, fact-checks. Toute carte qui mène à une fiche.
+
+## Le défaut qu'il corrige
+
+La liste des affaires exposait des lignes entières non cliquables, avec un unique lien « Voir détails » de 11 px poussé à droite. Sur mobile, la cible faisait moins de 30 px de haut, à l'endroit le plus difficile à atteindre au pouce.
+
+## Anatomie
+
+Un seul lien, qui enveloppe toute la ligne (ou toute la carte) et porte le libellé accessible complet. Les éléments internes ne sont pas des liens, sauf l'exception ci-dessous.
+
+```jsx
+<a href={href} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+  <article
+    style={{
+      minHeight: 44,
+      padding: "14px 16px",
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-lg)",
+      background: "var(--card)",
+      transition: "box-shadow 200ms, transform 200ms, border-color 200ms",
+    }}
+  >
+    …
+  </article>
+</a>
+```
+
+Affordance : `box-shadow: var(--shadow-sm)` au repos, `var(--shadow-md)` plus `translateY(-1px)` plus `border-color: color-mix(in oklch, var(--primary) 30%, var(--border))` au survol. Un chevron `ChevronRight` en `var(--muted-foreground)` à droite, qui avance de 2 px au survol.
+
+## Liens imbriqués
+
+Quand un élément interne doit mener ailleurs (une puce de parti vers la fiche du parti), ne pas imbriquer deux `<a>`. Deux solutions :
+
+1. **Préférée** : la ligne entière est le lien ; les cibles secondaires sortent du lien et se placent en frères, dans une colonne dédiée.
+2. Un lien de recouvrement (`position: absolute; inset: 0`) sur le titre, les cibles secondaires au-dessus en `z-index`. Le conteneur reste `position: relative`.
+
+## Règles
+
+- **Minimum 44 x 44 px** pour toute cible tactile, sans exception : puces de parti, chips de filtre, chevrons, boutons de pagination. En production, `min-h-11`.
+- Le libellé accessible du lien décrit la destination complète, pas « Voir détails » : « Affaire : tentatives d'ingérence… fiche complète ».
+- Un `:focus-visible` visible : `outline: 2px solid var(--ring); outline-offset: 2px`. Le survol seul ne suffit pas.
+- Le curseur `pointer` sur toute la surface, pas seulement sur le texte.
+- Transitions de 200 à 300 ms, annulées sous `prefers-reduced-motion`.
+- Ne pas mettre de `onClick` sur un `div` : un lien est un lien, il s'ouvre dans un nouvel onglet au clic milieu.
+
+## Thème sombre
+
+Les ombres portées ne se voient pas sur fond sombre. Porter l'affordance de survol sur la bordure et le fond : `border-color` vers `var(--primary)`, `background` vers `color-mix(in oklch, var(--card) 92%, var(--primary))`. Garder le micro-lift, retirer l'ombre.
+
+## À ne pas faire
+
+- Un lien « Voir détails » comme unique cible.
+- Rendre cliquable la carte et le titre séparément avec deux destinations différentes.
+- Compacter les lignes en mobile en dessous de 44 px pour « en voir plus ».
+- Un survol qui déplace le contenu (changement de padding) : seul le conteneur bouge.
+
+## État actuel dans le code
+
+- Référence de dimension : `src/components/ui/ToggleGroup.tsx` (`min-h-11`, soit 44 px). La liste d'affaires et sa carte de résultat sont dans `src/app/affaires/page.tsx`.
+- Le focus-visible global (`outline-2 outline-offset-2`) et la neutralisation des transitions sous `prefers-reduced-motion` sont déjà dans `src/app/globals.css`.
+- C'est le pattern le moins sensible juridiquement : il pourrait être extrait en helper réutilisable (`ClickableRow` ou équivalent) plus une story, sans toucher aux surfaces affaires/légales.

--- a/docs/design/patterns/ContextNav.md
+++ b/docs/design/patterns/ContextNav.md
@@ -1,0 +1,46 @@
+# ContextNav : navigation contextuelle
+
+Savoir où l'on est, d'où l'on vient, et repartir sans perdre son travail de filtrage.
+
+## Quand l'employer
+
+Sur toute page de détail atteinte depuis une liste : fiche d'affaire, fiche d'élu, scrutin, dossier législatif, fact-check.
+
+## Le défaut qu'il corrige
+
+La fiche d'affaire n'offrait aucun chemin visible vers la fiche de l'élu, la page du parti, ni la liste d'où venait le lecteur. Le seul retour disponible était le bouton du navigateur, qui, sur une liste filtrée, ramenait souvent à une liste vide de tout filtre.
+
+## Anatomie
+
+Trois éléments, dans cet ordre de priorité :
+
+1. **Fil d'Ariane** : `Affaires › <super-catégorie> › <titre tronqué>`. Le dernier segment n'est pas un lien, il est en `font-weight: 700`. Les segments intermédiaires portent du sens : une catégorie, une chambre, un parti, pas « Détail ».
+2. **Retour non destructif** : le lien « Affaires » du fil conserve la query string d'origine (filtres, tri, page). Passer les paramètres, ne pas se contenter d'un `href` nu.
+3. **Bloc « Poursuivre »** en fin de fiche : 2 à 4 destinations réelles (la fiche de la personne, la page du parti, les autres affaires de la même catégorie, la source officielle). Chacune décrite, pas « Voir plus ».
+
+Sur une fiche longue, une barre collante reprend le titre tronqué et le retour : `position: sticky; top: 0`, `background: color-mix(in oklch, var(--background) 80%, transparent)`, `backdrop-filter: blur(8px)`, hauteur 56 px.
+
+## Règles
+
+- Le fil d'Ariane est un `<nav aria-label="Fil d'Ariane">` avec une liste ordonnée, pas une suite de `<span>` séparés par des `›`.
+- Le séparateur `›` est décoratif : `aria-hidden`.
+- Cibles à 44 px minimum, y compris dans le fil (voir [`ClickTarget`](./ClickTarget.md)).
+- La barre collante ne masque jamais un encart de prudence au défilement : elle est fine et ne porte que le titre et le retour.
+- Ne jamais réécrire l'historique du navigateur pour simuler un retour.
+- Le bloc « Poursuivre » ne propose que des destinations qui existent : pas de lien vers une fiche de parti absente.
+
+## Thème sombre
+
+La barre translucide est le point sensible : `color-mix` avec `var(--background)` sombre donne un voile presque noir qui écrase la carte en dessous. Descendre à 70 % et augmenter le flou à 10 px. Vérifier que la bordure basse (`var(--border)`, soit `oklch(1 0 0 / 10%)`) reste perceptible, sinon la barre semble flotter sans attache.
+
+## À ne pas faire
+
+- Un fil d'Ariane qui répète la hiérarchie de l'URL sans valeur sémantique.
+- Un bouton « Retour » qui appelle `history.back()` : il casse l'arrivée directe depuis un partage ou un moteur de recherche.
+- Empiler barre collante, en-tête de site et barre de partage : au-delà de deux couches fixes, le mobile n'a plus de contenu visible.
+- Perdre les filtres au retour. C'est le défaut le plus coûteux de la navigation, et le moins visible en recette.
+
+## État actuel dans le code
+
+- Primitive : `src/components/ui/Breadcrumb.tsx` (`nav` labellisé, `aria-current`, chevrons `aria-hidden`, voir l'audit a11y). Surfaces : `src/app/affaires/[slug]/page.tsx`, `src/app/affaires/parti/[slug]/page.tsx`, `src/components/affairs/LinkedAffairBanner.tsx`.
+- **À vérifier sur la fiche actuelle** : que le fil d'Ariane et le retour préservent la query string de la liste d'origine, et que le bloc « Poursuivre » existe en fin de fiche.

--- a/docs/design/patterns/InvolvementBand.md
+++ b/docs/design/patterns/InvolvementBand.md
@@ -1,0 +1,54 @@
+# InvolvementBand : bandeau de rôle
+
+Le pattern le plus important du produit. Il répond à la question qu'un lecteur se pose en arrivant sur une fiche d'affaire : qu'est-ce que cette personne a à voir avec ça ?
+
+## Quand l'employer
+
+Sur toute vue qui associe une personne nommée à une affaire (fiche d'affaire, onglet « Affaires » d'une fiche d'élu, résultat de recherche), et **obligatoirement** dès que `isAccusedInvolvement(involvement)` est faux (`MENTIONED_ONLY`, `VICTIM`, `PLAINTIFF`).
+
+## Le défaut qu'il corrige
+
+Le rôle était rendu comme une pastille parmi d'autres : « Mentionné » en gris, même taille et même forme que « Atteintes à la probité » et « Conflit d'intérêts », juste au-dessus d'un portrait. Résultat, sur une affaire visant un groupe de presse, le lecteur voyait un élu, son parti, et trois qualifications d'infraction, et rien ne disait que la personne poursuivie était quelqu'un d'autre.
+
+Un mot gris ne porte pas une nuance juridique. Une phrase, si.
+
+## Anatomie
+
+Un seul bloc bordé, sous le titre de l'affaire, avant la description. Deux étages :
+
+1. **Étage identité** : avatar, nom lié à la fiche, mandat, fonction en lien avec l'affaire, puce de parti. Fond `color-mix(in oklch, var(--muted) 55%, var(--card))`.
+2. **Étage explicatif** : disque « i », un intertitre « Son rôle dans cette affaire : <rôle> », puis une phrase affirmative disant ce que la personne n'est pas, et ce que les qualifications ne visent pas. Fond `var(--notice-not-accused-bg)`, texte `var(--notice-not-accused-fg)`.
+
+Quand un sujet réel est renseigné, l'étage identité passe en deux colonnes : « Visé par la procédure » (le sujet réel, personne morale comprise) à gauche, « Suivi sur cette page » (l'élu) à droite. C'est la seule mise en page qui nomme l'accusé sans le confondre avec la personne suivie.
+
+## Règles
+
+- **[I3](../legal-invariants.md)** : le rôle s'énonce en phrase, jamais en pastille seule.
+- **[I1](../legal-invariants.md)** : aucun badge de certitude dans ce bloc quand la personne n'est pas mise en cause.
+- **[I2](../legal-invariants.md)** : les catégories d'infraction sortent de ce bloc ; elles appartiennent à l'affaire, préfixées « Faits qualifiés : ».
+- La phrase dit deux choses : la position réelle (« président de la commission visée ») et la négation explicite (« il n'est ni mis en cause, ni poursuivi »). L'une sans l'autre ne suffit pas.
+- Lisible sans défilement, en mobile comme en desktop. C'est un critère d'acceptation, pas une préférence.
+- Un lien « Que veulent dire mis en cause, mentionné, victime ? » sort vers la page de méthode.
+- Le nom est un lien réel vers la fiche, souligné, à `var(--primary)`, pas un simple texte gras.
+- Couleur d'implication : `--inv-<value>-bg / -fg / -border`. Elle teinte le bloc, elle ne le remplace pas.
+
+## Thème sombre
+
+Les tokens `--notice-not-accused-*` et `--inv-*` basculent seuls. Deux pièges :
+
+- Ne pas éclaircir l'étage explicatif au point qu'il se confonde avec la carte : en sombre il doit rester plus foncé que `var(--card)`, l'inverse du clair.
+- Les puces de parti gardent leur hex de marque : vérifier le contraste du libellé dessus (règle BT.601, `getContrastTextColor`), ne pas passer le texte en blanc par défaut.
+
+## À ne pas faire
+
+- Rendre le rôle uniquement dans un tooltip ou un `title` : un avertissement doit être lisible sans interaction.
+- Écrire « simplement mentionné » : le mot minimise et n'est pas neutre.
+- Employer `MENTIONED_ONLY` par prudence quand la personne est en réalité victime ([I9](../legal-invariants.md)). Le degré juste et sourcé protège mieux.
+- Mettre le bloc après la description : le fait décisif arrive alors sous la ligne de flottaison.
+- Additionner les implications dans un compteur d'affaires.
+
+## État actuel dans le code
+
+- `src/components/affairs/LinkedAffairBanner.tsx` rend aujourd'hui le lien entre une personne et une affaire ; `src/app/affaires/[slug]/page.tsx` porte l'en-tête et la ligne de pastilles.
+- Garde-fou : `isAccusedInvolvement()` dans `src/config/certainty.ts`. Libellés et couleurs : `INVOLVEMENT_LABELS`, `INVOLVEMENT_COLORS` dans `src/config/labels.ts`.
+- **Écart** : les tokens `--inv-*` et `--notice-not-accused-*` du bundle ne sont pas encore dans `src/app/globals.css` (les couleurs d'implication vivent en chaînes de classes Tailwind). L'étage explicatif à deux colonnes « Visé / Suivi » est une proposition du bundle, pas encore implémentée.

--- a/docs/design/patterns/JudicialCaution.md
+++ b/docs/design/patterns/JudicialCaution.md
@@ -1,0 +1,57 @@
+# JudicialCaution : encart de prudence
+
+Le rappel qui accompagne toute affaire publiée : la qualification procédurale exacte, énoncée avant toute lecture à charge.
+
+## Quand l'employer
+
+Sur toute vue publiant une affaire. Il n'y a pas de couple (statut, implication) qui dispense d'encart. C'est précisément le trou constaté : `getAffairNoticeVariant()` renvoie `null` pour une personne non mise en cause dont l'affaire n'est pas une condamnation, c'est-à-dire le cas le plus exposé du produit.
+
+## Variantes
+
+Neuf variantes, une par situation. Les huit premières existent, `not_accused` est la variante manquante.
+
+| Variante            | Situation                                                        | Ton                                             |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| `presumption`       | Procédure active, personne mise en cause                         | Présomption d'innocence                         |
+| `non_definitive`    | Condamnation de 1re instance, ou appel en cours                  | Recours possible                                |
+| `pourvoi`           | Condamnation en appel, pourvoi en cassation                      | Non définitive, la cassation peut annuler       |
+| `definitive`        | Condamnation définitive                                          | Factuel, sans emphase                           |
+| `favorable`         | Relaxe, acquittement, non-lieu, classement                       | Dominant, ne se lit pas comme une mise en cause |
+| `prescription`      | Action publique éteinte                                          | Close sans décision sur le fond                 |
+| `instruction_close` | Instruction close sans mise en examen                            | Réquisitions à venir                            |
+| `third_party`       | Personne non mise en cause, affaire conclue par une condamnation | La peine concerne quelqu'un d'autre             |
+| `not_accused`       | Personne non mise en cause, procédure en cours                   | Manquant : ni mise en cause, ni poursuivie      |
+
+Wording de `not_accused` : le rôle en clair, la négation explicite, et le rappel que les qualifications décrivent les faits reprochés dans l'affaire sans viser cette personne.
+
+## Anatomie
+
+Un `role="note"`, bordé, `border-radius: var(--radius-lg)`, `padding: 16px`. Un intertitre en gras suivi de deux-points, puis la phrase. Un `data-variant` sur le nœud, indispensable pour les tests de non-régression.
+
+Couleurs : `--notice-<variant>-border / -bg / -fg`. Le rouge de marque n'est jamais employé ici : un encart de prudence protège, il n'alerte pas.
+
+## Règles
+
+- **[I5](../legal-invariants.md)** : toute affaire publiée porte un encart.
+- Le wording colle exactement à l'état de la procédure. « Appel en cours » sur un pourvoi en cassation est faux : l'appel est terminé.
+- La prescription a un wording distinct des autres issues favorables : elle éteint l'action publique sans décision sur le fond.
+- Une issue favorable est rendue en vert sobre et se lit comme favorable. Ne pas la neutraliser en gris « pour rester neutre » : la neutralité de forme produit ici un doute injustifié.
+- Placement : après le bandeau de rôle, avant la description. Jamais en pied de page, jamais replié.
+- Ne jamais mettre l'encart dans un accordéon, un tooltip, une modale.
+
+## Thème sombre
+
+Tous les tokens basculent. Le principe : en clair les fonds sont plus clairs que la carte, en sombre ils sont plus sombres. Vérifier que `favorable` reste identifiable comme vert (`#a7f3d0` sur fond vert très sombre) et que `presumption` ne devient pas un jaune criard : l'ambre sombre doit rester une information, pas un avertissement de danger.
+
+## À ne pas faire
+
+- Un pictogramme d'alerte rouge : la présomption d'innocence n'est pas un danger.
+- Réutiliser `third_party` pour une procédure en cours : son wording suppose une condamnation déjà prononcée.
+- Retirer l'encart d'une fiche « parce qu'il est déjà sur la page de liste ».
+- Faire dépendre l'encart d'un état d'interface (onglet actif, filtre) : il suit la donnée, pas la vue.
+
+## État actuel dans le code
+
+- `src/components/affairs/AffairStatusNotice.tsx` : `getAffairNoticeVariant(status, involvement)` mappe les 8 variantes existantes ; `getJudicialMaturity()` vit dans `src/config/judicial-maturity.ts`.
+- **Écart (violation I5)** : pour une implication non poursuivie (`isAccusedInvolvement` faux) hors condamnation, la fonction renvoie `null`, donc aucun encart, alors que la page montre le visage de la personne à côté des qualifications de l'affaire. C'est la variante `not_accused` à ajouter (un correctif prod ciblé, à coordonner avec le travail en cours sur les affaires).
+- **Écart tokens** : `NOTICES` utilise des classes Tailwind codées en dur (`border-amber-200 bg-amber-50 ...`), pas les tokens `--notice-*` du bundle (absents de `globals.css`).

--- a/docs/design/patterns/MissingData.md
+++ b/docs/design/patterns/MissingData.md
@@ -1,0 +1,50 @@
+# MissingData : donnée absente
+
+Sur une plateforme de données publiques, l'absence est une information. Elle se dit, elle ne se comble pas.
+
+## Quand l'employer
+
+Partout où une valeur peut manquer : déclaration HATVP non publiée, juridiction non renseignée, peine sans objet, patrimoine inconnu, vote non enregistré, mandat sans date de fin.
+
+## Le défaut qu'il corrige
+
+Sur une fiche d'affaire visant un tiers, la page réservait deux cartes à un procès qui ne concernait pas la personne suivie : « Juridiction : informations non renseignées » et une carte « Peine » affichant successivement « les peines prononcées ne concernent pas cette personne » puis « affaire en cours, pas encore de verdict ». Deux blocs pleins de rien, et deux messages contradictoires.
+
+## Les trois cas, et leur traitement
+
+| Cas                                                                                                    | Traitement                                                                                   |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| **Sans objet** : la donnée ne peut pas exister ici (peine, alors que la personne n'est pas poursuivie) | Masquer le bloc. Une ligne discrète en fin de section explique l'absence, une fois.          |
+| **Inconnue** : la donnée existe mais Poligraph ne l'a pas                                              | Afficher le bloc avec un état vide explicite et daté : ce qui manque, pourquoi, où chercher. |
+| **Non publiée** : l'autorité ne l'a pas rendue publique                                                | État vide qui nomme l'autorité : « Aucune déclaration publiée par la HATVP à ce jour. »      |
+
+## Anatomie de l'état vide
+
+`border: 1px dashed var(--border)`, `border-radius: var(--radius-md)`, `padding: 12px 14px`, texte `var(--muted-foreground)` à 12,5 px. Un symbole Unicode discret en gris si nécessaire, jamais d'emoji, jamais d'illustration.
+
+## Règles
+
+- **[I8](../legal-invariants.md)** : le doute se documente. Pas de tiret, pas de « N/A », pas de `0` là où la valeur est inconnue.
+- **`0` et « inconnu » ne se rendent jamais pareil.** « 0 affaire » est un fait ; « aucune donnée » est une lacune.
+- **Un seul message par absence.** Deux phrases qui se contredisent valent moins que rien.
+- Ne jamais remplir un bloc pour tenir une grille. Si la grille se déséquilibre, c'est la grille qui change : passer en une colonne.
+- Dire où chercher quand c'est possible : lien vers la source officielle, « Signaler une erreur ».
+- Une absence n'est jamais un reproche. « Aucune déclaration publiée », pas « n'a pas déclaré ».
+- Ne pas employer un `Skeleton` pour une donnée absente : le squelette dit « ça arrive », pas « ça n'existe pas ».
+
+## Thème sombre
+
+`var(--border)` en pointillé devient très peu visible en sombre (`oklch(1 0 0 / 10%)`). Monter à `oklch(1 0 0 / 18%)` pour l'état vide, sinon le bloc semble cassé plutôt que vide.
+
+## À ne pas faire
+
+- « Non renseigné » seul, sans dire par qui ni pourquoi.
+- Un placeholder gris à la place d'un chiffre : le lecteur croit à un chargement.
+- Un ton évaluatif (« aucune transparence sur ce point »).
+- Masquer une absence pour rendre une fiche « plus complète » : c'est une falsification par omission.
+
+## État actuel dans le code
+
+- La condition de masquage du bloc Peine repose sur `isAccusedInvolvement()` (`src/config/certainty.ts`) ; les blocs Peine et Juridiction sont dans `src/app/affaires/[slug]/page.tsx`.
+- Le premier volet (l'encart tiers) a été traité (#511, variante `third_party` de [`JudicialCaution`](./JudicialCaution.md)).
+- **À vérifier sur la fiche actuelle** : qu'un seul message d'absence subsiste quand `isAccusedInvolvement` est faux (pas de bloc Peine vide contradictoire), et que les états vides HATVP nomment l'autorité et datent l'absence.

--- a/docs/design/patterns/PoliticianIdentity.md
+++ b/docs/design/patterns/PoliticianIdentity.md
@@ -1,0 +1,50 @@
+# PoliticianIdentity : identité d'élu
+
+Une personne se présente toujours de la même façon, partout dans le produit : même ordre, même densité, mêmes attributs. C'est ce qui rend les fiches comparables, et ce qui empêche une mise en page de charger quelqu'un.
+
+## Quand l'employer
+
+Carte d'élu, en-tête de fiche, ligne de résultat, bandeau de rôle dans une affaire, restitution de Boussole, résultat de recherche.
+
+## Anatomie : l'ordre est normatif
+
+1. **Photo** : ronde, `var(--muted)` en fond, initiales en repli. Ne jamais afficher une silhouette générique : les initiales sont plus dignes.
+2. **Nom complet** : Outfit 700/800, `tracking-tight`. C'est le seul élément à ne jamais tronquer.
+3. **Mandat en cours** : `MANDATE_TYPE_LABELS`, féminisé par `feminizeRole()` selon la civilité. « Députée du Calvados », pas « Député ».
+4. **Circonscription / territoire** : le rattachement géographique, souvent ce que le citoyen cherche.
+5. **Parti** : puce de la couleur du parti (15 % de fond, 30 % de bordure, texte contrasté par la règle BT.601 via `getContrastTextColor`). Toujours un libellé, jamais la couleur seule.
+6. **Chambre** : `CHAMBER_LABELS`, quand plusieurs chambres cohabitent dans la même vue.
+
+Tout le reste (statistiques, affaires, patrimoine, activité) vient après et n'entre jamais dans le bloc d'identité.
+
+## Règles
+
+- **[I1](../legal-invariants.md)** : aucun badge de certitude, de statut judiciaire ou de catégorie d'infraction dans le bloc d'identité. Une personne n'est pas une affaire. Les affaires ont leur propre section, avec leur bandeau de rôle.
+- **La féminisation est obligatoire.** `feminizeRole()` et `feminizePartyRole()` existent : les utiliser. Un titre au masculin par défaut est une erreur de données visible par la personne concernée.
+- **Un compteur d'affaires ne se met pas sur une carte d'identité** sans distinguer les implications et les statuts. « 3 affaires » additionne un mis en cause et deux mentions : c'est faux et diffamant ([I1](../legal-invariants.md), cas de refus 4).
+- Le badge de condamnation, s'il existe, dérive uniquement de `CONVICTION_BADGE_WHERE` (`DIRECT` + `CONDAMNATION_DEFINITIVE` + `CRITIQUE`). Aucune autre dérivation n'est admise.
+- Les mandats antérieurs vont dans un `CollapsibleCard`, jamais dans l'en-tête.
+- La puce de parti cliquable fait 44 px minimum (voir [`ClickTarget`](./ClickTarget.md)). C'est le défaut le plus fréquent en mobile.
+- Sur une carte, la densité est modérée : photo, nom, mandat, territoire, parti. Cinq informations, pas huit.
+
+## Thème sombre
+
+Les couleurs de parti sont des hex de marque, non tokenisées par thème : elles ne basculent pas. Trois conséquences :
+
+- Le fond à 15 % devient très sombre sur `var(--card)` sombre : monter à 22 % pour garder la puce identifiable.
+- Le texte contrasté calculé par la règle BT.601 l'est sur la couleur du parti, pas sur le fond de carte : il reste valide, ne pas le forcer en blanc.
+- L'avatar de repli (`var(--muted)` plus initiales) doit rester distinct de la carte : `var(--muted)` sombre est proche de `var(--card)`, ajouter une bordure `1px var(--border)`.
+
+## À ne pas faire
+
+- Trier ou colorer des personnes par gravité supposée.
+- Afficher un parti par sa seule couleur (illisible pour un daltonien, incompréhensible pour un citoyen non initié).
+- Un badge « suivi » ou « à surveiller » : Poligraph documente, ne désigne pas.
+- Tronquer un nom pour tenir une grille : c'est la grille qui s'adapte.
+- Mélanger des personnes et des personnes morales dans la même liste sans le dire.
+
+## État actuel dans le code
+
+- Surfaces : `src/components/politicians/PoliticianCard.tsx`, `src/app/politiques/[slug]/page.tsx`, `src/components/politicians/ProfileTabs.tsx`.
+- Contraste : `getContrastTextColor()`, `ensureContrast()` dans `src/config/party-colors.ts`. Libellés et féminisation : `MANDATE_TYPE_LABELS`, `feminizeRole()`, `feminizePartyRole()`, `CHAMBER_LABELS`, `CONVICTION_BADGE_WHERE` dans `src/config/labels.ts`.
+- Les couleurs de parti restent des hex de marque (non tokenisées par thème), conformément à la règle ci-dessus.

--- a/docs/design/patterns/README.md
+++ b/docs/design/patterns/README.md
@@ -1,0 +1,26 @@
+# Patterns
+
+Les fondations (`src/app/globals.css`, `src/config/*`) disent avec quoi dessiner. Les primitives (`src/components/ui/*`) donnent les briques. Les **patterns** disent comment on résout, chez Poligraph, un problème qui revient, et pourquoi la solution évidente est souvent fausse.
+
+Chaque pattern porte un nom anglais (celui du composant en code) et un libellé français (celui qu'on emploie à l'oral et dans les issues).
+
+| Pattern                                         | Libellé                 | Le problème qu'il résout                                                             |
+| ----------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| [`InvolvementBand`](./InvolvementBand.md)       | Bandeau de rôle         | Dire comment une personne est liée à une affaire, quand elle n'est pas mise en cause |
+| [`JudicialCaution`](./JudicialCaution.md)       | Encart de prudence      | Énoncer l'état exact d'une procédure avant toute lecture à charge                    |
+| [`MissingData`](./MissingData.md)               | Donnée absente          | Afficher une absence sans la déguiser en information                                 |
+| [`ClickTarget`](./ClickTarget.md)               | Cible de clic           | Rendre une ligne ou une carte réellement cliquable, au doigt comme au clavier        |
+| [`ContextNav`](./ContextNav.md)                 | Navigation contextuelle | Savoir où l'on est, d'où l'on vient, et repartir sans perdre son filtrage            |
+| [`SourceAttribution`](./SourceAttribution.md)   | Attribution de source   | Rendre chaque fait vérifiable, y compris hors du site                                |
+| [`VoteBreakdown`](./VoteBreakdown.md)           | Restitution de scrutin  | Montrer un vote sans le transformer en jugement                                      |
+| [`PoliticianIdentity`](./PoliticianIdentity.md) | Identité d'élu          | Présenter une personne de façon constante, dense et non incriminante                 |
+
+## Comment lire un pattern
+
+Chaque fiche suit la même structure : quand l'employer, anatomie, règles, thème sombre, à ne pas faire, état actuel dans le code. Les règles marquées **INVARIANT** renvoient à [`legal-invariants.md`](../legal-invariants.md) : elles ne se négocient pas.
+
+La section « état actuel dans le code » de chaque fiche relie le pattern à son implémentation réelle et signale les écarts connus (par exemple la variante `not_accused` manquante de `JudicialCaution`). Ces écarts sont des correctifs à cadrer séparément, pas des ajustements à faire au fil de l'eau, car ils touchent des surfaces affaires et légales sensibles.
+
+## Origine
+
+Ces patterns viennent de cinq séries de refonte menées sur le produit : liste et fiche d'affaires, refonte des scrutins, carte et fiche d'élu, patrimoine HATVP, et redesign de la Boussole. Ils ne sont pas théoriques : chacun corrige un défaut observé sur `poligraph.fr`. Source de spécification : le bundle `poligraph-design-system-*.zip` (dossiers `patterns/` et `guidelines/`).

--- a/docs/design/patterns/SourceAttribution.md
+++ b/docs/design/patterns/SourceAttribution.md
@@ -1,0 +1,52 @@
+# SourceAttribution : attribution de source
+
+« Données publiques, regard indépendant » n'est une promesse tenue que si chaque fait mène à sa source. Ce pattern couvre aussi ce qui quitte le site.
+
+## Quand l'employer
+
+Sur toute affirmation factuelle : une peine, un vote, un montant de patrimoine, une date, un mandat, un résumé généré.
+
+## Anatomie, sur la page
+
+- **Ligne de source** sous le bloc concerné : nom de l'organe (`DATA_SOURCE_LABELS`), date de consultation, lien sortant. 11,5 px, `var(--muted-foreground)`.
+- **`CiteAnchor`** en fin de titre de bloc, pour que le bloc soit citable par un tiers.
+- **Mention de génération** quand un texte est produit automatiquement : « Résumé généré automatiquement à partir de sources publiques », avec un symbole discret en gris.
+- **« Signaler une erreur »** accessible depuis toute fiche. Ce n'est pas un aveu de faiblesse, c'est la méthode.
+- **Date de vérification** quand elle existe : « Vérifié le 12 mai 2026 ». Une donnée sans date de vérification n'est pas fausse, mais elle n'est pas datée : le dire.
+
+## Anatomie, hors la page
+
+C'est la partie qu'on oublie, et celle qui fait le plus de dégâts. Quatre surfaces, une seule règle.
+
+| Surface                       | Règle                                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `<title>`                     | N'accole le nom d'une personne au titre d'une affaire que si `isAccusedInvolvement(involvement)`.      |
+| `og:title` / `og:description` | Idem, et le statut de la procédure figure dans la description.                                         |
+| `opengraph-image`             | Même règle que le titre. Jamais un visage plus un chef d'infraction sans le statut.                    |
+| Texte de `ShareBar`           | Énonce le rôle quand il n'est pas « mis en cause » : « Affaire : <titre>, rôle de <nom> : mentionné ». |
+
+## Règles
+
+- **[I6](../legal-invariants.md)** : une affirmation sans source est un bug de contenu.
+- **[I7](../legal-invariants.md)** : ce qui quitte le site est soumis aux mêmes règles que la page.
+- Nommer l'organe, pas le pipeline : « Assemblée nationale », pas « import AN v3 ».
+- Un lien sortant porte `target="_blank" rel="noopener noreferrer"` et un libellé qui dit où il mène.
+- Ne pas confondre source (d'où vient la donnée) et preuve (la décision de justice). Judilibre est une source consultable ; la presse est une source rapportée. Le dire quand c'est le cas.
+- Les résumés générés sont signalés à chaque occurrence, pas une fois en pied de page.
+
+## Thème sombre
+
+Les liens sortants à `var(--primary)` deviennent le bleu clair du thème sombre : vérifier le contraste sur `var(--card)` sombre (viser 4,5:1 sur du texte à 11,5 px, ce qui est déjà petit). Ne pas descendre toute la ligne de source à `var(--muted-foreground)` en sombre : la date de consultation peut rester discrète, le nom de l'organe doit rester lisible.
+
+## À ne pas faire
+
+- Une source affichée uniquement au survol.
+- Un « Sources (3) » replié qui masque l'origine de la donnée la plus sensible de la page.
+- Un partage qui gagne en clarté ce qu'il perd en exactitude.
+- Marquer « Vérifié » sans date : c'est une affirmation non vérifiable sur une plateforme de vérification.
+
+## État actuel dans le code
+
+- Libellés : `DATA_SOURCE_LABELS`, `SOURCE_TYPE_LABELS` dans `src/config/labels.ts`. Primitives : `src/components/ui/CiteAnchor.tsx` (`src/lib/cite.ts`), `src/components/ui/ShareBar.tsx` (`src/lib/share.ts`).
+- Diffusion : `generateMetadata()` dans `src/app/affaires/[slug]/page.tsx`, image OG dans `src/app/affaires/[slug]/opengraph-image.tsx`.
+- **À vérifier** : que le gating `isAccusedInvolvement` s'applique bien au `<title>`, à l'`og:*` et à l'image OG (c'est la surface la plus exposée : hors du site, il ne reste qu'un nom et un titre d'affaire).

--- a/docs/design/patterns/VoteBreakdown.md
+++ b/docs/design/patterns/VoteBreakdown.md
@@ -1,0 +1,47 @@
+# VoteBreakdown : restitution de scrutin
+
+Montrer un vote sans le transformer en jugement. Un vote « contre » n'est ni une faute ni un courage : c'est une position.
+
+## Quand l'employer
+
+Fiche de scrutin, onglet « Votes » d'une fiche d'élu, carte de scrutin dans une liste, restitution de la Boussole.
+
+## Anatomie
+
+- **Barre de répartition** (`VoteBar`) : pour, contre, abstention, non-votants, en une seule barre à segments proportionnels, chaque segment étiqueté avec son effectif en `fr-FR`. Couleurs : `--vote-pour`, `--vote-contre`, `--vote-abstention`, `--vote-absent`.
+- **Résultat** : « Adopté » ou « Rejeté » (`VOTING_RESULT_LABELS`), en badge, à côté du titre du scrutin. C'est le fait ; il précède toute analyse.
+- **Position de la personne** sur une fiche d'élu : sa position, et le taux de participation du scrutin. Une position sans participation est trompeuse.
+- **Position du groupe** (`GROUP_POSITION_LABELS`), pour situer la personne par rapport à son groupe. C'est le seul contexte qui permet de lire une dissidence.
+- **Anneau de participation** (`ParticipationRing`) sur les agrégats, jamais sur un scrutin isolé.
+
+## Règles
+
+- Les couleurs de vote sont désaturées à dessein (`#4a8a5c`, `#9e5454`) : un vert vif et un rouge vif fabriquent un bien et un mal. Ne pas les « corriger ».
+- **Séparer les segments par un filet** de 1 px à la couleur de la carte. `--vote-abstention` et `--vote-absent` sont deux gris très proches : sans filet, abstentions et non-votants se lisent comme un seul bloc, ce que la règle suivante interdit.
+- **Aucune information portée par la seule couleur** : chaque segment, chaque puce porte un libellé.
+- Un absent n'est pas un non-votant. `ABSENT` et `NON_VOTANT` ont des libellés, des couleurs et des sens distincts, ne pas les fusionner pour simplifier une barre.
+- **Ne jamais qualifier une absence.** Pas de « n'a pas daigné voter ». `dissidenceLabel()` donne le vocabulaire admis pour l'écart au groupe (« Très discipliné » vers « Indépendant »), descriptif et borné.
+- Un scrutin porte son intitulé complet et son type (`SCRUTIN_TYPE_LABELS`) : un amendement et un texte final n'ont pas le même poids et ne se comparent pas.
+- Les effectifs en `toLocaleString("fr-FR")`, avec espace insécable.
+- **Distinguer inscrits, votants et exprimés.** « 577 inscrits, 565 votants » n'est pas « 577 votants ». C'est l'erreur d'arithmétique la plus fréquente sur ce pattern.
+- Un taux de participation faible s'affiche comme un fait, avec l'effectif : « 84 votants sur 577 ».
+
+## Thème sombre
+
+Les couleurs de vote ont des variantes sombres dédiées (`--vote-pour: #7ab892`, etc.) : ne pas se contenter d'éclaircir les valeurs claires, elles perdent leur désaturation et redeviennent un feu tricolore. Sur un segment étroit, le libellé passe hors de la barre plutôt qu'en blanc sur fond clair.
+
+**Le piège du libellé sur le remplissage.** Ne jamais coder en dur `color:#fff` sur un segment : les remplissages sombres (`#7ab892`, `#c88a8a`) dépassent le seuil de luminosité BT.601 de 150, donc `getContrastTextColor()` impose un texte foncé. Employer `--vote-pour-fg` / `--vote-contre-fg` / `--vote-abstention-fg` / `--vote-absent-fg`, qui basculent avec le thème. Même règle pour tout texte posé sur une couleur de parti ou de chambre.
+
+## À ne pas faire
+
+- Un score, une note, un « taux de fidélité au groupe » présenté comme une performance.
+- Un classement d'élus par nombre de votes « contre ».
+- Une barre à segments sans effectifs : le pourcentage seul masque un scrutin à 40 votants.
+- Additionner des positions sur des scrutins de natures différentes.
+- Un emoji de vote. Les icônes sont Lucide, les couleurs sont des tokens.
+
+## État actuel dans le code
+
+- Surfaces existantes : `src/components/votes/VoteCard.tsx`, `src/components/votes/CardGroupPositions.tsx`, `src/components/parlement/ScrutinsListing.tsx`. Libellés : `VOTE_POSITION_LABELS`, `GROUP_POSITION_LABELS`, `SCRUTIN_TYPE_LABELS`, `dissidenceLabel()`, `AN_SEAT_COUNT` dans `src/config/labels.ts`.
+- Les tokens `--vote-*` (et leurs `-fg`) sont déjà dans `src/app/globals.css` et consommés par `VoteCard` / `CardGroupPositions`.
+- **Note dataviz** : la barre segmentée, l'anneau de participation et l'hémicycle existent déjà en production (`VoteCard`, `stats/Hemicycle.tsx`, `parlement/CompositionHemicycle.tsx`). Les extraire en primitives partagées (`VoteBar`, `ParticipationRing`) est un refactor de la feature votes, à coordonner, pas un ajout greenfield.


### PR DESCRIPTION
## Contexte

Livre la couche **patterns** du design system, listée dans `design-system.md` comme « reste à faire ». Comme signalé en amont, les patterns sont surtout de la guidance sur du comportement déjà en production plus des invariants légaux RGPD : cette PR est donc de la documentation, pas un changement de comportement.

## Ce que fait la PR

- `docs/design/legal-invariants.md` : le chapitre normatif (I1 à I9, vocabulaire imposé, checklist avant publication, cas de refus). C'est la colonne vertébrale RGPD article 10 sur laquelle s'ancrent les patterns.
- `docs/design/patterns/` : 8 fiches (InvolvementBand, JudicialCaution, MissingData, ClickTarget, ContextNav, SourceAttribution, VoteBreakdown, PoliticianIdentity) plus un index. Chaque fiche suit la même structure : quand l'employer, anatomie, règles, thème sombre, à ne pas faire, et « état actuel dans le code ».
- Les fiches sont adaptées du bundle mais **vérifiées contre le code réel** : chaque référence (`AffairStatusNotice`, `certainty.ts`, `PoliticianCard`, `VoteCard`…) existe sur `main`, et les em dashes du bundle sont retirés.
- `docs/design/design-system.md` : lien vers la couche patterns, garde-fou a11y marqué comme branché, section « reste à faire » mise à jour.

## Écarts prod catalogués (documentés, pas corrigés ici)

La section « état actuel dans le code » de chaque fiche signale les vrais trous, à corriger séparément car ils touchent des surfaces affaires et légales sensibles :

- `JudicialCaution` : variante `not_accused` manquante. `getAffairNoticeVariant()` renvoie `null` pour une personne non mise en cause hors condamnation, ce qui viole l'invariant I5 (toute affaire publiée porte un encart).
- Tokens `--notice-*` et `--inv-*` du bundle pas encore dans `globals.css` (les couleurs vivent en chaînes de classes Tailwind).

## Vérification

- Zéro changement de code applicatif : uniquement `docs/`.
- Liens internes vérifiés, prettier clean.
- Références de code vérifiées présentes sur `main`.
