### PR TITLE
Exiger une validation humaine là où la garde la promettait

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -77,9 +77,11 @@ async function updatePublicationStatus(
         // to strand the moderator: told that a decision blocked them, with no way to
         // reach it. They travel to the client so the block is resolvable in place.
         const { loadBlockingDecisions } = await import("@/lib/affairs/blocking-decisions");
-        const decisionIds = err.reasons.flatMap((r) =>
-          r.code === "UNREVIEWED_MATCHING_DECISION" ? r.decisionIds : []
-        );
+        // Toute raison qui porte des identifiants, pas seulement celle qui existait
+        // quand ce code a été écrit : la garde en a gagné une seconde
+        // (ASSISTED_MATCHING_DECISION), et filtrer sur un code nommé aurait rendu le
+        // panneau vide pour une affaire bloquée uniquement par une confirmation assistée.
+        const decisionIds = err.reasons.flatMap((r) => ("decisionIds" in r ? r.decisionIds : []));
         return {
           ok: false,
           error: `Affaire non publiable : ${err.reasons.map((r) => r.message).join(" ; ")}`,

--- a/src/components/admin/AffairPublishControl.tsx
+++ b/src/components/admin/AffairPublishControl.tsx
@@ -166,6 +166,13 @@ export function AffairPublishControl({
                   « {d.excerpt} »
                 </blockquote>
 
+                {d.provenance === "ASSISTED" && (
+                  <p className="mt-2 text-xs font-medium text-amber-800 dark:text-amber-300">
+                    Déjà confirmé par l&apos;assistance ({d.reviewedBy}) : il reste à valider ou à
+                    contredire.
+                  </p>
+                )}
+
                 <p className="mt-2 text-xs">
                   <span className="text-muted-foreground">Source : </span>
                   {d.sourceRef ? (

--- a/src/lib/affairs/__tests__/blocking-decisions.test.ts
+++ b/src/lib/affairs/__tests__/blocking-decisions.test.ts
@@ -140,3 +140,37 @@ describe("loadBlockingDecisions", () => {
     expect(d!.excerpt).toBe("Un titre sur plusieurs lignes");
   });
 });
+
+/**
+ * La garde distingue « jamais regardé » de « la machine a dit oui ». Le panneau doit
+ * porter la différence, sinon il repose la question à froid au lieu de demander un
+ * arbitrage, ce qui est précisément ce que la validation assistée doit éviter.
+ */
+describe("loadBlockingDecisions — provenance de la revue", () => {
+  it("marque une décision confirmée par assistance", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([
+      decision({ reviewedBy: "auto-triage" }),
+    ]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.provenance).toBe("ASSISTED");
+    expect(d!.reviewedBy).toBe("auto-triage");
+  });
+
+  it("marque une décision jamais revue", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision({ reviewedBy: null })]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.provenance).toBe("NONE");
+  });
+
+  it("marque une décision revue par un humain", async () => {
+    db.affairPoliticianDecision.findMany.mockResolvedValue([decision({ reviewedBy: "admin" })]);
+
+    const [d] = await loadBlockingDecisions(["dec_1"]);
+
+    expect(d!.provenance).toBe("HUMAN");
+  });
+});

