### PR TITLE
Bloquer la création d'affaires sans procédure judiciaire

### DIFF
--- a/src/lib/affair-matching/__tests__/procedure-guard.test.ts
+++ b/src/lib/affair-matching/__tests__/procedure-guard.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { assessProcedureEvidence } from "../procedure-guard";
+
+/**
+ * The press pipeline must not turn a political controversy into a judicial
+ * affair. AffairStatus has no "no procedure" value, so when the article
+ * describes no procedure at all the model still has to pick one, and it picked
+ * MISE_EN_EXAMEN with a confidence of 95 on affair AF-000515.
+ *
+ * The guard errs towards passing: a false pass reproduces today's behaviour
+ * (a draft a moderator reviews), a false block diverts a real affair.
+ */
+describe("assessProcedureEvidence", () => {
+  it("passes on an explicit mise en examen", () => {
+    const result = assessProcedureEvidence({
+      text: "Jérôme Barella a été mis en examen pour détournement de fonds publics.",
+    });
+    expect(result.hasProcedure).toBe(true);
+    expect(result.verdict).toBe("HAS_PROCEDURE");
+    expect(result.matched).not.toBeNull();
+  });
+
+  it("passes on an opened investigation", () => {
+    const result = assessProcedureEvidence({
+      text: "Le parquet de Paris a ouvert une enquête préliminaire après ce signalement.",
+    });
+    expect(result.hasProcedure).toBe(true);
+  });
+
+  it("passes on a court decision", () => {
+    const result = assessProcedureEvidence({
+      text: "Le tribunal correctionnel l'a condamné à deux ans avec sursis.",
+    });
+    expect(result.hasProcedure).toBe(true);
+  });
+
+  it("passes on a favourable outcome", () => {
+    const result = assessProcedureEvidence({
+      text: "La cour d'appel a prononcé une relaxe et le classement sans suite a été confirmé.",
+    });
+    expect(result.hasProcedure).toBe(true);
+  });
+
+  it("handles accents, curly quotes and hyphens", () => {
+    const result = assessProcedureEvidence({
+      text: "L’affaire s’est soldée par un non-lieu.",
+    });
+    expect(result.hasProcedure).toBe(true);
+  });
+
+  // Regression: AF-000515. Text anonymised on purpose: the repository is
+  // public and the affair was never published.
+  it("blocks a political controversy with no procedure", () => {
+    const result = assessProcedureEvidence({
+      text:
+        "Dans un documentaire, l'ancienne ministre des Sports reconnaît avoir fait " +
+        "cesser les contrôles inopinés avant la compétition, ce qu'elle avait nié " +
+        "devant une commission parlementaire. Les joueurs et leur fédération avaient " +
+        "fustigé ces contrôles.",
+    });
+    expect(result.hasProcedure).toBe(false);
+    expect(result.verdict).toBe("NO_PROCEDURE");
+    expect(result.matched).toBeNull();
+  });
+
+  it("does not take a speech act for a conviction", () => {
+    const result = assessProcedureEvidence({
+      text: "La députée a condamné ces propos et a condamné le recul du gouvernement.",
+    });
+    expect(result.hasProcedure).toBe(false);
+  });
+
+  it("does not take a journalistic investigation for a judicial one", () => {
+    const result = assessProcedureEvidence({
+      text: "Selon une enquête de la rédaction, le maire aurait favorisé cette association.",
+    });
+    expect(result.hasProcedure).toBe(false);
+  });
+
+  it("blocks on empty text", () => {
+    expect(assessProcedureEvidence({ text: "" }).hasProcedure).toBe(false);
+  });
+});

--- a/src/lib/affair-matching/index.ts
+++ b/src/lib/affair-matching/index.ts
@@ -27,3 +27,9 @@ export {
   type AttributionVerdict,
   type GuardInvolvement,
 } from "./attribution-guard";
+export {
+  assessProcedureEvidence,
+  type ProcedureGuardInput,
+  type ProcedureGuardResult,
+  type ProcedureVerdict,
+} from "./procedure-guard";

