### PR TITLE
Dévaluer l'appariement sur patronyme ambigu

### DIFF
--- a/scripts/rescan-affair-politicians.ts
+++ b/scripts/rescan-affair-politicians.ts
@@ -16,7 +16,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { db } from "@/lib/db";
 import { scoreAffairAgainstCandidates } from "@/lib/affair-matching";
-import { loadCandidatePool } from "@/lib/affair-matching/persistence";
+import { loadCandidatePool, loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
 import { CandidatePrefilter } from "@/lib/affair-matching/candidate-prefilter";
 import { SourceType } from "@/generated/prisma";
 
@@ -53,6 +53,7 @@ async function main() {
 
   console.log("[retrofit] Loading politician pool...");
   const pool = await loadCandidatePool();
+  const vocabulary = await loadSurnameVocabulary();
   const poolById = new Map(pool.map((p) => [p.id, p]));
   console.log(`[retrofit] Loaded ${pool.length} politicians`);
 
@@ -125,7 +126,8 @@ async function main() {
             sourceRef: `retrofit:${affair.id}`,
           },
         },
-        prefiltered
+        prefiltered,
+        vocabulary
       );
 
       const top = decision.topCandidates[0];

--- a/src/lib/affair-matching/__tests__/resolver.test.ts
+++ b/src/lib/affair-matching/__tests__/resolver.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/db", () => ({
 import { scoreAffairAgainstCandidates } from "../resolver";
 import type { AffairCandidateRecord, AffairScoringInput } from "../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../surname-ambiguity";
 
 function politician(overrides: Partial<AffairCandidateRecord>): AffairCandidateRecord {
   return {
@@ -63,7 +64,7 @@ describe("scoreAffairAgainstCandidates", () => {
       }),
     ];
 
-    const decision = scoreAffairAgainstCandidates(input, candidates);
+    const decision = scoreAffairAgainstCandidates(input, candidates, EMPTY_SURNAME_VOCABULARY);
     expect(decision.judgment).toBe("SAME");
     expect(decision.topCandidateId).toBe("winner");
   });
@@ -78,7 +79,7 @@ describe("scoreAffairAgainstCandidates", () => {
       politician({ id: "pol1", lastName: "Mendez", normalizedLastName: "mendez" }),
     ];
 
-    const decision = scoreAffairAgainstCandidates(input, candidates);
+    const decision = scoreAffairAgainstCandidates(input, candidates, EMPTY_SURNAME_VOCABULARY);
     expect(decision.judgment).toBe("NO_MATCH");
   });
 
@@ -100,7 +101,7 @@ describe("scoreAffairAgainstCandidates", () => {
       politician({ id: "pol2", mandates: [lyonMayor] }),
     ];
 
-    const decision = scoreAffairAgainstCandidates(input, candidates);
+    const decision = scoreAffairAgainstCandidates(input, candidates, EMPTY_SURNAME_VOCABULARY);
     expect(decision.judgment).toBe("UNDECIDED");
   });
 
@@ -117,7 +118,7 @@ describe("scoreAffairAgainstCandidates", () => {
       politician({ id: "pol2" }),
     ];
 
-    const decision = scoreAffairAgainstCandidates(input, candidates);
+    const decision = scoreAffairAgainstCandidates(input, candidates, EMPTY_SURNAME_VOCABULARY);
     expect(decision.judgment).toBe("NO_MATCH");
   });
 });