--- a/src/lib/affairs/__tests__/publish-guard.test.ts
+++ b/src/lib/affairs/__tests__/publish-guard.test.ts
@@ -207,3 +207,83 @@ describe("assertPublishable — écriture atomique", () => {
     expect(vi.mocked(db.$transaction)).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * La garde annonçait « non validée(s) par un humain » et testait `reviewedBy !== null`.
+ * `auto-triage` la franchissait donc : trois affaires publiées reposent sur un
+ * rattachement que seule la machine a confirmé (Estrosi, Massondo, Pedehontaa, mesuré le
+ * 2026-08-02, 60 confirmations automatiques au registre).
+ *
+ * L'assistance reste légitime, et c'est même 69 % des revues de ce registre. Ce qui ne
+ * l'était pas, c'est qu'une garde promette une chose et en vérifie une autre.
+ */
+describe("checkPublishable — humain contre assistance", () => {
+  beforeEach(() => {
+    tx.affair.findUnique.mockResolvedValue(AFFAIR);
+  });
+
+  it("une confirmation par assistance ne publie pas", async () => {
+    tx.affairPoliticianDecision.findMany.mockResolvedValue([
+      { ...VALID_DECISION, reviewedBy: "auto-triage" },
+    ]);
+
+    const reasons = await checkPublishable("aff_1");
+
+    expect(reasons.map((r) => r.code)).toContain("ASSISTED_MATCHING_DECISION");
+  });
+
+  // Deux situations distinctes pour le modérateur : « personne n'a regardé » demande un
+  // examen, « la machine a dit oui » demande un arbitrage. Les confondre sous un seul
+  // message est ce qui a rendu le blocage illisible.
+  it("distingue jamais validé de validé par assistance", async () => {
+    tx.affairPoliticianDecision.findMany.mockResolvedValue([
+      { ...VALID_DECISION, id: "dec_auto", reviewedBy: "auto-triage" },
+      { ...VALID_DECISION, id: "dec_rien", reviewedAt: null, reviewedBy: null },
+    ]);
+
+    const reasons = await checkPublishable("aff_1");
+    const assisted = reasons.find((r) => r.code === "ASSISTED_MATCHING_DECISION");
+    const never = reasons.find((r) => r.code === "UNREVIEWED_MATCHING_DECISION");
+
+    expect(assisted).toBeDefined();
+    expect(never).toBeDefined();
+    expect(assisted!.code === "ASSISTED_MATCHING_DECISION" && assisted!.decisionIds).toEqual([
+      "dec_auto",
+    ]);
+    expect(never!.code === "UNREVIEWED_MATCHING_DECISION" && never!.decisionIds).toEqual([
+      "dec_rien",
+    ]);
+  });
+
+  it("une confirmation humaine publie", async () => {
+    tx.affairPoliticianDecision.findMany.mockResolvedValue([VALID_DECISION]);
+
+    const reasons = await checkPublishable("aff_1");
+
+    expect(reasons.map((r) => r.code)).not.toContain("ASSISTED_MATCHING_DECISION");
+    expect(reasons.map((r) => r.code)).not.toContain("UNREVIEWED_MATCHING_DECISION");
+  });
+
+  // Le sens de la liste est délibéré : un réviseur automatique ajouté demain est assisté
+  // par défaut, sans qu'on ait à y penser. L'inverse le laisserait publier tout seul.
+  it("un réviseur inconnu est traité comme assisté, pas comme humain", async () => {
+    tx.affairPoliticianDecision.findMany.mockResolvedValue([
+      { ...VALID_DECISION, reviewedBy: "auto-triage-v3" },
+    ]);
+
+    const reasons = await checkPublishable("aff_1");
+
+    expect(reasons.map((r) => r.code)).toContain("ASSISTED_MATCHING_DECISION");
+  });
+
+  it("le message ne promet plus l'humain là où il ne l'exige pas", async () => {
+    tx.affairPoliticianDecision.findMany.mockResolvedValue([
+      { ...VALID_DECISION, reviewedBy: "auto-triage" },
+    ]);
+
+    const [reason] = await checkPublishable("aff_1");
+
+    expect(reason!.message).toMatch(/assistance automatique/);
+    expect(reason!.message).toMatch(/à valider par un humain/);
+  });
+});

--- a/src/lib/affairs/__tests__/review-provenance.test.ts
+++ b/src/lib/affairs/__tests__/review-provenance.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { HUMAN_REVIEWERS, isHumanReview, reviewProvenance } from "@/lib/affairs/review-provenance";
+
+/**
+ * Trois états et non deux : « personne », « une machine », « un humain ». Les deux
+ * premiers bloquent la publication mais n'appellent pas le même geste, et les confondre
+ * est ce qui a rendu le blocage illisible côté modération.
+ */
+describe("reviewProvenance", () => {
+  it("rend NONE quand personne n'a revu", () => {
+    expect(reviewProvenance(null)).toBe("NONE");
+    expect(reviewProvenance(undefined)).toBe("NONE");
+    expect(reviewProvenance("")).toBe("NONE");
+  });
+
+  it("rend HUMAN pour un réviseur déclaré", () => {
+    expect(reviewProvenance("admin")).toBe("HUMAN");
+  });
+
+  it("rend ASSISTED pour la passe de triage existante", () => {
+    expect(reviewProvenance("auto-triage")).toBe("ASSISTED");
+  });
+
+  /**
+   * Le point porteur de tout le module : ce qui n'est pas déclaré humain est assisté.
+   *
+   * Une liste des robots aurait le sens inverse, et un réviseur automatique ajouté demain
+   * publierait sans que personne l'ait décidé. Ici, l'oubli bloque au lieu de publier, et
+   * le coût d'un humain non déclaré est qu'il doit se déclarer.
+   */
+  it("traite tout réviseur inconnu comme assisté", () => {
+    for (const unknown of ["auto-triage-v2", "llm-judge", "cron", "Lamine", "sync:daily"]) {
+      expect(reviewProvenance(unknown), unknown).toBe("ASSISTED");
+    }
+  });
+
+  it("ne se laisse pas prendre par une casse différente", () => {
+    expect(reviewProvenance("Admin")).toBe("ASSISTED");
+    expect(reviewProvenance("ADMIN")).toBe("ASSISTED");
+  });
+
+  it("isHumanReview suit reviewProvenance", () => {
+    expect(isHumanReview("admin")).toBe(true);
+    expect(isHumanReview("auto-triage")).toBe(false);
+    expect(isHumanReview(null)).toBe(false);
+  });
+
+  it("la liste des humains reste explicite et non vide", () => {
+    // Une liste vide bloquerait toute publication : le dire ici plutôt que de le
+    // découvrir en production.
+    expect(HUMAN_REVIEWERS.length).toBeGreaterThan(0);
+    expect(HUMAN_REVIEWERS).toContain("admin");
+  });
+});

--- a/src/lib/affairs/blocking-decisions.ts
+++ b/src/lib/affairs/blocking-decisions.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { reviewProvenance, type ReviewProvenance } from "@/lib/affairs/review-provenance";
 
 /**
  * Display data for the matching decisions that block a publication.
@@ -21,6 +22,15 @@ export interface BlockingCandidate {
 export interface BlockingDecision {
   id: string;
   judgment: string;
+  /**
+   * Qui a déjà tranché, s'il y a eu une revue.
+   *
+   * « ASSISTED » change la question posée au modérateur : ce n'est plus « qui est-ce ? »
+   * mais « la machine dit oui, êtes-vous d'accord ? ». C'est le sens même de la
+   * validation assistée, et le cacher la ramènerait à un examen à froid.
+   */
+  provenance: ReviewProvenance;
+  reviewedBy: string | null;
   source: string;
   sourceRef: string;
   /** The press text the resolver read. This is what a human has to judge. */
@@ -57,6 +67,7 @@ export async function loadBlockingDecisions(
       sourceRef: true,
       candidateText: true,
       topCandidates: true,
+      reviewedBy: true,
     },
   });
 
