### PR TITLE
Afficher l'implication sur la fiche admin d'une affaire

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -9,8 +9,10 @@ import {
   AFFAIR_STATUS_LABELS,
   AFFAIR_STATUS_COLORS,
   AFFAIR_CATEGORY_LABELS,
-  AFFAIR_STATUS_NEEDS_PRESUMPTION,
+  INVOLVEMENT_LABELS,
+  INVOLVEMENT_COLORS,
 } from "@/config/labels";
+import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { formatDate } from "@/lib/utils";
 import { AffairPublishControl } from "@/components/admin/AffairPublishControl";
 import type { BlockingDecision as BlockingDecisionPayload } from "@/lib/affairs/blocking-decisions";
@@ -163,14 +165,24 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
+            {/* La fiche admin d'abord : depuis l'admin, on veut modérer la personne,
+                pas relire sa page publique. Le lien public reste, en second. */}
             <div>
               <p className="text-sm text-muted-foreground">Politique</p>
               <Link
-                href={`/politiques/${affair.politician.slug}`}
+                href={`/admin/politiques/${affair.politician.id}`}
                 className="font-medium text-primary hover:underline"
               >
                 {affair.politician.fullName}
               </Link>
+              <a
+                href={`/politiques/${affair.politician.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-2 text-xs text-muted-foreground hover:text-foreground hover:underline"
+              >
+                fiche publique &nearr;
+              </a>
             </div>
             <div>
               <p className="text-sm text-muted-foreground">Catégorie</p>
@@ -182,11 +194,35 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
                 {AFFAIR_STATUS_LABELS[affair.status]}
               </Badge>
             </div>
+            {/* Le champ qui dit si la personne est mise en cause ou visée par les
+                faits. Il n'était lisible qu'en ouvrant le formulaire d'édition, si
+                bien qu'une fiche « Insultes et menaces contre X » se lisait comme
+                une affaire de X. */}
+            <div>
+              <p className="text-sm text-muted-foreground">Implication</p>
+              <Badge variant="outline" className={INVOLVEMENT_COLORS[affair.involvement]}>
+                {INVOLVEMENT_LABELS[affair.involvement]}
+              </Badge>
+            </div>
             <div>
               <p className="text-sm text-muted-foreground">Slug</p>
               <p className="font-mono text-sm">{affair.slug}</p>
             </div>
           </div>
+
+          {affair.involvement !== "DIRECT" && (
+            <div className="pt-2 border-t">
+              <p className="text-sm text-muted-foreground mb-1">Rôle dans l{"'"}affaire</p>
+              {affair.involvementNote?.trim() ? (
+                <p className="whitespace-pre-wrap">{affair.involvementNote}</p>
+              ) : (
+                <p className="text-sm text-amber-800 dark:text-amber-300">
+                  Aucune note d{"'"}implication. Elle est obligatoire hors « mis en cause », et son
+                  absence empêche la publication.
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Références éditoriales. Les identifiants de décision (ECLI, pourvoi)
               se lisent sur les décisions rattachées, plus bas sur cette page (#545). */}
@@ -207,11 +243,10 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
             </div>
           )}
 
-          {AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status] && (
-            <div className="bg-amber-50 text-amber-800 p-3 rounded-md text-sm">
-              Cette affaire est en cours. La présomption d&apos;innocence s&apos;applique.
-            </div>
-          )}
+          {/* Le même encart que le public, et pour la même raison : celui d'avant
+              ne lisait que le statut, donc il annonçait « la présomption d'innocence
+              s'applique » sur la fiche d'une victime. */}
+          <AffairStatusNotice status={affair.status} involvement={affair.involvement} />
 
           <div>
             <p className="text-sm text-muted-foreground mb-1">Description</p>


### PR DESCRIPTION
Sur la fiche admin d'une affaire, on ne pouvait pas savoir si la personne était mise en
cause, victime ou plaignante sans ouvrir le formulaire d'édition. Sur une fiche intitulée
« Insultes et menaces contre Marine Tondelier », rien ne disait qu'elle était la cible.

**162 affaires non-DIRECT n'ont aucune note d'implication**, et c'est aussi le motif qui
bloque le plus de publications après les rattachements.

## Ce que la carte Informations montre maintenant

- **Implication** en pastille, avec les mêmes libellés et couleurs que le public
  (`INVOLVEMENT_LABELS` / `INVOLVEMENT_COLORS`)
- **Rôle dans l'affaire** dès que l'implication n'est pas « mis en cause » : la note si
  elle existe, sinon un avertissement qui dit qu'elle est obligatoire et qu'elle empêche
  la publication. C'est le même blocage que le panneau de #619 signale en aval.

## L'encart de prudence disait faux sur les victimes

Il testait `AFFAIR_STATUS_NEEDS_PRESUMPTION[affair.status]`, donc uniquement le statut :

> Cette affaire est en cours. La présomption d'innocence s'applique.

Sur la fiche d'une victime, cette phrase est au mieux hors sujet. Le public a déjà le bon
composant, `AffairStatusNotice`, qui prend `status` **et** `involvement` et sait rendre une
variante `not_accused`. L'admin l'utilise désormais, ce qui aligne les deux surfaces au
lieu d'entretenir deux formulations.

Vérifié sur la fiche citée : `data-variant="not_accused"`.

## Le lien vers le politique menait au site public

Depuis l'admin on veut modérer la personne, pas relire sa page publique. Le nom pointe
maintenant vers `/admin/politiques/{id}`, et un lien secondaire « fiche publique » ouvre
l'autre dans un nouvel onglet.

## Test plan

- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run test:run` : 3005 passés. La logique d'encart est déjà couverte par
  `AffairStatusNotice.test.tsx` ; cette PR la réutilise au lieu de la dupliquer.
- Rendu vérifié sur un serveur local : pastille d'implication présente, note affichée,
  `data-variant="not_accused"`, lien admin et lien public tous deux présents

Pas de test de rendu pour cette page : c'est un composant serveur qui interroge la base
directement, et le projet n'a pas de harnais pour ce cas. Ce qui est testable, la
correspondance implication → encart, l'est déjà dans le composant réutilisé.

## Rollback

Aucune écriture, aucune migration. Revenir au commit précédent restaure l'ancienne carte
et l'ancien encart.
