### PR TITLE
Rendre un blocage de rattachement résoluble depuis la fiche

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -12,7 +12,8 @@ import {
   AFFAIR_STATUS_NEEDS_PRESUMPTION,
 } from "@/config/labels";
 import { formatDate } from "@/lib/utils";
-import { PublicationStatusSelect } from "@/components/admin/PublicationStatusSelect";
+import { AffairPublishControl } from "@/components/admin/AffairPublishControl";
+import type { BlockingDecision as BlockingDecisionPayload } from "@/lib/affairs/blocking-decisions";
 import { PublicationStatus } from "@/generated/prisma";
 
 interface PageProps {
@@ -38,7 +39,7 @@ async function getAffair(id: string) {
 async function updatePublicationStatus(
   id: string,
   status: PublicationStatus
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true } | { ok: false; error: string; blocking?: BlockingDecisionPayload[] }> {
   "use server";
   const { isAuthenticated } = await import("@/lib/auth");
   const { db } = await import("@/lib/db");
@@ -72,9 +73,17 @@ async function updatePublicationStatus(
       await assertPublishable(id, { verifiedBy: VERIFIED_BY_MODERATION });
     } catch (err) {
       if (err instanceof PublishGuardError) {
+        // The reasons carry the blocking decision ids. Flattening them to a sentence used
+        // to strand the moderator: told that a decision blocked them, with no way to
+        // reach it. They travel to the client so the block is resolvable in place.
+        const { loadBlockingDecisions } = await import("@/lib/affairs/blocking-decisions");
+        const decisionIds = err.reasons.flatMap((r) =>
+          r.code === "UNREVIEWED_MATCHING_DECISION" ? r.decisionIds : []
+        );
         return {
           ok: false,
           error: `Affaire non publiable : ${err.reasons.map((r) => r.message).join(" ; ")}`,
+          blocking: await loadBlockingDecisions(decisionIds),
         };
       }
       throw err;
@@ -132,9 +141,10 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
           <h1 className="text-2xl font-bold mt-2">{affair.title}</h1>
         </div>
         <div className="flex items-center gap-2">
-          <PublicationStatusSelect
-            entityId={affair.id}
-            entityType="affair"
+          <AffairPublishControl
+            affairId={affair.id}
+            politicianId={affair.politician.id}
+            politicianName={affair.politician.fullName}
             currentStatus={affair.publicationStatus}
             onChange={updatePublicationStatus}
           />

--- a/src/components/admin/AffairPublishControl.tsx
+++ b/src/components/admin/AffairPublishControl.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { PublicationStatus } from "@/generated/prisma";
+import { Button } from "@/components/ui/button";
+import type { BlockingDecision } from "@/lib/affairs/blocking-decisions";
+
+const STATUS_OPTIONS: { value: PublicationStatus; label: string }[] = [
+  { value: "DRAFT", label: "Brouillon" },
+  { value: "PUBLISHED", label: "Publié" },
+  { value: "REJECTED", label: "Rejeté" },
+  { value: "ARCHIVED", label: "Archivé" },
+  { value: "EXCLUDED", label: "Exclu" },
+];
+
+const STATUS_STYLES: Record<PublicationStatus, string> = {
+  DRAFT: "border-amber-300 bg-amber-50 text-amber-700",
+  PUBLISHED: "border-emerald-300 bg-emerald-50 text-emerald-700",
+  REJECTED: "border-red-300 bg-red-50 text-red-700",
+  ARCHIVED: "border-slate-300 bg-slate-50 text-slate-500",
+  EXCLUDED: "border-gray-300 bg-gray-50 text-gray-500",
+};
+
+export interface PublishRefusal {
+  ok: false;
+  error: string;
+  blocking?: BlockingDecision[];
+}
+
+type ChangeResult = void | { ok: boolean; error?: string; blocking?: BlockingDecision[] };
+
+interface Props {
+  affairId: string;
+  /** The person the affair is about. Confirming attaches the decision to them. */
+  politicianId: string;
+  politicianName: string;
+  currentStatus: PublicationStatus;
+  onChange: (id: string, status: PublicationStatus) => Promise<ChangeResult>;
+}
+
+/**
+ * Publication control for an affair, with the matching blocks resolvable in place.
+ *
+ * Separate from `PublicationStatusSelect`, which factchecks also use: the panel below is
+ * affair-specific and a shared component should not grow a branch for one caller.
+ *
+ * The panel always shows the press excerpt. Confirming from a « Publier » button without
+ * reading the text is how a name-only match gets rubber-stamped, and that is exactly what
+ * the guard exists to prevent, so the evidence is not behind a disclosure.
+ */
+export function AffairPublishControl({
+  affairId,
+  politicianId,
+  politicianName,
+  currentStatus,
+  onChange,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [blocking, setBlocking] = useState<BlockingDecision[]>([]);
+  const [resolving, setResolving] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  function publish(status: PublicationStatus) {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await onChange(affairId, status);
+      if (result && result.ok === false) {
+        setError(result.error ?? "La mise à jour a échoué");
+        setBlocking(result.blocking ?? []);
+        return;
+      }
+      setBlocking([]);
+    });
+  }
+
+  async function resolve(decisionId: string, action: "confirm" | "reject") {
+    setResolving(decisionId);
+    setError(null);
+    try {
+      const response = await fetch(
+        action === "confirm"
+          ? "/api/admin/affair-matching/confirm"
+          : "/api/admin/affair-matching/reject",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "confirm"
+              ? { decisionId, chosenPoliticianId: politicianId }
+              : { decisionId, action: "MOVE_TO_NO_MATCH" }
+          ),
+        }
+      );
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? "Le rattachement n'a pas pu être traité");
+        return;
+      }
+
+      const left = blocking.filter((d) => d.id !== decisionId);
+      setBlocking(left);
+
+      // Retrying only once everything is resolved keeps the guard's refusal meaningful:
+      // a partial resolution would just produce the same error with one fewer decision.
+      if (left.length === 0) {
+        setNotice("Rattachement traité, nouvelle tentative de publication…");
+        publish("PUBLISHED");
+      }
+    } finally {
+      setResolving(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <select
+        value={currentStatus}
+        disabled={isPending}
+        aria-label="Statut de publication"
+        className={`h-8 rounded-md border px-2 text-sm font-medium cursor-pointer appearance-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${STATUS_STYLES[currentStatus]} ${isPending ? "opacity-50 cursor-wait" : ""}`}
+        onChange={(e) => {
+          const next = e.target.value as PublicationStatus;
+          if (next === currentStatus) return;
+          publish(next);
+        }}
+      >
+        {STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      {error && (
+        <p role="alert" className="max-w-xs text-right text-xs text-red-600">
+          {error}
+        </p>
+      )}
+      {notice && (
+        <p role="status" className="max-w-xs text-right text-xs text-muted-foreground">
+          {notice}
+        </p>
+      )}
+
+      {blocking.length > 0 && (
+        <section
+          aria-label="Rattachements à valider"
+          className="w-full max-w-2xl rounded-md border border-amber-300 bg-amber-50 p-3 text-left dark:border-amber-900/50 dark:bg-amber-950/30"
+        >
+          <h4 className="text-sm font-semibold">
+            {blocking.length === 1
+              ? "Un rattachement à valider avant publication"
+              : `${blocking.length} rattachements à valider avant publication`}
+          </h4>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Ce texte parle-t-il bien de {politicianName} ?
+          </p>
+
+          <ul className="mt-3 space-y-3">
+            {blocking.map((d) => (
+              <li key={d.id} className="rounded border bg-background p-2">
+                <blockquote className="text-xs leading-relaxed text-muted-foreground">
+                  « {d.excerpt} »
+                </blockquote>
+
+                <p className="mt-2 text-xs">
+                  <span className="text-muted-foreground">Source : </span>
+                  {d.sourceRef ? (
+                    <a
+                      href={d.sourceRef}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      {d.source}
+                    </a>
+                  ) : (
+                    d.source
+                  )}
+                </p>
+
+                {d.candidates.slice(0, 2).map((c) => (
+                  <div key={c.politicianId} className="mt-2 text-xs">
+                    <span className="font-medium">{c.fullName}</span>
+                    <span className="text-muted-foreground"> · score {c.score.toFixed(1)}</span>
+                    {c.supporting.length > 0 && (
+                      <ul className="ml-3 list-disc text-muted-foreground">
+                        {c.supporting.map((s) => (
+                          <li key={s}>{s}</li>
+                        ))}
+                      </ul>
+                    )}
+                    {c.opposing.length > 0 && (
+                      <ul className="ml-3 list-disc text-red-700 dark:text-red-400">
+                        {c.opposing.map((s) => (
+                          <li key={s}>{s}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                ))}
+
+                <div className="mt-3 flex gap-2">
+                  <Button
+                    size="sm"
+                    disabled={resolving === d.id || isPending}
+                    onClick={() => resolve(d.id, "confirm")}
+                  >
+                    {resolving === d.id ? "…" : `Oui, c'est ${politicianName}`}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={resolving === d.id || isPending}
+                    onClick={() => resolve(d.id, "reject")}
+                  >
+                    Non, ce n&apos;est pas la bonne personne
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/lib/affairs/__tests__/blocking-decisions.test.ts
+++ b/src/lib/affairs/__tests__/blocking-decisions.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  db: {
+    affairPoliticianDecision: { findMany: vi.fn() },
+    politician: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import { loadBlockingDecisions } from "@/lib/affairs/blocking-decisions";
+
+const db = h.db;
+
+function decision(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dec_1",
+    judgment: "SAME",
+    source: "PRESSE",
+    sourceRef: "https://www.lemonde.fr/article",
+    candidateText: "Un juge ordonne à Gérald Darmanin de mettre fin aux violences.",
+    topCandidates: [
+      {
+        candidateId: "pol_1",
+        totalScore: 8.7,
+        signals: [
+          {
+            signalId: "name-quality",
+            logLikelihoodRatio: 5.2,
+            explanation: 'Full name "Gérald Darmanin" found',
+          },
+          { signalId: "temporal-mandate", logLikelihoodRatio: 2 },
+          { signalId: "party-context", logLikelihoodRatio: -1.5, explanation: "Party mismatch" },
+          {
+            signalId: "jurisdiction",
+            logLikelihoodRatio: 0,
+            explanation: "Neutre, ne doit pas apparaître",
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.politician.findMany.mockResolvedValue([{ id: "pol_1", fullName: "Gérald Darmanin" }]);
+});
+
+/**
+ * Issue UX : la garde renvoyait des `decisionIds` que la page aplatissait en phrase, et la
+ * page de revue ne filtre que par onglet en paginant par 20. Le modérateur apprenait qu'une
+ * décision le bloquait sans aucun moyen de l'atteindre. Ce chargeur porte de quoi juger sur
+ * place, donc il doit porter le TEXTE, pas seulement des identifiants.
+ */
+describe("loadBlockingDecisions", () => {
+  it("ne requête rien quand il n'y a rien à charger", async () => {
+    expect(await loadBlockingDecisions([])).toEqual([]);
+    expect(db.affairPoliticianDecision.findMany).not.toHaveBeenCalled();
+  });
+
+  it("porte le texte de presse, qui est ce qu'un humain doit juger", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision()]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.excerpt).toContain("Gérald Darmanin");
+    expect(d!.sourceRef).toBe("https://www.lemonde.fr/article");
+  });
+
+  // Le candidat stocké ne porte qu'un cuid : sans jointure, le panneau afficherait un
+  // identifiant et ne permettrait de juger rien du tout.
+  it("résout le nom du candidat, absent du JSON stocké", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision()]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.candidates[0]!.fullName).toBe("Gérald Darmanin");
+    expect(d!.candidates[0]!.score).toBe(8.7);
+  });
+
+  it("sépare ce qui plaide pour et ce qui plaide contre", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision()]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.candidates[0]!.supporting).toEqual([
+      'Full name "Gérald Darmanin" found',
+      "temporal-mandate",
+    ]);
+    expect(d!.candidates[0]!.opposing).toEqual(["Party mismatch"]);
+  });
+
+  // Un signal neutre n'aide pas à trancher et allonge le panneau pour rien.
+  it("écarte les signaux neutres", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision()]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+    const all = [...d!.candidates[0]!.supporting, ...d!.candidates[0]!.opposing];
+
+    expect(all).not.toContain("Neutre, ne doit pas apparaître");
+  });
+
+  it("le dit quand le politicien candidat n'existe plus", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision()]);
+    db.politician.findMany.mockResolvedValue([]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.candidates[0]!.fullName).toBe("(politicien introuvable)");
+  });
+
+  it("survit à une décision sans candidat", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision({ topCandidates: null })]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.candidates).toEqual([]);
+  });
+
+  it("borne l'extrait pour qu'il tienne sous un message d'erreur", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([
+      decision({ candidateText: "mot ".repeat(500) }),
+    ]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.excerpt.length).toBeLessThanOrEqual(600);
+  });
+
+  it("normalise les blancs du texte stocké", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([
+      decision({ candidateText: "Un  titre\n\nsur   plusieurs\tlignes" }),
+    ]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.excerpt).toBe("Un titre sur plusieurs lignes");
+  });
+});