--- a/src/lib/affair-matching/procedure-guard.ts
+++ b/src/lib/affair-matching/procedure-guard.ts
@@ -1,0 +1,148 @@
+import { normalizeForMatching } from "./normalize";
+
+/**
+ * Procedure guard.
+ *
+ * `AffairStatus` is non-nullable and its fourteen values are all steps of a
+ * criminal procedure, so the press extraction has no correct output for an
+ * article that describes none. On affair AF-000515 it emitted MISE_EN_EXAMEN,
+ * with a confidence of 95, on a political controversy where no procedure ever
+ * existed. Under RGPD article 10 that is the one category of claim we cannot
+ * get wrong.
+ *
+ * This guard answers a single question: does the article evidence that a
+ * judicial procedure EXISTS? It says nothing about who it targets, which is
+ * `attribution-guard`'s job. An affair may legitimately target a third party
+ * (`subjectLabel`), so a procedure aimed at someone else still passes.
+ *
+ * Deliberately generous: a false pass reproduces the current behaviour (a draft
+ * a moderator reviews), a false block diverts a real affair into
+ * PressAnalysisRejection. Known limitation: the scan is article-wide, so an
+ * article covering both a real procedure and an unrelated controversy passes
+ * for both. Narrowing the person axis is attribution-guard's role.
+ *
+ * Pure: no DB, no AI.
+ */
+
+export type ProcedureVerdict = "HAS_PROCEDURE" | "NO_PROCEDURE";
+
+export interface ProcedureGuardInput {
+  /** Full text of the article analysed by the press pipeline. */
+  text: string;
+}
+
+export interface ProcedureGuardResult {
+  verdict: ProcedureVerdict;
+  /** True when the pipeline may go on creating an affair. */
+  hasProcedure: boolean;
+  /** Source of the pattern that decided a pass, null on a block. */
+  matched: string | null;
+  reason: string;
+}
+
+/**
+ * A procedure has been opened.
+ *
+ * "enquête" alone is absent on purpose: a journalistic investigation ("selon
+ * une enquête de la rédaction") is not a judicial one, and that phrasing is
+ * common in the very articles this guard has to reject.
+ */
+const PROCEDURE_OUVERTE: RegExp[] = [
+  /\benquete preliminaire\b/,
+  /\benquete judiciaire\b/,
+  /\benquete (?:a ete|est|avait ete) ouverte\b/,
+  /\bouvert une enquete\b/,
+  /\bouverture d'une enquete\b/,
+  /\binformation judiciaire\b/,
+  /\binstruction judiciaire\b/,
+  /\bjuge d'instruction\b/,
+  /\bparquet\b/,
+  /\bprocureur\b/,
+  /\bplainte\b/,
+  /\bperquisition/,
+  /\bgarde a vue\b/,
+  /\bdetention provisoire\b/,
+  /\bcontrole judiciaire\b/,
+];
+
+/** A named person is a party to the procedure. */
+const PERSONNE_VISEE: RegExp[] = [
+  /\bmise?s? en examen\b/,
+  /\bmis(?:e|es)? en cause\b/,
+  /\bpoursuivi(?:e|s|es)?\b/,
+  /\bprevenu(?:e|s|es)?\b/,
+  /\binculp(?:e|ee|es|ees)\b/,
+  /\bdefere(?:e|s|es)?\b/,
+  /\becroue(?:e|s|es)?\b/,
+  /\bmandat de depot\b/,
+];
+
+/**
+ * A court is seized or has ruled.
+ *
+ * "condamné" is matched only in passive or sentence forms. A speech act
+ * ("a condamné ces propos", "a condamné le recul") must NOT count, which is why
+ * `le`, `les` and `ces` are absent from the follower list.
+ */
+const JURIDICTION_DECISION: RegExp[] = [
+  /\btribunal\b/,
+  /\bcour d'appel\b/,
+  /\bcour de cassation\b/,
+  /\bcour de justice de la republique\b/,
+  /\bproces\b/,
+  /\baudience\b/,
+  /\brequisitoire\b/,
+  /\brequisitions\b/,
+  /\bcomparution\b/,
+  /\b(?:a ete|ont ete|est|sont|sera|seront|fut|furent|avait ete|avaient ete) condamne(?:e|s|es)?\b/,
+  /\bcondamne(?:e|s|es)? (?:a|pour)\b/,
+  /\bjuge(?:e|s|es)? pour\b/,
+  /\brelaxe\b/,
+  /\bacquitte(?:e|s|es)?\b/,
+  /\bacquittement\b/,
+  /\bnon lieu\b/,
+  /\bclassement sans suite\b/,
+  /\bclasse sans suite\b/,
+];
+
+const FAMILIES: ReadonlyArray<{ name: string; patterns: RegExp[] }> = [
+  { name: "procedure-ouverte", patterns: PROCEDURE_OUVERTE },
+  { name: "personne-visee", patterns: PERSONNE_VISEE },
+  { name: "juridiction-decision", patterns: JURIDICTION_DECISION },
+];
+
+/**
+ * Decide whether the article evidences an existing judicial procedure.
+ * Pure function, no DB/AI access.
+ */
+export function assessProcedureEvidence(input: ProcedureGuardInput): ProcedureGuardResult {
+  const text = normalizeForMatching(input.text);
+
+  if (!text) {
+    return {
+      verdict: "NO_PROCEDURE",
+      hasProcedure: false,
+      matched: null,
+      reason: "Empty article text",
+    };
+  }
+
+  for (const family of FAMILIES) {
+    const hit = family.patterns.find((pattern) => pattern.test(text));
+    if (hit) {
+      return {
+        verdict: "HAS_PROCEDURE",
+        hasProcedure: true,
+        matched: `${family.name}:${hit.source}`,
+        reason: `Judicial procedure marker found (${family.name})`,
+      };
+    }
+  }
+
+  return {
+    verdict: "NO_PROCEDURE",
+    hasProcedure: false,
+    matched: null,
+    reason: "No judicial procedure marker in the article",
+  };
+}

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({ db: {} }));
 
