### PR TITLE
Poser le substrat de recherche lexicale (lot 1B)

### DIFF
--- a/docker-compose.test-search.yml
+++ b/docker-compose.test-search.yml
@@ -18,7 +18,10 @@ services:
       - pgdata_search:/var/lib/postgresql/data
       - ./docker/init-search.sql:/docker-entrypoint-initdb.d/init-search.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U poligraph_test -d poligraph_test"]
+      # Over TCP (-h localhost) and not the Unix socket: the temporary server the
+      # entrypoint runs for the init scripts listens on the socket only, so a socket
+      # probe reports healthy before the real server exists.
+      test: ["CMD-SHELL", "pg_isready -h localhost -U poligraph_test -d poligraph_test"]
       interval: 2s
       timeout: 3s
       retries: 30

--- a/docker-compose.test-search.yml
+++ b/docker-compose.test-search.yml
@@ -1,0 +1,26 @@
+# Disposable PostgreSQL 17 for the lot 1B search substrate tests ONLY.
+# NEVER for production or shared data. Torn down with `down -v` by scripts/test-db-search.sh.
+#
+# PostgreSQL 17 and not 16 (docker-compose.test.yml): this lot asserts how `db:push`
+# treats an Unsupported("tsvector") column and two GIN indexes. The spike measured that
+# on 17.7, production runs 17.6. Asserting it on 16 would check a third engine.
+name: poligraph-test-search
+services:
+  db-search:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: poligraph_test
+      POSTGRES_PASSWORD: poligraph_test
+      POSTGRES_DB: poligraph_test
+    ports:
+      - "55433:5432"
+    volumes:
+      - pgdata_search:/var/lib/postgresql/data
+      - ./docker/init-search.sql:/docker-entrypoint-initdb.d/init-search.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U poligraph_test -d poligraph_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+volumes:
+  pgdata_search:

--- a/docker/init-search.sql
+++ b/docker/init-search.sql
@@ -1,8 +1,9 @@
 -- Extensions required by the lot 1B search substrate.
--- Runs once at container creation, before any `prisma db push`:
--- the GIN trigram index cannot be created if pg_trgm is missing.
+-- Runs once at container creation, before any `prisma db push`.
 --
--- unaccent is deliberately here and absent from docker/init.sql: the #477 harness
--- never needed it, this substrate calls it on every write and every read.
-CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+-- unaccent only, and deliberately absent from docker/init.sql: the #477 harness never
+-- needed it, this substrate calls it on every write and every read.
+--
+-- pg_trgm used to be created here, for a GIN trigram index this lot no longer declares.
+-- Lot 7 owns approximate search and will create whatever its own measurements justify.
 CREATE EXTENSION IF NOT EXISTS "unaccent";

--- a/docker/init-search.sql
+++ b/docker/init-search.sql
@@ -1,0 +1,8 @@
+-- Extensions required by the lot 1B search substrate.
+-- Runs once at container creation, before any `prisma db push`:
+-- the GIN trigram index cannot be created if pg_trgm is missing.
+--
+-- unaccent is deliberately here and absent from docker/init.sql: the #477 harness
+-- never needed it, this substrate calls it on every write and every read.
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS "unaccent";

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
     "test:db:477": "bash scripts/test-db-477.sh",
+    "test:db:search": "bash scripts/test-db-search.sh",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2681,3 +2681,56 @@ model AffairCourtDecision {
   @@id([affairId, courtDecisionId])
   @@index([courtDecisionId])
 }