--- a/src/lib/affair-matching/__tests__/signals/context-plausibility.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/context-plausibility.test.ts
@@ -7,9 +7,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new ContextPlausibilitySignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function candidate(): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/signals/external-id.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/external-id.test.ts
@@ -7,9 +7,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new ExternalIdSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function makeCandidate(overrides: Partial<AffairCandidateRecord> = {}): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/signals/first-name.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/first-name.test.ts
@@ -7,9 +7,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new FirstNameSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function makeCandidate(firstName = "Jean", lastName = "Dupont"): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/signals/jurisdiction.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/jurisdiction.test.ts
@@ -11,9 +11,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new JurisdictionSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function candidate(
   departments: string[],

--- a/src/lib/affair-matching/__tests__/signals/name-quality.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/name-quality.test.ts
@@ -5,6 +5,8 @@ import {
   NAME_LEGAL_TITLE_SURNAME_LLR,
   NAME_SURNAME_PROXIMITY_LLR,
   NAME_SURNAME_ONLY_LLR,
+  NAME_SURNAME_AMBIGUOUS_LLR,
+  ROLE_LOCATION_MATCH_LLR,
 } from "../../signals/constants";
 import type {
   AffairScoringInput,
@@ -12,9 +14,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY, type SurnameAmbiguity } from "../../surname-ambiguity";
 
 const signal = new NameQualitySignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function makeCandidate(overrides: Partial<AffairCandidateRecord> = {}): AffairCandidateRecord {
   return {
@@ -109,5 +115,102 @@ describe("NameQualitySignal", () => {
     });
     const result = signal.evaluate(makeInput("Le sujet Jean Do est évoqué."), candidate, context);
     expect(result.disqualified).toBeDefined();
+  });
+});
+
+describe("NameQualitySignal — patronyme ambigu", () => {
+  /** Stub rather than a built vocabulary: this suite tests the signal, not the rules. */
+  const ambiguous = (kinds: Record<string, SurnameAmbiguity["kind"]>): AffairSignalContext => ({
+    resolverVersion: "v1",
+    vocabulary: {
+      lookup: (s) => (kinds[s] ? { kind: kinds[s]!, detail: "raison mesurée" } : null),
+    },
+  });
+
+  it("pénalise un appariement sur patronyme seul quand le token est ambigu", () => {
+    const candidate = makeCandidate({
+      firstName: "Sophie",
+      lastName: "Mariné",
+      fullName: "Sophie Mariné",
+      normalizedLastName: "marine",
+    });
+    const result = signal.evaluate(
+      makeInput("Marine Le Pen a été condamnée par le tribunal."),
+      candidate,
+      ambiguous({ marine: "GIVEN_NAME" })
+    );
+    expect(result.logLikelihoodRatio).toBe(NAME_SURNAME_AMBIGUOUS_LLR);
+    expect(result.logLikelihoodRatio).toBeLessThan(0);
+    expect(result.evidence).toMatchObject({
+      matchType: "SURNAME_ONLY_AMBIGUOUS",
+      ambiguity: "GIVEN_NAME",
+    });
+  });
+
+  it("porte la raison dans l'explication, pour que la revue puisse la lire", () => {
+    const candidate = makeCandidate({
+      lastName: "Justice",
+      fullName: "Paul Justice",
+      normalizedLastName: "justice",
+    });
+    const result = signal.evaluate(
+      makeInput("Le Palais de Justice a été évacué."),
+      candidate,
+      ambiguous({ justice: "COMMON_WORD" })
+    );
+    expect(result.explanation).toContain("raison mesurée");
+  });
+
+  it("n'applique jamais la pénalité quand le nom complet est présent", () => {
+    // La garde centrale : au-dessus du palier « patronyme seul », le prénom ou un
+    // titre a déjà établi qu'il s'agit d'un nom et non d'un mot de la phrase.
+    const candidate = makeCandidate({
+      firstName: "Jean",
+      lastName: "Paris",
+      fullName: "Jean Paris",
+      normalizedLastName: "paris",
+    });
+    const result = signal.evaluate(
+      makeInput("Jean Paris, adjoint au maire, a été mis en examen."),
+      candidate,
+      ambiguous({ paris: "MAJOR_COMMUNE" })
+    );
+    expect(result.logLikelihoodRatio).toBe(NAME_FULL_EXACT_LLR);
+  });
+
+  it("n'applique pas la pénalité sur un appariement par titre de civilité", () => {
+    const candidate = makeCandidate({
+      firstName: "Luc",
+      lastName: "Paris",
+      fullName: "Luc Paris",
+      normalizedLastName: "paris",
+    });
+    const result = signal.evaluate(
+      makeInput("M. Paris a été entendu par les enquêteurs."),
+      candidate,
+      ambiguous({ paris: "MAJOR_COMMUNE" })
+    );
+    expect(result.logLikelihoodRatio).toBe(NAME_LEGAL_TITLE_SURNAME_LLR);
+  });
+
+  it("laisse le patronyme seul non ambigu à sa valeur habituelle", () => {
+    const candidate = makeCandidate({
+      firstName: "Jean-Luc",
+      lastName: "Mélenchon",
+      fullName: "Jean-Luc Mélenchon",
+      normalizedLastName: "melenchon",
+    });
+    const result = signal.evaluate(
+      makeInput("Mélenchon est visé par une plainte."),
+      candidate,
+      ambiguous({ paris: "MAJOR_COMMUNE" })
+    );
+    expect(result.logLikelihoodRatio).toBe(NAME_SURNAME_ONLY_LLR);
+  });
+
+  it("reste rattrapable par la preuve : la pénalité ne dépasse pas un signal corroborant", () => {
+    // Un candidat vraiment lié à l'affaire par son rôle doit encore pouvoir
+    // franchir FLOOR_SCORE. C'est ce qui distingue la pénalité d'une disqualification.
+    expect(NAME_SURNAME_AMBIGUOUS_LLR + ROLE_LOCATION_MATCH_LLR).toBeGreaterThan(0);
   });
 });

--- a/src/lib/affair-matching/__tests__/signals/party-context.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/party-context.test.ts
@@ -11,9 +11,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new PartyContextSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function candidate(parties: AffairCandidateRecord["parties"]): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/signals/role-context.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/role-context.test.ts
@@ -11,9 +11,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new RoleContextSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function candidate(mandates: AffairCandidateRecord["mandates"]): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/signals/temporal-mandate.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/temporal-mandate.test.ts
@@ -11,9 +11,13 @@ import type {
   AffairSignalContext,
 } from "../../signals/types";
 import { SourceType } from "@/generated/prisma";
+import { EMPTY_SURNAME_VOCABULARY } from "../../surname-ambiguity";
 
 const signal = new TemporalMandateSignal();