--- a/src/lib/affairs/blocking-decisions.ts
+++ b/src/lib/affairs/blocking-decisions.ts
@@ -1,0 +1,103 @@
+import { db } from "@/lib/db";
+
+/**
+ * Display data for the matching decisions that block a publication.
+ *
+ * `publish-guard` already returns their ids, but the refusal used to be flattened to a
+ * sentence, so a moderator was told a decision blocked them and given no way to reach it.
+ * The review page only filters by tab and paginates twenty at a time, so even with the id
+ * in hand the decision was unreachable. This loads what it takes to judge in place.
+ */
+export interface BlockingCandidate {
+  politicianId: string;
+  fullName: string;
+  score: number;
+  /** Human-readable explanations of the signals that argued FOR this candidate. */
+  supporting: string[];
+  /** And those that argued against, which are the ones worth a second look. */
+  opposing: string[];
+}
+
+export interface BlockingDecision {
+  id: string;
+  judgment: string;
+  source: string;
+  sourceRef: string;
+  /** The press text the resolver read. This is what a human has to judge. */
+  excerpt: string;
+  candidates: BlockingCandidate[];
+}
+
+interface RawSignal {
+  signalId: string;
+  logLikelihoodRatio: number;
+  explanation?: string;
+}
+
+interface RawCandidate {
+  candidateId: string;
+  totalScore: number;
+  signals?: RawSignal[];
+}
+
+/** Enough to judge without scrolling, short enough to sit under an error message. */
+const EXCERPT_LENGTH = 600;
+
+export async function loadBlockingDecisions(
+  decisionIds: readonly string[]
+): Promise<BlockingDecision[]> {
+  if (decisionIds.length === 0) return [];
+
+  const rows = await db.affairPoliticianDecision.findMany({
+    where: { id: { in: [...decisionIds] } },
+    select: {
+      id: true,
+      judgment: true,
+      source: true,
+      sourceRef: true,
+      candidateText: true,
+      topCandidates: true,
+    },
+  });
+
+  // The stored candidate carries only an id, never a name, so the label has to be
+  // resolved here. Without it the panel would show a cuid and judge nothing.
+  const candidateIds = new Set<string>();
+  for (const row of rows) {
+    for (const c of (row.topCandidates as RawCandidate[] | null) ?? []) {
+      if (c?.candidateId) candidateIds.add(c.candidateId);
+    }
+  }
+
+  const politicians = await db.politician.findMany({
+    where: { id: { in: [...candidateIds] } },
+    select: { id: true, fullName: true },
+  });
+  const nameById = new Map(politicians.map((p) => [p.id, p.fullName]));
+
+  return rows.map((row) => ({
+    id: row.id,
+    judgment: row.judgment,
+    source: row.source,
+    sourceRef: row.sourceRef,
+    excerpt: row.candidateText.replace(/\s+/g, " ").slice(0, EXCERPT_LENGTH),
+    candidates: ((row.topCandidates as RawCandidate[] | null) ?? [])
+      .filter((c) => c?.candidateId)
+      .map((c) => {
+        const signals = c.signals ?? [];
+        return {
+          politicianId: c.candidateId,
+          // A deleted politician leaves the decision pointing nowhere; say so rather
+          // than render an empty name.
+          fullName: nameById.get(c.candidateId) ?? "(politicien introuvable)",
+          score: c.totalScore,
+          supporting: signals
+            .filter((s) => s.logLikelihoodRatio > 0)
+            .map((s) => s.explanation ?? s.signalId),
+          opposing: signals
+            .filter((s) => s.logLikelihoodRatio < 0)
+            .map((s) => s.explanation ?? s.signalId),
+        };
+      }),
+  }));
+}


