### PR TITLE
feat(affaires): bandeau sujet deux colonnes + note d'implication rendue

### DIFF
--- a/src/app/affaires/[slug]/page.tsx
+++ b/src/app/affaires/[slug]/page.tsx
@@ -399,6 +399,10 @@ export default async function AffairDetailPage({ params }: PageProps) {
             affairCount={affairCount}
             party={contextParty}
             involvement={affair.involvement}
+            subjectLabel={affair.subjectLabel}
+            subjectKind={affair.subjectKind}
+            subjectNote={affair.subjectNote}
+            involvementNote={affair.involvementNote}
           />
         </div>
 

--- a/src/components/affairs/AffairContextBand.stories.tsx
+++ b/src/components/affairs/AffairContextBand.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AffairContextBand } from "./AffairContextBand";
+
+const meta: Meta<typeof AffairContextBand> = {
+  title: "Affaires/AffairContextBand",
+  component: AffairContextBand,
+};
+
+export default meta;
+type Story = StoryObj<typeof AffairContextBand>;
+
+const base = {
+  politicianSlug: "jean-dupont",
+  fullName: "Jean Dupont",
+  photoUrl: null,
+  meta: "Député du Calvados · Assemblée nationale · en mandat depuis 2017",
+  affairCount: 3,
+  party: {
+    name: "Renaissance",
+    shortName: "RE",
+    color: "#ffb700",
+    slug: "renaissance",
+    atTime: false,
+  },
+  subjectLabel: null,
+  subjectKind: null,
+  subjectNote: null,
+  involvementNote: null,
+};
+
+/** Mis en cause : bandeau d'identité simple, sans étage de rôle. */
+export const MisEnCause: Story = {
+  args: { ...base, involvement: "DIRECT" },
+};
+
+/** Non mis en cause : étage de rôle avec la phrase générique. */
+export const Mentionne: Story = {
+  args: { ...base, involvement: "MENTIONED_ONLY" },
+};
+
+/** Sujet tiers renseigné : deux colonnes « Visé » / « Suivi » + note sourcée. */
+export const SujetTiers: Story = {
+  args: {
+    ...base,
+    involvement: "MENTIONED_ONLY",
+    subjectLabel: "Lagardère News",
+    subjectKind: "ORGANISATION",
+    subjectNote: "Groupe de presse, propriété de Vincent Bolloré",
+    involvementNote:
+      "Président de la commission d'enquête visée ; a reçu et rejeté les sollicitations.",
+  },
+};

--- a/src/components/affairs/AffairContextBand.tsx
+++ b/src/components/affairs/AffairContextBand.tsx
@@ -11,10 +11,20 @@ import type { Involvement } from "@/types";
  * journeys a reader wants next (their affairs, their party's affairs, their
  * votes). Turns the fiche from a cul-de-sac into a crossroads.
  *
- * This is the identity étage of the InvolvementBand pattern. B1 will add the
- * role étage (the "ni mis en cause, ni poursuivi" sentence + not_accused notice)
- * below the identity row for non-accused involvements, without reshaping this.
+ * It is the InvolvementBand pattern. For a non-accused involvement it carries a
+ * role étage (the "ni mise en cause, ni poursuivie" sentence, or the sourced
+ * involvementNote when present). When subjectLabel names who the procedure
+ * really targets, the identity étage splits into two columns: "Visé par la
+ * procédure" (the subject) and "Suivi sur cette page" (the tracked person).
  */
