### PR TITLE
fix(affaires): encart de rôle pour non mis en cause (RGPD art. 10)

### DIFF
--- a/src/app/affaires/[slug]/opengraph-image.tsx
+++ b/src/app/affaires/[slug]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { db } from "@/lib/db";
 import { OgLayout, OgCategoryLabel, OgBadge, OG_SIZE, truncateOg } from "@/lib/og-utils";
+import { isAccusedInvolvement } from "@/config/certainty";
 import type { AffairStatus } from "@/generated/prisma";
 
 export const alt = "Affaire judiciaire sur Poligraph";
@@ -43,6 +44,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
     select: {
       title: true,
       status: true,
+      involvement: true,
       politician: {
         select: { firstName: true, lastName: true },
       },
@@ -87,9 +89,13 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         {truncateOg(affair.title, 100)}
       </div>
 
-      <div style={{ fontSize: 26, color: "#94a3b8", marginBottom: 24 }}>
-        {`${affair.politician.firstName} ${affair.politician.lastName}`}
-      </div>
+      {/* Hors du site, ne pas accoler le nom au titre d'une personne non mise
+          en cause (I7) : l'image OG suit la même règle que le <title>. */}
+      {isAccusedInvolvement(affair.involvement) && (
+        <div style={{ fontSize: 26, color: "#94a3b8", marginBottom: 24 }}>
+          {`${affair.politician.firstName} ${affair.politician.lastName}`}
+        </div>
+      )}
 
       <div style={{ display: "flex" }}>
         <OgBadge label={statusLabel} color={statusColor} />

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -27,7 +27,10 @@ import {
   CERTAINTY_DESCRIPTIONS,
   isAccusedInvolvement,
 } from "@/config/certainty";
-import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
+import {
+  AffairStatusNotice,
+  getAffairNoticeVariant,
+} from "@/components/affairs/AffairStatusNotice";
 import { LinkedAffairBanner } from "@/components/affairs/LinkedAffairBanner";
 import { SentenceDetails } from "@/components/affairs/SentenceDetails";
 import { StatusTooltip } from "@/components/affairs/StatusTooltip";
@@ -196,15 +199,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return { title: "Affaire non trouvée" };
   }
 
+  // Hors du site il ne reste souvent qu'un nom et un titre d'affaire : on
+  // n'accole le nom que si la personne est mise en cause (I7).
+  const title = isAccusedInvolvement(affair.involvement)
+    ? `${affair.title} - ${affair.politician.fullName}`
+    : affair.title;
+  const description = stripMarkdown(affair.description).slice(0, 160);
+
   return {
-    title: `${affair.title} - ${affair.politician.fullName}`,
-    description: stripMarkdown(affair.description).slice(0, 160),
+    title,
+    description,
     alternates: { canonical: `/affaires/${affair.slug}` },
-    openGraph: {
-      title: `${affair.title} - ${affair.politician.fullName}`,
-      description: stripMarkdown(affair.description).slice(0, 160),
-      type: "article",
-    },
+    openGraph: { title, description, type: "article" },
   };
 }
 
