### PR TITLE
chore(affaires): commentaires de code en anglais

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -547,13 +547,13 @@ model Affair {
   category    AffairCategory
   involvement Involvement    @default(MENTIONED_ONLY)
 
-  // Qui / quoi la procédure vise réellement quand ce n'est pas la personne
-  // suivie (I2/I3). subjectLabel null = la personne suivie est le sujet.
+  // Who / what the procedure actually targets when it is not the tracked person
+  // (I2/I3). subjectLabel null = the tracked person is the subject.
   subjectLabel    String? // Ex: "Lagardère News"
   subjectKind     SubjectKind?
   subjectNote     String? // Ex: "Groupe de presse, propriété de Vincent Bolloré"
-  // Nature sourcée du lien (pas son degré), <= 280 caractères. Obligatoire à la
-  // publication pour tout involvement != DIRECT (publish-guard).
+  // Sourced nature of the link (not its degree), <= 280 chars. Required to
+  // publish any involvement != DIRECT (publish-guard).
   involvementNote String?
 
   // Severity hierarchy (computed from category + isRelatedToMandate)
@@ -732,9 +732,9 @@ enum Involvement {
   PLAINTIFF
 }
 
-// Nature du sujet réellement visé par la procédure quand ce n'est pas la
-// personne suivie. Reste du texte libre côté subjectLabel : pas de fiche pour
-// les personnes morales.
+// Nature of the subject actually targeted by the procedure when it is not the
+// tracked person. subjectLabel stays free text: no profile page for legal
+// entities.
 enum SubjectKind {
   PERSON
   ORGANISATION

--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -199,8 +199,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return { title: "Affaire non trouvée" };
   }
 
-  // Hors du site il ne reste souvent qu'un nom et un titre d'affaire : on
-  // n'accole le nom que si la personne est mise en cause (I7).
+  // Off-site there is often only a name and an affair title left: append the
+  // name only when the person is accused (I7).
   const title = isAccusedInvolvement(affair.involvement)
     ? `${affair.title} - ${affair.politician.fullName}`
     : affair.title;
@@ -286,9 +286,9 @@ export default async function AffairDetailPage({ params }: PageProps) {
     { name: affair.title, url: `${SITE_URL}/affaires/${affair.slug}` },
   ];
 
-  // Pour une personne non mise en cause, les blocs Peine et Juridiction vides ne
-  // s'affichent pas : deux cartes réservées à un procès qui ne la vise pas
-  // contredisaient le rôle. Renseignés, ils restent (peine d'un tiers).
+  // For a non-accused person the empty Peine and Juridiction cards are hidden:
+  // two cards reserved for a trial that does not target them contradicted the
+  // role. When populated they stay (a third party's sentence).
   const hasSentence = Boolean(
     affair.sentence ||
     affair.prisonMonths ||
@@ -354,10 +354,10 @@ export default async function AffairDetailPage({ params }: PageProps) {
                 )}
               </>
             ) : (
-              // Non mis en cause : ni pastille de certitude à charge, ni catégorie
-              // d'infraction posée à côté de la personne (I1, I2). Le statut reste,
-              // en neutre, pour situer la procédure ; le rôle et la ligne « Faits
-              // qualifiés » ci-dessous rattachent tout à l'affaire.
+              // Not accused: no charging certainty pill and no offence category
+              // next to the person (I1, I2). The status stays, neutral, to situate
+              // the procedure; the role and the "Faits qualifiés" line below
+              // re-attach everything to the affair.
               <StatusTooltip
                 status={affair.status}
                 label={AFFAIR_STATUS_LABELS[affair.status]}
@@ -402,11 +402,11 @@ export default async function AffairDetailPage({ params }: PageProps) {
           />
         </div>
 
-        {/* Encart de prudence juridique (RGPD art. 10, I5). Pour un non mis en
-            cause hors condamnation, la caution est déjà portée par l'étage de
-            rôle du bandeau : on ne répète pas (not_accused). On garde l'encart
-            pour l'accusé et pour le tiers d'une affaire conclue par une
-            condamnation (third_party), qui dit que la peine est celle d'un autre. */}
+        {/* Legal caution notice (RGPD art. 10, I5). For a non-accused person
+            outside a conviction the caution is already carried by the band's role
+            étage, so we do not repeat it (not_accused). We keep the notice for the
+            accused and for the third party of an affair concluded by a conviction
+            (third_party), which states the sentence is someone else's. */}
         {noticeVariant && noticeVariant !== "not_accused" && (
           <AffairStatusNotice
             status={affair.status}
@@ -480,7 +480,7 @@ export default async function AffairDetailPage({ params }: PageProps) {
             </CardContent>
           </Card>
 
-          {/* Jurisdiction — masqué pour un non mis en cause sans donnée (I8) */}
+          {/* Jurisdiction — hidden for a non-accused person with no data (I8) */}
           {showJuridiction && (
             <Card>
               <CardHeader>
@@ -556,8 +556,8 @@ export default async function AffairDetailPage({ params }: PageProps) {
           )}
         </div>
 
-        {/* Sentence — masquée pour un non mis en cause sans donnée (I8) ; sinon
-            l'en-tête rappelle que la peine ne vise pas cette personne. */}
+        {/* Sentence — hidden for a non-accused person with no data (I8); otherwise
+            the header reminds that the sentence does not target this person. */}
         {showPeine && (
           <Card className="mb-6">
             <CardHeader>

--- a/src/lib/affairs/publish-guard.ts
+++ b/src/lib/affairs/publish-guard.ts
@@ -129,8 +129,8 @@ export async function checkPublishable(
     });
   }
 
-  // Une personne non mise en cause ne peut plus être publiée sans dire pourquoi
-  // elle figure dans l'affaire : la nature du lien, sourcée (I3, I5).
+  // A non-accused person can no longer be published without stating why they
+  // appear in the affair: the sourced nature of the link (I3, I5).
   if (affair.involvement !== "DIRECT" && !affair.involvementNote?.trim()) {
     reasons.push({
       code: "MISSING_INVOLVEMENT_NOTE",

--- a/src/lib/validations/affairs.ts
+++ b/src/lib/validations/affairs.ts
@@ -67,9 +67,9 @@ const createAffairFields = z.object({
   status: z.enum(AFFAIR_STATUSES),
   category: z.enum(AFFAIR_CATEGORIES),
   involvement: z.enum(INVOLVEMENTS).optional(),
-  // Sujet réel de la procédure quand ce n'est pas la personne suivie, et nature
-  // sourcée du lien. involvementNote est obligatoire à la publication hors DIRECT
-  // (publish-guard) ; la longueur suit la contrainte éditoriale (<= 280).
+  // Real subject of the procedure when it is not the tracked person, and the
+  // sourced nature of the link. involvementNote is required to publish any
+  // non-DIRECT involvement (publish-guard); length follows the editorial cap (<= 280).
   subjectLabel: z.string().max(200).optional(),
   subjectKind: z.enum(["PERSON", "ORGANISATION", "UNKNOWN"]).optional(),
   subjectNote: z.string().max(500).optional(),


### PR DESCRIPTION
Repasse en anglais les commentaires de code que j'ai introduits dans #607, #608 et #609, pour respecter la convention du repo (commentaires en anglais, français réservé au texte user-facing). Changement de commentaires uniquement, aucun comportement modifié. Le français préexistant du domaine (publish-guard, AffairStatusNotice) est laissé tel quel.