+// Only the resolver is mocked: it loads the whole politician pool from the DB.
+// assessProcedureEvidence and assessPressAttribution stay real — they are pure,
+// and mocking them would empty these tests of their meaning.
+vi.mock("@/lib/affair-matching", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/affair-matching")>()),
+  resolveAffairPolitician: vi.fn(async () => ({
+    judgment: "NO_MATCH",
+    topCandidateId: null,
+    decisionId: null,
+  })),
+}));
+
 import { isPressAnalysisSuccessful, processAnalyzedArticle } from "./press-analysis";
 
 function zeroStats() {
@@ -108,5 +120,67 @@ describe("processAnalyzedArticle", () => {
     // affairs is empty, so the early return still fires: analyzed but no affair work.
     expect(stats.articlesAnalyzed).toBe(1);
     expect(stats.articlesAffairRelated).toBe(0);
+  });
+});
+
+/**
+ * Regression for affair AF-000515: the extraction returned MISE_EN_EXAMEN with a
+ * confidence of 95 on a political controversy where no procedure ever existed.
+ * AffairStatus has no "no procedure" value, so the guard has to catch it here,
+ * before the resolver writes an AffairPoliticianDecision audit row.
+ */
+describe("processAnalyzedArticle : garde-fou procédure", () => {
+  const article = {
+    id: "a2",
+    url: "https://example.com/y",
+    title: "Titre",
+    feedSource: "lemonde",
+    publishedAt: new Date("2026-08-03"),
+  };
+
+  function detected() {
+    return {
+      politicianName: "Jeanne Martin",
+      involvement: "DIRECT" as const,
+      category: "AUTRE",
+      status: "MISE_EN_EXAMEN",
+      title: "Titre affaire",
+      description: "Description",
+      factsDate: null,
+      court: null,
+      charges: [],
+      excerpts: [],
+      isNewRevelation: true,
+      confidenceScore: 95,
+      mentionedNames: ["Jeanne Martin"],
+    };
+  }
+
+  it("rejette une détection quand l'article ne décrit aucune procédure", async () => {
+    const stats = zeroStats();
+    await processAnalyzedArticle(
+      article,
+      "Dans un documentaire, l'ancienne ministre reconnaît avoir fait cesser les " +
+        "contrôles inopinés, ce qu'elle avait nié devant une commission parlementaire.",
+      { isAffairRelated: true, summary: "résumé", affairs: [detected()] },
+      stats,
+      { dryRun: true, verbose: false }
+    );
+
+    expect(stats.affairsRejected).toBe(1);
+    expect(stats.affairsCreated).toBe(0);
+  });
+
+  it("laisse passer une détection quand l'article décrit une procédure", async () => {
+    const stats = zeroStats();
+    await processAnalyzedArticle(
+      article,
+      "Jeanne Martin a été mise en examen pour détournement de fonds publics.",
+      { isAffairRelated: true, summary: "résumé", affairs: [detected()] },
+      stats,
+      { dryRun: true, verbose: false }
+    );
+
+    expect(stats.affairsRejected).toBe(0);
   });
 });

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -1,20 +1,56 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/db", () => ({ db: {} }));
+// Only the DB-backed collaborators are mocked. assessProcedureEvidence and
+// assessPressAttribution stay real: they are pure, and mocking them would empty
+// these tests of their meaning.
+const mocks = vi.hoisted(() => ({
+  resolveAffairPolitician: vi.fn(),
+  findMatchingAffairs: vi.fn(),
+  createDraftAffairFromDiscovery: vi.fn(),
+}));
 
