### PR TITLE
Retirer prisonSuspended du schéma (étape 1 sur 2)

### DIFF
--- a/prisma/migrations/manual/2026-08-02-drop-prison-suspended.sql
+++ b/prisma/migrations/manual/2026-08-02-drop-prison-suspended.sql
@@ -1,0 +1,19 @@
+-- Contract step: drop the boolean the firm-months columns replaced (#576).
+--
+-- Documentation only, applied via `npm run db:push`. This database has no
+-- `_prisma_migrations` table, so `prisma migrate deploy` is never run against it and a
+-- versioned migration directory here would only arm the staging workflow with a history
+-- it cannot replay. Companion of 2026-07-31-sentence-firm-months.sql, which added the
+-- replacements.
+--
+-- ORDER MATTERS, AND THE DEPLOY IS PART OF IT. Several Affair queries use `include`
+-- without `select`, so Prisma names every scalar column in the SELECT it emits. A client
+-- generated while `prisonSuspended` still existed keeps asking for it, and a runtime
+-- built from that client breaks the moment the column is gone. The schema change must
+-- therefore be deployed BEFORE this statement runs, never in the same step.
+--
+-- The 81 rows carrying a value (50 true, 31 false) were exported before the drop. Their
+-- meaning already lives in prisonFirmMonths, and sentence-split.ts is the sole authority
+-- on reading it; the boolean could not express "not established" at all, which is what
+-- made it report a suspended sentence as firm on 15 published fiches.
+ALTER TABLE "Affair" DROP COLUMN "prisonSuspended";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -575,7 +575,6 @@ model Affair {
   // established", which is distinct from 0 ("entirely suspended"). See
   // src/lib/affairs/sentence-split.ts, sole authority on reading the pair (#576).
   prisonMonths            Int? // Prison sentence in months (0 if none)
-  prisonSuspended         Boolean? // DEPRECATED (#576), dropped once the switch is verified
   prisonFirmMonths        Int? // Firm part of the prison term; null = not established
   fineAmount              Decimal? @db.Decimal(12, 2) // Fine in euros
   ineligibilityMonths     Int? // Ineligibility period in months


### PR DESCRIPTION
Étape de contraction de #576. Le booléen `prisonSuspended` avait deux états pour une
réalité qui en a trois, et il a fait afficher « (ferme) » sur 15 fiches publiées dont la
peine était partiellement assortie du sursis. `prisonFirmMonths` l'a remplacé le
2026-07-31, et plus aucun code ne le lit.

**Cette PR ne supprime pas la colonne.** Elle retire le champ du schéma, ce qui est le
premier des deux temps.

## Pourquoi deux temps

Plusieurs requêtes sur `Affair` utilisent `include` sans `select` :

```ts
// src/app/admin/affaires/[id]/page.tsx:24
return db.affair.findUnique({ where: { id }, include: { … } });
```

Prisma y nomme alors toutes les colonnes scalaires dans le `SELECT` qu'il émet. Un client
généré alors que `prisonSuspended` existait encore continue donc de la demander, et le
runtime construit à partir de ce client casse à la seconde où la colonne disparaît.

La production tourne aujourd'hui le build du 31 juillet. Supprimer la colonne maintenant
ferait planter la fiche admin d'une affaire et sa page d'édition. Il faut donc **déployer
ce schéma d'abord**, puis supprimer.

## Ce qui a été fait

- Champ retiré de `prisma/schema.prisma`, client régénéré, tout compile sans lui
- `prisma/migrations/manual/2026-08-02-drop-prison-suspended.sql` documente l'instruction
  et l'ordre à respecter, sans être exécutable automatiquement : cette base n'a pas de
  table `_prisma_migrations`, un répertoire versionné armerait le workflow de staging
  d'un historique qu'il ne peut pas rejouer
- Les **81 lignes** portant une valeur (50 `true`, 31 `false`) exportées hors du dépôt
  avant toute modification
- Trois scripts jetables de `scripts/.local/` référençaient le champ et auraient cassé
  `tsc` une fois le client régénéré. Archivés hors du dépôt plutôt que supprimés.

## Vérification avant le futur `db:push`

Le diff entre le schéma et la base réelle ne contient qu'une instruction, donc rien
d'autre n'a divergé et le `db:push` à venir ne fera que ça :

```sql
-- AlterTable
ALTER TABLE "Affair" DROP COLUMN "prisonSuspended";
```

C'est une vérification qui compte particulièrement ici : `.env` et `.env.prod` pointent la
même base, donc un `db:push` local écrit en production.

## Séquence pour clore #576

1. Merger cette PR
2. **Déployer** — c'est l'étape qui rend la suppression sûre
3. `npm run db:push`, qui applique l'unique instruction ci-dessus
4. Vérifier qu'une fiche d'affaire s'ouvre encore en admin
5. Fermer #576

## Test plan

- `npx prisma generate` puis `npx tsc` : code de sortie 0, hors cache incrémental et hors
  `.next/`
- `npm run test:run` : 3004 passés, dont ceux qui vérifient que le champ n'est plus
  proposable ni exporté
- `npm run build` : code de sortie 0
- `prisma migrate diff` contre la base réelle : une seule instruction

## Rollback

Rien n'est écrit en base par cette PR. Revenir au commit précédent restaure le champ dans
le schéma ; la colonne, elle, n'a pas bougé. Si la suppression se révélait mauvaise après
coup, les 81 valeurs sont dans l'export.
