### PR TITLE
Re-résoudre les décisions portant un politicien choisi

### DIFF
--- a/scripts/rescore-affair-decisions.ts
+++ b/scripts/rescore-affair-decisions.ts
@@ -53,11 +53,33 @@ function parseArgs() {
     const a = args.find((x) => x.startsWith(prefix));
     return a ? Number(a.split("=")[1]) : 0;
   };
-  return { apply: args.includes("--apply"), sample: num("--sample="), limit: num("--limit=") };
+  return {
+    apply: args.includes("--apply"),
+    sample: num("--sample="),
+    limit: num("--limit="),
+    includeChosen: args.includes("--include-chosen"),
+  };
+}
+
+/**
+ * Rows the widened mode refuses to write, with the affair they currently gate.
+ * Only DRAFT and PUBLISHED count: releasing a block on a REJECTED affair changes
+ * nothing, since publishing one means changing its status first, which runs the
+ * guard again from scratch.
+ */
+interface Withheld {
+  id: string;
+  affairTitle: string;
+  status: string;
+  who: string;
+  change: string;
 }
 
 interface Rescored {
   id: string;
+  /** State read at scoring time; re-asserted at write time as a concurrency check. */
+  expectAffairId: string | null;
+  expectChosenPoliticianId: string | null;
   before: string;
   after: string;
   partial: boolean;
@@ -69,18 +91,18 @@ interface Rescored {
   excerpt: string;
 }
 
-async function compute(limit: number) {
+async function compute(limit: number, includeChosen: boolean) {
   const [pool, vocabulary] = await Promise.all([loadCandidatePool(), loadSurnameVocabulary()]);
   const prefilter = new CandidatePrefilter(pool);
   const byId = new Map(pool.map((p) => [p.id, p]));
 
   const rows = await db.affairPoliticianDecision.findMany({
-    // Neither guard path can reach these, so nothing publishable moves.
     where: {
       reviewedAt: null,
-      affairId: null,
-      chosenPoliticianId: null,
       resolverVersion: { notIn: [RESOLVER_VERSION, PARTIAL_VERSION] },
+      // Default scope: neither guard path can reach these rows. The widened mode
+      // gives that up and buys the safety back per row, below.
+      ...(includeChosen ? {} : { affairId: null, chosenPoliticianId: null }),
     },
     select: {
       id: true,
@@ -91,6 +113,8 @@ async function compute(limit: number) {
       source: true,
       sourceRef: true,
       topCandidates: true,
+      affairId: true,
+      chosenPoliticianId: true,
     },
     orderBy: { createdAt: "asc" },
     ...(limit > 0 ? { take: limit } : {}),
@@ -109,7 +133,45 @@ async function compute(limit: number) {
     blocklist.set(b.textHash, set);
   }
 
+  // Which live affair, if any, each row currently gates. Mirrors the two paths of
+  // checkPublishable, but only to DECIDE WHAT TO SKIP; the real guard is called
+  // afterwards as the oracle, so a drift here withholds too much, never too little.
+  const gating = new Map<string, { title: string; status: string }>();
+  if (includeChosen) {
+    const live = await db.affair.findMany({
+      where: { publicationStatus: { in: ["DRAFT", "PUBLISHED"] } },
+      select: {
+        id: true,
+        title: true,
+        politicianId: true,
+        publicationStatus: true,
+        sources: { select: { url: true } },
+      },
+    });
+    const byUrlAndPolitician = new Map<string, { title: string; status: string }>();
+    const byAffairId = new Map<string, { title: string; status: string }>();
+    for (const a of live) {
+      byAffairId.set(a.id, { title: a.title, status: a.publicationStatus });
+      for (const src of a.sources) {
+        if (src.url.length > 0)
+          byUrlAndPolitician.set(`${a.politicianId}::${src.url}`, {
+            title: a.title,
+            status: a.publicationStatus,
+          });
+      }
+    }
+    for (const r of rows) {
+      const direct = r.affairId ? byAffairId.get(r.affairId) : undefined;
+      const fallback = r.chosenPoliticianId
+        ? byUrlAndPolitician.get(`${r.chosenPoliticianId}::${r.sourceRef}`)
+        : undefined;
+      const hit = direct ?? fallback;
+      if (hit) gating.set(r.id, hit);
+    }
+  }
+
   const results: Rescored[] = [];
+  const withheld: Withheld[] = [];
 
   for (const row of rows) {
     const meta = (row.metadata ?? {}) as Record<string, unknown>;
@@ -140,8 +202,32 @@ async function compute(limit: number) {
       .filter((c) => !previousIds.has(c.candidateId))
       .map((c) => byId.get(c.candidateId)?.fullName ?? c.candidateId);
 
+    // A row that gates a live affair only gets written when nothing the guard
+    // reads would change: same judgment class, same politician. The reverse case,
+    // a row that would START gating one, is deliberately not withheld: blocking
+    // more is the safe direction, and the post-write guard snapshot names them.
+    const gated = gating.get(row.id);
+    if (gated) {
+      const stillBlocks = decision.judgment === "SAME" || decision.judgment === "UNDECIDED";
+      const samePolitician = decision.topCandidateId === row.chosenPoliticianId;
+      if (!stillBlocks || !samePolitician) {
+        withheld.push({
+          id: row.id,
+          affairTitle: gated.title,
+          status: gated.status,
+          who: byId.get(row.chosenPoliticianId ?? "")?.fullName ?? "?",
+          change: !samePolitician
+            ? `attribution → ${byId.get(decision.topCandidateId ?? "")?.fullName ?? "?"}`
+            : `${row.judgment} → ${decision.judgment}`,
+        });
+        continue;
+      }
+    }
+
     results.push({
       id: row.id,
+      expectAffairId: row.affairId,
+      expectChosenPoliticianId: row.chosenPoliticianId,
       before: row.judgment as string,
       after: decision.judgment,
       partial: row.candidateText.length >= TEXT_STORAGE_LIMIT,
@@ -154,7 +240,7 @@ async function compute(limit: number) {
     });
   }
 
-  return results;
+  return { results, withheld };
 }
 
 function report(results: Rescored[]) {
@@ -195,6 +281,34 @@ function report(results: Rescored[]) {
   for (const [n, c] of top) console.log(`  ${String(c).padStart(4)}  ${n}`);
 }
 
+/**
+ * Blocking state of every live affair, read through `checkPublishable` itself.
+ *
+ * The withholding filter above reimplements the guard's two paths to decide what
+ * to skip, and a reimplementation drifts. This calls the real thing before and
+ * after the write, so a drift shows up as an affair that changed state instead
+ * of passing unnoticed. Slow on purpose: correctness here is worth a minute.
+ */
+async function guardSnapshot(): Promise<
+  Map<string, { title: string; status: string; blocked: boolean }>
+> {
+  const { checkPublishable } = await import("@/lib/affairs/publish-guard");
+  const affairs = await db.affair.findMany({
+    where: { publicationStatus: { in: ["DRAFT", "PUBLISHED"] } },
+    select: { id: true, title: true, publicationStatus: true },
+  });
+  const out = new Map<string, { title: string; status: string; blocked: boolean }>();
+  for (const a of affairs) {
+    const reasons = await checkPublishable(a.id);
+    out.set(a.id, {
+      title: a.title,
+      status: a.publicationStatus,
+      blocked: reasons.some((r) => "decisionIds" in r),
+    });
+  }
+  return out;
+}
+
 async function apply(results: Rescored[]) {
   console.log(`\nÉcriture sur ${results.length} décisions…`);
   let done = 0;
@@ -207,11 +321,14 @@ async function apply(results: Rescored[]) {
         // to review one meanwhile, and only a filtered write re-asserts the three
         // conditions that make this safe. An update by id would overwrite them.
         db.affairPoliticianDecision.updateMany({
+          // Optimistic concurrency on the exact state that was scored, rather
+          // than on a scope constant: the widened mode reads rows that DO carry
+          // these fields, and hardcoding null silently wrote nothing at all.
           where: {
             id: r.id,
             reviewedAt: null,
-            affairId: null,
-            chosenPoliticianId: null,
+            affairId: r.expectAffairId,
+            chosenPoliticianId: r.expectChosenPoliticianId,
           },
           data: {
             judgment: r.after as "SAME" | "UNDECIDED" | "NO_MATCH",
@@ -234,16 +351,29 @@ async function apply(results: Rescored[]) {
   console.log(`\n${done} décisions re-résolues.`);
   if (done !== results.length) {
     console.log(
-      `${results.length - done} ignorées : touchées pendant le scoring, elles gardent leur état.`
+      `${results.length - done} non écrites : leur état a changé depuis le scoring, ou la ` +
+        `condition de re-vérification ne correspond plus. Rien n'a été forcé.`
     );
   }
   console.log(`Trier ensuite : npm run triage:matching`);
 }
 
 async function main() {
-  const { apply: shouldApply, sample, limit } = parseArgs();
-  const results = await compute(limit);
+  const { apply: shouldApply, sample, limit, includeChosen } = parseArgs();
+  const { results, withheld } = await compute(limit, includeChosen);
   report(results);
+
+  if (includeChosen) {
+    console.log(`\n=== MODE ÉTENDU : lignes portant un politicien choisi ou une affaire ===`);
+    console.log(
+      `${withheld.length} retirées du lot : elles gouvernent une affaire vivante et changeraient.`
+    );
+    for (const w of withheld)
+      console.log(
+        `  ${w.status.padEnd(9)} « ${w.affairTitle.slice(0, 58)} » — ${w.who} : ${w.change}`
+      );
+    if (withheld.length > 0) console.log(`  À trancher depuis la fiche, panneau de rattachement.`);
+  }
 
   if (sample > 0) {
     const pool = [...results];
@@ -260,8 +390,38 @@ async function main() {
     }
   }
 
-  if (shouldApply) await apply(results);
-  else console.log(`\nAucune écriture. --sample=15 pour relire, --apply pour écrire.`);
+  if (shouldApply) {
+    const before = includeChosen ? await guardSnapshot() : null;
+    await apply(results);
+    if (before) {
+      console.log(`\nVérification par la garde elle-même sur ${before.size} affaires vivantes…`);
+      const after = await guardSnapshot();
+      // Direction matters. Newly blocked is the safe outcome and the expected one
+      // when an attribution gets corrected onto the right affair. Newly unblocked
+      // is the failure this whole mode exists to prevent, so it is reported as one.
+      const released = [...before.entries()].filter(
+        ([id, b]) => b.blocked && after.get(id)?.blocked === false
+      );
+      const acquired = [...before.entries()].filter(
+        ([id, b]) => !b.blocked && after.get(id)?.blocked === true
+      );
+
+      if (released.length === 0) {
+        console.log(`  aucune affaire vivante n'a perdu de blocage. C'est l'invariant.`);
+      } else {
+        console.log(`  ÉCHEC : ${released.length} affaire(s) ne sont plus bloquées :`);
+        for (const [, b] of released) console.log(`    ${b.status} « ${b.title.slice(0, 58)} »`);
+      }
+
+      if (acquired.length > 0) {
+        console.log(
+          `\n  ${acquired.length} affaire(s) gagnent un blocage : une attribution corrigée les`
+        );
+        console.log(`  désigne enfin, et la garde demande la confirmation humaine correspondante.`);
+        for (const [, b] of acquired) console.log(`    ${b.status} « ${b.title.slice(0, 58)} »`);
+      }
+    }
+  } else console.log(`\nAucune écriture. --sample=15 pour relire, --apply pour écrire.`);
 
   await db.$disconnect();
 }


### PR DESCRIPTION
Les 480 décisions `SAME` restées en `v1` étaient le dernier bloc du backlog, et le seul que
le tableau de bord n'affiche pas : il ne montre que `UNDECIDED` et `NO_MATCH`. Le rejeu de
#617 les avait volontairement écartées parce qu'elles portent un `chosenPoliticianId` et
gouvernent donc la garde de publication.

Elles ne sont pas un problème de capacité de revue. **43 % d'entre elles ne tiennent plus.**

| ce que dit le résolveur courant           |     |
| ----------------------------------------- | --- |
| confirmées à l'identique                  | 251 |
| rétrogradées en `NO_MATCH` ou `UNDECIDED` | 208 |
| **attribuées à quelqu'un d'autre**        | 21  |

Les réattributions ne sont pas des cas limites :

```
Emmanuel Macron      → Marine Le Pen        texte sur les assistants parlementaires du RN
Emmanuel Macron      → François Asselineau  texte sur le président de l'UPR
Jérémie Patrier-Leitus → Charles Alloncle   ×5, textes nommant le rapporteur
Olivier Grima        → Laurent Bruneau      texte nommant le maire d'Agen
```

Et parmi les rétrogradations : « Affaire Jubillar » attribuée à Alexandre Martin à 9.7,
désormais -0.2. « Propos racistes envers Kylian Mbappé » attribuée à Emmanuel Macron.

## Le mode étendu

`--include-chosen` lève la restriction structurelle de #617 et rachète la sûreté ligne à
ligne, parce qu'il n'y a pas d'invariant gratuit disponible : par définition, chacune de
ces lignes porte un champ que la garde lit.

**Écarter plutôt que forcer.** Une ligne qui gouverne une affaire `DRAFT` ou `PUBLISHED` et
dont le jugement ou le politicien changerait n'est pas écrite. Sur 614 lignes, **3** :

```
DRAFT « Affaire Delphine Jubillar »              Jean Marc Escoutes → Gérard Pierre
DRAFT « Affaire Lyhanna : enlèvement, viol… »    Gérald Darmanin   → Francis Barella
DRAFT « Cyberattaques contre le RN et Le Pen »   Jean-Philippe Tanguy → Marine Le Pen
```

Les affaires `REJECTED` ne comptent pas : les publier suppose d'abord de changer leur
statut, ce qui relance la garde à zéro.

**La garde est son propre oracle.** Le filtre ci-dessus réimplémente les deux chemins de
`checkPublishable` pour décider quoi écarter, et une réimplémentation dérive. Le script
appelle donc la vraie fonction sur les 359 affaires vivantes avant et après écriture, et
compare. Une dérive du filtre apparaît comme une affaire qui a changé d'état, au lieu de
passer inaperçue.

**La direction compte.** Perdre un blocage est l'échec que ce mode existe pour empêcher.
En gagner un est le résultat sûr, et c'est ce qui s'est produit :

```
aucune affaire vivante n'a perdu de blocage. C'est l'invariant.

3 affaire(s) gagnent un blocage :
  PUBLISHED « Plainte pour prise illégale d'intérêts… »   ← Charles Alloncle
  PUBLISHED « Menaces de mort contre le maire d'Agen »     ← Laurent Bruneau
  PUBLISHED « Renvoi pour harcèlement sexuel… »            ← François Asselineau
```

Ce sont les trois attributions corrigées. Chaque texte nomme la bonne personne, l'affaire
publiée porte ce sujet, et la garde réclame désormais la confirmation humaine qui
manquait. Le blocage n'est pas un effet de bord : c'est le correctif qui devient visible.

## Une écriture silencieusement vide, attrapée par son propre compteur

Première exécution : `0 décisions re-résolues` sur 614. La condition de re-vérification de
l'écriture était figée sur le périmètre étroit de #617 :

```js
where: { id, reviewedAt: null, affairId: null, chosenPoliticianId: null }
```

En mode étendu, toutes les lignes portent justement l'un de ces champs, donc le filtre les
excluait toutes. Elle est remplacée par une vérification optimiste sur l'état réellement
lu au scoring (`affairId` et `chosenPoliticianId` attendus par ligne), ce qui fonctionne
dans les deux modes et détecte une modification concurrente.

Le compteur additionne `updateMany().count` plutôt que la taille du lot : c'est lui qui a
dit la vérité pendant que le message l'interprétait mal. Le message est corrigé aussi.

## Effet sur la base

```
614 lignes re-résolues (480 en v1 + 134 résiduelles en v2/v3)
  SAME → NO_MATCH    157
  SAME → UNDECIDED    53
  108 lignes atteignant enfin Marine Le Pen
```

File non revue, état final : `v5` 749, `v5-partial` 1048, `v1` 3 (les écartées).
Plus aucune décision ne traîne sous une version antérieure.

## Test plan

- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run test:run` : 2996 passés
- `npm run build` : code de sortie 0
- Exécuté sur la base réelle en mode rapport puis en écriture, avec vérification de la
  garde avant et après sur les 359 affaires vivantes

## Rollback

Aucune migration. Le rejeu n'a pas d'inverse en ligne de commande ; l'état antérieur des
lignes concernées vit dans l'export réalisé avant la première passe. Les trois lignes
écartées n'ont pas été touchées et se tranchent depuis la fiche, panneau de rattachement
de #613.
