### PR TITLE
feat(affaires): fiche carrefour, retour non destructif, ligne cliquable

### DIFF
--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { Suspense } from "react";
 import { cacheTag, cacheLife } from "next/cache";
 import { notFound, permanentRedirect } from "next/navigation";
 import Link from "next/link";
@@ -31,13 +32,15 @@ import { LinkedAffairBanner } from "@/components/affairs/LinkedAffairBanner";
 import { SentenceDetails } from "@/components/affairs/SentenceDetails";
 import { StatusTooltip } from "@/components/affairs/StatusTooltip";
 import { AffairTimeline } from "@/components/affairs/AffairTimeline";
-import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
-import { ArticleJsonLd } from "@/components/seo/JsonLd";
-import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/seo/JsonLd";
+import { AffairStickyBar } from "@/components/affairs/AffairStickyBar";
+import { AffairContextBand } from "@/components/affairs/AffairContextBand";
+import { AffairContinue } from "@/components/affairs/AffairContinue";
+import { AffairNeighborBar } from "@/components/affairs/AffairNeighborBar";
+import { pickDisplayMandate, formatMandateMeta } from "@/lib/affairs/context-meta";
 import type { AffairCategory, Involvement } from "@/types";
 import type { Prisma } from "@/generated/prisma";
 import { SITE_URL } from "@/config/site";
-import { ShareBar } from "@/components/ui/ShareBar";
 import { getAffairPartyDisplay } from "@/lib/affairs/party-display";
 import { buildPublicAffairLookupWheres, pickPublicLinkedAffair } from "@/lib/affairs/affair-lookup";
 import { resolveDecisionFields } from "@/lib/affairs/decision-fields";
@@ -76,12 +79,19 @@ const affairInclude = {
       currentParty: {
         select: {
           id: true,
+          slug: true,
           shortName: true,
           name: true,
           color: true,
           foundedDate: true,
         },
       },
+      mandates: {
+        where: { isCurrent: true },
+        select: { type: true, constituency: true, startDate: true },
+        orderBy: { startDate: "asc" as const },
+      },
+      _count: { select: { affairs: { where: { publicationStatus: "PUBLISHED" as const } } } },
     },
   },
   partyAtTime: {
@@ -92,6 +102,9 @@ const affairInclude = {
       name: true,
       color: true,
       foundedDate: true,
+      _count: {
+        select: { affairsAtTime: { where: { publicationStatus: "PUBLISHED" as const } } },
+      },
     },
   },
   sources: {
@@ -227,6 +240,45 @@ export default async function AffairDetailPage({ params }: PageProps) {
   });
   const linked = pickPublicLinkedAffair(affair.linkedAffair, affair.linkedBy);
 
+  // Context band: who the tracked politician is, plus lateral journeys.
+  const displayMandate = pickDisplayMandate(affair.politician.mandates);
+  const politicianMeta = formatMandateMeta(displayMandate, affair.politician.civility);
+  const affairCount = affair.politician._count.affairs;
+
+  const contextParty =
+    partyDisplay.kind === "at-time"
+      ? {
+          name: partyDisplay.party.name,
+          shortName: partyDisplay.party.shortName,
+          color: partyDisplay.party.color ?? null,
+          slug: partyDisplay.party.slug ?? null,
+          atTime: !partyDisplay.sameAsCurrent,
+        }
+      : partyDisplay.kind === "current"
+        ? {
+            name: partyDisplay.party.name,
+            shortName: partyDisplay.party.shortName,
+            color: partyDisplay.party.color ?? null,
+            slug: partyDisplay.party.slug ?? null,
+            atTime: false,
+          }
+        : null;
+
+  // Only the historical party carries a count we fetched; the current-party
+  // fallback shows the tile without an unverified number.
+  const partyAffairCount =
+    partyDisplay.kind === "at-time" ? (affair.partyAtTime?._count?.affairsAtTime ?? null) : null;
+
+  const superCategoryLabel = AFFAIR_SUPER_CATEGORY_LABELS[superCategory];
+  const superCategoryHref = `/affaires?supercat=${superCategory}`;
+
+  const breadcrumbItems = [
+    { name: "Accueil", url: `${SITE_URL}/` },
+    { name: "Affaires", url: `${SITE_URL}/affaires` },
+    { name: superCategoryLabel, url: `${SITE_URL}${superCategoryHref}` },
+    { name: affair.title, url: `${SITE_URL}/affaires/${affair.slug}` },
+  ];
+
   return (
     <>
       <ArticleJsonLd
@@ -241,16 +293,15 @@ export default async function AffairDetailPage({ params }: PageProps) {
           url: `${SITE_URL}/politiques/${affair.politician.slug}`,
         }}
       />
-      <ShareBar
-        data={{
-          title: affair.title,
-          text: `Affaire judiciaire : ${affair.title} (${AFFAIR_STATUS_LABELS[affair.status]})`,
-          url: `${SITE_URL}/affaires/${affair.slug}`,
-        }}
+      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <AffairStickyBar
+        title={affair.title}
+        shareUrl={`${SITE_URL}/affaires/${affair.slug}`}
+        shareText={`Affaire : ${affair.title} (${AFFAIR_STATUS_LABELS[affair.status]})`}
+        superCategoryLabel={superCategoryLabel}
+        superCategoryHref={superCategoryHref}
       />
-      <div className="container mx-auto px-4 pt-4 pb-8 max-w-4xl">
-        <Breadcrumb items={[{ label: "Affaires", href: "/affaires" }, { label: affair.title }]} />
-
+      <div className="container mx-auto max-w-4xl px-4 pt-4 pb-24 sm:pb-8">
         {/* Header */}
         <div className="mb-8">
           <div className="flex flex-wrap items-center gap-2 mb-3">
