### PR TITLE
Unifier le normaliseur du résolveur et rejouer le backlog

### DIFF
--- a/scripts/rescore-affair-decisions.ts
+++ b/scripts/rescore-affair-decisions.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env tsx
+/**
+ * Re-scores queued affair-matching decisions with the current resolver.
+ *
+ * Bumping RESOLVER_VERSION freezes the assisted triage: it only acts on rows the
+ * current resolver produced, so a backlog scored by an older version stays put
+ * forever unless something re-runs it. This is that something, and it is
+ * committed rather than thrown away for the same reason the triage script is.
+ *
+ * **The safety property is structural, not a filter to keep in sync.** The
+ * publish guard blocks on two paths: `affairId`, and orphan rows matched by
+ * `chosenPoliticianId` plus a `sourceRef` equal to one of the affair's source
+ * URLs. A row carrying neither field cannot be on either path, so re-scoring it
+ * cannot change what is publishable. Duplicating the guard's OR clause here
+ * would have worked today and drifted the first time the guard changed.
+ *
+ * That restriction also excludes every SAME row on its own, since a SAME always
+ * carries a chosen politician. What is left is exactly the noise queue.
+ *
+ * **Truncated texts.** `candidateText` keeps only the first 2000 characters, so
+ * more than half the backlog has lost its original text. Re-scoring those on
+ * less text than the first pass saw is still an improvement for a human reading
+ * the queue, but it must not feed automatic closure: they are written as
+ * `v2-partial`, which the triage version guard refuses without needing to know
+ * about this script.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/rescore-affair-decisions.ts              # rapport
+ *   npx tsx --env-file=.env scripts/rescore-affair-decisions.ts --sample=15
+ *   npx tsx --env-file=.env scripts/rescore-affair-decisions.ts --apply
+ *   npx tsx --env-file=.env scripts/rescore-affair-decisions.ts --apply --limit=100
+ */
+import { db } from "@/lib/db";
+import { scoreAffairAgainstCandidates } from "@/lib/affair-matching";
+import { loadCandidatePool, loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
+import { CandidatePrefilter } from "@/lib/affair-matching/candidate-prefilter";
+import { RESOLVER_VERSION } from "@/lib/affair-matching/signals/constants";
+import type { AffairScoringInput } from "@/lib/affair-matching/signals/types";
+import type { SourceType } from "@/generated/prisma";
+
+/** Marks a row re-scored on a text we know is incomplete. Never auto-triaged. */
+const PARTIAL_VERSION = `${RESOLVER_VERSION}-partial`;
+
+/** candidateText is stored as `text.slice(0, 2000)`. */
+const TEXT_STORAGE_LIMIT = 2000;
+
+/** Concurrent updates. Kept low: the connection pool is sized for lambdas. */
+const CONCURRENCY = 10;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const num = (prefix: string) => {
+    const a = args.find((x) => x.startsWith(prefix));
+    return a ? Number(a.split("=")[1]) : 0;
+  };
+  return { apply: args.includes("--apply"), sample: num("--sample="), limit: num("--limit=") };
+}
+
+interface Rescored {
+  id: string;
+  before: string;
+  after: string;
+  partial: boolean;
+  topCandidateId: string | null;
+  topScore: number;
+  gap: number;
+  topCandidates: unknown;
+  gained: string[];
+  excerpt: string;
+}
+
+async function compute(limit: number) {
+  const [pool, vocabulary] = await Promise.all([loadCandidatePool(), loadSurnameVocabulary()]);
+  const prefilter = new CandidatePrefilter(pool);
+  const byId = new Map(pool.map((p) => [p.id, p]));
+
+  const rows = await db.affairPoliticianDecision.findMany({
+    // Neither guard path can reach these, so nothing publishable moves.
+    where: {
+      reviewedAt: null,
+      affairId: null,
+      chosenPoliticianId: null,
+      resolverVersion: { notIn: [RESOLVER_VERSION, PARTIAL_VERSION] },
+    },
+    select: {
+      id: true,
+      judgment: true,
+      textHash: true,
+      candidateText: true,
+      metadata: true,
+      source: true,
+      sourceRef: true,
+      topCandidates: true,
+    },
+    orderBy: { createdAt: "asc" },
+    ...(limit > 0 ? { take: limit } : {}),
+  });
+
+  // One query for every blocklist entry that could apply, rather than one per row.
+  const blocked = await db.affairPoliticianDecision.findMany({
+    where: { textHash: { in: rows.map((r) => r.textHash) }, judgment: "NOT_SAME" },
+    select: { textHash: true, chosenPoliticianId: true },
+  });
+  const blocklist = new Map<string, Set<string>>();
+  for (const b of blocked) {
+    if (!b.chosenPoliticianId) continue;
+    const set = blocklist.get(b.textHash) ?? new Set<string>();
+    set.add(b.chosenPoliticianId);
+    blocklist.set(b.textHash, set);
+  }
+
+  const results: Rescored[] = [];
+
+  for (const row of rows) {
+    const meta = (row.metadata ?? {}) as Record<string, unknown>;
+    const input: AffairScoringInput = {
+      text: row.candidateText,
+      metadata: {
+        source: (meta.source as SourceType) ?? row.source,
+        sourceRef: (meta.sourceRef as string) ?? row.sourceRef,
+        factsDate: meta.factsDate ? new Date(meta.factsDate as string) : null,
+        verdictDate: meta.verdictDate ? new Date(meta.verdictDate as string) : null,
+        court: (meta.court as string) ?? null,
+        department: (meta.department as string) ?? null,
+        externalIds:
+          (meta.externalIds as AffairScoringInput["metadata"]["externalIds"]) ?? undefined,
+      },
+    };
+
+    const excluded = blocklist.get(row.textHash) ?? new Set<string>();
+    const candidates = prefilter.filter(input.text).filter((p) => !excluded.has(p.id));
+    const decision = scoreAffairAgainstCandidates(input, candidates, vocabulary);
+
+    const previousIds = new Set(
+      ((row.topCandidates as unknown as Array<{ candidateId: string }>) ?? []).map(
+        (c) => c.candidateId
+      )
+    );
+    const gained = decision.topCandidates
+      .filter((c) => !previousIds.has(c.candidateId))
+      .map((c) => byId.get(c.candidateId)?.fullName ?? c.candidateId);
+
+    results.push({
+      id: row.id,
+      before: row.judgment as string,
+      after: decision.judgment,
+      partial: row.candidateText.length >= TEXT_STORAGE_LIMIT,
+      topCandidateId: decision.topCandidateId,
+      topScore: decision.topScore,
+      gap: decision.gap,
+      topCandidates: decision.topCandidates,
+      gained,
+      excerpt: row.candidateText.replace(/\s+/g, " ").slice(0, 200),
+    });
+  }
+
+  return results;
+}
+
+function report(results: Rescored[]) {
+  const transitions = new Map<string, number>();
+  const gainedNames = new Map<string, number>();
+  let partial = 0;
+  let becameSame = 0;
+
+  for (const r of results) {
+    if (r.after !== r.before)
+      transitions.set(
+        `${r.before} → ${r.after}`,
+        (transitions.get(`${r.before} → ${r.after}`) ?? 0) + 1
+      );
+    if (r.partial) partial++;
+    if (r.after === "SAME") becameSame++;
+    for (const n of r.gained) gainedNames.set(n, (gainedNames.get(n) ?? 0) + 1);
+  }
+
+  console.log(`${results.length} décisions à re-résoudre`);
+  console.log(`  texte intact  : ${results.length - partial} → ${RESOLVER_VERSION}`);
+  console.log(`  texte tronqué : ${partial} → ${PARTIAL_VERSION} (non triable automatiquement)`);
+
+  console.log(`\n=== TRANSITIONS ===`);
+  if (transitions.size === 0) console.log("  aucune");
+  for (const [k, n] of [...transitions.entries()].sort((a, b) => b[1] - a[1]))
+    console.log(`  ${k.padEnd(26)} ${n}`);
+  if (becameSame > 0) {
+    console.log(
+      `\n  ${becameSame} deviennent SAME et prendront un chosenPoliticianId : elles pourront`
+    );
+    console.log(`  bloquer une publication de plus, jamais une de moins.`);
+  }
+
+  console.log(`\n=== CANDIDATS NOUVELLEMENT ATTEINTS (top 15) ===`);
+  const top = [...gainedNames.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15);
+  if (top.length === 0) console.log("  aucun");
+  for (const [n, c] of top) console.log(`  ${String(c).padStart(4)}  ${n}`);
+}
+
+async function apply(results: Rescored[]) {
+  console.log(`\nÉcriture sur ${results.length} décisions…`);
+  let done = 0;
+
+  for (let i = 0; i < results.length; i += CONCURRENCY) {
+    const batch = results.slice(i, i + CONCURRENCY);
+    const written = await Promise.all(
+      batch.map((r) =>
+        // updateMany, not update: scoring 1423 rows takes long enough for a human
+        // to review one meanwhile, and only a filtered write re-asserts the three
+        // conditions that make this safe. An update by id would overwrite them.
+        db.affairPoliticianDecision.updateMany({
+          where: {
+            id: r.id,
+            reviewedAt: null,
+            affairId: null,
+            chosenPoliticianId: null,
+          },
+          data: {
+            judgment: r.after as "SAME" | "UNDECIDED" | "NO_MATCH",
+            topCandidates: r.topCandidates as never,
+            topScore: r.topScore,
+            gap: r.gap,
+            resolverVersion: r.partial ? PARTIAL_VERSION : RESOLVER_VERSION,
+            ...(r.after === "SAME" && r.topCandidateId
+              ? { chosenPoliticianId: r.topCandidateId }
+              : {}),
+          },
+        })
+      )
+    );
+    done += written.reduce((n, w) => n + w.count, 0);
+    const seen = Math.min(i + CONCURRENCY, results.length);
+    if (seen % 200 === 0 || seen === results.length) console.log(`  ${seen}/${results.length}`);
+  }
+
+  console.log(`\n${done} décisions re-résolues.`);
+  if (done !== results.length) {
+    console.log(
+      `${results.length - done} ignorées : touchées pendant le scoring, elles gardent leur état.`
+    );
+  }
+  console.log(`Trier ensuite : npm run triage:matching`);
+}
+
+async function main() {
+  const { apply: shouldApply, sample, limit } = parseArgs();
+  const results = await compute(limit);
+  report(results);
+
+  if (sample > 0) {
+    const pool = [...results];
+    const drawn: Rescored[] = [];
+    for (let i = 0; i < Math.min(sample, pool.length); i++)
+      drawn.push(pool.splice(Math.floor(Math.random() * pool.length), 1)[0]!);
+    console.log(`\n=== ÉCHANTILLON DE ${drawn.length} ===\n`);
+    for (const [i, r] of drawn.entries()) {
+      console.log(
+        `${String(i + 1).padStart(3)}. ${r.before} → ${r.after}${r.partial ? " (texte tronqué)" : ""}` +
+          `${r.gained.length ? `  nouveaux: ${r.gained.join(", ")}` : ""}`
+      );
+      console.log(`     « ${r.excerpt} »\n`);
+    }
+  }
+
+  if (shouldApply) await apply(results);
+  else console.log(`\nAucune écriture. --sample=15 pour relire, --apply pour écrire.`);
+
+  await db.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await db.$disconnect();
+  process.exit(1);
+});

