### PR TITLE
Conserver un instantané de l'affaire absorbée lors d'une fusion

### DIFF
--- a/src/services/affairs/__tests__/absorbed-snapshot.test.ts
+++ b/src/services/affairs/__tests__/absorbed-snapshot.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { Prisma } from "@/generated/prisma";
+import {
+  buildAbsorbedSnapshot,
+  absorbedAffairSelect,
+  ABSORBED_SNAPSHOT_VERSION,
+  type AbsorbedAffairRow,
+} from "@/services/affairs/absorbed-snapshot";
+
+/**
+ * A merge deletes the absorbed row. What these tests hold is that the editorial
+ * fields stay readable in the audit trail afterwards (#534) — most of all the
+ * description, which is what merges used to be decided by, since the survivor was
+ * chosen for being the richer row rather than the right one.
+ */
+
+function row(overrides: Partial<AbsorbedAffairRow> = {}): AbsorbedAffairRow {
+  return {
+    id: "aff_absorbed",
+    publicId: "AF-000123",
+    slug: "plainte-classee-sans-suite",
+    oldSlugs: ["ancien-slug"],
+    title: "Plainte classée sans suite",
+    description: "Le parquet a classé la plainte sans suite le 3 mars 2026.",
+    category: "PRISE_ILLEGALE_INTERETS",
+    status: "CLASSEMENT_SANS_SUITE",
+    involvement: "DIRECT",
+    involvementNote: null,
+    subjectLabel: "Lagardère News",
+    subjectKind: "ORGANISATION",
+    subjectNote: "Groupe de presse",
+    severity: "SIGNIFICATIF",
+    isRelatedToMandate: true,
+    publicationStatus: "DRAFT",
+    factsDate: new Date("2025-06-01T00:00:00.000Z"),
+    startDate: null,
+    verdictDate: new Date("2026-03-03T00:00:00.000Z"),
+    court: "Parquet de Paris",
+    caseNumber: "2026/00042",
+    sentence: null,
+    prisonMonths: null,
+    prisonFirmMonths: null,
+    fineAmount: new Prisma.Decimal("12345.67"),
+    ineligibilityMonths: null,
+    ineligibilityFirmMonths: null,
+    communityService: null,
+    otherSentence: null,
+    confidenceScore: 80,
+    rejectionReason: null,
+    linkedAffairId: null,
+    ...overrides,
+  } as AbsorbedAffairRow;
+}
+
+describe("buildAbsorbedSnapshot", () => {
+  it("garde la description, ce que la fusion faisait disparaître", () => {
+    const snap = buildAbsorbedSnapshot(row());
+    expect(snap.description).toBe("Le parquet a classé la plainte sans suite le 3 mars 2026.");
+  });
+
+  it("porte un numéro de version, pour qu'un lecteur sache ce qu'il tient", () => {
+    expect(buildAbsorbedSnapshot(row()).version).toBe(ABSORBED_SNAPSHOT_VERSION);
+  });
+
+  it("garde l'état procédural et les dates", () => {
+    const snap = buildAbsorbedSnapshot(row());
+    expect(snap.status).toBe("CLASSEMENT_SANS_SUITE");
+    expect(snap.category).toBe("PRISE_ILLEGALE_INTERETS");
+    expect(snap.factsDate).toBe("2025-06-01T00:00:00.000Z");
+    expect(snap.verdictDate).toBe("2026-03-03T00:00:00.000Z");
+    expect(snap.startDate).toBeNull();
+  });
+
+  it("rend l'amende en chaîne, pas en nombre flottant", () => {
+    // Un decimal Postgres passé par un float perd des centimes, sur les chiffres
+    // mêmes que ce projet existe pour énoncer exactement.
+    const snap = buildAbsorbedSnapshot(row());
+    expect(snap.fineAmount).toBe("12345.67");
+    expect(typeof snap.fineAmount).toBe("string");
+  });
+
+  it("garde les identifiants publics et les anciens slugs", () => {
+    const snap = buildAbsorbedSnapshot(row());
+    expect(snap.publicId).toBe("AF-000123");
+    expect(snap.oldSlugs).toEqual(["ancien-slug"]);
+  });
+
+  it("n'émet aucun undefined sur une ligne complète", () => {
+    const snap = buildAbsorbedSnapshot(row());
+    for (const [key, value] of Object.entries(snap)) {
+      expect(value, `${key} ne doit pas être undefined`).not.toBeUndefined();
+    }
+  });
+
+  it("ramène à null un champ optionnel absent de la ligne", () => {
+    // Les champs obligatoires ne sont pas protégés : Prisma les renvoie toujours,
+    // et un undefined visible sur l'un d'eux est un symptôme qu'il vaut mieux voir
+    // que masquer. Les optionnels, si : undefined et null y sont deux entrées
+    // différentes, et JSON.stringify supprime la première sans bruit.
+    const partial = {
+      id: "x",
+      slug: "s",
+      title: "t",
+      description: "d",
+      category: "AUTRE",
+      status: "ENQUETE_PRELIMINAIRE",
+    } as AbsorbedAffairRow;
+    const snap = buildAbsorbedSnapshot(partial);
+    const roundTripped = JSON.parse(JSON.stringify(snap)) as Record<string, unknown>;
+
+    for (const field of ["fineAmount", "court", "caseNumber", "publicId", "involvementNote"]) {
+      expect(snap[field], `${field} doit être null, pas undefined`).toBeNull();
+      expect(roundTripped, `${field} doit survivre au passage en JSON`).toHaveProperty(field);
+    }
+  });
+
+  it("ne copie aucune relation déjà transférée au survivant", () => {
+    // Sources, événements et liens d'articles sont déplacés ligne par ligne : les
+    // dupliquer ici gonflerait la table d'audit sans rien préserver.
+    const selected = Object.keys(absorbedAffairSelect);
+    for (const relation of ["sources", "events", "pressArticles", "courtDecisions"]) {
+      expect(selected).not.toContain(relation);
+    }
+  });
+
+  it("n'emporte pas la description pré-enrichissement", () => {
+    // Artefact de rollback interne, pas une affirmation de la fiche.
+    expect(Object.keys(absorbedAffairSelect)).not.toContain("originalDescription");
+  });
+});