+
+// ============================================
+// SEARCH SUBSTRATE (lot 1B)
+// ============================================
+
+enum SearchEntityType {
+  MEASURE
+  QUESTION
+}
+
+enum SearchVisibility {
+  PUBLIC
+  ADMIN_ONLY
+}
+
+// Central inverted index. Deliberately agnostic of the entity it describes:
+// entityType + entityId and no foreign key, so a single write path serves the
+// measures of lot 1, the questions of lot 6 and the six existing entity families
+// that lot 9 will migrate.
+model SearchDocument {
+  id String @id @default(cuid())
+
+  entityType SearchEntityType
+  entityId   String
+
+  title String
+  body  String @db.Text
+  url   String // result destination, so a search never needs a second query
+
+  visibility SearchVisibility
+
+  // Opaque identifier, deliberately NOT a relation: Question has its own revision
+  // family and the lot 9 entities have no revision at all. Nothing guarantees this
+  // value points at an existing row, which is what `search:audit` is for.
+  sourceRevisionId String?
+
+  // Filled by SQL in upsertSearchDocument(). Prisma cannot read this type; only the
+  // GIN index uses it. Must stay nullable: a non-nullable Unsupported column makes
+  // some write operations disappear from the generated client.
+  searchVector Unsupported("tsvector")?
+
+  // Accent-folded, lowercased title + body, for the trigram fallback. An empty
+  // string means the second statement of the upsert never ran, which is detectable.
+  searchText String @default("")
+
+  indexedAt       DateTime @default(now())
+  sourceUpdatedAt DateTime // the reference revision's updatedAt at indexing time
+
+  @@unique([entityType, entityId])
+  @@index([searchVector], type: Gin)
+  @@index([searchText(ops: raw("gin_trgm_ops"))], type: Gin)
+  @@index([visibility])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2720,23 +2720,21 @@ model SearchDocument {
   // Filled by SQL in upsertSearchDocument(). Prisma cannot read this type; only the
   // GIN index uses it. Must stay nullable: a non-nullable Unsupported column makes
   // some write operations disappear from the generated client.
-  searchVector Unsupported("tsvector")?
-
-  // Accent-folded, lowercased title + body. An empty string means the second statement
-  // of the upsert never ran, which is detectable.
   //
-  // NOT read by searchPublic(): a substring match over this column recovers the plural
-  // we want (loyer -> loyers) and the false positive we refuse (retrait -> retraite)
-  // with no way to tell them apart, so the public fallback enumerates controlled
-  // variants against searchVector instead. The column and its trigram index stay for
-  // the approximate search of lot 7, which owns the thresholds and the negative corpus.
-  searchText String @default("")
+  // The only derived column, and deliberately so. An accent-folded text column with a
+  // GIN trigram index used to sit next to it for a substring fallback, which turned out
+  // to recover the plural we want (loyer -> loyers) and the false positive we refuse
+  // (retrait -> retraite) with no way to tell them apart. searchPublic() enumerates
+  // controlled variants against this vector instead. Approximate search is lot 7's
+  // subject: it measures its own operators and thresholds against a negative corpus, so
+  // it declares its own columns rather than inheriting a guess made here. title and body
+  // stay on the row, so any derived column can be rebuilt when the need is demonstrated.
+  searchVector Unsupported("tsvector")?
 
   indexedAt       DateTime @default(now())
   sourceUpdatedAt DateTime // the reference revision's updatedAt at indexing time
 
   @@unique([entityType, entityId])
   @@index([searchVector], type: Gin)
-  @@index([searchText(ops: raw("gin_trgm_ops"))], type: Gin)
   @@index([visibility])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2722,8 +2722,14 @@ model SearchDocument {
   // some write operations disappear from the generated client.
   searchVector Unsupported("tsvector")?
 
-  // Accent-folded, lowercased title + body, for the trigram fallback. An empty
-  // string means the second statement of the upsert never ran, which is detectable.
+  // Accent-folded, lowercased title + body. An empty string means the second statement
+  // of the upsert never ran, which is detectable.
+  //
+  // NOT read by searchPublic(): a substring match over this column recovers the plural
+  // we want (loyer -> loyers) and the false positive we refuse (retrait -> retraite)
+  // with no way to tell them apart, so the public fallback enumerates controlled
+  // variants against searchVector instead. The column and its trigram index stay for
+  // the approximate search of lot 7, which owns the thresholds and the negative corpus.
   searchText String @default("")
 
   indexedAt       DateTime @default(now())

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -42,8 +42,13 @@ echo "[test:db:search] DATABASE_SSL=$DATABASE_SSL  DOTENV_CONFIG_PATH=$DOTENV_CO
 "${COMPOSE[@]}" up -d
 
 echo "[test:db:search] waiting for postgres..."
+# -h localhost is not cosmetic: the entrypoint starts a TEMPORARY server to run
+# /docker-entrypoint-initdb.d/*.sql, with listen_addresses='' so it only answers on
+# the Unix socket. A socket probe therefore reports "ready" against a server that is
+# about to be shut down, and the next command fails with "the database system is
+# shutting down". Probing over TCP only succeeds once the real server is listening.
 for i in $(seq 1 60); do
-  if "${COMPOSE[@]}" exec -T db-search pg_isready -U poligraph_test -d poligraph_test >/dev/null 2>&1; then
+  if "${COMPOSE[@]}" exec -T db-search pg_isready -h localhost -U poligraph_test -d poligraph_test >/dev/null 2>&1; then
     echo "[test:db:search] ready (${i}s)"; break
   fi
   [ "$i" -eq 60 ] && { echo "[test:db:search] not ready after 60s" >&2; exit 1; }

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Disposable Docker Postgres 17 harness for the lot 1B search substrate tests.
+#
+# SAFETY: never uses .env / .env.prod / Supabase / any shared DB. It injects its
+# own DATABASE_URL + DIRECT_URL pointing at a local throwaway container, forces
+# DATABASE_SSL=false, and sets DOTENV_CONFIG_PATH=/dev/null so the Prisma CLI
+# (prisma.config.ts runs `import "dotenv/config"`) cannot read the real .env.
+# The container + volume are always destroyed on exit, including on failure.
+set -euo pipefail
+
+COMPOSE=(docker compose -f docker-compose.test-search.yml)
+PORT=55433
+TEST_DB_URL="postgresql://poligraph_test:poligraph_test@localhost:${PORT}/poligraph_test?sslmode=disable"
+
+# --- self-contained env; .env is never used to target the DB ---
+export DATABASE_URL="$TEST_DB_URL"
+export DIRECT_URL="$TEST_DB_URL"        # prisma.config.ts prefers DIRECT_URL for migrations
+export DATABASE_SSL=false
+export NODE_ENV=test
+export DOTENV_CONFIG_PATH=/dev/null     # neutralize prisma.config.ts's dotenv/config
+
+# --- refuse to run against anything that is not the local disposable DB ---
+for v in DATABASE_URL DIRECT_URL; do
+  val="${!v}"
+  case "$val" in
+    *"localhost:${PORT}/poligraph_test"*) : ;;
+    *) echo "REFUSING: $v is not the local test DB: $val" >&2; exit 1 ;;
+  esac
+  case "$val" in
+    *supabase*|*pooler*|*amazonaws*|*neon*) echo "REFUSING: $v looks remote/prod: $val" >&2; exit 1 ;;
+  esac
+done
+
+cleanup() {
+  echo "[test:db:search] teardown: destroying container + volume (down -v)"
+  "${COMPOSE[@]}" down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "[test:db:search] DATABASE_URL=$DATABASE_URL"
+echo "[test:db:search] DATABASE_SSL=$DATABASE_SSL  DOTENV_CONFIG_PATH=$DOTENV_CONFIG_PATH"
+"${COMPOSE[@]}" up -d
+
+echo "[test:db:search] waiting for postgres..."
+for i in $(seq 1 60); do
+  if "${COMPOSE[@]}" exec -T db-search pg_isready -U poligraph_test -d poligraph_test >/dev/null 2>&1; then
+    echo "[test:db:search] ready (${i}s)"; break
+  fi
+  [ "$i" -eq 60 ] && { echo "[test:db:search] not ready after 60s" >&2; exit 1; }
+  sleep 1
+done
+
+echo "[test:db:search] engine + extensions"
+"${COMPOSE[@]}" exec -T db-search psql -U poligraph_test -d poligraph_test -c \
+  "SELECT current_setting('server_version') AS version, string_agg(extname, ',' ORDER BY extname) AS extensions FROM pg_extension WHERE extname IN ('pg_trgm','unaccent');"
+
+echo "[test:db:search] prisma generate"
+npx prisma generate
+
+echo "[test:db:search] prisma db push (schema -> disposable DB)"
+npx prisma db push --url "$DATABASE_URL" --accept-data-loss
+
+# --no-file-parallelism is not optional: the drift test runs `prisma db push` mid-suite,
+# which takes a lock on SearchDocument and drops an undeclared column. With vitest's
+# default parallel file execution, that races against the other test files and the
+# failures look random.
+if [ "$#" -gt 0 ]; then
+  echo "[test:db:search] running requested test files: $*"
+  npx vitest run --no-file-parallelism "$@"
+else
+  echo "[test:db:search] running the lot 1B integration test files"
+  npx vitest run --no-file-parallelism src/lib/search
+fi

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -57,7 +57,7 @@ done
 
 echo "[test:db:search] engine + extensions"
 "${COMPOSE[@]}" exec -T db-search psql -U poligraph_test -d poligraph_test -c \
-  "SELECT current_setting('server_version') AS version, string_agg(extname, ',' ORDER BY extname) AS extensions FROM pg_extension WHERE extname IN ('pg_trgm','unaccent');"
+  "SELECT current_setting('server_version') AS version, string_agg(extname, ',' ORDER BY extname) AS extensions FROM pg_extension WHERE extname = 'unaccent';"
 
 echo "[test:db:search] prisma generate"
 npx prisma generate

--- a/src/lib/search/__tests__/documents.integration.test.ts
+++ b/src/lib/search/__tests__/documents.integration.test.ts
@@ -1,15 +1,16 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import { describeIfLocalDb } from "@/test/db-guard";
+
 import { deleteSearchDocument, upsertSearchDocument } from "../documents";
-import { uniqueEntityId } from "./helpers";
+import { assertSearchTestDb, describeIfSearchTestDb, uniqueEntityId } from "./helpers";
 
 // Deferred import, and not a convenience: `@/lib/db` throws at module load when
 // DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
-// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+// skipping this block. describeIfSearchTestDb only skips the block, it cannot undo an import.
 let db: typeof import("@/lib/db").db;
 
-describeIfLocalDb("upsertSearchDocument", () => {
+describeIfSearchTestDb("upsertSearchDocument", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
   });
 

--- a/src/lib/search/__tests__/documents.integration.test.ts
+++ b/src/lib/search/__tests__/documents.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
 import { describeIfLocalDb } from "@/test/db-guard";
-import { upsertSearchDocument } from "../documents";
+import { deleteSearchDocument, upsertSearchDocument } from "../documents";
 import { uniqueEntityId } from "./helpers";
 
 // Deferred import, and not a convenience: `@/lib/db` throws at module load when
@@ -113,5 +113,71 @@ describeIfLocalDb("upsertSearchDocument", () => {
     expect(rows[0]?.searchText).toContain("geler");
     expect(rows[0]?.searchText).not.toContain("encadrer");
     expect(rows[0]?.sourceRevisionId).toBe("rev-2");
+  });
+
+  it("keeps the row and its text when visibility drops to ADMIN_ONLY", async () => {
+    const entityId = uniqueEntityId("depublish");
+    const base = {
+      entityType: "MEASURE" as const,
+      entityId,
+      title: "Encadrer les loyers",
+      body: "Plafonner les loyers.",
+      url: `/elections/presidentielle-2027/mesures/${entityId}`,
+      sourceRevisionId: "rev-1",
+      sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+    };
+
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, { ...base, visibility: "PUBLIC" });
+    });
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, { ...base, visibility: "ADMIN_ONLY" });
+    });
+
+    const row = await db.searchDocument.findUnique({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId } },
+    });
+
+    // Deleting on depublication would lose the indexed text and force a full
+    // reindex to bring the entity back, which spec 7.2 forbids explicitly.
+    expect(row).not.toBeNull();
+    expect(row?.visibility).toBe("ADMIN_ONLY");
+    expect(row?.searchText).toContain("loyers");
+  });
+
+  it("removes the row when the entity is deleted", async () => {
+    const entityId = uniqueEntityId("delete");
+
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, {
+        entityType: "MEASURE",
+        entityId,
+        title: "Mesure supprimée",
+        body: "Corps du document.",
+        url: `/elections/presidentielle-2027/mesures/${entityId}`,
+        visibility: "PUBLIC",
+        sourceRevisionId: null,
+        sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+      });
+    });
+
+    await db.$transaction(async (tx) => {
+      await deleteSearchDocument(tx, "MEASURE", entityId);
+    });
+
+    const row = await db.searchDocument.findUnique({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId } },
+    });
+    expect(row).toBeNull();
+  });
+
+  it("does not throw when deleting an entity that was never indexed", async () => {
+    // Ordinary case, not an error: an entity can be created and deleted while still
+    // in draft, before anything ever indexed it.
+    await expect(
+      db.$transaction(async (tx) => {
+        await deleteSearchDocument(tx, "MEASURE", uniqueEntityId("never-indexed"));
+      })
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/lib/search/__tests__/documents.integration.test.ts
+++ b/src/lib/search/__tests__/documents.integration.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { describeIfLocalDb } from "@/test/db-guard";
+import { upsertSearchDocument } from "../documents";
+import { uniqueEntityId } from "./helpers";
+
+// Deferred import, and not a convenience: `@/lib/db` throws at module load when
+// DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
+// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+let db: typeof import("@/lib/db").db;
+
+describeIfLocalDb("upsertSearchDocument", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("leaves no row when the caller transaction fails afterwards", async () => {
+    const entityId = uniqueEntityId("atomicity");
+
+    await expect(
+      db.$transaction(async (tx) => {
+        await upsertSearchDocument(tx, {
+          entityType: "MEASURE",
+          entityId,
+          title: "Encadrer les loyers",
+          body: "Plafonner les loyers dans les zones tendues.",
+          url: `/elections/presidentielle-2027/mesures/${entityId}`,
+          visibility: "PUBLIC",
+          sourceRevisionId: "rev-1",
+          sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+        });
+        throw new Error("caller failed after indexing");
+      })
+    ).rejects.toThrow("caller failed after indexing");
+
+    const rows = await db.searchDocument.findMany({ where: { entityType: "MEASURE", entityId } });
+
+    // The primitive must never open its own transaction: if it did, the document
+    // would survive the caller's rollback and the index would describe a row that
+    // does not exist.
+    expect(rows).toHaveLength(0);
+  });
+
+  it("fills both derived columns on insert", async () => {
+    const entityId = uniqueEntityId("insert");
+
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, {
+        entityType: "MEASURE",
+        entityId,
+        title: "Encadrer les loyers",
+        body: "Plafonner les loyers dans les zones tendues.",
+        url: `/elections/presidentielle-2027/mesures/${entityId}`,
+        visibility: "PUBLIC",
+        sourceRevisionId: "rev-1",
+        sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+      });
+    });
+
+    const rows = await db.$queryRaw<{ searchText: string; lexemes: string }[]>`
+      SELECT "searchText", "searchVector"::text AS lexemes
+      FROM "SearchDocument"
+      WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${entityId}
+    `;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.searchText).toContain("encadrer les loyers");
+    expect(rows[0]?.lexemes).toContain("loyers");
+    // The default is an empty string: a non-empty value proves the second statement ran.
+    expect(rows[0]?.searchText).not.toBe("");
+  });
+
+  it("recomputes the derived columns when the text changes", async () => {
+    const entityId = uniqueEntityId("update");
+    const base = {
+      entityType: "MEASURE" as const,
+      entityId,
+      url: `/elections/presidentielle-2027/mesures/${entityId}`,
+      visibility: "PUBLIC" as const,
+      sourceRevisionId: "rev-1",
+      sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+    };
+
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, {
+        ...base,
+        title: "Encadrer les loyers",
+        body: "Zones tendues.",
+      });
+    });
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, {
+        ...base,
+        title: "Geler les loyers",
+        body: "Gel pendant trois ans.",
+        sourceRevisionId: "rev-2",
+      });
+    });
+
+    const rows = await db.$queryRaw<{ searchText: string; sourceRevisionId: string }[]>`
+      SELECT "searchText", "sourceRevisionId"
+      FROM "SearchDocument"
+      WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${entityId}
+    `;
+
+    // A stale searchText is the failure mode the central model exists to prevent:
+    // the row is unique on (entityType, entityId), so a second call must overwrite
+    // the derived columns and not leave the previous formulation searchable.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.searchText).toContain("geler");
+    expect(rows[0]?.searchText).not.toContain("encadrer");
+    expect(rows[0]?.sourceRevisionId).toBe("rev-2");
+  });
+});

--- a/src/lib/search/__tests__/documents.integration.test.ts
+++ b/src/lib/search/__tests__/documents.integration.test.ts
@@ -45,7 +45,7 @@ describeIfSearchTestDb("upsertSearchDocument", () => {
     expect(rows).toHaveLength(0);
   });
 