-// Only the resolver is mocked: it loads the whole politician pool from the DB.
-// assessProcedureEvidence and assessPressAttribution stay real — they are pure,
-// and mocking them would empty these tests of their meaning.
+vi.mock("@/lib/db", () => ({
+  db: {
+    pressArticle: { update: vi.fn(async () => ({})) },
+    politician: {
+      findUnique: vi.fn(async () => ({
+        firstName: "Jeanne",
+        lastName: "Martin",
+        fullName: "Jeanne Martin",
+      })),
+    },
+    pressArticleAffair: { upsert: vi.fn(async () => ({})) },
+    affairPoliticianDecision: { update: vi.fn(async () => ({})) },
+  },
+}));
+
 vi.mock("@/lib/affair-matching", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/affair-matching")>()),
-  resolveAffairPolitician: vi.fn(async () => ({
-    judgment: "NO_MATCH",
-    topCandidateId: null,
-    decisionId: null,
-  })),
+  resolveAffairPolitician: mocks.resolveAffairPolitician,
+}));
+
+// pickConfidentMatch is pure and stays real; only the DB lookup is replaced.
+vi.mock("@/services/affairs/matching", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/affairs/matching")>()),
+  findMatchingAffairs: mocks.findMatchingAffairs,
+}));
+
+vi.mock("@/services/affairs/create-draft", () => ({
+  createDraftAffairFromDiscovery: mocks.createDraftAffairFromDiscovery,
 }));
 
 import { isPressAnalysisSuccessful, processAnalyzedArticle } from "./press-analysis";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveAffairPolitician.mockResolvedValue({
+    judgment: "NO_MATCH",
+    topCandidateId: null,
+    decisionId: null,
+  });
+  mocks.findMatchingAffairs.mockResolvedValue([]);
+  mocks.createDraftAffairFromDiscovery.mockResolvedValue({ id: "aff-1", slug: "aff-1" });
+});
 
 function zeroStats() {
   return {
@@ -182,5 +218,62 @@ describe("processAnalyzedArticle : garde-fou procédure", () => {
     );
 
     expect(stats.affairsRejected).toBe(0);
+  });
+});
+
+/**
+ * createAffairFromPress never passed `involvement` to
+ * createDraftAffairFromDiscovery, so Prisma applied the schema default,
+ * MENTIONED_ONLY. Yet the loop `continue`s on MENTIONED_ONLY detections: no
+ * press-created affair should carry that value. A politician actually mis en
+ * cause was stored as "ni mise en cause, ni poursuivie".
+ */
+describe("createAffairFromPress : involvement", () => {
+  it("écrit l'implication détectée au lieu du défaut de schéma", async () => {
+    mocks.resolveAffairPolitician.mockResolvedValue({
+      judgment: "SAME",
+      topCandidateId: "pol-1",
+      decisionId: "dec-1",
+    });
+
+    const stats = zeroStats();
+    await processAnalyzedArticle(
+      {
+        id: "a3",
+        url: "https://example.com/z",
+        title: "Titre",
+        feedSource: "lemonde",
+        publishedAt: new Date("2026-08-03"),
+      },
+      "Jeanne Martin a été mise en examen pour détournement de fonds publics.",
+      {
+        isAffairRelated: true,
+        summary: "résumé",
+        affairs: [
+          {
+            politicianName: "Jeanne Martin",
+            involvement: "DIRECT" as const,
+            category: "AUTRE",
+            status: "MISE_EN_EXAMEN",
+            title: "Titre affaire",
+            description: "Description",
+            factsDate: null,
+            court: null,
+            charges: [],
+            excerpts: [],
+            isNewRevelation: true,
+            confidenceScore: 95,
+            mentionedNames: ["Jeanne Martin"],
+          },
+        ],
+      },
+      stats,
+      { dryRun: false, verbose: false }
+    );
+
+    expect(stats.affairsCreated).toBe(1);
+    expect(mocks.createDraftAffairFromDiscovery).toHaveBeenCalledWith(
+      expect.objectContaining({ involvement: "DIRECT" })
+    );
   });
 });

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -628,6 +628,10 @@ async function createAffairFromPress(
       description: detected.description,
       status: detected.status as AffairStatus,
       category: detected.category as AffairCategory,
+      // Without this the Prisma default (MENTIONED_ONLY) applied, while the loop
+      // above `continue`s on MENTIONED_ONLY detections: every press-created
+      // affair claimed the politician was neither mis en cause nor poursuivi.
+      involvement: detected.involvement,
       confidenceScore: detected.confidenceScore,
       factsDate: detected.factsDate ? new Date(detected.factsDate) : null,
       court: detected.court,

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -27,7 +27,11 @@ import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matc
 import { syncMetadata } from "@/lib/sync";
 import { classifyArticleTier, type ArticleTier } from "@/config/press-keywords";
 import { MIN_CONFIDENCE_THRESHOLD } from "@/config/press-analysis";
-import { resolveAffairPolitician, assessPressAttribution } from "@/lib/affair-matching";
+import {
+  resolveAffairPolitician,
+  assessPressAttribution,
+  assessProcedureEvidence,
+} from "@/lib/affair-matching";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 
 // ============================================
@@ -324,6 +328,20 @@ export async function processAnalyzedArticle(
       if (verbose) {
         console.log(`  - ${detected.politicianName} simplement mentionné, pas impliqué → ignoré`);
       }
+      continue;
+    }
+
+    // Procedure guard: AffairStatus has no "no procedure" value, so the
+    // extraction has to emit a judicial status even on an article that
+    // describes none. Block before the resolver, which would otherwise write an
+    // AffairPoliticianDecision audit row for a detection we are discarding.
+    const procedure = assessProcedureEvidence({ text: analysisContent });
+    if (!procedure.hasProcedure) {
+      if (verbose) {
+        console.log(`  - Aucune procédure judiciaire dans l'article → "${detected.title}" ignoré`);
+      }
+      await rejectWeakAttribution(article.id, null, detected, procedure.verdict, dryRun);
+      stats.affairsRejected++;
       continue;
     }
 


### PR DESCRIPTION
## Description

Le pipeline presse a créé un brouillon d'affaire portant `status: MISE_EN_EXAMEN` avec un score de confiance de 95, sur un article qui ne décrivait aucune procédure judiciaire (polémique politique, faits de 1997, aucune enquête jamais ouverte). La fiche a été rejetée en base.

La cause est structurelle : `AffairStatus` est non-nullable et ses quatorze valeurs sont toutes des étapes d'une procédure pénale. L'extraction n'a donc aucune sortie correcte pour un article qui n'en décrit aucune, et elle finit par affirmer un fait faux sur une personne vivante, dans la catégorie exacte que protège l'article 10 du RGPD.

Deux correctifs, plus un constat.

**1. Garde-fou déterministe sur l'existence d'une procédure**

`assessProcedureEvidence` (`src/lib/affair-matching/procedure-guard.ts`) est une fonction pure qui répond à une seule question : l'article atteste-t-il qu'une procédure judiciaire existe ? Trois familles de marqueurs (procédure ouverte, personne visée, juridiction ou décision), la présence d'un seul suffit à laisser passer.

Il est branché dans `processAnalyzedArticle` avant `resolveAffairPolitician`, donc avant toute écriture, et avant que le resolver ne produise une ligne d'audit `AffairPoliticianDecision` pour une détection qu'on écarte. Un verdict `NO_PROCEDURE` envoie la détection dans `PressAnalysisRejection` : le signal n'est pas perdu, il reste consultable et récupérable via la route admin existante.

Le garde-fou se trompe volontairement du côté du passage. Un faux passage reproduit le comportement actuel (un brouillon qu'un modérateur relit), un faux blocage détournerait une vraie affaire. Deux pièges connus sont exclus : « enquête » seul ne suffit pas (une enquête journalistique n'est pas judiciaire) et « a condamné le / les / ces » non plus (acte de parole).

Il porte sur l'existence de la procédure, pas sur la personne qu'elle vise : une affaire peut légitimement cibler un tiers via `subjectLabel`, et l'axe « qui » reste couvert par `attribution-guard`. Limite assumée et documentée dans le module : le scan est à l'échelle de l'article, donc un article couvrant à la fois une vraie procédure et une controverse sans lien passe pour les deux.

**2. `involvement` était calculé puis jeté à l'écriture**

`createAffairFromPress` ne passait pas `involvement` à `createDraftAffairFromDiscovery`, où le champ est optionnel. Prisma appliquait donc son défaut de schéma, `MENTIONED_ONLY`.

Conséquence contre-intuitive : la boucle fait déjà `continue` sur les détections `MENTIONED_ONLY`, donc aucune affaire créée par la presse ne devrait porter cette valeur. Elles la portaient toutes. Un élu réellement mis en cause était enregistré comme « simplement mentionnée, sans être ni mise en cause, ni poursuivie », texte rendu tel quel sur la fiche publique si un modérateur publiait sans corriger l'implication à la main.

**3. Audit de l'existant : rien à réparer**

Sur les 71 affaires en `MENTIONED_ONLY` liées à un article de presse, 66 étaient déjà rejetées, 1 exclue, et les 4 publiées portent `ENQUETE_PRELIMINAIRE` ou `INSTRUCTION`, statuts pour lesquels « mentionnée » est cohérent. Zéro fiche publiée incohérente (statut à charge sans tiers désigné). Aucune mutation de masse n'a été faite ni n'est nécessaire.

Aucun compteur public n'était affecté : les cinq where-builders de `public-filters.ts` codent `publicationStatus: "PUBLISHED"` en dur, un brouillon n'entre dans aucun agrégat.

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Autre : \_\_\_

## Issue liée

Aucune.

## Checklist

- [x] Le code suit les conventions du projet
- [ ] `npm run lint` passe sans erreur (vérifié via `eslint` sur les fichiers touchés, exit 0 ; le lint complet est laissé à la CI, qui ne scanne que `src/`)
- [ ] `npm run build` passe sans erreur (non exécuté en local, laissé à la CI)
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Tests

Suite complète après rebase sur `main` : **3159 passés, 166 skippés, 0 échec**. `tsc --noEmit` sans erreur source.

12 tests ajoutés :

- 9 unitaires purs sur `assessProcedureEvidence` : mise en examen explicite, enquête ouverte, décision de justice, issue favorable, accents et guillemets typographiques et traits d'union, plus les trois cas négatifs (controverse sans procédure, acte de parole, enquête journalistique) et le texte vide.
- 2 de régression sur le branchement : une détection sans procédure est rejetée et rien n'est créé, une détection avec procédure passe.
- 1 de régression sur `involvement` : l'implication détectée est bien écrite plutôt que le défaut de schéma.

La fixture du cas déclencheur est synthétique et anonymisée : le dépôt est public et la fiche concernée n'a jamais été publiée.

## Périmètre

Hors des deux points d'insertion dans `press-analysis.ts`, aucun fichier existant n'est modifié. Deux options ont été écartées en cours de route : extraire un `normalize()` partagé (le module `affair-matching` a déjà le sien, et onze helpers de dé-accentuation existent dans le dépôt) et placer le garde-fou dans `src/lib/affairs/` (aurait créé une arête de dépendance entre deux modules aujourd'hui sans import croisé).

Volontairement non traités : cohérence entre le statut annoncé et la famille de marqueurs trouvée, rétrogradation automatique de statut, durcissement du prompt d'extraction.
