### PR TITLE
Afficher les affaires bloquées plutôt que la taille du registre

### DIFF
--- a/src/app/admin/affair-matching/dashboard/__tests__/page.test.tsx
+++ b/src/app/admin/affair-matching/dashboard/__tests__/page.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "../page";
+
+/**
+ * The point of this page is that a moderator can tell, in one glance, what they
+ * have to do. These tests hold that promise in place: the actionable list comes
+ * first and names the fiche, and the big registry counters stay labelled as
+ * context rather than as a backlog.
+ */
+
+const STATS = {
+  pendingUndecided: 295,
+  pendingNoMatch: 1098,
+  last7Days: [{ source: "PRESS", judgment: "SAME", count: 4 }],
+};
+
+const BLOCKED = {
+  decisionCount: 3,
+  affairs: [
+    {
+      id: "aff_draft",
+      slug: "gymnase",
+      title: "Attribution controversée d'un gymnase",
+      publicationStatus: "DRAFT",
+      politicianName: "Laurent Wauquiez",
+      decisionIds: ["dec_1"],
+      messages: ["1 rattachement(s) automatique(s) jamais validé(s)"],
+      otherBlockers: [],
+    },
+    {
+      id: "aff_pub",
+      slug: "notes-de-frais",
+      title: "Notes de frais : saisine du procureur",
+      publicationStatus: "PUBLISHED",
+      politicianName: "Christian Estrosi",
+      decisionIds: ["dec_2", "dec_3"],
+      messages: ["2 rattachement(s) confirmé(s) par l'assistance automatique"],
+      otherBlockers: ["note d'implication manquante"],
+    },
+  ],
+};
+
+function mockFetch(blocked: unknown = BLOCKED, stats: unknown = STATS) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const body = url.includes("/blocked") ? blocked : stats;
+    return { ok: true, status: 200, json: async () => body } as Response;
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Tableau de bord — ce qu'il y a à trancher", () => {
+  it("annonce le nombre de rattachements et d'affaires concernées", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText(/3 rattachements sur 2 affaires/)).toBeInTheDocument();
+  });
+
+  it("sépare les brouillons des fiches déjà en ligne", async () => {
+    // Les deux ne disent pas la même chose : un brouillon ne sort pas, une fiche
+    // publiée est déjà sortie sur une attribution que personne n'a confirmée.
+    render(<DashboardPage />);
+    expect(
+      await screen.findByText(/Brouillons qui ne peuvent pas être publiés/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fiches en ligne dont l'attribution n'a jamais été validée/)
+    ).toBeInTheDocument();
+  });
+
+  it("pointe chaque affaire vers sa fiche, où le panneau tranche", async () => {
+    render(<DashboardPage />);
+    const link = await screen.findByRole("link", {
+      name: /Attribution controversée d'un gymnase/,
+    });
+    expect(link).toHaveAttribute("href", "/admin/affaires/aff_draft");
+  });
+
+  it("nomme les autres motifs de blocage au lieu de promettre une publication", async () => {
+    // Trancher le rattachement ne suffit pas si la note d'implication manque.
+    render(<DashboardPage />);
+    expect(await screen.findByText(/note d'implication manquante/)).toBeInTheDocument();
+  });
+
+  it("annonce l'état vide comme un objectif atteint, pas comme une absence de données", async () => {
+    vi.stubGlobal("fetch", mockFetch({ decisionCount: 0, affairs: [] }));
+    render(<DashboardPage />);
+    expect(await screen.findByText(/Aucune publication retenue/)).toBeInTheDocument();
+  });
+
+  it("survit à une panne de la liste sans emporter le reste de la page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes("/blocked")) return { ok: false, status: 500 } as Response;
+        return { ok: true, status: 200, json: async () => STATS } as Response;
+      })
+    );
+    render(<DashboardPage />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/indisponible/);
+    expect(await screen.findByText("295")).toBeInTheDocument();
+  });
+});
+
+describe("Tableau de bord — les compteurs restent du contexte", () => {
+  it("dit explicitement que les compteurs ne sont pas la charge de travail", async () => {
+    render(<DashboardPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/seules celles listées plus haut/)).toBeInTheDocument()
+    );
+  });
+
+  it("dit qu'un NO_MATCH ne bloque jamais une publication", async () => {
+    // Vrai par construction : la garde ne requête que SAME et UNDECIDED.
+    render(<DashboardPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/ne bloquent jamais une publication/)).toBeInTheDocument()
+    );
+  });
+});