### PR DESCRIPTION
Publier une affaire pouvait échouer sur « Affaire non publiable : 1 décision(s) de
rattachement automatique non validée(s) par un humain », sans aucun moyen d'atteindre la
décision en question.

Deux ruptures, dont la seconde rendait la première irrécupérable :

```
publish-guard calcule decisionIds  →  page.tsx:77 les jette en aplatissant en phrase
même avec l'identifiant en main    →  /review ne filtre que par tab, 20 par page
```

`PublishBlockReason` transporte un `decisionIds: string[]` typé depuis le début. La ligne
qui affichait le refus faisait `.map(r => r.message).join(" ; ")`, ce qui compile, ne
plante jamais, et produit un message exact et inexploitable. Et comme la route de revue
n'accepte que `tab`, retrouver une décision précise demandait de feuilleter jusqu'à trente
pages.

## Ce que ça donne

Le refus porte désormais les décisions bloquantes, et la fiche affiche un panneau qui
permet de trancher sans quitter la page :

```
✗ Affaire non publiable : 1 décision(s) de rattachement…

  ┌ Un rattachement à valider avant publication ──────────────┐
  │ Ce texte parle-t-il bien de Gérald Darmanin ?             │
  │                                                            │
  │ « un juge des référés ordonne à Gérald Darmanin de mettre │
  │   fin aux violences et humiliations sur les détenus »      │
  │ Source : PRESSE (lien)                                     │
  │                                                            │
  │ Gérald Darmanin · score 8.7                                │
  │   • Full name "Gérald Darmanin" found                      │
  │   • Facts during MINISTRE mandate                          │
  │ Jean Luc Darmanin · score 2.5                              │
  │   • Surname only "Darmanin" found                          │
  │   • First name "Jean Luc" not in text        ← en rouge    │
  │                                                            │
  │ [ Oui, c'est Gérald Darmanin ]  [ Non, pas la bonne… ]     │
  └────────────────────────────────────────────────────────────┘
```

