### PR TITLE
Réparer les vignettes Commons et recadrer les portraits sur le visage

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -151,6 +151,22 @@ jobs:
             exit 1
           fi
 
+      - name: Commons thumbnail URLs built only via lib/photos/commons
+        run: |
+          # upload.wikimedia.org only serves the widths listed on
+          # https://www.mediawiki.org/wiki/Common_thumbnail_sizes ; any other
+          # width returns HTTP 400. Building these URLs by hand silently broke
+          # 549 portraits once already, so the MD5-shard construction lives in
+          # src/lib/photos/commons.ts and nowhere else.
+          VIOLATIONS=$(grep -rn 'wikipedia/commons/thumb' src/ scripts/ --include='*.ts' --include='*.tsx' \
+            | grep -v 'src/lib/photos/commons.ts' \
+            | grep -v '__tests__' | grep -v '\.test\.' || true)
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::Build Commons thumbnail URLs with commonsThumbnailUrl() from @/lib/photos/commons — hardcoded widths get rejected by Wikimedia."
+            echo "$VIOLATIONS"
+            exit 1
+          fi
+
       - name: No secrets in NEXT_PUBLIC_ vars
         run: |
           VIOLATIONS=$(grep -rn 'NEXT_PUBLIC_.*SECRET\|NEXT_PUBLIC_.*TOKEN\|NEXT_PUBLIC_.*PASSWORD\|NEXT_PUBLIC_.*API_KEY' src/ .env.example --include='*.ts' --include='*.tsx' --include='*.env*' || true)

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ data/affairs-compliance-audit.json
 # Conviction audit ledger (#566), regenerated locally
 data/audit-convictions.json
 
+# Portrait pass report (repair-portraits.ts) — holds the from/to URL pairs a
+# rollback would need, regenerated on each run
+data/portraits-report.json
+
 # debug / logs
 *.log
 npm-debug.log*