--- a/src/app/admin/affair-matching/dashboard/page.tsx
+++ b/src/app/admin/affair-matching/dashboard/page.tsx
@@ -14,6 +14,22 @@ interface StatsResponse {
   last7Days: StatsRow[];
 }
 
+interface BlockedAffair {
+  id: string;
+  slug: string;
+  title: string;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  politicianName: string;
+  decisionIds: string[];
+  messages: string[];
+  otherBlockers: string[];
+}
+
+interface BlockedResponse {
+  affairs: BlockedAffair[];
+  decisionCount: number;
+}
+
 // ─── Constants ───────────────────────────────────────────────────
 
 const SOURCES = ["JUDILIBRE", "PRESS", "FACTCHECK", "MANUAL"];
@@ -33,6 +49,11 @@ export default function AffairMatchingDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Loaded separately: the blocking list calls the publish guard per affair, so
+  // it takes about a second and a half. The counters must not wait for it.
+  const [blocked, setBlocked] = useState<BlockedResponse | null>(null);
+  const [blockedError, setBlockedError] = useState<string | null>(null);
+
   useEffect(() => {
     (async () => {
       try {
@@ -43,6 +64,16 @@ export default function AffairMatchingDashboardPage() {
         setError((err as Error).message);
       } finally {
         setLoading(false);
+      }
+    })();
+
+    (async () => {
+      try {
+        const res = await fetch("/api/admin/affair-matching/blocked");
+        if (!res.ok) throw new Error(`Erreur ${res.status}`);
+        setBlocked(await res.json());
+      } catch (err) {
+        setBlockedError((err as Error).message);
       }
     })();
   }, []);
@@ -59,6 +90,8 @@ export default function AffairMatchingDashboardPage() {
         Vue d{"'"}ensemble des décisions de liaison affaire vers politicien.
       </p>
 
+      <BlockedSection data={blocked} error={blockedError} />
+
       {loading && <p className="text-muted-foreground">Chargement...</p>}
       {error && (
         <p className="text-destructive" role="alert">
@@ -68,26 +101,38 @@ export default function AffairMatchingDashboardPage() {
 
       {data && (
         <>
-          {/* Pending counters */}
-          <section className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-            <Link href="/admin/affair-matching/review?tab=UNDECIDED">
-              <Card className="hover:bg-muted/50 transition-colors cursor-pointer">
-                <CardContent className="pt-6">
-                  <p className="text-sm text-muted-foreground">En attente de revue</p>
-                  <p className="text-4xl font-bold mt-2">{data.pendingUndecided}</p>
-                  <p className="text-xs text-muted-foreground mt-1">décisions UNDECIDED</p>
-                </CardContent>
-              </Card>
-            </Link>
-            <Link href="/admin/affair-matching/review?tab=NO_MATCH">
-              <Card className="hover:bg-muted/50 transition-colors cursor-pointer">
-                <CardContent className="pt-6">
-                  <p className="text-sm text-muted-foreground">Sans candidat</p>
-                  <p className="text-4xl font-bold mt-2">{data.pendingNoMatch}</p>
-                  <p className="text-xs text-muted-foreground mt-1">décisions NO_MATCH</p>
-                </CardContent>
-              </Card>
-            </Link>
+          {/* Registry size. Context, not workload: kept small and labelled as such,
+              because two big counters here used to read as a backlog to clear. */}
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-1">Taille du registre</h2>
+            <p className="text-sm text-muted-foreground mb-3">
+              Ces décisions attendent une relecture, mais seules celles listées plus haut retiennent
+              une publication.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Link href="/admin/affair-matching/review?tab=UNDECIDED">
+                <Card className="hover:bg-muted/50 transition-colors cursor-pointer">
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-muted-foreground">Hésitations du résolveur</p>
+                    <p className="text-3xl font-bold mt-2 tabular-nums">{data.pendingUndecided}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      décisions UNDECIDED jamais relues
+                    </p>
+                  </CardContent>
+                </Card>
+              </Link>
+              <Link href="/admin/affair-matching/review?tab=NO_MATCH">
+                <Card className="hover:bg-muted/50 transition-colors cursor-pointer">
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-muted-foreground">Aucun candidat retenu</p>
+                    <p className="text-3xl font-bold mt-2 tabular-nums">{data.pendingNoMatch}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      décisions NO_MATCH, qui ne bloquent jamais une publication
+                    </p>
+                  </CardContent>
+                </Card>
+              </Link>
+            </div>
           </section>
 
           {/* Activity table */}
@@ -147,6 +192,115 @@ export default function AffairMatchingDashboardPage() {
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+// ─── Blocked affairs ─────────────────────────────────────────────
+
+/**
+ * The only part of this page that is a to-do list.
+ *
+ * Drafts and published fiches are separated because the two say different
+ * things: a draft cannot go out until its attribution is settled, while a
+ * published one is already out on an attribution nobody confirmed. Merging them
+ * under one count would hide the second, which is the more serious of the two.
+ */
+function BlockedSection({ data, error }: { data: BlockedResponse | null; error: string | null }) {
+  if (error) {
+    return (
+      <p className="text-destructive mb-8" role="alert">
+        Liste des affaires bloquées indisponible : {error}
+      </p>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-muted-foreground mb-8">Recherche des affaires bloquées...</p>;
+  }
+
+  if (data.affairs.length === 0) {
+    return (
+      <Card className="mb-8">
+        <CardContent className="pt-6">
+          <p className="font-medium">Aucune publication retenue.</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Toutes les attributions qui gouvernent une fiche vivante sont tranchées.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const drafts = data.affairs.filter((a) => a.publicationStatus === "DRAFT");
+  const published = data.affairs.filter((a) => a.publicationStatus === "PUBLISHED");
+
+  return (
+    <section className="mb-10">
+      <h2 className="text-lg font-semibold mb-1">
+        À trancher : {data.decisionCount} rattachement
+        {data.decisionCount > 1 ? "s" : ""} sur {data.affairs.length} affaire
+        {data.affairs.length > 1 ? "s" : ""}
+      </h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        Chaque fiche s{"'"}ouvre sur un panneau qui montre l{"'"}extrait de presse et les candidats.
+        Deux boutons par décision.
+      </p>
+
+      <BlockedGroup
+        title="Brouillons qui ne peuvent pas être publiés"
+        affairs={drafts}
+        emptyHint={null}
+      />
+      <BlockedGroup
+        title="Fiches en ligne dont l'attribution n'a jamais été validée"
+        affairs={published}
+        emptyHint={null}
+      />
+    </section>
+  );
+}
+
+function BlockedGroup({
+  title,
+  affairs,
+  emptyHint,
+}: {
+  title: string;
+  affairs: BlockedAffair[];
+  emptyHint: string | null;
+}) {
+  if (affairs.length === 0) return emptyHint ? <p className="text-sm">{emptyHint}</p> : null;
+
+  return (
+    <div className="mb-5">
+      <h3 className="text-sm font-medium text-muted-foreground mb-2">
+        {title} ({affairs.length})
+      </h3>
+      <Card>
+        <CardContent className="p-0">
+          <ul>
+            {affairs.map((a, i) => (
+              <li key={a.id} className={i < affairs.length - 1 ? "border-b" : undefined}>
+                <Link
+                  href={`/admin/affaires/${a.id}`}
+                  className="block px-4 py-3 hover:bg-muted/50 transition-colors"
+                >
+                  <p className="font-medium">{a.title}</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {a.politicianName} &bull; {a.messages.join(" ; ")}
+                  </p>
+                  {a.otherBlockers.length > 0 && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Bloquée aussi par : {a.otherBlockers.join(" ; ")}
+                    </p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/api/admin/affair-matching/blocked/route.ts
+++ b/src/app/api/admin/affair-matching/blocked/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { loadBlockedAffairs } from "@/lib/affairs/blocked-affairs";
+
+/**
+ * Separate from /stats on purpose: this one calls the publish guard once per
+ * candidate affair, so it costs about a second and a half. The counters render
+ * immediately and this list fills in behind them.
+ */
+export const GET = withAdminAuth(async () => {
+  const affairs = await loadBlockedAffairs();
+  // Distinct, not summed: one orphan decision can hold up two affairs through the
+  // guard's fallback path, and counting it twice would overstate the work.
+  const distinct = new Set(affairs.flatMap((a) => a.decisionIds));
+  return NextResponse.json({ affairs, decisionCount: distinct.size });
+});

--- a/src/lib/affairs/blocked-affairs.ts
+++ b/src/lib/affairs/blocked-affairs.ts
@@ -1,0 +1,136 @@
+import { db } from "@/lib/db";
+import { checkPublishable, type PublishBlockReason } from "@/lib/affairs/publish-guard";
+import type { PublicationStatus } from "@/generated/prisma";
+
+/**
+ * Which affairs a moderator actually has to unblock.
+ *
+ * The dashboard used to show two counters, « en attente de revue » and « sans
+ * candidat », and neither answers the only question that matters: what do I have
+ * to do today? Measured on the live base, 1800 unreviewed decisions came down to
+ * 26 that hold up a publication. A counter that large reads as a wall and hides
+ * the work behind it.
+ *
+ * **The guard is the authority, not this file.** A cheap query narrows the field
+ * to affairs a decision could plausibly reach, then `checkPublishable` decides.
+ * The alternative, reimplementing the guard's predicate to answer in one query,
+ * was tried elsewhere today and drifted within the hour: the same reasoning that
+ * looked complete missed rows that would *start* blocking after a write.
+ */
+
+/** Guard calls run in waves; the pool is sized for a serverless function. */
+const GUARD_CONCURRENCY = 8;
+
+export interface BlockedAffair {
+  id: string;
+  slug: string;
+  title: string;
+  publicationStatus: PublicationStatus;
+  politicianName: string;
+  /** Decision ids the moderator has to settle, from the guard itself. */
+  decisionIds: string[];
+  /** Guard message per matching-related reason, shown as-is. */
+  messages: string[];
+  /**
+   * Non-matching reasons on the same affair, named so the page does not promise
+   * that settling the attributions is enough to publish.
+   */
+  otherBlockers: string[];
+}
+
+/** Reasons this page is about: the ones the attribution panel can resolve. */
+function isMatchingReason(
+  reason: PublishBlockReason
+): reason is Extract<PublishBlockReason, { decisionIds: string[] }> {
+  return "decisionIds" in reason;
+}
+
+/**
+ * Affairs held up by an unsettled attribution, newest activity first.
+ *
+ * Only DRAFT and PUBLISHED are considered. A REJECTED affair cannot be published
+ * without changing its status first, which runs the guard again from scratch, so
+ * listing it would be busywork.
+ */
+export async function loadBlockedAffairs(): Promise<BlockedAffair[]> {
+  // Deliberately over-inclusive: every decision that carries a link the guard
+  // could follow. Filtering precisely here would mean copying the guard.
+  const decisions = await db.affairPoliticianDecision.findMany({
+    where: {
+      judgment: { in: ["SAME", "UNDECIDED"] },
+      OR: [{ affairId: { not: null } }, { chosenPoliticianId: { not: null } }],
+    },
+    select: { affairId: true, chosenPoliticianId: true, sourceRef: true },
+  });
+
+  const affairIds = new Set<string>();
+  for (const d of decisions) if (d.affairId) affairIds.add(d.affairId);
+
+  // Orphan decisions reach an affair through the guard's fallback: same
+  // politician, and a sourceRef equal to one of the affair's source URLs.
+  const orphanRefs = [
+    ...new Set(
+      decisions.filter((d) => !d.affairId && d.sourceRef.length > 0).map((d) => d.sourceRef)
+    ),
+  ];
+  if (orphanRefs.length > 0) {
+    const sources = await db.source.findMany({
+      where: { url: { in: orphanRefs } },
+      select: { url: true, affairId: true, affair: { select: { politicianId: true } } },
+    });
+    const byUrl = new Map<string, { affairId: string; politicianId: string }[]>();
+    for (const s of sources) {
+      const list = byUrl.get(s.url) ?? [];
+      list.push({ affairId: s.affairId, politicianId: s.affair.politicianId });
+      byUrl.set(s.url, list);
+    }
+    for (const d of decisions) {
+      if (d.affairId || !d.chosenPoliticianId) continue;
+      for (const hit of byUrl.get(d.sourceRef) ?? []) {
+        if (hit.politicianId === d.chosenPoliticianId) affairIds.add(hit.affairId);
+      }
+    }
+  }
+
+  if (affairIds.size === 0) return [];
+
+  const affairs = await db.affair.findMany({
+    where: { id: { in: [...affairIds] }, publicationStatus: { in: ["DRAFT", "PUBLISHED"] } },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      publicationStatus: true,
+      updatedAt: true,
+      politician: { select: { fullName: true } },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  // Two queries each, run in small waves: sequential took 7.6s on the live base,
+  // which is long enough that the page would feel broken.
+  const blocked: BlockedAffair[] = [];
+  for (let i = 0; i < affairs.length; i += GUARD_CONCURRENCY) {
+    const wave = await Promise.all(
+      affairs.slice(i, i + GUARD_CONCURRENCY).map(async (affair) => {
+        const reasons = await checkPublishable(affair.id);
+        const matching = reasons.filter(isMatchingReason);
+        if (matching.length === 0) return null;
+
+        return {
+          id: affair.id,
+          slug: affair.slug,
+          title: affair.title,
+          publicationStatus: affair.publicationStatus,
+          politicianName: affair.politician.fullName,
+          decisionIds: matching.flatMap((r) => r.decisionIds),
+          messages: matching.map((r) => r.message),
+          otherBlockers: reasons.filter((r) => !isMatchingReason(r)).map((r) => r.message),
+        } satisfies BlockedAffair;
+      })
+    );
+    for (const entry of wave) if (entry) blocked.push(entry);
+  }
+
+  return blocked;
+}


### PR DESCRIPTION
Le tableau de bord ouvrait sur deux compteurs à quatre chiffres, « en attente de revue » et
« sans candidat ». Aucun des deux ne répond à la seule question qu'on se pose en arrivant :
qu'est-ce que j'ai à faire ?

Mesuré sur la base : **1800 décisions non relues, 26 retiennent une publication.**

```
1800  jamais relues                     ← ce que la page affichait
 702  verdict SAME ou UNDECIDED         les NO_MATCH ne sont jamais lus par la garde
 460  rattachées à quelque chose
  26  bloquent vraiment une publication ← ce qu'elle affiche maintenant
```

15 brouillons qui ne peuvent pas sortir, 8 fiches en ligne dont l'attribution n'a jamais
été validée.

## Ce que la page montre

La liste des affaires bloquées passe en tête, chacune liée à sa fiche où le panneau de
#613 tranche sans quitter la page. Brouillons et fiches publiées sont séparés, parce que
les deux ne disent pas la même chose : un brouillon ne sort pas, une fiche publiée est
déjà sortie sur une attribution que personne n'a confirmée. Les fusionner sous un seul
compteur cacherait la seconde, qui est la plus sérieuse.

Les compteurs du registre restent, plus petits, sous un titre qui dit ce qu'ils sont :

> **Taille du registre** — Ces décisions attendent une relecture, mais seules celles
> listées plus haut retiennent une publication.

Et pour les `NO_MATCH`, une affirmation vraie par construction, puisque la garde ne
requête que `SAME` et `UNDECIDED` : « ne bloquent jamais une publication ».

Chaque ligne nomme aussi les **autres** motifs de blocage de l'affaire, faute de quoi la
page promettrait qu'un rattachement tranché suffit à publier. Sur les 23 affaires, 15
portent en plus une note d'implication manquante.

## La garde est l'autorité, pas cette page

`loadBlockedAffairs()` fait une requête large et bon marché pour réduire le champ aux
affaires qu'une décision pourrait atteindre, puis appelle `checkPublishable` sur chacune.
C'est elle qui tranche.

Répondre en une seule requête aurait voulu dire réimplémenter le prédicat de la garde. Ce
raisonnement a été tenu deux fois aujourd'hui et il a dérivé les deux fois : un filtre qui
paraissait complet a manqué les lignes qui se mettraient à bloquer _après_ écriture.
Ici le coût de l'autorité réelle est d'environ une seconde et demie, payée sur un endpoint
séparé pour que les compteurs s'affichent tout de suite.

Les appels à la garde partent par vagues de huit. En séquentiel, 7,6 s : assez long pour
que la page paraisse cassée.

## Un compteur qui disait faux

Première version : « 27 rattachements sur 23 affaires ». Une décision orpheline peut
retenir deux affaires par le chemin de repli de la garde, et la somme par affaire la
comptait deux fois. Le compteur dédoublonne désormais, et annonce 26.

## Test plan

- 8 tests de rendu sur la page : le nombre annoncé, la séparation brouillons / publiées,
  le lien vers la bonne fiche, les autres motifs de blocage affichés, l'état vide formulé
  comme un objectif atteint, et une panne de la liste qui n'emporte pas les compteurs
- 2 tests tiennent la formulation des compteurs, pour qu'ils ne redeviennent pas une
  file à vider
- `npm run test:run` : 3004 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run build` : code de sortie 0
- Endpoint vérifié contre la base réelle : `HTTP 200`, 23 affaires, 15 brouillons et 8
  publiées, 2,8 s bout en bout

**Non vérifié** : le rendu visuel dans un navigateur. Playwright réclame une extension qui
n'est pas installée ici, donc la validation passe par les tests de rendu et par le HTML
servi, pas par une capture d'écran.

## Rollback

Aucune migration, aucune écriture. La route est en lecture seule. Revenir au commit
précédent restaure les deux compteurs.