--- a/src/services/affairs/__tests__/merge-affairs.test.ts
+++ b/src/services/affairs/__tests__/merge-affairs.test.ts
@@ -739,3 +739,55 @@ describe("mergeAffairs — transfert des liaisons de décision (#536)", () => {
     expect(order).toEqual(["transfer", "delete"]);
   });
 });
+
+describe("mergeAffairs — snapshot de l'affaire absorbée (#534)", () => {
+  it("écrit la description de l'absorbée dans l'audit, champ par champ", async () => {
+    // Le critère porteur : la fusion supprime la ligne, et jusqu'ici sa description
+    // disparaissait avec elle. Les fusions se décidaient donc sur la richesse de la
+    // ligne plutôt que sur le bon survivant.
+    stub(
+      affair(),
+      affair({
+        id: "remove",
+        title: "Plainte classée sans suite",
+        slug: "plainte-classee",
+        publicId: "AF-000002",
+        description: "Le parquet a classé la plainte sans suite.",
+        category: "PRISE_ILLEGALE_INTERETS",
+        status: "CLASSEMENT_SANS_SUITE",
+        court: "Parquet de Paris",
+      })
+    );
+
+    await mergeAffairs("keep", "remove");
+
+    const changes = tx.auditLog.create.mock.calls[0]?.[0].data.changes as Record<string, unknown>;
+    const snapshot = changes.absorbedAffairSnapshot as Record<string, unknown>;
+    expect(snapshot).toBeDefined();
+    expect(snapshot.description).toBe("Le parquet a classé la plainte sans suite.");
+    expect(snapshot.status).toBe("CLASSEMENT_SANS_SUITE");
+    expect(snapshot.category).toBe("PRISE_ILLEGALE_INTERETS");
+    expect(snapshot.court).toBe("Parquet de Paris");
+    expect(snapshot.publicId).toBe("AF-000002");
+    expect(snapshot.version).toBe(1);
+  });
+
+  it("annule la suppression quand l'écriture de l'audit échoue", async () => {
+    // Même transaction : un audit perdu laisserait une fiche supprimée sans trace
+    // de ce qu'elle disait. L'erreur doit remonter pour que le rollback ait lieu.
+    stub(affair(), affair({ id: "remove", slug: "absorbee", publicId: "AF-000002" }));
+    tx.auditLog.create.mockRejectedValueOnce(new Error("audit indisponible"));
+
+    await expect(mergeAffairs("keep", "remove")).rejects.toThrow("audit indisponible");
+  });
+
+  it("lit l'absorbée avant de la supprimer", async () => {
+    // L'ordre compte : lue après le delete, la ligne n'existe plus.
+    stub(affair(), affair({ id: "remove", slug: "absorbee", publicId: "AF-000002" }));
+    await mergeAffairs("keep", "remove");
+
+    const readOrder = tx.affair.findUnique.mock.invocationCallOrder[0] ?? Infinity;
+    const deleteOrder = tx.affair.delete.mock.invocationCallOrder[0] ?? -Infinity;
+    expect(readOrder).toBeLessThan(deleteOrder);
+  });
+});