+type SubjectKind = "PERSON" | "ORGANISATION" | "UNKNOWN";
+
+const SUBJECT_KIND_LABELS: Record<SubjectKind, string> = {
+  PERSON: "Personne",
+  ORGANISATION: "Personne morale (hors périmètre Poligraph)",
+  UNKNOWN: "Sujet non déterminé",
+};
+
 interface AffairContextBandProps {
   politicianSlug: string;
   fullName: string;
@@ -32,6 +42,12 @@ interface AffairContextBandProps {
   /** Drives the role étage: for a non-accused involvement the band states, in a
       sentence, that the person is neither mise en cause nor poursuivie (I3, I5). */
   involvement: Involvement;
+  /** Who/what the procedure really targets, when it is not the tracked person. */
+  subjectLabel: string | null;
+  subjectKind: SubjectKind | null;
+  subjectNote: string | null;
+  /** Sourced nature of the link; replaces the generic role sentence when set. */
+  involvementNote: string | null;
 }
 
 function RailLink({
@@ -63,53 +79,91 @@ export function AffairContextBand({
   affairCount,
   party,
   involvement,
+  subjectLabel,
+  subjectKind,
+  subjectNote,
+  involvementNote,
 }: AffairContextBandProps) {
   const ficheHref = `/politiques/${politicianSlug}`;
   const votesHref = `/politiques/${politicianSlug}/votes`;
   const partyAffairsHref = party?.slug ? `/affaires/parti/${party.slug}` : null;
   const accused = isAccusedInvolvement(involvement);
   const roleCopy = accused ? null : getRoleNoticeCopy(involvement);
+  // The sourced note is more specific than the generic role sentence.
+  const rolePosition = involvementNote?.trim() || roleCopy?.position;
+
+  const identity = (
+    <div className="flex items-center gap-3">
+      <Link
+        href={ficheHref}
+        className="shrink-0 rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <PoliticianAvatar fullName={fullName} photoUrl={photoUrl} size="md" />
+      </Link>
+      <div>
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <Link
+            href={ficheHref}
+            className="font-display text-lg font-semibold text-primary underline-offset-2 hover:underline"
+          >
+            {fullName}
+          </Link>
+          <Link
+            href={ficheHref}
+            className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Fiche complète
+            <ArrowRight className="ml-0.5 inline size-3" aria-hidden="true" />
+          </Link>
+        </div>
+        {meta && <p className="mt-0.5 text-sm text-muted-foreground">{meta}</p>}
+      </div>
+    </div>
+  );
+
+  const partyChip = party ? (
+    <AffairPartyChip
+      name={party.name}
+      shortName={party.shortName}
+      color={party.color}
+      href={partyAffairsHref ?? undefined}
+      atTime={party.atTime}
+    />
+  ) : null;
 
   return (
     <div className="mb-6 rounded-xl border bg-card p-4">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <Link
-            href={ficheHref}
-            className="shrink-0 rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <PoliticianAvatar fullName={fullName} photoUrl={photoUrl} size="md" />
-          </Link>
-          <div>
-            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-              <Link
-                href={ficheHref}
-                className="font-display text-lg font-semibold text-primary underline-offset-2 hover:underline"
-              >
-                {fullName}
-              </Link>
-              <Link
-                href={ficheHref}
-                className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-              >
-                Fiche complète
-                <ArrowRight className="ml-0.5 inline size-3" aria-hidden="true" />
-              </Link>
-            </div>
-            {meta && <p className="mt-0.5 text-sm text-muted-foreground">{meta}</p>}
+      {subjectLabel ? (
+        // Two columns: name the real subject without confusing it with the
+        // tracked person (the only layout that does both).
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="rounded-lg border bg-muted/40 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Visé par la procédure
+            </p>
+            <p className="mt-1 font-semibold text-foreground">{subjectLabel}</p>
+            {subjectKind && (
+              <p className="text-sm text-muted-foreground">{SUBJECT_KIND_LABELS[subjectKind]}</p>
+            )}
+            {subjectNote && <p className="mt-0.5 text-sm text-muted-foreground">{subjectNote}</p>}
+          </div>
+          <div className="rounded-lg border p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Suivi sur cette page
+            </p>
+            <div className="mt-1">{identity}</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Non poursuivi · aucune peine encourue
+            </p>
+            {partyChip && <div className="mt-2">{partyChip}</div>}
           </div>
         </div>
-
-        {party && (
-          <AffairPartyChip
-            name={party.name}
-            shortName={party.shortName}
-            color={party.color}
-            href={partyAffairsHref ?? undefined}
-            atTime={party.atTime}
-          />
-        )}
-      </div>
+      ) : (
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          {identity}
+          {partyChip}
+        </div>
+      )}
 
       {roleCopy && (
         <div
@@ -120,8 +174,8 @@ export function AffairContextBand({
           <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
           <div className="text-sm">
             <p>
-              <strong>Son rôle dans cette affaire : {roleCopy.roleLabel}.</strong>{" "}
-              {roleCopy.position} {roleCopy.reminder}
+              <strong>Son rôle dans cette affaire : {roleCopy.roleLabel}.</strong> {rolePosition}{" "}
+              {roleCopy.reminder}
             </p>
             <Link
               href="/methodologie"

--- a/src/components/affairs/AffairListingCard.tsx
+++ b/src/components/affairs/AffairListingCard.tsx
@@ -46,6 +46,7 @@ export interface AffairListingCardData {
   description: string;
   status: AffairStatus;
   involvement: Involvement;
+  involvementNote: string | null;
   category: AffairCategory;
   verdictDate: Date | null;
   startDate: Date | null;
@@ -181,6 +182,13 @@ export function AffairListingCard({ affair, retour, resultCount }: AffairListing
           <> · {INVOLVEMENT_LABELS[affair.involvement]}</>
         )}
       </p>
+
+      {!accused && affair.involvementNote && (
+        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">Rôle : </span>
+          {affair.involvementNote}
+        </p>
+      )}
 
       <AffairStatusNotice
         status={affair.status}

--- a/src/components/affairs/__tests__/AffairContextBand.test.tsx
+++ b/src/components/affairs/__tests__/AffairContextBand.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AffairContextBand } from "@/components/affairs/AffairContextBand";
+
+const base = {
+  politicianSlug: "jean-dupont",
+  fullName: "Jean Dupont",
+  photoUrl: null,
+  meta: "Député du Calvados",
+  affairCount: 3,
+  party: null,
+  involvement: "MENTIONED_ONLY" as const,
+  subjectLabel: null,
+  subjectKind: null,
+  subjectNote: null,
+  involvementNote: null,
+};
+
+describe("AffairContextBand — affichage sujet / rôle (B1 P2)", () => {
+  it("sujet renseigné : deux colonnes « Visé » / « Suivi »", () => {
+    render(
+      <AffairContextBand
+        {...base}
+        subjectLabel="Lagardère News"
+        subjectKind="ORGANISATION"
+        subjectNote="Groupe de presse"
+      />
+    );
+    expect(screen.getByText("Visé par la procédure")).toBeTruthy();
+    expect(screen.getByText("Suivi sur cette page")).toBeTruthy();
+    expect(screen.getByText("Lagardère News")).toBeTruthy();
+    expect(screen.getByText(/Personne morale/)).toBeTruthy();
+    expect(screen.getByText(/Non poursuivi/)).toBeTruthy();
+  });
+
+  it("sans sujet : pas de colonnes", () => {
+    render(<AffairContextBand {...base} />);
+    expect(screen.queryByText("Visé par la procédure")).toBeNull();
+  });
+
+  it("involvementNote : remplace la phrase de rôle générique", () => {
+    render(
+      <AffairContextBand {...base} involvementNote="Président de la commission d'enquête visée." />
+    );
+    expect(screen.getByRole("note").textContent).toContain(
+      "Président de la commission d'enquête visée."
+    );
+  });
+
+  it("sans involvementNote : phrase de rôle générique selon l'implication", () => {
+    render(<AffairContextBand {...base} involvement="VICTIM" />);
+    expect(screen.getByRole("note").textContent).toContain("figure comme victime");
+  });
+
+  it("accusé (DIRECT) : pas d'étage de rôle", () => {
+    render(<AffairContextBand {...base} involvement="DIRECT" />);
+    expect(screen.queryByRole("note")).toBeNull();
+  });
+});

--- a/src/components/affairs/__tests__/AffairListingCard.test.tsx
+++ b/src/components/affairs/__tests__/AffairListingCard.test.tsx
@@ -10,6 +10,7 @@ function baseAffair(overrides: Partial<AffairListingCardData> = {}): AffairListi
     description: "Description factuelle des faits reprochés.",
     status: "RELAXE",
     involvement: "DIRECT",
+    involvementNote: null,
     category: "CORRUPTION",
     verdictDate: new Date("2024-06-15"),
     startDate: null,


### PR DESCRIPTION
## Contexte

Partie 2b (affichage) de la refonte « lien élu / affaire », suite de #609 qui a posé les champs (`subjectLabel`, `subjectKind`, `subjectNote`, `involvementNote`) et la garde. Ce lot rend ces données visibles. Sans donnée saisie, l'affichage est identique à aujourd'hui : le changement est purement additif.

## Ce que fait la PR

- **Bandeau de contexte à deux colonnes** quand `subjectLabel` est renseigné : « Visé par la procédure » (le sujet réel, son type, mention « personne morale (hors périmètre Poligraph) » et la note de sujet) face à « Suivi sur cette page » (l'élu, sa puce de parti, « non poursuivi · aucune peine encourue »). C'est la seule mise en page qui nomme l'accusé sans le confondre avec la personne suivie (pattern InvolvementBand).
- **Note d'implication rendue** : quand `involvementNote` est renseignée, elle remplace la phrase de rôle générique dans l'étage de rôle (la version sourcée et spécifique prime sur le libellé par défaut).
- **Réemploi sur la carte de liste** : sous-titre « Rôle : … » sur les affaires non mises en cause qui portent une note.

## Vérification

- `next build` vert, `/affaires/[slug]` toujours en SSG/ISR.
- Source tsc et eslint propres.
- Suite complète : 2918 tests, dont 5 nouveaux sur `AffairContextBand` (deux colonnes sur sujet, absence de colonnes sans sujet, note qui remplace la phrase générique, phrase générique par défaut, pas d'étage de rôle pour un accusé) et la carte mise à jour.

## Notes

- La story `AffairContextBand.stories.tsx` documente les variantes. Le build statique de Storybook rend actuellement un `MissingRenderToCanvasError` (dérive de versions `@storybook/*`, préexistante, sans lien avec ce lot ; hors périmètre CI). À réaligner séparément.
- Données réelles : la bascule éditoriale de l'affaire Lagardère (`MENTIONED_ONLY → VICTIM` + saisie de `subjectLabel`/`involvementNote`) reste une action `/moderate`, hors PR. Une fois faite, le bandeau deux colonnes s'affichera sur cette fiche.