-const context: AffairSignalContext = { resolverVersion: "v1" };
+const context: AffairSignalContext = {
+  resolverVersion: "v1",
+  vocabulary: EMPTY_SURNAME_VOCABULARY,
+};
 
 function candidate(overrides: Partial<AffairCandidateRecord> = {}): AffairCandidateRecord {
   return {

--- a/src/lib/affair-matching/__tests__/surname-ambiguity.test.ts
+++ b/src/lib/affair-matching/__tests__/surname-ambiguity.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSurnameVocabulary,
+  normalizeForMatching,
+  AMBIGUITY_RULES,
+  type VocabularyInput,
+} from "../surname-ambiguity";
+
+/**
+ * Wordings below are drawn from the real registry. The two lists that matter
+ * are "must be flagged" and "must survive": each entry in the second list is a
+ * name a previous formulation of these rules actually killed.
+ */
+const communes = [
+  { name: "Paris", population: 2_103_778 },
+  { name: "Toulouse", population: 514_819 },
+  { name: "Marseille", population: 886_040 },
+  { name: "Cahuzac", population: 356 },
+  { name: "François", population: 999 },
+  { name: "Boyer", population: 725 },
+  { name: "Mathieu", population: 2_331 },
+  { name: "Marie", population: 109 },
+  { name: "Bourg-la-Reine", population: null },
+];
+
+const politicianNames = [
+  // "Marine" is overwhelmingly a given name; one politician is named Mariné.
+  ...Array.from({ length: 6 }, () => ({ firstName: "Marine", lastName: "Dupont" })),
+  { firstName: "Sophie", lastName: "Mariné" },
+  { firstName: "Claire", lastName: "Mariné" },
+  // "Thomas" is genuinely both, and must stay usable.
+  ...Array.from({ length: 66 }, () => ({ firstName: "Thomas", lastName: "Durand" })),
+  ...Array.from({ length: 63 }, () => ({ firstName: "Alain", lastName: "Thomas" })),
+  // Real surnames that must never be flagged.
+  { firstName: "Jean-Luc", lastName: "Mélenchon" },
+  { firstName: "Marine", lastName: "Le Pen" },
+  { firstName: "Nicolas", lastName: "Sarkozy" },
+  { firstName: "Jérôme", lastName: "Cahuzac" },
+  ...Array.from({ length: 35 }, () => ({ firstName: "Valérie", lastName: "Boyer" })),
+];
+
+const corpus = [
+  "La justice a ouvert une enquête. Justice sera rendue en appel.",
+  "Le juge d'instruction a été saisi ; le juge a ordonné une expertise.",
+  "Depuis 2019, la cour d'appel examine le dossier, mis en délibéré depuis mars.",
+  "L'enquête est ouverte depuis deux ans, et depuis, aucune audience.",
+  "Marine Le Pen a été condamnée par le tribunal de Paris.",
+  "Nicolas Sarkozy a été renvoyé devant la cour. La cour statuera.",
+  "Jean-Luc Mélenchon a porté plainte. La justice tranchera.",
+];
+
+/** Repeats the corpus so tokens clear the minimum-occurrence floor. */
+function realisticInput(): VocabularyInput {
+  const repeated: string[] = [];
+  for (let i = 0; i < 12; i++) repeated.push(...corpus);
+  return { communes, politicianNames, corpus: repeated };
+}
+
+describe("normalizeForMatching", () => {
+  it("supprime les accents, la casse et normalise l'apostrophe typographique", () => {
+    expect(normalizeForMatching("Mélenchon")).toBe("melenchon");
+    expect(normalizeForMatching("  D’Estaing ")).toBe("d'estaing");
+    expect(normalizeForMatching("LE PEN")).toBe("le pen");
+  });
+
+  it("conserve le trait d'union, contrairement au préfiltre", () => {
+    expect(normalizeForMatching("Dupond-Moretti")).toBe("dupond-moretti");
+  });
+});
+
+describe("buildSurnameVocabulary — couche communes", () => {
+  const vocab = buildSurnameVocabulary(realisticInput());
+
+  it("signale une grande ville", () => {
+    expect(vocab.lookup("paris")).toMatchObject({ kind: "MAJOR_COMMUNE" });
+    expect(vocab.lookup("toulouse")).toMatchObject({ kind: "MAJOR_COMMUNE" });
+    expect(vocab.lookup("marseille")).toMatchObject({ kind: "MAJOR_COMMUNE" });
+  });
+
+  it("épargne un patronyme qui est aussi une petite commune", () => {
+    // Le cas qui a invalidé la règle « est une commune » : Cahuzac compte 356
+    // habitants, et une grande part des patronymes français viennent de toponymes.
+    expect(vocab.lookup("cahuzac")).toBeNull();
+    expect(vocab.lookup("boyer")).toBeNull();
+    expect(vocab.lookup("marie")).toBeNull();
+    expect(vocab.lookup("mathieu")).toBeNull();
+  });
+
+  it("traite une population absente comme zéro", () => {
+    expect(vocab.lookup("bourg-la-reine")).toBeNull();
+  });
+});
+
+describe("buildSurnameVocabulary — couche prénoms", () => {
+  const vocab = buildSurnameVocabulary(realisticInput());
+
+  it("signale un token porté surtout comme prénom", () => {
+    expect(vocab.lookup("marine")).toMatchObject({ kind: "GIVEN_NAME" });
+  });
+
+  it("épargne un token réellement porté des deux façons", () => {
+    // 66 prénoms contre 63 patronymes : le ratio est sous le seuil.
+    expect(vocab.lookup("thomas")).toBeNull();
+  });
+
+  it("exige un nombre minimal de porteurs avant de conclure", () => {
+    const vocab = buildSurnameVocabulary({
+      communes: [],
+      politicianNames: [{ firstName: "Aldebrande", lastName: "Zzz" }],
+      corpus: [],
+    });
+    // Un seul porteur donne un ratio de 1,0 sans rien prouver.
+    expect(vocab.lookup("aldebrande")).toBeNull();
+  });
+});
+
+describe("buildSurnameVocabulary — couche mot commun", () => {
+  const vocab = buildSurnameVocabulary(realisticInput());
+
+  it("signale un mot qui vit en minuscule dans le corpus", () => {
+    expect(vocab.lookup("justice")).toMatchObject({ kind: "COMMON_WORD" });
+    expect(vocab.lookup("cour")).toMatchObject({ kind: "COMMON_WORD" });
+    expect(vocab.lookup("juge")).toMatchObject({ kind: "COMMON_WORD" });
+    expect(vocab.lookup("depuis")).toMatchObject({ kind: "COMMON_WORD" });
+  });
+
+  it("épargne un nom propre très fréquent dans le corpus", () => {
+    // Le cas qui a invalidé la fréquence documentaire : « Le Pen » apparaît dans
+    // 18% des documents du registre. La fréquence mesure la notoriété.
+    expect(vocab.lookup("le pen")).toBeNull();
+    expect(vocab.lookup("sarkozy")).toBeNull();
+    expect(vocab.lookup("melenchon")).toBeNull();
+  });
+
+  it("ne juge pas un token vu trop peu de fois", () => {
+    const vocab = buildSurnameVocabulary({
+      communes: [],
+      politicianNames: [],
+      corpus: ["un mot rare et rare encore"],
+    });
+    expect(vocab.lookup("rare")).toBeNull();
+  });
+
+  it("laisse passer un patronyme à particule au lieu de le condamner", () => {
+    // « de Villiers » se lit 100% minuscule à cause de sa particule : la couche
+    // ne s'applique qu'aux patronymes d'un seul mot.
+    const withParticle = buildSurnameVocabulary({
+      communes: [],
+      politicianNames: [],
+      corpus: Array.from({ length: 40 }, () => "il de vient de la de ville de Villiers"),
+    });
+    expect(withParticle.lookup("de villiers")).toBeNull();
+  });
+});
+
+describe("buildSurnameVocabulary — priorité des couches", () => {
+  it("rend la couche qui déclenche en premier, commune avant prénom", () => {
+    const vocab = buildSurnameVocabulary({
+      communes: [{ name: "Valence", population: 64_458 }],
+      politicianNames: Array.from({ length: 10 }, () => ({
+        firstName: "Valence",
+        lastName: "Dupont",
+      })),
+      corpus: [],
+    });
+    expect(vocab.lookup("valence")).toMatchObject({ kind: "MAJOR_COMMUNE" });
+  });
+
+  it("porte un détail lisible pour la revue", () => {
+    const vocab = buildSurnameVocabulary(realisticInput());
+    expect(vocab.lookup("paris")?.detail).toContain("habitants");
+    expect(vocab.lookup("marine")?.detail).toContain("élus");
+    expect(vocab.lookup("justice")?.detail).toContain("occurrences");
+  });
+});
+
+describe("AMBIGUITY_RULES", () => {
+  it("garde le seuil de population au-dessus des communes homonymes de patronymes", () => {
+    // Boyer 725, François 999, Mathieu 2331 : le seuil doit rester franchement
+    // au-dessus, sinon la règle tue des patronymes portés par des dizaines d'élus.
+    expect(AMBIGUITY_RULES.minCommunePopulation).toBeGreaterThan(2_331);
+  });
+});

--- a/src/lib/affair-matching/persistence.ts
+++ b/src/lib/affair-matching/persistence.ts
@@ -5,6 +5,7 @@ import type { AffairCandidateRecord, AffairScoringInput } from "./signals/types"
 import type { CombinerDecision } from "./combiner";
 import { RESOLVER_VERSION } from "./signals/constants";
 import { normalizeText } from "./candidate-prefilter";
+import { buildSurnameVocabulary, type SurnameVocabulary } from "./surname-ambiguity";
 
 /** SHA256 hex digest of a text input, used as the idempotency key. */
 export function computeTextHash(text: string): string {
@@ -112,6 +113,40 @@ export async function loadCandidatePool(): Promise<AffairCandidateRecord[]> {
       parties,
       externalIds,
     };
+  });
+}
+
+/**
+ * How many past decisions feed the casing statistic. The corpus only has to be
+ * large enough for the lowercase rate to be stable; the separation it measures
+ * is wide (2% for "paris" against 76% for "justice"), so a few thousand texts
+ * settle it. Bounded because this loads text into memory on a serverless
+ * function, and ordered by recency so the vocabulary tracks current coverage.
+ */
+const VOCABULARY_CORPUS_SIZE = 3_000;
+
+/**
+ * Loads the surname ambiguity vocabulary. Same contract as loadCandidatePool:
+ * called once per batch, result passed down to every scoring call.
+ *
+ * Three queries, none of them per-candidate. The corpus one is the only heavy
+ * read, and it is why batch callers must hoist this out of their loop.
+ */
+export async function loadSurnameVocabulary(): Promise<SurnameVocabulary> {
+  const [communes, politicianNames, decisions] = await Promise.all([
+    db.commune.findMany({ select: { name: true, population: true } }),
+    db.politician.findMany({ select: { firstName: true, lastName: true } }),
+    db.affairPoliticianDecision.findMany({
+      select: { candidateText: true },
+      orderBy: { createdAt: "desc" },
+      take: VOCABULARY_CORPUS_SIZE,
+    }),
+  ]);
+
+  return buildSurnameVocabulary({
+    communes,
+    politicianNames,
+    corpus: decisions.map((d) => d.candidateText),
   });
 }
 