--- a/src/services/affairs/absorbed-snapshot.ts
+++ b/src/services/affairs/absorbed-snapshot.ts
@@ -1,0 +1,126 @@
+import type { Prisma } from "@/generated/prisma";
+
+/**
+ * Snapshot of an affair about to be absorbed, written to the audit trail in the
+ * same transaction as the merge.
+ *
+ * A merge deletes the absorbed row. Sources, events and article links are moved
+ * to the survivor, so they survive; the editorial fields do not. Description,
+ * procedural state, dates and sentence data disappeared for good, which is why
+ * merges used to be decided by which row was richer rather than by which one was
+ * right (#534).
+ *
+ * That trade-off got worse when merging became a two-click action from the affair
+ * page (#623): the panel fixes the direction, so the survivor can no longer be
+ * chosen to preserve the fuller description.
+ *
+ * Not a bin: nothing restores from this. The point is that a mistake stays
+ * traceable, not that it can be undone.
+ */
+
+/** Bumped whenever a field is added or removed, so a reader knows what they hold. */
+export const ABSORBED_SNAPSHOT_VERSION = 1;
+
+/**
+ * Exactly what the snapshot needs, and nothing more.
+ *
+ * Relations are excluded on purpose: they are transferred row by row to the
+ * survivor, so copying them here would duplicate live data and inflate the audit
+ * table. `originalDescription` is left out too — it is a pre-enrichment rollback
+ * artefact, not something the fiche asserted.
+ */
+export const absorbedAffairSelect = {
+  id: true,
+  publicId: true,
+  slug: true,
+  oldSlugs: true,
+  title: true,
+  description: true,
+  category: true,
+  status: true,
+  involvement: true,
+  involvementNote: true,
+  subjectLabel: true,
+  subjectKind: true,
+  subjectNote: true,
+  severity: true,
+  isRelatedToMandate: true,
+  publicationStatus: true,
+  factsDate: true,
+  startDate: true,
+  verdictDate: true,
+  court: true,
+  caseNumber: true,
+  sentence: true,
+  prisonMonths: true,
+  prisonFirmMonths: true,
+  fineAmount: true,
+  ineligibilityMonths: true,
+  ineligibilityFirmMonths: true,
+  communityService: true,
+  otherSentence: true,
+  confidenceScore: true,
+  rejectionReason: true,
+  linkedAffairId: true,
+} as const satisfies Prisma.AffairSelect;
+
+/** The row shape `absorbedAffairSelect` produces. */
+export type AbsorbedAffairRow = Prisma.AffairGetPayload<{
+  select: typeof absorbedAffairSelect;
+}>;
+
+export interface AbsorbedAffairSnapshot {
+  version: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Turns the row into something an audit `changes` column can hold.
+ *
+ * Dates become ISO strings and the fine becomes a string rather than a number:
+ * `fineAmount` is a Postgres decimal, and routing it through a float would lose
+ * cents on the exact figures this project exists to state precisely.
+ */
+export function buildAbsorbedSnapshot(affair: AbsorbedAffairRow): AbsorbedAffairSnapshot {
+  const iso = (d: Date | null | undefined) => (d ? d.toISOString() : null);
+  // `?? null` on every optional field rather than trusting the row shape: a stray
+  // `undefined` in a Json column vanishes on write, and a snapshot that silently
+  // drops the field it was meant to preserve is worse than no snapshot.
+  const or = <T>(v: T | null | undefined): T | null => v ?? null;
+
+  return {
+    version: ABSORBED_SNAPSHOT_VERSION,
+    id: affair.id,
+    publicId: or(affair.publicId),
+    slug: affair.slug,
+    oldSlugs: or(affair.oldSlugs),
+    title: affair.title,
+    description: affair.description,
+    category: affair.category,
+    status: affair.status,
+    involvement: or(affair.involvement),
+    involvementNote: or(affair.involvementNote),
+    subjectLabel: or(affair.subjectLabel),
+    subjectKind: or(affair.subjectKind),
+    subjectNote: or(affair.subjectNote),
+    severity: or(affair.severity),
+    isRelatedToMandate: or(affair.isRelatedToMandate),
+    publicationStatus: or(affair.publicationStatus),
+    factsDate: iso(affair.factsDate),
+    startDate: iso(affair.startDate),
+    verdictDate: iso(affair.verdictDate),
+    court: or(affair.court),
+    caseNumber: or(affair.caseNumber),
+    sentence: or(affair.sentence),
+    prisonMonths: or(affair.prisonMonths),
+    prisonFirmMonths: or(affair.prisonFirmMonths),
+    fineAmount: affair.fineAmount == null ? null : affair.fineAmount.toString(),
+    ineligibilityMonths: or(affair.ineligibilityMonths),
+    ineligibilityFirmMonths: or(affair.ineligibilityFirmMonths),
+    communityService: or(affair.communityService),
+    otherSentence: or(affair.otherSentence),
+    confidenceScore: or(affair.confidenceScore),
+    rejectionReason: or(affair.rejectionReason),
+    linkedAffairId: or(affair.linkedAffairId),
+  };
+}

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -15,6 +15,7 @@ import {
   type PublicationStatus,
   type SourceType,
 } from "@/generated/prisma";
+import { absorbedAffairSelect, buildAbsorbedSnapshot } from "./absorbed-snapshot";
 import {
   findMatchingAffairs,
   pairingRestsOnWildcard,
@@ -500,16 +501,11 @@ export async function mergeAffairsInTransaction(
   options: MergeAffairsOptions = {}
 ): Promise<MergeAffairsResult> {
   {
+    // The snapshot fields ride along: they have to be read before the row is
+    // deleted, and a second query would open a window where they could change.
     const affairSelect = {
-      id: true,
-      title: true,
-      slug: true,
-      publicId: true,
-      oldSlugs: true,
+      ...absorbedAffairSelect,
       politicianId: true,
-      publicationStatus: true,
-      court: true,
-      caseNumber: true,
     } as const;
 
     const [keep, remove] = await Promise.all([
@@ -738,6 +734,9 @@ export async function mergeAffairsInTransaction(
         changes: {
           mergedFrom: removeId,
           mergedFromTitle: remove.title,
+          // Written in the same transaction as the delete: if this insert fails,
+          // the merge rolls back and the absorbed row is still there (#534).
+          absorbedAffairSnapshot: buildAbsorbedSnapshot(remove),
           sourcesMoved,
           sourcesEnriched,
           eventsMoved,


### PR DESCRIPTION
Une fusion transfère les sources, les événements et les liens d'articles vers le
survivant, puis supprime la ligne absorbée. Sa description, son état procédural, ses
dates et ses peines partaient avec elle.

Conséquence décrite dans #534 : les fusions se décidaient sur la richesse de la ligne
plutôt que sur le bon survivant, faute de quoi rien n'aurait rattrapé la perte. Et
#623 a supprimé ce contournement : le panneau de fusion depuis la fiche impose un sens
fixe, donc on ne peut plus choisir le survivant pour préserver la description la plus
fournie.

## Ce que ça écrit

`src/services/affairs/absorbed-snapshot.ts` définit **une fois** le `select` et le
constructeur. L'instantané part dans `changes.absorbedAffairSnapshot` de l'entrée d'audit
`MERGE`, dans la **même transaction** que la suppression.

Un seul point de code couvre les deux chemins de fusion : l'absorption vers une fiche
publiée délègue à `mergeAffairsInTransaction`, elle en hérite donc sans modification.

La liste de champs de l'issue était périmée : `ecli`, `pourvoiNumber`, `chamber` et
`caseNumbers` ont été retirées de `Affair` en #545. Le format retenu suit le schéma
actuel et porte `version: 1`.

## Deux décisions que les tests ont imposées

**L'amende passe en chaîne, pas en nombre.** `fineAmount` est un decimal Postgres, et un
aller-retour par un flottant perd des centimes, sur les chiffres mêmes que ce projet
existe pour énoncer exactement.

**Les champs obligatoires ne sont pas protégés contre `undefined`, les optionnels le
sont.** J'avais d'abord tout protégé ; mon propre test a montré l'incohérence. Prisma
garantit les champs requis, donc un `undefined` sur l'un d'eux est un symptôme qu'il vaut
mieux voir que masquer. Les optionnels ont besoin du `?? null` parce que
`JSON.stringify` supprime `undefined` sans bruit : l'instantané perdrait précisément le
champ qu'il devait préserver.

## Ce que ça ne copie pas

Aucune relation déjà transférée ligne par ligne : les dupliquer gonflerait la table
d'audit sans rien préserver. Un test le vérifie sur la définition du `select`, pas
seulement sur une sortie.

`originalDescription` non plus : c'est un artefact de rollback interne, pas une
affirmation de la fiche.

Pas de restauration automatique. L'objectif est qu'une erreur reste traçable, pas de
construire une corbeille.

## Critères d'acceptation

| critère | où |
| ------- | -- |
| la description reste récupérable depuis l'audit | test « garde la description » |
| écrit dans la même transaction | test « annule la suppression quand l'écriture de l'audit échoue » |
| l'échec de l'audit annule la suppression | idem, l'erreur remonte donc la transaction rollback |
| aucune relation dupliquée | test sur les clés de `absorbedAffairSelect` |
| le format porte une version | test « porte un numéro de version » |
| les deux chemins de fusion sont couverts | l'absorption délègue à `mergeAffairsInTransaction` |
| relisible champ par champ | test d'intégration sur `changes.absorbedAffairSnapshot` |

Un test supplémentaire vérifie que l'absorbée est **lue avant** d'être supprimée : lue
après, la ligne n'existe plus.

## Test plan

- 9 tests sur le constructeur, 3 tests d'intégration sur la fusion
- `npm run test:run` : 3026 passés
- `npx tsc` : code de sortie 0, hors cache incrémental et hors `.next/`
- `npx eslint` : 0 erreur
- `npm run build` : code de sortie 0

Les 27 tests de fusion existants ont échoué à la première tentative : leurs fixtures ne
portent pas tous les champs. C'est ce qui a fait apparaître la question `undefined` /
`null` ci-dessus, traitée dans le constructeur plutôt qu'en réécrivant les fixtures.

## Rollback

Aucune migration. L'instantané n'est qu'une clé de plus dans la colonne `changes` de
l'audit. Revenir au commit précédent arrête de l'écrire ; ceux déjà écrits restent
lisibles.