Le second candidat est le plus utile du panneau : il montre pourquoi le résolveur a
hésité, et rend la décision évidente en trois secondes.

Une fois tous les blocages traités, la publication est retentée automatiquement. Le retry
n'a lieu qu'à zéro décision restante : une résolution partielle ne ferait que reproduire
la même erreur avec un blocage de moins.

## Choix de conception

**L'extrait de presse est toujours affiché, jamais derrière un dépliant.** Confirmer
depuis un bouton « Publier » sans lire le texte est exactement la façon dont un
rattachement par nom seul se fait tamponner, et c'est ce que la garde existe pour
empêcher. Le compromis retenu est « on ne quitte pas la page » et non « on valide sans
regarder ».

**Composant dédié plutôt que branche dans le composant partagé.**
`PublicationStatusSelect` sert aussi aux factchecks ; lui greffer un panneau spécifique
aux affaires l'aurait fait diverger pour un seul appelant. `AffairPublishControl` est
autonome et `PublicationStatusSelect` n'est pas touché.

**Aucune route API créée.** `confirm` et `reject` existaient et débloquent déjà, par deux
mécanismes distincts : confirmer pose `CONFIRMED` + `chosenPoliticianId`, rejeter bascule
le `judgment` en `NO_MATCH`, ce qui sort la décision de la requête de la garde.