--- a/scripts/triage-matching.ts
+++ b/scripts/triage-matching.ts
@@ -25,11 +25,13 @@ import { db } from "@/lib/db";
 import { loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
 import {
   classifyForTriage,
+  unproposedNames,
   TRIAGE_VERSION,
   KNOWN_TRIAGE_VERSIONS,
   type TriageCandidate,
   type TriageRow,
 } from "@/lib/affair-matching/triage";
+import { looseWords } from "@/lib/affair-matching/triage";
 
 /** Postgres tolerates far more, but a bounded chunk keeps the statement readable in logs. */
 const CHUNK = 200;
@@ -59,6 +61,10 @@ interface Eligible {
   excerpt: string;
 }
 
+interface Withheld extends Eligible {
+  named: string[];
+}
+
 async function collect() {
   const vocabulary = await loadSurnameVocabulary();
 
@@ -86,7 +92,22 @@ async function collect() {
   const byId = new Map(politicians.map((p) => [p.id, p]));
   const surnameOf = (id: string) => byId.get(id)?.lastName ?? null;
 
+  // Every known politician, not just the ones this text proposed: the check has
+  // to be able to disagree with the prefilter.
+  const allNames = await db.politician.findMany({ select: { id: true, fullName: true } });
+  const nameOf = new Map(allNames.map((p) => [p.id, p.fullName]));
+  const fullNameIndex = new Map<string, string[]>();
+  for (const p of allNames) {
+    const key = looseWords(p.fullName).join(" ");
+    if (key.split(" ").length < 2) continue;
+    const list = fullNameIndex.get(key) ?? [];
+    list.push(p.id);
+    fullNameIndex.set(key, list);
+  }
+  const maxNameWords = Math.max(2, ...[...fullNameIndex.keys()].map((k) => k.split(" ").length));
+
   const eligible: Eligible[] = [];
+  const withheld: Withheld[] = [];
   const kept = new Map<string, number>();
 
   for (const r of rows) {
@@ -103,20 +124,30 @@ async function collect() {
       kept.set(verdict.reason, (kept.get(verdict.reason) ?? 0) + 1);
       continue;
     }
-    eligible.push({
+    const entry: Eligible = {
       id: r.id,
       previousJudgment: row.judgment,
       reason: verdict.reason,
       who: candidates.map((c) => byId.get(c.candidateId)?.fullName ?? "?").join(", "),
       excerpt: r.candidateText.replace(/\s+/g, " ").slice(0, 240),
-    });
+    };
+
+    const named = unproposedNames(
+      r.candidateText,
+      new Set(candidates.map((c) => c.candidateId)),
+      fullNameIndex,
+      maxNameWords
+    ).map((id) => nameOf.get(id) ?? id);
+
+    if (named.length > 0) withheld.push({ ...entry, named });
+    else eligible.push(entry);
   }
 
-  return { total: rows.length, eligible, kept };
+  return { total: rows.length, eligible, withheld, kept };
 }
 
 async function report() {
-  const { total, eligible, kept } = await collect();
+  const { total, eligible, withheld, kept } = await collect();
   const byJudgment = new Map<string, number>();
   for (const e of eligible)
     byJudgment.set(e.previousJudgment, (byJudgment.get(e.previousJudgment) ?? 0) + 1);
@@ -124,6 +155,15 @@ async function report() {
   console.log(`File non revue : ${total} décisions`);
   console.log(`Éligibles à la clôture hors périmètre : ${eligible.length}`);
   for (const [j, n] of byJudgment) console.log(`  depuis ${j} : ${n}`);
+  if (withheld.length > 0) {
+    console.log(`\nRetirées du lot : ${withheld.length} nomment un élu qui n'est pas candidat`);
+    for (const w of withheld.slice(0, 10)) {
+      console.log(`  ${w.named.join(", ")}  (candidats: ${w.who || "aucun"})`);
+      console.log(`    « ${w.excerpt.slice(0, 130)} »`);
+    }
+    if (withheld.length > 10) console.log(`  … et ${withheld.length - 10} autres`);
+  }
+
   console.log(`\nLaissées à l'humain : ${total - eligible.length}`);
   for (const [reason, n] of [...kept.entries()].sort((a, b) => b[1] - a[1]))
     console.log(`  ${String(n).padStart(5)}  ${reason}`);

--- a/src/lib/affair-matching/__tests__/candidate-prefilter.test.ts
+++ b/src/lib/affair-matching/__tests__/candidate-prefilter.test.ts
@@ -83,6 +83,17 @@ describe("CandidatePrefilter", () => {
     expect(result.map((p) => p.id)).toContain("lepen");
   });
 
+  it("atteint un patronyme malgré le possessif anglais", () => {
+    // Le corpus contient de la couverture anglophone de la politique française :
+    // « Marine Le Pen's appeal » produisait la clé « le pen's ».
+    const pool = [politician("Le Pen", "lepen")];
+    const prefilter = new CandidatePrefilter(pool);
+    const result = prefilter.filter(
+      "A ruling in Marine Le Pen's appeal could settle the question."
+    );
+    expect(result.map((p) => p.id)).toContain("lepen");
+  });
+
   it("n'invente pas de candidat quand les mots capitalisés ne forment aucun patronyme connu", () => {
     const pool = [politician("Le Pen", "lepen")];
     const prefilter = new CandidatePrefilter(pool);

--- a/src/lib/affair-matching/__tests__/signals/name-quality.test.ts
+++ b/src/lib/affair-matching/__tests__/signals/name-quality.test.ts
@@ -107,6 +107,44 @@ describe("NameQualitySignal", () => {
     expect(result.logLikelihoodRatio).toBe(NAME_LEGAL_TITLE_SURNAME_LLR);
   });
 
+  it("apparie un patronyme composé quel que soit le séparateur des deux côtés", () => {
+    // Le préfiltre proposait « Mayer Rossignol » sur un texte écrivant
+    // « Mayer-Rossignol », et ce signal le disqualifiait comme absent du texte.
+    // Rien ne plantait : le candidat disparaissait du classement.
+    const candidate = makeCandidate({
+      firstName: "Nicolas",
+      lastName: "Mayer Rossignol",
+      fullName: "Nicolas Mayer Rossignol",
+      normalizedLastName: "mayer rossignol",
+    });
+    const result = signal.evaluate(
+      makeInput("Le maire de Rouen, Nicolas Mayer-Rossignol, a déposé plainte."),
+      candidate,
+      context
+    );
+    expect(result.disqualified).toBeUndefined();
+    expect(result.logLikelihoodRatio).toBe(NAME_FULL_EXACT_LLR);
+  });
+
+  it("apparie malgré une espace insécable, que la typographie française sème partout", () => {
+    // Le texte stocké s'écrit « Marine Le\u00A0Pen\u00A0: 6 questions ». Le préfiltre
+    // tokenise avec \\s et proposait la candidate ; ce signal comparait « le pen »
+    // à « le\u00A0pen » et la disqualifiait comme absente du texte.
+    const candidate = makeCandidate({
+      firstName: "Marine",
+      lastName: "Le Pen",
+      fullName: "Marine Le Pen",
+      normalizedLastName: "le pen",
+    });
+    const result = signal.evaluate(
+      makeInput("Marine Le\u00A0Pen\u00A0: 6 questions sur un pourvoi en cassation."),
+      candidate,
+      context
+    );
+    expect(result.disqualified).toBeUndefined();
+    expect(result.logLikelihoodRatio).toBe(NAME_FULL_EXACT_LLR);
+  });
+
   it("disqualifies when the surname is too short", () => {
     const candidate = makeCandidate({
       lastName: "Do",

--- a/src/lib/affair-matching/__tests__/surname-ambiguity.test.ts
+++ b/src/lib/affair-matching/__tests__/surname-ambiguity.test.ts
@@ -63,8 +63,12 @@ describe("normalizeForMatching", () => {
     expect(normalizeForMatching("LE PEN")).toBe("le pen");
   });
 
-  it("conserve le trait d'union, contrairement au préfiltre", () => {
-    expect(normalizeForMatching("Dupond-Moretti")).toBe("dupond-moretti");
+  it("ramène le trait d'union à une espace, comme tout le reste du dépôt", () => {
+    // Le décalage qui a fait disparaître Nicolas Mayer-Rossignol : le préfiltre
+    // le proposait sur la clé « mayer rossignol », name-quality cherchait
+    // « mayer-rossignol » dans le texte et le disqualifiait comme absent.
+    expect(normalizeForMatching("Dupond-Moretti")).toBe("dupond moretti");
+    expect(normalizeForMatching("Mayer-Rossignol")).toBe(normalizeForMatching("Mayer Rossignol"));
   });
 });
 

--- a/src/lib/affair-matching/__tests__/triage.test.ts
+++ b/src/lib/affair-matching/__tests__/triage.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { classifyForTriage, TRIAGE_VERSION, type TriageRow } from "../triage";
+import {
+  classifyForTriage,
+  unproposedNames,
+  looseWords,
+  TRIAGE_VERSION,
+  type TriageRow,
+} from "../triage";
 import { RESOLVER_VERSION } from "../signals/constants";
 import type { SurnameVocabulary } from "../surname-ambiguity";
 import { HUMAN_REVIEWERS } from "@/lib/affairs/review-provenance";
@@ -173,5 +179,53 @@ describe("TRIAGE_VERSION", () => {
 
   it("porte un numéro de version, pour qu'un lot entier reste révocable", () => {
     expect(TRIAGE_VERSION).toMatch(/-v\d+$/);
+  });
+});
+
+describe("unproposedNames — le contrôle qui n'écoute pas le résolveur", () => {
+  const index = new Map<string, string[]>([
+    ["marine le pen", ["lepen"]],
+    ["jean luc melenchon", ["jlm"]],
+  ]);
+
+  it("repère un élu nommé en toutes lettres qui n'est pas candidat", () => {
+    // Le cas réel : un texte anglophone, « Marine Le Pen's appeal », dont le seul
+    // candidat était Benoît Mariné. Trois correctifs de normalisation successifs
+    // avaient chacun l'air d'être le dernier.
+    const found = unproposedNames(
+      "A ruling in Marine Le Pen's appeal could settle the question.",
+      new Set(["autre"]),
+      index,
+      3
+    );
+    expect(found).toEqual(["lepen"]);
+  });
+
+  it("se tait quand l'élu nommé est déjà candidat", () => {
+    const found = unproposedNames("Marine Le Pen a été condamnée.", new Set(["lepen"]), index, 3);
+    expect(found).toEqual([]);
+  });
+
+  it("ignore traits d'union, insécables et ponctuation", () => {
+    const found = unproposedNames("Jean-Luc\u00A0Mélenchon, visé.", new Set(), index, 3);
+    expect(found).toEqual(["jlm"]);
+  });
+
+  it("n'exige pas de patronyme seul, seulement un nom complet", () => {
+    // Un patronyme nu est ce que le vocabulaire juge déjà ; ce contrôle ne parle
+    // que de preuve non ambiguë.
+    expect(unproposedNames("Le Pen était présente.", new Set(), index, 3)).toEqual([]);
+  });
+});
+
+describe("looseWords", () => {
+  it("réduit à des mots de lettres et chiffres", () => {
+    expect(looseWords("L'« Affaire » Dupond-Moretti : 2026")).toEqual([
+      "l",
+      "affaire",
+      "dupond",
+      "moretti",
+      "2026",
+    ]);
   });
 });

--- a/src/lib/affair-matching/candidate-prefilter.ts
+++ b/src/lib/affair-matching/candidate-prefilter.ts
@@ -1,18 +1,16 @@
 import type { AffairCandidateRecord } from "./signals/types";
+import { normalizeForMatching } from "./normalize";
+
+/** @deprecated Importer `normalizeForMatching` depuis ./normalize. Conservé pour les appelants existants. */
+export const normalizeText = normalizeForMatching;
 
 /**
- * Normalizes text by lowercasing, stripping accents, and normalizing dashes.
- * Shared with the identity resolver's `normalizeText` in `src/lib/name-matching.ts`
- * but kept local here to avoid importing server-only modules into signals.
+ * Drops an English possessive so « Marine Le Pen's appeal » still yields the key
+ * "le pen". The corpus carries English-language coverage of French politics, and
+ * the suffix rode along with the token, turning the surname into "le pen's".
  */
-export function normalizeText(text: string): string {
-  return text
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[-–—]/g, " ")
-    .trim();
+function stripPossessive(token: string): string {
+  return token.replace(/'s$/, "");
 }
 
 /**
@@ -32,13 +30,13 @@ export function normalizeText(text: string): string {
  */
 export function extractSurnameCandidates(text: string): string[] {
   const matches = text.match(/(?:^|\s)[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']{3,}(?=\s|$|[^\w\-'])/g) ?? [];
-  const tokens = matches.map((m) => normalizeText(m.trim()));
+  const tokens = matches.map((m) => stripPossessive(normalizeText(m.trim())));
 
   const runs = text.match(/(?:[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']*)(?:\s+[A-ZÀ-ÿ][a-zA-ZÀ-ÿ\-']*)+/g) ?? [];
   for (const run of runs) {
     const words = run.split(/\s+/);
     for (let i = 0; i + 1 < words.length; i++) {
-      tokens.push(normalizeText(`${words[i]} ${words[i + 1]}`));
+      tokens.push(stripPossessive(normalizeText(`${words[i]} ${words[i + 1]}`)));
     }
   }
 

--- a/src/lib/affair-matching/normalize.ts
+++ b/src/lib/affair-matching/normalize.ts
@@ -1,0 +1,34 @@
+/**
+ * The single normalizer of the affair-matching module.
+ *
+ * It exists as its own file because two copies of it drifted and cost a real
+ * recall failure: the prefilter turned hyphens into spaces, the name-quality
+ * signal did not. The prefilter proposed « Mayer Rossignol » on a text spelling
+ * it « Mayer-Rossignol », and name-quality then disqualified the candidate as
+ * "surname not present in text". Nothing threw, nothing scored low, the
+ * candidate simply vanished, and 1835 politicians carry a compound surname.
+ *
+ * Semantics match `src/lib/name-matching.ts::normalizeText`, the project-wide
+ * normalizer used by the identity resolver, the candidature importer and the
+ * mention blocklist. The affair-matching module keeps a local copy rather than
+ * importing that one, which pulls in server-only dependencies signals must not
+ * see, but the behaviour is deliberately identical.
+ */
+export function normalizeForMatching(text: string): string {
+  return (
+    text
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+      .replace(/[‘’]/g, "'")
+      .replace(/[-–—]/g, " ")
+      // Any run of whitespace becomes one plain space. French typography puts a
+      // non-breaking space before « : » and inside names, so a press text spells
+      // « Le Pen » while the base holds « Le Pen ». The prefilter tokenizes with
+      // \s and never noticed; this function compared the two literally and declared
+      // the surname absent. One deliberate divergence from
+      // `src/lib/name-matching.ts::normalizeText`, which does not collapse.
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}

--- a/src/lib/affair-matching/signals/constants.ts
+++ b/src/lib/affair-matching/signals/constants.ts
@@ -96,9 +96,14 @@ export const MIN_GAP = 2.0;
 // Versioning
 // ============================================================================
 /**
- * Bumped to v2 when the ambiguity vocabulary and the compound-surname pairs
- * landed. Both change which candidates a text produces, so a v1 row and a v2 row
- * are not comparable and must not be triaged by the same rule: assisted triage
- * only touches rows scored by the current version.
+ * Bumped whenever a change alters which candidates a text produces, so rows
+ * scored under different versions are never triaged by the same rule: assisted
+ * triage only touches rows carrying the current version.
+ *
+ * v2 added the ambiguity vocabulary and the compound-surname pairs. v3 and v4
+ * unified the module on one normalizer: hyphens, then any run of whitespace,
+ * which recovers compound surnames the press spells with a hyphen or a
+ * non-breaking space while the base holds a plain one. v5 drops the English
+ * possessive, which glued itself to the surname in anglophone coverage.
  */
-export const RESOLVER_VERSION = "v2";
+export const RESOLVER_VERSION = "v5";

--- a/src/lib/affair-matching/surname-ambiguity.ts
+++ b/src/lib/affair-matching/surname-ambiguity.ts
@@ -26,16 +26,10 @@
  * 0% for "le pen", against 71% for "cour" and 96% for "juge".
  */
 
-/**
- * Normalizes a name or token for case- and accent-insensitive comparison.
- *
- * Shared with the name-quality signal on purpose: the vocabulary is keyed by the
- * normalized surname, so the two must agree exactly or every lookup misses in
- * silence.
- */
-export function normalizeForMatching(s: string): string {
-  return s.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "").replace(/[‘’]/g, "'").trim();
-}
+import { normalizeForMatching } from "./normalize";
+
+/** Re-exported so callers of the vocabulary key it with the same function. */
+export { normalizeForMatching };
 
 /** Why a surname is not usable as the sole evidence of a match. */
 export type SurnameAmbiguity =

--- a/src/lib/affair-matching/triage.ts
+++ b/src/lib/affair-matching/triage.ts
@@ -148,3 +148,50 @@ export function classifyForTriage(
     reason: `les ${row.candidates.length} candidats tiennent à un patronyme ambigu`,
   };
 }
+
+/**
+ * Letters and digits only, single-spaced. Deliberately looser than the resolver's
+ * normalizer: this check exists to disagree with the pipeline, so it must not
+ * reuse the tokenizing decisions the pipeline made.
+ */
+export function looseWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+}
+
+/**
+ * Names a text mentions in full that are not among its candidates.
+ *
+ * The last line of defence before closing a row, and the one that earns its
+ * keep: it reads the text against the whole name index instead of trusting the
+ * prefilter, so it catches a blind spot without having to know which one. It
+ * found « Marine Le Pen's appeal » after three separate normalizer fixes had
+ * each looked like the last.
+ *
+ * A hit does not mean the row is wrong, only that a person should look. Callers
+ * drop the row from the batch rather than failing the batch, so a false positive
+ * costs one line instead of the whole pass.
+ */
+export function unproposedNames(
+  text: string,
+  candidateIds: ReadonlySet<string>,
+  fullNameIndex: ReadonlyMap<string, readonly string[]>,
+  maxWords: number
+): string[] {
+  const words = looseWords(text);
+  const found = new Set<string>();
+  for (let n = 2; n <= maxWords; n++) {
+    for (let i = 0; i + n <= words.length; i++) {
+      for (const id of fullNameIndex.get(words.slice(i, i + n).join(" ")) ?? []) {
+        if (!candidateIds.has(id)) found.add(id);
+      }
+    }
+  }
+  return [...found];
+}


### PR DESCRIPTION
Le rejeu du backlog devait être une opération mécanique : re-scorer les décisions en
attente avec le résolveur courant pour que le tri assisté de #616 puisse enfin agir. Il a
mis au jour trois défauts de la même famille, tous trouvés par échantillonnage, aucun
détectable par un test qui ne connaît pas déjà le cas.

## Le motif

Le module portait **trois copies du même normaliseur**, et elles divergeaient.

```
préfiltre        propose « mayer rossignol »   (trait d'union → espace)
name-quality     DISQUALIFIÉ « surname not present in text »
```

Rien ne plante, aucun score ne baisse : le candidat **disparaît du classement**, et une
absence ne se voit pas. Le tri conclut alors « aucun candidat valable » là où la lecture
juste est « nous n'avons pas su proposer le bon ».

| divergence                                 | ce qu'elle coûtait                                                       |
| ------------------------------------------ | ------------------------------------------------------------------------ |
| trait d'union converti d'un côté seulement | « Mayer-Rossignol » dans la presse, « Mayer Rossignol » en base          |
| espace insécable non réduite               | la typographie française en sème partout, « Le Pen » devenait « Le Pen » |
| possessif anglais collé au token           | « Marine Le Pen's appeal » donnait la clé « le pen's »                   |

`src/lib/affair-matching/normalize.ts` est désormais le seul normaliseur du module.
Sémantique alignée sur `src/lib/name-matching.ts::normalizeText`, avec une divergence
assumée et commentée : la réduction des espaces, que le normaliseur canonique ne fait pas.

## Le contrôle qui a trouvé le troisième

Après deux correctifs, j'ai cessé de chercher des cas à la main pour tester une propriété
sur tout le corpus : _si le préfiltre propose un candidat, `name-quality` ne doit pas le
déclarer absent du texte_. Première mesure, 2854 contradictions sur 67 019 propositions.

La plupart n'en étaient pas : le préfiltre indexe aussi un patronyme composé sous son
dernier mot, donc « Guillain De France » est proposé dès qu'un texte contient « France »,
et la disqualification est le pipeline qui fonctionne. En resserrant sur « le patronyme
complet **est** dans le texte », il reste **0** après correction.

Ce contrôle est maintenant dans le code, pas dans un script jetable. `unproposedNames()`
relit chaque ligne éligible contre l'index complet des noms, sans passer par le préfiltre,
et **retire du lot** celles qui nomment un élu absent des candidats. Un filtre plutôt
qu'une barrière : un faux positif coûte une ligne, pas la passe entière.

## `scripts/rescore-affair-decisions.ts`

La contrepartie de la garde de version de #616, sans laquelle elle est un cul-de-sac.

**La sûreté est structurelle.** La garde de publication bloque par deux chemins,
`affairId` et le repli `chosenPoliticianId` + `sourceRef`. Une ligne qui ne porte ni l'un
ni l'autre n'est sur aucun des deux, donc la re-résoudre ne peut rien rendre publiable.
Dupliquer la clause `OR` de `checkPublishable` aurait marché aujourd'hui et dérivé au
premier changement de la garde. Cette restriction exclut d'elle-même toutes les `SAME`,
qui portent toujours un politicien choisi.

**Textes tronqués.** `candidateText` ne garde que 2000 caractères, et plus de la moitié du
backlog a perdu son texte d'origine. Les re-scorer sur moins de matière reste utile à un
humain qui relit la file, mais ne doit pas nourrir une fermeture automatique : ils partent
en `v5-partial`, que la garde de version refuse sans avoir à connaître ce script.

`updateMany` filtré plutôt qu'`update` par identifiant : scorer 1400 lignes prend assez de
temps pour qu'un humain en revoie une entre-temps.

## Ce qui a été exécuté sur la base

Cinq passes, parce que chaque correctif change les candidats produits et donc impose un
`RESOLVER_VERSION` neuf. C'est la doctrine de #616 qui fonctionne, pas un incident.

```
v2 → v3   1291 lignes    trait d'union
v3 → v4   1286 lignes    espace insécable
v4 → v5   1286 lignes    possessif anglais
```

Effet cumulé du rejeu, mesuré en différentiel :

|                                       |     |
| ------------------------------------- | --- |
| `UNDECIDED → NO_MATCH`                | 223 |
| `UNDECIDED → SAME`                    | 125 |
| `NO_MATCH → SAME`                     | 8   |
| lignes atteignant enfin Marine Le Pen | 242 |

Les promotions ne sont pas du bruit. Retirer les faux prétendants restaure l'écart que
`MIN_GAP` exigeait :

```
Marine Le Pen     6.2 / écart 1.0  →  9.7 / 6.2
Nicolas Naudet    3.0 / écart 0.0  →  12.7 / 9.7   (le texte qui proposait « David Nicolas »)
Robert Boulin     2e candidat « Christian Boulin » désormais à -2.5
```

Puis le tri assisté : **103 décisions fermées hors périmètre**, marqueur `auto-triage-v2`,
révocables en une commande. File non revue **1903 → 1800**.

Avant écriture, l'état des 1423 lignes a été figé hors du dépôt, et l'audit indépendant a
signalé une seule ligne sur 103 : un faux positif de l'audit lui-même (« Jean-Michel
Aulas » contient le nom d'un élu appelé Jean Michel), retirée du lot comme prévu.

## Ce qui reste

`480` lignes en `v1` et `137` en `v2`/`v3` gardent leur version : elles portent un
`chosenPoliticianId`, donc le rejeu les exclut par construction. Ce sont des `SAME` en
attente d'un humain, et le panneau de #613 les traite depuis la fiche.

`637` en `v5-partial` ne seront jamais fermées automatiquement, faute de texte complet.

Côté garde : 16 affaires bloquées par une décision non revue, dont 15 brouillons, contre 14
avant le rejeu. Un brouillon de plus, dans le sens qui protège.

## Test plan

- 6 tests sur `unproposedNames` et `looseWords`, dont le cas réel du possessif anglais
- 3 tests de régression sur `name-quality` : trait d'union, espace insécable, et le
  patronyme composé apparié quel que soit le séparateur des deux côtés
- 1 test sur le préfiltre pour le possessif
- `normalizeForMatching` teste désormais l'équivalence « Mayer-Rossignol » / « Mayer Rossignol »
- `npm run test:run` : 2996 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run build` : code de sortie 0
- Propriété vérifiée sur les 67 019 propositions du corpus réel : 0 contradiction entre
  préfiltre et `name-quality`

## Rollback

Aucune migration. Le lot de tri se révoque par
`npm run triage:matching -- --revoke=auto-triage-v2`, qui restaure le jugement précédent
depuis le journal d'audit. Le rejeu n'a pas d'inverse en ligne de commande, mais l'état
antérieur des 1423 lignes a été exporté avant la première écriture.
