### PR TITLE
Rendre la passe de tri assistée durable et atteindre les patronymes composés

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "storybook:build": "STORYBOOK_DISABLE_TELEMETRY=1 storybook build",
     "test": "vitest",
     "test:run": "vitest run",
+    "triage:matching": "tsx --env-file=.env scripts/triage-matching.ts",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
     "test:db:477": "bash scripts/test-db-477.sh",

--- a/scripts/triage-matching.ts
+++ b/scripts/triage-matching.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env tsx
+/**
+ * Assisted triage of the affair-matching review queue.
+ *
+ * Closes only the decisions whose every candidate rests on a surname the
+ * vocabulary flags as an ordinary word of the text. The rule itself lives in
+ * `src/lib/affair-matching/triage.ts` and is unit-tested there; this file is the
+ * database shell around it.
+ *
+ * Why it is versioned and committed rather than thrown away: the July pass ran
+ * from a script in `scripts/.local/` that was deleted afterwards, so the review
+ * capacity vanished with the file and the backlog grew straight back.
+ *
+ * What it cannot do: publish anything. It writes `reviewedBy = auto-triage-vN`,
+ * which `review-provenance` classifies as assisted, so the publish guard still
+ * demands a human before an affair goes public.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/triage-matching.ts                  # rapport, aucune écriture
+ *   npx tsx --env-file=.env scripts/triage-matching.ts --sample=20      # échantillon à relire
+ *   npx tsx --env-file=.env scripts/triage-matching.ts --apply
+ *   npx tsx --env-file=.env scripts/triage-matching.ts --revoke=auto-triage-v2
+ */
+import { db } from "@/lib/db";
+import { loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
+import {
+  classifyForTriage,
+  TRIAGE_VERSION,
+  KNOWN_TRIAGE_VERSIONS,
+  type TriageCandidate,
+  type TriageRow,
+} from "@/lib/affair-matching/triage";
+
+/** Postgres tolerates far more, but a bounded chunk keeps the statement readable in logs. */
+const CHUNK = 200;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const sampleArg = args.find((a) => a.startsWith("--sample="));
+  const revokeArg = args.find((a) => a.startsWith("--revoke="));
+  return {
+    apply: args.includes("--apply"),
+    sample: sampleArg ? Number(sampleArg.split("=")[1]) : 0,
+    revoke: revokeArg ? (revokeArg.split("=")[1] ?? "") : null,
+  };
+}
+
+function chunked<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+interface Eligible {
+  id: string;
+  previousJudgment: string;
+  reason: string;
+  who: string;
+  excerpt: string;
+}
+
+async function collect() {
+  const vocabulary = await loadSurnameVocabulary();
+
+  const rows = await db.affairPoliticianDecision.findMany({
+    where: { reviewedAt: null },
+    select: {
+      id: true,
+      judgment: true,
+      affairId: true,
+      resolverVersion: true,
+      topCandidates: true,
+      candidateText: true,
+    },
+  });
+
+  const candidateIds = new Set<string>();
+  for (const r of rows)
+    for (const c of (r.topCandidates as unknown as TriageCandidate[]) ?? [])
+      candidateIds.add(c.candidateId);
+
+  const politicians = await db.politician.findMany({
+    where: { id: { in: [...candidateIds] } },
+    select: { id: true, lastName: true, fullName: true },
+  });
+  const byId = new Map(politicians.map((p) => [p.id, p]));
+  const surnameOf = (id: string) => byId.get(id)?.lastName ?? null;
+
+  const eligible: Eligible[] = [];
+  const kept = new Map<string, number>();
+
+  for (const r of rows) {
+    const candidates = (r.topCandidates as unknown as TriageCandidate[]) ?? [];
+    const row: TriageRow = {
+      id: r.id,
+      judgment: r.judgment as string,
+      affairId: r.affairId,
+      resolverVersion: r.resolverVersion,
+      candidates,
+    };
+    const verdict = classifyForTriage(row, vocabulary, surnameOf);
+    if (verdict.kind === "KEEP") {
+      kept.set(verdict.reason, (kept.get(verdict.reason) ?? 0) + 1);
+      continue;
+    }
+    eligible.push({
+      id: r.id,
+      previousJudgment: row.judgment,
+      reason: verdict.reason,
+      who: candidates.map((c) => byId.get(c.candidateId)?.fullName ?? "?").join(", "),
+      excerpt: r.candidateText.replace(/\s+/g, " ").slice(0, 240),
+    });
+  }
+
+  return { total: rows.length, eligible, kept };
+}
+
+async function report() {
+  const { total, eligible, kept } = await collect();
+  const byJudgment = new Map<string, number>();
+  for (const e of eligible)
+    byJudgment.set(e.previousJudgment, (byJudgment.get(e.previousJudgment) ?? 0) + 1);
+
+  console.log(`File non revue : ${total} décisions`);
+  console.log(`Éligibles à la clôture hors périmètre : ${eligible.length}`);
+  for (const [j, n] of byJudgment) console.log(`  depuis ${j} : ${n}`);
+  console.log(`\nLaissées à l'humain : ${total - eligible.length}`);
+  for (const [reason, n] of [...kept.entries()].sort((a, b) => b[1] - a[1]))
+    console.log(`  ${String(n).padStart(5)}  ${reason}`);
+  return eligible;
+}
+
+async function showSample(size: number) {
+  const eligible = await report();
+  if (eligible.length === 0) return;
+
+  // Sampling is how this stays honest: an exhaustive re-read would defeat the
+  // purpose, but a random draw gives a real error rate on the batch.
+  const pool = [...eligible];
+  const drawn: Eligible[] = [];
+  const n = Math.min(size, pool.length);
+  for (let i = 0; i < n; i++) {
+    const idx = Math.floor(Math.random() * pool.length);
+    drawn.push(pool.splice(idx, 1)[0]!);
+  }
+
+  console.log(`\n=== ÉCHANTILLON DE ${n} SUR ${eligible.length} ===`);
+  console.log("Relire chaque entrée : une seule erreur sur vingt vaut 5 % sur le lot.\n");
+  for (const [i, e] of drawn.entries()) {
+    console.log(`${String(i + 1).padStart(3)}. [${e.previousJudgment}] ${e.who}`);
+    console.log(`     « ${e.excerpt} »\n`);
+  }
+}
+
+async function apply() {
+  const eligible = await report();
+  if (eligible.length === 0) {
+    console.log("\nRien à appliquer.");
+    return;
+  }
+
+  console.log(`\nApplication sur ${eligible.length} décisions, marqueur ${TRIAGE_VERSION}…`);
+  const reviewedAt = new Date();
+  let written = 0;
+
+  // Grouped by previous judgment so each updateMany carries identical data while
+  // the audit trail still records what each row came from, which is what makes
+  // --revoke able to put them back.
+  const groups = new Map<string, Eligible[]>();
+  for (const e of eligible) {
+    const g = groups.get(e.previousJudgment) ?? [];
+    g.push(e);
+    groups.set(e.previousJudgment, g);
+  }
+
+  for (const [previousJudgment, group] of groups) {
+    for (const batch of chunked(group, CHUNK)) {
+      const ids = batch.map((e) => e.id);
+      const result = await db.affairPoliticianDecision.updateMany({
+        // reviewedAt still null: never clobber a review a human made meanwhile.
+        where: { id: { in: ids }, reviewedAt: null },
+        data: {
+          judgment: "NOT_SAME",
+          chosenPoliticianId: null,
+          reviewedAt,
+          reviewedBy: TRIAGE_VERSION,
+          reviewAction: "REJECTED_OUT_OF_SCOPE",
+        },
+      });
+      written += result.count;
+
+      await db.auditLog.createMany({
+        data: batch.map((e) => ({
+          action: "UPDATE" as const,
+          entityType: "AffairPoliticianDecision",
+          entityId: e.id,
+          changes: {
+            action: "AFFAIR_DECISION_TRIAGE_OUT_OF_SCOPE",
+            version: TRIAGE_VERSION,
+            previousJudgment,
+            newJudgment: "NOT_SAME",
+            reason: e.reason,
+          },
+        })),
+      });
+    }
+    console.log(`  ${previousJudgment} → NOT_SAME : ${group.length}`);
+  }
+
+  console.log(`\n${written} décisions écrites.`);
+  if (written !== eligible.length) {
+    console.log(
+      `${eligible.length - written} ignorées : revues entre-temps, elles gardent la décision humaine.`
+    );
+  }
+  console.log(`Révoquer ce lot : --revoke=${TRIAGE_VERSION}`);
+}
+
+async function revoke(version: string) {
+  if (!(KNOWN_TRIAGE_VERSIONS as readonly string[]).includes(version)) {
+    console.error(
+      `Version inconnue : ${version}. Connues : ${KNOWN_TRIAGE_VERSIONS.join(", ")}.\n` +
+        `Refus plutôt que de vider un marqueur au hasard.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = await db.affairPoliticianDecision.findMany({
+    where: { reviewedBy: version },
+    select: { id: true },
+  });
+  if (rows.length === 0) {
+    console.log(`Aucune décision marquée ${version}.`);
+    return;
+  }
+
+  // The previous judgment lives in the audit trail, not on the row: restoring it
+  // is the whole reason apply() writes it there.
+  const logs = await db.auditLog.findMany({
+    where: {
+      entityType: "AffairPoliticianDecision",
+      entityId: { in: rows.map((r) => r.id) },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { entityId: true, changes: true },
+  });
+
+  const previousOf = new Map<string, string>();
+  for (const l of logs) {
+    const c = l.changes as { version?: string; previousJudgment?: string } | null;
+    if (c?.version === version && c.previousJudgment && !previousOf.has(l.entityId)) {
+      previousOf.set(l.entityId, c.previousJudgment);
+    }
+  }
+
+  const restorable = rows.filter((r) => previousOf.has(r.id));
+  console.log(`${rows.length} décisions marquées ${version}, ${restorable.length} restaurables.`);
+  if (restorable.length < rows.length) {
+    console.log(
+      `${rows.length - restorable.length} sans trace d'audit exploitable : laissées en l'état ` +
+        `plutôt que remises à un jugement deviné.`
+    );
+  }
+
+  const byPrevious = new Map<string, string[]>();
+  for (const r of restorable) {
+    const p = previousOf.get(r.id)!;
+    const list = byPrevious.get(p) ?? [];
+    list.push(r.id);
+    byPrevious.set(p, list);
+  }
+
+  for (const [previous, ids] of byPrevious) {
+    for (const batch of chunked(ids, CHUNK)) {
+      await db.affairPoliticianDecision.updateMany({
+        where: { id: { in: batch }, reviewedBy: version },
+        data: {
+          judgment: previous as "NO_MATCH" | "UNDECIDED",
+          reviewedAt: null,
+          reviewedBy: null,
+          reviewAction: null,
+        },
+      });
+    }
+    console.log(`  NOT_SAME → ${previous} : ${ids.length}`);
+  }
+}
+
+async function main() {
+  const { apply: shouldApply, sample, revoke: revokeVersion } = parseArgs();
+
+  if (revokeVersion !== null) await revoke(revokeVersion);
+  else if (shouldApply) await apply();
+  else if (sample > 0) await showSample(sample);
+  else {
+    await report();
+    console.log("\nAucune écriture. --sample=20 pour relire un échantillon, --apply pour écrire.");
+  }
+
+  await db.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await db.$disconnect();
+  process.exit(1);
+});

--- a/src/lib/affair-matching/__tests__/candidate-prefilter.test.ts
+++ b/src/lib/affair-matching/__tests__/candidate-prefilter.test.ts
@@ -69,4 +69,24 @@ describe("CandidatePrefilter", () => {
     const result = prefilter.filter("Aucun nom politique connu ici.");
     expect(result).toEqual([]);
   });
+
+  it("atteint un patronyme composé dont aucun mot ne passe le plancher de 4 caractères", () => {
+    // La régression qui a bloqué le tri assisté. « Le » fait deux caractères,
+    // « Pen » en fait trois, et la clé d'index est « le pen » : aucun token seul
+    // ne peut la produire. La condamnation la plus couverte du corpus proposait
+    // donc Benoît Mariné, sur le prénom « Marine », et jamais Marine Le Pen.
+    const pool = [politician("Le Pen", "lepen"), politician("Mariné", "marine")];
+    const prefilter = new CandidatePrefilter(pool);
+    const result = prefilter.filter(
+      "Condamnée par la cour d'appel de Paris, Marine Le Pen a annoncé se pourvoir en cassation."
+    );
+    expect(result.map((p) => p.id)).toContain("lepen");
+  });
+
+  it("n'invente pas de candidat quand les mots capitalisés ne forment aucun patronyme connu", () => {
+    const pool = [politician("Le Pen", "lepen")];
+    const prefilter = new CandidatePrefilter(pool);
+    const result = prefilter.filter("Le Tribunal Administratif a rendu sa décision.");
+    expect(result).toEqual([]);
+  });
 });

--- a/src/lib/affair-matching/__tests__/triage.test.ts
+++ b/src/lib/affair-matching/__tests__/triage.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { classifyForTriage, TRIAGE_VERSION, type TriageRow } from "../triage";
+import { RESOLVER_VERSION } from "../signals/constants";
+import type { SurnameVocabulary } from "../surname-ambiguity";
+import { HUMAN_REVIEWERS } from "@/lib/affairs/review-provenance";
+
+/** Flags exactly the surnames it is given, so the tests exercise triage, not the rules. */
+const vocabularyFlagging = (...surnames: string[]): SurnameVocabulary => ({
+  lookup: (s) => (surnames.includes(s) ? { kind: "COMMON_WORD", detail: "mesuré" } : null),
+});
+
+const surnames: Record<string, string> = {
+  "pol-paris": "Paris",
+  "pol-justice": "Justice",
+  "pol-melenchon": "Mélenchon",
+};
+const surnameOf = (id: string) => surnames[id] ?? null;
+
+function candidate(id: string, matchType: string | null, score = 1) {
+  return {
+    candidateId: id,
+    totalScore: score,
+    signals: [
+      {
+        signalId: "name-quality",
+        logLikelihoodRatio: score,
+        evidence: matchType ? { matchType } : null,
+      },
+    ],
+  };
+}
+
+function row(overrides: Partial<TriageRow> = {}): TriageRow {
+  return {
+    id: "dec-1",
+    judgment: "NO_MATCH",
+    affairId: null,
+    resolverVersion: RESOLVER_VERSION,
+    candidates: [candidate("pol-paris", "SURNAME_ONLY")],
+    ...overrides,
+  };
+}
+
+const vocab = vocabularyFlagging("paris", "justice");
+
+describe("classifyForTriage — ce qui se ferme", () => {
+  it("ferme une décision dont tous les candidats sont des artefacts", () => {
+    const verdict = classifyForTriage(
+      row({
+        candidates: [
+          candidate("pol-paris", "SURNAME_ONLY"),
+          candidate("pol-justice", "SURNAME_ONLY"),
+        ],
+      }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("OUT_OF_SCOPE");
+    expect(verdict.reason).toContain("2 candidats");
+  });
+
+  it("accepte les deux types d'appariement, avant et après la pénalité", () => {
+    // Les lignes scorées avant #615 portent SURNAME_ONLY, celles d'après
+    // SURNAME_ONLY_AMBIGUOUS. Les deux décrivent la même situation.
+    const verdict = classifyForTriage(
+      row({ candidates: [candidate("pol-paris", "SURNAME_ONLY_AMBIGUOUS")] }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("OUT_OF_SCOPE");
+  });
+
+  it("traite aussi les UNDECIDED, pas seulement les NO_MATCH", () => {
+    const verdict = classifyForTriage(row({ judgment: "UNDECIDED" }), vocab, surnameOf);
+    expect(verdict.kind).toBe("OUT_OF_SCOPE");
+  });
+});
+
+describe("classifyForTriage — ce qui reste à l'humain", () => {
+  it("garde une décision rattachée à une affaire", () => {
+    // Elle peut bloquer une publication : le panneau de #613 la traite depuis la fiche.
+    const verdict = classifyForTriage(row({ affairId: "aff-1" }), vocab, surnameOf);
+    expect(verdict.kind).toBe("KEEP");
+    expect(verdict.reason).toContain("affaire");
+  });
+
+  it("garde une décision sans aucun candidat", () => {
+    // File de découverte : le texte nomme peut-être un élu absent de la base.
+    const verdict = classifyForTriage(row({ candidates: [] }), vocab, surnameOf);
+    expect(verdict.kind).toBe("KEEP");
+    expect(verdict.reason).toContain("découverte");
+  });
+
+  it("garde dès qu'un seul candidat échappe au vocabulaire", () => {
+    const verdict = classifyForTriage(
+      row({
+        candidates: [
+          candidate("pol-paris", "SURNAME_ONLY"),
+          candidate("pol-melenchon", "SURNAME_ONLY"),
+        ],
+      }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("KEEP");
+    expect(verdict.reason).toContain("1 candidat");
+  });
+
+  it("garde un appariement sur nom complet, même si le patronyme est ambigu", () => {
+    // « Jean Paris » n'est pas la ville : le palier au-dessus a déjà tranché.
+    const verdict = classifyForTriage(
+      row({ candidates: [candidate("pol-paris", "FULL_EXACT", 5.2)] }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("KEEP");
+  });
+
+  it("garde un appariement par titre de civilité", () => {
+    const verdict = classifyForTriage(
+      row({ candidates: [candidate("pol-paris", "LEGAL_TITLE_SURNAME", 3.6)] }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("KEEP");
+  });
+
+  it("ne touche jamais un SAME", () => {
+    // Aucune confirmation automatique : la mesure n'a trouvé aucune décision en
+    // file portant un external-id, donc toute confirmation restante est un jugement.
+    const verdict = classifyForTriage(row({ judgment: "SAME" }), vocab, surnameOf);
+    expect(verdict.kind).toBe("KEEP");
+    expect(verdict.reason).toContain("SAME");
+  });
+
+  it("ne touche jamais un NOT_SAME déjà tranché", () => {
+    const verdict = classifyForTriage(row({ judgment: "NOT_SAME" }), vocab, surnameOf);
+    expect(verdict.kind).toBe("KEEP");
+  });
+
+  it("garde une décision dont le candidat est introuvable en base", () => {
+    const verdict = classifyForTriage(
+      row({ candidates: [candidate("pol-inconnu", "SURNAME_ONLY")] }),
+      vocab,
+      surnameOf
+    );
+    expect(verdict.kind).toBe("KEEP");
+  });
+});
+
+describe("classifyForTriage — garde de version du résolveur", () => {
+  it("refuse de trier une ligne scorée par un résolveur antérieur", () => {
+    // Le cas qui a bloqué la première version de cette passe : avant v2, le
+    // préfiltre ne pouvait pas atteindre « Le Pen », donc des textes sur sa
+    // condamnation n'avaient que des artefacts pour candidats. Les fermer aurait
+    // inscrit « hors périmètre » sur un échec de rappel.
+    const verdict = classifyForTriage(row({ resolverVersion: "v1" }), vocab, surnameOf);
+    expect(verdict.kind).toBe("KEEP");
+    expect(verdict.reason).toContain("re-résoudre");
+  });
+
+  it("trie une ligne scorée par le résolveur courant", () => {
+    const verdict = classifyForTriage(row({ resolverVersion: RESOLVER_VERSION }), vocab, surnameOf);
+    expect(verdict.kind).toBe("OUT_OF_SCOPE");
+  });
+});
+
+describe("TRIAGE_VERSION", () => {
+  it("n'est pas une identité humaine, donc la garde de publication continue d'exiger un humain", () => {
+    // L'invariant qui rend cette passe sûre : elle ne peut rien publier.
+    expect(HUMAN_REVIEWERS).not.toContain(TRIAGE_VERSION);
+  });
+
+  it("porte un numéro de version, pour qu'un lot entier reste révocable", () => {
+    expect(TRIAGE_VERSION).toMatch(/-v\d+$/);
+  });
+});

--- a/src/lib/affair-matching/candidate-prefilter.ts
+++ b/src/lib/affair-matching/candidate-prefilter.ts
@@ -21,10 +21,28 @@ export function normalizeText(text: string): string {
  * Returns normalized tokens for use as blocking keys.
  * Note: word boundaries (\b) don't work reliably with accented characters,
  * so we use a lookahead/lookbehind approach instead.
+ *
+ * Pairs of adjacent capitalized words are emitted too, because a compound
+ * surname is indexed under its whole normalized form. Without them the four
+ * character floor made « Le Pen » unreachable: "Le" is two characters, "Pen" is
+ * three, and no single token ever spells the key "le pen". The most covered
+ * conviction of the corpus proposed Benoît Mariné, on the first name « Marine »,
+ * and never Marine Le Pen. Measured cost of the pairs: 0.2 extra candidates per
+ * text, since a pair only matches when the compound surname appears verbatim.
  */
 export function extractSurnameCandidates(text: string): string[] {
   const matches = text.match(/(?:^|\s)[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']{3,}(?=\s|$|[^\w\-'])/g) ?? [];
-  return matches.map((m) => normalizeText(m.trim()));
+  const tokens = matches.map((m) => normalizeText(m.trim()));
+
+  const runs = text.match(/(?:[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']*)(?:\s+[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']*)+/g) ?? [];
+  for (const run of runs) {
+    const words = run.split(/\s+/);
+    for (let i = 0; i + 1 < words.length; i++) {
+      tokens.push(normalizeText(`${words[i]} ${words[i + 1]}`));
+    }
+  }
+
+  return tokens;
 }
 
 /**

--- a/src/lib/affair-matching/signals/constants.ts
+++ b/src/lib/affair-matching/signals/constants.ts
@@ -95,4 +95,10 @@ export const MIN_GAP = 2.0;
 // ============================================================================
 // Versioning
 // ============================================================================
-export const RESOLVER_VERSION = "v1";
+/**
+ * Bumped to v2 when the ambiguity vocabulary and the compound-surname pairs
+ * landed. Both change which candidates a text produces, so a v1 row and a v2 row
+ * are not comparable and must not be triaged by the same rule: assisted triage
+ * only touches rows scored by the current version.
+ */
+export const RESOLVER_VERSION = "v2";

--- a/src/lib/affair-matching/triage.ts
+++ b/src/lib/affair-matching/triage.ts
@@ -1,0 +1,150 @@
+/**
+ * Assisted triage of the affair-matching review queue.
+ *
+ * A single person cannot outpace twelve to eighteen new decisions a day, and the
+ * July pass proved the point in the worst way: it ran from a throwaway script
+ * that was deleted afterwards, so the capacity to review disappeared with the
+ * file and the backlog grew straight back. This module is the durable form of
+ * that pass, and it lives in src/ rather than in the script so its rule can be
+ * tested without a database.
+ *
+ * **One rule, deliberately.** Only decisions whose every candidate is a
+ * vocabulary artefact are resolved, and only out of scope. Nothing is ever
+ * auto-confirmed: the measurement found zero queued decisions carrying a
+ * deterministic external-id match, so every confirmation left in the queue is a
+ * judgment call and belongs to a human.
+ *
+ * Two rules from the July pass are known not to generalise and must not come
+ * back (see the project memory on triage):
+ *  - `name-quality < 3` would close real affairs. The French press names by bare
+ *    surname; that is the norm, not a weak signal.
+ *  - auto-rejecting on `role-context` or `context-plausibility` fires on former
+ *    office-holders and on EU contexts, so it discards genuine convictions.
+ */
+
+import type { SurnameVocabulary } from "./surname-ambiguity";
+import { normalizeForMatching } from "./surname-ambiguity";
+import { RESOLVER_VERSION } from "./signals/constants";
+
+/**
+ * Version marker written to `reviewedBy`. It is not in HUMAN_REVIEWERS, so
+ * `review-provenance` classifies it as assisted and the publish guard keeps
+ * asking for a human before anything goes public.
+ *
+ * The version is part of the marker on purpose: it makes a whole batch
+ * revocable by a single query when a rule turns out to be wrong. v1 was the
+ * July pass, written as the bare string `auto-triage`.
+ */
+export const TRIAGE_VERSION = "auto-triage-v2";
+
+/** Names the July pass used, kept so a revoke can still reach that batch. */
+export const KNOWN_TRIAGE_VERSIONS = ["auto-triage", "auto-triage-v2"] as const;
+
+export interface TriageSignal {
+  signalId: string;
+  logLikelihoodRatio: number;
+  evidence?: { matchType?: string } | null;
+}
+
+export interface TriageCandidate {
+  candidateId: string;
+  totalScore: number;
+  signals: TriageSignal[];
+}
+
+export interface TriageRow {
+  id: string;
+  judgment: string;
+  affairId: string | null;
+  resolverVersion: string;
+  candidates: TriageCandidate[];
+}
+
+export type TriageVerdict =
+  | { kind: "OUT_OF_SCOPE"; reason: string }
+  | { kind: "KEEP"; reason: string };
+
+/** Surname lookup for a candidate, resolved by the caller from the pool. */
+export type SurnameOf = (candidateId: string) => string | null;
+
+/** Judgments a decision may still be sitting in when triage looks at it. */
+const TRIAGEABLE_JUDGMENTS = new Set(["NO_MATCH", "UNDECIDED"]);
+
+/**
+ * A candidate whose only evidence is a surname that the vocabulary flags as an
+ * ordinary word of the text. Accepts both match types: rows scored before the
+ * penalty shipped carry SURNAME_ONLY, rows scored after carry
+ * SURNAME_ONLY_AMBIGUOUS, and both describe the same situation.
+ */
+function isVocabularyArtefact(
+  candidate: TriageCandidate,
+  vocabulary: SurnameVocabulary,
+  surnameOf: SurnameOf
+): boolean {
+  const surname = surnameOf(candidate.candidateId);
+  if (!surname) return false;
+
+  const nameQuality = candidate.signals.find((s) => s.signalId === "name-quality");
+  const matchType = nameQuality?.evidence?.matchType;
+  if (matchType !== "SURNAME_ONLY" && matchType !== "SURNAME_ONLY_AMBIGUOUS") return false;
+
+  return vocabulary.lookup(normalizeForMatching(surname)) !== null;
+}
+
+/**
+ * Decides whether a queued decision can be closed without a human reading it.
+ *
+ * Every guard below is a refusal, and each one is there because the opposite
+ * would be a silent loss: a real attribution dropped from the queue is never
+ * seen again, while noise left in it costs a click.
+ */
+export function classifyForTriage(
+  row: TriageRow,
+  vocabulary: SurnameVocabulary,
+  surnameOf: SurnameOf
+): TriageVerdict {
+  // The guard that makes this safe by construction rather than by documentation.
+  //
+  // A row scored before the current resolver carries a candidate list the current
+  // resolver would not produce. Closing it out of scope would record an editorial
+  // judgment about a text the resolver had not properly read: the pre-v2 sample
+  // was full of Marine Le Pen convictions whose only candidates were artefacts,
+  // because the four character floor made her surname unreachable. Those rows need
+  // re-resolving, not closing.
+  if (row.resolverVersion !== RESOLVER_VERSION) {
+    return {
+      kind: "KEEP",
+      reason: `scorée par ${row.resolverVersion}, à re-résoudre avant tout tri`,
+    };
+  }
+
+  if (!TRIAGEABLE_JUDGMENTS.has(row.judgment)) {
+    return { kind: "KEEP", reason: `jugement ${row.judgment} hors périmètre` };
+  }
+
+  // An attached decision can block a publication, so a person decides it. The
+  // panel added in #613 makes that a two-click job from the affair itself.
+  if (row.affairId !== null) {
+    return { kind: "KEEP", reason: "rattachée à une affaire" };
+  }
+
+  // No candidate at all is the discovery queue: the text may name a politician
+  // missing from the base. Telling that apart from a text about a private person
+  // means reading it.
+  if (row.candidates.length === 0) {
+    return { kind: "KEEP", reason: "aucun candidat, file de découverte" };
+  }
+
+  const artefacts = row.candidates.filter((c) => isVocabularyArtefact(c, vocabulary, surnameOf));
+  if (artefacts.length !== row.candidates.length) {
+    return {
+      kind: "KEEP",
+      reason: `${row.candidates.length - artefacts.length} candidat(s) hors vocabulaire`,
+    };
+  }
+
+  return {
+    kind: "OUT_OF_SCOPE",
+    reason: `les ${row.candidates.length} candidats tiennent à un patronyme ambigu`,
+  };
+}


### PR DESCRIPTION
La passe de triage de juillet tournait sur un script de `scripts/.local/` supprimé après
usage. La capacité de revue a disparu avec le fichier, et le backlog est reparti à la
hausse : 1903 décisions non revues pour une dernière revue humaine le 27 juillet.

Cette PR livre la forme durable de cette passe. Elle en livre aussi le préalable, que
l'échantillonnage a fait apparaître au moment de l'appliquer.

## Ce que l'échantillon a trouvé

La règle de tri retenue est étroite : fermer hors périmètre les décisions dont **tous** les
candidats tiennent à un patronyme que le vocabulaire de #615 signale comme un mot ordinaire
du texte. 380 lignes éligibles sur 1903, aucune rattachée à une affaire.

Un tirage de 20 avant d'écrire. Dix portaient sur la condamnation de Marine Le Pen :

```
[NO_MATCH] Dany Paris, Sylvie Paris, Christian Paris
  « Condamnée à trois ans de prison, dont un an ferme sous bracelet électronique, par la
    cour d'appel de Paris dans l'affaire des assistants parlementaires européens,
    Marine Le Pen a annoncé se pourvoir en cassation… »
```

Les candidats sont bien des artefacts. Le texte, lui, est parfaitement dans le périmètre.
Il manquait la bonne candidate, et pas par accident :

```
préfiltre sur ce texte → ["condamnee", "paris", "marine"]
```

L'extracteur exige un token capitalisé de 4 caractères. « Le » en fait 2, « Pen » en fait
3, et la clé d'index est `"le pen"`, avec une espace, qu'un extracteur de tokens simples
ne produira jamais. Le résolveur ne se contentait pas de proposer la mauvaise personne : il
était **structurellement incapable** de proposer la bonne. 435 élus sur 37 670 sont dans ce
cas, 377 au patronyme trop court et 58 composés dont le dernier mot l'est.

Fermer ces lignes en `REJECTED_OUT_OF_SCOPE` aurait inscrit au registre un jugement
éditorial faux sur la condamnation politique la plus couverte du corpus.

## Trois pièces

**Le préfiltre émet les paires de mots capitalisés adjacents.** Mesuré sur les 2134 textes
du registre : +404 candidats, dont **402 fois Marine Le Pen**, pour 0,2 candidat
supplémentaire par texte. Une paire ne se déclenche que si le patronyme composé apparaît
littéralement, donc le gain est en rappel sans coût en précision.

**`src/lib/affair-matching/triage.ts`** porte la règle, séparée du script parce qu'un
script qui se connecte à la production n'est pas testable. Chaque garde y est un refus, et
chacune est là parce que l'inverse serait une perte silencieuse : une vraie attribution
sortie de la file n'est jamais revue, alors que du bruit qui y reste coûte un clic.

| refus                         | raison                                                          |
| ----------------------------- | --------------------------------------------------------------- |
| `resolverVersion` différent   | la ligne n'a pas été lue par le résolveur courant               |
| rattachée à une affaire       | elle peut bloquer une publication, le panneau de #613 la traite |
| aucun candidat                | file de découverte, le texte nomme peut-être un élu absent      |
| un candidat hors vocabulaire  | il reste quelque chose à juger                                  |
| jugement `SAME` ou `NOT_SAME` | hors périmètre                                                  |

**`scripts/triage-matching.ts`**, versionné et committé, quatre modes : rapport sans
écriture par défaut, `--sample=N` pour relire un tirage avant de décider, `--apply`,
`--revoke=<version>`.

## Ce qui rend la passe sûre

**Elle ne peut rien publier.** Le marqueur `auto-triage-v2` n'est pas dans
`HUMAN_REVIEWERS`, donc `review-provenance` le classe en assisté et la garde de #614
continue d'exiger un humain avant toute publication. Un test le vérifie plutôt que de le
supposer.

**Elle ne confirme jamais rien.** La mesure n'a trouvé aucune décision en file portant un
`external-id` positif, donc toute confirmation restante est un jugement et revient à un
humain. Cette branche de conception n'existe pas dans le code.

**La garde de version est mécanique, pas documentaire.** `RESOLVER_VERSION` passe à `v2`
parce que le vocabulaire et les paires changent quels candidats un texte produit. Le tri
n'agit que sur les lignes scorées par la version courante, donc le cas Le Pen ne peut plus
se reproduire par simple oubli de séquencement.

**Un lot entier est révocable.** La version vit dans le marqueur, et `apply()` écrit le
jugement précédent dans le journal d'audit, ce dont `--revoke` se sert pour restaurer.
Une ligne sans trace exploitable est laissée en l'état plutôt que remise à un jugement
deviné.

**L'écriture ne piétine pas une revue humaine.** Le `updateMany` filtre encore sur
`reviewedAt: null`, et le rapport final dit combien de lignes ont été ignorées à ce titre.

## Effet aujourd'hui

```
File non revue : 1903 décisions
Éligibles à la clôture hors périmètre : 0
Laissées à l'humain : 1903
   1903  scorée par v1, à re-résoudre avant tout tri
```

**Cette PR ne vide pas la file, et c'est voulu.** Les lignes existantes gardent les
candidats que l'ancien résolveur leur a donnés ; les trier serait refaire l'erreur que
l'échantillon vient d'attraper. Le rejeu du backlog non revu est l'étape suivante, avec son
propre rayon d'action : ce sont des lignes sans décision humaine, donc un rescoring n'y
détruit rien, mais c'est une écriture sur 1903 lignes qui mérite sa propre revue.

Ce qui est acquis immédiatement, c'est le rappel : à partir de maintenant, un texte sur la
condamnation de Marine Le Pen la propose comme candidate.

## Test plan

- 15 tests sur la règle de tri, dont l'invariant porteur (`TRIAGE_VERSION` absent de
  `HUMAN_REVIEWERS`, donc la passe ne peut pas publier) et la garde de version
- 2 tests sur le préfiltre : « Le Pen » est atteint, et des mots capitalisés qui ne forment
  aucun patronyme connu n'inventent pas de candidat
- `npm run test:run` : 2988 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run build` : code de sortie 0
- Script exécuté contre la base réelle en mode rapport et en mode échantillon, aucune
  écriture

## Rollback

Aucune migration. Le script n'écrit que sur `--apply`, et `--revoke=auto-triage-v2` rend
un lot appliqué. Revenir au commit précédent restaure le plancher du préfiltre et
`RESOLVER_VERSION = v1` ; les décisions déjà écrites en v2 gardent leur marqueur, ce qui
les exclut du tri au lieu de les y exposer.