@@ -233,6 +239,7 @@ export default async function AffairDetailPage({ params }: PageProps) {
   // the tracked politician is a plaintiff, victim or merely mentioned, a
   // charging badge ("Condamnation définitive") would misrepresent them (#383).
   const accused = isAccusedInvolvement(affair.involvement);
+  const noticeVariant = getAffairNoticeVariant(affair.status, affair.involvement);
   const partyDisplay = getAffairPartyDisplay({
     factsDate: affair.factsDate,
     partyAtTime: affair.partyAtTime,
@@ -279,10 +286,30 @@ export default async function AffairDetailPage({ params }: PageProps) {
     { name: affair.title, url: `${SITE_URL}/affaires/${affair.slug}` },
   ];
 
+  // Pour une personne non mise en cause, les blocs Peine et Juridiction vides ne
+  // s'affichent pas : deux cartes réservées à un procès qui ne la vise pas
+  // contredisaient le rôle. Renseignés, ils restent (peine d'un tiers).
+  const hasSentence = Boolean(
+    affair.sentence ||
+    affair.prisonMonths ||
+    affair.fineAmount ||
+    affair.ineligibilityMonths ||
+    affair.communityService ||
+    affair.otherSentence
+  );
+  const hasJuridiction = Boolean(
+    affair.court ||
+    resolvedDecisionFields.chamber.value ||
+    affair.caseNumber ||
+    linkedDecisions.length > 0
+  );
+  const showPeine = accused || hasSentence;
+  const showJuridiction = accused || hasJuridiction;
+
   return (
     <>
       <ArticleJsonLd
-        headline={`${affair.title} - ${affair.politician.fullName}`}
+        headline={accused ? `${affair.title} - ${affair.politician.fullName}` : affair.title}
         description={stripMarkdown(affair.description).slice(0, 300)}
         datePublished={affair.factsDate?.toISOString()}
         dateModified={affair.updatedAt?.toISOString()}
@@ -304,38 +331,39 @@ export default async function AffairDetailPage({ params }: PageProps) {
       <div className="container mx-auto max-w-4xl px-4 pt-4 pb-24 sm:pb-8">
         {/* Header */}
         <div className="mb-8">
-          <div className="flex flex-wrap items-center gap-2 mb-3">
-            {/* For a plaintiff/victim/mentioned politician the charging certainty
-                badge is suppressed: the involvement badge leads and the status is
-                shown with a neutral colour, so the affair is not read as their
-                own conviction (#383). */}
+          <div className="mb-3 flex flex-wrap items-center gap-2">
             {accused ? (
-              <Badge className={`${CERTAINTY_COLORS[certainty]} text-sm px-3 py-1`}>
-                {CERTAINTY_LABELS[certainty]}
-              </Badge>
+              <>
+                <Badge className={`${CERTAINTY_COLORS[certainty]} px-3 py-1 text-sm`}>
+                  {CERTAINTY_LABELS[certainty]}
+                </Badge>
+                <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCategory]}>
+                  {AFFAIR_SUPER_CATEGORY_LABELS[superCategory]}
+                </Badge>
+                <Badge variant="outline">{AFFAIR_CATEGORY_LABELS[affair.category]}</Badge>
+                <StatusTooltip
+                  status={affair.status}
+                  label={AFFAIR_STATUS_LABELS[affair.status]}
+                  description={AFFAIR_STATUS_DESCRIPTIONS[affair.status]}
+                  colorClass={AFFAIR_STATUS_COLORS[affair.status]}
+                />
+                {affair.involvement !== "DIRECT" && (
+                  <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
+                    {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
+                  </Badge>
+                )}
+              </>
             ) : (
-              <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
-                {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
-              </Badge>
-            )}
-            <Badge className={AFFAIR_SUPER_CATEGORY_COLORS[superCategory]}>
-              {AFFAIR_SUPER_CATEGORY_LABELS[superCategory]}
-            </Badge>
-            <Badge variant="outline">{AFFAIR_CATEGORY_LABELS[affair.category]}</Badge>
-            <StatusTooltip
-              status={affair.status}
-              label={AFFAIR_STATUS_LABELS[affair.status]}
-              description={AFFAIR_STATUS_DESCRIPTIONS[affair.status]}
-              colorClass={
-                accused
-                  ? AFFAIR_STATUS_COLORS[affair.status]
-                  : "bg-muted text-muted-foreground border-transparent"
-              }
-            />
-            {accused && affair.involvement !== "DIRECT" && (
-              <Badge className={INVOLVEMENT_COLORS[affair.involvement as Involvement]}>
-                {INVOLVEMENT_LABELS[affair.involvement as Involvement]}
-              </Badge>
+              // Non mis en cause : ni pastille de certitude à charge, ni catégorie
+              // d'infraction posée à côté de la personne (I1, I2). Le statut reste,
+              // en neutre, pour situer la procédure ; le rôle et la ligne « Faits
+              // qualifiés » ci-dessous rattachent tout à l'affaire.
+              <StatusTooltip
+                status={affair.status}
+                label={AFFAIR_STATUS_LABELS[affair.status]}
+                description={AFFAIR_STATUS_DESCRIPTIONS[affair.status]}
+                colorClass="bg-muted text-muted-foreground border-transparent"
+              />
             )}
             {affair.isSlapp && affair.slappCriteria ? (
               <SlappBadge
@@ -346,6 +374,13 @@ export default async function AffairDetailPage({ params }: PageProps) {
               />
             ) : null}
           </div>
+          {!accused && (
+            <p className="mb-3 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">Faits qualifiés :</span>{" "}
+              {AFFAIR_SUPER_CATEGORY_LABELS[superCategory]} ·{" "}
+              {AFFAIR_CATEGORY_LABELS[affair.category]}
+            </p>
+          )}
           {accused && (
             <p className="text-sm text-muted-foreground mb-4">
               {CERTAINTY_DESCRIPTIONS[certainty]}
@@ -363,16 +398,22 @@ export default async function AffairDetailPage({ params }: PageProps) {
             meta={politicianMeta}
             affairCount={affairCount}
             party={contextParty}
+            involvement={affair.involvement}
           />
         </div>
 
-        {/* Encart de prudence juridique : présomption, recours, issue favorable
-            ou prescription selon le statut (RGPD art. 10, invariant I5) */}
-        <AffairStatusNotice
-          status={affair.status}
-          involvement={affair.involvement}
-          className="mb-6"
-        />
+        {/* Encart de prudence juridique (RGPD art. 10, I5). Pour un non mis en
+            cause hors condamnation, la caution est déjà portée par l'étage de
+            rôle du bandeau : on ne répète pas (not_accused). On garde l'encart
+            pour l'accusé et pour le tiers d'une affaire conclue par une
+            condamnation (third_party), qui dit que la peine est celle d'un autre. */}
+        {noticeVariant && noticeVariant !== "not_accused" && (
+          <AffairStatusNotice
+            status={affair.status}
+            involvement={affair.involvement}
+            className="mb-6"
+          />
+        )}
 
         {/* Linked affair cross-reference */}
         {linked && (
@@ -406,7 +447,7 @@ export default async function AffairDetailPage({ params }: PageProps) {
         ) : null}
 
         {/* Dates & Jurisdiction */}
-        <div className="grid md:grid-cols-2 gap-6 mb-6">
+        <div className={showJuridiction ? "mb-6 grid gap-6 md:grid-cols-2" : "mb-6"}>
           {/* Dates */}
           <Card>
             <CardHeader>
@@ -439,99 +480,111 @@ export default async function AffairDetailPage({ params }: PageProps) {
             </CardContent>
           </Card>
 
-          {/* Jurisdiction */}
-          <Card>
-            <CardHeader>
-              <h2 className="text-lg font-semibold">Juridiction</h2>
-            </CardHeader>
-            <CardContent>
-              {affair.court || resolvedDecisionFields.chamber.value || affair.caseNumber ? (
-                <dl className="space-y-3">
-                  {affair.court && (
-                    <div className="flex justify-between">
-                      <dt className="text-muted-foreground">Tribunal</dt>
-                      <dd className="font-medium text-right">{affair.court}</dd>
-                    </div>
-                  )}
-                  {resolvedDecisionFields.chamber.value && (
-                    <div className="flex justify-between">
-                      <dt className="text-muted-foreground">Chambre</dt>
-                      <dd className="font-medium">{resolvedDecisionFields.chamber.value}</dd>
-                    </div>
-                  )}
-                  {affair.caseNumber && (
-                    <div className="flex justify-between">
-                      <dt className="text-muted-foreground">N° dossier</dt>
-                      <dd className="font-mono text-sm">{affair.caseNumber}</dd>
-                    </div>
-                  )}
-                </dl>
-              ) : (
-                <p className="text-muted-foreground text-sm">Informations non renseignées</p>
-              )}
+          {/* Jurisdiction — masqué pour un non mis en cause sans donnée (I8) */}
+          {showJuridiction && (
+            <Card>
+              <CardHeader>
+                <h2 className="text-lg font-semibold">
+                  {accused ? "Juridiction" : "Juridiction (procédure de l'affaire)"}
+                </h2>
+              </CardHeader>
+              <CardContent>
+                {affair.court || resolvedDecisionFields.chamber.value || affair.caseNumber ? (
+                  <dl className="space-y-3">
+                    {affair.court && (
+                      <div className="flex justify-between">
+                        <dt className="text-muted-foreground">Tribunal</dt>
+                        <dd className="font-medium text-right">{affair.court}</dd>
+                      </div>
+                    )}
+                    {resolvedDecisionFields.chamber.value && (
+                      <div className="flex justify-between">
+                        <dt className="text-muted-foreground">Chambre</dt>
+                        <dd className="font-medium">{resolvedDecisionFields.chamber.value}</dd>
+                      </div>
+                    )}
+                    {affair.caseNumber && (
+                      <div className="flex justify-between">
+                        <dt className="text-muted-foreground">N° dossier</dt>
+                        <dd className="font-mono text-sm">{affair.caseNumber}</dd>
+                      </div>
+                    )}
+                  </dl>
+                ) : (
+                  <p className="text-muted-foreground text-sm">Informations non renseignées</p>
+                )}
 
-              {linkedDecisions.length > 0 && (
-                <div className="mt-4 border-t pt-4">
-                  <h3 className="mb-2 text-sm font-medium">
-                    Décision{linkedDecisions.length > 1 ? "s" : ""} de justice rattachée
-                    {linkedDecisions.length > 1 ? "s" : ""}
-                  </h3>
-                  <ul className="space-y-2 text-sm">
-                    {linkedDecisions.map((decision) => {
-                      const display = buildCourtDecisionDisplay(decision, formatDate);
-                      return (
-                        <li key={decision.id} className="text-muted-foreground">
-                          <span>{display.parts.join(" — ")}</span>
-                          {display.link && (
-                            <>
-                              {" "}
-                              <a
-                                href={display.link.href}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline underline-offset-4 hover:text-foreground"
-                              >
-                                {display.link.label}
-                              </a>
-                            </>
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                  {resolvedDecisionFields.hasMultipleDecisions && (
-                    <p className="mt-2 text-xs text-muted-foreground">
-                      Cette affaire est rattachée à plusieurs décisions. Les références sont listées
-                      séparément plutôt que résumées en une seule valeur.
-                    </p>
-                  )}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                {linkedDecisions.length > 0 && (
+                  <div className="mt-4 border-t pt-4">
+                    <h3 className="mb-2 text-sm font-medium">
+                      Décision{linkedDecisions.length > 1 ? "s" : ""} de justice rattachée
+                      {linkedDecisions.length > 1 ? "s" : ""}
+                    </h3>
+                    <ul className="space-y-2 text-sm">
+                      {linkedDecisions.map((decision) => {
+                        const display = buildCourtDecisionDisplay(decision, formatDate);
+                        return (
+                          <li key={decision.id} className="text-muted-foreground">
+                            <span>{display.parts.join(" — ")}</span>
+                            {display.link && (
+                              <>
+                                {" "}
+                                <a
+                                  href={display.link.href}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="underline underline-offset-4 hover:text-foreground"
+                                >
+                                  {display.link.label}
+                                </a>
+                              </>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {resolvedDecisionFields.hasMultipleDecisions && (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        Cette affaire est rattachée à plusieurs décisions. Les références sont
+                        listées séparément plutôt que résumées en une seule valeur.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
         </div>
 
-        {/* Sentence */}
-        <Card className="mb-6">
-          <CardHeader>
-            <h2 className="text-lg font-semibold">Peine</h2>
-          </CardHeader>
-          <CardContent>
-            <SentenceDetails affair={affair} involvement={affair.involvement} />
-            {!affair.sentence &&
-              !affair.prisonMonths &&
-              !affair.fineAmount &&
-              !affair.ineligibilityMonths &&
-              !affair.communityService &&
-              !affair.otherSentence && (
-                <p className="text-muted-foreground text-sm">
-                  {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status]
-                    ? "Affaire en cours - pas encore de verdict"
-                    : "Peine non renseignée"}
-                </p>
-              )}
-          </CardContent>
-        </Card>
+        {/* Sentence — masquée pour un non mis en cause sans donnée (I8) ; sinon
+            l'en-tête rappelle que la peine ne vise pas cette personne. */}
+        {showPeine && (
+          <Card className="mb-6">
+            <CardHeader>
+              <h2 className="text-lg font-semibold">
+                {accused
+                  ? "Peine"
+                  : "Peine prononcée dans l'affaire (ne concerne pas cette personne)"}
+              </h2>
+            </CardHeader>
+            <CardContent>
+              <SentenceDetails affair={affair} involvement={affair.involvement} />
+              {accused &&
+                !affair.sentence &&
+                !affair.prisonMonths &&
+                !affair.fineAmount &&
+                !affair.ineligibilityMonths &&
+                !affair.communityService &&
+                !affair.otherSentence && (
+                  <p className="text-muted-foreground text-sm">
+                    {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status]
+                      ? "Affaire en cours - pas encore de verdict"
+                      : "Peine non renseignée"}
+                  </p>
+                )}
+            </CardContent>
+          </Card>
+        )}
 
         {/* Timeline */}
         {affair.events.length > 0 && (

--- a/src/components/affairs/AffairContextBand.tsx
+++ b/src/components/affairs/AffairContextBand.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
-import { Scale, Landmark, Vote, ArrowRight } from "lucide-react";
+import { Scale, Landmark, Vote, ArrowRight, Info } from "lucide-react";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import { AffairPartyChip } from "@/components/affairs/AffairPartyChip";
+import { isAccusedInvolvement } from "@/config/certainty";
+import { getRoleNoticeCopy } from "@/lib/affairs/role-notice";
+import type { Involvement } from "@/types";
 
 /**
  * Context band under the <h1>: who the tracked politician is, and the lateral
@@ -26,6 +29,9 @@ interface AffairContextBandProps {
     slug: string | null;
     atTime: boolean;
   } | null;
+  /** Drives the role étage: for a non-accused involvement the band states, in a
+      sentence, that the person is neither mise en cause nor poursuivie (I3, I5). */
+  involvement: Involvement;
 }
 
 function RailLink({
@@ -56,10 +62,13 @@ export function AffairContextBand({
   meta,
   affairCount,
   party,
+  involvement,
 }: AffairContextBandProps) {
   const ficheHref = `/politiques/${politicianSlug}`;
   const votesHref = `/politiques/${politicianSlug}/votes`;
   const partyAffairsHref = party?.slug ? `/affaires/parti/${party.slug}` : null;
+  const accused = isAccusedInvolvement(involvement);
+  const roleCopy = accused ? null : getRoleNoticeCopy(involvement);
 
   return (
     <div className="mb-6 rounded-xl border bg-card p-4">
@@ -101,6 +110,30 @@ export function AffairContextBand({
           />
         )}
       </div>
+
+      {roleCopy && (
+        <div
+          role="note"
+          data-variant="not_accused"
+          className="mt-3 flex gap-2 rounded-lg border bg-slate-50 p-3 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200"
+        >
+          <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+          <div className="text-sm">
+            <p>
+              <strong>Son rôle dans cette affaire : {roleCopy.roleLabel}.</strong>{" "}
+              {roleCopy.position} {roleCopy.reminder}
+            </p>
+            <Link
+              href="/methodologie"
+              className="mt-1 inline-flex items-center font-medium text-primary hover:underline"
+            >
+              Que veulent dire «&nbsp;mis en cause&nbsp;», «&nbsp;mentionné&nbsp;»,
+              «&nbsp;victime&nbsp;»&nbsp;?
+              <ArrowRight className="ml-0.5 size-3" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      )}
 
       <div className="mt-3 flex flex-wrap gap-2 border-t pt-3">
         <RailLink href={ficheHref} icon={Scale}>

--- a/src/components/affairs/AffairStatusNotice.tsx
+++ b/src/components/affairs/AffairStatusNotice.tsx
@@ -20,6 +20,7 @@ export type AffairNoticeVariant =
   | "favorable"
   | "prescription"
   | "third_party"
+  | "not_accused"
   | "instruction_close";
 
 const FAVORABLE_STATUSES: readonly AffairStatus[] = [
@@ -48,10 +49,11 @@ export function getAffairNoticeVariant(
 ): AffairNoticeVariant | null {
   // Les encarts qualifient la situation d'une personne mise en cause. Quand le
   // politicien est victime, plaignant ou simplement mentionné, aucun encart à charge
-  // ne s'applique, mais le silence total laissait un statut de condamnation et une
-  // peine sur la page sans dire qu'ils ne sont pas les siens (#511).
+  // ne s'applique. Une condamnation déjà prononcée est celle d'un tiers ; sinon la
+  // personne n'est ni mise en cause ni poursuivie, et le silence total laissait le
+  // statut et les qualifications se lire comme les siens (I5, #511).
   if (!isAccusedInvolvement(involvement)) {
-    return getJudicialMaturity(status) === "CONDAMNATION" ? "third_party" : null;
+    return getJudicialMaturity(status) === "CONDAMNATION" ? "third_party" : "not_accused";
   }
   if (status === "PRESCRIPTION") return "prescription";
   if (FAVORABLE_STATUSES.includes(status)) return "favorable";
@@ -81,6 +83,12 @@ const NOTICES: Record<AffairNoticeVariant, { title: string; body: string; classN
   third_party: {
     title: "Résultat judiciaire d'un tiers",
     body: "cette personne n'est pas celle qui a été poursuivie dans cette affaire. La condamnation et les peines prononcées concernent une autre personne.",
+    className:
+      "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200",
+  },
+  not_accused: {
+    title: "Personne non mise en cause",
+    body: "cette personne n'est ni mise en cause, ni poursuivie ; le statut et les peines éventuelles de cette affaire ne la concernent pas.",
     className:
       "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200",
   },

--- a/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
+++ b/src/components/affairs/__tests__/AffairStatusNotice.test.tsx
@@ -37,12 +37,14 @@ describe("getAffairNoticeVariant — sélection par statut et involvement", () =
     }
   });
 
-  it("aucun encart à charge pour les victimes, plaignants et simples mentions", () => {
+  it("non mis en cause : encart de rôle, jamais un encart à charge (I5)", () => {
     for (const inv of ["VICTIM", "PLAINTIFF", "MENTIONED_ONLY"] as const) {
-      expect(getAffairNoticeVariant("RELAXE", inv)).toBeNull();
-      expect(getAffairNoticeVariant("INSTRUCTION", inv)).toBeNull();
-      // Sur une affaire de condamnation, le silence total laissait un statut à
-      // charge et une peine sans dire qu'ils ne sont pas les siens (#511).
+      // Procédure en cours ou issue favorable : la personne n'est pas poursuivie,
+      // mais un encart doit le dire — le silence laissait le statut se lire comme
+      // le sien (I5, #511).
+      expect(getAffairNoticeVariant("RELAXE", inv)).toBe("not_accused");
+      expect(getAffairNoticeVariant("INSTRUCTION", inv)).toBe("not_accused");
+      // Affaire conclue par une condamnation : celle d'un tiers.
       expect(getAffairNoticeVariant("CONDAMNATION_DEFINITIVE", inv)).toBe("third_party");
     }
   });
@@ -78,9 +80,11 @@ describe("AffairStatusNotice — wordings validés (RGPD art. 10)", () => {
     expect(getByRole("note").textContent).toContain("Décision non définitive");
   });
 
-  it("rien ne s'affiche pour une victime", () => {
-    const { container } = render(<AffairStatusNotice status="RELAXE" involvement="VICTIM" />);
-    expect(container.firstChild).toBeNull();
+  it("non mis en cause : encart « personne non mise en cause » (I5)", () => {
+    const { getByRole } = render(<AffairStatusNotice status="INSTRUCTION" involvement="VICTIM" />);
+    const note = getByRole("note");
+    expect(note.getAttribute("data-variant")).toBe("not_accused");
+    expect(note.textContent).toContain("ni mise en cause, ni poursuivie");
   });
 });
 
@@ -91,10 +95,10 @@ describe("instruction close sans mise en examen", () => {
     );
   });
 
-  it("ne rend aucun encart quand la personne est seulement mentionnée", () => {
+  it("mentionné : encart de rôle, pas la variante à charge instruction_close", () => {
     expect(
       getAffairNoticeVariant("INSTRUCTION_CLOTUREE_SANS_MISE_EN_EXAMEN", "MENTIONED_ONLY")
-    ).toBeNull();
+    ).toBe("not_accused");
   });
 });
 

--- a/src/components/politicians/__tests__/AffairCard.test.tsx
+++ b/src/components/politicians/__tests__/AffairCard.test.tsx
@@ -78,14 +78,16 @@ describe("AffairCard — issues favorables dominantes (RGPD art. 10)", () => {
     expect(container.textContent).toContain("présumée innocente");
   });
 
-  it("aucun encart quand le politicien est victime", () => {
+  it("victime : encart « personne non mise en cause », jamais un encart à charge (I5)", () => {
     const { container } = render(
       <AffairCard
         affair={makeAffair({ status: "ENQUETE_PRELIMINAIRE", involvement: "VICTIM" })}
         variant="other"
       />
     );
-    expect(container.querySelector('[role="note"]')).toBeNull();
+    const note = container.querySelector('[role="note"]');
+    expect(note).not.toBeNull();
+    expect(note?.getAttribute("data-variant")).toBe("not_accused");
   });
 });
 

--- a/src/lib/affairs/__tests__/role-notice.test.ts
+++ b/src/lib/affairs/__tests__/role-notice.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getRoleNoticeCopy } from "@/lib/affairs/role-notice";
+
+describe("getRoleNoticeCopy", () => {
+  it("mentionné : rôle nommé, négation explicite", () => {
+    const c = getRoleNoticeCopy("MENTIONED_ONLY");
+    expect(c.roleLabel).toBe("Mentionné");
+    expect(c.position).toContain("ni mise en cause, ni poursuivie");
+  });
+
+  it("victime : nommée victime, pas mise en cause", () => {
+    const c = getRoleNoticeCopy("VICTIM");
+    expect(c.roleLabel).toBe("Victime");
+    expect(c.position).toContain("victime");
+    expect(c.position).toContain("pas mise en cause");
+  });
+
+  it("plaignant : à l'origine d'une plainte", () => {
+    const c = getRoleNoticeCopy("PLAINTIFF");
+    expect(c.roleLabel).toBe("Plaignant");
+    expect(c.position).toContain("plainte");
+  });
+
+  it("le rappel dit que les qualifications ne visent pas la personne", () => {
+    expect(getRoleNoticeCopy("MENTIONED_ONLY").reminder).toContain("ne la visent pas");
+  });
+});

--- a/src/lib/affairs/role-notice.ts
+++ b/src/lib/affairs/role-notice.ts
@@ -1,0 +1,42 @@
+import type { Involvement } from "@/types";
+import { INVOLVEMENT_LABELS } from "@/config/labels";
+
+/**
+ * Single source of truth for the "this person is not accused" wording, shared by
+ * the role band on the affair page and the not_accused notice on compact
+ * surfaces (listing card). Pure, so it unit-tests without a database.
+ *
+ * The subject is always "Cette personne" so the agreement stays feminine and
+ * consistent without gendering the actual individual. Follows the imposed
+ * vocabulary (legal-invariants.md): "mis en cause", "poursuivie", never
+ * "coupable" / "innocentée".
+ */
+export interface RoleNoticeCopy {
+  /** The role label, e.g. "Mentionné", "Victime", "Plaignant". */
+  roleLabel: string;
+  /** The role-specific position sentence. */
+  position: string;
+  /** The shared reminder that the qualifications do not target this person. */
+  reminder: string;
+}
+
+const POSITION: Partial<Record<Involvement, string>> = {
+  MENTIONED_ONLY:
+    "Cette personne est mentionnée dans l'affaire, sans être ni mise en cause, ni poursuivie.",
+  VICTIM: "Cette personne figure comme victime dans cette affaire. Elle n'est pas mise en cause.",
+  PLAINTIFF:
+    "Cette personne est à l'origine d'une plainte dans cette affaire. Elle n'est pas mise en cause.",
+};
+
+const REMINDER =
+  "Les qualifications rappelées ci-dessus décrivent les faits reprochés dans l'affaire et ne la visent pas.";
+
+export function getRoleNoticeCopy(involvement: Involvement): RoleNoticeCopy {
+  return {
+    roleLabel: INVOLVEMENT_LABELS[involvement],
+    position:
+      POSITION[involvement] ??
+      "Cette personne n'est ni mise en cause, ni poursuivie dans cette affaire.",
+    reminder: REMINDER,
+  };
+}


### PR DESCRIPTION
## Contexte

Sur une affaire où l'élu suivi n'est **pas** mis en cause (victime, plaignant, simplement mentionné), la fiche donnait à lire sa situation comme celle d'un accusé. `getAffairNoticeVariant()` renvoyait `null` hors condamnation, donc aucun encart de prudence ; les catégories d'infraction étaient posées en pastilles à côté de son nom ; le statut de la procédure et le nom partaient dans le `<title>` et l'image OG. Cas d'école : Jérémie Patrier-Leitus sur l'ingérence de Lagardère News, ou Rima Hassan, plaignante.

Cette PR livre la Partie 1 (données constantes, aucune migration) de la refonte « lien élu / affaire » du bundle design system. Elle prolonge le bandeau de contexte introduit par #607.

## Ce que fait la PR

- **Variante `not_accused`** dans `getAffairNoticeVariant()` : elle est renvoyée pour `MENTIONED_ONLY`, `VICTIM` et `PLAINTIFF` hors condamnation (auparavant `null`). Un encart de prudence est donc rendu sur 100 % des fiches non mises en cause (I5).
- **Étage de rôle** dans `AffairContextBand` : pour un non mis en cause, une phrase énonce le rôle et la négation explicite (« Son rôle dans cette affaire : Mentionné. Cette personne est mentionnée dans l'affaire, sans être ni mise en cause, ni poursuivie… »), avec un lien vers la méthodologie. Le rôle passe d'une pastille grise à une phrase (I3).
- **Réattribution des catégories** : pour un non mis en cause, plus de pastille de certitude ni d'infraction à côté de la personne ; les qualifications deviennent une ligne « Faits qualifiés : … » rattachée à l'affaire, le statut reste en neutre (I1, I2).
- **Peine et Juridiction** : masquées quand la personne n'est pas mise en cause et qu'aucun champ n'est renseigné ; sinon rendues avec l'en-tête « (ne concerne pas cette personne) ». Le double message contradictoire (« les peines ne concernent pas cette personne » puis « pas encore de verdict ») disparaît (I8).
- **Diffusion** : le nom n'est accolé au titre d'affaire que si la personne est mise en cause, dans le `<title>`, `og:title`, le headline `ArticleJsonLd` et l'image OG (I7).

Sur la fiche, l'encart standalone n'est plus répété pour un `not_accused` (l'étage de rôle porte la caution), mais reste pour l'accusé et pour le tiers d'une affaire déjà conclue par une condamnation (`third_party`, qui dit que la peine est celle d'un autre).

## Choix

- Le wording de rôle vit dans un helper pur `getRoleNoticeCopy(involvement)`, testable sans base et source unique.
- La formulation prend « Cette personne » comme sujet pour garder l'accord au féminin sans genrer l'individu.

## Vérification

- `next build` vert.
- tsc et eslint propres.
- Tests affaires : 4 cas mis à jour vers le comportement corrigé (les non mis en cause portent désormais un encart) plus un test du helper de rôle.
- Rendu contrôlé sur trois cas réels : plaignant (Rima Hassan), victime (Sandrine Josso), mentionné sur condamnation (Macron / affaire Benalla).

## Suite

- Partie 2 (champs éditoriaux `subjectLabel` / `involvementNote` + garde de publication) demande une migration Prisma : PR séparée après arbitrage produit.