@@ -305,49 +356,14 @@ export default async function AffairDetailPage({ params }: PageProps) {
             {affair.title}
           </h1>
 
-          {/* Politician card */}
-          <div className="inline-flex items-center gap-3 p-3 rounded-lg border bg-muted/30">
-            <Link
-              href={`/politiques/${affair.politician.slug}`}
-              className="inline-flex items-center gap-3 hover:opacity-80 transition-opacity"
-            >
-              <PoliticianAvatar
-                fullName={affair.politician.fullName}
-                photoUrl={affair.politician.photoUrl}
-                size="md"
-              />
-              <div>
-                <p className="font-semibold">{affair.politician.fullName}</p>
-              </div>
-            </Link>
-            {partyDisplay.kind === "at-time" && (
-              <p className="text-sm text-muted-foreground">
-                {partyDisplay.party.slug ? (
-                  <Link
-                    href={`/affaires/parti/${partyDisplay.party.slug}`}
-                    className="hover:underline hover:text-foreground"
-                  >
-                    {partyDisplay.party.name}
-                  </Link>
-                ) : (
-                  partyDisplay.party.name
-                )}
-                {!partyDisplay.sameAsCurrent && <span className="text-xs"> (à l&apos;époque)</span>}
-              </p>
-            )}
-            {partyDisplay.kind === "current" && (
-              <p className="text-sm text-muted-foreground">{partyDisplay.party.name}</p>
-            )}
-            {partyDisplay.kind === "unknown" &&
-              partyDisplay.reason === "pre-dates-current-party" && (
-                <p
-                  className="text-sm text-muted-foreground italic"
-                  title={`Parti actuel (${partyDisplay.currentPartyName}) fondé en ${partyDisplay.currentPartyFoundedDate?.getFullYear()}, soit après la date des faits.`}
-                >
-                  Parti à l&apos;époque : non renseigné
-                </p>
-              )}
-          </div>
+          <AffairContextBand
+            politicianSlug={affair.politician.slug}
+            fullName={affair.politician.fullName}
+            photoUrl={affair.politician.photoUrl}
+            meta={politicianMeta}
+            affairCount={affairCount}
+            party={contextParty}
+          />
         </div>
 
         {/* Encart de prudence juridique : présomption, recours, issue favorable
@@ -596,26 +612,25 @@ export default async function AffairDetailPage({ params }: PageProps) {
           </Card>
         )}
 
-        {/* Actions */}
-        <div className="mt-8 flex flex-wrap gap-4">
-          <Link
-            href={`/politiques/${affair.politician.slug}`}
-            className="text-sm text-primary hover:underline"
-          >
-            ← Voir la fiche de {affair.politician.fullName}
-          </Link>
-          <Link href="/affaires" className="text-sm text-primary hover:underline">
-            ← Retour à la liste des affaires
-          </Link>
-          {affair.partyAtTime?.slug && (
-            <Link
-              href={`/affaires/parti/${affair.partyAtTime.slug}`}
-              className="text-sm text-primary hover:underline"
-            >
-              ← Affaires {affair.partyAtTime.shortName}
-            </Link>
-          )}
-        </div>
+        {/* Poursuivre — lateral journeys replace the former stacked "← …" footer */}
+        <AffairContinue
+          politicianSlug={affair.politician.slug}
+          politicianName={affair.politician.fullName}
+          affairCount={affairCount}
+          party={
+            contextParty
+              ? {
+                  name: contextParty.name,
+                  shortName: contextParty.shortName,
+                  slug: contextParty.slug,
+                }
+              : null
+          }
+          partyAffairCount={partyAffairCount}
+        />
+        <Suspense fallback={null}>
+          <AffairNeighborBar slug={affair.slug} politicianSlug={affair.politician.slug} />
+        </Suspense>
       </div>
     </>
   );

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -28,6 +28,7 @@ import type { AffairStatus, Involvement } from "@/types";
 import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing-robots";
 import { AFFAIRES_DEFAULT_TITLE, AFFAIRES_DEFAULT_DESCRIPTION } from "@/lib/seo/affaires-metadata";
 import { AFFAIRES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
+import { buildRetourParam } from "@/lib/affairs/listing-return";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
 
@@ -145,6 +146,20 @@ export default async function AffairesPage({ searchParams }: PageProps) {
     ]);
 
   const totalAffairs = Object.values(superCounts).reduce((a, b) => a + b, 0);