@@ -78,6 +89,8 @@ export async function loadBlockingDecisions(
   return rows.map((row) => ({
     id: row.id,
     judgment: row.judgment,
+    provenance: reviewProvenance(row.reviewedBy),
+    reviewedBy: row.reviewedBy,
     source: row.source,
     sourceRef: row.sourceRef,
     excerpt: row.candidateText.replace(/\s+/g, " ").slice(0, EXCERPT_LENGTH),

--- a/src/lib/affairs/publish-guard.ts
+++ b/src/lib/affairs/publish-guard.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import type { Prisma } from "@/generated/prisma";
 import type { Involvement } from "@/types";
+import { isHumanReview } from "@/lib/affairs/review-provenance";
 
 /**
  * Garde de publication des affaires judiciaires (RGPD article 10,
@@ -23,10 +24,21 @@ export const VERIFIED_BY_MODERATION = "Poligraph Moderation";
  */
 export const PUBLISHED_STATUS = "PUBLISHED" as const;
 
-/** reviewActions valant confirmation humaine d'un rattachement. */
+/**
+ * reviewActions valant confirmation d'un rattachement.
+ *
+ * L'action dit ce qui a été décidé, pas qui l'a décidé : c'est `reviewedBy`, lu par
+ * `review-provenance`, qui distingue l'humain de l'assistance.
+ */
 const CONFIRMING_REVIEW_ACTIONS = ["CONFIRMED", "REASSIGNED", "CREATED_POLITICIAN"] as const;
 
 export type PublishBlockReason =
+  | {
+      /** Confirmé, mais par une passe assistée : demande une confirmation humaine. */
+      code: "ASSISTED_MATCHING_DECISION";
+      message: string;
+      decisionIds: string[];
+    }
   | { code: "NO_SOURCE"; message: string }
   | { code: "MISSING_INVOLVEMENT_NOTE"; message: string }
   | {
@@ -92,9 +104,17 @@ type GuardClient = {
  * 1. Au moins une Source.
  * 2. Aucune décision de matching automatique (SAME ou UNDECIDED) non validée
  *    par un humain. Une décision est validée si et seulement si :
- *    reviewedAt non null, reviewedBy non null, reviewAction confirmant
- *    (CONFIRMED, REASSIGNED, CREATED_POLITICIAN) et chosenPoliticianId égal
- *    au politicien de l'affaire.
+ *    reviewedAt non null, reviewAction confirmant (CONFIRMED, REASSIGNED,
+ *    CREATED_POLITICIAN), chosenPoliticianId égal au politicien de l'affaire,
+ *    ET `reviewedBy` désignant un humain au sens de `review-provenance`.
+ *
+ *    Cette dernière condition est le correctif du décalage entre ce que la
+ *    garde annonçait et ce qu'elle vérifiait : `reviewedBy non null` acceptait
+ *    `auto-triage`, donc une confirmation machine publiait sous un message
+ *    promettant un humain. Une décision confirmée par assistance ne bloque plus
+ *    pour la même raison qu'une décision jamais regardée : elle sort en
+ *    ASSISTED_MATCHING_DECISION, qui dit au modérateur qu'il lui reste à
+ *    trancher, pas à tout reprendre.
  *
  * Les décisions sont cherchées par deux chemins : lien direct `affairId`,
  * et fallback sur les décisions orphelines (affairId null) partageant le
@@ -165,22 +185,37 @@ export async function checkPublishable(
     },
   });
 
-  const blocking = decisions.filter(
-    (d) =>
-      !(
-        d.reviewedAt !== null &&
-        d.reviewedBy !== null &&
-        d.reviewAction !== null &&
-        (CONFIRMING_REVIEW_ACTIONS as readonly string[]).includes(d.reviewAction) &&
-        d.chosenPoliticianId === affair.politicianId
-      )
-  );
+  // Confirmée pour ce politicien, quelle que soit la main qui l'a fait.
+  //
+  // `reviewedBy` reste exigé ici : une ligne horodatée sans réviseur est un
+  // enregistrement incomplet, pas une revue assistée, et la ranger dans « assisté »
+  // laisserait croire que quelqu'un ou quelque chose a tranché.
+  const confirmed = (d: (typeof decisions)[number]) =>
+    d.reviewedAt !== null &&
+    d.reviewedBy !== null &&
+    d.reviewAction !== null &&
+    (CONFIRMING_REVIEW_ACTIONS as readonly string[]).includes(d.reviewAction) &&
+    d.chosenPoliticianId === affair.politicianId;
 
-  if (blocking.length > 0) {
+  const unreviewed = decisions.filter((d) => !confirmed(d));
+  const assisted = decisions.filter((d) => confirmed(d) && !isHumanReview(d.reviewedBy));
+
+  if (unreviewed.length > 0) {
     reasons.push({
       code: "UNREVIEWED_MATCHING_DECISION",
-      message: `${blocking.length} décision(s) de rattachement automatique non validée(s) par un humain`,
-      decisionIds: blocking.map((d) => d.id),
+      message: `${unreviewed.length} rattachement(s) automatique(s) jamais validé(s)`,
+      decisionIds: unreviewed.map((d) => d.id),
+    });
+  }
+
+  // Séparé volontairement : « personne n'a regardé » et « la machine a dit oui »
+  // n'appellent pas le même geste, et les confondre sous un seul message a laissé
+  // trois affaires se publier sur une confirmation automatique.
+  if (assisted.length > 0) {
+    reasons.push({
+      code: "ASSISTED_MATCHING_DECISION",
+      message: `${assisted.length} rattachement(s) confirmé(s) par l'assistance automatique, à valider par un humain`,
+      decisionIds: assisted.map((d) => d.id),
     });
   }
 

--- a/src/lib/affairs/review-provenance.ts
+++ b/src/lib/affairs/review-provenance.ts
@@ -1,0 +1,38 @@
+/**
+ * Qui a validé un rattachement : un humain, ou une passe assistée ?
+ *
+ * `AffairPoliticianDecision.reviewedBy` est un texte libre, et il a longtemps porté une
+ * seule valeur, `admin`. Depuis la passe de triage de juillet il en porte deux, et
+ * `auto-triage` y compte pour 159 revues contre 72 humaines. La garde de publication
+ * testait `reviewedBy !== null` tout en annonçant « non validée par un humain » : trois
+ * affaires publiées reposent sur un rattachement que seule la machine a confirmé.
+ *
+ * L'assistance est légitime et reste la seule façon de tenir le rythme à une personne.
+ * Ce qui ne l'est pas, c'est qu'une garde promette une chose et en vérifie une autre.
+ */
+
+/**
+ * Les identités humaines connues, énumérées explicitement.
+ *
+ * Le sens de la liste est délibéré : **tout ce qui n'y figure pas est considéré comme
+ * assisté**. Ajouter un nouveau réviseur automatique ne demande donc aucune modification
+ * ici et reste sûr par défaut. Oublier d'y déclarer un nouvel humain a pour seule
+ * conséquence que ses validations ne débloquent pas une publication, ce qui bloque au
+ * lieu de publier.
+ *
+ * L'inverse, une liste des robots où l'inconnu vaudrait humain, laisserait un réviseur
+ * automatique ajouté demain publier sans que personne le décide.
+ */
+export const HUMAN_REVIEWERS: readonly string[] = ["admin"];
+
+export type ReviewProvenance = "HUMAN" | "ASSISTED" | "NONE";
+
+export function reviewProvenance(reviewedBy: string | null | undefined): ReviewProvenance {
+  if (!reviewedBy) return "NONE";
+  return HUMAN_REVIEWERS.includes(reviewedBy) ? "HUMAN" : "ASSISTED";
+}
+
+/** Raccourci de lecture pour les gardes. Ne dit rien de la qualité de la revue. */
+export function isHumanReview(reviewedBy: string | null | undefined): boolean {
+  return reviewProvenance(reviewedBy) === "HUMAN";
+}


### PR DESCRIPTION
La garde de publication annonçait une chose et en vérifiait une autre.

```
ce qu'elle ANNONCE :  « non validée(s) par un humain »
ce qu'elle EXIGEAIT :  reviewedBy !== null        ← n'importe qui
```

`AffairPoliticianDecision.reviewedBy` est un texte libre. Il n'a longtemps porté qu'une
valeur, `admin`, et la condition était alors juste. Depuis la passe de triage de juillet
il en porte deux, et `auto-triage` compte pour **159 revues contre 72 humaines**. La
condition a cessé de signifier ce que son message affirme, sans que rien ne le signale :
les deux vivent dans des fichiers différents.

Conséquence mesurée, pas hypothétique : **60 décisions confirmées par `auto-triage`**, dont
5 rattachées à une affaire, dont **3 affaires publiées** dont l'attribution n'a jamais été
validée par un humain.

## Ce que ça change

`src/lib/affairs/review-provenance.ts` distingue trois états, parce que « personne n'a
regardé » et « la machine a dit oui » n'appellent pas le même geste du modérateur :

```ts
reviewProvenance(reviewedBy): "HUMAN" | "ASSISTED" | "NONE"
```

La garde sort donc deux raisons distinctes au lieu d'une :

| code                           | signification         | message                                                                                 |
| ------------------------------ | --------------------- | --------------------------------------------------------------------------------------- |
| `UNREVIEWED_MATCHING_DECISION` | jamais regardé        | « N rattachement(s) automatique(s) jamais validé(s) »                                   |
| `ASSISTED_MATCHING_DECISION`   | la machine a confirmé | « N rattachement(s) confirmé(s) par l'assistance automatique, à valider par un humain » |

**Le sens de la liste des humains est délibéré.** `HUMAN_REVIEWERS` énumère les humains, et
tout ce qui n'y figure pas est assisté. Un réviseur automatique ajouté demain est donc sûr
par défaut, sans qu'on ait à y penser. Une liste des robots aurait le sens inverse : un
nouveau réviseur automatique publierait sans que personne l'ait décidé. Ici l'oubli bloque
au lieu de publier, et le coût d'un humain non déclaré est qu'il doit se déclarer.

Ce n'est pas une position contre l'assistance : elle représente 69 % des revues de ce
registre et reste la seule façon de tenir le rythme. Ce qui n'était pas tenable, c'est
qu'une garde promette une chose et en vérifie une autre.

## Impact mesuré sur la base

```
affaires portant une décision de rattachement : 70
  bloquées avant : 53
  bloquées après : 58   (+5)
```

Les cinq nouvelles :

| statut    | fiche              |
| --------- | ------------------ |
| PUBLISHED | Jacques Pedehontaa |
| PUBLISHED | Charles Massondo   |
| PUBLISHED | Christian Estrosi  |
| REJECTED  | Karim Bouamrane    |
| REJECTED  | Louis Aliot        |

**Aucune dépublication.** La garde ne s'exécute qu'au moment de publier, donc les trois
fiches en ligne y restent. Ce qui change, c'est qu'elles ne repasseraient pas la garde
aujourd'hui, et que leur attribution devient visiblement non validée. Les deux REJECTED
n'ont vocation à être publiées par personne.

Le coût réel de ce correctif est donc de trois confirmations humaines à faire, pas d'un
blocage de travail.

## Une régression attrapée par un test existant

Première version : j'avais retiré `reviewedBy !== null` de la condition de confirmation,
ce qui rangeait une ligne horodatée sans réviseur dans « assisté ». Le test
`reviewedAt seul sans reviewedBy ne vaut pas validation` a échoué immédiatement. Un
enregistrement incomplet n'est pas une revue par machine, et le ranger là aurait laissé
croire que quelque chose avait tranché. La condition est rétablie et commentée.

## Test plan

- 5 tests ajoutés sur la garde : une confirmation assistée ne publie pas, les deux codes
  sont bien distingués avec les bons `decisionIds`, une confirmation humaine publie, un
  réviseur inconnu est assisté, le message ne promet plus l'humain là où il ne l'exige pas
- 7 tests sur `review-provenance`, dont le cas porteur : tout réviseur inconnu est
  assisté, y compris `auto-triage-v2`, `llm-judge`, `cron`
- `npm run test:run` : 2938 passés
- `npx tsc --noEmit` : 0 erreur
- `npx eslint` sur les 4 fichiers : 0 erreur, 0 warning
- `npm run build` : code de sortie 0
- Delta mesuré contre la base réelle, chiffres ci-dessus

## Rollback

Aucune migration, aucune écriture. Revenir au commit précédent restaure l'ancienne
condition. Rien n'est écrit en base par ce changement.

## Suites

- Trois fiches publiées à faire confirmer par un humain (Pedehontaa, Massondo, Estrosi).
  Le panneau de la PR #613 permet de le faire depuis la fiche.
- `HUMAN_REVIEWERS` ne contient que `admin` parce que c'est la seule identité humaine que
  les routes écrivent aujourd'hui. Le jour où plusieurs personnes modèrent, c'est là que
  ça se déclare.