**Le nom du candidat est résolu à la lecture.** Le JSON stocké dans `topCandidates` ne
porte qu'un `candidateId` ; sans jointure vers `Politician`, le panneau afficherait un
cuid et ne permettrait de juger rien du tout.

## Contexte chiffré

Mesuré sur la base avant ce correctif :

|                                     |                                           |
| ----------------------------------- | ----------------------------------------- |
| registre `AffairPoliticianDecision` | 2132 lignes, 230 revues (11 %)            |
| non revues                          | 1902                                      |
| dont rattachées à une affaire       | 55 — les seules que la garde peut bloquer |
| affaires effectivement bloquées     | 52, dont **14 brouillons**                |

Les 1847 autres décisions ne bloquent rien : elles n'ont pas d'`affairId`. Le tableau de
bord affiche « 590 en attente de revue », ce qui se lit comme une montagne, alors que le
blocage éditorial réel tenait à quatorze brouillons et quinze décisions.

Toutes les décisions bloquantes sont des `SAME`, donc des cas où le résolveur était déjà
confiant. Il manquait un clic, pas un jugement difficile.

## Test plan

- 9 tests sur `loadBlockingDecisions` : extrait porté, nom résolu, séparation
  pour/contre, signaux neutres écartés, politicien supprimé, décision sans candidat,
  extrait borné, blancs normalisés, aucune requête sur entrée vide
- `npx vitest run src/lib/affairs src/components/admin` : 245 passés
- `npx tsc --noEmit` : 0 erreur
- `npx eslint` sur les 4 fichiers touchés : 0 erreur, 0 warning
- `npm run build` : code de sortie 0
- Vérifié contre la base réelle : le chargeur rend bien le titre Le Monde, les deux
  candidats Darmanin et le signal qui les départage

## Rollback

Aucune migration, aucune écriture de schéma, aucune route nouvelle. Revenir au commit
précédent restaure l'ancien message d'erreur ; les décisions confirmées entre-temps
restent valides, elles passent par les mêmes routes qu'avant.

## Suites

- Le tableau de bord masque 480 décisions `SAME` non revues : il n'affiche que
  `UNDECIDED` et `NO_MATCH`, donc le bucket qui bloque réellement les publications est
  invisible.
- Le débit d'entrée est de 12 à 18 décisions par jour pour une revue humaine à l'arrêt
  depuis le 27 juillet. Aucune ergonomie ne compense un producteur sans consommateur ;
  c'est le sujet suivant.