--- a/scripts/repair-portraits.ts
+++ b/scripts/repair-portraits.ts
@@ -1,0 +1,476 @@
+/**
+ * Portrait maintenance pass for politician photos.
+ *
+ * Three independent phases, all read-only unless --apply is passed:
+ *
+ *   --repair    Rewrite stored Commons thumbnail URLs to a width Wikimedia
+ *               still serves. Fixes portraits that went blank when the allowed
+ *               width list was restricted.
+ *   --discover  Attach a portrait to politicians who have none, from the
+ *               Wikidata P18 claim on their own item.
+ *   --crop      Re-frame Commons portraits on the subject's face and cache the
+ *               result on Vercel Blob.
+ *
+ * Scope:
+ *   --only-bio  Restrict to politicians who already have a biography.
+ *   --limit=N   Cap the number of rows examined in each phase.
+ *
+ * Usage:
+ *   npx tsx scripts/repair-portraits.ts --repair
+ *   npx tsx scripts/repair-portraits.ts --repair --apply
+ *   npx tsx scripts/repair-portraits.ts --discover --only-bio --apply
+ *   npx tsx scripts/repair-portraits.ts --crop --only-bio --apply
+ */
+import "dotenv/config";
+import { writeFile } from "fs/promises";
+import { db } from "../src/lib/db";
+import { HTTPClient } from "../src/lib/api/http-client";
+import {
+  COMMONS_CROP_WIDTH,
+  COMMONS_STORED_WIDTH,
+  commonsThumbnailUrl,
+  isCommonsThumbnailUrl,
+  parseCommonsThumbnailWidth,
+  rewriteCommonsThumbnailWidth,
+  COMMONS_THUMBNAIL_WIDTHS,
+} from "../src/lib/photos/commons";
+import { cropToPortrait, readDimensions } from "../src/lib/photos/crop";
+import { screenFilename, screenGeometry } from "../src/lib/photos/portrait-guard";
+import { fetchP18Filenames, filenameFromThumbnailUrl } from "../src/lib/photos/wikidata-image";
+import { uploadCroppedPortrait } from "../src/lib/photos/blob";
+
+const client = new HTTPClient({ rateLimitMs: 150 });
+
+/** Default cap for the crop phase, which downloads and uploads per row. */
+const DEFAULT_CROP_LIMIT = 300;
+
+interface Options {
+  repair: boolean;
+  discover: boolean;
+  crop: boolean;
+  onlyBio: boolean;
+  limit: number | null;
+  apply: boolean;
+  reportPath: string;
+}
+
+function parseOptions(argv: string[]): Options {
+  const limitArg = argv.find((a) => a.startsWith("--limit="));
+  const reportArg = argv.find((a) => a.startsWith("--report="));
+  return {
+    repair: argv.includes("--repair"),
+    discover: argv.includes("--discover"),
+    crop: argv.includes("--crop"),
+    onlyBio: argv.includes("--only-bio"),
+    limit: limitArg ? Number(limitArg.split("=")[1] ?? "") : null,
+    apply: argv.includes("--apply"),
+    reportPath: reportArg?.split("=")[1] || "data/portraits-report.json",
+  };
+}
+
+const NO_PHOTO = { OR: [{ photoUrl: null }, { photoUrl: "" }] };
+
+interface RepairEntry {
+  id: string;
+  name: string;
+  from: string;
+  to: string;
+}
+
+interface DiscoverEntry {
+  id: string;
+  name: string;
+  qid: string;
+  filename: string;
+  url?: string;
+  status: "attached" | "refused" | "needs-review" | "unreachable";
+  reason?: string;
+  blobUrl?: string;
+}
+
+interface CropEntry {
+  id: string;
+  name: string;
+  filename: string;
+  status: "cropped" | "refused" | "unreachable";
+  reason?: string;
+  strategy?: string;
+  region?: { left: number; top: number; size: number };
+  blobUrl?: string;
+}
+
+/**
+ * Minimum gap between image downloads.
+ *
+ * upload.wikimedia.org answers 429 well before a few requests per second, and a
+ * throttled response is indistinguishable from a missing file unless you slow
+ * down and retry — which once made a perfectly good batch look half-broken.
+ */
+const IMAGE_FETCH_INTERVAL_MS = 700;
+
+/** Attempts per image, to ride out a 429 rather than record a false failure. */
+const IMAGE_FETCH_ATTEMPTS = 3;
+
+let lastImageFetchAt = 0;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchImage(url: string): Promise<Buffer> {
+  let lastError = "";
+
+  for (let attempt = 1; attempt <= IMAGE_FETCH_ATTEMPTS; attempt++) {
+    const waitFor = lastImageFetchAt + IMAGE_FETCH_INTERVAL_MS - Date.now();
+    if (waitFor > 0) await sleep(waitFor);
+    lastImageFetchAt = Date.now();
+
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Poligraph/1.0 (https://poligraph.fr)" },
+      signal: AbortSignal.timeout(20000),
+    });
+
+    if (res.ok) return Buffer.from(await res.arrayBuffer());
+
+    lastError = `HTTP ${res.status}`;
+    // Only throttling is worth retrying; a 404 will not become a 200.
+    if (res.status !== 429) break;
+    await sleep(2000 * attempt);
+  }
+
+  throw new Error(lastError);
+}
+
+async function urlIsServed(url: string): Promise<boolean> {
+  try {
+    const { ok } = await client.head(url);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/* ------------------------------------------------------------------ repair */
+
+async function runRepair(options: Options): Promise<RepairEntry[]> {
+  const rows = await db.politician.findMany({
+    where: {
+      photoUrl: { contains: "/thumb/" },
+      ...(options.onlyBio ? { biography: { not: null } } : {}),
+    },
+    select: { id: true, fullName: true, photoUrl: true },
+    take: options.limit ?? undefined,
+  });
+
+  const allowed = new Set<number>(COMMONS_THUMBNAIL_WIDTHS);
+  const entries: RepairEntry[] = [];
+
+  for (const row of rows) {
+    const current = row.photoUrl!;
+    if (!isCommonsThumbnailUrl(current)) continue;
+    const width = parseCommonsThumbnailWidth(current);
+    if (width === null || allowed.has(width)) continue;
+
+    const fixed = rewriteCommonsThumbnailWidth(current, COMMONS_STORED_WIDTH);
+    if (fixed === current) continue;
+    entries.push({ id: row.id, name: row.fullName, from: current, to: fixed });
+  }
+
+  console.log(`\n[repair] ${rows.length} Commons URLs examined, ${entries.length} on a dead width`);
+
+  // Prove the rewrite before trusting it on the whole set.
+  const sample = entries.slice(0, 5);
+  for (const entry of sample) {
+    const [before, after] = await Promise.all([urlIsServed(entry.from), urlIsServed(entry.to)]);
+    console.log(
+      `[repair]   ${entry.name.padEnd(26)} stored=${before ? "200" : "dead"} rewritten=${after ? "200" : "DEAD"}`
+    );
+  }
+
+  if (!options.apply) {
+    console.log(`[repair] dry run — pass --apply to write ${entries.length} rows`);
+    return entries;
+  }
+
+  let written = 0;
+  for (const entry of entries) {
+    await db.politician.update({
+      where: { id: entry.id },
+      // The cached Blob copy was made from the old URL and is still a valid
+      // image, so it is left alone; only the source pointer moves.
+      data: { photoUrl: entry.to },
+    });
+    written++;
+    if (written % 100 === 0) console.log(`[repair]   ${written}/${entries.length} written`);
+  }
+  console.log(`[repair] wrote ${written} rows`);
+  return entries;
+}
+
+/* ---------------------------------------------------------------- discover */
+
+async function runDiscover(options: Options): Promise<DiscoverEntry[]> {
+  const rows = await db.politician.findMany({
+    where: {
+      ...NO_PHOTO,
+      externalIds: { some: { source: "WIKIDATA" } },
+      ...(options.onlyBio ? { biography: { not: null } } : {}),
+    },
+    select: {
+      id: true,
+      fullName: true,
+      externalIds: { where: { source: "WIKIDATA" }, select: { externalId: true } },
+    },
+    orderBy: { prominenceScore: "desc" },
+    take: options.limit ?? undefined,
+  });
+
+  console.log(`\n[discover] ${rows.length} photo-less politicians carrying a Wikidata id`);
+
+  const byQid = new Map<string, (typeof rows)[number]>();
+  for (const row of rows) {
+    const qid = row.externalIds[0]?.externalId;
+    if (qid) byQid.set(qid, row);
+  }
+
+  const filenames = await fetchP18Filenames([...byQid.keys()]);
+  console.log(`[discover] ${filenames.size} of them have a P18 image claim`);
+
+  const entries: DiscoverEntry[] = [];
+
+  for (const [qid, filename] of filenames) {
+    const row = byQid.get(qid)!;
+    const base: DiscoverEntry = {
+      id: row.id,
+      name: row.fullName,
+      qid,
+      filename,
+      status: "refused",
+    };
+
+    const verdict = screenFilename(filename, row.fullName);
+    if (!verdict.ok) {
+      entries.push({ ...base, reason: `${verdict.reason}: ${verdict.detail}` });
+      continue;
+    }
+
+    const url = commonsThumbnailUrl(filename, COMMONS_STORED_WIDTH);
+    let buffer: Buffer;
+    try {
+      buffer = await fetchImage(commonsThumbnailUrl(filename, COMMONS_CROP_WIDTH));
+    } catch (e) {
+      entries.push({ ...base, url, status: "unreachable", reason: String(e).slice(0, 80) });
+      continue;
+    }
+
+    const dims = await readDimensions(buffer);
+    const geometry = screenGeometry(dims);
+    if (!geometry.ok) {
+      entries.push({ ...base, url, reason: `${geometry.reason}: ${geometry.detail}` });
+      continue;
+    }
+
+    let cropped;
+    try {
+      cropped = await cropToPortrait(buffer);
+    } catch (e) {
+      entries.push({
+        ...base,
+        url,
+        status: "unreachable",
+        reason: `crop failed: ${String(e).slice(0, 60)}`,
+      });
+      continue;
+    }
+
+    // Attaching a photo is adding a claim about someone's appearance, so it
+    // needs a positive face detection — not just an image that failed to be
+    // refused. The fallback framing cannot zoom, so on a greyscale wide shot it
+    // would publish a portrait in which the face is a handful of pixels.
+    // Those go to a review queue instead of being attached or silently dropped.
+    if (cropped.strategy !== "face") {
+      entries.push({
+        ...base,
+        url,
+        status: "needs-review",
+        reason: "no face detected; framing could not be verified automatically",
+      });
+      continue;
+    }
+
+    const entry: DiscoverEntry = { ...base, url, status: "attached" };
+
+    if (options.apply) {
+      const blobUrl = await uploadCroppedPortrait(row.id, cropped.buffer);
+      await db.politician.update({
+        where: { id: row.id },
+        data: {
+          photoUrl: url,
+          photoSource: "wikidata",
+          blobPhotoUrl: blobUrl,
+          photoCheckedAt: new Date(),
+        },
+      });
+      entry.blobUrl = blobUrl;
+    }
+
+    entries.push(entry);
+  }
+
+  const attached = entries.filter((e) => e.status === "attached");
+  const review = entries.filter((e) => e.status === "needs-review");
+  console.log(
+    `[discover] ${attached.length} attached, ${review.length} need review, ` +
+      `${entries.filter((e) => e.status === "refused").length} refused, ` +
+      `${entries.filter((e) => e.status === "unreachable").length} unreachable`
+  );
+  for (const entry of entries.filter((e) => e.status === "refused")) {
+    console.log(`[discover]   refused      ${entry.name.padEnd(26)} ${entry.reason}`);
+  }
+  for (const entry of review) {
+    console.log(`[discover]   needs review ${entry.name.padEnd(26)} ${entry.filename}`);
+  }
+  if (!options.apply) console.log(`[discover] dry run — pass --apply to attach ${attached.length}`);
+
+  return entries;
+}
+
+/* -------------------------------------------------------------------- crop */
+
+async function runCrop(options: Options): Promise<CropEntry[]> {
+  const limit = options.limit ?? DEFAULT_CROP_LIMIT;
+
+  const where = {
+    photoSource: "wikidata",
+    photoUrl: { contains: "/thumb/" },
+    ...(options.onlyBio ? { biography: { not: null } } : {}),
+  };
+
+  const total = await db.politician.count({ where });
+  const rows = await db.politician.findMany({
+    where,
+    select: { id: true, fullName: true, photoUrl: true },
+    orderBy: { prominenceScore: "desc" },
+    take: limit,
+  });
+
+  if (total > rows.length) {
+    console.log(
+      `\n[crop] ${total} candidates, taking the ${rows.length} most prominent — ` +
+        `${total - rows.length} left for a later run (raise --limit)`
+    );
+  } else {
+    console.log(`\n[crop] ${rows.length} candidates`);
+  }
+
+  const entries: CropEntry[] = [];
+
+  for (const row of rows) {
+    const filename = filenameFromThumbnailUrl(row.photoUrl!);
+    if (!filename) continue;
+
+    const base: CropEntry = { id: row.id, name: row.fullName, filename, status: "refused" };
+
+    const verdict = screenFilename(filename, row.fullName);
+    if (!verdict.ok) {
+      entries.push({ ...base, reason: `${verdict.reason}: ${verdict.detail}` });
+      continue;
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = await fetchImage(commonsThumbnailUrl(filename, COMMONS_CROP_WIDTH));
+    } catch (e) {
+      entries.push({ ...base, status: "unreachable", reason: String(e).slice(0, 80) });
+      continue;
+    }
+
+    const dims = await readDimensions(buffer);
+    const geometry = screenGeometry(dims);
+    if (!geometry.ok) {
+      entries.push({ ...base, reason: `${geometry.reason}: ${geometry.detail}` });
+      continue;
+    }
+
+    let cropped;
+    try {
+      cropped = await cropToPortrait(buffer);
+    } catch (e) {
+      entries.push({
+        ...base,
+        status: "unreachable",
+        reason: `crop failed: ${String(e).slice(0, 60)}`,
+      });
+      continue;
+    }
+
+    const entry: CropEntry = {
+      ...base,
+      status: "cropped",
+      strategy: cropped.strategy,
+      region: cropped.region,
+    };
+
+    if (options.apply) {
+      const blobUrl = await uploadCroppedPortrait(row.id, cropped.buffer);
+      await db.politician.update({
+        where: { id: row.id },
+        data: { blobPhotoUrl: blobUrl },
+      });
+      entry.blobUrl = blobUrl;
+    }
+
+    entries.push(entry);
+    if (entries.length % 25 === 0)
+      console.log(`[crop]   ${entries.length}/${rows.length} processed`);
+  }
+
+  const cropped = entries.filter((e) => e.status === "cropped");
+  const byStrategy = cropped.reduce<Record<string, number>>((acc, e) => {
+    acc[e.strategy ?? "?"] = (acc[e.strategy ?? "?"] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(
+    `[crop] ${cropped.length} cropped ${JSON.stringify(byStrategy)}, ` +
+      `${entries.filter((e) => e.status === "refused").length} refused, ` +
+      `${entries.filter((e) => e.status === "unreachable").length} unreachable`
+  );
+  if (!options.apply) console.log(`[crop] dry run — pass --apply to upload ${cropped.length}`);
+
+  return entries;
+}
+
+/* -------------------------------------------------------------------- main */
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+
+  if (!options.repair && !options.discover && !options.crop) {
+    console.log("Nothing to do. Pass at least one of --repair, --discover, --crop.");
+    return;
+  }
+
+  console.log(
+    `repair-portraits — ${options.apply ? "APPLY (writes to the database)" : "dry run"}` +
+      `${options.onlyBio ? ", scope: politicians with a biography" : ""}`
+  );
+
+  const report: Record<string, unknown> = {
+    generatedAt: new Date().toISOString(),
+    options: { ...options },
+  };
+
+  if (options.repair) report.repair = await runRepair(options);
+  if (options.discover) report.discover = await runDiscover(options);
+  if (options.crop) report.crop = await runCrop(options);
+
+  await writeFile(options.reportPath, JSON.stringify(report, null, 2));
+  console.log(`\nreport written to ${options.reportPath}`);
+
+  await db.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -295,6 +295,7 @@ export default async function PoliticianPage({ params }: PageProps) {
         <div className="flex items-start gap-6 mb-8">
           <PoliticianAvatar
             photoUrl={politician.photoUrl}
+            blobPhotoUrl={politician.blobPhotoUrl}
             firstName={politician.firstName}
             lastName={politician.lastName}
             size="lg"

--- a/src/components/politicians/PoliticianAvatar.test.tsx
+++ b/src/components/politicians/PoliticianAvatar.test.tsx
@@ -26,6 +26,39 @@ describe("PoliticianAvatar", () => {
     expect(img).toHaveAttribute("alt", "Jean Dupont");
   });
 
+  it("should prefer the Blob copy over the source photo", () => {
+    render(
+      <PoliticianAvatar
+        photoUrl="https://upload.wikimedia.org/source.jpg"
+        blobPhotoUrl="https://abc.public.blob.vercel-storage.com/politicians/x-portrait"
+        fullName="Jean Dupont"
+      />
+    );
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://abc.public.blob.vercel-storage.com/politicians/x-portrait"
+    );
+  });
+
+  it("should fall back to the source photo when there is no Blob copy", () => {
+    render(
+      <PoliticianAvatar
+        photoUrl="https://upload.wikimedia.org/source.jpg"
+        blobPhotoUrl={null}
+        fullName="Jean Dupont"
+      />
+    );
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://upload.wikimedia.org/source.jpg"
+    );
+  });
+
+  it("should render initials when neither photo is available", () => {
+    render(<PoliticianAvatar photoUrl={null} blobPhotoUrl={null} fullName="Jean Dupont" />);
+    expect(screen.getByText("JD")).toBeInTheDocument();
+  });
+
   it("should fallback to initials on image error", () => {
     render(
       <PoliticianAvatar

--- a/src/components/politicians/PoliticianAvatar.tsx
+++ b/src/components/politicians/PoliticianAvatar.tsx
@@ -6,6 +6,15 @@ import { cn, normalizeImageUrl } from "@/lib/utils";
 
 interface PoliticianAvatarProps {
   photoUrl: string | null;
+  /**
+   * Cached copy on Vercel Blob, preferred over `photoUrl` when present.
+   *
+   * For Commons-sourced portraits this is the version cropped on the subject's
+   * face, so passing it is what makes the framing visible. It also stops the
+   * page depending on an external host staying up: `photoUrl` is the provenance
+   * record, not the best thing to serve.
+   */
+  blobPhotoUrl?: string | null;
   firstName?: string;
   lastName?: string;
   fullName?: string;
@@ -23,6 +32,7 @@ const sizeClasses = {
 
 export function PoliticianAvatar({
   photoUrl,
+  blobPhotoUrl,
   firstName,
   lastName,
   fullName,
@@ -40,8 +50,9 @@ export function PoliticianAvatar({
   const displayName = fullName || `${derivedFirstName} ${derivedLastName}`;
   const sizeClass = sizeClasses[size];
 
-  const normalizedUrl = normalizeImageUrl(photoUrl);
-  const imageSrc = normalizedUrl;
+  // The Blob copy wins when there is one: it is the cropped portrait, and it is
+  // served from our own CDN rather than from the upstream source.
+  const imageSrc = normalizeImageUrl(blobPhotoUrl ?? photoUrl);
 
   // Fallback to initials if no photo or image fails to load
   if (!imageSrc || imageError) {

--- a/src/components/politicians/PoliticianCard.tsx
+++ b/src/components/politicians/PoliticianCard.tsx
@@ -68,6 +68,7 @@ export function PoliticianCard({
               <div className="transition-transform duration-300 group-hover:scale-110">
                 <PoliticianAvatar
                   photoUrl={politician.photoUrl}
+                  blobPhotoUrl={politician.blobPhotoUrl}
                   firstName={politician.firstName}
                   lastName={politician.lastName}
                   size="md"

--- a/src/lib/photos/__tests__/commons.test.ts
+++ b/src/lib/photos/__tests__/commons.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  COMMONS_THUMBNAIL_WIDTHS,
+  commonsThumbnailUrl,
+  isCommonsThumbnailUrl,
+  parseCommonsThumbnailWidth,
+  rewriteCommonsThumbnailWidth,
+  roundUpToAllowedWidth,
+} from "../commons";
+
+describe("roundUpToAllowedWidth", () => {
+  it("keeps a width that is already allowed", () => {
+    expect(roundUpToAllowedWidth(500)).toBe(500);
+    expect(roundUpToAllowedWidth(960)).toBe(960);
+  });
+
+  it("rounds up to the next allowed bucket", () => {
+    // 400 is the width that broke every stored URL.
+    expect(roundUpToAllowedWidth(400)).toBe(500);
+    expect(roundUpToAllowedWidth(121)).toBe(250);
+    expect(roundUpToAllowedWidth(1)).toBe(20);
+  });
+
+  it("caps at the largest allowed bucket", () => {
+    expect(roundUpToAllowedWidth(99999)).toBe(3840);
+  });
+
+  it("never returns a width outside the official list", () => {
+    for (let width = 1; width <= 4000; width += 7) {
+      expect(COMMONS_THUMBNAIL_WIDTHS).toContain(roundUpToAllowedWidth(width));
+    }
+  });
+});
+
+describe("commonsThumbnailUrl", () => {
+  it("builds the MD5-sharded thumbnail path", () => {
+    // Hash checked against the live file served by upload.wikimedia.org.
+    expect(commonsThumbnailUrl("François ASSELINEAU.jpg", 500)).toBe(
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/" +
+        "Fran%C3%A7ois_ASSELINEAU.jpg/500px-Fran%C3%A7ois_ASSELINEAU.jpg"
+    );
+  });
+
+  it("accepts a File: prefix and spaces", () => {
+    const url = commonsThumbnailUrl("File:Roussel Fabien 1.jpg", 500);
+    expect(url).toContain("/Roussel_Fabien_1.jpg/500px-Roussel_Fabien_1.jpg");
+    expect(url).not.toContain("File%3A");
+  });
+
+  it("coerces a forbidden width to an allowed one", () => {
+    expect(commonsThumbnailUrl("Roussel Fabien 1.jpg", 400)).toContain("/500px-");
+  });
+
+  it("appends .png for SVG sources, as Commons does", () => {
+    const url = commonsThumbnailUrl("Blason ville fr.svg", 250);
+    expect(url).toContain("/250px-Blason_ville_fr.svg.png");
+  });
+});
+
+describe("parseCommonsThumbnailWidth", () => {
+  it("reads the width out of a thumbnail URL", () => {
+    expect(
+      parseCommonsThumbnailWidth(
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/David-amiel.jpg/400px-David-amiel.jpg"
+      )
+    ).toBe(400);
+  });
+
+  it("returns null for an original-file URL", () => {
+    expect(
+      parseCommonsThumbnailWidth(
+        "https://upload.wikimedia.org/wikipedia/commons/9/9e/David-amiel.jpg"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("isCommonsThumbnailUrl", () => {
+  it("recognises upload.wikimedia.org thumbnails", () => {
+    expect(
+      isCommonsThumbnailUrl(
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/David-amiel.jpg/400px-David-amiel.jpg"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects other hosts and non-thumbnails", () => {
+    expect(isCommonsThumbnailUrl("https://www.senat.fr/senimg/12345.jpg")).toBe(false);
+    expect(
+      isCommonsThumbnailUrl("https://upload.wikimedia.org/wikipedia/commons/9/9e/David-amiel.jpg")
+    ).toBe(false);
+    expect(isCommonsThumbnailUrl(null)).toBe(false);
+  });
+});
+
+describe("rewriteCommonsThumbnailWidth", () => {
+  const broken =
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/" +
+    "%C3%89douard_Philippe_2019_(cropped).jpg/400px-%C3%89douard_Philippe_2019_(cropped).jpg";
+
+  it("moves a forbidden width to the next allowed one", () => {
+    expect(rewriteCommonsThumbnailWidth(broken, 400)).toBe(broken.replace("400px-", "500px-"));
+  });
+
+  it("rewrites only the width segment, not the filename", () => {
+    const url =
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/" +
+      "20241008-P1120704_Jeanbrun_Vincent_Wikipedia.jpg/" +
+      "400px-20241008-P1120704_Jeanbrun_Vincent_Wikipedia.jpg";
+    const fixed = rewriteCommonsThumbnailWidth(url, 500);
+    expect(fixed).toContain("/500px-20241008-P1120704_Jeanbrun_Vincent_Wikipedia.jpg");
+    // The "400px-" token must not have eaten into the numeric filename prefix.
+    expect(fixed).toContain("/20241008-P1120704_Jeanbrun_Vincent_Wikipedia.jpg/");
+  });
+
+  it("leaves a non-Commons URL untouched", () => {
+    const senat = "https://www.senat.fr/senimg/12345.jpg";
+    expect(rewriteCommonsThumbnailWidth(senat, 500)).toBe(senat);
+  });
+
+  it("is idempotent", () => {
+    const once = rewriteCommonsThumbnailWidth(broken, 500);
+    expect(rewriteCommonsThumbnailWidth(once, 500)).toBe(once);
+  });
+});

--- a/src/lib/photos/__tests__/crop.test.ts
+++ b/src/lib/photos/__tests__/crop.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { cropToPortrait, PORTRAIT_SIZE, readDimensions } from "../crop";
+
+/**
+ * Synthetic sources: a skin-toned "head" blob on a flat cool background. Both
+ * the skin-region scan and sharp's attention strategy are drawn to it, which
+ * lets us assert framing without depending on a network fixture.
+ */
+async function syntheticPortrait(
+  width: number,
+  height: number,
+  head: { left: number; top: number; size: number }
+): Promise<Buffer> {
+  const blob = await sharp({
+    create: {
+      width: head.size,
+      height: head.size,
+      channels: 3,
+      background: { r: 205, g: 145, b: 115 },
+    },
+  })
+    .png()
+    .toBuffer();
+
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 30, g: 40, b: 90 } },
+  })
+    .composite([{ input: blob, left: head.left, top: head.top }])
+    .jpeg()
+    .toBuffer();
+}
+
+/** A source with no skin tones at all, to exercise the fallback. */
+async function greyscaleScene(width: number, height: number): Promise<Buffer> {
+  const patch = await sharp({
+    create: { width: 200, height: 200, channels: 3, background: { r: 150, g: 150, b: 150 } },
+  })
+    .png()
+    .toBuffer();
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 60, g: 60, b: 60 } },
+  })
+    .composite([{ input: patch, left: 40, top: 40 }])
+    .jpeg()
+    .toBuffer();
+}
+
+describe("cropToPortrait", () => {
+  it("returns a square JPEG at the portrait size", async () => {
+    const source = await syntheticPortrait(900, 1400, { left: 300, top: 150, size: 300 });
+    const { buffer } = await cropToPortrait(source);
+
+    const meta = await sharp(buffer).metadata();
+    expect(meta.format).toBe("jpeg");
+    expect(meta.width).toBe(PORTRAIT_SIZE);
+    expect(meta.height).toBe(PORTRAIT_SIZE);
+  });
+
+  it("reports the source dimensions it worked from", async () => {
+    const source = await syntheticPortrait(900, 1400, { left: 300, top: 150, size: 300 });
+    const { source: dims } = await cropToPortrait(source);
+    expect(dims).toEqual({ width: 900, height: 1400 });
+  });
+
+  it("zooms towards the head on a distant square shot", async () => {
+    // The case a plain cover crop cannot fix: square source, small subject. The
+    // extracted square must be a fraction of the frame, not the whole frame.
+    const distant = await syntheticPortrait(960, 960, { left: 420, top: 220, size: 120 });
+    const { region, strategy } = await cropToPortrait(distant);
+
+    expect(strategy).toBe("face");
+    expect(region.size).toBeLessThan(600);
+  });
+
+  it("sizes the crop from the head, so a bigger head yields a bigger square", async () => {
+    const small = await syntheticPortrait(960, 1200, { left: 430, top: 200, size: 140 });
+    const large = await syntheticPortrait(960, 1200, { left: 330, top: 200, size: 340 });
+
+    const smallCrop = await cropToPortrait(small);
+    const largeCrop = await cropToPortrait(large);
+
+    expect(largeCrop.region.size).toBeGreaterThan(smallCrop.region.size);
+  });
+
+  it("keeps the whole head inside the crop, with margin", async () => {
+    const head = { left: 380, top: 260, size: 200 };
+    const source = await syntheticPortrait(960, 1400, head);
+    const { region } = await cropToPortrait(source);
+
+    expect(region.left).toBeLessThanOrEqual(head.left);
+    expect(region.top).toBeLessThanOrEqual(head.top);
+    expect(region.left + region.size).toBeGreaterThanOrEqual(head.left + head.size);
+    expect(region.top + region.size).toBeGreaterThanOrEqual(head.top + head.size);
+  });
+
+  it("follows the head down a tall photo instead of centring", async () => {
+    const headHigh = await syntheticPortrait(600, 1800, { left: 200, top: 120, size: 200 });
+    const headLow = await syntheticPortrait(600, 1800, { left: 200, top: 1400, size: 200 });
+
+    const high = await cropToPortrait(headHigh);
+    const low = await cropToPortrait(headLow);
+
+    expect(low.region.top).toBeGreaterThan(high.region.top + 800);
+  });
+
+  it("always returns a region inside the source bounds", async () => {
+    // Head jammed into a corner: the clamped region must still be extractable.
+    const corner = await syntheticPortrait(800, 1000, { left: 0, top: 0, size: 180 });
+    const { region, source } = await cropToPortrait(corner);
+
+    expect(region.left).toBeGreaterThanOrEqual(0);
+    expect(region.top).toBeGreaterThanOrEqual(0);
+    expect(region.left + region.size).toBeLessThanOrEqual(source.width);
+    expect(region.top + region.size).toBeLessThanOrEqual(source.height);
+  });
+
+  it("falls back to the largest square when no face is found", async () => {
+    const scene = await greyscaleScene(900, 1300);
+    const { strategy, region } = await cropToPortrait(scene);
+
+    expect(strategy).toBe("attention");
+    // The fallback never zooms: the square is as large as the image allows.
+    expect(region.size).toBe(900);
+  });
+
+  it("applies EXIF orientation before cropping", async () => {
+    // orient 6 = rotate 90 CW on display, so a 1400x900 file renders 900x1400.
+    const landscape = await syntheticPortrait(1400, 900, { left: 600, top: 200, size: 300 });
+    const rotated = await sharp(landscape).withMetadata({ orientation: 6 }).jpeg().toBuffer();
+
+    const { source } = await cropToPortrait(rotated);
+    expect(source).toEqual({ width: 900, height: 1400 });
+  });
+
+  it("rejects an unreadable buffer", async () => {
+    await expect(cropToPortrait(Buffer.from("not an image"))).rejects.toThrow();
+  });
+});
+
+describe("readDimensions", () => {
+  it("reports post-orientation dimensions", async () => {
+    const landscape = await syntheticPortrait(1400, 900, { left: 600, top: 200, size: 300 });
+    const rotated = await sharp(landscape).withMetadata({ orientation: 6 }).jpeg().toBuffer();
+    await expect(readDimensions(rotated)).resolves.toEqual({ width: 900, height: 1400 });
+  });
+});

--- a/src/lib/photos/__tests__/crop.test.ts
+++ b/src/lib/photos/__tests__/crop.test.ts
@@ -115,6 +115,22 @@ describe("cropToPortrait", () => {
     expect(region.top + region.size).toBeLessThanOrEqual(source.height);
   });
 
+  it("refuses to size the crop from a skin region low in the frame", async () => {
+    // A gesturing hand over a warm-toned background, no head. In a portrait the
+    // head is up top, so a region centred this low is not one; framing from it
+    // published a portrait of a hand on François Alfonsi's file.
+    const handLow = await syntheticPortrait(960, 1200, { left: 500, top: 860, size: 180 });
+    const { strategy, region } = await cropToPortrait(handLow);
+
+    expect(strategy).toBe("attention");
+    expect(region.size).toBe(960);
+  });
+
+  it("still frames from a head in the upper half", async () => {
+    const headHigh = await syntheticPortrait(960, 1200, { left: 400, top: 180, size: 180 });
+    expect((await cropToPortrait(headHigh)).strategy).toBe("face");
+  });
+
   it("falls back to the largest square when no face is found", async () => {
     const scene = await greyscaleScene(900, 1300);
     const { strategy, region } = await cropToPortrait(scene);

--- a/src/lib/photos/__tests__/portrait-guard.test.ts
+++ b/src/lib/photos/__tests__/portrait-guard.test.ts
@@ -49,6 +49,25 @@ describe("screenFilename — several people in frame", () => {
     ).toBe(false);
   });
 
+  it("reserves multiple-subjects for a conjunction, and reports the rest honestly", () => {
+    // Measured over 554 real files: most unaccounted words are places and event
+    // descriptions, so claiming a second person would be a false statement.
+    const place = screenFilename("Eric_Bocquet,_sénateur,_2023_à_Roeulx,.jpg", "Eric Bocquet");
+    expect(place.ok).toBe(false);
+    if (!place.ok) expect(place.reason).toBe("unexplained-words");
+
+    const scene = screenFilename(
+      "Frédéric_Delannoy_Aniche_quatre_jours_de_Dunkerque.jpg",
+      "Frédéric Delannoy"
+    );
+    expect(scene.ok).toBe(false);
+    if (!scene.ok) expect(scene.reason).toBe("unexplained-words");
+
+    const companion = screenFilename("Ségolène_Royal_&_Guillaume_Coutey.jpg", "Guillaume Coutey");
+    expect(companion.ok).toBe(false);
+    if (!companion.ok) expect(companion.reason).toBe("multiple-subjects");
+  });
+
   it("accepts a photo a Commons contributor already cropped to one person", () => {
     // "(cropped)" means a human framed it on the subject; the extra names in
     // the filename describe the original scene, not what is in the frame.

--- a/src/lib/photos/__tests__/portrait-guard.test.ts
+++ b/src/lib/photos/__tests__/portrait-guard.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { screenFilename, screenGeometry, screenPortrait } from "../portrait-guard";
+
+/**
+ * The fixtures below are real P18 filenames pulled from the politicians in our
+ * base on 2026-08-05, not invented examples.
+ */
+
+describe("screenFilename — non-portrait subjects", () => {
+  const cases: [string, string][] = [
+    ["Tombe d'André Fosset (1918–2001) 2.jpg", "André Fosset"],
+    ["Tombe de François Doubin (1933–2019) 3.jpg", "François Doubin"],
+    ["Tombe d'André Postel-Vinay (1911–2007) 1.jpg", "André Postel-Vinay"],
+    ["HC ICART F CIM-Nice-Caucade 2024-02.jpg", "Fernand Icart"],
+  ];
+
+  it.each(cases)("rejects %s", (filename, politician) => {
+    const verdict = screenFilename(filename, politician);
+    expect(verdict.ok).toBe(false);
+  });
+
+  it("names the subject reason so the report is readable", () => {
+    const verdict = screenFilename("Tombe de François Doubin (1933–2019) 3.jpg", "François Doubin");
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("non-portrait-subject");
+  });
+
+  it("rejects coats of arms, statues and signatures", () => {
+    expect(screenFilename("Blason ville fr Paris.svg", "Jean Dupont").ok).toBe(false);
+    expect(screenFilename("Statue de Jean Jaurès Toulouse.jpg", "Jean Jaurès").ok).toBe(false);
+    expect(screenFilename("Signature de Jean Dupont.svg", "Jean Dupont").ok).toBe(false);
+    expect(screenFilename("Plaque commemorative Jean Dupont.jpg", "Jean Dupont").ok).toBe(false);
+  });
+});
+
+describe("screenFilename — several people in frame", () => {
+  it("rejects an explicit two-person filename", () => {
+    const verdict = screenFilename("Fernand et Carl.jpg", "Fernand Le Rachinel");
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("multiple-subjects");
+  });
+
+  it("rejects a filename naming another politician", () => {
+    expect(screenFilename("Azzedine Taibi Michel Fourcade.jpg", "Azzédine Taïbi").ok).toBe(false);
+    expect(screenFilename("Mitterrand-Baumet.jpg", "Gilbert Baumet").ok).toBe(false);
+    expect(
+      screenFilename("René Tomasini- Jean-Pierre Cassabel- Carcassonne 1971.jpg", "René Tomasini")
+        .ok
+    ).toBe(false);
+  });
+
+  it("accepts a photo a Commons contributor already cropped to one person", () => {
+    // "(cropped)" means a human framed it on the subject; the extra names in
+    // the filename describe the original scene, not what is in the frame.
+    expect(
+      screenFilename(
+        "Catherine Pégard - courtesy call Catherine Pégard French Minister of Culture " +
+          "Gakuji Ito Commissioner for Cultural Affairs 20260402 3 (cropped).jpg",
+        "Catherine Pégard"
+      ).ok
+    ).toBe(true);
+    expect(
+      screenFilename(
+        "Marie-Christine Boutonnet at a EP Plenary session (Cropped).jpg",
+        "Marie-Christine Boutonnet"
+      ).ok
+    ).toBe(true);
+  });
+});
+
+describe("screenFilename — own name written without separators", () => {
+  // Commons filenames often glue the name together. Splitting on non-letters
+  // then leaves one long token that matches neither first nor last name.
+  const cases: [string, string][] = [
+    ["Hervemorin2008_recadre.PNG", "Hervé Morin"],
+    ["LaurentHénart.jpg", "Laurent Hénart"],
+    ["AlfonsiFrancois.jpg", "François Alfonsi"],
+    ["Ericka14Juillet.jpg", "Ericka Bareigts"],
+  ];
+
+  it.each(cases)("accepts %s", (filename, politician) => {
+    expect(screenFilename(filename, politician).ok).toBe(true);
+  });
+
+  it("still refuses a glued name that is not the politician's", () => {
+    expect(screenFilename("SegoleneRoyal.jpg", "Guillaume Coutey").ok).toBe(false);
+  });
+});
+
+describe("screenFilename — photographer credits", () => {
+  // "par <photographer>" is the Commons convention for attribution, and Claude
+  // Truong-Ngoc alone shot a large share of the French political portraits.
+  it.each([
+    ["Jean-Marie_Bockel_par_Claude_Truong-Ngoc_juin_2014.jpg", "Jean-Marie Bockel"],
+    ["Thierry_Repentin_par_Claude_Truong-Ngoc_avril_2013.jpg", "Thierry Repentin"],
+    ["Marie Dupont by John Smith 2019.jpg", "Marie Dupont"],
+  ])("accepts %s", (filename, politician) => {
+    expect(screenFilename(filename, politician).ok).toBe(true);
+  });
+
+  it("does not let a credit hide a second subject named before it", () => {
+    expect(
+      screenFilename("Ségolène Royal & Guillaume Coutey par un photographe.jpg", "Guillaume Coutey")
+        .ok
+    ).toBe(false);
+  });
+});
+
+describe("screenFilename — dates and scene words", () => {
+  it.each([
+    ["Extract_Jean-François_Debat,_mars_2012.JPG", "Jean-François Debat"],
+    ["Marie Dupont janvier 2020.jpg", "Marie Dupont"],
+    ["Marie Dupont, sénatrice, lors des voeux 2023.jpg", "Marie Dupont"],
+  ])("accepts %s", (filename, politician) => {
+    expect(screenFilename(filename, politician).ok).toBe(true);
+  });
+});
+
+describe("screenFilename — plain portraits pass", () => {
+  const cases: [string, string][] = [
+    ["François ASSELINEAU.jpg", "François Asselineau"],
+    ["David-amiel.jpg", "David Amiel"],
+    ["Roussel Fabien 1.jpg", "Fabien Roussel"],
+    ["Josee Massi 2026, AV.jpg", "Josée Massi"],
+    ["Hubert de Jenlis 2025.jpg", "Hubert De Jenlis"],
+    ["Roland Nungesser - 1967 (cropped).tif", "Roland Nungesser"],
+    ["Édouard Philippe 2019 (cropped).jpg", "Édouard Philippe"],
+    ["20241008-P1120704 Jeanbrun Vincent Wikipedia.jpg", "Vincent Jeanbrun"],
+    ["20210819 tondelier.m-cr3.jpg", "Marine Tondelier"],
+    ["SNCF Jean-Pierre Farandou (cropped).jpg", "Jean-Pierre Farandou"],
+    ["Nafissa Sid Cara.jpg", "Nafissa Sid Cara"],
+  ];
+
+  it.each(cases)("accepts %s", (filename, politician) => {
+    const verdict = screenFilename(filename, politician);
+    expect(verdict.ok).toBe(true);
+  });
+
+  it("tolerates a misspelling of the surname in the filename", () => {
+    // Commons file is "Roger Quillot.webp"; our record says "Roger Quilliot".
+    expect(screenFilename("Roger Quillot.webp", "Roger Quilliot").ok).toBe(true);
+  });
+
+  it("ignores accents and case when matching the politician's own name", () => {
+    expect(screenFilename("AZZEDINE TAIBI.jpg", "Azzédine Taïbi").ok).toBe(true);
+  });
+});
+
+describe("screenGeometry", () => {
+  it("accepts portrait and near-square images", () => {
+    expect(screenGeometry({ width: 992, height: 1276 }).ok).toBe(true);
+    expect(screenGeometry({ width: 800, height: 800 }).ok).toBe(true);
+    expect(screenGeometry({ width: 1000, height: 800 }).ok).toBe(true);
+  });
+
+  it("rejects wide images, which are scenes rather than portraits", () => {
+    const verdict = screenGeometry({ width: 1600, height: 900 });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("too-wide");
+  });
+
+  it("rejects images too small to crop without visible loss", () => {
+    const verdict = screenGeometry({ width: 150, height: 190 });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("too-small");
+  });
+
+  it("treats missing dimensions as unusable", () => {
+    expect(screenGeometry({ width: undefined, height: undefined }).ok).toBe(false);
+  });
+});
+
+describe("screenPortrait", () => {
+  it("combines both screens and reports the first failure", () => {
+    const verdict = screenPortrait({
+      filename: "Tombe de François Doubin (1933–2019) 3.jpg",
+      politicianName: "François Doubin",
+      width: 900,
+      height: 1200,
+    });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("non-portrait-subject");
+  });
+
+  it("passes a clean portrait", () => {
+    expect(
+      screenPortrait({
+        filename: "François ASSELINEAU.jpg",
+        politicianName: "François Asselineau",
+        width: 992,
+        height: 1276,
+      }).ok
+    ).toBe(true);
+  });
+
+  it("fails a clean filename on bad geometry", () => {
+    const verdict = screenPortrait({
+      filename: "François ASSELINEAU.jpg",
+      politicianName: "François Asselineau",
+      width: 1600,
+      height: 900,
+    });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("too-wide");
+  });
+});

--- a/src/lib/photos/blob.ts
+++ b/src/lib/photos/blob.ts
@@ -1,0 +1,18 @@
+import { put } from "@vercel/blob";
+
+/**
+ * Store a cropped portrait on Vercel Blob.
+ *
+ * The `-portrait` suffix keeps these apart from the raw copies that
+ * `/api/images/[id]` writes under `politicians/{id}`, so a cropped portrait is
+ * identifiable from its URL alone and no extra column is needed to record that
+ * the image is derived.
+ */
+export async function uploadCroppedPortrait(politicianId: string, buffer: Buffer): Promise<string> {
+  const { url } = await put(`politicians/${politicianId}-portrait`, buffer, {
+    access: "public",
+    contentType: "image/jpeg",
+    allowOverwrite: true,
+  });
+  return url;
+}

--- a/src/lib/photos/commons.ts
+++ b/src/lib/photos/commons.ts
@@ -1,0 +1,121 @@
+import { createHash } from "crypto";
+
+/**
+ * Wikimedia restricts the thumbnail widths that upload.wikimedia.org will
+ * serve. Any other width is answered with:
+ *
+ *   HTTP 400 — Use thumbnail sizes listed on https://w.wiki/GHai
+ *
+ * See https://www.mediawiki.org/wiki/Common_thumbnail_sizes. Requests going
+ * through PHP (the imageinfo API) get rounded up to the next bucket, but direct
+ * hotlinks — which is what we build and what next/image fetches — are rejected
+ * outright.
+ */
+export const COMMONS_THUMBNAIL_WIDTHS = [
+  20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840,
+] as const;
+
+const UPLOAD_HOST = "upload.wikimedia.org";
+const THUMB_SEGMENT = "/thumb/";
+
+/**
+ * Width stored in `Politician.photoUrl`. Big enough for the largest avatar we
+ * render (128 px at 2x) while staying an allowed bucket.
+ */
+export const COMMONS_STORED_WIDTH = 500;
+
+/**
+ * Width fetched when an image is about to be cropped. Cropping throws away
+ * pixels, so the source needs headroom over the 512 px output.
+ */
+export const COMMONS_CROP_WIDTH = 960;
+
+/** Largest bucket, used when a caller asks for more than Commons will serve. */
+const MAX_WIDTH = Math.max(...COMMONS_THUMBNAIL_WIDTHS);
+
+/**
+ * Smallest allowed width greater than or equal to `width`.
+ *
+ * Rounding up rather than down keeps the thumbnail at least as detailed as the
+ * caller asked for, which matters when the result feeds a crop.
+ */
+export function roundUpToAllowedWidth(width: number): number {
+  return COMMONS_THUMBNAIL_WIDTHS.find((allowed) => allowed >= width) ?? MAX_WIDTH;
+}
+
+/**
+ * Thumbnail extension Commons appends for formats it cannot serve natively.
+ * Raster formats keep their own extension.
+ */
+function thumbnailSuffix(filename: string): string {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith(".svg")) return ".png";
+  if (lower.endsWith(".tif") || lower.endsWith(".tiff")) return ".jpg";
+  return "";
+}
+
+/** Strip a leading `File:` / `Image:` namespace and turn spaces into underscores. */
+function normalizeFilename(filename: string): string {
+  return filename.replace(/^(File|Image|Fichier):/i, "").replace(/ /g, "_");
+}
+
+/**
+ * Build a direct Commons thumbnail URL from a P18 filename.
+ *
+ * Commons shards originals by the MD5 of the underscored filename:
+ *   /wikipedia/commons/thumb/{h[0]}/{h[0..1]}/{name}/{width}px-{name}
+ *
+ * The width is always coerced to an allowed bucket, so this function cannot
+ * produce a URL that Wikimedia will reject.
+ */
+export function commonsThumbnailUrl(filename: string, width: number): string {
+  const normalized = normalizeFilename(filename);
+  const hash = createHash("md5").update(normalized).digest("hex");
+  const encoded = encodeURIComponent(normalized);
+  const allowed = roundUpToAllowedWidth(width);
+  const suffix = thumbnailSuffix(normalized);
+
+  return (
+    `https://${UPLOAD_HOST}/wikipedia/commons/thumb/` +
+    `${hash[0]}/${hash.slice(0, 2)}/${encoded}/${allowed}px-${encoded}${suffix}`
+  );
+}
+
+/** True when `url` is a Commons thumbnail (not an original-file URL). */
+export function isCommonsThumbnailUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  return url.includes(UPLOAD_HOST) && url.includes(THUMB_SEGMENT);
+}
+
+/**
+ * Width encoded in a Commons thumbnail URL, or null when there is none.
+ *
+ * The width lives at the start of the last path segment, which is the only
+ * place it can be read without tripping over filenames that themselves start
+ * with digits (e.g. `20241008-P1120704_Jeanbrun_Vincent_Wikipedia.jpg`).
+ */
+export function parseCommonsThumbnailWidth(url: string): number | null {
+  if (!isCommonsThumbnailUrl(url)) return null;
+  const lastSegment = url.split("/").pop() ?? "";
+  const match = /^(\d+)px-/.exec(lastSegment);
+  return match?.[1] ? Number(match[1]) : null;
+}
+
+/**
+ * Rewrite a stored Commons thumbnail URL to an allowed width.
+ *
+ * Used to repair rows written before Wikimedia restricted the width list, and
+ * without going back to Wikidata: the filename is already in the URL.
+ * Non-Commons URLs are returned unchanged so callers can pass anything.
+ */
+export function rewriteCommonsThumbnailWidth(url: string, width: number): string {
+  if (!isCommonsThumbnailUrl(url)) return url;
+
+  const segments = url.split("/");
+  const lastSegment = segments[segments.length - 1];
+  if (!lastSegment || !/^\d+px-/.test(lastSegment)) return url;
+
+  const allowed = roundUpToAllowedWidth(width);
+  segments[segments.length - 1] = lastSegment.replace(/^\d+px-/, `${allowed}px-`);
+  return segments.join("/");
+}

--- a/src/lib/photos/crop.ts
+++ b/src/lib/photos/crop.ts
@@ -1,0 +1,207 @@
+import sharp from "sharp";
+import { detectFaceBox, type FaceBox } from "./face-box";
+
+/** Side of the square portrait we produce, in pixels. */
+export const PORTRAIT_SIZE = 512;
+
+/** JPEG quality for the cropped portrait. */
+const PORTRAIT_QUALITY = 82;
+
+/**
+ * Crop side as a multiple of the face span.
+ *
+ * Shoulders are about three face widths across, so a shade over three and a
+ * half frames head-and-shoulders with margin: the whole face at minimum, the
+ * bust at maximum.
+ */
+const BUST_FACTOR = 3.4;
+
+/**
+ * Where the centre of the head sits in the finished crop, top to bottom. Above
+ * the middle, so the shoulders have room and the subject is not floating.
+ */
+const FACE_VERTICAL_POSITION = 0.38;
+
+/** A face span under this share of the frame's short side is treated as noise. */
+const MIN_FACE_SPAN_SHARE = 0.03;
+
+/** Never crop so tight that filling PORTRAIT_SIZE would blur the result. */
+const MAX_UPSCALE = 1.7;
+
+/**
+ * Size of the head, inferred from the detected skin region.
+ *
+ * The region routinely runs from the forehead down through the neck into an
+ * open collar, so its *height* overstates the head badly — measured on real
+ * portraits it came out at 1.5 to 2 times the face. Its narrow side tracks
+ * cheek-to-cheek width, which is what actually scales with the head.
+ */
+function faceSpan(faceBox: FaceBox): number {
+  return Math.min(faceBox.width, faceBox.height);
+}
+
+export type CropStrategy = "face" | "attention";
+
+export interface CroppedPortrait {
+  buffer: Buffer;
+  /** Dimensions of the source image after EXIF auto-orientation. */
+  source: { width: number; height: number };
+  /** The square that was extracted, in source coordinates. */
+  region: { left: number; top: number; size: number };
+  /** How the square was chosen. */
+  strategy: CropStrategy;
+  /** The face box the framing was built from, when one was found. */
+  faceBox: FaceBox | null;
+}
+
+/**
+ * Crop an image to a square portrait framed on the subject's face.
+ *
+ * Two strategies, in order of preference.
+ *
+ * `face`: a skin-region scan gives a face box, so the crop can be sized
+ * relative to the head — `BUST_FACTOR` face heights, with the face placed
+ * slightly above centre. This is what satisfies both ends of the brief: the
+ * whole face plus margin at minimum, the bust at maximum, whatever the framing
+ * of the source. It is the only strategy that can zoom, which matters for the
+ * distant square shots where a plain cover crop changes nothing.
+ *
+ * `attention`: no convincing face box (greyscale archive photos, odd lighting).
+ * Falls back to the largest square sharp's attention strategy will place. That
+ * cannot zoom past head-and-shoulders, so it is safe but sometimes loose.
+ *
+ * `rotate()` runs first, with no argument, so EXIF orientation is applied before
+ * any geometry is computed. Skipping it crops sideways images wrongly.
+ */
+export async function cropToPortrait(input: Buffer): Promise<CroppedPortrait> {
+  const { width, height } = await readDimensions(input);
+  if (!width || !height) {
+    throw new Error("cropToPortrait: source image has no readable dimensions");
+  }
+  const source = { width, height };
+
+  const attention = await findAttentionPoint(input, source);
+  const faceBox = await detectFaceBox(input, source, attention);
+  const region = chooseRegion(source, faceBox, attention);
+
+  const buffer = await sharp(input)
+    .rotate()
+    .extract({
+      left: region.left,
+      top: region.top,
+      width: region.size,
+      height: region.size,
+    })
+    .resize({ width: PORTRAIT_SIZE, height: PORTRAIT_SIZE, fit: "cover" })
+    .jpeg({ quality: PORTRAIT_QUALITY, mozjpeg: true })
+    .toBuffer();
+
+  return {
+    buffer,
+    source,
+    region,
+    strategy: usesFaceBox(source, faceBox) ? "face" : "attention",
+    faceBox,
+  };
+}
+
+/** True when the detected box is solid enough to size the crop from. */
+function usesFaceBox(
+  source: { width: number; height: number },
+  faceBox: FaceBox | null
+): faceBox is FaceBox {
+  if (!faceBox) return false;
+  const span = faceSpan(faceBox);
+  if (span < Math.min(source.width, source.height) * MIN_FACE_SPAN_SHARE) return false;
+  // A crop that has to be blown up too far would look worse than a loose one.
+  return span * BUST_FACTOR >= PORTRAIT_SIZE / MAX_UPSCALE;
+}
+
+/**
+ * Square to extract, in source coordinates.
+ *
+ * Both branches clamp into the image, so the returned square is always a valid
+ * `extract()` region.
+ */
+function chooseRegion(
+  source: { width: number; height: number },
+  faceBox: FaceBox | null,
+  attention: { x: number; y: number } | null
+): { left: number; top: number; size: number } {
+  const maxSize = Math.min(source.width, source.height);
+
+  if (usesFaceBox(source, faceBox)) {
+    const span = faceSpan(faceBox);
+    const size = Math.min(maxSize, Math.round(span * BUST_FACTOR));
+    // The region's top edge is the top of the forehead, so the head's centre is
+    // half a span below it — not the centre of the box, which sits in the neck.
+    const headCentreX = faceBox.x + faceBox.width / 2;
+    const headCentreY = faceBox.y + span / 2;
+    return {
+      left: clamp(Math.round(headCentreX - size / 2), 0, source.width - size),
+      top: clamp(Math.round(headCentreY - size * FACE_VERTICAL_POSITION), 0, source.height - size),
+      size,
+    };
+  }
+
+  // Largest square, centred on the attention point when we have one.
+  const centreX = attention?.x ?? source.width / 2;
+  const centreY = attention?.y ?? source.height / 2;
+  return {
+    left: clamp(Math.round(centreX - maxSize / 2), 0, source.width - maxSize),
+    top: clamp(Math.round(centreY - maxSize / 2), 0, source.height - maxSize),
+    size: maxSize,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * sharp's attention point, converted to source coordinates.
+ *
+ * `attentionX` / `attentionY` are reported in the space of the image *after* the
+ * cover rescale, so dividing by that scale factor brings them back.
+ */
+async function findAttentionPoint(
+  input: Buffer,
+  source: { width: number; height: number }
+): Promise<{ x: number; y: number } | null> {
+  try {
+    const { info } = await sharp(input)
+      .rotate()
+      .resize({
+        width: PORTRAIT_SIZE,
+        height: PORTRAIT_SIZE,
+        fit: "cover",
+        position: sharp.strategy.attention,
+      })
+      .toBuffer({ resolveWithObject: true });
+
+    if (info.attentionX === undefined || info.attentionY === undefined) return null;
+
+    const scale = PORTRAIT_SIZE / Math.min(source.width, source.height);
+    return { x: info.attentionX / scale, y: info.attentionY / scale };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read an image's displayed dimensions without decoding it fully, so the
+ * portrait guard can screen geometry before we spend time cropping.
+ *
+ * `metadata()` reports the dimensions as *stored*, and `rotate()` does not
+ * change that — it only affects the pipeline output. EXIF orientations 5 to 8
+ * involve a quarter turn, so the axes have to be swapped by hand. Without this,
+ * a sideways-stored portrait reads as landscape and the guard rejects it as
+ * "too wide".
+ */
+export async function readDimensions(
+  input: Buffer
+): Promise<{ width: number | undefined; height: number | undefined }> {
+  const { width, height, orientation } = await sharp(input).metadata();
+  const quarterTurned = orientation !== undefined && orientation >= 5 && orientation <= 8;
+  return quarterTurned ? { width: height, height: width } : { width, height };
+}

--- a/src/lib/photos/crop.ts
+++ b/src/lib/photos/crop.ts
@@ -25,6 +25,18 @@ const FACE_VERTICAL_POSITION = 0.38;
 /** A face span under this share of the frame's short side is treated as noise. */
 const MIN_FACE_SPAN_SHARE = 0.03;
 
+/**
+ * Lowest the centre of a detected region may sit and still be a head.
+ *
+ * In a portrait the head is in the upper part of the frame. A skin region found
+ * below this line is something else: measured on François Alfonsi's file, a
+ * beige wall pushed the detector onto his gesturing hand at 66% of the height,
+ * and sharp's attention point landed low too, so neither signal could be
+ * trusted. Falling back keeps the uncropped source rather than publishing a
+ * portrait of a hand.
+ */
+const MAX_HEAD_CENTRE_SHARE = 0.55;
+
 /** Never crop so tight that filling PORTRAIT_SIZE would blur the result. */
 const MAX_UPSCALE = 1.7;
 
@@ -113,6 +125,11 @@ function usesFaceBox(
   if (!faceBox) return false;
   const span = faceSpan(faceBox);
   if (span < Math.min(source.width, source.height) * MIN_FACE_SPAN_SHARE) return false;
+
+  // Too low in the frame to be a head.
+  const centreShare = (faceBox.y + span / 2) / source.height;
+  if (centreShare > MAX_HEAD_CENTRE_SHARE) return false;
+
   // A crop that has to be blown up too far would look worse than a loose one.
   return span * BUST_FACTOR >= PORTRAIT_SIZE / MAX_UPSCALE;
 }

--- a/src/lib/photos/face-box.ts
+++ b/src/lib/photos/face-box.ts
@@ -1,0 +1,213 @@
+import sharp from "sharp";
+
+/**
+ * Locate the subject's face well enough to frame a portrait around it.
+ *
+ * This is deliberately not a machine-learning face detector. Adding one would
+ * mean native TensorFlow bindings or a WASM runtime in a project that deploys to
+ * Vercel, for a job that runs offline on a few hundred images. What we need is
+ * narrower than recognition: a plausible face *box*, so the crop can be sized
+ * relative to the head instead of to the image.
+ *
+ * The method is the classic pre-ML one: threshold for skin chromaticity, find
+ * connected regions, and pick the region that best matches a face — roughly as
+ * tall as it is wide, high in the frame, near sharp's attention point. When
+ * nothing matches (greyscale archive photos, unusual lighting), the caller falls
+ * back to a crop that cannot over-zoom.
+ */
+
+/** Width the image is reduced to before scanning. Keeps the scan trivial. */
+const SCAN_WIDTH = 160;
+
+export interface FaceBox {
+  /** Source-image coordinates. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Skin chromaticity test, after Kovac et al. Two rules: one for ordinary
+ * lighting, one for flash-washed highlights, which portraits of politicians at
+ * podiums are full of.
+ */
+function isSkin(r: number, g: number, b: number): boolean {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+
+  const daylight =
+    r > 95 && g > 40 && b > 20 && max - min > 15 && Math.abs(r - g) > 15 && r > g && r > b;
+
+  const flash = r > 220 && g > 210 && b > 170 && Math.abs(r - g) <= 15 && b < r && b < g;
+
+  return daylight || flash;
+}
+
+interface Region {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  area: number;
+}
+
+/** Label connected skin regions with an iterative flood fill (4-connected). */
+function findRegions(mask: Uint8Array, width: number, height: number): Region[] {
+  const seen = new Uint8Array(mask.length);
+  const regions: Region[] = [];
+  const stack: number[] = [];
+
+  for (let start = 0; start < mask.length; start++) {
+    if (!mask[start] || seen[start]) continue;
+
+    let minX = width;
+    let maxX = 0;
+    let minY = height;
+    let maxY = 0;
+    let area = 0;
+
+    stack.push(start);
+    seen[start] = 1;
+
+    while (stack.length > 0) {
+      const index = stack.pop()!;
+      const x = index % width;
+      const y = (index - x) / width;
+
+      area++;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+
+      const neighbours = [
+        x > 0 ? index - 1 : -1,
+        x < width - 1 ? index + 1 : -1,
+        y > 0 ? index - width : -1,
+        y < height - 1 ? index + width : -1,
+      ];
+      for (const next of neighbours) {
+        if (next >= 0 && mask[next] && !seen[next]) {
+          seen[next] = 1;
+          stack.push(next);
+        }
+      }
+    }
+
+    regions.push({ minX, maxX, minY, maxY, area });
+  }
+
+  return regions;
+}
+
+/** Smallest share of the frame a region must cover to be a face rather than noise. */
+const MIN_AREA_SHARE = 0.004;
+
+/** A face is roughly as tall as it is wide; anything flatter or thinner is not one. */
+const MIN_ASPECT = 0.55;
+const MAX_ASPECT = 1.9;
+
+/**
+ * Score a candidate region. Higher is more face-like.
+ *
+ * Three terms, all in 0..1: how much of the frame it covers (bigger regions are
+ * more likely to be the subject than a bystander), how high it sits (faces are
+ * above the middle in portraits), and how close it is to sharp's attention
+ * point, which is independently drawn to the subject.
+ */
+function scoreRegion(
+  region: Region,
+  width: number,
+  height: number,
+  attention: { x: number; y: number } | null
+): number {
+  const boxWidth = region.maxX - region.minX + 1;
+  const boxHeight = region.maxY - region.minY + 1;
+  const centreX = region.minX + boxWidth / 2;
+  const centreY = region.minY + boxHeight / 2;
+
+  const coverage = Math.min(1, region.area / (width * height) / 0.08);
+  const heightBonus = 1 - centreY / height;
+
+  let proximity = 0.5;
+  if (attention) {
+    const dx = (centreX - attention.x) / width;
+    const dy = (centreY - attention.y) / height;
+    proximity = 1 - Math.min(1, Math.hypot(dx, dy));
+  }
+
+  // Regions that fill their bounding box are more likely a face than a
+  // scattered set of skin-coloured background pixels.
+  const density = region.area / (boxWidth * boxHeight);
+
+  return coverage * 1.0 + heightBonus * 0.8 + proximity * 1.2 + density * 0.6;
+}
+
+/**
+ * Find the subject's face box, in source-image coordinates, or null when no
+ * region is convincing enough.
+ *
+ * `attention` is sharp's attention point in source coordinates; passing it
+ * sharpens the choice when several people are in frame, but the function works
+ * without it.
+ */
+export async function detectFaceBox(
+  input: Buffer,
+  source: { width: number; height: number },
+  attention: { x: number; y: number } | null = null
+): Promise<FaceBox | null> {
+  const { data, info } = await sharp(input)
+    .rotate()
+    .resize({ width: SCAN_WIDTH, fit: "inside" })
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const { width, height, channels } = info;
+  if (!width || !height || channels < 3) return null;
+
+  const mask = new Uint8Array(width * height);
+  for (let pixel = 0; pixel < width * height; pixel++) {
+    const offset = pixel * channels;
+    const r = data[offset] ?? 0;
+    const g = data[offset + 1] ?? 0;
+    const b = data[offset + 2] ?? 0;
+    if (isSkin(r, g, b)) mask[pixel] = 1;
+  }
+
+  // Attention point expressed in scan coordinates.
+  const scanAttention = attention
+    ? {
+        x: (attention.x / source.width) * width,
+        y: (attention.y / source.height) * height,
+      }
+    : null;
+
+  const candidates = findRegions(mask, width, height).filter((region) => {
+    const boxWidth = region.maxX - region.minX + 1;
+    const boxHeight = region.maxY - region.minY + 1;
+    const aspect = boxWidth / boxHeight;
+    return (
+      region.area / (width * height) >= MIN_AREA_SHARE &&
+      aspect >= MIN_ASPECT &&
+      aspect <= MAX_ASPECT
+    );
+  });
+
+  if (candidates.length === 0) return null;
+
+  const best = candidates.reduce((a, b) =>
+    scoreRegion(b, width, height, scanAttention) > scoreRegion(a, width, height, scanAttention)
+      ? b
+      : a
+  );
+
+  const scale = source.width / width;
+  return {
+    x: Math.round(best.minX * scale),
+    y: Math.round(best.minY * scale),
+    width: Math.round((best.maxX - best.minX + 1) * scale),
+    height: Math.round((best.maxY - best.minY + 1) * scale),
+  };
+}

--- a/src/lib/photos/portrait-guard.ts
+++ b/src/lib/photos/portrait-guard.ts
@@ -10,7 +10,16 @@
 
 export type PortraitRejectionReason =
   | "non-portrait-subject"
+  /** Another person is named in the frame, joined by "et", "avec", "&". */
   | "multiple-subjects"
+  /**
+   * Words in the filename we cannot account for. Measured over 554 real files,
+   * these are mostly places and event descriptions ("Roeulx", "Toulouse",
+   * "quatre jours de Dunkerque") rather than second people, so calling them
+   * `multiple-subjects` would state something false in the report. Either way
+   * the framing cannot be trusted, so the crop is refused.
+   */
+  | "unexplained-words"
   | "too-wide"
   | "too-small";
 
@@ -199,6 +208,14 @@ const HUMAN_CROPPED_MARKERS = [/\(\s*cropped\s*\)/i, /\(\s*recadr\w*\s*\)/i, /_c
  */
 const CREDIT_MARKER = /[_\s-](par|by|photo de|foto)[_\s]/i;
 
+/**
+ * Joins two people in a filename: "Fernand et Carl", "Ségolène Royal & Guillaume
+ * Coutey". This is the only positive evidence of a second subject we can read
+ * from a filename, so it is what separates `multiple-subjects` from words we
+ * merely fail to recognise.
+ */
+const COMPANION_CONJUNCTION = /[_\s](et|avec|and|with)[_\s]|&/i;
+
 function stripAccents(value: string): string {
   return value.normalize("NFD").replace(/[̀-ͯ]/g, "");
 }
@@ -296,11 +313,15 @@ export function screenFilename(filename: string, politicianName: string): Portra
       !isGluedOwnName(token, nameTokens)
   );
 
-  if (leftovers.length > 0) {
-    return reject("multiple-subjects", `unexplained name(s) in filename: ${leftovers.join(", ")}`);
+  if (leftovers.length === 0) return PASS;
+
+  // A conjunction is the one signal that positively means "and this other
+  // person", as opposed to a word we simply do not recognise.
+  if (COMPANION_CONJUNCTION.test(credited)) {
+    return reject("multiple-subjects", `another person named alongside: ${leftovers.join(", ")}`);
   }
 
-  return PASS;
+  return reject("unexplained-words", `cannot account for: ${leftovers.join(", ")}`);
 }
 
 /** Widest aspect ratio we still treat as a portrait rather than a scene. */

--- a/src/lib/photos/portrait-guard.ts
+++ b/src/lib/photos/portrait-guard.ts
@@ -1,0 +1,341 @@
+/**
+ * Quality gate deciding whether a Commons image may be auto-cropped to a
+ * portrait, and whether a newly discovered image may be attached at all.
+ *
+ * The asymmetry that shapes every rule here: showing the wrong person's face on
+ * a politician's page is a serious data error, while not cropping is merely a
+ * cosmetic one. So the gate errs towards refusing, and a refusal never removes
+ * an existing photo — it only means "leave this one alone".
+ */
+
+export type PortraitRejectionReason =
+  | "non-portrait-subject"
+  | "multiple-subjects"
+  | "too-wide"
+  | "too-small";
+
+export type PortraitVerdict =
+  | { ok: true }
+  | { ok: false; reason: PortraitRejectionReason; detail: string };
+
+const PASS: PortraitVerdict = { ok: true };
+
+function reject(reason: PortraitRejectionReason, detail: string): PortraitVerdict {
+  return { ok: false, reason, detail };
+}
+
+/**
+ * Tokens that mean the image is of something other than the person: a grave, a
+ * statue, a coat of arms, a signature. Matched on whole tokens, so "cim" cannot
+ * fire inside an unrelated word.
+ */
+const NON_PORTRAIT_TOKENS = new Set([
+  "tombe",
+  "tombeau",
+  "sepulture",
+  "grave",
+  "cimetiere",
+  "cim",
+  "funerailles",
+  "obseques",
+  "monument",
+  "memorial",
+  "plaque",
+  "commemorative",
+  "statue",
+  "buste",
+  "bust",
+  "blason",
+  "armoiries",
+  "logo",
+  "signature",
+  "caricature",
+  "timbre",
+  "affiche",
+  "banderole",
+  "manifestation",
+  "meeting",
+]);
+
+/**
+ * Words that routinely appear in Commons filenames without naming a person.
+ * Anything left over after this list is treated as a possible second subject.
+ */
+const NON_PERSON_TOKENS = new Set([
+  // provenance and framing
+  "file",
+  "image",
+  "fichier",
+  "wikipedia",
+  "wikimedia",
+  "commons",
+  "cropped",
+  "crop",
+  "recadre",
+  "portrait",
+  "photo",
+  "picture",
+  "img",
+  "dsc",
+  "scan",
+  "detail",
+  "version",
+  "copie",
+  "copy",
+  // roles and institutions
+  "monsieur",
+  "madame",
+  "mme",
+  "president",
+  "presidente",
+  "ministre",
+  "secretaire",
+  "depute",
+  "deputee",
+  "senateur",
+  "senatrice",
+  "maire",
+  "conseiller",
+  "candidat",
+  "candidate",
+  "official",
+  "officiel",
+  "officielle",
+  "assemblee",
+  "nationale",
+  "senat",
+  "gouvernement",
+  "government",
+  "parlement",
+  "parliament",
+  "european",
+  "europeen",
+  "commission",
+  "commissioner",
+  "minister",
+  "ministry",
+  "sncf",
+  "edf",
+  "ratp",
+  "onu",
+  "unesco",
+  // dates
+  "janvier",
+  "fevrier",
+  "mars",
+  "avril",
+  "mai",
+  "juin",
+  "juillet",
+  "aout",
+  "septembre",
+  "octobre",
+  "novembre",
+  "decembre",
+  "january",
+  "february",
+  "march",
+  "april",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+  // scene words
+  "lors",
+  "des",
+  "voeux",
+  "extract",
+  "extrait",
+  "mini",
+  "session",
+  "plenary",
+  "pleniere",
+  "conference",
+  "presse",
+  "press",
+  "interview",
+  "discours",
+  "speech",
+  "visite",
+  "visit",
+  "courtesy",
+  "call",
+  "reunion",
+  "sommet",
+  "summit",
+  "campagne",
+  "campaign",
+  "congres",
+  "congress",
+  "debat",
+  "debate",
+  "ceremonie",
+  "ceremony",
+  "salon",
+  "forum",
+  "culture",
+  "cultural",
+  "affairs",
+  "french",
+  "france",
+  "paris",
+  "bruxelles",
+  "brussels",
+  "strasbourg",
+]);
+
+/** Marks left by a contributor who already framed the image on one person. */
+const HUMAN_CROPPED_MARKERS = [/\(\s*cropped\s*\)/i, /\(\s*recadr\w*\s*\)/i, /_cropped/i];
+
+/**
+ * Photographer attribution, which on Commons follows the subject's name:
+ * "Jean-Marie Bockel par Claude Truong-Ngoc juin 2014.jpg". Everything from the
+ * marker on names the photographer, not another person in the frame, so it is
+ * cut before the filename is read. The subject always precedes it, so a second
+ * subject written before the credit is still caught.
+ */
+const CREDIT_MARKER = /[_\s-](par|by|photo de|foto)[_\s]/i;
+
+function stripAccents(value: string): string {
+  return value.normalize("NFD").replace(/[̀-ͯ]/g, "");
+}
+
+/** Drop the file extension so it is not mistaken for a name token. */
+function dropExtension(filename: string): string {
+  return filename.replace(/\.(jpe?g|png|gif|tiff?|webp|svg)$/i, "");
+}
+
+/** Lowercase, accent-free alphabetic tokens. Digits and punctuation split. */
+function tokenize(value: string): string[] {
+  return stripAccents(value)
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter(Boolean);
+}
+
+/** Levenshtein distance, capped early since we only care about <= 1. */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (Math.abs(a.length - b.length) > 1) return false;
+
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  let i = 0;
+  let j = 0;
+  let edits = 0;
+  while (i < shorter.length && j < longer.length) {
+    if (shorter[i] === longer[j]) {
+      i++;
+      j++;
+      continue;
+    }
+    if (++edits > 1) return false;
+    if (shorter.length === longer.length) i++;
+    j++;
+  }
+  return edits + (longer.length - j) + (shorter.length - i) <= 1;
+}
+
+/**
+ * True when `token` plausibly belongs to the politician's own name. Short
+ * tokens must match exactly; longer ones tolerate a single typo, because
+ * Commons filenames misspell surnames often enough to matter (our record says
+ * "Quilliot", the file says "Quillot").
+ */
+function matchesOwnName(token: string, nameTokens: string[]): boolean {
+  return nameTokens.some((part) =>
+    token.length >= 5 && part.length >= 5 ? withinOneEdit(token, part) : token === part
+  );
+}
+
+/**
+ * True when a token is just the politician's name written without separators —
+ * `Hervemorin2008`, `LaurentHénart`, `AlfonsiFrancois`. Tokenising on
+ * non-letters leaves these as one long token that matches neither name part, so
+ * they used to read as a stranger.
+ *
+ * The name parts are consumed as substrings in either order; a token that
+ * disappears was the politician's own name. `SegoleneRoyal` on Guillaume
+ * Coutey's file leaves `segoleneroyal` behind and is still refused.
+ */
+function isGluedOwnName(token: string, nameTokens: string[]): boolean {
+  let remaining = token;
+  for (const part of nameTokens) {
+    if (part.length < 3) continue;
+    remaining = remaining.replace(part, "");
+  }
+  return remaining.length < 3;
+}
+
+/**
+ * Screen a Commons filename for subjects that are not a lone portrait of the
+ * politician.
+ */
+export function screenFilename(filename: string, politicianName: string): PortraitVerdict {
+  const stem = dropExtension(filename);
+  const tokens = tokenize(stem);
+
+  const subjectHit = tokens.find((token) => NON_PORTRAIT_TOKENS.has(token));
+  if (subjectHit) {
+    return reject("non-portrait-subject", `filename mentions "${subjectHit}"`);
+  }
+
+  // A contributor-cropped file is framed on one person by construction; the
+  // other names in its filename describe the original scene.
+  if (HUMAN_CROPPED_MARKERS.some((marker) => marker.test(filename))) return PASS;
+
+  const credited = stem.split(CREDIT_MARKER)[0] ?? stem;
+  const nameTokens = tokenize(politicianName);
+  const leftovers = tokenize(credited).filter(
+    (token) =>
+      token.length >= 3 &&
+      !NON_PERSON_TOKENS.has(token) &&
+      !matchesOwnName(token, nameTokens) &&
+      !isGluedOwnName(token, nameTokens)
+  );
+
+  if (leftovers.length > 0) {
+    return reject("multiple-subjects", `unexplained name(s) in filename: ${leftovers.join(", ")}`);
+  }
+
+  return PASS;
+}
+
+/** Widest aspect ratio we still treat as a portrait rather than a scene. */
+const MAX_ASPECT_RATIO = 1.4;
+
+/** Below this, cropping would visibly degrade the image. */
+const MIN_SIDE_PX = 200;
+
+export function screenGeometry(dimensions: {
+  width?: number | null;
+  height?: number | null;
+}): PortraitVerdict {
+  const { width, height } = dimensions;
+  if (!width || !height) {
+    return reject("too-small", "image dimensions unavailable");
+  }
+  if (width < MIN_SIDE_PX || height < MIN_SIDE_PX) {
+    return reject("too-small", `${width}x${height} is under ${MIN_SIDE_PX}px`);
+  }
+  if (width / height > MAX_ASPECT_RATIO) {
+    return reject(
+      "too-wide",
+      `aspect ratio ${(width / height).toFixed(2)} exceeds ${MAX_ASPECT_RATIO}`
+    );
+  }
+  return PASS;
+}
+
+export function screenPortrait(input: {
+  filename: string;
+  politicianName: string;
+  width?: number | null;
+  height?: number | null;
+}): PortraitVerdict {
+  const byFilename = screenFilename(input.filename, input.politicianName);
+  if (!byFilename.ok) return byFilename;
+  return screenGeometry({ width: input.width, height: input.height });
+}

--- a/src/lib/photos/wikidata-image.ts
+++ b/src/lib/photos/wikidata-image.ts
@@ -1,0 +1,79 @@
+import { HTTPClient } from "@/lib/api/http-client";
+import { WIKIDATA_RATE_LIMIT_MS } from "@/config/rate-limits";
+
+/**
+ * Read Wikidata's "image" claim (P18) for many entities at once.
+ *
+ * P18 is authoritative for our purpose: the claim hangs off the item that *is*
+ * the person, so there is no name matching involved and therefore no risk of
+ * attaching a stranger's face. Searching Commons by name would have that risk,
+ * which is why it is not offered here.
+ */
+
+/** wbgetentities accepts at most 50 ids per request. */
+const BATCH_SIZE = 50;
+
+const client = new HTTPClient({ rateLimitMs: WIKIDATA_RATE_LIMIT_MS });
+
+interface WbEntitiesResponse {
+  entities?: Record<
+    string,
+    {
+      claims?: {
+        P18?: Array<{ mainsnak?: { datavalue?: { value?: string } }; rank?: string }>;
+      };
+    }
+  >;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Map of Q-id to Commons filename, holding only entities that carry a P18.
+ *
+ * A deprecated claim is skipped: editors use that rank to mark an image as the
+ * wrong person or otherwise unsuitable, which is exactly what we must not
+ * publish.
+ */
+export async function fetchP18Filenames(qids: string[]): Promise<Map<string, string>> {
+  const found = new Map<string, string>();
+  const unique = [...new Set(qids.filter(Boolean))];
+
+  for (const batch of chunk(unique, BATCH_SIZE)) {
+    const url =
+      `https://www.wikidata.org/w/api.php?action=wbgetentities` +
+      `&ids=${batch.join("|")}&props=claims&format=json&origin=*`;
+
+    const { data } = await client.get<WbEntitiesResponse>(url);
+
+    for (const [qid, entity] of Object.entries(data.entities ?? {})) {
+      const claim = entity.claims?.P18?.find((c) => c.rank !== "deprecated");
+      const filename = claim?.mainsnak?.datavalue?.value;
+      if (filename) found.set(qid, filename);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Recover the Commons filename from a thumbnail URL we stored earlier.
+ *
+ * The filename sits in the second-to-last path segment, percent-encoded. This
+ * lets the repair and crop passes work without going back to Wikidata.
+ */
+export function filenameFromThumbnailUrl(url: string): string | null {
+  const segments = url.split("/");
+  if (segments.length < 2) return null;
+  const candidate = segments[segments.length - 2];
+  if (!candidate) return null;
+  try {
+    return decodeURIComponent(candidate);
+  } catch {
+    return null;
+  }
+}

--- a/src/services/sync/photos.ts
+++ b/src/services/sync/photos.ts
@@ -1,9 +1,9 @@
-import { createHash } from "crypto";
 import { db } from "@/lib/db";
 import { DataSource, MandateType } from "@/generated/prisma";
 import { HTTPClient } from "@/lib/api/http-client";
 import { WIKIDATA_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { PHOTO_SOURCE_PRIORITY, shouldUpdatePhoto } from "@/config/photos";
+import { COMMONS_STORED_WIDTH, commonsThumbnailUrl } from "@/lib/photos/commons";
 
 const wikidataClient = new HTTPClient({ rateLimitMs: WIKIDATA_RATE_LIMIT_MS });
 
@@ -29,23 +29,12 @@ async function isPhotoUrlValid(url: string): Promise<boolean> {
 }
 
 /**
- * Build a Wikimedia Commons thumbnail URL from a filename.
- *
- * Wikimedia Commons uses MD5-based directory hashing:
- *   /wikipedia/commons/thumb/{hash[0]}/{hash[0:2]}/{filename}/{width}px-{filename}
- */
-function buildCommonsThumbnailUrl(filename: string, width = 400): string {
-  const normalized = filename.replace(/ /g, "_");
-  const hash = createHash("md5").update(normalized).digest("hex");
-  const encoded = encodeURIComponent(normalized);
-  return `https://upload.wikimedia.org/wikipedia/commons/thumb/${hash[0]}/${hash.slice(0, 2)}/${encoded}/${width}px-${encoded}`;
-}
-
-/**
  * Get photo URL from Wikidata P18 via REST API + Wikimedia Commons thumbnail.
  *
- * Uses the Wikidata REST API (not SPARQL) for speed and reliability,
- * then constructs a direct thumbnail URL via MD5 hash convention.
+ * Uses the Wikidata REST API (not SPARQL) for speed and reliability, then
+ * constructs a direct thumbnail URL. The width must come from the official
+ * allowed list, otherwise upload.wikimedia.org rejects the hotlink — see
+ * `@/lib/photos/commons`.
  */
 async function getWikidataPhoto(wikidataId: string): Promise<string | null> {
   try {
@@ -58,7 +47,7 @@ async function getWikidataPhoto(wikidataId: string): Promise<string | null> {
     const filename = data.claims?.P18?.[0]?.mainsnak?.datavalue?.value;
     if (!filename) return null;
 
-    return buildCommonsThumbnailUrl(filename);
+    return commonsThumbnailUrl(filename, COMMONS_STORED_WIDTH);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Le problème

Wikimedia a restreint les largeurs de vignettes que sert `upload.wikimedia.org` à
une liste fixe (`20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840`, cf.
[Common thumbnail sizes](https://www.mediawiki.org/wiki/Common_thumbnail_sizes)).
Toute autre largeur reçoit un `HTTP 400`.

`src/services/sync/photos.ts` construisait ses URLs avec `400px` codé en dur.
Deux conséquences, vérifiées en production :

- **551 fiches** avaient un `photoUrl` désormais rejeté et affichaient les
  initiales au lieu du visage. Entre autres : Édouard Philippe, Christine
  Lagarde, Fabien Roussel, Marine Tondelier, Jean-Louis Borloo, David Amiel.
  `poligraph.fr/_next/image` renvoyait 400 sur l'URL stockée et 200 sur la
  variante `500px`.
- La branche Wikidata du sync ne trouvait plus rien pour personne, ce qui
  explique les fiches marquées `photoCheckedAt` récent et toujours sans photo.

Troisième constat au passage : les pages passaient `photoUrl` directement à
`next/image`, donc le cache Vercel Blob alimenté par `/api/images/[id]` n'était
jamais lu côté public. Rien n'amortissait la source externe.

## Ce que fait cette PR

`src/lib/photos/` regroupe la connaissance du contrat Wikimedia et le cadrage :

- `commons.ts` : liste officielle des largeurs, arrondi à la valeur autorisée,
  construction et réécriture d'URL. Il devient impossible de fabriquer une
  largeur invalide par API.
- `face-box.ts` : localisation du visage par seuillage des teintes de peau et
  régions connexes. Pas de dépendance nouvelle, donc pas de binaire natif
  TensorFlow ni de runtime WASM dans un projet déployé sur Vercel.
- `crop.ts` : recadrage carré 512 px. Le côté vaut 3,4 fois l'empan du visage,
  ce qui donne le buste au maximum et le visage entier avec marge au minimum.
  Repli sur la stratégie `attention` de sharp quand aucun visage n'est détecté.
- `portrait-guard.ts` : refuse tombes, statues, blasons, signatures, photos de
  groupe, images trop larges ou trop petites.

`scripts/repair-portraits.ts` orchestre trois phases indépendantes (`--repair`,
`--discover`, `--crop`), en dry-run tant que `--apply` n'est pas passé.

Un check CI interdit désormais de construire une URL `commons/thumb` ailleurs que
dans `commons.ts`.

## Règle de décision

Le garde décide si on a le droit de **recadrer**, pas si la photo peut exister :

- réparer une URL cassée ne passe pas par le garde (sinon on retirerait des
  photos qui s'affichaient hier) ;
- un refus au recadrage laisse la photo telle quelle, jamais de régression ;
- attacher une **nouvelle** photo exige en plus une détection de visage
  positive, sinon la fiche part en `needs-review`. Sans cette règle, un plan
  large en noir et blanc passe tous les filtres et publie un visage de quelques
  pixels (cas réel rencontré sur le fichier de Roger Quilliot).

## Déjà appliqué en base

- 551 URLs réparées, vérifiées par comptage avant/après (551 → 0 largeur morte)
  et par sondage HTTP sur 30 lignes réparties dans la liste.
- 5 portraits attachés sur la cible « avec bio », après relecture visuelle de
  chaque recadrage. 3 partis en `needs-review`, 4 refusés (photos de groupe).
- 340 portraits Commons recadrés et mis en cache sur Blob (252 par détection de
  visage, 88 par repli), 212 refusés par le garde, 2 injoignables.

Rapports de rollback (paires `from`/`to`) conservés hors dépôt dans
`~/Documents/poligraph-portraits/`.

## Précision du recadrage, mesurée

Relecture visuelle de 48 portraits recadrés relus depuis Blob : **1 échec net**
(Alain Cremont, où la pierre calcaire ensoleillée d'une arche déclenche le seuil
de peau et la boîte se pose sur le mur), 3 cadrages lâches, le reste correct.
Soit environ **2 % d'échec**.

J'ai cherché un second signal pour écarter ces cas et **mesuré qu'il n'existe
pas** dans ce cadre : la distance entre la boîte de peau et le point d'attention
de sharp ne sépare pas les bons des mauvais (bons jusqu'à 0,530 de diagonale,
mauvais entre 0,010 et 0,197). Le point d'attention est souvent loin du visage
même sur un bon portrait. Une règle de désaccord aurait rejeté de bons
recadrages en gardant les mauvais.

Un garde a en revanche été ajouté après mesure : une zone de peau dont le centre
descend sous 55 % de la hauteur n'est pas une tête. Il corrige le cas François
Alfonsi, où le portrait publié était sa main.

Aller sous les 2 % demande un vrai détecteur de visages, donc une dépendance
native ou WASM. C'est une décision à prendre séparément.

## Rien n'est encore visible

Le changement d'affichage (`PoliticianAvatar` préférant `blobPhotoUrl`) est dans
cette PR, **pas en production**. Les recadrages existent sur Blob mais rien ne
les rend tant que la PR n'est pas mergée et déployée. Les 551 URLs réparées, en
revanche, sont déjà en base et réapparaîtront au fil des revalidations ISR
(`cacheLife("synced")`, 24 h). Pas de revalidation en masse : le tag global
purgerait tout le cache.

## Vérification

- `npx vitest run` : 3230 tests, 0 échec. 71 tests sur `src/lib/photos/`.
- `npx tsc --noEmit` : propre. 8 checks CI verts.
- Le nouveau step CI a bien tourné (vérifié dans les logs du job Security).
- URL Blob sans extension acceptée par l'optimiseur de prod (200, `image/jpeg`).
- Tests du garde écrits sur les noms de fichiers réels rencontrés : noms
  concaténés (`Hervemorin2008`), crédits photo (`par Claude Truong-Ngoc`), mois
  français, photos de groupe.

## Suites

- `--discover` hors cible bio : environ 200 portraits récupérables sur les 26 929
  fiches sans photo portant un Q-ID (taux P18 mesuré à 0,8 %).
- La cible « bio sans photo » est épuisée : sur 270, seuls 12 avaient un P18, et
  3 des 4 rattrapables via frwiki étaient des photos de **tombes**. Vérifié
  aussi qu'aucun de ces anciens députés n'a d'identifiant AN, donc aucune photo
  institutionnelle à récupérer.
- `blobPhotoUrl` n'est câblé que dans la fiche et `PoliticianCard` ; les autres
  appelants servent encore `photoUrl` brut.
- Bally Bagayoko pointe sur un fichier Commons supprimé (404 réel, pas du
  throttling).