+
+  // Serialise the active perimeter so each card's detail link can offer a
+  // non-destructive "Retour aux N résultats" (read client-side on the detail
+  // page; the detail canonical stays clean, so no `?retour=` is ever indexed).
+  const retourParam = buildRetourParam({
+    search: searchFilter,
+    sort: sortFilter,
+    status: statusFilter,
+    supercat: superCatFilter,
+    category: categoryFilter,
+    certainty: certaintyFilter,
+    parti: partiFilter,
+    mode: mode !== "mise-en-cause" ? mode : "",
+  });
 
   // Build URL helper (only used for super-category cards + pagination)
   function buildUrl(params: Record<string, string>) {
@@ -269,7 +284,12 @@ export default async function AffairesPage({ searchParams }: PageProps) {
           <>
             <div className="space-y-4">
               {affairs.map((affair) => (
-                <AffairListingCard key={affair.id} affair={affair} />
+                <AffairListingCard
+                  key={affair.id}
+                  affair={affair}
+                  retour={retourParam}
+                  resultCount={total}
+                />
               ))}
             </div>
 
@@ -306,10 +326,12 @@ export default async function AffairesPage({ searchParams }: PageProps) {
         )}
 
         {/* Info box */}
-        <Card className="mt-8 bg-blue-50 border-blue-200">
+        <Card className="mt-8 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30">
           <CardContent className="pt-6">
-            <h3 className="font-semibold text-blue-900 mb-2">À propos des données</h3>
-            <p className="text-sm text-blue-800">
+            <h3 className="mb-2 font-semibold text-blue-900 dark:text-blue-200">
+              À propos des données
+            </h3>
+            <p className="text-sm text-blue-800 dark:text-blue-300">
               Les affaires listées sont issues de sources publiques vérifiables (articles de presse,
               décisions de justice) et font l&apos;objet d&apos;une validation éditoriale avant
               publication. Les procédures en cours sont présentées avec rappel de la présomption

--- a/src/app/api/affaires/neighbors/route.ts
+++ b/src/app/api/affaires/neighbors/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { getAffairNeighborsList } from "@/lib/data/affairs";
+import { pickNeighbors } from "@/lib/affairs/neighbors";
+import { CERTAINTY_LABELS, type CertaintyLevel } from "@/config/certainty";
+import {
+  AFFAIR_SUPER_CATEGORY_LABELS,
+  AFFAIR_STATUS_LABELS,
+  AFFAIR_CATEGORY_LABELS,
+  type AffairSuperCategory,
+} from "@/config/labels";
+import type { AffairStatus, Involvement } from "@/types";
+
+/**
+ * Prev/next resolution for the affair detail page, within the reader's listing
+ * perimeter. Client-fetched so the detail page stays static (ISR): the filters
+ * ride in the query string exactly as /affaires serialised them into `?retour=`.
+ * Read-only, published-only. Params are whitelisted so a crafted value can only
+ * ever narrow the published set, never widen it.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  const slug = searchParams.get("slug");
+  if (!slug) {
+    return NextResponse.json({ error: "slug requis" }, { status: 400 });
+  }
+
+  const mode = searchParams.get("mode") === "victime" ? "victime" : "mise-en-cause";
+  const involvements: Involvement[] =
+    mode === "victime" ? ["VICTIM", "PLAINTIFF"] : ["DIRECT", "INDIRECT", "MENTIONED_ONLY"];
+
+  // Only accept values from the known vocabularies; anything else is ignored so
+  // it can never reach getStatusesForCertainty / getCategoriesForSuper as junk.
+  const certaintyRaw = searchParams.get("certainty");
+  const certainty =
+    certaintyRaw && certaintyRaw in CERTAINTY_LABELS ? (certaintyRaw as CertaintyLevel) : undefined;
+
+  const supercatRaw = searchParams.get("supercat");
+  const superCategory =
+    supercatRaw && supercatRaw in AFFAIR_SUPER_CATEGORY_LABELS
+      ? (supercatRaw as AffairSuperCategory)
+      : undefined;
+
+  const statusRaw = searchParams.get("status");
+  const status =
+    statusRaw && statusRaw in AFFAIR_STATUS_LABELS ? (statusRaw as AffairStatus) : undefined;
+
+  const categoryRaw = searchParams.get("category");
+  const category = categoryRaw && categoryRaw in AFFAIR_CATEGORY_LABELS ? categoryRaw : undefined;
+
+  const ordered = await getAffairNeighborsList({
+    search: searchParams.get("search") || undefined,
+    status,
+    superCategory,
+    category,
+    involvements,
+    partySlug: searchParams.get("parti") || undefined,
+    certainty,
+    sort: searchParams.get("sort") || undefined,
+  });
+
+  const neighbors = pickNeighbors(ordered, slug);
+
+  return NextResponse.json(neighbors, {
+    // Small CDN cache: the perimeter changes at most daily (synced data).
+    headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400" },
+  });
+}

--- a/src/components/affairs/AffairContextBand.tsx
+++ b/src/components/affairs/AffairContextBand.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+import { Scale, Landmark, Vote, ArrowRight } from "lucide-react";
+import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
+import { AffairPartyChip } from "@/components/affairs/AffairPartyChip";
+
+/**
+ * Context band under the <h1>: who the tracked politician is, and the lateral
+ * journeys a reader wants next (their affairs, their party's affairs, their
+ * votes). Turns the fiche from a cul-de-sac into a crossroads.
+ *
+ * This is the identity étage of the InvolvementBand pattern. B1 will add the
+ * role étage (the "ni mis en cause, ni poursuivi" sentence + not_accused notice)
+ * below the identity row for non-accused involvements, without reshaping this.
+ */
+interface AffairContextBandProps {
+  politicianSlug: string;
+  fullName: string;
+  photoUrl: string | null;
+  /** Mandate · chamber · seniority, pre-formatted; omitted when unknown. */
+  meta: string | null;
+  affairCount: number;
+  party: {
+    name: string;
+    shortName: string;
+    color: string | null;
+    slug: string | null;
+    atTime: boolean;
+  } | null;
+}
+
+function RailLink({
+  href,
+  icon: Icon,
+  children,
+}: {
+  href: string;
+  icon: typeof Scale;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex min-h-11 items-center gap-1.5 rounded-md border bg-card px-3 text-sm font-medium outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+    >
+      <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      {children}
+      <ArrowRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+    </Link>
+  );
+}
+
+export function AffairContextBand({
+  politicianSlug,
+  fullName,
+  photoUrl,
+  meta,
+  affairCount,
+  party,
+}: AffairContextBandProps) {
+  const ficheHref = `/politiques/${politicianSlug}`;
+  const votesHref = `/politiques/${politicianSlug}/votes`;
+  const partyAffairsHref = party?.slug ? `/affaires/parti/${party.slug}` : null;
+
+  return (
+    <div className="mb-6 rounded-xl border bg-card p-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Link
+            href={ficheHref}
+            className="shrink-0 rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <PoliticianAvatar fullName={fullName} photoUrl={photoUrl} size="md" />
+          </Link>
+          <div>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <Link
+                href={ficheHref}
+                className="font-display text-lg font-semibold text-primary underline-offset-2 hover:underline"
+              >
+                {fullName}
+              </Link>
+              <Link
+                href={ficheHref}
+                className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                Fiche complète
+                <ArrowRight className="ml-0.5 inline size-3" aria-hidden="true" />
+              </Link>
+            </div>
+            {meta && <p className="mt-0.5 text-sm text-muted-foreground">{meta}</p>}
+          </div>
+        </div>
+
+        {party && (
+          <AffairPartyChip
+            name={party.name}
+            shortName={party.shortName}
+            color={party.color}
+            href={partyAffairsHref ?? undefined}
+            atTime={party.atTime}
+          />
+        )}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2 border-t pt-3">
+        <RailLink href={ficheHref} icon={Scale}>
+          {affairCount > 1 ? `Ses ${affairCount} affaires documentées` : "Sa fiche d'affaires"}
+        </RailLink>
+        {partyAffairsHref && (
+          <RailLink href={partyAffairsHref} icon={Landmark}>
+            Affaires {party?.shortName}
+          </RailLink>
+        )}
+        <RailLink href={votesHref} icon={Vote}>
+          Ses votes
+        </RailLink>
+      </div>
+    </div>
+  );
+}

--- a/src/components/affairs/AffairContinue.tsx
+++ b/src/components/affairs/AffairContinue.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+/**
+ * "Poursuivre" — the reading continuation at the end of an affair page, three
+ * tiles in place of the former stacked "← …" footer links. Its arrows point
+ * forward (lateral journeys), never back: the only "←" on the page is the return.
+ */
+interface AffairContinueProps {
+  politicianSlug: string;
+  politicianName: string;
+  affairCount: number;
+  party: { name: string; shortName: string; slug: string | null } | null;
+  partyAffairCount: number | null;
+}
+
+interface Tile {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  href: string;
+}
+
+export function AffairContinue({
+  politicianSlug,
+  politicianName,
+  affairCount,
+  party,
+  partyAffairCount,
+}: AffairContinueProps) {
+  const tiles: Tile[] = [
+    {
+      eyebrow: "La personne suivie",
+      title: politicianName,
+      subtitle:
+        affairCount > 1
+          ? `Ses ${affairCount} affaires, mandats et votes`
+          : "Mandats, votes et patrimoine",
+      href: `/politiques/${politicianSlug}`,
+    },
+  ];
+
+  if (party?.slug) {
+    tiles.push({
+      eyebrow: "Le parti",
+      title: party.name,
+      subtitle:
+        partyAffairCount && partyAffairCount > 0
+          ? `${partyAffairCount.toLocaleString("fr-FR")} affaire${partyAffairCount > 1 ? "s" : ""} documentée${partyAffairCount > 1 ? "s" : ""}`
+          : "Affaires du parti",
+      href: `/affaires/parti/${party.slug}`,
+    });
+  }
+
+  tiles.push({
+    eyebrow: "Méthode",
+    title: "Comment nous qualifions",
+    subtitle: "Statuts, certitude et sources",
+    href: "/methodologie",
+  });
+
+  return (
+    <section className="mt-8" aria-labelledby="poursuivre-heading">
+      <h2 id="poursuivre-heading" className="mb-3 text-lg font-semibold">
+        Poursuivre
+      </h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {tiles.map((tile) => (
+          <Link
+            key={tile.href}
+            href={tile.href}
+            className="group flex min-h-11 flex-col gap-1 rounded-xl border bg-card p-4 outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {tile.eyebrow}
+            </span>
+            <span className="flex items-center gap-1 font-semibold text-foreground">
+              <span className="min-w-0 truncate">{tile.title}</span>
+              <ArrowRight
+                className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                aria-hidden="true"
+              />
+            </span>
+            <span className="text-sm text-muted-foreground">{tile.subtitle}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/affairs/AffairListingCard.tsx
+++ b/src/components/affairs/AffairListingCard.tsx
@@ -62,15 +62,26 @@ export interface AffairListingCardData {
 
 interface AffairListingCardProps {
   affair: AffairListingCardData;
+  /** Serialised origin filters, for the non-destructive return on the detail page. */
+  retour?: string;
+  /** Origin result count, so the return can read "Retour aux N résultats". */
+  resultCount?: number;
 }
 
-export function AffairListingCard({ affair }: AffairListingCardProps) {
+export function AffairListingCard({ affair, retour, resultCount }: AffairListingCardProps) {
   const certainty = getCertaintyLevel(affair.status);
   // Charging certainty pill only for the accused; otherwise the involvement
   // badge carries the politician's role, never a status that is not theirs (#383).
   const accused = isAccusedInvolvement(affair.involvement);
   const superCat = CATEGORY_TO_SUPER[affair.category];
-  const detailHref = `/affaires/${affair.slug ?? affair.id}`;
+  const detailBase = `/affaires/${affair.slug ?? affair.id}`;
+  const detailHref = (() => {
+    const sp = new URLSearchParams();
+    if (retour) sp.set("retour", retour);
+    if (resultCount !== undefined) sp.set("rn", String(resultCount));
+    const qs = sp.toString();
+    return qs ? `${detailBase}?${qs}` : detailBase;
+  })();
 
   const relevantDate = affair.verdictDate || affair.startDate || affair.factsDate;
   const dateLabel = affair.verdictDate ? "Verdict" : affair.startDate ? "Révélation" : "Faits";
@@ -86,7 +97,7 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
   return (
     <article
       id={citeAnchorId.affair(affair.id)}
-      className="group rounded-xl border border-l-4 bg-card p-4 text-card-foreground shadow-sm transition-shadow hover:shadow-md"
+      className="group relative rounded-xl border border-l-4 bg-card p-4 text-card-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
       style={{ borderLeftColor: accused ? CERTAINTY_BORDER[certainty] : NON_ACCUSED_BORDER }}
     >
       <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -112,7 +123,13 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
       </div>
 
       <h2 className="mb-1 text-lg font-semibold">
-        <Link href={detailHref} className="hover:underline focus-visible:underline">
+        {/* Stretched link: the title is the single card-navigation link; its
+            ::after overlay makes the whole card clickable. Nested links below sit
+            at z-10 so they stay independently clickable. */}
+        <Link
+          href={detailHref}
+          className="after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none"
+        >
           {affair.title}
         </Link>
       </h2>
@@ -120,7 +137,7 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
       <p className="text-sm">
         <Link
           href={`/politiques/${affair.politician.slug}`}
-          className="text-primary hover:underline"
+          className="relative z-10 text-primary hover:underline"
         >
           {affair.politician.fullName}
         </Link>
@@ -130,7 +147,7 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
             {partyDisplay.party.slug ? (
               <Link
                 href={`/affaires/parti/${partyDisplay.party.slug}`}
-                className="hover:underline hover:text-foreground"
+                className="relative z-10 hover:text-foreground hover:underline"
               >
                 {partyDisplay.party.shortName}
               </Link>
@@ -186,11 +203,14 @@ export function AffairListingCard({ affair }: AffairListingCardProps) {
             <CiteAnchor
               permalink={`${SITE_URL}/affaires/${affair.slug ?? affair.id}`}
               label={affair.title}
+              className="relative z-10"
             />
           </span>
-          <Link href={detailHref} className="font-medium text-primary hover:underline">
+          {/* Decorative affordance only: the whole card is the link (stretched
+              above), so this must not be a second link to the same target. */}
+          <span aria-hidden="true" className="font-medium text-primary">
             Voir détails →
-          </Link>
+          </span>
         </div>
       </div>
     </article>

--- a/src/components/affairs/AffairNeighborBar.tsx
+++ b/src/components/affairs/AffairNeighborBar.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { ArrowLeft, ArrowRight, User } from "lucide-react";
+import type { AffairNeighbors } from "@/lib/affairs/neighbors";
+
+/**
+ * Prev/next within the reader's listing perimeter, plus a mobile bottom action
+ * bar whose primary action is the politician's fiche. Neighbours are fetched
+ * client-side from /api/affaires/neighbors using the filters carried in
+ * `?retour=`, so the detail page stays static (ISR) and no perimeter is baked
+ * into the cached HTML. Without `?retour=` (a direct visit) there is no
+ * perimeter, so no prev/next is shown.
+ */
+interface AffairNeighborBarProps {
+  slug: string;
+  politicianSlug: string;
+}
+
+export function AffairNeighborBar({ slug, politicianSlug }: AffairNeighborBarProps) {
+  const searchParams = useSearchParams();
+  const retour = searchParams.get("retour");
+  const rn = searchParams.get("rn");
+  const [neighbors, setNeighbors] = useState<AffairNeighbors | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    if (!retour) return;
+    const query = new URLSearchParams(retour);
+    query.set("slug", slug);
+    const controller = new AbortController();
+    fetch(`/api/affaires/neighbors?${query.toString()}`, { signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setNeighbors(data))
+      .catch(() => {
+        /* aborted or offline: no neighbour nav, not a page error */
+      });
+    return () => controller.abort();
+  }, [retour, slug]);
+
+  // Collapse the mobile bar on downward scroll, reveal on upward — it never sits
+  // above the status notice (which lives at the top of the page).
+  const lastY = useRef(0);
+  useEffect(() => {
+    function onScroll() {
+      const y = window.scrollY;
+      if (Math.abs(y - lastY.current) > 8) {
+        setHidden(y > lastY.current && y > 200);
+        lastY.current = y;
+      }
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // Gate on the perimeter at render time: if `?retour=` is gone (navigated to an
+  // affair reached without a listing), show no prev/next even if stale state
+  // lingers on a persisted instance.
+  const hasPerimeter = Boolean(retour);
+  const prev = hasPerimeter ? (neighbors?.prev ?? null) : null;
+  const next = hasPerimeter ? (neighbors?.next ?? null) : null;
+  const position = hasPerimeter ? (neighbors?.position ?? null) : null;
+  const total = hasPerimeter ? (neighbors?.total ?? 0) : 0;
+
+  function neighborHref(target: string) {
+    const sp = new URLSearchParams();
+    if (retour) sp.set("retour", retour);
+    if (rn) sp.set("rn", rn);
+    const qs = sp.toString();
+    return `/affaires/${target}${qs ? `?${qs}` : ""}`;
+  }
+
+  const ficheHref = `/politiques/${politicianSlug}`;
+
+  return (
+    <>
+      {/* Desktop: prev/next by title, in the reading flow after "Poursuivre". */}
+      {(prev || next) && (
+        <nav
+          aria-label="Navigation entre affaires"
+          className="mt-4 hidden gap-3 sm:grid sm:grid-cols-2"
+        >
+          {prev ? (
+            <Link
+              href={neighborHref(prev.slug)}
+              className="group flex min-h-11 items-center gap-2 rounded-xl border bg-card p-3 outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <ArrowLeft className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block text-xs text-muted-foreground">Affaire précédente</span>
+                <span className="block truncate font-medium">{prev.title}</span>
+              </span>
+            </Link>
+          ) : (
+            <span aria-hidden="true" />
+          )}
+          {next ? (
+            <Link
+              href={neighborHref(next.slug)}
+              className="group flex min-h-11 items-center justify-end gap-2 rounded-xl border bg-card p-3 text-right outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <span className="min-w-0">
+                <span className="block text-xs text-muted-foreground">Affaire suivante</span>
+                <span className="block truncate font-medium">{next.title}</span>
+              </span>
+              <ArrowRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            </Link>
+          ) : (
+            <span aria-hidden="true" />
+          )}
+        </nav>
+      )}
+      {position !== null && total > 1 && (
+        <p className="mt-2 hidden text-center text-xs text-muted-foreground sm:block">
+          Affaire {position.toLocaleString("fr-FR")} sur {total.toLocaleString("fr-FR")} dans ce
+          périmètre
+        </p>
+      )}
+
+      {/* Mobile: fixed bottom action bar, thumb zone, safe-area aware. */}
+      <div
+        className={`fixed inset-x-0 bottom-0 z-30 border-t bg-background/95 backdrop-blur-sm transition-transform duration-200 motion-reduce:transition-none sm:hidden ${
+          hidden ? "translate-y-full" : "translate-y-0"
+        }`}
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      >
+        <div className="flex items-center gap-2 px-3 py-2">
+          {prev ? (
+            <Link
+              href={neighborHref(prev.slug)}
+              aria-label={`Affaire précédente : ${prev.title}`}
+              className="grid min-h-11 min-w-11 place-items-center rounded-md border outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <ArrowLeft className="size-5" aria-hidden="true" />
+            </Link>
+          ) : (
+            <span className="min-h-11 min-w-11" aria-hidden="true" />
+          )}
+
+          <Link
+            href={ficheHref}
+            className="inline-flex min-h-11 flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 font-semibold text-primary-foreground outline-none hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+          >
+            <User className="size-4 shrink-0" aria-hidden="true" />
+            Fiche complète
+          </Link>
+
+          {next ? (
+            <Link
+              href={neighborHref(next.slug)}
+              aria-label={`Affaire suivante : ${next.title}`}
+              className="grid min-h-11 min-w-11 place-items-center rounded-md border outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <ArrowRight className="size-5" aria-hidden="true" />
+            </Link>
+          ) : (
+            <span className="min-h-11 min-w-11" aria-hidden="true" />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/affairs/AffairPartyChip.tsx
+++ b/src/components/affairs/AffairPartyChip.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+/**
+ * Party chip tinted by the party's own colour, theme-safe by construction: the
+ * hue rides a solid dot and a low tint mixed toward var(--card), while the label
+ * stays var(--foreground) so it reads in both themes (no ensureContrast guess
+ * against a single background, no colour-only signal). Renders as a link when a
+ * slug is given, a span otherwise.
+ */
+interface AffairPartyChipProps {
+  name: string;
+  shortName: string;
+  color: string | null;
+  href?: string;
+  /** Append "à l'époque" when the party differs from the politician's current one. */
+  atTime?: boolean;
+  className?: string;
+}
+
+export function AffairPartyChip({
+  name,
+  shortName,
+  color,
+  href,
+  atTime = false,
+  className = "",
+}: AffairPartyChipProps) {
+  const tint = color
+    ? {
+        backgroundColor: `color-mix(in oklch, ${color} 12%, var(--card))`,
+        borderColor: `color-mix(in oklch, ${color} 32%, var(--border))`,
+      }
+    : undefined;
+
+  const label = shortName && shortName !== name ? `${name} (${shortName})` : name;
+
+  const inner = (
+    <span
+      className="inline-flex min-h-[1.75rem] items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold text-foreground"
+      style={tint}
+    >
+      {color && (
+        <span
+          aria-hidden="true"
+          className="inline-block size-2 shrink-0 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      )}
+      {label}
+      {atTime && <span className="font-normal text-muted-foreground">à l&apos;époque</span>}
+    </span>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={`inline-flex rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${className}`}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return <span className={className}>{inner}</span>;
+}

--- a/src/components/affairs/AffairReturnLink.tsx
+++ b/src/components/affairs/AffairReturnLink.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { parseReturn } from "@/lib/affairs/listing-return";
+
+/**
+ * The non-destructive return control. Isolated as its own client island (read
+ * of useSearchParams) so the rest of the sticky bar and the page stay static
+ * (ISR): it is rendered inside a <Suspense> whose fallback is the generic
+ * return below. The canonical stays /affaires/<slug>, so `?retour=` never
+ * enters the index.
+ */
+const LINK_CLASS =
+  "inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm font-medium outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1";
+
+export function AffairReturnLinkFallback() {
+  return (
+    <Link href="/affaires" className={LINK_CLASS}>
+      <ArrowLeft className="size-4 shrink-0" aria-hidden="true" />
+      Retour aux affaires
+    </Link>
+  );
+}
+
+export function AffairReturnLink() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { href, label } = parseReturn(searchParams.get("retour"), searchParams.get("rn"));
+
+  // Prefer a real "back" (restores scroll + filters) only when the previous page
+  // is the listing itself; otherwise the labelled destination always wins.
+  function handleReturn(e: React.MouseEvent<HTMLAnchorElement>) {
+    if (typeof window === "undefined") return;
+    try {
+      const ref = new URL(document.referrer);
+      if (ref.origin === window.location.origin && ref.pathname === "/affaires") {
+        e.preventDefault();
+        router.back();
+      }
+    } catch {
+      // No/opaque referrer: let the Link navigate to href.
+    }
+  }
+
+  return (
+    <Link href={href} onClick={handleReturn} className={LINK_CLASS}>
+      <ArrowLeft className="size-4 shrink-0" aria-hidden="true" />
+      {label}
+    </Link>
+  );
+}

--- a/src/components/affairs/AffairShareActions.tsx
+++ b/src/components/affairs/AffairShareActions.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Link2, Check, Share2 } from "lucide-react";
+
+/**
+ * Citer / Partager actions for the sticky bar, folded in from the former
+ * floating ShareBar (whose fixed bottom bar clashed with the mobile action
+ * bar). No searchParams read, so it needs no Suspense boundary. Partager uses
+ * the native share sheet where available (mobile), copy elsewhere.
+ */
+interface AffairShareActionsProps {
+  title: string;
+  shareUrl: string;
+  shareText: string;
+}
+
+const ACTION_CLASS =
+  "inline-flex min-h-11 items-center gap-1.5 rounded-md px-2.5 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1";
+
+export function AffairShareActions({ title, shareUrl, shareText }: AffairShareActionsProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCite() {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      toast.success("Lien de l'affaire copié");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Impossible de copier le lien");
+    }
+  }
+
+  async function handleShare() {
+    if (typeof navigator !== "undefined" && "share" in navigator) {
+      try {
+        await navigator.share({ title, text: shareText, url: shareUrl });
+        return;
+      } catch {
+        // Cancelled or unsupported: fall through to copy.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success("Lien copié, à coller où vous voulez");
+    } catch {
+      toast.error("Impossible de partager le lien");
+    }
+  }
+
+  return (
+    <>
+      <button type="button" onClick={handleCite} aria-label="Citer" className={ACTION_CLASS}>
+        {copied ? (
+          <Check className="size-4 shrink-0 text-emerald-600" aria-hidden="true" />
+        ) : (
+          <Link2 className="size-4 shrink-0" aria-hidden="true" />
+        )}
+        <span className="hidden sm:inline">Citer</span>
+      </button>
+      <button type="button" onClick={handleShare} aria-label="Partager" className={ACTION_CLASS}>
+        <Share2 className="size-4 shrink-0" aria-hidden="true" />
+        <span className="hidden sm:inline">Partager</span>
+      </button>
+    </>
+  );
+}

--- a/src/components/affairs/AffairStickyBar.tsx
+++ b/src/components/affairs/AffairStickyBar.tsx
@@ -1,0 +1,56 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { AffairReturnLink, AffairReturnLinkFallback } from "@/components/affairs/AffairReturnLink";
+import { AffairShareActions } from "@/components/affairs/AffairShareActions";
+
+/**
+ * Sticky sub-bar under the site header on an affair detail page: non-destructive
+ * return, a compact breadcrumb, and Citer/Partager. Server shell so the page
+ * stays static (ISR); only the return link (URL-dependent) and the share
+ * buttons (clipboard) are client islands, the return one behind a Suspense
+ * boundary with a generic fallback.
+ */
+interface AffairStickyBarProps {
+  title: string;
+  shareUrl: string;
+  shareText: string;
+  superCategoryLabel: string;
+  superCategoryHref: string;
+}
+
+export function AffairStickyBar({
+  title,
+  shareUrl,
+  shareText,
+  superCategoryLabel,
+  superCategoryHref,
+}: AffairStickyBarProps) {
+  return (
+    <div className="sticky top-16 z-30 border-b bg-background/80 backdrop-blur-md">
+      <div className="container mx-auto flex max-w-4xl items-center gap-2 px-4 py-1.5">
+        <Suspense fallback={<AffairReturnLinkFallback />}>
+          <AffairReturnLink />
+        </Suspense>
+
+        <nav
+          aria-label="Fil d'Ariane"
+          className="hidden min-w-0 flex-1 items-center gap-1 text-sm text-muted-foreground md:flex"
+        >
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" aria-hidden="true" />
+          <Link href={superCategoryHref} className="shrink-0 hover:text-foreground hover:underline">
+            {superCategoryLabel}
+          </Link>
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" aria-hidden="true" />
+          <span className="truncate text-foreground" title={title}>
+            {title}
+          </span>
+        </nav>
+
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <AffairShareActions title={title} shareUrl={shareUrl} shareText={shareText} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/affairs/__tests__/AffairListingCard.test.tsx
+++ b/src/components/affairs/__tests__/AffairListingCard.test.tsx
@@ -85,3 +85,34 @@ describe("AffairListingCard : citabilité", () => {
     expect(container.textContent).toContain("5 sources vérifiées");
   });
 });
+
+describe("AffairListingCard : cible de clic étendue", () => {
+  it("le titre est le lien de navigation de la carte et porte le périmètre de retour", () => {
+    render(
+      <AffairListingCard affair={baseAffair()} retour="certainty=EN_COURS" resultCount={12} />
+    );
+    const titleLink = screen.getByRole("link", { name: "Affaire de test" });
+    const href = titleLink.getAttribute("href")!;
+    expect(href).toContain("/affaires/affaire-de-test");
+    expect(href).toContain("retour=certainty");
+    expect(href).toContain("rn=12");
+  });
+
+  it("« Voir détails » n'est pas un second lien vers la même cible", () => {
+    render(<AffairListingCard affair={baseAffair()} />);
+    expect(screen.getByText(/Voir détails/)).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /Voir détails/ })).toBeNull();
+  });
+
+  it("l'élu reste un lien imbriqué indépendant", () => {
+    render(<AffairListingCard affair={baseAffair()} />);
+    const elu = screen.getByRole("link", { name: "Jean Test" });
+    expect(elu.getAttribute("href")).toBe("/politiques/jean-test");
+  });
+
+  it("sans périmètre, le lien du titre reste propre", () => {
+    render(<AffairListingCard affair={baseAffair()} />);
+    const titleLink = screen.getByRole("link", { name: "Affaire de test" });
+    expect(titleLink.getAttribute("href")).toBe("/affaires/affaire-de-test");
+  });
+});

--- a/src/lib/affairs/__tests__/context-meta.test.ts
+++ b/src/lib/affairs/__tests__/context-meta.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { pickDisplayMandate, formatMandateMeta } from "@/lib/affairs/context-meta";
+
+describe("pickDisplayMandate", () => {
+  it("prefers a parliamentary mandate over another current one", () => {
+    const m = pickDisplayMandate([
+      { type: "MINISTRE", constituency: null, startDate: new Date("2020-01-01") },
+      { type: "SENATEUR", constituency: "Moselle", startDate: new Date("2017-09-01") },
+    ]);
+    expect(m?.type).toBe("SENATEUR");
+  });
+
+  it("falls back to the first when none is parliamentary", () => {
+    const m = pickDisplayMandate([{ type: "MAIRE", constituency: "Lyon", startDate: null }]);
+    expect(m?.type).toBe("MAIRE");
+  });
+
+  it("returns null with no mandate", () => {
+    expect(pickDisplayMandate([])).toBeNull();
+  });
+});
+
+describe("formatMandateMeta", () => {
+  it("names the chamber and the seniority year", () => {
+    const meta = formatMandateMeta(
+      { type: "SENATEUR", constituency: "Moselle", startDate: new Date("2017-09-01") },
+      "Mme"
+    );
+    expect(meta).toContain("Sénat");
+    expect(meta).toContain("Moselle");
+    expect(meta).toContain("en mandat depuis 2017");
+  });
+
+  it("omits the department segment when unknown (MissingData)", () => {
+    const meta = formatMandateMeta({ type: "DEPUTE", constituency: null, startDate: null }, "M.");
+    expect(meta).toContain("Assemblée nationale");
+    expect(meta).not.toContain(" ·  · ");
+  });
+
+  it("extracts the department from a parenthesised constituency", () => {
+    const meta = formatMandateMeta(
+      { type: "DEPUTE", constituency: "Rhône (3ème)", startDate: null },
+      null
+    );
+    expect(meta).toContain("Rhône");
+    expect(meta).not.toContain("3ème");
+  });
+
+  it("returns null without a mandate", () => {
+    expect(formatMandateMeta(null, null)).toBeNull();
+  });
+});

--- a/src/lib/affairs/__tests__/listing-return.test.ts
+++ b/src/lib/affairs/__tests__/listing-return.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { buildRetourParam, parseReturn } from "@/lib/affairs/listing-return";
+
+describe("buildRetourParam", () => {
+  it("keeps active whitelisted filters in a stable order", () => {
+    const value = buildRetourParam({
+      certainty: "ETABLI",
+      supercat: "PROBITE",
+      search: "",
+      sort: undefined,
+    });
+    expect(value).toBe("certainty=ETABLI&supercat=PROBITE");
+  });
+
+  it("drops empty and unknown keys", () => {
+    const value = buildRetourParam({ parti: "", evil: "x", mode: "victime" } as Record<
+      string,
+      string
+    >);
+    expect(value).toBe("mode=victime");
+  });
+
+  it("returns an empty string for the bare listing", () => {
+    expect(buildRetourParam({})).toBe("");
+  });
+});
+
+describe("parseReturn", () => {
+  it("rebuilds the filtered href and a counted label", () => {
+    const r = parseReturn("certainty=ETABLI&supercat=PROBITE", "12");
+    expect(r.href).toBe("/affaires?certainty=ETABLI&supercat=PROBITE");
+    expect(r.label).toBe("Retour aux 12 résultats");
+    expect(r.count).toBe(12);
+    expect(r.filtered).toBe(true);
+  });
+
+  it("formats the count in fr-FR with a non-breaking thousands separator", () => {
+    const r = parseReturn("", "1234");
+    expect(r.label).toBe(`Retour aux ${(1234).toLocaleString("fr-FR")} résultats`);
+  });
+
+  it("falls back to the bare listing with no retour", () => {
+    const r = parseReturn(null, null);
+    expect(r.href).toBe("/affaires");
+    expect(r.label).toBe("Retour aux affaires");
+    expect(r.count).toBeNull();
+    expect(r.filtered).toBe(false);
+  });
+
+  it("names a filtered origin even without a count", () => {
+    const r = parseReturn("parti=lfi", null);
+    expect(r.href).toBe("/affaires?parti=lfi");
+    expect(r.label).toBe("Retour à la liste filtrée");
+  });
+
+  it("singularises a lone result", () => {
+    expect(parseReturn("certainty=ETABLI", "1").label).toBe("Retour au résultat");
+  });
+
+  it("strips non-whitelisted keys from a crafted retour value", () => {
+    const r = parseReturn("certainty=ETABLI&redirect=https://evil.test", "5");
+    expect(r.href).toBe("/affaires?certainty=ETABLI");
+  });
+
+  it("ignores a non-numeric count", () => {
+    const r = parseReturn("", "abc");
+    expect(r.count).toBeNull();
+  });
+});

--- a/src/lib/affairs/__tests__/neighbors.test.ts
+++ b/src/lib/affairs/__tests__/neighbors.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { pickNeighbors, type AffairNeighborRef } from "@/lib/affairs/neighbors";
+
+const list: AffairNeighborRef[] = [
+  { slug: "a", title: "Affaire A" },
+  { slug: "b", title: "Affaire B" },
+  { slug: "c", title: "Affaire C" },
+];
+
+describe("pickNeighbors", () => {
+  it("returns both neighbours in the middle", () => {
+    expect(pickNeighbors(list, "b")).toEqual({
+      prev: { slug: "a", title: "Affaire A" },
+      next: { slug: "c", title: "Affaire C" },
+      position: 2,
+      total: 3,
+    });
+  });
+
+  it("has no prev at the first item", () => {
+    const r = pickNeighbors(list, "a");
+    expect(r.prev).toBeNull();
+    expect(r.next).toEqual({ slug: "b", title: "Affaire B" });
+    expect(r.position).toBe(1);
+  });
+
+  it("has no next at the last item", () => {
+    const r = pickNeighbors(list, "c");
+    expect(r.next).toBeNull();
+    expect(r.prev).toEqual({ slug: "b", title: "Affaire B" });
+    expect(r.position).toBe(3);
+  });
+
+  it("offers nothing when the affair is outside the perimeter", () => {
+    expect(pickNeighbors(list, "z")).toEqual({
+      prev: null,
+      next: null,
+      position: null,
+      total: 3,
+    });
+  });
+
+  it("handles a single-item perimeter", () => {
+    const r = pickNeighbors([{ slug: "a", title: "Affaire A" }], "a");
+    expect(r.prev).toBeNull();
+    expect(r.next).toBeNull();
+    expect(r.position).toBe(1);
+    expect(r.total).toBe(1);
+  });
+
+  it("handles an empty perimeter", () => {
+    expect(pickNeighbors([], "a")).toEqual({
+      prev: null,
+      next: null,
+      position: null,
+      total: 0,
+    });
+  });
+});

--- a/src/lib/affairs/context-meta.ts
+++ b/src/lib/affairs/context-meta.ts
@@ -1,0 +1,49 @@
+import { MANDATE_TYPE_LABELS, feminizeRole } from "@/config/labels";
+import type { MandateType } from "@/generated/prisma";
+
+/**
+ * Meta line for the affair context band ("Sénatrice · Moselle · Sénat · en
+ * mandat depuis 2017"). Pure so it unit-tests without a database. Shows only
+ * what is known (MissingData: no fabricated segment for an absent field).
+ */
+const CHAMBER_BY_TYPE: Partial<Record<MandateType, string>> = {
+  DEPUTE: "Assemblée nationale",
+  SENATEUR: "Sénat",
+  DEPUTE_EUROPEEN: "Parlement européen",
+};
+
+const PARLIAMENTARY_TYPES: MandateType[] = ["DEPUTE", "SENATEUR", "DEPUTE_EUROPEEN"];
+
+export interface DisplayMandate {
+  type: MandateType;
+  constituency: string | null;
+  startDate: Date | null;
+}
+
+/** Prefer a parliamentary mandate (the one that names a chamber), else the first. */
+export function pickDisplayMandate(mandates: DisplayMandate[]): DisplayMandate | null {
+  return mandates.find((m) => PARLIAMENTARY_TYPES.includes(m.type)) ?? mandates[0] ?? null;
+}
+
+export function formatMandateMeta(
+  mandate: DisplayMandate | null,
+  civility: string | null
+): string | null {
+  if (!mandate) return null;
+
+  const parts: string[] = [feminizeRole(MANDATE_TYPE_LABELS[mandate.type], civility)];
+
+  if (mandate.constituency) {
+    const dept = mandate.constituency.match(/^([^(]+)/)?.[1]?.trim();
+    if (dept) parts.push(dept);
+  }
+
+  const chamber = CHAMBER_BY_TYPE[mandate.type];
+  if (chamber) parts.push(chamber);
+
+  if (mandate.startDate) {
+    parts.push(`en mandat depuis ${new Date(mandate.startDate).getFullYear()}`);
+  }
+
+  return parts.join(" · ");
+}

--- a/src/lib/affairs/listing-return.ts
+++ b/src/lib/affairs/listing-return.ts
@@ -1,0 +1,77 @@
+import { AFFAIRES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
+
+/**
+ * Non-destructive "back to the listing" plumbing for the affair detail page.
+ *
+ * The listing serialises its active filters (and result count) into a `retour`
+ * query param on each card link; the detail page's sticky bar reads it back to
+ * offer "Retour aux N résultats" pointing at the exact filtered listing. Kept
+ * pure and free of Next internals so it unit-tests without a router.
+ *
+ * The detail page's canonical stays /affaires/<slug>, so these `?retour=`
+ * variants never enter the index (no server-side searchParams read, ISR intact).
+ */
+
+// Only these keys survive a round-trip. Anything else in a crafted `retour`
+// value is dropped, so the reconstructed href is always a clean /affaires URL.
+const RETURN_ALLOWED_KEYS = new Set<string>([...AFFAIRES_LISTING_FILTER_KEYS, "mode", "page"]);
+
+/** Serialise the active listing params into the inner value of `?retour=`. */
+export function buildRetourParam(params: Record<string, string | undefined>): string {
+  const sp = new URLSearchParams();
+  for (const key of RETURN_ALLOWED_KEYS) {
+    const value = params[key];
+    if (value) sp.set(key, value);
+  }
+  // Stable order for cache-friendly, comparable URLs.
+  sp.sort();
+  return sp.toString();
+}
+
+export interface ParsedReturn {
+  /** Where the back button leads: /affaires, possibly with the origin filters. */
+  href: string;
+  /** Human label naming the destination, e.g. "Retour aux 12 résultats". */
+  label: string;
+  /** Result count of the origin perimeter, when known. */
+  count: number | null;
+  /** True when the origin carried at least one filter (not the bare listing). */
+  filtered: boolean;
+}
+
+function parseCount(rn: string | null): number | null {
+  if (!rn) return null;
+  const n = Number.parseInt(rn, 10);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+/**
+ * Reconstruct the return destination from the `retour` (inner querystring) and
+ * `rn` (count) params, keeping only whitelisted keys.
+ */
+export function parseReturn(retour: string | null, rn: string | null): ParsedReturn {
+  const count = parseCount(rn);
+  const clean = new URLSearchParams();
+
+  if (retour) {
+    const raw = new URLSearchParams(retour);
+    for (const [key, value] of raw) {
+      if (RETURN_ALLOWED_KEYS.has(key) && value) clean.set(key, value);
+    }
+  }
+
+  clean.sort();
+  const qs = clean.toString();
+  const href = qs ? `/affaires?${qs}` : "/affaires";
+  const filtered = qs.length > 0;
+
+  let label: string;
+  if (count !== null) {
+    const formatted = count.toLocaleString("fr-FR");
+    label = count === 1 ? "Retour au résultat" : `Retour aux ${formatted} résultats`;
+  } else {
+    label = filtered ? "Retour à la liste filtrée" : "Retour aux affaires";
+  }
+
+  return { href, label, count, filtered };
+}

--- a/src/lib/affairs/neighbors.ts
+++ b/src/lib/affairs/neighbors.ts
@@ -1,0 +1,37 @@
+/**
+ * Prev/next resolution within a listing perimeter, kept pure so it can be unit
+ * tested without a database. The ordered list is produced by the same WHERE +
+ * ORDER BY as /affaires (see getAffairNeighborsList), so the neighbours match the
+ * order the reader was browsing.
+ */
+
+export interface AffairNeighborRef {
+  slug: string;
+  title: string;
+}
+
+export interface AffairNeighbors {
+  prev: AffairNeighborRef | null;
+  next: AffairNeighborRef | null;
+  /** 1-based position in the perimeter, or null when the current affair is not in it. */
+  position: number | null;
+  total: number;
+}
+
+export function pickNeighbors(ordered: AffairNeighborRef[], currentSlug: string): AffairNeighbors {
+  const index = ordered.findIndex((a) => a.slug === currentSlug);
+  const total = ordered.length;
+
+  if (index === -1) {
+    // The affair is not in the current filter perimeter (filters changed, or it
+    // was reached without a listing). No neighbours to offer.
+    return { prev: null, next: null, position: null, total };
+  }
+
+  return {
+    prev: index > 0 ? ordered[index - 1]! : null,
+    next: index < total - 1 ? ordered[index + 1]! : null,
+    position: index + 1,
+    total,
+  };
+}

--- a/src/lib/data/affairs.ts
+++ b/src/lib/data/affairs.ts
@@ -39,6 +39,63 @@ export async function getPartiesWithAffairs() {
   return parties;
 }
 
+interface AffairFilterOpts {
+  search?: string;
+  status?: string;
+  superCategory?: AffairSuperCategory;
+  category?: string;
+  severity?: AffairSeverity;
+  involvements: Involvement[];
+  partySlug?: string;
+  certainty?: CertaintyLevel;
+}
+
+// Single source of truth for the listing WHERE clause, shared by the paginated
+// query and the neighbour query so "affaire précédente / suivante" matches the
+// exact perimeter the reader was browsing.
+function buildAffairWhere(opts: AffairFilterOpts) {
+  const { search, status, superCategory, category, severity, involvements, partySlug, certainty } =
+    opts;
+
+  // Build category filter based on super-category or specific category
+  let categoryFilter: AffairCategory[] | undefined;
+  if (category) {
+    categoryFilter = [category as AffairCategory];
+  } else if (superCategory) {
+    categoryFilter = getCategoriesForSuper(superCategory);
+  }
+
+  // In victim mode, restrict to violence-related categories
+  if (involvements.includes("VICTIM")) {
+    categoryFilter = categoryFilter
+      ? categoryFilter.filter((c) => VIOLENCE_CATEGORIES.includes(c))
+      : VIOLENCE_CATEGORIES;
+  }
+
+  // Build status filter: certainty takes precedence over individual status
+  let statusFilter: { status: AffairStatus } | { status: { in: AffairStatus[] } } | undefined;
+  if (certainty) {
+    statusFilter = { status: { in: getStatusesForCertainty(certainty) } };
+  } else if (status) {
+    statusFilter = { status: status as AffairStatus };
+  }
+
+  return {
+    publicationStatus: "PUBLISHED" as const,
+    involvement: { in: involvements },
+    ...statusFilter,
+    ...(categoryFilter && { category: { in: categoryFilter } }),
+    ...(severity && { severity }),
+    ...(partySlug && { partyAtTime: { slug: partySlug } }),
+    ...(search && {
+      OR: [
+        { title: { contains: search, mode: "insensitive" as const } },
+        { description: { contains: search, mode: "insensitive" as const } },
+      ],
+    }),
+  };
+}
+
 // Tier 1: Core query — accepts free-text search (never cached directly)
 async function queryAffairs(
   search?: string,
@@ -55,44 +112,16 @@ async function queryAffairs(
   const limit = 20;
   const skip = (page - 1) * limit;
 
-  // Build category filter based on super-category or specific category
-  let categoryFilter: AffairCategory[] | undefined;
-  if (category) {
-    categoryFilter = [category as AffairCategory];
-  } else if (superCategory) {
-    categoryFilter = getCategoriesForSuper(superCategory);
-  }
-
-  // In victim mode, restrict to violence-related categories
-  const isVictimMode = involvements.includes("VICTIM");
-  if (isVictimMode) {
-    categoryFilter = categoryFilter
-      ? categoryFilter.filter((c) => VIOLENCE_CATEGORIES.includes(c))
-      : VIOLENCE_CATEGORIES;
-  }
-
-  // Build status filter: certainty takes precedence over individual status
-  let statusFilter: { status: AffairStatus } | { status: { in: AffairStatus[] } } | undefined;
-  if (certainty) {
-    statusFilter = { status: { in: getStatusesForCertainty(certainty) } };
-  } else if (status) {
-    statusFilter = { status: status as AffairStatus };
-  }
-
-  const where = {
-    publicationStatus: "PUBLISHED" as const,
-    involvement: { in: involvements },
-    ...statusFilter,
-    ...(categoryFilter && { category: { in: categoryFilter } }),
-    ...(severity && { severity }),
-    ...(partySlug && { partyAtTime: { slug: partySlug } }),
-    ...(search && {
-      OR: [
-        { title: { contains: search, mode: "insensitive" as const } },
-        { description: { contains: search, mode: "insensitive" as const } },
-      ],
-    }),
-  };
+  const where = buildAffairWhere({
+    search,
+    status,
+    superCategory,
+    category,
+    severity,
+    involvements,
+    partySlug,
+    certainty,
+  });
 
   const orderBy = buildOrderBy(sort);
 
@@ -258,6 +287,21 @@ export async function getAffairs(
     sort,
     certainty
   );
+}
+
+/**
+ * Ordered slug+title list for a filter perimeter, no pagination, used by the
+ * neighbour API to resolve prev/next. Bounded (the full published set is small)
+ * and select-only, so an unpaginated scan is cheap. Same WHERE + ORDER BY as the
+ * listing, so the order matches what the reader was browsing.
+ */
+export async function getAffairNeighborsList(
+  opts: AffairFilterOpts & { sort?: string }
+): Promise<Array<{ slug: string; title: string }>> {
+  const where = buildAffairWhere(opts);
+  const orderBy = buildOrderBy(opts.sort);
+  const rows = await db.affair.findMany({ where, orderBy, select: { slug: true, title: true } });
+  return rows.flatMap((r) => (r.slug ? [{ slug: r.slug, title: r.title }] : []));
 }
 
 export async function getSuperCategoryCounts() {


### PR DESCRIPTION
## Contexte

La fiche `/affaires/[slug]` était un cul-de-sac. Les trois portes de sortie (fiche de l'élu, liste, affaires du parti) s'empilaient en pied de page, toutes préfixées d'une flèche « ← » alors que ce sont des parcours latéraux, et le retour à la liste renvoyait sur `/affaires` nu, filtres et position perdus. La ligne de résultat, elle, n'était cliquable que via un petit « Voir détails → » en pied de carte.

Cette PR reprend la refonte « Fiche d'affaire & cible de clic » du bundle design system.

## Ce que fait la PR

- **Bandeau de contexte** sous le titre : l'élu en lien franc, sa fonction (mandat, chambre, ancienneté), sa puce de parti en couleur, et un rail de parcours latéraux (ses affaires, affaires du parti, ses votes). Il est construit pour accueillir plus tard le bandeau de rôle `not_accused` (B1) sans nouvelle refonte.
- **Barre collante** de retour non destructif : « ← Retour aux N résultats » restitue les filtres via `?retour=`, avec `router.back()` quand le référent est la liste. Fil d'Ariane utile (catégorie) et actions Citer / Partager, fusionnées depuis l'ancienne ShareBar flottante.
- **Bloc « Poursuivre »** en fin de lecture (la personne, le parti, la méthode) à la place des liens « ← » empilés, et une pagination affaire précédente / suivante dans le périmètre de filtres.
- **Barre d'action basse** sur mobile : fiche de l'élu en action primaire, précédent / suivant, zone du pouce, `safe-area` respectée.
- **Ligne de résultat entièrement cliquable** sur `/affaires` (stretched link, un seul lien de navigation nommé par le titre ; l'élu, le parti et Citer restent des cibles indépendantes).
- Correctif thème sombre sur l'encart « À propos des données » de la liste.

## Choix techniques

- La fiche reste **statique (ISR)**. Le retour et la pagination sont donc lus côté client (`?retour=`), jamais côté serveur, pour ne pas basculer la page en rendu dynamique. Les deux consommateurs de `useSearchParams` sont isolés derrière `Suspense`. Le canonical reste `/affaires/[slug]`, ce qui dédoublonne les variantes `?retour=` sans balise robots.
- Les voisins précédent / suivant sont calculés par une route API `/api/affaires/neighbors`, qui réutilise exactement le `WHERE` + `ORDER BY` de la liste (extrait dans `buildAffairWhere`). Paramètres passés en liste blanche.
- La logique non triviale vit dans des helpers purs testables sans base : `listing-return.ts` (aller-retour du périmètre), `neighbors.ts` (`pickNeighbors`), `context-meta.ts` (ligne de méta).

## Vérification

- `next build` vert, `/affaires/[slug]` toujours en SSG/ISR.
- tsc et eslint propres.
- 234 tests, dont 23 nouveaux sur la logique pure et 4 sur la ligne cliquable.
- Rendu contrôlé en desktop et mobile sur données réelles : liste, fiche, retour compté, pagination dans le périmètre, barre basse mobile.

## Portée et suites

- Aucune migration, aucune modification de donnée.
- Compromis assumé du stretched link : le corps de la carte n'est pas sélectable au texte (les liens imbriqués restent cliquables).
- B1 (bandeau de rôle `not_accused`, correctif RGPD) se branchera sur le bandeau de contexte introduit ici.
- La ligne de méta n'est pas féminisée quand la civilité manque en base : suite qualité de données.