-  it("fills both derived columns on insert", async () => {
+  it("fills the search vector on insert", async () => {
     const entityId = uniqueEntityId("insert");
 
     await db.$transaction(async (tx) => {
@@ -61,20 +61,23 @@ describeIfSearchTestDb("upsertSearchDocument", () => {
       });
     });
 
-    const rows = await db.$queryRaw<{ searchText: string; lexemes: string }[]>`
-      SELECT "searchText", "searchVector"::text AS lexemes
+    const rows = await db.$queryRaw<{ lexemes: string | null }[]>`
+      SELECT "searchVector"::text AS lexemes
       FROM "SearchDocument"
       WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${entityId}
     `;
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.searchText).toContain("encadrer les loyers");
+    // The column is nullable and Prisma cannot write it, so a non-null value is the proof
+    // that the second statement of the upsert ran at all.
+    expect(rows[0]?.lexemes).not.toBeNull();
     expect(rows[0]?.lexemes).toContain("loyers");
-    // The default is an empty string: a non-empty value proves the second statement ran.
-    expect(rows[0]?.searchText).not.toBe("");
+    expect(rows[0]?.lexemes).toContain("encadrer");
+    // Words from both fields, which is what proves the vector is built from title AND body.
+    expect(rows[0]?.lexemes).toContain("tendues");
   });
 
-  it("recomputes the derived columns when the text changes", async () => {
+  it("recomputes the search vector when the text changes", async () => {
     const entityId = uniqueEntityId("update");
     const base = {
       entityType: "MEASURE" as const,
@@ -101,18 +104,18 @@ describeIfSearchTestDb("upsertSearchDocument", () => {
       });
     });
 
-    const rows = await db.$queryRaw<{ searchText: string; sourceRevisionId: string }[]>`
-      SELECT "searchText", "sourceRevisionId"
+    const rows = await db.$queryRaw<{ lexemes: string | null; sourceRevisionId: string }[]>`
+      SELECT "searchVector"::text AS lexemes, "sourceRevisionId"
       FROM "SearchDocument"
       WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${entityId}
     `;
 
-    // A stale searchText is the failure mode the central model exists to prevent:
-    // the row is unique on (entityType, entityId), so a second call must overwrite
-    // the derived columns and not leave the previous formulation searchable.
+    // A stale vector is the failure mode the central model exists to prevent: the row is
+    // unique on (entityType, entityId), so a second call must overwrite the vector and
+    // not leave the previous formulation searchable.
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.searchText).toContain("geler");
-    expect(rows[0]?.searchText).not.toContain("encadrer");
+    expect(rows[0]?.lexemes).toContain("geler");
+    expect(rows[0]?.lexemes).not.toContain("encadrer");
     expect(rows[0]?.sourceRevisionId).toBe("rev-2");
   });
 
@@ -138,12 +141,18 @@ describeIfSearchTestDb("upsertSearchDocument", () => {
     const row = await db.searchDocument.findUnique({
       where: { entityType_entityId: { entityType: "MEASURE", entityId } },
     });
+    const rows = await db.$queryRaw<{ lexemes: string | null }[]>`
+      SELECT "searchVector"::text AS lexemes
+      FROM "SearchDocument"
+      WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${entityId}
+    `;
 
     // Deleting on depublication would lose the indexed text and force a full
     // reindex to bring the entity back, which spec 7.2 forbids explicitly.
     expect(row).not.toBeNull();
     expect(row?.visibility).toBe("ADMIN_ONLY");
-    expect(row?.searchText).toContain("loyers");
+    expect(row?.title).toBe("Encadrer les loyers");
+    expect(rows[0]?.lexemes).toContain("loyers");
   });
 
   it("removes the row when the entity is deleted", async () => {

--- a/src/lib/search/__tests__/helpers.ts
+++ b/src/lib/search/__tests__/helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Fixtures for the lot 1B search substrate tests.
+ *
+ * The database gate is NOT here: it is `describeIfLocalDb` from `@/test/db-guard`,
+ * which already exists (issue #547) and parses the URL instead of matching a port.
+ * A second gate would be a second convention to keep in sync.
+ */
+
+// Fixtures must not reuse fixed identifiers: a `@@unique([entityType, entityId])`
+// collides on the second test of a block if two tests pick the same one, and the
+// failure looks like a logic bug rather than a fixture bug.
+let sequence = 0;
+
+export function uniqueEntityId(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${process.pid}-${sequence}`;
+}
+
+// A token safe to embed in indexed text. Letters and digits only: hyphens make the
+// text-search parser emit several lexemes per token, which would make an assertion
+// about the dictionary depend on tokenizer details instead.
+export function uniqueToken(): string {
+  sequence += 1;
+  return `zk${process.pid}x${sequence}`;
+}

--- a/src/lib/search/__tests__/helpers.ts
+++ b/src/lib/search/__tests__/helpers.ts
@@ -1,10 +1,67 @@
 /**
- * Fixtures for the lot 1B search substrate tests.
+ * Gate and fixtures for the lot 1B search substrate tests.
  *
- * The database gate is NOT here: it is `describeIfLocalDb` from `@/test/db-guard`,
- * which already exists (issue #547) and parses the URL instead of matching a port.
- * A second gate would be a second convention to keep in sync.
+ * The gate NARROWS the repository one, it does not replace it. `describeIfLocalDb` from
+ * `@/test/db-guard` (issue #547) answers "is this a local database", which is the right
+ * question for a suite that only writes rows. It is not enough here: these tests run
+ * `ALTER TABLE`, `CREATE INDEX` and `prisma db push --accept-data-loss` against whatever
+ * `DATABASE_URL` names, and "local" also describes a persistent development database or
+ * a tunnel to a remote one. So this gate requires the exact throwaway container.
+ *
+ * Checking inside `dbPush()` alone was not enough either: the drift test adds a column
+ * and an index BEFORE calling it, so a refusal there left both behind on someone else's
+ * database. The gate has to come before the first statement, which is what a skipped
+ * `describe` guarantees.
  */
+
+import { describe } from "vitest";
+import { isLocalTestDb } from "@/test/db-guard";
+
+/** The container from docker-compose.test-search.yml, and nothing else. */
+const SEARCH_TEST_DB = {
+  hostname: "localhost",
+  port: "55433",
+  database: "poligraph_test",
+} as const;
+
+/**
+ * Whether `DATABASE_URL` names the disposable search container.
+ *
+ * Parses rather than pattern-matches, so a credentialed URL and a bare one both work and
+ * a substring cannot be smuggled in through a password or a query parameter. Anything
+ * unparseable counts as "not it": an unreadable URL is not evidence of safety.
+ */
+export function isSearchTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
+  if (!url || !isLocalTestDb(url)) return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.toLowerCase() === SEARCH_TEST_DB.hostname &&
+      parsed.port === SEARCH_TEST_DB.port &&
+      parsed.pathname.replace(/^\//, "") === SEARCH_TEST_DB.database
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** `describe` for the destructive suites of this lot: runs on the throwaway container, skips everywhere else. */
+export const describeIfSearchTestDb = isSearchTestDb() ? describe : describe.skip;
+
+/**
+ * Hard refusal, second layer behind {@link describeIfSearchTestDb}.
+ *
+ * Called from every `beforeAll` of the lot: a block can be added later with the wrong
+ * `describe`, and a helper must not depend on its caller having been careful.
+ */
+export function assertSearchTestDb(): void {
+  if (!isSearchTestDb()) {
+    throw new Error(
+      "Ces tests refusent de s'exécuter : DATABASE_URL ne désigne pas le conteneur jetable " +
+        "de recherche (localhost:55433/poligraph_test). Lancer npm run test:db:search."
+    );
+  }
+}
 
 // Fixtures must not reuse fixed identifiers: a `@@unique([entityType, entityId])`
 // collides on the second test of a block if two tests pick the same one, and the

--- a/src/lib/search/__tests__/lexical-corpus.integration.test.ts
+++ b/src/lib/search/__tests__/lexical-corpus.integration.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { describeIfLocalDb } from "@/test/db-guard";
+import { upsertSearchDocument } from "../documents";
+import { uniqueEntityId } from "./helpers";
+
+// Deferred import, and not a convenience: `@/lib/db` throws at module load when
+// DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
+// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+let db: typeof import("@/lib/db").db;
+
+// The dictionary name cannot be a bound parameter of to_tsvector, and $executeRawUnsafe
+// is banned by CI, so each dictionary gets its own tagged template.
+async function lexemes(dictionary: "simple" | "french", word: string): Promise<string> {
+  const rows =
+    dictionary === "french"
+      ? await db.$queryRaw<{ v: string }[]>`SELECT to_tsvector('french', ${word})::text AS v`
+      : await db.$queryRaw<{ v: string }[]>`SELECT to_tsvector('simple', ${word})::text AS v`;
+  return rows[0]?.v ?? "";
+}
+
+describeIfLocalDb("why the french dictionary is unusable here", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("collapses loyer into loi", async () => {
+    // Measured at spike 0B. A rent search would return budget bills.
+    expect(await lexemes("french", "loyer")).toContain("loi");
+    expect(await lexemes("simple", "loyer")).toContain("loyer");
+  });
+
+  it("collapses retraite and the plural retraits into the same lexeme", async () => {
+    // Measured on 17.10, and NOT what the spike had noted: retraite, retraites,
+    // retraits and retraitement all stem to 'retrait', while the singular retrait
+    // stems to 'retr'. So the stemmer confuses two unrelated subjects and misses the
+    // link between a word and its own plural at the same time. RETRAIT is an act kind
+    // of the measure model and retraites is one of the most searched subjects of a
+    // presidential campaign, so the collision is not theoretical.
+    expect(await lexemes("french", "retraite")).toBe(await lexemes("french", "retraits"));
+    expect(await lexemes("french", "retrait")).not.toBe(await lexemes("french", "retraits"));
+
+    expect(await lexemes("simple", "retraite")).not.toBe(await lexemes("simple", "retraits"));
+  });
+
+  it("does not even share a lexeme between loyer and loyers", async () => {
+    // The stemmer is not merely aggressive, it is inconsistent: the plural is not
+    // reduced to the same root as the singular, so it loses recall as well.
+    expect(await lexemes("french", "loyers")).not.toBe(await lexemes("french", "loyer"));
+  });
+});
+
+describeIfLocalDb("domain lexical corpus", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  async function index(entityId: string, title: string, body: string): Promise<void> {
+    await db.$transaction(async (tx) => {
+      await upsertSearchDocument(tx, {
+        entityType: "MEASURE",
+        entityId,
+        title,
+        body,
+        url: `/elections/presidentielle-2027/mesures/${entityId}`,
+        visibility: "PUBLIC",
+        sourceRevisionId: null,
+        sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+      });
+    });
+  }
+
+  async function matchesExact(entityId: string, query: string): Promise<boolean> {
+    const rows = await db.$queryRaw<{ hit: number }[]>`
+      SELECT 1 AS hit FROM "SearchDocument"
+      WHERE "entityId" = ${entityId}
+        AND "searchVector" @@ plainto_tsquery('simple', unaccent(${query}))
+    `;
+    return rows.length > 0;
+  }
+
+  async function matchesSubstring(entityId: string, query: string): Promise<boolean> {
+    const rows = await db.$queryRaw<{ hit: number }[]>`
+      SELECT 1 AS hit FROM "SearchDocument"
+      WHERE "entityId" = ${entityId}
+        AND "searchText" LIKE '%' || lower(unaccent(${query})) || '%'
+    `;
+    return rows.length > 0;
+  }
+
+  it("matches the exact lexeme and nothing around it", async () => {
+    const entityId = uniqueEntityId("loyers");
+    await index(entityId, "Encadrer les loyers", "Plafonner les loyers dans les zones tendues.");
+
+    expect(await matchesExact(entityId, "loyer")).toBe(false); // exact lexeme only
+    expect(await matchesExact(entityId, "loyers")).toBe(true);
+    expect(await matchesExact(entityId, "loi")).toBe(false);
+  });
+
+  it("does not return a rent measure for a query about loi", async () => {
+    const entityId = uniqueEntityId("loyer-singulier");
+    await index(entityId, "Plafonner le loyer", "Un loyer de référence par zone.");
+
+    // The singular is the whole point of this fixture. Under the french dictionary
+    // "loyer" stems to 'loi', so a query about laws returns this rent measure. The
+    // plural "loyers" stems to 'loyer' instead, which is why the plural-only fixture
+    // of the test above stays green under a dictionary switch and proves nothing.
+    expect(await matchesExact(entityId, "loyer")).toBe(true);
+    expect(await matchesExact(entityId, "loi")).toBe(false);
+  });
+
+  it("does not return a pension measure for a query about retraits", async () => {
+    const entityId = uniqueEntityId("retraites");
+    await index(entityId, "Retraite à 60 ans", "Rétablir le départ à la retraite à 60 ans.");
+
+    expect(await matchesExact(entityId, "retraite")).toBe(true);
+    // The plural and not the singular: under the french dictionary both this document
+    // and the query "retraits" reduce to 'retrait', so the false positive appears. The
+    // singular "retrait" reduces to 'retr' and would match nothing, which would leave
+    // this test green under a dictionary switch and prove nothing.
+    expect(await matchesExact(entityId, "retraits")).toBe(false);
+  });
+
+  it("does not confuse impot and import", async () => {
+    const entityId = uniqueEntityId("impots");
+    // No apostrophe in the fixture on purpose: how the default parser splits "l'impôt"
+    // is not what this test is about, and relying on it would make the assertion
+    // depend on tokenizer details instead of on the dictionary choice.
+    // Singular in the document, so the exact-lexeme assertion is meaningful.
+    await index(entityId, "Réforme de la tranche supérieure", "Un impôt progressif sur le revenu.");
+
+    // The document is written with accents and the query is not: this proves unaccent
+    // runs on the write side as well as the read side.
+    expect(await matchesExact(entityId, "impot")).toBe(true);
+    expect(await matchesExact(entityId, "impôt")).toBe(true);
+    expect(await matchesExact(entityId, "import")).toBe(false);
+  });
+
+  it("recovers the plural through the trigram column", async () => {
+    const entityId = uniqueEntityId("trigram");
+    await index(entityId, "Encadrer les loyers", "Plafonner les loyers.");
+
+    // This is the division of labour of spec 7.2: the tsvector index answers exact
+    // words with no false positive, the trigram column catches the morphological
+    // variants the simple dictionary cannot.
+    expect(await matchesExact(entityId, "loyer")).toBe(false);
+    expect(await matchesSubstring(entityId, "loyer")).toBe(true);
+  });
+});

--- a/src/lib/search/__tests__/lexical-corpus.integration.test.ts
+++ b/src/lib/search/__tests__/lexical-corpus.integration.test.ts
@@ -90,11 +90,18 @@ describeIfSearchTestDb("domain lexical corpus", () => {
     return rows.length > 0;
   }
 
+  /**
+   * The substring match the substrate does NOT use, computed on the fly.
+   *
+   * Deliberately not backed by a stored column: the accent-folded searchText column and
+   * its GIN trigram index were removed with the fallback they served. What remains here
+   * is the demonstration of why, which needs no column to hold.
+   */
   async function matchesSubstring(entityId: string, query: string): Promise<boolean> {
     const rows = await db.$queryRaw<{ hit: number }[]>`
       SELECT 1 AS hit FROM "SearchDocument"
       WHERE "entityId" = ${entityId}
-        AND "searchText" LIKE '%' || lower(unaccent(${query})) || '%'
+        AND lower(unaccent(title || ' ' || body)) LIKE '%' || lower(unaccent(${query})) || '%'
     `;
     return rows.length > 0;
   }

--- a/src/lib/search/__tests__/lexical-corpus.integration.test.ts
+++ b/src/lib/search/__tests__/lexical-corpus.integration.test.ts
@@ -8,8 +8,10 @@ import { uniqueEntityId } from "./helpers";
 // skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
 let db: typeof import("@/lib/db").db;
 
-// The dictionary name cannot be a bound parameter of to_tsvector, and $executeRawUnsafe
-// is banned by CI, so each dictionary gets its own tagged template.
+// The dictionary name cannot be a bound parameter of to_tsvector, and the unparameterized
+// raw-SQL escape hatch is banned by CI, so each dictionary gets its own tagged template.
+// That ban is a plain grep over src/, so it also fires on a comment that merely names the
+// forbidden method. Hence the periphrasis.
 async function lexemes(dictionary: "simple" | "french", word: string): Promise<string> {
   const rows =
     dictionary === "french"

--- a/src/lib/search/__tests__/lexical-corpus.integration.test.ts
+++ b/src/lib/search/__tests__/lexical-corpus.integration.test.ts
@@ -1,11 +1,11 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import { describeIfLocalDb } from "@/test/db-guard";
+
 import { upsertSearchDocument } from "../documents";
-import { uniqueEntityId } from "./helpers";
+import { assertSearchTestDb, describeIfSearchTestDb, uniqueEntityId } from "./helpers";
 
 // Deferred import, and not a convenience: `@/lib/db` throws at module load when
 // DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
-// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+// skipping this block. describeIfSearchTestDb only skips the block, it cannot undo an import.
 let db: typeof import("@/lib/db").db;
 
 // The dictionary name cannot be a bound parameter of to_tsvector, and the unparameterized
@@ -20,8 +20,9 @@ async function lexemes(dictionary: "simple" | "french", word: string): Promise<s
   return rows[0]?.v ?? "";
 }
 
-describeIfLocalDb("why the french dictionary is unusable here", () => {
+describeIfSearchTestDb("why the french dictionary is unusable here", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
   });
 
@@ -55,8 +56,9 @@ describeIfLocalDb("why the french dictionary is unusable here", () => {
   });
 });
 
-describeIfLocalDb("domain lexical corpus", () => {
+describeIfSearchTestDb("domain lexical corpus", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
   });
 
@@ -145,14 +147,23 @@ describeIfLocalDb("domain lexical corpus", () => {
     expect(await matchesExact(entityId, "import")).toBe(false);
   });
 
-  it("recovers the plural through the trigram column", async () => {
-    const entityId = uniqueEntityId("trigram");
-    await index(entityId, "Encadrer les loyers", "Plafonner les loyers.");
+  it("shows why substring matching cannot be the morphological fallback", async () => {
+    const rent = uniqueEntityId("substring-rent");
+    const pension = uniqueEntityId("substring-pension");
+    await index(rent, "Encadrer les loyers", "Plafonner les loyers.");
+    await index(pension, "Retraite à 60 ans", "Rétablir le départ à la retraite.");
 
-    // This is the division of labour of spec 7.2: the tsvector index answers exact
-    // words with no false positive, the trigram column catches the morphological
-    // variants the simple dictionary cannot.
-    expect(await matchesExact(entityId, "loyer")).toBe(false);
-    expect(await matchesSubstring(entityId, "loyer")).toBe(true);
+    // The two relations have the exact same shape: the query is a prefix of a word in
+    // the document. A substring fallback therefore recovers the plural we want AND the
+    // false positive we refuse, with no way to tell them apart. Neither a prefix tsquery
+    // nor a trigram similarity threshold separates them either.
+    expect(await matchesSubstring(rent, "loyer")).toBe(true);
+    expect(await matchesSubstring(pension, "retrait")).toBe(true);
+
+    // The lexeme index does separate them, which is what searchPublic() builds its
+    // fallback on: it enumerates the controlled variants of a term (loyer / loyers)
+    // rather than matching loosely, so "retraite" stays out of a search for "retrait".
+    expect(await matchesExact(rent, "loyers")).toBe(true);
+    expect(await matchesExact(pension, "retrait")).toBe(false);
   });
 });

--- a/src/lib/search/__tests__/query.integration.test.ts
+++ b/src/lib/search/__tests__/query.integration.test.ts
@@ -1,12 +1,12 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import { describeIfLocalDb } from "@/test/db-guard";
+
 import { upsertSearchDocument } from "../documents";
-import { uniqueEntityId, uniqueToken } from "./helpers";
+import { assertSearchTestDb, describeIfSearchTestDb, uniqueEntityId, uniqueToken } from "./helpers";
 
 // Two deferred imports, and neither is a convenience. `@/lib/db` throws at module load
 // when DATABASE_URL is unset, and `../query` imports it as a VALUE, unlike
 // `../documents` which only imports its type. A top-level import of either would fail
-// the whole suite instead of skipping this block: describeIfLocalDb skips a block, it
+// the whole suite instead of skipping this block: describeIfSearchTestDb skips a block, it
 // cannot undo an import.
 let db: typeof import("@/lib/db").db;
 let searchPublic: typeof import("../query").searchPublic;
@@ -30,8 +30,9 @@ async function index(
   });
 }
 
-describeIfLocalDb("searchPublic", () => {
+describeIfSearchTestDb("searchPublic", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
     ({ searchPublic } = await import("../query"));
   });
@@ -79,8 +80,8 @@ describeIfLocalDb("searchPublic", () => {
 
     // The decisive case. Under the simple dictionary "loyer" is a lexeme of the first
     // document only, so an implementation that stops as soon as the exact pass returns
-    // something would silently drop the plural, which is the exact thing the trigram
-    // column exists to catch.
+    // something would silently drop the plural, which is the exact thing the variant
+    // pass exists to catch.
     expect(ids).toContain(singular);
     expect(ids).toContain(plural);
     expect(ids.indexOf(singular)).toBeLessThan(ids.indexOf(plural));
@@ -91,9 +92,9 @@ describeIfLocalDb("searchPublic", () => {
     const entityId = uniqueEntityId("multiterm");
     await index(entityId, `Encadrer les loyers ${token}`, "PUBLIC");
 
-    // Two terms, one exact and one that only the trigram pass can match. A fallback
-    // comparing the whole query as one substring fails here: "loyer <token>" is not a
-    // substring of "loyers <token>", the plural breaks the run.
+    // Two terms, one that matches exactly and one that only its plural variant matches.
+    // The fallback has to work term by term: a pass comparing the whole query at once
+    // never relates "loyer <token>" to "loyers <token>".
     const hits = await searchPublic(`loyer ${token}`);
 
     expect(hits.map((h) => h.entityId)).toContain(entityId);
@@ -112,6 +113,59 @@ describeIfLocalDb("searchPublic", () => {
   it("returns nothing for an empty or whitespace-only query", async () => {
     expect(await searchPublic("")).toEqual([]);
     expect(await searchPublic("   ")).toEqual([]);
+  });
+
+  it("does not return retraite for retrait", async () => {
+    const token = uniqueToken();
+    const retraite = uniqueEntityId("retraite");
+    await index(retraite, `Retraite à 60 ans ${token}`, "PUBLIC");
+
+    const hits = await searchPublic(`retrait ${token}`);
+
+    // The false positive the whole dictionary choice exists to avoid, asserted on the
+    // public entry point and not on one SQL pass. The exact pass avoids it, so it can
+    // only come back through the fallback: "retrait" is a prefix of "retraite", exactly
+    // like "loyer" is a prefix of "loyers", so any loose match recovers both.
+    expect(hits.map((hit) => hit.entityId)).not.toContain(retraite);
+  });
+
+  it("treats LIKE wildcards as ordinary characters", async () => {
+    const token = uniqueToken();
+    const entityId = uniqueEntityId("wildcard");
+    await index(entityId, `Encadrer les loyers ${token}`, "PUBLIC");
+
+    // A bound parameter is safe against injection but its characters are still read
+    // with LIKE semantics: "%%%" builds a pattern that matches every public document,
+    // and "_" matches any single character.
+    expect(await searchPublic("%%%")).toEqual([]);
+    expect(await searchPublic("___")).toEqual([]);
+    expect((await searchPublic(`%oyer% ${token}`)).map((h) => h.entityId)).not.toContain(entityId);
+  });
+
+  it("still derives the plural when the term carries punctuation", async () => {
+    const token = uniqueToken();
+    const entityId = uniqueEntityId("punctuation");
+    await index(entityId, `Encadrer les loyers ${token}`, "PUBLIC");
+
+    // The singular with a trailing comma against a document holding the plural. This is
+    // where punctuation normalization earns its place: on the raw term the derived plural
+    // would be "loyer,s", which plainto_tsquery reads as two lexemes and never matches.
+    // plainto_tsquery cleans up punctuation on its own, so a query already spelled the
+    // way the document is would pass without any normalization and prove nothing.
+    const hits = await searchPublic(`loyer, ${token}`);
+
+    expect(hits.map((h) => h.entityId)).toContain(entityId);
+  });
+
+  it("bounds the limit instead of passing it through to SQL", async () => {
+    const token = uniqueToken();
+    await index(uniqueEntityId("bounded"), `Encadrer les loyers ${token}`, "PUBLIC");
+
+    // A negative LIMIT is an error in PostgreSQL, so an unbounded limit turns a caller
+    // mistake into a 500. An excessive one turns a search box into a bulk export.
+    await expect(searchPublic(token, -1)).resolves.toHaveLength(1);
+    await expect(searchPublic(token, 0)).resolves.toHaveLength(1);
+    await expect(searchPublic(token, 10_000)).resolves.toHaveLength(1);
   });
 
   it("caps the query length at 200 characters", async () => {

--- a/src/lib/search/__tests__/query.integration.test.ts
+++ b/src/lib/search/__tests__/query.integration.test.ts
@@ -129,6 +129,34 @@ describeIfSearchTestDb("searchPublic", () => {
     expect(hits.map((hit) => hit.entityId)).not.toContain(retraite);
   });
 
+  it("does not invent a singular by stripping a trailing s", async () => {
+    const token = uniqueToken();
+    const faith = uniqueEntityId("foi");
+    const court = uniqueEntityId("cour");
+    await index(faith, `Une question de foi ${token}`, "PUBLIC");
+    await index(court, `Saisir la Cour des comptes ${token}`, "PUBLIC");
+
+    // Deriving the singular by dropping an s invents French: fois gives foi, cours gives
+    // cour, pays gives pay. Both words below are ordinary in this corpus, and "cours"
+    // returning the Cour des comptes is the same class of false positive the simple
+    // dictionary was chosen to avoid.
+    expect((await searchPublic(`fois ${token}`)).map((h) => h.entityId)).not.toContain(faith);
+    expect((await searchPublic(`cours ${token}`)).map((h) => h.entityId)).not.toContain(court);
+  });
+
+  it("does not reach a singular document from a plural query, and that is the accepted cost", async () => {
+    const token = uniqueToken();
+    const singular = uniqueEntityId("asymmetry");
+    await index(singular, `Plafonner le loyer ${token}`, "PUBLIC");
+
+    // The counterpart of the rule above, asserted rather than left to be discovered: the
+    // expansion runs in one direction. Making it symmetric needs a morphological lexicon
+    // with its exceptions, which is lot 7's subject. This test is here to fail the day
+    // someone believes the substrate already does it.
+    expect((await searchPublic(`loyers ${token}`)).map((h) => h.entityId)).not.toContain(singular);
+    expect((await searchPublic(`loyer ${token}`)).map((h) => h.entityId)).toContain(singular);
+  });
+
   it("treats LIKE wildcards as ordinary characters", async () => {
     const token = uniqueToken();
     const entityId = uniqueEntityId("wildcard");

--- a/src/lib/search/__tests__/query.integration.test.ts
+++ b/src/lib/search/__tests__/query.integration.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { describeIfLocalDb } from "@/test/db-guard";
+import { upsertSearchDocument } from "../documents";
+import { uniqueEntityId, uniqueToken } from "./helpers";
+
+// Two deferred imports, and neither is a convenience. `@/lib/db` throws at module load
+// when DATABASE_URL is unset, and `../query` imports it as a VALUE, unlike
+// `../documents` which only imports its type. A top-level import of either would fail
+// the whole suite instead of skipping this block: describeIfLocalDb skips a block, it
+// cannot undo an import.
+let db: typeof import("@/lib/db").db;
+let searchPublic: typeof import("../query").searchPublic;
+
+async function index(
+  entityId: string,
+  title: string,
+  visibility: "PUBLIC" | "ADMIN_ONLY"
+): Promise<void> {
+  await db.$transaction(async (tx) => {
+    await upsertSearchDocument(tx, {
+      entityType: "MEASURE",
+      entityId,
+      title,
+      body: "Corps du document.",
+      url: `/elections/presidentielle-2027/mesures/${entityId}`,
+      visibility,
+      sourceRevisionId: null,
+      sourceUpdatedAt: new Date("2026-08-04T10:00:00Z"),
+    });
+  });
+}
+
+describeIfLocalDb("searchPublic", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+    ({ searchPublic } = await import("../query"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("never returns an ADMIN_ONLY document", async () => {
+    const token = uniqueToken();
+    const hidden = uniqueEntityId("hidden");
+    await index(hidden, `Mesure confidentielle ${token}`, "ADMIN_ONLY");
+
+    const hits = await searchPublic(token);
+
+    expect(hits.map((h) => h.entityId)).not.toContain(hidden);
+    expect(hits).toHaveLength(0);
+  });
+
+  it("filters inside the query and not after it", async () => {
+    const token = uniqueToken();
+    const hidden = uniqueEntityId("hidden");
+    const shown = uniqueEntityId("shown");
+    await index(hidden, `Confidentielle ${token}`, "ADMIN_ONLY");
+    await index(shown, `Publique ${token}`, "PUBLIC");
+
+    // Both documents match. With a limit of 1, a filter applied after the SQL would
+    // let the hidden row consume the only slot and return nothing, or worse return it.
+    // "Confidentielle" also sorts before "Publique", so a missing filter surfaces it first.
+    const hits = await searchPublic(token, 1);
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.entityId).toBe(shown);
+  });
+
+  it("returns both the exact match and the morphological variant, exact first", async () => {
+    const token = uniqueToken();
+    const singular = uniqueEntityId("singular");
+    const plural = uniqueEntityId("plural");
+    await index(singular, `Plafonner le loyer ${token}`, "PUBLIC");
+    await index(plural, `Encadrer les loyers ${token}`, "PUBLIC");
+
+    const hits = await searchPublic(`loyer ${token}`);
+    const ids = hits.map((h) => h.entityId);
+
+    // The decisive case. Under the simple dictionary "loyer" is a lexeme of the first
+    // document only, so an implementation that stops as soon as the exact pass returns
+    // something would silently drop the plural, which is the exact thing the trigram
+    // column exists to catch.
+    expect(ids).toContain(singular);
+    expect(ids).toContain(plural);
+    expect(ids.indexOf(singular)).toBeLessThan(ids.indexOf(plural));
+  });
+
+  it("finds a variant even when another term of the query matches exactly", async () => {
+    const token = uniqueToken();
+    const entityId = uniqueEntityId("multiterm");
+    await index(entityId, `Encadrer les loyers ${token}`, "PUBLIC");
+
+    // Two terms, one exact and one that only the trigram pass can match. A fallback
+    // comparing the whole query as one substring fails here: "loyer <token>" is not a
+    // substring of "loyers <token>", the plural breaks the run.
+    const hits = await searchPublic(`loyer ${token}`);
+
+    expect(hits.map((h) => h.entityId)).toContain(entityId);
+  });
+
+  it("ignores case, accents and repeated whitespace", async () => {
+    const token = uniqueToken();
+    const entityId = uniqueEntityId("accents");
+    await index(entityId, `Réforme fiscale et impôt ${token}`, "PUBLIC");
+
+    const hits = await searchPublic(`   IMPÔT    ${token}  `);
+
+    expect(hits.map((h) => h.entityId)).toContain(entityId);
+  });
+
+  it("returns nothing for an empty or whitespace-only query", async () => {
+    expect(await searchPublic("")).toEqual([]);
+    expect(await searchPublic("   ")).toEqual([]);
+  });
+
+  it("caps the query length at 200 characters", async () => {
+    // A 10 000 character query must not reach plainto_tsquery: it would be parsed in
+    // full for nothing. The assertion is that the call returns instead of throwing.
+    await expect(searchPublic("a".repeat(10_000))).resolves.toEqual([]);
+  });
+});

--- a/src/lib/search/__tests__/schema-drift.integration.test.ts
+++ b/src/lib/search/__tests__/schema-drift.integration.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, expect, it } from "vitest";
 import { describeIfLocalDb } from "@/test/db-guard";
 
@@ -63,5 +64,90 @@ describeIfLocalDb("SearchDocument schema", () => {
     const indexes = await searchDocumentIndexes();
 
     expect(indexes.some((i) => i.indexdef.includes("visibility"))).toBe(true);
+  });
+});
+
+// Runs `prisma db push` the way the harness does: explicit --url so prisma.config.ts
+// cannot retarget it, and DOTENV_CONFIG_PATH=/dev/null so its `import "dotenv/config"`
+// cannot read the real .env. The describeIfLocalDb gate already guarantees the URL
+// is the throwaway container, this is the second lock.
+function dbPush(): void {
+  const url = process.env["DATABASE_URL"];
+  if (!url?.includes("localhost:55433/poligraph_test")) {
+    throw new Error(`refusing db:push against ${url}`);
+  }
+  execFileSync("npx", ["prisma", "db", "push", "--url", url, "--accept-data-loss"], {
+    env: { ...process.env, DOTENV_CONFIG_PATH: "/dev/null" },
+    stdio: "pipe",
+  });
+}
+
+// One `prisma db push` through npx costs about four seconds, so the two tests below
+// blow through vitest's 5s default. The timeout is per test and generous on purpose:
+// a tighter one would fail on a cold npx cache rather than on a real regression.
+const DB_PUSH_TIMEOUT_MS = 60_000;
+
+describeIfLocalDb("db:push drift", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+  });
+
+  it(
+    "silently drops a column and an index that the schema does not declare",
+    async () => {
+      await db.$executeRaw`ALTER TABLE "SearchDocument" ADD COLUMN IF NOT EXISTS "legacyVector" tsvector`;
+      await db.$executeRaw`CREATE INDEX IF NOT EXISTS "idx_legacy_vector" ON "SearchDocument" USING gin ("legacyVector")`;
+
+      const before = await db.$queryRaw<{ column_name: string }[]>`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'SearchDocument' AND column_name = 'legacyVector'
+    `;
+      expect(before).toHaveLength(1);
+
+      dbPush();
+
+      const after = await db.$queryRaw<{ column_name: string }[]>`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'SearchDocument' AND column_name = 'legacyVector'
+    `;
+      const index = await db.$queryRaw<{ indexname: string }[]>`
+      SELECT indexname FROM pg_indexes WHERE indexname = 'idx_legacy_vector'
+    `;
+
+      // No warning, no --accept-data-loss prompt, just gone. This is why the substrate
+      // declares everything in schema.prisma and nothing in a manual SQL file.
+      expect(after).toHaveLength(0);
+      expect(index).toHaveLength(0);
+    },
+    DB_PUSH_TIMEOUT_MS
+  );
+
+  it(
+    "keeps the declared tsvector column and both GIN indexes across two pushes",
+    async () => {
+      dbPush();
+      dbPush();
+
+      const column = await db.$queryRaw<{ data_type: string }[]>`
+      SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'SearchDocument' AND column_name = 'searchVector'
+    `;
+      const indexes = await db.$queryRaw<{ indexdef: string }[]>`
+      SELECT indexdef FROM pg_indexes WHERE tablename = 'SearchDocument'
+    `;
+
+      expect(column[0]?.data_type).toBe("tsvector");
+      expect(
+        indexes.filter(
+          (i) => i.indexdef.includes("USING gin") && i.indexdef.includes("searchVector")
+        )
+      ).toHaveLength(1);
+      expect(indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"))).toHaveLength(1);
+    },
+    DB_PUSH_TIMEOUT_MS
+  );
+
+  afterAll(async () => {
+    await db.$disconnect();
   });
 });

--- a/src/lib/search/__tests__/schema-drift.integration.test.ts
+++ b/src/lib/search/__tests__/schema-drift.integration.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { describeIfLocalDb } from "@/test/db-guard";
+
+// Deferred import, and not a convenience: `@/lib/db` throws at module load when
+// DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
+// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+let db: typeof import("@/lib/db").db;
+
+type IndexRow = { indexname: string; indexdef: string };
+type ColumnRow = { data_type: string; is_nullable: string };
+
+async function searchDocumentIndexes(): Promise<IndexRow[]> {
+  return db.$queryRaw<IndexRow[]>`
+    SELECT indexname, indexdef
+    FROM pg_indexes
+    WHERE tablename = 'SearchDocument'
+  `;
+}
+
+describeIfLocalDb("SearchDocument schema", () => {
+  beforeAll(async () => {
+    ({ db } = await import("@/lib/db"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("declares searchVector as a nullable tsvector column", async () => {
+    const rows = await db.$queryRaw<ColumnRow[]>`
+      SELECT data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'SearchDocument' AND column_name = 'searchVector'
+    `;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.data_type).toBe("tsvector");
+    // Not a style preference: a non-nullable Unsupported column makes some write
+    // operations disappear from the generated client (spec 7.2).
+    expect(rows[0]?.is_nullable).toBe("YES");
+  });
+
+  it("indexes searchVector with GIN", async () => {
+    const indexes = await searchDocumentIndexes();
+    const gin = indexes.filter(
+      (i) => i.indexdef.includes("USING gin") && i.indexdef.includes("searchVector")
+    );
+
+    expect(gin).toHaveLength(1);
+  });
+
+  it("indexes searchText with the trigram operator class", async () => {
+    const indexes = await searchDocumentIndexes();
+    const trigram = indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"));
+
+    // Without the explicit opclass the index exists but never serves a LIKE '%...%',
+    // so the morphological fallback of spec 7.2 silently degrades to a sequential scan.
+    expect(trigram).toHaveLength(1);
+    expect(trigram[0]?.indexdef).toContain("searchText");
+  });
+
+  it("indexes visibility", async () => {
+    const indexes = await searchDocumentIndexes();
+
+    expect(indexes.some((i) => i.indexdef.includes("visibility"))).toBe(true);
+  });
+});

--- a/src/lib/search/__tests__/schema-drift.integration.test.ts
+++ b/src/lib/search/__tests__/schema-drift.integration.test.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from "node:child_process";
 import { afterAll, beforeAll, expect, it } from "vitest";
-import { describeIfLocalDb } from "@/test/db-guard";
+import { assertSearchTestDb, describeIfSearchTestDb } from "./helpers";
 
 // Deferred import, and not a convenience: `@/lib/db` throws at module load when
 // DATABASE_URL is unset, so a top-level import would fail the whole suite instead of
-// skipping this block. describeIfLocalDb only skips the block, it cannot undo an import.
+// skipping this block. describeIfSearchTestDb only skips the block, it cannot undo an import.
 let db: typeof import("@/lib/db").db;
 
 type IndexRow = { indexname: string; indexdef: string };
@@ -18,8 +18,9 @@ async function searchDocumentIndexes(): Promise<IndexRow[]> {
   `;
 }
 
-describeIfLocalDb("SearchDocument schema", () => {
+describeIfSearchTestDb("SearchDocument schema", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
   });
 
@@ -69,7 +70,7 @@ describeIfLocalDb("SearchDocument schema", () => {
 
 // Runs `prisma db push` the way the harness does: explicit --url so prisma.config.ts
 // cannot retarget it, and DOTENV_CONFIG_PATH=/dev/null so its `import "dotenv/config"`
-// cannot read the real .env. The describeIfLocalDb gate already guarantees the URL
+// cannot read the real .env. The describeIfSearchTestDb gate already guarantees the URL
 // is the throwaway container, this is the second lock.
 function dbPush(): void {
   const url = process.env["DATABASE_URL"];
@@ -87,8 +88,9 @@ function dbPush(): void {
 // a tighter one would fail on a cold npx cache rather than on a real regression.
 const DB_PUSH_TIMEOUT_MS = 60_000;
 
-describeIfLocalDb("db:push drift", () => {
+describeIfSearchTestDb("db:push drift", () => {
   beforeAll(async () => {
+    assertSearchTestDb();
     ({ db } = await import("@/lib/db"));
   });
 

--- a/src/lib/search/__tests__/schema-drift.integration.test.ts
+++ b/src/lib/search/__tests__/schema-drift.integration.test.ts
@@ -51,14 +51,22 @@ describeIfSearchTestDb("SearchDocument schema", () => {
     expect(gin).toHaveLength(1);
   });
 
-  it("indexes searchText with the trigram operator class", async () => {
-    const indexes = await searchDocumentIndexes();
-    const trigram = indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"));
+  it("declares no derived column besides the vector", async () => {
+    const columns = await db.$queryRaw<{ column_name: string }[]>`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'SearchDocument'
+    `;
+    const names = columns.map((c) => c.column_name);
 
-    // Without the explicit opclass the index exists but never serves a LIKE '%...%',
-    // so the morphological fallback of spec 7.2 silently degrades to a sequential scan.
-    expect(trigram).toHaveLength(1);
-    expect(trigram[0]?.indexdef).toContain("searchText");
+    // searchText and its GIN trigram index were removed with the substring fallback.
+    // Asserting their absence, and not merely not asserting their presence: a column
+    // recomputed on every write and indexed on every write, that nothing reads, is a
+    // cost no test would otherwise notice.
+    expect(names).toContain("searchVector");
+    expect(names).not.toContain("searchText");
+
+    const indexes = await searchDocumentIndexes();
+    expect(indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"))).toHaveLength(0);
   });
 
   it("indexes visibility", async () => {
@@ -125,7 +133,7 @@ describeIfSearchTestDb("db:push drift", () => {
   );
 
   it(
-    "keeps the declared tsvector column and both GIN indexes across two pushes",
+    "keeps the declared tsvector column and its GIN index across two pushes",
     async () => {
       dbPush();
       dbPush();
@@ -144,7 +152,9 @@ describeIfSearchTestDb("db:push drift", () => {
           (i) => i.indexdef.includes("USING gin") && i.indexdef.includes("searchVector")
         )
       ).toHaveLength(1);
-      expect(indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"))).toHaveLength(1);
+      // No trigram index survives either, because none is declared any more. A push that
+      // reintroduced one would mean the schema drifted back.
+      expect(indexes.filter((i) => i.indexdef.includes("gin_trgm_ops"))).toHaveLength(0);
     },
     DB_PUSH_TIMEOUT_MS
   );

--- a/src/lib/search/__tests__/search-test-db-gate.test.ts
+++ b/src/lib/search/__tests__/search-test-db-gate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { isSearchTestDb } from "./helpers";
+
+/**
+ * Unit test, no database: this is the gate that decides whether the destructive suites of
+ * the lot run at all, so it must be covered by CI, which has no database.
+ */
+describe("isSearchTestDb", () => {
+  it("accepts the disposable search container", () => {
+    expect(
+      isSearchTestDb(
+        "postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable"
+      )
+    ).toBe(true);
+  });
+
+  it("refuses another local database on another port", () => {
+    // The whole reason this gate exists. `describeIfLocalDb` says yes to this URL, and
+    // the suite would run ALTER TABLE and db:push --accept-data-loss against it.
+    expect(isSearchTestDb("postgresql://user:pass@localhost:5432/poligraph_dev")).toBe(false);
+  });
+
+  it("refuses the #477 harness, which is a different container", () => {
+    expect(isSearchTestDb("postgresql://poligraph_test@localhost:55432/poligraph_test")).toBe(
+      false
+    );
+  });
+
+  it("refuses another database name on the right port", () => {
+    expect(isSearchTestDb("postgresql://poligraph_test@localhost:55433/poligraph")).toBe(false);
+  });
+
+  it("refuses a remote host", () => {
+    expect(
+      isSearchTestDb("postgresql://u:p@aws-0-eu-west-3.pooler.supabase.com:55433/poligraph_test")
+    ).toBe(false);
+  });
+
+  it("refuses a local tunnel that forwards to somewhere else", () => {
+    // Same shape as the throwaway container but a port nobody would use for it. The gate
+    // cannot see through a tunnel, which is exactly why it pins the port and the name.
+    expect(isSearchTestDb("postgresql://u:p@localhost:6543/poligraph_test")).toBe(false);
+  });
+
+  it("is not fooled by the expected values appearing in credentials", () => {
+    expect(
+      isSearchTestDb("postgresql://localhost:55433:poligraph_test@db.example.com:5432/prod")
+    ).toBe(false);
+  });
+
+  it("refuses an unparseable URL", () => {
+    expect(isSearchTestDb("")).toBe(false);
+    expect(isSearchTestDb("not a url")).toBe(false);
+    expect(isSearchTestDb("localhost:55433/poligraph_test")).toBe(false); // no scheme
+  });
+
+  it("refuses an unset DATABASE_URL", () => {
+    // Deliberately NOT written as isSearchTestDb(undefined): the default parameter would
+    // then read process.env anyway, so the assertion passed with no database and failed
+    // under the harness. The variable has to actually be removed.
+    const saved = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      expect(isSearchTestDb()).toBe(false);
+    } finally {
+      if (saved !== undefined) process.env.DATABASE_URL = saved;
+    }
+  });
+});

--- a/src/lib/search/documents.ts
+++ b/src/lib/search/documents.ts
@@ -1,0 +1,55 @@
+import type { SearchEntityType, SearchVisibility } from "@/generated/prisma";
+import type { DbTransactionClient } from "@/lib/db";
+
+export type SearchDocumentInput = {
+  entityType: SearchEntityType;
+  entityId: string;
+  title: string;
+  body: string;
+  url: string;
+  visibility: SearchVisibility;
+  /** Opaque: the revision this document represents, or null for revisionless entities. */
+  sourceRevisionId: string | null;
+  /** The entity's updatedAt at indexing time. */
+  sourceUpdatedAt: Date;
+};
+
+/**
+ * The only authorized way to write a SearchDocument.
+ *
+ * Takes the caller's transaction client and never opens a transaction: the atomicity
+ * requirement of spec 7.2 belongs to the caller, which knows what else has to succeed
+ * or fail with the indexing.
+ *
+ * Two statements because searchVector is Unsupported("tsvector") and therefore absent
+ * from the generated client. The second one recomputes both derived columns from the
+ * row's own title and body, so searchText can never disagree with the indexed text.
+ */
+export async function upsertSearchDocument(
+  tx: DbTransactionClient,
+  input: SearchDocumentInput
+): Promise<void> {
+  const scalars = {
+    title: input.title,
+    body: input.body,
+    url: input.url,
+    visibility: input.visibility,
+    sourceRevisionId: input.sourceRevisionId,
+    sourceUpdatedAt: input.sourceUpdatedAt,
+    indexedAt: new Date(),
+  };
+
+  await tx.searchDocument.upsert({
+    where: { entityType_entityId: { entityType: input.entityType, entityId: input.entityId } },
+    create: { entityType: input.entityType, entityId: input.entityId, ...scalars },
+    update: scalars,
+  });
+
+  await tx.$executeRaw`
+    UPDATE "SearchDocument"
+    SET "searchVector" = to_tsvector('simple', unaccent(title || ' ' || body)),
+        "searchText"   = lower(unaccent(title || ' ' || body))
+    WHERE "entityType" = ${input.entityType}::"SearchEntityType"
+      AND "entityId" = ${input.entityId}
+  `;
+}

--- a/src/lib/search/documents.ts
+++ b/src/lib/search/documents.ts
@@ -53,3 +53,20 @@ export async function upsertSearchDocument(
       AND "entityId" = ${input.entityId}
   `;
 }
+
+/**
+ * Entity deletion path, and the only one that removes a row.
+ *
+ * A depublication is NOT a deletion: it is an upsert with ADMIN_ONLY visibility, which
+ * keeps the indexed text so bringing the entity back needs no reindex (spec 7.2).
+ *
+ * deleteMany and not delete: deleting an entity that was never indexed is an ordinary
+ * case, not an error, and delete would raise P2025.
+ */
+export async function deleteSearchDocument(
+  tx: DbTransactionClient,
+  entityType: SearchEntityType,
+  entityId: string
+): Promise<void> {
+  await tx.searchDocument.deleteMany({ where: { entityType, entityId } });
+}

--- a/src/lib/search/documents.ts
+++ b/src/lib/search/documents.ts
@@ -22,8 +22,9 @@ export type SearchDocumentInput = {
  * or fail with the indexing.
  *
  * Two statements because searchVector is Unsupported("tsvector") and therefore absent
- * from the generated client. The second one recomputes both derived columns from the
- * row's own title and body, so searchText can never disagree with the indexed text.
+ * from the generated client. The second one recomputes the vector from the row's own
+ * title and body rather than from the input, so the index can never disagree with the
+ * text stored next to it.
  */
 export async function upsertSearchDocument(
   tx: DbTransactionClient,
@@ -47,8 +48,7 @@ export async function upsertSearchDocument(
 
   await tx.$executeRaw`
     UPDATE "SearchDocument"
-    SET "searchVector" = to_tsvector('simple', unaccent(title || ' ' || body)),
-        "searchText"   = lower(unaccent(title || ' ' || body))
+    SET "searchVector" = to_tsvector('simple', unaccent(title || ' ' || body))
     WHERE "entityType" = ${input.entityType}::"SearchEntityType"
       AND "entityId" = ${input.entityId}
   `;

--- a/src/lib/search/query.ts
+++ b/src/lib/search/query.ts
@@ -10,13 +10,57 @@ export type SearchHit = {
 
 const MAX_QUERY_LENGTH = 200;
 const DEFAULT_LIMIT = 20;
-// Below three characters a trigram index degrades to a sequential scan, and a
-// one-letter substring matches almost everything.
-const MIN_TRIGRAM_TERM_LENGTH = 3;
+const MIN_LIMIT = 1;
+// A search box is not a bulk export, and PostgreSQL raises on a negative LIMIT, so an
+// unbounded caller value turns a mistake into a 500.
+const MAX_LIMIT = 50;
 
-/** Trim, collapse runs of whitespace, and cap the length. Returns "" when there is nothing to search. */
+/**
+ * Fold a raw query into terms that are safe to match on.
+ *
+ * Everything that is not a letter, a digit or a space is dropped. Two reasons, and the
+ * first one is a defect this replaced: with a substring pass, "%%%" built a LIKE pattern
+ * that matched every public document and "_" matched any character. Parameter binding
+ * protects against injection, not against the pattern semantics of the operator. The
+ * second reason is that spec 7.2 asks for punctuation normalization, so "loyers," and
+ * "loyers" have to reach the same terms.
+ *
+ * Accents survive here on purpose: unaccent runs in SQL, on both sides.
+ */
 function normalize(rawQuery: string): string {
-  return rawQuery.trim().replace(/\s+/g, " ").slice(0, MAX_QUERY_LENGTH);
+  return rawQuery
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, MAX_QUERY_LENGTH)
+    .trim();
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.trunc(limit), MIN_LIMIT), MAX_LIMIT);
+}
+
+/**
+ * The controlled variants of a term: itself, plus the other side of the -s plural.
+ *
+ * Enumerated and not inferred, which is the whole point. No lexical rule separates the
+ * recall we want from the false positive we refuse: "loyer" is a prefix of "loyers" and
+ * "retrait" is a prefix of "retraite", so a substring match, a prefix tsquery and a
+ * trigram similarity threshold all treat the two pairs the same way. Deriving the plural
+ * instead of matching loosely keeps "retraite" out of a search for "retrait", because
+ * "retraite" is not "retrait" plus an s.
+ *
+ * Not covered, deliberately: the -al/-aux plurals, and typos. A transposition such as
+ * "retratite" shares no lexeme with "retraite" and no amount of suffix work finds it.
+ * That is lot 7's subject, with the vector index and its own negative corpus.
+ */
+function variantsOf(term: string): string[] {
+  if (term.endsWith("s")) {
+    const singular = term.slice(0, -1);
+    return singular.length > 0 ? [term, singular] : [term];
+  }
+  return [term, `${term}s`];
 }
 
 function key(hit: SearchHit): string {
@@ -36,18 +80,29 @@ async function searchExact(query: string, limit: number): Promise<SearchHit[]> {
 }
 
 /**
- * Morphological variants and typos, through the trigram column.
+ * Singular and plural recall, term by term.
  *
- * Term by term and not on the whole query: "loyer zk1x2" as a single substring never
- * matches "loyers zk1x2", because the plural breaks the run. Each term has to be found
- * on its own, which is also what lets the trigram index serve each condition.
+ * Term by term and not on the whole query: each term has to be found on its own, which
+ * is what makes "loyer <token>" match a document reading "loyers <token>".
+ *
+ * Each variant goes through plainto_tsquery rather than to_tsquery: the latter parses an
+ * operator syntax and raises on input it does not like, which is not something a public
+ * search box may do. The `||` operator ORs the resulting queries.
  */
-async function searchFuzzy(query: string, limit: number): Promise<SearchHit[]> {
-  const terms = query.split(" ").filter((term) => term.length >= MIN_TRIGRAM_TERM_LENGTH);
+async function searchVariants(query: string, limit: number): Promise<SearchHit[]> {
+  const terms = query.split(" ").filter((term) => term.length > 0);
   if (terms.length === 0) return [];
 
   const conditions = Prisma.join(
-    terms.map((term) => Prisma.sql`"searchText" LIKE '%' || lower(unaccent(${term})) || '%'`),
+    terms.map((term) => {
+      const alternatives = Prisma.join(
+        variantsOf(term).map(
+          (variant) => Prisma.sql`plainto_tsquery('simple', unaccent(${variant}))`
+        ),
+        " || "
+      );
+      return Prisma.sql`"searchVector" @@ (${alternatives})`;
+    }),
     " AND "
   );
 
@@ -75,10 +130,14 @@ export async function searchPublic(
   const query = normalize(rawQuery);
   if (query === "") return [];
 
-  const [exact, fuzzy] = await Promise.all([searchExact(query, limit), searchFuzzy(query, limit)]);
+  const bounded = clampLimit(limit);
+  const [exact, variants] = await Promise.all([
+    searchExact(query, bounded),
+    searchVariants(query, bounded),
+  ]);
 
   const seen = new Set(exact.map(key));
-  const merged = [...exact, ...fuzzy.filter((hit) => !seen.has(key(hit)))];
+  const merged = [...exact, ...variants.filter((hit) => !seen.has(key(hit)))];
 
-  return merged.slice(0, limit);
+  return merged.slice(0, bounded);
 }

--- a/src/lib/search/query.ts
+++ b/src/lib/search/query.ts
@@ -42,24 +42,28 @@ function clampLimit(limit: number): number {
 }
 
 /**
- * The controlled variants of a term: itself, plus the other side of the -s plural.
+ * The controlled variants of a term: itself, plus its -s plural. One direction only.
  *
  * Enumerated and not inferred, which is the whole point. No lexical rule separates the
  * recall we want from the false positive we refuse: "loyer" is a prefix of "loyers" and
  * "retrait" is a prefix of "retraite", so a substring match, a prefix tsquery and a
- * trigram similarity threshold all treat the two pairs the same way. Deriving the plural
- * instead of matching loosely keeps "retraite" out of a search for "retrait", because
- * "retraite" is not "retrait" plus an s.
+ * trigram similarity threshold all treat the two pairs the same way. Adding an s keeps
+ * "retraite" out of a search for "retrait", because "retraite" is not "retrait" plus an s.
  *
- * Not covered, deliberately: the -al/-aux plurals, and typos. A transposition such as
- * "retratite" shares no lexeme with "retraite" and no amount of suffix work finds it.
- * That is lot 7's subject, with the vector index and its own negative corpus.
+ * Stripping a trailing s would NOT be the mirror image of that, it would invent French:
+ * fois -> foi, cours -> cour, fonds -> fond, pays -> pay, plus -> plu. The first two are
+ * ordinary words of this corpus, and "cours" returning the Cour des comptes is the very
+ * class of false positive the simple dictionary was chosen to avoid.
+ *
+ * The accepted cost: a query already written in the plural does not yet reach a document
+ * written in the singular. Making it symmetric needs a morphological lexicon with its
+ * exceptions, not a suffix rule, so it belongs with lot 7's approximate search.
+ *
+ * Also not covered: the -al/-aux plurals, and typos. A transposition such as "retratite"
+ * shares no lexeme with "retraite" and no amount of suffix work finds it.
  */
 function variantsOf(term: string): string[] {
-  if (term.endsWith("s")) {
-    const singular = term.slice(0, -1);
-    return singular.length > 0 ? [term, singular] : [term];
-  }
+  if (term.endsWith("s")) return [term];
   return [term, `${term}s`];
 }
 
@@ -80,7 +84,7 @@ async function searchExact(query: string, limit: number): Promise<SearchHit[]> {
 }
 
 /**
- * Singular and plural recall, term by term.
+ * Plural recall, term by term.
  *
  * Term by term and not on the whole query: each term has to be found on its own, which
  * is what makes "loyer <token>" match a document reading "loyers <token>".

--- a/src/lib/search/query.ts
+++ b/src/lib/search/query.ts
@@ -1,0 +1,84 @@
+import { Prisma, type SearchEntityType } from "@/generated/prisma";
+import { db } from "@/lib/db";
+
+export type SearchHit = {
+  entityType: SearchEntityType;
+  entityId: string;
+  title: string;
+  url: string;
+};
+
+const MAX_QUERY_LENGTH = 200;
+const DEFAULT_LIMIT = 20;
+// Below three characters a trigram index degrades to a sequential scan, and a
+// one-letter substring matches almost everything.
+const MIN_TRIGRAM_TERM_LENGTH = 3;
+
+/** Trim, collapse runs of whitespace, and cap the length. Returns "" when there is nothing to search. */
+function normalize(rawQuery: string): string {
+  return rawQuery.trim().replace(/\s+/g, " ").slice(0, MAX_QUERY_LENGTH);
+}
+
+function key(hit: SearchHit): string {
+  return `${hit.entityType}:${hit.entityId}`;
+}
+
+/** Exact words through the tsvector index. No stemming, so no loyer/loi false positive. */
+async function searchExact(query: string, limit: number): Promise<SearchHit[]> {
+  return db.$queryRaw<SearchHit[]>`
+    SELECT "entityType", "entityId", title, url
+    FROM "SearchDocument"
+    WHERE visibility = 'PUBLIC'::"SearchVisibility"
+      AND "searchVector" @@ plainto_tsquery('simple', unaccent(${query}))
+    ORDER BY ts_rank("searchVector", plainto_tsquery('simple', unaccent(${query}))) DESC, title ASC
+    LIMIT ${limit}
+  `;
+}
+
+/**
+ * Morphological variants and typos, through the trigram column.
+ *
+ * Term by term and not on the whole query: "loyer zk1x2" as a single substring never
+ * matches "loyers zk1x2", because the plural breaks the run. Each term has to be found
+ * on its own, which is also what lets the trigram index serve each condition.
+ */
+async function searchFuzzy(query: string, limit: number): Promise<SearchHit[]> {
+  const terms = query.split(" ").filter((term) => term.length >= MIN_TRIGRAM_TERM_LENGTH);
+  if (terms.length === 0) return [];
+
+  const conditions = Prisma.join(
+    terms.map((term) => Prisma.sql`"searchText" LIKE '%' || lower(unaccent(${term})) || '%'`),
+    " AND "
+  );
+
+  return db.$queryRaw<SearchHit[]>`
+    SELECT "entityType", "entityId", title, url
+    FROM "SearchDocument"
+    WHERE visibility = 'PUBLIC'::"SearchVisibility"
+      AND ${conditions}
+    ORDER BY title ASC
+    LIMIT ${limit}
+  `;
+}
+
+/**
+ * Public lexical search. Both passes always run and their results are merged, exact
+ * matches first, deduplicated on (entityType, entityId), limit applied after the merge.
+ *
+ * `visibility = 'PUBLIC'` is part of both queries. It is not a convenience filter:
+ * without it the index bypasses the publication filter of the data layer.
+ */
+export async function searchPublic(
+  rawQuery: string,
+  limit: number = DEFAULT_LIMIT
+): Promise<SearchHit[]> {
+  const query = normalize(rawQuery);
+  if (query === "") return [];
+
+  const [exact, fuzzy] = await Promise.all([searchExact(query, limit), searchFuzzy(query, limit)]);
+
+  const seen = new Set(exact.map(key));
+  const merged = [...exact, ...fuzzy.filter((hit) => !seen.has(key(hit)))];
+
+  return merged.slice(0, limit);
+}


### PR DESCRIPTION
## Description

Premier lot du hub présidentielle 2027, et il vient volontairement avant le lot du modèle éditorial.
Le sens de la dépendance l'impose : `SearchDocument` est agnostique de l'entité qu'il décrit
(`entityType` + `entityId`, aucune clé étrangère, `sourceRevisionId` en chaîne opaque), et c'est la
transaction de publication du lot suivant qui l'appellera. Une clé étrangère vers une révision de mesure
aurait rendu le modèle inapte à indexer les questions citoyennes et les six familles d'entités qui
n'ont pas de révision du tout.

Ce que la PR ajoute :

- le modèle `SearchDocument` et ses deux index (GIN sur `tsvector`, index sur `visibility`), plus les
  enums `SearchEntityType` et `SearchVisibility` ;
- `src/lib/search/documents.ts` : les deux seules écritures autorisées, `upsertSearchDocument()` et
  `deleteSearchDocument()`. Elles prennent le client de transaction de l'appelant et n'ouvrent jamais
  la leur, ce qui rend l'indexation atomique avec l'écriture de l'entité ;
- `src/lib/search/query.ts` : `searchPublic()`, avec le filtre `visibility = 'PUBLIC'` **dans** le SQL
  des deux requêtes. Filtrer après coup en JavaScript aurait l'air correct sur un petit jeu de données
  et laisserait fuiter des titres dès qu'une limite entre en jeu ;
- un harnais Docker PostgreSQL 17 jetable (`npm run test:db:search`), séparé de celui de l'issue #477
  qui tourne en 16, parce que ce lot teste justement le comportement de `db:push` face à une colonne
  `Unsupported` et à son index GIN.

Le lot est strictement additif : aucune suppression, aucun modèle Prisma existant touché, aucune
relation inverse ajoutée nulle part. C'est ce qui le rend livrable seul.

### Deux points de conception qui méritent une phrase

**Deux instructions dans l'upsert, pas une.** `searchVector` est de type `Unsupported("tsvector")`,
donc absent du client généré : Prisma ne peut pas l'écrire. La primitive fait donc un upsert pour les
colonnes scalaires puis un `UPDATE` qui recalcule le vecteur en relisant `title` et `body` depuis la
ligne elle-même, et non depuis l'entrée. Un index en désaccord avec le texte stocké à côté de lui devient
impossible.

**Le rattrapage morphologique est énuméré, pas deviné.** L'index `tsvector` répond aux mots exacts sans
faux positif. Le second étage cherche les variantes contrôlées de chaque terme, aujourd'hui le pluriel
en -s, comme lexèmes exacts sur la même colonne. Les deux requêtes tournent toujours et leurs résultats
fusionnent, exacts d'abord : s'arrêter dès que la passe exacte renvoie quelque chose faisait perdre
« loyers » quand un autre document contenait « loyer ».

Pourquoi énumérer plutôt que matcher largement, c'est le point le plus important de la PR. « loyer » est
un préfixe de « loyers » et « retrait » est un préfixe de « retraite » : les deux relations ont la même
forme. Un `LIKE '%terme%'`, un `to_tsquery('terme:*')` et un seuil de `similarity()` rattrapent donc le
pluriel voulu **et** le faux positif retraites, sans pouvoir les distinguer. Dériver le pluriel garde
« retraite » hors d'une recherche « retrait », puisque « retraite » n'est pas « retrait » plus un s.

L'expansion va dans **un seul sens**, et c'est délibéré : retirer un `s` final inventerait du français,
`fois` donnerait `foi`, `cours` donnerait `cour`, `pays` donnerait `pay`. Une recherche « cours »
remonterait la Cour des comptes, soit exactement la classe de faux positif que le dictionnaire `simple`
sert à éviter. Contrepartie assumée, et testée comme telle plutôt que laissée à découvrir : une requête
déjà au pluriel n'atteint pas encore un document au singulier. La symétrie demande un lexique
morphologique avec ses exceptions, pas une règle de suffixe.

Non couvert non plus : les pluriels en -aux, et les fautes de frappe. Une sous-chaîne n'en rattrape
aucune de toute façon (« retratite » ne contient pas « retraite » et ne partage aucun lexème avec elle).

**Une seule colonne dérivée, donc.** Une version précédente de cette PR gardait `searchText`, son index
GIN trigramme et l'extension `pg_trgm` dans le harnais, en prévision du lot 7. Retirés : plus rien ne les
lisait, et ils coûtaient un recalcul et une mise à jour d'index à chaque écriture. Figer aujourd'hui une
colonne et un opérateur préjugerait par ailleurs des mesures que le lot 7 doit faire, alors qu'il pourrait
retenir `word_similarity`, une recherche par mots ou une combinaison vectorielle. `title` et `body`
restent sur la ligne, donc n'importe quelle colonne dérivée est reconstructible le jour où le besoin est
démontré, au prix d'un `db:push` additif.

### Dictionnaire `simple` et pas `french`

Contre-intuitif pour un corpus français, et mesuré. Le stemmer français de PostgreSQL réduit `loyer` au
lexème `loi`, et `retraite`, `retraites`, `retraits`, `retraitement` produisent tous `retrait` alors que
le singulier `retrait` produit `retr`. Or `RETRAIT` est un type d'acte du modèle éditorial et les
retraites seront l'un des sujets les plus recherchés d'une présidentielle. Le fichier
`lexical-corpus.integration.test.ts` fige ces mesures, pour que personne ne rebascule un jour sur
`french` en croyant améliorer la recherche française.

### La garde des tests, resserrée sur le conteneur exact

Les suites de ce lot exécutent `ALTER TABLE`, `CREATE INDEX` et `prisma db push --accept-data-loss`.
`describeIfLocalDb` répond à « est-ce une base locale », ce qui suffit à une suite qui n'écrit que des
lignes mais pas à celle-ci : « local » décrit aussi une base de développement persistante ou un tunnel
vers une base distante. La garde de ce lot exige donc le conteneur jetable exact, hôte, port et nom de
base. Elle est testée unitairement, donc couverte par la CI qui n'a pas de base.

Vérifié : avec `DATABASE_URL` sur une autre base locale, les six tests de drift **sautent** au lieu de
poser leur colonne.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Aucune. Ce lot est une étape interne du chantier hub présidentielle, il n'y a pas d'issue à clore.

## Vérifications

42 tests verts sous `npm run test:db:search` : 6 sur le comportement de `db:push`, 6 sur les primitives
d'écriture, 8 sur le corpus lexical, 13 sur la lecture publique, 9 sur la garde de base.

Sans base, sous `npx vitest run`, les 33 tests d'intégration passent **en skip** et jamais en échec,
tandis que les 9 tests de la garde tournent. Suite complète : 3147 tests verts, aucun échec.

Chaque garantie a été confrontée à son ablation, c'est-à-dire qu'on a retiré la protection pour
constater l'échec du test avant de la remettre. Huit ablations :

| Ce qu'on retire | Ce qui tombe |
|---|---|
| `@@index([searchVector], type: Gin)` | les deux tests d'index et de survie au push |
| dictionnaire basculé en `french` | les deux tests de faux positif du corpus |
| filtre `visibility` de la requête exacte | les deux tests de fuite de brouillon |
| fusion remplacée par un retour anticipé | le test qui exige la variante morphologique |
| variantes remplacées par une sous-chaîne | le faux positif retraites et le test des jokers |
| normalisation de la ponctuation | la dérivation du pluriel sur un terme suivi d'une virgule |
| bornage de `limit` | l'appel à limite négative, qui casse en `P2010` |
| dérivation du pluriel rendue réversible | « fois » retrouve « foi », et l'asymétrie assumée n'est plus vraie |

Trois de ces ablations ont corrigé le lot lui-même plutôt que de le confirmer. Une fixture au pluriel
(« Encadrer les loyers ») reste verte sous `french`, parce que `loyers` donne `loyer` et pas `loi` : il
fallait une fixture au singulier. Interroger `retrait` au singulier ne remonte rien sous `french` : il
fallait interroger le pluriel. Et un test de ponctuation écrit sur `loyers,` passait sans aucune
normalisation, parce que `plainto_tsquery` nettoie déjà la ponctuation : il fallait le cas où la virgule
casse la dérivation du pluriel.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (ESLint sur `src/lib/search`, code 0 ; Prettier `--check` propre)
- [ ] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (spec et plan, hors dépôt)
- [x] Pas de données sensibles dans le code

Le build n'a pas été lancé en local, et la CI ne le couvre pas : la collecte des pages lit la base de
production via `.env`, et ce lot n'ajoute ni route ni page. À valider au moment du déploiement.

## Avant la mise en service

`SearchDocument` n'existe pas encore dans la base de production. Le lot suivant écrit dedans dès sa
deuxième tâche, donc le `db:push` doit précéder sa mise en service. Merger cette PR seule ne casse rien :
aucun code appelé en production ne touche à ce modèle.