--- a/src/lib/affair-matching/resolver.ts
+++ b/src/lib/affair-matching/resolver.ts
@@ -4,7 +4,14 @@ import type {
   AffairScoringInput,
   AffairSignalContext,
 } from "./signals/types";
-import { computeTextHash, loadCandidatePool, loadBlocklist, persistDecision } from "./persistence";
+import {
+  computeTextHash,
+  loadCandidatePool,
+  loadBlocklist,
+  loadSurnameVocabulary,
+  persistDecision,
+} from "./persistence";
+import type { SurnameVocabulary } from "./surname-ambiguity";
 import { CandidatePrefilter } from "./candidate-prefilter";
 import { RESOLVER_VERSION } from "./signals/constants";
 import { ExternalIdSignal } from "./signals/external-id";
@@ -39,9 +46,10 @@ const combiner = new AffairCombiner();
  */
 export function scoreAffairAgainstCandidates(
   input: AffairScoringInput,
-  candidates: AffairCandidateRecord[]
+  candidates: AffairCandidateRecord[],
+  vocabulary: SurnameVocabulary
 ): CombinerDecision {
-  const context: AffairSignalContext = { resolverVersion: RESOLVER_VERSION };
+  const context: AffairSignalContext = { resolverVersion: RESOLVER_VERSION, vocabulary };
 
   const candidateSignals = candidates.map((candidate) => ({
     candidateId: candidate.id,
@@ -69,7 +77,7 @@ export async function resolveAffairPolitician(input: AffairScoringInput): Promis
     throw new Error("Affair text exceeds 100KB limit");
   }
 
-  const pool = await loadCandidatePool();
+  const [pool, vocabulary] = await Promise.all([loadCandidatePool(), loadSurnameVocabulary()]);
   const prefilter = new CandidatePrefilter(pool);
   const prefiltered = prefilter.filter(input.text);
 
@@ -77,7 +85,7 @@ export async function resolveAffairPolitician(input: AffairScoringInput): Promis
   const blocklist = await loadBlocklist(textHash);
   const candidates = prefiltered.filter((p) => !blocklist.has(p.id));
 
-  const decision = scoreAffairAgainstCandidates(input, candidates);
+  const decision = scoreAffairAgainstCandidates(input, candidates, vocabulary);
 
   const { decisionId } = await persistDecision({
     text: input.text,

--- a/src/lib/affair-matching/signals/constants.ts
+++ b/src/lib/affair-matching/signals/constants.ts
@@ -20,6 +20,19 @@ export const NAME_LEGAL_TITLE_SURNAME_LLR = 3.6;
 export const NAME_SURNAME_PROXIMITY_LLR = 2.6;
 export const NAME_SURNAME_ONLY_LLR = 0.7;
 
+/**
+ * Surname-only match where the surname is also an ordinary word of the text:
+ * a major city, a common given name, or a word that lives in lowercase.
+ *
+ * Negative rather than disqualifying, for two reasons. A disqualified candidate
+ * is filtered out of the ranking, so its reason never reaches the persisted row
+ * and the moderator cannot tell an artefact from a genuine unknown. And a
+ * penalty stays revocable by evidence: a candidate really tied to the affair by
+ * role-context (+4.0) or jurisdiction (+3.0) still clears FLOOR_SCORE, which is
+ * the right outcome for someone whose surname happens to be Pierre or Marie.
+ */
+export const NAME_SURNAME_AMBIGUOUS_LLR = -2.0;
+
 /** Minimum surname length for non-disqualifying match. */
 export const MIN_SURNAME_LENGTH = 3;
 

--- a/src/lib/affair-matching/signals/name-quality.ts
+++ b/src/lib/affair-matching/signals/name-quality.ts
@@ -11,22 +11,11 @@ import {
   NAME_LEGAL_TITLE_SURNAME_LLR,
   NAME_SURNAME_PROXIMITY_LLR,
   NAME_SURNAME_ONLY_LLR,
+  NAME_SURNAME_AMBIGUOUS_LLR,
   MIN_SURNAME_LENGTH,
   FIRST_NAME_PROXIMITY_CHARS,
 } from "./constants";
-
-/**
- * Normalizes text for case- and accent-insensitive matching.
- * Keeps word characters, spaces, hyphens, and apostrophes.
- */
-function normalize(s: string): string {
-  return s
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[\u2018\u2019]/g, "'")
-    .trim();
-}
+import { normalizeForMatching as normalize } from "../surname-ambiguity";
 
 /**
  * Legal titles that indicate the following word is a surname in French
@@ -59,7 +48,7 @@ export class NameQualitySignal implements AffairSignalEvaluator {
   evaluate(
     input: AffairScoringInput,
     candidate: AffairCandidateRecord,
-    _context: AffairSignalContext
+    context: AffairSignalContext
   ): AffairSignalResult {
     if (candidate.lastName.length < MIN_SURNAME_LENGTH) {
       return {
@@ -125,7 +114,20 @@ export class NameQualitySignal implements AffairSignalEvaluator {
       }
     }
 
-    // 4. Surname only. Weakest positive, vulnerable to common-word false positives.
+    // 4. Surname only, the weakest positive. This is where common-word false
+    //    positives live, so it is the only tier the ambiguity vocabulary judges:
+    //    above it the first name or a legal title has already been seen, which
+    //    settles that the token is a name and not a word of the sentence.
+    const ambiguity = context.vocabulary.lookup(normalizedLast);
+    if (ambiguity) {
+      return {
+        signalId: this.id,
+        logLikelihoodRatio: NAME_SURNAME_AMBIGUOUS_LLR,
+        explanation: `Surname only "${candidate.lastName}", ambiguous token (${ambiguity.detail})`,
+        evidence: { matchType: "SURNAME_ONLY_AMBIGUOUS", ambiguity: ambiguity.kind },
+      };
+    }
+
     return {
       signalId: this.id,
       logLikelihoodRatio: NAME_SURNAME_ONLY_LLR,

--- a/src/lib/affair-matching/signals/types.ts
+++ b/src/lib/affair-matching/signals/types.ts
@@ -1,4 +1,5 @@
 import type { SourceType } from "@/generated/prisma";
+import type { SurnameVocabulary } from "../surname-ambiguity";
 
 /**
  * Importance tier of a signal in the resolver pipeline.
@@ -83,6 +84,13 @@ export interface AffairCandidateRecord {
  */
 export interface AffairSignalContext {
   resolverVersion: string;
+  /**
+   * Surname ambiguity lookup, loaded once per batch alongside the candidate
+   * pool. Required rather than optional so the compiler names every call site
+   * that would otherwise score without it and lose the fix in silence; pass
+   * EMPTY_SURNAME_VOCABULARY where the corpus is genuinely unavailable.
+   */
+  vocabulary: SurnameVocabulary;
 }
 
 /**

--- a/src/lib/affair-matching/surname-ambiguity.ts
+++ b/src/lib/affair-matching/surname-ambiguity.ts
@@ -1,0 +1,185 @@
+/**
+ * Surname ambiguity vocabulary.
+ *
+ * The dominant noise in the affair-matching registry is a surname that is also
+ * an ordinary word of the text. The prefilter fires on any capitalized token of
+ * 4+ characters, so "Depuis 2019…", "Palais de Justice" and "Marine Le Pen" all
+ * propose a politician whose surname happens to be Depuis, Justice or Mariné.
+ *
+ * Three layers answer "is this token a plausible surname *here*?", all computed
+ * from data the project already holds. No external dictionary: the INSEE and
+ * given-name files exist, but a vocabulary measured on our own corpus is better
+ * calibrated to the texts we actually resolve.
+ *
+ * Thresholds were measured against the real SURNAME_ONLY corpus, not chosen by
+ * eye. Two earlier formulations were refuted by that measurement and are
+ * recorded here because both are the obvious thing to reach for:
+ *
+ *  - **Raw document frequency** kills "Le Pen" (18% of documents). In a registry
+ *    of political affairs, df measures notoriety, not ambiguity.
+ *  - **Bare commune membership** kills "Cahuzac" (a commune of 356) and
+ *    "François" (999). A large share of French surnames derive from toponyms.
+ *
+ * What survives is the distinction between a word and a name: a common word
+ * appears in lowercase in running text, a proper noun essentially never does.
+ * Measured on the corpus, the separation is total — 2% lowercase for "paris",
+ * 0% for "le pen", against 71% for "cour" and 96% for "juge".
+ */
+
+/**
+ * Normalizes a name or token for case- and accent-insensitive comparison.
+ *
+ * Shared with the name-quality signal on purpose: the vocabulary is keyed by the
+ * normalized surname, so the two must agree exactly or every lookup misses in
+ * silence.
+ */
+export function normalizeForMatching(s: string): string {
+  return s.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "").replace(/[‘’]/g, "'").trim();
+}
+
+/** Why a surname is not usable as the sole evidence of a match. */
+export type SurnameAmbiguity =
+  | { kind: "MAJOR_COMMUNE"; detail: string }
+  | { kind: "GIVEN_NAME"; detail: string }
+  | { kind: "COMMON_WORD"; detail: string };
+
+export interface SurnameVocabulary {
+  /** Returns null when the surname carries no ambiguity signal. */
+  lookup(normalizedSurname: string): SurnameAmbiguity | null;
+}
+
+/**
+ * Thresholds, measured on the 1473 SURNAME_ONLY lines of the registry.
+ *
+ * The risk here is asymmetric. Dropping a real attribution loses an affair
+ * silently; keeping noise costs the moderator a click. Every threshold is
+ * therefore set on the conservative side of what the measurement allows.
+ */
+export const AMBIGUITY_RULES = {
+  /**
+   * 20 000, not 1 000. The sweep from 1 000 to 100 000 moves the result by ten
+   * lines out of 1473, so the permissive end buys nothing and puts real
+   * surnames at risk: Boyer (35 politicians, commune of 725), Marie (26, 109)
+   * and Mathieu (28, 2331) all survive at 20 000 and would not at 1 000.
+   */
+  minCommunePopulation: 20_000,
+
+  /**
+   * The ratio beats membership. "Frédéric" is borne as a given name by 344
+   * politicians and as a surname by one; "Thomas" is 66 against 63 and stays.
+   */
+  minGivenNameRatio: 0.7,
+  /** Guards the ratio against tiny denominators. */
+  minGivenNameBearers: 5,
+
+  /**
+   * Anywhere in 20%-50% gives the same answer to within eleven lines: the gap
+   * between the two populations is that wide.
+   */
+  minLowercaseRate: 0.3,
+  /** A token seen twice, once lowercase, is not evidence of anything. */
+  minOccurrences: 20,
+} as const;
+
+export interface VocabularyInput {
+  communes: ReadonlyArray<{ name: string; population: number | null }>;
+  politicianNames: ReadonlyArray<{ firstName: string; lastName: string }>;
+  /** Free text of the corpus the resolver works on, used for the case test. */
+  corpus: readonly string[];
+}
+
+/** Strips diacritics while preserving case, which the lowercase test needs. */
+function deaccent(s: string): string {
+  return s.normalize("NFD").replace(/[̀-ͯ]/g, "");
+}
+
+/**
+ * Single-word, letters only. The case test is a per-token statistic, so it
+ * cannot speak about "de france" or "saint-etienne"; more to the point, a
+ * surname carrying a lowercase particle ("de Villiers", "van Grieken") would
+ * read as 100% lowercase and be condemned for its particle. Compound surnames
+ * are also the more distinctive ones, so excluding them costs little.
+ */
+function isSingleToken(s: string): boolean {
+  return /^[a-z']+$/.test(s);
+}
+
+/**
+ * Builds the vocabulary from plain data. Takes no database handle so it stays
+ * testable and so signals remain pure; the loader lives in persistence.ts.
+ */
+export function buildSurnameVocabulary(input: VocabularyInput): SurnameVocabulary {
+  // Layer 1: communes, weighted by population.
+  const communePopulation = new Map<string, number>();
+  for (const c of input.communes) {
+    const key = normalizeForMatching(c.name);
+    const pop = c.population ?? 0;
+    if (pop > (communePopulation.get(key) ?? 0)) communePopulation.set(key, pop);
+  }
+
+  // Layer 2: how often each token is borne as a given name versus a surname.
+  const asGivenName = new Map<string, number>();
+  const asSurname = new Map<string, number>();
+  const bump = (m: Map<string, number>, k: string) => m.set(k, (m.get(k) ?? 0) + 1);
+  for (const p of input.politicianNames) {
+    for (const t of normalizeForMatching(p.firstName).split(/\s+/)) if (t) bump(asGivenName, t);
+    for (const t of normalizeForMatching(p.lastName).split(/\s+/)) if (t) bump(asSurname, t);
+  }
+
+  // Layer 3: one pass over the corpus, counting each token's casing.
+  const casing = new Map<string, { lower: number; upper: number }>();
+  for (const doc of input.corpus) {
+    for (const m of deaccent(doc).matchAll(/[A-Za-z][A-Za-z']*/g)) {
+      const token = m[0];
+      const key = token.toLowerCase();
+      const entry = casing.get(key) ?? { lower: 0, upper: 0 };
+      const initial = token.charAt(0);
+      if (initial === initial.toLowerCase()) entry.lower++;
+      else entry.upper++;
+      casing.set(key, entry);
+    }
+  }
+
+  return {
+    lookup(normalizedSurname: string): SurnameAmbiguity | null {
+      const population = communePopulation.get(normalizedSurname) ?? 0;
+      if (population >= AMBIGUITY_RULES.minCommunePopulation) {
+        return {
+          kind: "MAJOR_COMMUNE",
+          detail: `commune de ${population.toLocaleString("fr-FR")} habitants`,
+        };
+      }
+
+      const given = asGivenName.get(normalizedSurname) ?? 0;
+      const surname = asSurname.get(normalizedSurname) ?? 0;
+      if (given >= AMBIGUITY_RULES.minGivenNameBearers && given + surname > 0) {
+        const ratio = given / (given + surname);
+        if (ratio >= AMBIGUITY_RULES.minGivenNameRatio) {
+          return {
+            kind: "GIVEN_NAME",
+            detail: `prénom pour ${given} élus contre ${surname} patronymes`,
+          };
+        }
+      }
+
+      if (isSingleToken(normalizedSurname)) {
+        const entry = casing.get(normalizedSurname);
+        if (entry) {
+          const total = entry.lower + entry.upper;
+          const rate = total > 0 ? entry.lower / total : 0;
+          if (total >= AMBIGUITY_RULES.minOccurrences && rate >= AMBIGUITY_RULES.minLowercaseRate) {
+            return {
+              kind: "COMMON_WORD",
+              detail: `en minuscule dans ${Math.round(rate * 100)}% de ses ${total} occurrences`,
+            };
+          }
+        }
+      }
+
+      return null;
+    },
+  };
+}
+
+/** A vocabulary that flags nothing. For callers that score without a corpus. */
+export const EMPTY_SURNAME_VOCABULARY: SurnameVocabulary = { lookup: () => null };

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -29,7 +29,8 @@ import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { extractDateFromUrl } from "@/lib/extract-date-from-url";
 import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
-import { loadCandidatePool } from "@/lib/affair-matching/persistence";
+import { loadCandidatePool, loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
+import type { SurnameVocabulary } from "@/lib/affair-matching/surname-ambiguity";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
 import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
@@ -303,9 +304,18 @@ export async function discoverAffairs(options?: {
   if (!wikidataOnly) {
     // Load the candidate pool once for the entire Wikipedia pass.
     // Building a Map avoids repeated array scans during per-politician lookups.
-    const candidatePool = await loadCandidatePool();
+    const [candidatePool, vocabulary] = await Promise.all([
+      loadCandidatePool(),
+      loadSurnameVocabulary(),
+    ]);
     const poolById = new Map<string, AffairCandidateRecord>(candidatePool.map((c) => [c.id, c]));
-    phase2Affairs = await runPhase2Wikipedia(politicians, phase1Affairs, stats, poolById);
+    phase2Affairs = await runPhase2Wikipedia(
+      politicians,
+      phase1Affairs,
+      stats,
+      poolById,
+      vocabulary
+    );
   }
 
   // Phase 3: Reconciliation
@@ -442,7 +452,8 @@ async function runPhase2Wikipedia(
   }>,
   phase1Affairs: DiscoveredAffair[],
   stats: DiscoverAffairsResult,
-  poolById: Map<string, AffairCandidateRecord>
+  poolById: Map<string, AffairCandidateRecord>,
+  vocabulary: SurnameVocabulary
 ): Promise<DiscoveredAffair[]> {
   const discovered: DiscoveredAffair[] = [];
   const phase1Keys = new Set(phase1Affairs.map((a) => `${a.politicianId}:${a.category}`));
@@ -496,7 +507,8 @@ async function runPhase2Wikipedia(
                 factsDate: extracted.factsDate ? new Date(extracted.factsDate) : null,
               },
             },
-            [candidate]
+            [candidate],
+            vocabulary
           );
 
           if (sanityCheck.judgment !== "SAME") {


### PR DESCRIPTION
Le bruit dominant du registre d'appariement n'est pas une erreur de jugement, c'est un
patronyme qui est aussi un mot du texte.

Le préfiltre propose tout token capitalisé de 4 caractères et plus. « Depuis 2019… »,
« Palais de Justice » et « Marine Le Pen » proposent donc un élu dont le patronyme est
Depuis, Justice ou Mariné. Sur les 1473 appariements par patronyme seul du registre, 25
patronymes en couvrent 337, et le premier d'entre eux est déclenché par un prénom.

Ce n'est pas qu'un encombrement de file. Ces lignes rapprochent un élu de la condamnation
d'un tiers :

```
« Hubert Christophe »  ← le texte parle de Christophe Ellul, un particulier
« David Nicolas »      ← le texte parle de Nicolas Naudet
« Sylvie Paris »       ← le texte parle de la ville
```

Le registre alimente la liaison décision→affaire. Tant que ça vit en interne personne
n'est lésé, mais c'est le matériau dont une publication erronée est faite, et il est
produit à raison de douze à dix-huit lignes par jour.

## Trois couches, aucune dépendance externe

`src/lib/affair-matching/surname-ambiguity.ts` répond à « ce token est-il un patronyme
plausible **ici** ? » à partir de données que le projet détient déjà.

| couche     | source                  | seuil                         | attrape                           |
| ---------- | ----------------------- | ----------------------------- | --------------------------------- |
| commune    | table `Commune` (INSEE) | population >= 20 000          | Paris, Toulouse, Marseille        |
| prénom     | 37 670 élus en base     | ratio >= 0,7, min. 5 porteurs | Marine, Pierre, Laurent, Nicolas  |
| mot commun | corpus du registre      | minuscules >= 30 %            | Justice, Cour, Juge, Deux, Depuis |

Les fichiers INSEE et les dictionnaires de prénoms existent en ligne. Un vocabulaire
mesuré sur notre propre corpus est mieux calibré aux textes que le résolveur traite
réellement, et ne rajoute pas une dépendance à tenir à jour.

## Deux formulations réfutées par la mesure

Elles sont documentées dans le module parce que ce sont les deux réflexes évidents.

**La fréquence documentaire tue « Le Pen ».** Il apparaît dans 18 % des documents du
registre. J'avais lu la séparation « bruit 21-29 % contre signal 0,3-4,3 % » comme une
propriété du vocabulaire ; c'en est une du corpus. Dans un registre d'affaires politiques,
la fréquence mesure la notoriété.

**L'appartenance à une commune tue « Cahuzac ».** 356 habitants. Et « François », 999. Une
large part des patronymes français dérivent de toponymes.

Ce qui sépare vraiment un mot d'un nom est la casse, parce qu'un mot commun n'est
capitalisé qu'en tête de phrase :

```
justice 76 %   cour 71 %   deux 90 %   juge 96 %   |   paris 2 %   le pen 0 %   sarkozy 0 %
```

Le seuil est insensible entre 20 % et 50 % : onze lignes d'écart sur 1473.

## Choix de conception

**Pénalité négative, pas disqualification.** Un candidat disqualifié est filtré du
classement par le combineur, donc sa raison n'atteint jamais la ligne persistée et le
modérateur ne peut plus distinguer un artefact d'un vrai inconnu. Une pénalité laisse la
trace lisible et reste révocable par la preuve : un candidat réellement lié par
`role-context` (+4,0) franchit encore `FLOOR_SCORE`, ce qui est le bon résultat pour
quelqu'un dont le patronyme est Pierre ou Marie.

**Seul le palier « patronyme seul » est jugé.** Au-dessus, le nom complet, un titre de
civilité ou la proximité du prénom ont déjà établi qu'il s'agit d'un nom. « Jean Paris »
garde `NAME_FULL_EXACT_LLR`.

**Seuils choisis du côté conservateur.** Perdre une vraie attribution fait disparaître une
affaire en silence ; garder du bruit coûte un clic. Le seuil de population passe de 1 000
à 20 000 pour dix lignes de rendement en moins, parce qu'à 1 000 il tuerait Boyer
(35 élus, commune de 725), Marie (26, 109) et Mathieu (28, 2331).

**Le vocabulaire est un paramètre obligatoire.** `AffairSignalContext.vocabulary` n'est pas
optionnel : le compilateur nomme ainsi chaque site d'appel qui scorerait sans lui, ce qui a
fait remonter les six appelants réels. Un champ optionnel aurait perdu le correctif en
silence dans le prochain appelant écrit.

**Chargé une fois par lot**, même contrat que `loadCandidatePool`. Les appelants en boucle
(`discover-affairs`, script de rescan) le hissent hors de leur boucle.

## Effet mesuré

Rejeu différentiel sur les 2134 décisions du registre : le même combineur deux fois, avec
et sans la pénalité.

```
UNDECIDED -> NO_MATCH    56
tout le reste             0
```

Les 56 sont toutes non revues, aucune n'est rattachée à une affaire. Aucune décision
`SAME` ne change, donc aucune fiche publiée n'est concernée.

Un premier rejeu annonçait 125 pertes de `SAME` dont deux fiches publiées. Il comparait au
jugement stocké, donc il appliquait aussi la garde nom-seul de #448 à des lignes
antérieures et créditait ce correctif de son effet. La règle du projet « ne jamais
soustraire deux mesures prises sous des règles différentes » vaut aussi dans ce sens.

## Portée

Le correctif ne vide pas la file. Une ligne « Depuis 2019, la justice enquête » existait en
`NO_MATCH` avec deux candidats bidons, elle existera en `NO_MATCH` avec zéro candidat.
Chaque ligne devient honnête, et c'est ce qui rend une passe assistée sûre ensuite : on
n'écarte pas automatiquement « candidat Justice » sans savoir pourquoi, on peut écarter
« tous les candidats rejetés comme artefacts de vocabulaire ».

Les lignes déjà en base gardent leurs scores. Le rejeu du backlog est une opération à part,
avec son propre rayon d'action.

**Limites connues** : `bruel` (Patrick Bruel le chanteur) et `french` échappent aux trois
couches. Une trentaine de lignes, laissées en découverte.

## Test plan

- 15 tests sur le vocabulaire, dont les deux listes qui comptent : ce qui doit être
  signalé (Paris, Marine, Justice, Cour, Juge, Depuis) et ce qui doit survivre (Mélenchon,
  Le Pen, Sarkozy, Cahuzac, Boyer, Marie, Mathieu, Thomas), chaque entrée de la seconde
  liste étant un nom qu'une formulation précédente tuait réellement
- 6 tests sur le signal : la pénalité s'applique au bon palier, jamais au nom complet ni au
  titre de civilité, la raison voyage dans l'explication, et la pénalité reste inférieure à
  un signal corroborant
- `npm run test:run` : 2971 passés
- `npx tsc` : 0 erreur, code de sortie 0, vérifié hors du cache incrémental et hors
  `.next/dev/types` dont les erreurs de syntaxe interrompaient la compilation avant les
  sources
- `npx eslint` sur les fichiers touchés : 0 erreur
- `npm run build` : code de sortie 0
- Rejeu différentiel contre la base réelle, chiffres ci-dessus

## Rollback

Aucune migration, aucune écriture. Revenir au commit précédent restaure le score
`NAME_SURNAME_ONLY_LLR` sur tous les paliers. Les décisions persistées entre-temps gardent
leur jugement ; rien ne les réécrit.
