### PR TITLE
Fusionner un doublon depuis la fiche de l'affaire

### DIFF
--- a/src/app/admin/affaires/[id]/page.tsx
+++ b/src/app/admin/affaires/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { AffairStatusNotice } from "@/components/affairs/AffairStatusNotice";
 import { formatDate } from "@/lib/utils";
 import { AffairPublishControl } from "@/components/admin/AffairPublishControl";
+import { AffairMergePanel } from "@/components/admin/AffairMergePanel";
 import type { BlockingDecision as BlockingDecisionPayload } from "@/lib/affairs/blocking-decisions";
 import { PublicationStatus } from "@/generated/prisma";
 
@@ -35,6 +36,28 @@ async function getAffair(id: string) {
         orderBy: { createdAt: "asc" },
       },
     },
+  });
+}
+
+/**
+ * The person's other affairs, for the merge panel. Same politician only: the
+ * merge service refuses a cross-person absorption, since Affair is 1:1 with
+ * Politician and moving one person's sources onto another's fiche then deleting
+ * the row would be a loss, not a merge.
+ */
+async function getSiblingAffairs(politicianId: string, exceptId: string) {
+  return db.affair.findMany({
+    where: { politicianId, id: { not: exceptId } },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      category: true,
+      publicationStatus: true,
+      _count: { select: { sources: true } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
   });
 }
 
@@ -131,6 +154,8 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
   if (!affair) {
     notFound();
   }
+
+  const siblings = await getSiblingAffairs(affair.politician.id, affair.id);
 
   return (
     <div className="max-w-4xl space-y-6">
@@ -329,6 +354,20 @@ export default async function AdminAffairDetailPage({ params }: PageProps) {
           </ul>
         </CardContent>
       </Card>
+
+      <AffairMergePanel
+        affairId={affair.id}
+        affairTitle={affair.title}
+        affairIsPublished={affair.publicationStatus === "PUBLISHED"}
+        siblings={siblings.map((s) => ({
+          id: s.id,
+          title: s.title,
+          status: s.status,
+          category: s.category,
+          publicationStatus: s.publicationStatus,
+          sourceCount: s._count.sources,
+        }))}
+      />
 
       <Card>
         <CardContent className="pt-6">

--- a/src/components/admin/AffairMergePanel.tsx
+++ b/src/components/admin/AffairMergePanel.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AFFAIR_STATUS_LABELS, AFFAIR_CATEGORY_LABELS } from "@/config/labels";
+import type { AffairStatus, AffairCategory } from "@/types";
+import type { PublicationStatus } from "@/generated/prisma";
+
+/**
+ * Merging a duplicate from the affair itself.
+ *
+ * The machinery already existed and was correct: `/doublons/fusionner` writes a
+ * DUPLICATE ruling in the same transaction, refuses to delete a published fiche,
+ * and turns everything a draft says about a published record into proposals
+ * instead of overwriting it. What was missing is the way in. The duplicates page
+ * only lists pairs the detector scored above 40, and detection is the part that
+ * fails: the two Alloncle fiches on the same complaint scored 33, because they
+ * name different offences and the « same category » signal therefore counts
+ * against exactly the case where one complaint spans several charges.
+ *
+ * So the panel does not detect anything. It lists the person's other affairs and
+ * lets a human say « that one ». A moderator who has read both fiches is a better
+ * judge than a threshold, and until now had no way to act on it.
+ */
+
+export interface SiblingAffair {
+  id: string;
+  title: string;
+  status: AffairStatus;
+  category: AffairCategory;
+  publicationStatus: PublicationStatus;
+  sourceCount: number;
+}
+
+interface Props {
+  affairId: string;
+  affairTitle: string;
+  affairIsPublished: boolean;
+  siblings: SiblingAffair[];
+}
+
+/**
+ * Exhaustive on purpose: a value added to the enum tomorrow breaks the build here
+ * instead of rendering an unstyled pill nobody notices.
+ */
+const STATUS_TONE: Record<PublicationStatus, string> = {
+  PUBLISHED: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  DRAFT: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  REJECTED: "bg-gray-100 text-gray-700 dark:bg-gray-800/40 dark:text-gray-300",
+  ARCHIVED: "bg-gray-100 text-gray-700 dark:bg-gray-800/40 dark:text-gray-300",
+  EXCLUDED: "bg-gray-100 text-gray-700 dark:bg-gray-800/40 dark:text-gray-300",
+};
+
+export function AffairMergePanel({ affairId, affairTitle, affairIsPublished, siblings }: Props) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+
+  if (siblings.length === 0) return null;
+
+  const absorb = async (other: SiblingAffair) => {
+    // Direction is fixed and stated: the fiche you are on survives. Offering a
+    // choice here would invite absorbing the page you came from, which is the one
+    // case the endpoint refuses anyway.
+    const confirmed = window.confirm(
+      `Fusionner « ${other.title} » dans « ${affairTitle} » ?\n\n` +
+        `L'affaire absorbée sera supprimée et ses anciennes URL redirigeront ici.` +
+        (affairIsPublished
+          ? `\n\nCette fiche étant publiée, ce que l'absorbée dit du volet judiciaire ` +
+            `arrivera en propositions à valider, pas en écriture directe.`
+          : "")
+    );
+    if (!confirmed) return;
+
+    setBusyId(other.id);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/admin/affaires/doublons/fusionner", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          keepId: affairId,
+          removeId: other.id,
+          notes: "Doublon confirmé depuis la fiche de l'affaire",
+          // A human who read both fiches, not a score: CERTAIN and 1 say exactly that.
+          signal: { confidence: "CERTAIN", matchedBy: "fiche-affaire", score: 1 },
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        proposalsCreated?: number;
+      };
+      if (!res.ok) throw new Error(json.error ?? `Erreur ${res.status}`);
+
+      setResult(
+        json.proposalsCreated
+          ? `Fusion effectuée. ${json.proposalsCreated} proposition(s) à valider.`
+          : "Fusion effectuée."
+      );
+      router.refresh();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Autres affaires de cette personne ({siblings.length})</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Si l{"'"}une décrit les mêmes faits, absorbez-la ici : cette fiche est conservée, l{"'"}
+          autre disparaît et ses URL redirigent vers celle-ci.
+        </p>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {result && (
+          <p className="text-sm text-emerald-700 dark:text-emerald-400" role="status">
+            {result}
+          </p>
+        )}
+
+        <ul className="divide-y border rounded-md">
+          {siblings.map((s) => {
+            // The endpoint refuses to delete a published fiche, whoever asks. Saying
+            // so before the click beats a 409 after it.
+            const blocked = s.publicationStatus === "PUBLISHED";
+            return (
+              <li key={s.id} className="flex items-start gap-3 p-3">
+                <div className="min-w-0 flex-1">
+                  <Link
+                    href={`/admin/affaires/${s.id}`}
+                    className="font-medium hover:underline break-words"
+                  >
+                    {s.title}
+                  </Link>
+                  <p className="text-xs text-muted-foreground mt-1 flex flex-wrap items-center gap-1.5">
+                    <Badge variant="outline" className={STATUS_TONE[s.publicationStatus]}>
+                      {s.publicationStatus}
+                    </Badge>
+                    <span>{AFFAIR_STATUS_LABELS[s.status]}</span>
+                    <span aria-hidden>&bull;</span>
+                    <span>{AFFAIR_CATEGORY_LABELS[s.category]}</span>
+                    <span aria-hidden>&bull;</span>
+                    <span>
+                      {s.sourceCount} source{s.sourceCount > 1 ? "s" : ""}
+                    </span>
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={blocked || busyId !== null}
+                  onClick={() => void absorb(s)}
+                  title={
+                    blocked
+                      ? "Une fiche publiée ne peut pas être absorbée : dépubliez-la, ou fusionnez depuis elle."
+                      : undefined
+                  }
+                >
+                  {busyId === s.id ? "Fusion…" : "Absorber"}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/__tests__/AffairMergePanel.test.tsx
+++ b/src/components/admin/__tests__/AffairMergePanel.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), back: vi.fn() }),
+}));
+
+import { AffairMergePanel, type SiblingAffair } from "@/components/admin/AffairMergePanel";
+
+const DRAFT: SiblingAffair = {
+  id: "aff_draft",
+  title: "Plainte classée sans suite",
+  status: "CLASSEMENT_SANS_SUITE",
+  category: "PRISE_ILLEGALE_INTERETS",
+  publicationStatus: "DRAFT",
+  sourceCount: 1,
+};
+
+const PUBLISHED: SiblingAffair = {
+  id: "aff_pub",
+  title: "Autre affaire déjà en ligne",
+  status: "ENQUETE_PRELIMINAIRE",
+  category: "TRAFIC_INFLUENCE",
+  publicationStatus: "PUBLISHED",
+  sourceCount: 3,
+};
+
+function setup(siblings: SiblingAffair[], published = true) {
+  return render(
+    <AffairMergePanel
+      affairId="aff_current"
+      affairTitle="Plainte pour trafic d'influence"
+      affairIsPublished={published}
+      siblings={siblings}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ proposalsCreated: 2 }) }))
+  );
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => true)
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("AffairMergePanel", () => {
+  it("ne s'affiche pas quand la personne n'a pas d'autre affaire", () => {
+    const { container } = setup([]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("liste les autres affaires avec ce qui permet de les reconnaître", () => {
+    setup([DRAFT]);
+    expect(screen.getByText("Plainte classée sans suite")).toBeInTheDocument();
+    expect(screen.getByText("DRAFT")).toBeInTheDocument();
+    expect(screen.getByText(/1 source/)).toBeInTheDocument();
+  });
+
+  it("refuse d'absorber une fiche publiée avant même le clic", async () => {
+    // La route refuse de supprimer une page qu'un lecteur peut atteindre. Le dire
+    // dans l'interface vaut mieux qu'un 409 après coup.
+    setup([PUBLISHED]);
+    const button = screen.getByRole("button", { name: /Absorber/ });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", expect.stringContaining("dépubliez"));
+  });
+
+  it("absorbe dans le sens annoncé : la fiche courante survit", async () => {
+    setup([DRAFT]);
+    await userEvent.click(screen.getByRole("button", { name: /Absorber/ }));
+
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call?.[0]).toBe("/api/admin/affaires/doublons/fusionner");
+    const body = JSON.parse((call?.[1] as RequestInit).body as string);
+    expect(body.keepId).toBe("aff_current");
+    expect(body.removeId).toBe("aff_draft");
+  });
+
+  it("marque la décision comme humaine, pas comme un score", () => {
+    // Le registre des paires distingue ce qu'un seuil a proposé de ce qu'une
+    // personne a tranché ; envoyer un score calculé effacerait la différence.
+    setup([DRAFT]);
+    return userEvent.click(screen.getByRole("button", { name: /Absorber/ })).then(() => {
+      const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse((call?.[1] as RequestInit).body as string);
+      expect(body.signal).toMatchObject({ confidence: "CERTAIN", score: 1 });
+    });
+  });
+
+  it("annonce les propositions créées quand la survivante est publiée", async () => {
+    setup([DRAFT]);
+    await userEvent.click(screen.getByRole("button", { name: /Absorber/ }));
+    expect(await screen.findByRole("status")).toHaveTextContent(/2 proposition/);
+  });
+
+  it("prévient que rien ne sera écrit directement sur une fiche publiée", async () => {
+    setup([DRAFT], true);
+    await userEvent.click(screen.getByRole("button", { name: /Absorber/ }));
+    const message = (globalThis.confirm as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(message).toContain("propositions à valider");
+  });
+
+  it("remonte l'erreur de l'API au lieu de laisser croire à un succès", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 409, json: async () => ({ error: "Refusé" }) }))
+    );
+    setup([DRAFT]);
+    await userEvent.click(screen.getByRole("button", { name: /Absorber/ }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Refusé");
+  });
+
+  it("n'appelle rien si la confirmation est refusée", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false)
+    );
+    setup([DRAFT]);
+    await userEvent.click(screen.getByRole("button", { name: /Absorber/ }));
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Deux fiches Charles Alloncle décrivent la même plainte. L'une est **publiée** et annonce
la plainte pour trafic d'influence ; l'autre est un **brouillon** intitulé « classée sans
suite ». Une accusation en ligne dont l'issue favorable dort dans un brouillon que rien ne
relie.

Impossible d'agir : la revue des doublons ne liste que les paires détectées, et depuis une
fiche il n'existait aucun chemin vers la fusion.

## Pourquoi la détection rate cette paire

Score calculé sur la paire réelle :

```
titres similaires  67 %  → 33 points
même catégorie           →  0    TRAFIC_INFLUENCE vs PRISE_ILLEGALE_INTERETS
dates proches            →  0    aucune date des deux côtés
sources communes         →  0    Libération vs BFM
                          ───
                           33    seuil : 40
```

Sept points manquants, mais la cause n'est pas le réglage. **Le signal « même catégorie »
joue contre exactement ce cas** : une plainte visant plusieurs infractions produit des
fiches qui en retiennent chacune une, et le critère censé les rapprocher les éloigne.

Cette PR ne touche pas au score. Baisser un seuil pour rattraper un cas connu déplace le
problème vers les faux positifs, et je n'ai pas de mesure pour arbitrer ça aujourd'hui.

## Ce que la PR ajoute

Une carte « Autres affaires de cette personne » sur la fiche admin, qui liste les autres
affaires du même politicien avec de quoi les reconnaître (statut de publication, statut
judiciaire, catégorie, nombre de sources) et un bouton **Absorber**.

Aucune détection. La machine ne propose rien, elle laisse une personne qui a lu les deux
fiches désigner la paire. Jusqu'ici cette personne n'avait aucun moyen d'agir sur ce
qu'elle voyait.

## Ce que la PR ne réinvente pas

Tout le mécanisme existait et il est correct. `/api/admin/affaires/doublons/fusionner`
écrit la décision `DUPLICATE` dans la même transaction, refuse de supprimer une fiche
publiée quel que soit l'appelant, et quand la survivante est publiée passe par
`absorbDraftIntoPublished()` : ce que le brouillon dit du volet judiciaire arrive en
**propositions à valider**, jamais en écriture directe. Exactement l'invariant du projet.

Le panneau appelle cette route. Il n'y a pas de nouvelle route, pas de nouveau service.

Deux choix de conception :

**Le sens est fixe et annoncé.** La fiche ouverte survit, l'autre est absorbée. Proposer
le choix inviterait à absorber la page d'où l'on vient, et c'est le seul cas que la route
refuse de toute façon.

**Le bouton est désactivé sur une fiche publiée**, avec l'explication au survol. La route
répondrait 409 ; le dire avant le clic évite de découvrir la règle par l'échec.

**La décision est marquée `CERTAIN` / score 1.** Le registre des paires distingue ce qu'un
seuil a proposé de ce qu'une personne a tranché ; envoyer un score calculé effacerait la
différence.

## Test plan

- 9 tests sur le composant : le sens de l'absorption, le refus avant clic sur une fiche
  publiée, le marquage humain de la décision, l'annonce des propositions créées, l'erreur
  API remontée au lieu d'un faux succès, et l'absence d'appel si la confirmation est
  refusée
- `npm run test:run` : 3014 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- Rendu vérifié sur la vraie fiche Alloncle : la carte liste le brouillon « classée sans
  suite » avec son bouton, et les fiches publiées portent bien l'explication de refus

Le compilateur a attrapé au passage une valeur d'enum oubliée (`EXCLUDED`) : le `Record`
des pastilles est exhaustif, donc une valeur ajoutée demain casse la compilation au lieu
de rendre une pastille sans style.

## Ce qui reste

La liaison victime ↔ mis en cause, l'autre demande. `linkedAffairId` et
`/doublons/lier` existent, mais **aucune des 470 affaires n'est liée** : le geste n'a
jamais été fait une seule fois, ce qui en dit long sur son coût actuel. Elle concerne des
politiciens différents, donc une recherche transverse, pas la liste des affaires sœurs.

## Rollback

Aucune migration, aucune route nouvelle. Revenir au commit précédent retire la carte ;
les fusions déjà faites restent, elles passent par le chemin existant.
