### PR TITLE
Afficher le statut de candidature et sa source

### DIFF
--- a/src/app/elections/[slug]/page.tsx
+++ b/src/app/elections/[slug]/page.tsx
@@ -22,7 +22,7 @@ import { AddToCalendar } from "@/components/elections/AddToCalendar";
 import { isFeatureEnabled } from "@/lib/feature-flags";
 import { ELECTION_GUIDES } from "@/config/election-guides";
 import { EventJsonLd } from "@/components/seo/JsonLd";
-import { PoligraphBadge } from "@/components/elections/PoligraphBadge";
+import { CandidacyCard } from "@/components/elections/CandidacyCard";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import type { ElectionStatus } from "@/types";
 import { SITE_URL } from "@/config/site";
@@ -135,77 +135,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     alternates: { canonical: `/elections/${slug}` },
   };
-}
-
-function CandidacyCard({
-  candidacy,
-}: {
-  candidacy: {
-    id: string;
-    candidateName: string;
-    partyLabel: string | null;
-    constituencyName: string | null;
-    isElected: boolean;
-    round1Pct: number | null;
-    round2Pct: number | null;
-    politician: { slug: string } | null;
-    party: { color: string | null } | null;
-  };
-}) {
-  return (
-    <Card className="hover:shadow-sm transition-shadow">
-      <CardContent className="py-3 px-4">
-        <div className="flex items-center gap-3">
-          {candidacy.party?.color && (
-            <span
-              className="w-3 h-3 rounded-full flex-shrink-0"
-              style={{ backgroundColor: candidacy.party.color }}
-              aria-hidden="true"
-            />
-          )}
-          <div className="min-w-0">
-            <p className="font-medium">
-              {candidacy.politician ? (
-                <Link
-                  href={`/politiques/${candidacy.politician.slug}`}
-                  className="hover:text-primary transition-colors"
-                  prefetch={false}
-                >
-                  {candidacy.candidateName}
-                </Link>
-              ) : (
-                candidacy.candidateName
-              )}
-            </p>
-            {candidacy.partyLabel && (
-              <p className="text-sm text-muted-foreground">{candidacy.partyLabel}</p>
-            )}
-            {candidacy.constituencyName && (
-              <p className="text-xs text-muted-foreground">{candidacy.constituencyName}</p>
-            )}
-          </div>
-          <div className="ml-auto flex items-center gap-2 shrink-0">
-            {(candidacy.round1Pct != null || candidacy.round2Pct != null) && (
-              <div className="text-right text-xs">
-                {candidacy.round1Pct != null && (
-                  <div className="font-semibold tabular-nums">
-                    T1 : {candidacy.round1Pct.toFixed(2)}%
-                  </div>
-                )}
-                {candidacy.round2Pct != null && (
-                  <div className="text-muted-foreground tabular-nums">
-                    T2 : {candidacy.round2Pct.toFixed(2)}%
-                  </div>
-                )}
-              </div>
-            )}
-            {candidacy.politician && <PoligraphBadge />}
-            {candidacy.isElected && <Badge className="bg-green-100 text-green-800">Élu(e)</Badge>}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
 }
 
 export default async function ElectionDetailPage({ params }: PageProps) {

--- a/src/components/elections/CandidacyCard.tsx
+++ b/src/components/elections/CandidacyCard.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PoligraphBadge } from "@/components/elections/PoligraphBadge";
+import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
+import type { CandidacyStatus } from "@/generated/prisma";
+
+export interface CandidacyCardData {
+  id: string;
+  candidateName: string;
+  partyLabel: string | null;
+  constituencyName: string | null;
+  isElected: boolean;
+  round1Pct: number | null;
+  round2Pct: number | null;
+  status: CandidacyStatus | null;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+  politician: { slug: string } | null;
+  party: { color: string | null } | null;
+}
+
+export function CandidacyCard({ candidacy }: { candidacy: CandidacyCardData }) {
+  return (
+    <Card className="hover:shadow-sm transition-shadow">
+      <CardContent className="py-3 px-4">
+        <div className="flex items-center gap-3">
+          {candidacy.party?.color && (
+            <span
+              className="w-3 h-3 rounded-full flex-shrink-0"
+              style={{ backgroundColor: candidacy.party.color }}
+              aria-hidden="true"
+            />
+          )}
+          <div className="min-w-0">
+            <p className="font-medium">
+              {candidacy.politician ? (
+                <Link
+                  href={`/politiques/${candidacy.politician.slug}`}
+                  className="hover:text-primary transition-colors"
+                  prefetch={false}
+                >
+                  {candidacy.candidateName}
+                </Link>
+              ) : (
+                candidacy.candidateName
+              )}
+            </p>
+            {candidacy.status && (
+              <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1">
+                <Badge variant="outline" className="text-xs font-normal">
+                  {CANDIDACY_STATUS_LABELS[candidacy.status]}
+                </Badge>
+                {candidacy.sourceUrl && candidacy.sourceLabel && (
+                  <a
+                    href={candidacy.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-muted-foreground underline hover:text-primary"
+                  >
+                    {candidacy.sourceLabel}
+                  </a>
+                )}
+              </p>
+            )}
+            {candidacy.partyLabel && (
+              <p className="text-sm text-muted-foreground">{candidacy.partyLabel}</p>
+            )}
+            {candidacy.constituencyName && (
+              <p className="text-xs text-muted-foreground">{candidacy.constituencyName}</p>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-2 shrink-0">
+            {(candidacy.round1Pct != null || candidacy.round2Pct != null) && (
+              <div className="text-right text-xs">
+                {candidacy.round1Pct != null && (
+                  <div className="font-semibold tabular-nums">
+                    T1 : {candidacy.round1Pct.toFixed(2)}%
+                  </div>
+                )}
+                {candidacy.round2Pct != null && (
+                  <div className="text-muted-foreground tabular-nums">
+                    T2 : {candidacy.round2Pct.toFixed(2)}%
+                  </div>
+                )}
+              </div>
+            )}
+            {candidacy.politician && <PoligraphBadge />}
+            {candidacy.isElected && <Badge className="bg-green-100 text-green-800">Élu(e)</Badge>}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/elections/__tests__/CandidacyCard.test.tsx
+++ b/src/components/elections/__tests__/CandidacyCard.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CandidacyCard } from "@/components/elections/CandidacyCard";
+
+const baseCandidacy = {
+  id: "c1",
+  candidateName: "Camille Durand",
+  partyLabel: "Parti A",
+  constituencyName: null,
+  isElected: false,
+  round1Pct: null,
+  round2Pct: null,
+  status: null,
+  sourceUrl: null,
+  sourceLabel: null,
+  politician: { slug: "camille-durand" },
+  party: { color: "#123456" },
+};
+
+describe("CandidacyCard", () => {
+  it("affiche le nom du candidat et son étiquette de parti", () => {
+    render(<CandidacyCard candidacy={baseCandidacy} />);
+
+    expect(screen.getByText("Camille Durand")).toBeInTheDocument();
+    expect(screen.getByText("Parti A")).toBeInTheDocument();
+  });
+
+  it("affiche le statut quand la candidature n'est que pressentie", () => {
+    render(<CandidacyCard candidacy={{ ...baseCandidacy, status: "PRESSENTI" }} />);
+
+    expect(screen.getByText("Candidature pressentie")).toBeInTheDocument();
+  });
+
+  it("affiche le statut quand la candidature est déclarée", () => {
+    render(<CandidacyCard candidacy={{ ...baseCandidacy, status: "DECLARE" }} />);
+
+    expect(screen.getByText("Candidature déclarée")).toBeInTheDocument();
+  });
+
+  it("n'affiche aucun statut quand la candidature n'en porte pas", () => {
+    render(<CandidacyCard candidacy={baseCandidacy} />);
+
+    expect(screen.queryByText(/^Candidature /)).not.toBeInTheDocument();
+  });
+
+  it("renvoie vers la source qui atteste le statut", () => {
+    render(
+      <CandidacyCard
+        candidacy={{
+          ...baseCandidacy,
+          status: "PRESSENTI",
+          sourceUrl: "https://example.org/article",
+          sourceLabel: "Le Monde, 12 mars 2026",
+        }}
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /Le Monde, 12 mars 2026/ });
+    expect(link).toHaveAttribute("href", "https://example.org/article");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("n'affiche pas de lien de source quand l'URL manque", () => {
+    render(
+      <CandidacyCard
+        candidacy={{ ...baseCandidacy, status: "PRESSENTI", sourceLabel: "Le Monde" }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: /Le Monde/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/config/labels.test.ts
+++ b/src/config/labels.test.ts
@@ -13,6 +13,7 @@ import {
   DOSSIER_STATUS_ICONS,
   DOSSIER_STATUS_DESCRIPTIONS,
   DOSSIER_STATUS_SITUATIONS,
+  CANDIDACY_STATUS_LABELS,
 } from "./labels";
 
 describe("AFFAIR_STATUS_LABELS", () => {
@@ -222,5 +223,30 @@ describe("DOSSIER_STATUS_LABELS", () => {
 
   it("should not conflate ADOPTE with promulgation", () => {
     expect(DOSSIER_STATUS_SITUATIONS.ADOPTE.toLowerCase()).not.toContain("promulgu");
+  });
+});
+
+describe("CANDIDACY_STATUS_LABELS", () => {
+  it("should have a label for each candidacy status", () => {
+    const statuses = ["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"];
+
+    expect(Object.keys(CANDIDACY_STATUS_LABELS)).toHaveLength(statuses.length);
+
+    statuses.forEach((status) => {
+      expect(CANDIDACY_STATUS_LABELS).toHaveProperty(status);
+      const label = CANDIDACY_STATUS_LABELS[status as keyof typeof CANDIDACY_STATUS_LABELS];
+      expect(typeof label).toBe("string");
+      expect(label).not.toHaveLength(0);
+    });
+  });
+
+  it("should keep every status distinct so none can be read as another", () => {
+    const labels = Object.values(CANDIDACY_STATUS_LABELS);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("should not describe an unannounced candidacy as declared", () => {
+    expect(CANDIDACY_STATUS_LABELS.PRESSENTI).not.toMatch(/déclar/i);
+    expect(CANDIDACY_STATUS_LABELS.ENVISAGE).not.toMatch(/déclar/i);
   });
 });

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -27,6 +27,7 @@ import type {
   QuizElectionScope,
   PromiseSourceKind,
   PromiseExtractionStatus,
+  CandidacyStatus,
 } from "@/types";
 
 // Nombre de sièges à l'Assemblée nationale (XVIIe législature)
@@ -1349,4 +1350,13 @@ export const PROMISE_EXTRACTION_STATUS_LABELS: Record<PromiseExtractionStatus, s
   PUBLISHED: "Publiée",
   REJECTED: "Rejetée",
   NEEDS_REVIEW: "À retraiter",
+};
+
+// Pre-campaign candidacy status. Before official filing, no one is formally a candidate:
+// the four levels must stay distinguishable so a rumour is never rendered as an announcement.
+export const CANDIDACY_STATUS_LABELS: Record<CandidacyStatus, string> = {
+  DECLARE: "Candidature déclarée",
+  PRESSENTI: "Candidature pressentie",
+  ENVISAGE: "Candidature évoquée",
+  RETIRE: "Candidature retirée",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,7 @@ import type {
   ProfessionDeFoiSource,
   PromiseSourceKind,
   PromiseExtractionStatus,
+  CandidacyStatus,
 } from "@/generated/prisma";
 
 // Compare types
@@ -100,6 +101,7 @@ export type {
   ProfessionDeFoiSource,
   PromiseSourceKind,
   PromiseExtractionStatus,
+  CandidacyStatus,
 };
 
 // Serialized types (for client components)


### PR DESCRIPTION
## Pourquoi

`/elections/[slug]` masque les candidatures tant que l'élection est en phase `UPCOMING`. Le jour où
quelqu'un la passe en `CANDIDACIES`, les 11 prétendants de la présidentielle 2027 sortent sur des
cartes identiques, présentés comme candidats, sans que rien ne distingue une candidature déclarée
d'une candidature simplement pressentie ou évoquée par la presse.

La protection actuelle est un effet de bord de l'ordre des phases, pas une décision. Cette PR la
remplace par un affichage explicite du statut et de sa source.

## Ce que ça change à l'écran

Sous le nom du candidat, un badge de statut et le lien vers la source qui l'atteste :

```
● Camille Durand
  [ Candidature pressentie ]  Le Monde, 12 mars 2026
  Parti A
```

Statut à `null` (municipales, élections passées) : rien ne s'affiche, aucun badge vide.

Badge en `variant="outline"`, volontairement hors vert et rouge : une couleur d'appréciation sur un
statut de candidature laisserait entendre qu'on juge sa crédibilité.

## Contenu

- `CANDIDACY_STATUS_LABELS` créé dans `src/config/labels.ts`. L'enum `CandidacyStatus` existait depuis
  mai 2026 sans aucun libellé dans le projet.
- `CandidacyCard` extrait de `src/app/elections/[slug]/page.tsx` vers
  `src/components/elections/CandidacyCard.tsx`, pour être testable.
- `CandidacyStatus` réexporté depuis `@/types`.
- 6 tests sur le composant, 3 sur les libellés.

## Une correction de diagnostic

L'analyse initiale attribuait le problème à la requête, qui « ne sélectionnait pas » `status`,
`sourceUrl` et `sourceLabel`. C'était faux : elle utilise `include` et non `select`, donc Prisma
retournait déjà tous les champs scalaires. La perte se faisait en aval, dans le type de props de
`CandidacyCard` qui énumérait onze champs et omettait ces trois-là. Rien à changer côté base.

## Vérifications

- `npx tsc --noEmit` : exit 0, aucune sortie
- `npx vitest run` : 3045 tests passent, 133 ignorés, aucun échec
- Les 6 tests du composant couvrent le nom, le statut renseigné, le statut absent, le lien de source,
  et l'absence de lien quand l'URL manque

## Hors périmètre

Aucune modification du modèle éditorial des mesures, ni de la recherche. Cette branche est isolée et
mergeable indépendamment.

Le critère d'acceptation « Sondages présidentielle avec mentions légales » et la section NSPPolls ont
été retirés de #46 séparément, par décision éditoriale : Poligraph ne publie pas de sondages.
