### PR TITLE
Déplacer les affaires bloquées sur la page de revue

### DIFF
--- a/src/app/admin/affair-matching/dashboard/__tests__/page.test.tsx
+++ b/src/app/admin/affair-matching/dashboard/__tests__/page.test.tsx
@@ -4,10 +4,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import DashboardPage from "../page";
 
 /**
- * The point of this page is that a moderator can tell, in one glance, what they
- * have to do. These tests hold that promise in place: the actionable list comes
- * first and names the fiche, and the big registry counters stay labelled as
- * context rather than as a backlog.
+ * The to-do list lives on the review page, not here: this one is activity and
+ * volume. What these tests hold is that the two large counters keep saying what
+ * they are, because presented bare they read as a backlog to clear and sent a
+ * moderator looking for 1800 pieces of work that did not exist.
  */
 
 const STATS = {
@@ -16,100 +16,23 @@ const STATS = {
   last7Days: [{ source: "PRESS", judgment: "SAME", count: 4 }],
 };
 
-const BLOCKED = {
-  decisionCount: 3,
-  affairs: [
-    {
-      id: "aff_draft",
-      slug: "gymnase",
-      title: "Attribution controversée d'un gymnase",
-      publicationStatus: "DRAFT",
-      politicianName: "Laurent Wauquiez",
-      decisionIds: ["dec_1"],
-      messages: ["1 rattachement(s) automatique(s) jamais validé(s)"],
-      otherBlockers: [],
-    },
-    {
-      id: "aff_pub",
-      slug: "notes-de-frais",
-      title: "Notes de frais : saisine du procureur",
-      publicationStatus: "PUBLISHED",
-      politicianName: "Christian Estrosi",
-      decisionIds: ["dec_2", "dec_3"],
-      messages: ["2 rattachement(s) confirmé(s) par l'assistance automatique"],
-      otherBlockers: ["note d'implication manquante"],
-    },
-  ],
-};
-
-function mockFetch(blocked: unknown = BLOCKED, stats: unknown = STATS) {
-  return vi.fn(async (input: RequestInfo | URL) => {
-    const url = String(input);
-    const body = url.includes("/blocked") ? blocked : stats;
-    return { ok: true, status: 200, json: async () => body } as Response;
-  });
-}
-
 beforeEach(() => {
-  vi.stubGlobal("fetch", mockFetch());
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => STATS }) as Response)
+  );
 });
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("Tableau de bord — ce qu'il y a à trancher", () => {
-  it("annonce le nombre de rattachements et d'affaires concernées", async () => {
-    render(<DashboardPage />);
-    expect(await screen.findByText(/3 rattachements sur 2 affaires/)).toBeInTheDocument();
-  });
-
-  it("sépare les brouillons des fiches déjà en ligne", async () => {
-    // Les deux ne disent pas la même chose : un brouillon ne sort pas, une fiche
-    // publiée est déjà sortie sur une attribution que personne n'a confirmée.
-    render(<DashboardPage />);
-    expect(
-      await screen.findByText(/Brouillons qui ne peuvent pas être publiés/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Fiches en ligne dont l'attribution n'a jamais été validée/)
-    ).toBeInTheDocument();
-  });
-
-  it("pointe chaque affaire vers sa fiche, où le panneau tranche", async () => {
-    render(<DashboardPage />);
-    const link = await screen.findByRole("link", {
-      name: /Attribution controversée d'un gymnase/,
-    });
-    expect(link).toHaveAttribute("href", "/admin/affaires/aff_draft");
-  });
-
-  it("nomme les autres motifs de blocage au lieu de promettre une publication", async () => {
-    // Trancher le rattachement ne suffit pas si la note d'implication manque.
-    render(<DashboardPage />);
-    expect(await screen.findByText(/note d'implication manquante/)).toBeInTheDocument();
-  });
-
-  it("annonce l'état vide comme un objectif atteint, pas comme une absence de données", async () => {
-    vi.stubGlobal("fetch", mockFetch({ decisionCount: 0, affairs: [] }));
-    render(<DashboardPage />);
-    expect(await screen.findByText(/Aucune publication retenue/)).toBeInTheDocument();
-  });
-
-  it("survit à une panne de la liste sans emporter le reste de la page", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        if (String(input).includes("/blocked")) return { ok: false, status: 500 } as Response;
-        return { ok: true, status: 200, json: async () => STATS } as Response;
-      })
-    );
-    render(<DashboardPage />);
-    expect(await screen.findByRole("alert")).toHaveTextContent(/indisponible/);
-    expect(await screen.findByText("295")).toBeInTheDocument();
-  });
-});
-
 describe("Tableau de bord — les compteurs restent du contexte", () => {
+  it("affiche les volumes du registre", async () => {
+    render(<DashboardPage />);
+    expect(await screen.findByText("295")).toBeInTheDocument();
+    expect(screen.getByText("1098")).toBeInTheDocument();
+  });
+
   it("dit explicitement que les compteurs ne sont pas la charge de travail", async () => {
     render(<DashboardPage />);
     await waitFor(() =>

--- a/src/app/admin/affair-matching/dashboard/page.tsx
+++ b/src/app/admin/affair-matching/dashboard/page.tsx
@@ -14,22 +14,6 @@ interface StatsResponse {
   last7Days: StatsRow[];
 }
 
-interface BlockedAffair {
-  id: string;
-  slug: string;
-  title: string;
-  publicationStatus: "DRAFT" | "PUBLISHED";
-  politicianName: string;
-  decisionIds: string[];
-  messages: string[];
-  otherBlockers: string[];
-}
-
-interface BlockedResponse {
-  affairs: BlockedAffair[];
-  decisionCount: number;
-}
-
 // ─── Constants ───────────────────────────────────────────────────
 
 const SOURCES = ["JUDILIBRE", "PRESS", "FACTCHECK", "MANUAL"];
@@ -49,11 +33,6 @@ export default function AffairMatchingDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Loaded separately: the blocking list calls the publish guard per affair, so
-  // it takes about a second and a half. The counters must not wait for it.
-  const [blocked, setBlocked] = useState<BlockedResponse | null>(null);
-  const [blockedError, setBlockedError] = useState<string | null>(null);
-
   useEffect(() => {
     (async () => {
       try {
@@ -64,16 +43,6 @@ export default function AffairMatchingDashboardPage() {
         setError((err as Error).message);
       } finally {
         setLoading(false);
-      }
-    })();
-
-    (async () => {
-      try {
-        const res = await fetch("/api/admin/affair-matching/blocked");
-        if (!res.ok) throw new Error(`Erreur ${res.status}`);
-        setBlocked(await res.json());
-      } catch (err) {
-        setBlockedError((err as Error).message);
       }
     })();
   }, []);
@@ -89,8 +58,6 @@ export default function AffairMatchingDashboardPage() {
       <p className="text-sm text-muted-foreground mb-6">
         Vue d{"'"}ensemble des décisions de liaison affaire vers politicien.
       </p>
-
-      <BlockedSection data={blocked} error={blockedError} />
 
       {loading && <p className="text-muted-foreground">Chargement...</p>}
       {error && (
@@ -192,115 +159,6 @@ export default function AffairMatchingDashboardPage() {
           </div>
         </>
       )}
-    </div>
-  );
-}
-
-// ─── Blocked affairs ─────────────────────────────────────────────
-
-/**
- * The only part of this page that is a to-do list.
- *
- * Drafts and published fiches are separated because the two say different
- * things: a draft cannot go out until its attribution is settled, while a
- * published one is already out on an attribution nobody confirmed. Merging them
- * under one count would hide the second, which is the more serious of the two.
- */
-function BlockedSection({ data, error }: { data: BlockedResponse | null; error: string | null }) {
-  if (error) {
-    return (
-      <p className="text-destructive mb-8" role="alert">
-        Liste des affaires bloquées indisponible : {error}
-      </p>
-    );
-  }
-
-  if (!data) {
-    return <p className="text-muted-foreground mb-8">Recherche des affaires bloquées...</p>;
-  }
-
-  if (data.affairs.length === 0) {
-    return (
-      <Card className="mb-8">
-        <CardContent className="pt-6">
-          <p className="font-medium">Aucune publication retenue.</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            Toutes les attributions qui gouvernent une fiche vivante sont tranchées.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const drafts = data.affairs.filter((a) => a.publicationStatus === "DRAFT");
-  const published = data.affairs.filter((a) => a.publicationStatus === "PUBLISHED");
-
-  return (
-    <section className="mb-10">
-      <h2 className="text-lg font-semibold mb-1">
-        À trancher : {data.decisionCount} rattachement
-        {data.decisionCount > 1 ? "s" : ""} sur {data.affairs.length} affaire
-        {data.affairs.length > 1 ? "s" : ""}
-      </h2>
-      <p className="text-sm text-muted-foreground mb-4">
-        Chaque fiche s{"'"}ouvre sur un panneau qui montre l{"'"}extrait de presse et les candidats.
-        Deux boutons par décision.
-      </p>
-
-      <BlockedGroup
-        title="Brouillons qui ne peuvent pas être publiés"
-        affairs={drafts}
-        emptyHint={null}
-      />
-      <BlockedGroup
-        title="Fiches en ligne dont l'attribution n'a jamais été validée"
-        affairs={published}
-        emptyHint={null}
-      />
-    </section>
-  );
-}
-
-function BlockedGroup({
-  title,
-  affairs,
-  emptyHint,
-}: {
-  title: string;
-  affairs: BlockedAffair[];
-  emptyHint: string | null;
-}) {
-  if (affairs.length === 0) return emptyHint ? <p className="text-sm">{emptyHint}</p> : null;
-
-  return (
-    <div className="mb-5">
-      <h3 className="text-sm font-medium text-muted-foreground mb-2">
-        {title} ({affairs.length})
-      </h3>
-      <Card>
-        <CardContent className="p-0">
-          <ul>
-            {affairs.map((a, i) => (
-              <li key={a.id} className={i < affairs.length - 1 ? "border-b" : undefined}>
-                <Link
-                  href={`/admin/affaires/${a.id}`}
-                  className="block px-4 py-3 hover:bg-muted/50 transition-colors"
-                >
-                  <p className="font-medium">{a.title}</p>
-                  <p className="text-sm text-muted-foreground mt-0.5">
-                    {a.politicianName} &bull; {a.messages.join(" ; ")}
-                  </p>
-                  {a.otherBlockers.length > 0 && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Bloquée aussi par : {a.otherBlockers.join(" ; ")}
-                    </p>
-                  )}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/app/admin/affair-matching/review/page.tsx
+++ b/src/app/admin/affair-matching/review/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, ChevronRight, LinkIcon, Loader2, Search } from "lucide-react";
+import { BlockedAffairs } from "@/components/admin/BlockedAffairs";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -200,12 +201,14 @@ export default function AffairMatchingReviewPage() {
           Révision des décisions de liaison
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Décisions en attente de validation humaine. L{"'"}onglet{" "}
-          <span className="font-medium">En attente</span> liste les cas où plusieurs politiciens
-          sont plausibles. L{"'"}onglet <span className="font-medium">Sans candidat</span> regroupe
-          les cas sans candidat plausible (politiciens étrangers ou absents de la base).
+          Les onglets listent l{"'"}ensemble du registre, qui compte plusieurs milliers de lignes.
+          La plupart ne retiennent rien : seules celles reprises ci-dessous empêchent une
+          publication.
         </p>
       </div>
+
+      {/* What actually has to be settled, before the full registry. */}
+      <BlockedAffairs />
 
       {/* Tab bar */}
       <div

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -51,7 +51,7 @@ const contentItems: NavItem[] = [
   { href: "/admin/dossiers", label: "Dossiers", icon: FileText },
   { href: "/admin/policy-titles", label: "Titres de scrutins", icon: Vote },
   { href: "/admin/affair-matching/review", label: "Liaison affaires", icon: Fingerprint },
-  { href: "/admin/affair-matching/dashboard", label: "Stats liaison", icon: BarChart3 },
+  { href: "/admin/affair-matching/dashboard", label: "Liaison — activité", icon: BarChart3 },
 ];
 
 const mediaItems: NavItem[] = [

--- a/src/components/admin/BlockedAffairs.tsx
+++ b/src/components/admin/BlockedAffairs.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+
+export interface BlockedAffair {
+  id: string;
+  slug: string;
+  title: string;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  politicianName: string;
+  decisionIds: string[];
+  messages: string[];
+  otherBlockers: string[];
+}
+
+interface BlockedResponse {
+  affairs: BlockedAffair[];
+  decisionCount: number;
+}
+
+/**
+ * Fetches on mount rather than taking props: it lives at the top of the review
+ * page, which is where a moderator actually lands, and that page must not wait
+ * on a guard call that takes about a second and a half.
+ */
+export function BlockedAffairs() {
+  const [data, setData] = useState<BlockedResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/admin/affair-matching/blocked");
+        if (!res.ok) throw new Error(`Erreur ${res.status}`);
+        setData(await res.json());
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    })();
+  }, []);
+
+  return <BlockedAffairsPanel data={data} error={error} />;
+}
+
+/**
+ * The only part of this page that is a to-do list.
+ *
+ * Drafts and published fiches are separated because the two say different
+ * things: a draft cannot go out until its attribution is settled, while a
+ * published one is already out on an attribution nobody confirmed. Merging them
+ * under one count would hide the second, which is the more serious of the two.
+ */
+export function BlockedAffairsPanel({
+  data,
+  error,
+}: {
+  data: BlockedResponse | null;
+  error: string | null;
+}) {
+  if (error) {
+    return (
+      <p className="text-destructive mb-8" role="alert">
+        Liste des affaires bloquées indisponible : {error}
+      </p>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-muted-foreground mb-8">Recherche des affaires bloquées...</p>;
+  }
+
+  if (data.affairs.length === 0) {
+    return (
+      <Card className="mb-8">
+        <CardContent className="pt-6">
+          <p className="font-medium">Aucune publication retenue.</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Toutes les attributions qui gouvernent une fiche vivante sont tranchées.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const drafts = data.affairs.filter((a) => a.publicationStatus === "DRAFT");
+  const published = data.affairs.filter((a) => a.publicationStatus === "PUBLISHED");
+
+  return (
+    <section className="mb-10">
+      <h2 className="text-lg font-semibold mb-1">
+        À trancher : {data.decisionCount} rattachement
+        {data.decisionCount > 1 ? "s" : ""} sur {data.affairs.length} affaire
+        {data.affairs.length > 1 ? "s" : ""}
+      </h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        Chaque fiche s{"'"}ouvre sur un panneau qui montre l{"'"}extrait de presse et les candidats.
+        Deux boutons par décision.
+      </p>
+
+      <BlockedGroup
+        title="Brouillons qui ne peuvent pas être publiés"
+        affairs={drafts}
+        emptyHint={null}
+      />
+      <BlockedGroup
+        title="Fiches en ligne dont l'attribution n'a jamais été validée"
+        affairs={published}
+        emptyHint={null}
+      />
+    </section>
+  );
+}
+
+function BlockedGroup({
+  title,
+  affairs,
+  emptyHint,
+}: {
+  title: string;
+  affairs: BlockedAffair[];
+  emptyHint: string | null;
+}) {
+  if (affairs.length === 0) return emptyHint ? <p className="text-sm">{emptyHint}</p> : null;
+
+  return (
+    <div className="mb-5">
+      <h3 className="text-sm font-medium text-muted-foreground mb-2">
+        {title} ({affairs.length})
+      </h3>
+      <Card>
+        <CardContent className="p-0">
+          <ul>
+            {affairs.map((a, i) => (
+              <li key={a.id} className={i < affairs.length - 1 ? "border-b" : undefined}>
+                <Link
+                  href={`/admin/affaires/${a.id}`}
+                  className="block px-4 py-3 hover:bg-muted/50 transition-colors"
+                >
+                  <p className="font-medium">{a.title}</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {a.politicianName} &bull; {a.messages.join(" ; ")}
+                  </p>
+                  {a.otherBlockers.length > 0 && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Bloquée aussi par : {a.otherBlockers.join(" ; ")}
+                    </p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/admin/__tests__/BlockedAffairs.test.tsx
+++ b/src/components/admin/__tests__/BlockedAffairs.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { BlockedAffairs } from "@/components/admin/BlockedAffairs";
+
+/**
+ * This panel is the only part of the matching admin that is a to-do list, and it
+ * sits at the top of the review page because that is where a moderator actually
+ * lands. It first shipped on the stats dashboard, which nobody opens looking for
+ * work; these tests hold the promise it makes wherever it is mounted.
+ */
+
+const BLOCKED = {
+  decisionCount: 3,
+  affairs: [
+    {
+      id: "aff_draft",
+      slug: "gymnase",
+      title: "Attribution controversée d'un gymnase",
+      publicationStatus: "DRAFT",
+      politicianName: "Laurent Wauquiez",
+      decisionIds: ["dec_1"],
+      messages: ["1 rattachement(s) automatique(s) jamais validé(s)"],
+      otherBlockers: [],
+    },
+    {
+      id: "aff_pub",
+      slug: "notes-de-frais",
+      title: "Notes de frais : saisine du procureur",
+      publicationStatus: "PUBLISHED",
+      politicianName: "Christian Estrosi",
+      decisionIds: ["dec_2", "dec_3"],
+      messages: ["2 rattachement(s) confirmé(s) par l'assistance automatique"],
+      otherBlockers: ["note d'implication manquante"],
+    },
+  ],
+};
+
+function mockFetch(body: unknown = BLOCKED, ok = true) {
+  return vi.fn(async () => ({ ok, status: ok ? 200 : 500, json: async () => body }) as Response);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("BlockedAffairs", () => {
+  it("annonce le nombre de rattachements et d'affaires concernées", async () => {
+    render(<BlockedAffairs />);
+    expect(await screen.findByText(/3 rattachements sur 2 affaires/)).toBeInTheDocument();
+  });
+
+  it("sépare les brouillons des fiches déjà en ligne", async () => {
+    // Les deux ne disent pas la même chose : un brouillon ne sort pas, une fiche
+    // publiée est déjà sortie sur une attribution que personne n'a confirmée.
+    render(<BlockedAffairs />);
+    expect(
+      await screen.findByText(/Brouillons qui ne peuvent pas être publiés/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fiches en ligne dont l'attribution n'a jamais été validée/)
+    ).toBeInTheDocument();
+  });
+
+  it("pointe chaque affaire vers sa fiche, où le panneau tranche", async () => {
+    render(<BlockedAffairs />);
+    const link = await screen.findByRole("link", {
+      name: /Attribution controversée d'un gymnase/,
+    });
+    expect(link).toHaveAttribute("href", "/admin/affaires/aff_draft");
+  });
+
+  it("nomme les autres motifs de blocage au lieu de promettre une publication", async () => {
+    // Trancher le rattachement ne suffit pas si la note d'implication manque.
+    render(<BlockedAffairs />);
+    expect(await screen.findByText(/note d'implication manquante/)).toBeInTheDocument();
+  });
+
+  it("annonce l'état vide comme un objectif atteint, pas comme une absence de données", async () => {
+    vi.stubGlobal("fetch", mockFetch({ decisionCount: 0, affairs: [] }));
+    render(<BlockedAffairs />);
+    expect(await screen.findByText(/Aucune publication retenue/)).toBeInTheDocument();
+  });
+
+  it("signale une panne sans masquer le reste de la page", async () => {
+    vi.stubGlobal("fetch", mockFetch({}, false));
+    render(<BlockedAffairs />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/indisponible/);
+  });
+});


### PR DESCRIPTION
La liste des affaires bloquées de #619 était au mauvais endroit. Elle vivait sur le
tableau de bord, dont l'entrée de menu s'appelait « Stats liaison », et personne n'ouvre
une page de stats pour trouver sa liste de tâches. La page de revue, celle qu'on ouvre
réellement, n'y renvoyait même pas.

```
Sidebar
  « Liaison affaires »  → /review      ← là où on va
  « Stats liaison »     → /dashboard   ← là où était le travail
```

Résultat concret : le compteur « En attente 295 » restait la première chose vue, et les 26
rattachements à trancher n'apparaissaient nulle part sur le chemin habituel.

## Ce qui change

Le panneau devient `src/components/admin/BlockedAffairs.tsx` et se monte **en tête de la
page de revue**, avant les onglets. Le chapô de la page dit désormais ce que les onglets
sont vraiment :

> Les onglets listent l'ensemble du registre, qui compte plusieurs milliers de lignes. La
> plupart ne retiennent rien : seules celles reprises ci-dessous empêchent une publication.

Le tableau de bord garde ses compteurs et son tableau d'activité, sans le panneau : une
seule page porte la liste de tâches. Son entrée de menu passe de « Stats liaison » à
« Liaison — activité », qui décrit ce qu'on y trouve.

## Tests

Les six tests du panneau suivent le composant dans
`src/components/admin/__tests__/BlockedAffairs.test.tsx`, où ils sont indépendants de la
page qui l'héberge. Le tableau de bord garde trois tests, ceux qui tiennent la formulation
de ses compteurs pour qu'ils ne redeviennent pas une file à vider.

- `npm run test:run` : 3005 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- Vérifié sur un serveur local : `/admin/affair-matching/review` répond 200 et monte bien
  le panneau ; l'endpoint renvoie 26 rattachements sur 23 affaires

## Rollback

Aucune écriture, aucune migration. Revenir au commit précédent remet le panneau sur le
tableau de bord.
