### PR TITLE
Faire tourner la sélection des votes clés du hub parlement

### DIFF
--- a/src/components/parlement/ParlementHub.tsx
+++ b/src/components/parlement/ParlementHub.tsx
@@ -191,7 +191,7 @@ export async function ParlementHub() {
 
       {/* Hero Spotlight */}
       {keyVotes.hero && (
-        <section className="mb-8" aria-label="Vote clé de la semaine">
+        <section className="mb-8" aria-label="Vote clé mis en avant">
           <HeroSpotlight
             id={keyVotes.hero.id}
             slug={keyVotes.hero.slug}
@@ -212,7 +212,7 @@ export async function ParlementHub() {
       {/* Votes clés + exploration des scrutins */}
       <section className="mb-8">
         <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 mb-1">
-          <h2 className="text-lg font-semibold">Votes clés récents</h2>
+          <h2 className="text-lg font-semibold">Votes clés</h2>
           <Link
             href={ROUTES.votes}
             className="inline-flex items-center gap-1.5 rounded-md border px-3 py-2 text-sm font-medium text-primary hover:bg-muted transition-colors shrink-0"
@@ -223,7 +223,8 @@ export async function ParlementHub() {
         </div>
         <p className="text-sm text-muted-foreground mb-3 max-w-3xl">
           Sélection de scrutins mis en avant pour leur portée politique, institutionnelle ou
-          citoyenne. Ce n{"'"}est ni un classement exhaustif, ni un palmarès.
+          citoyenne, renouvelée chaque jour parmi les votes les plus marquants des dernières
+          semaines. Ce n{"'"}est ni un classement exhaustif, ni un palmarès.
         </p>
         {keyVotes.grid.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/config/scrutin-importance.ts
+++ b/src/config/scrutin-importance.ts
@@ -39,5 +39,16 @@ export const GOVERNMENT_GROUP_CODE = "EPR";
 export const SENATE_GOVERNMENT_GROUP_CODE = "RDPI";
 export const CURRENT_LEGISLATURE = 17;
 export const CURRENT_SENATE_SESSION = 2023;
-export const KEY_VOTES_HUB_WINDOW_DAYS = 30;
+/**
+ * Hub "votes clés": windows tried in order, widening only when the narrower one
+ * cannot fill the surface. A single fixed window emptied the hub during every
+ * recess, when the last scrutin is more than 30 days old.
+ */
+export const KEY_VOTES_WINDOWS_DAYS = [30, 90, 180] as const;
 export const KEY_VOTES_GRID_COUNT = 5;
+/** Candidates kept for rotation, larger than the 1 hero + grid actually shown. */
+export const KEY_VOTES_POOL_SIZE = 12;
+/** Cap per dossier législatif, so the hub is not six votes on the same texte. */
+export const KEY_VOTES_MAX_PER_DOSSIER = 2;
+/** Rows fetched before ranking. Roughly one semester of key votes. */
+export const KEY_VOTES_QUERY_LIMIT = 400;

--- a/src/lib/data/scrutins.ts
+++ b/src/lib/data/scrutins.ts
@@ -1,9 +1,16 @@
 import { cacheTag, cacheLife } from "next/cache";
 import { db } from "@/lib/db";
 import type { Chamber, VotingResult, ThemeCategory, ScrutinType, Prisma } from "@/generated/prisma";
-import { KEY_VOTES_HUB_WINDOW_DAYS, KEY_VOTES_GRID_COUNT } from "@/config/scrutin-importance";
+import {
+  KEY_VOTES_WINDOWS_DAYS,
+  KEY_VOTES_GRID_COUNT,
+  KEY_VOTES_POOL_SIZE,
+  KEY_VOTES_MAX_PER_DOSSIER,
+  KEY_VOTES_QUERY_LIMIT,
+} from "@/config/scrutin-importance";
 import type { PolicyForView } from "@/lib/votes/to-public-title-view";
 import { scoreExplainedVote, diversify } from "@/lib/votes/explained-scoring";
+import { selectKeyVotes } from "@/lib/votes/key-vote-selection";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -611,7 +618,33 @@ export async function getChamberAdoptionRates(): Promise<
 // Key votes (parlement-riche hub)
 // ---------------------------------------------------------------------------
 
-/** Key votes from last N days for the hub hero + grid. */
+const KEY_VOTE_SELECT = {
+  ...DAILY_SELECT,
+  dossierLegislatifId: true, // scalar FK — the per-dossier cap reads it
+  importance: { select: { score: true } },
+} satisfies Prisma.ScrutinSelect;
+
+type KeyVoteRow = Prisma.ScrutinGetPayload<{ select: typeof KEY_VOTE_SELECT }>;
+
+function toKeyVoteCandidate(s: KeyVoteRow) {
+  return {
+    id: s.id,
+    title: s.title,
+    votingDate: s.votingDate,
+    dossierLegislatifId: s.dossierLegislatifId ?? null,
+    type: s.type,
+    importanceScore: s.importance?.score ?? 0,
+    _row: s,
+  };
+}
+
+/**
+ * Key votes for the hub hero + grid, ranked by `selectKeyVotes` (importance,
+ * recency, procedural weight), capped per dossier and rotated daily. The window
+ * widens (30 / 90 / 180 days) only when the narrower one cannot fill the surface,
+ * so a parliamentary recess reaches further back instead of emptying the hub.
+ * Falls back to the best-scored scrutins when no key vote has been promoted at all.
+ */
 export async function getKeyVotes(): Promise<{
   hero: (DailyScrutin & { score: number }) | null;
   grid: Array<DailyScrutin & { score: number }>;
@@ -620,50 +653,52 @@ export async function getKeyVotes(): Promise<{
   cacheTag("votes", "votes-key");
   cacheLife("synced");
 
-  const windowStart = new Date();
-  windowStart.setDate(windowStart.getDate() - KEY_VOTES_HUB_WINDOW_DAYS);
+  const now = new Date();
+  const widestWindow = KEY_VOTES_WINDOWS_DAYS[KEY_VOTES_WINDOWS_DAYS.length - 1]!;
+  const windowStart = new Date(now);
+  windowStart.setDate(windowStart.getDate() - widestWindow);
 
-  const keyVotes = await db.scrutin.findMany({
-    where: {
-      importance: { isKeyVote: true },
-      votingDate: { gte: windowStart },
-    },
-    orderBy: [{ votingDate: "desc" }, { importance: { score: "desc" } }],
-    take: KEY_VOTES_GRID_COUNT + 1,
-    select: {
-      ...DAILY_SELECT,
-      importance: { select: { score: true } },
-    },
+  const selectOpts = {
+    now,
+    gridCount: KEY_VOTES_GRID_COUNT,
+    poolSize: KEY_VOTES_POOL_SIZE,
+    maxPerDossier: KEY_VOTES_MAX_PER_DOSSIER,
+  };
+  const toResult = (picked: { hero: KeyVoteRow | null; grid: KeyVoteRow[] }) => ({
+    hero: picked.hero ? { ...picked.hero, score: picked.hero.importance?.score ?? 0 } : null,
+    grid: picked.grid.map((s) => ({ ...s, score: s.importance?.score ?? 0 })),
+  });
+  const pick = (pool: KeyVoteRow[]) => {
+    const { hero, grid } = selectKeyVotes(pool.map(toKeyVoteCandidate), selectOpts);
+    return { hero: hero?._row ?? null, grid: grid.map((c) => c._row) };
+  };
+
+  const rows = await db.scrutin.findMany({
+    where: { importance: { isKeyVote: true }, votingDate: { gte: windowStart } },
+    orderBy: { votingDate: "desc" },
+    take: KEY_VOTES_QUERY_LIMIT,
+    select: KEY_VOTE_SELECT,
   });
 
-  if (keyVotes.length === 0) {
-    const fallback = await db.scrutin.findMany({
-      where: {
-        importance: { isNot: null },
-        votingDate: { gte: windowStart },
-      },
-      orderBy: { importance: { score: "desc" } },
-      take: KEY_VOTES_GRID_COUNT + 1,
-      select: {
-        ...DAILY_SELECT,
-        importance: { select: { score: true } },
-      },
-    });
-
-    const mapped = fallback.map((s) => ({
-      ...s,
-      score: s.importance?.score ?? 0,
-    }));
-
-    return { hero: mapped[0] ?? null, grid: mapped.slice(1) };
+  let picked: { hero: KeyVoteRow | null; grid: KeyVoteRow[] } = { hero: null, grid: [] };
+  for (const days of KEY_VOTES_WINDOWS_DAYS) {
+    const cutoff = new Date(now);
+    cutoff.setDate(cutoff.getDate() - days);
+    picked = pick(rows.filter((r) => r.votingDate >= cutoff));
+    if (picked.grid.length >= KEY_VOTES_GRID_COUNT) return toResult(picked);
   }
+  if (picked.hero) return toResult(picked);
 
-  const mapped = keyVotes.map((s) => ({
-    ...s,
-    score: s.importance?.score ?? 0,
-  }));
+  // No key vote promoted in the widest window: show the best-scored scrutins
+  // rather than an empty hub.
+  const fallback = await db.scrutin.findMany({
+    where: { importance: { isNot: null }, votingDate: { gte: windowStart } },
+    orderBy: { importance: { score: "desc" } },
+    take: KEY_VOTES_QUERY_LIMIT,
+    select: KEY_VOTE_SELECT,
+  });
 
-  return { hero: mapped[0] ?? null, grid: mapped.slice(1) };
+  return toResult(pick(fallback));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/votes/__tests__/key-vote-selection.test.ts
+++ b/src/lib/votes/__tests__/key-vote-selection.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  scoreKeyVote,
+  buildKeyVotePool,
+  rotationOffset,
+  selectKeyVotes,
+  type KeyVoteCandidate,
+} from "@/lib/votes/key-vote-selection";
+
+const NOW = new Date("2026-08-03T00:00:00Z");
+const DAY = 86_400_000;
+
+const base = (o: Partial<KeyVoteCandidate>): KeyVoteCandidate => ({
+  id: "x",
+  title: "Vote",
+  votingDate: NOW,
+  dossierLegislatifId: "d1",
+  type: "FINAL",
+  importanceScore: 75,
+  ...o,
+});
+
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * DAY);
+
+describe("scoreKeyVote", () => {
+  it("ranks a higher importance above a lower one, all else equal", () => {
+    expect(scoreKeyVote(base({ importanceScore: 90 }), NOW)).toBeGreaterThan(
+      scoreKeyVote(base({ importanceScore: 70 }), NOW)
+    );
+  });
+
+  it("ranks a decisive vote above an amendement at equal importance", () => {
+    expect(scoreKeyVote(base({ type: "FINAL" }), NOW)).toBeGreaterThan(
+      scoreKeyVote(base({ type: "AMENDEMENT" }), NOW)
+    );
+  });
+
+  it("lets a strong older vote solennel beat a fresh borderline amendement", () => {
+    const solennel = base({ importanceScore: 95, type: "FINAL", votingDate: daysAgo(45) });
+    const amendement = base({ importanceScore: 70.4, type: "AMENDEMENT", votingDate: NOW });
+    expect(scoreKeyVote(solennel, NOW)).toBeGreaterThan(scoreKeyVote(amendement, NOW));
+  });
+
+  it("still prefers the newer of two identical votes", () => {
+    expect(scoreKeyVote(base({ votingDate: NOW }), NOW)).toBeGreaterThan(
+      scoreKeyVote(base({ votingDate: daysAgo(120) }), NOW)
+    );
+  });
+
+  it("treats a missing type as no procedural bonus", () => {
+    expect(scoreKeyVote(base({ type: null }), NOW)).toBe(
+      scoreKeyVote(base({ type: "AUTRE" }), NOW)
+    );
+  });
+});
+
+describe("buildKeyVotePool", () => {
+  it("caps candidates per dossier", () => {
+    const sorted = [
+      base({ id: "a", dossierLegislatifId: "d1", title: "Article 1" }),
+      base({ id: "b", dossierLegislatifId: "d1", title: "Article 2" }),
+      base({ id: "c", dossierLegislatifId: "d1", title: "Article 3" }),
+      base({ id: "d", dossierLegislatifId: "d2", title: "Autre texte" }),
+    ];
+    const pool = buildKeyVotePool(sorted, { size: 10, maxPerDossier: 2 });
+    expect(pool.map((c) => c.id)).toEqual(["a", "b", "d"]);
+  });
+
+  it("never caps candidates without a dossier", () => {
+    const sorted = [
+      base({ id: "a", dossierLegislatifId: null, title: "Motion de censure" }),
+      base({ id: "b", dossierLegislatifId: null, title: "Declaration de politique generale" }),
+      base({ id: "c", dossierLegislatifId: null, title: "Motion referendaire" }),
+    ];
+    const pool = buildKeyVotePool(sorted, { size: 10, maxPerDossier: 1 });
+    expect(pool).toHaveLength(3);
+  });
+
+  it("drops a near-duplicate of the same dossier on the same day", () => {
+    const sorted = [
+      base({ id: "a", title: "l'ensemble du projet de loi relatif a la protection des enfants" }),
+      base({ id: "b", title: "l ensemble du projet de loi relatif a la protection des enfants" }),
+    ];
+    expect(buildKeyVotePool(sorted, { size: 10, maxPerDossier: 2 }).map((c) => c.id)).toEqual([
+      "a",
+    ]);
+  });
+
+  it("honors the pool size", () => {
+    const sorted = Array.from({ length: 20 }, (_, i) =>
+      base({ id: `s${i}`, dossierLegislatifId: `d${i}` })
+    );
+    expect(buildKeyVotePool(sorted, { size: 6, maxPerDossier: 2 })).toHaveLength(6);
+  });
+});
+
+describe("rotationOffset", () => {
+  it("advances by one per day", () => {
+    const a = rotationOffset(NOW, 7);
+    const b = rotationOffset(new Date(NOW.getTime() + DAY), 7);
+    expect(b).toBe((a + 1) % 7);
+  });
+
+  it("stays stable within the same day", () => {
+    expect(rotationOffset(new Date("2026-08-03T02:00:00Z"), 7)).toBe(
+      rotationOffset(new Date("2026-08-03T22:00:00Z"), 7)
+    );
+  });
+
+  it("wraps around the pool", () => {
+    expect(rotationOffset(new Date(NOW.getTime() + 7 * DAY), 7)).toBe(rotationOffset(NOW, 7));
+  });
+
+  it("returns 0 on an empty pool", () => {
+    expect(rotationOffset(NOW, 0)).toBe(0);
+  });
+});
+
+describe("selectKeyVotes", () => {
+  const opts = { now: NOW, gridCount: 5, poolSize: 12, maxPerDossier: 2 };
+
+  const corpus = (): KeyVoteCandidate[] =>
+    Array.from({ length: 12 }, (_, i) =>
+      base({
+        id: `s${i}`,
+        dossierLegislatifId: `d${i}`,
+        title: `Texte ${i}`,
+        type: i % 2 === 0 ? "FINAL" : "AMENDEMENT",
+        importanceScore: 90 - i,
+        votingDate: daysAgo(i),
+      })
+    );
+
+  it("returns an empty selection on no candidate", () => {
+    expect(selectKeyVotes([], opts)).toEqual({ hero: null, grid: [] });
+  });
+
+  it("never repeats the hero in the grid", () => {
+    const { hero, grid } = selectKeyVotes(corpus(), opts);
+    expect(grid.map((c) => c.id)).not.toContain(hero!.id);
+  });
+
+  it("changes the selection from one day to the next", () => {
+    const today = selectKeyVotes(corpus(), opts);
+    const tomorrow = selectKeyVotes(corpus(), { ...opts, now: new Date(NOW.getTime() + DAY) });
+    expect(tomorrow.hero!.id).not.toBe(today.hero!.id);
+    expect(tomorrow.grid.map((c) => c.id)).not.toEqual(today.grid.map((c) => c.id));
+  });
+
+  it("keeps rotating when no new vote has been recorded for weeks", () => {
+    // Frozen corpus, as during a recess: the surface must still move.
+    const frozen = corpus().map((c) => ({ ...c, votingDate: daysAgo(30 + Number(c.id.slice(1))) }));
+    const heroes = new Set(
+      Array.from(
+        { length: 6 },
+        (_, d) =>
+          selectKeyVotes(frozen, { ...opts, now: new Date(NOW.getTime() + d * DAY) }).hero!.id
+      )
+    );
+    expect(heroes.size).toBeGreaterThan(1);
+  });
+
+  it("headlines a decisive vote even when amendements score higher", () => {
+    const candidates = [
+      base({ id: "amend", type: "AMENDEMENT", importanceScore: 99, dossierLegislatifId: "d1" }),
+      base({ id: "final", type: "FINAL", importanceScore: 71, dossierLegislatifId: "d2" }),
+    ];
+    expect(selectKeyVotes(candidates, opts).hero!.id).toBe("final");
+  });
+
+  it("falls back to the best candidate when none is decisive", () => {
+    const candidates = [
+      base({ id: "a", type: "AMENDEMENT", importanceScore: 80, dossierLegislatifId: "d1" }),
+      base({ id: "b", type: "ARTICLE", importanceScore: 75, dossierLegislatifId: "d2" }),
+    ];
+    expect(selectKeyVotes(candidates, opts).hero).not.toBeNull();
+  });
+
+  it("does not fill the hub with a single dossier", () => {
+    const sameDossier = Array.from({ length: 20 }, (_, i) =>
+      base({
+        id: `s${i}`,
+        dossierLegislatifId: "d1",
+        title: `Amendement ${i}`,
+        type: "AMENDEMENT",
+        votingDate: daysAgo(i % 5),
+      })
+    );
+    const { hero, grid } = selectKeyVotes(sameDossier, opts);
+    expect([hero, ...grid].filter(Boolean)).toHaveLength(2);
+  });
+});

--- a/src/lib/votes/key-vote-selection.ts
+++ b/src/lib/votes/key-vote-selection.ts
@@ -1,0 +1,144 @@
+import type { ScrutinType } from "@/generated/prisma";
+import { normalizeTitle, titleSimilarity } from "@/lib/votes/explained-scoring";
+
+/**
+ * Ranking and rotation for the "votes clés" hub surface.
+ *
+ * The previous selection ordered strictly by `votingDate desc`, so the hero was
+ * always the newest key vote and the hub froze for weeks as soon as the Parlement
+ * stopped voting (recess, dissolution, any gap between two séances). It also let a
+ * sub-amendement headline the page, because the importance score alone barely
+ * separates an amendement from a vote solennel.
+ *
+ * Three changes fix that, all of them here so they stay testable:
+ *  - the rank blends importance, recency decay and the procedural weight of the
+ *    vote, instead of sorting on the date;
+ *  - a pool wider than the surface is built and de-duplicated per dossier, so the
+ *    hub is not six views of the same texte;
+ *  - the visible slice rotates through that pool on a daily index, so the page
+ *    moves even when no new scrutin has been recorded.
+ */
+
+/** Points added to a vote of the day, decaying by half every half-life. */
+const RECENCY_MAX = 40;
+const RECENCY_HALFLIFE_DAYS = 60;
+
+/**
+ * Procedural weight. A vote solennel or a motion decides a text or the fate of a
+ * government; an amendement rarely does. `IMPORTANCE_WEIGHTS.voteType` already
+ * carries part of this, but it is diluted by the other signals: 522 of the 615 key
+ * votes recorded over the last six months are amendements.
+ */
+const DECISIVENESS_BONUS: Record<ScrutinType, number> = {
+  FINAL: 18,
+  MOTION: 18,
+  ARTICLE: 6,
+  AMENDEMENT: 0,
+  AUTRE: 0,
+};
+
+/** Types allowed to headline the hero slot when the pool offers a choice. */
+const HERO_TYPES: ScrutinType[] = ["FINAL", "MOTION"];
+
+/** Same dossier, same day, near-identical wording: keep only the first. */
+const TITLE_SIMILARITY_THRESHOLD = 0.8;
+
+/** How long a given rotation offset stays in place. */
+const ROTATION_PERIOD_DAYS = 1;
+
+export interface KeyVoteCandidate {
+  id: string;
+  title: string;
+  votingDate: Date;
+  dossierLegislatifId: string | null;
+  type: ScrutinType | null;
+  importanceScore: number;
+}
+
+export function scoreKeyVote(c: KeyVoteCandidate, now: Date): number {
+  const ageDays = Math.max(0, (now.getTime() - c.votingDate.getTime()) / 86_400_000);
+  const recency = RECENCY_MAX * Math.pow(0.5, ageDays / RECENCY_HALFLIFE_DAYS);
+  const decisiveness = c.type ? DECISIVENESS_BONUS[c.type] : 0;
+  return c.importanceScore + recency + decisiveness;
+}
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+  return a.toISOString().slice(0, 10) === b.toISOString().slice(0, 10);
+}
+
+function isNearDuplicate(a: KeyVoteCandidate, b: KeyVoteCandidate): boolean {
+  if (!a.dossierLegislatifId || !b.dossierLegislatifId) return false;
+  if (a.dossierLegislatifId !== b.dossierLegislatifId) return false;
+  if (!isSameCalendarDay(a.votingDate, b.votingDate)) return false;
+  return (
+    titleSimilarity(normalizeTitle(a.title), normalizeTitle(b.title)) >= TITLE_SIMILARITY_THRESHOLD
+  );
+}
+
+/**
+ * Best `size` candidates, at most `maxPerDossier` per dossier législatif.
+ * Expects `sorted` ranked best-first.
+ */
+export function buildKeyVotePool<T extends KeyVoteCandidate>(
+  sorted: T[],
+  opts: { size: number; maxPerDossier: number }
+): T[] {
+  const perDossier = new Map<string, number>();
+  const pool: T[] = [];
+  for (const c of sorted) {
+    if (pool.length >= opts.size) break;
+    if (c.dossierLegislatifId) {
+      const n = perDossier.get(c.dossierLegislatifId) ?? 0;
+      if (n >= opts.maxPerDossier) continue;
+      if (pool.some((p) => isNearDuplicate(p, c))) continue;
+      perDossier.set(c.dossierLegislatifId, n + 1);
+    }
+    pool.push(c);
+  }
+  return pool;
+}
+
+/**
+ * Which slice of the pool is on display right now. Advances once per
+ * `ROTATION_PERIOD_DAYS`, deterministically: two renders of the same day pick the
+ * same votes, which keeps the cached page stable and the URL shareable.
+ */
+export function rotationOffset(now: Date, poolSize: number): number {
+  if (poolSize <= 0) return 0;
+  const dayIndex = Math.floor(now.getTime() / 86_400_000);
+  return Math.floor(dayIndex / ROTATION_PERIOD_DAYS) % poolSize;
+}
+
+function rotate<T>(items: T[], offset: number): T[] {
+  if (items.length === 0) return items;
+  const o = ((offset % items.length) + items.length) % items.length;
+  return [...items.slice(o), ...items.slice(0, o)];
+}
+
+/**
+ * Hero + grid for the hub. The hero rotates through the decisive votes of the pool
+ * (falling back to the whole pool when none is decisive), the grid rotates through
+ * the rest.
+ */
+export function selectKeyVotes<T extends KeyVoteCandidate>(
+  candidates: T[],
+  opts: { now: Date; gridCount: number; poolSize: number; maxPerDossier: number }
+): { hero: T | null; grid: T[] } {
+  const ranked = [...candidates].sort(
+    (a, b) => scoreKeyVote(b, opts.now) - scoreKeyVote(a, opts.now)
+  );
+  const pool = buildKeyVotePool(ranked, {
+    size: opts.poolSize,
+    maxPerDossier: opts.maxPerDossier,
+  });
+  if (pool.length === 0) return { hero: null, grid: [] };
+
+  const heroPool = pool.filter((c) => c.type && HERO_TYPES.includes(c.type));
+  const effectiveHeroPool = heroPool.length > 0 ? heroPool : pool;
+  const hero = effectiveHeroPool[rotationOffset(opts.now, effectiveHeroPool.length)]!;
+
+  const rest = pool.filter((c) => c.id !== hero.id);
+  const grid = rotate(rest, rotationOffset(opts.now, rest.length)).slice(0, opts.gridCount);
+
+  return { hero, grid };
+}


### PR DESCRIPTION
Le hero et la grille étaient ordonnés par date de scrutin décroissante sur
une fenêtre fixe de 30 jours. Dès que le Parlement cesse de voter (suspension
des travaux, entre deux séances), la sélection gelait sur le dernier scrutin
enregistré, parfois pendant des semaines, et le hero pouvait être un
sous-amendement puisque le score d'importance sépare mal un amendement d'un
vote solennel. Passé 30 jours sans scrutin, la fenêtre se vidait et le hub
n'affichait plus rien.

La sélection vit maintenant dans un module pur, key-vote-selection :

- le classement combine le score d'importance, une décote de récence
  (demi-vie 60 jours) et le poids procédural du scrutin (vote solennel et
  motion devant article, puis amendement) ;
- un vivier de 12 candidats est constitué avec au plus 2 votes par dossier
  législatif, ce qui évite six vues du même texte ;
- le hero tourne parmi les votes décisifs du vivier et la grille parmi le
  reste, sur un index journalier : la page bouge même sans nouveau scrutin ;
- la fenêtre s'élargit (30, 90 puis 180 jours) seulement si la plus courte ne
  remplit pas la surface, et le repli sur les meilleurs scores reste en place.

Le libellé du hero devient « Vote clé mis en avant » et le chapeau annonce le
renouvellement quotidien, la sélection n'étant plus une liste des scrutins
les plus récents.
