### PR TITLE
Construire l'application en CI, sur une base vide et sans secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,73 @@ jobs:
 
       - name: Run tests
         run: npm run test:run
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    # An EMPTY PostgreSQL 17, and no .env: the point of this job is to prove the build
+    # holds without secrets and without production data. Every earlier build ran locally,
+    # where `next build` silently loads .env by itself, so "it builds here" never tested
+    # what this job tests.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: poligraph_test
+          POSTGRES_PASSWORD: poligraph_test
+          POSTGRES_DB: poligraph_test
+        ports:
+          - 5432:5432
+        # -h localhost forces TCP: the entrypoint runs a temporary server on the Unix
+        # socket while executing its init scripts, and a socket probe reports healthy
+        # against that one.
+        options: >-
+          --health-cmd "pg_isready -h localhost -U poligraph_test -d poligraph_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DIRECT_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DATABASE_SSL: "false"
+      NEXT_TELEMETRY_DISABLED: "1"
+      CHECKPOINT_DISABLE: "1"
+      BUILD_NET_LOG: ${{ github.workspace }}/build-network.log
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The same file the local harness feeds its container, so the two cannot drift:
+      # unaccent, which the search queries call, and the ten publicId sequences, which
+      # are not in the datamodel and which `db push` therefore cannot create.
+      - name: Create extensions and publicId sequences
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f docker/init-search.sql
+
+      # No --accept-data-loss: the database is empty, so there is nothing to lose, and
+      # a push that WOULD need the flag is a signal rather than something to force.
+      - name: Apply the schema
+        run: npx prisma db push
+
+      - name: Build
+        run: npm run build
+        env:
+          NODE_OPTIONS: --require ${{ github.workspace }}/scripts/build-net-probe.cjs
+
+      # Runs even when the build fails: a build that died halfway may still have reached
+      # somewhere new, and that is worth seeing.
+      - name: Check the hosts the build reached
+        if: always()
+        run: npm run build:net-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main, staging]
 
+# Cancel the superseded run when a new commit lands on the same pull request: the build
+# job makes an obsolete run expensive rather than merely noisy. Only for pull requests,
+# so every run on main and staging is kept: a cancelled run there would leave a commit
+# unverified.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: ESLint

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "setup": "bash scripts/setup.sh",
     "dev": "next dev",
     "build": "prisma generate && next build --webpack",
+    "build:net-check": "tsx scripts/check-build-network.mts",
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/scripts/build-net-probe.cjs
+++ b/scripts/build-net-probe.cjs
@@ -1,5 +1,9 @@
 /**
- * Records every outbound host a `next build` reaches, so CI can fail on an unknown one.
+ * Records the hosts a `next build` reaches over HTTP(S), so CI can fail on an unknown one.
+ *
+ * NOT a firewall, and the distinction matters: it observes requests going through
+ * `globalThis.fetch`, undici and `node:http`/`node:https`. A child binary with its own
+ * network client, or a raw socket, would not necessarily show up here.
  *
  * Loaded through NODE_OPTIONS=--require, which is what makes it land in the static
  * generation workers Next forks: a probe living only in the parent process would miss
@@ -19,19 +23,38 @@ if (!LOG) {
   throw new Error("build-net-probe: BUILD_NET_LOG is required, refusing to run blind");
 }
 
+/**
+ * Being unable to observe must fail the build.
+ *
+ * An earlier version swallowed write errors, "so a probe never breaks the build". That
+ * left a silent-success hole the probe-loaded proof does not close: the first write
+ * succeeds, the disk fills mid-build, later calls go unrecorded, and the checker finds
+ * its proof of loading and reports that all is well.
+ *
+ * Exiting rather than throwing, and this is not paranoia: this code runs INSIDE the
+ * fetch call it wraps, and application code that wraps its own fetch in a try/catch
+ * would swallow the throw. process.exit cannot be caught.
+ */
 function write(line) {
   try {
-    // O_APPEND keeps the 13 workers from interleaving inside a line.
+    // O_APPEND keeps the workers from interleaving inside a line.
     fs.appendFileSync(LOG, `${line}\n`);
-  } catch {
-    // A probe must never be the reason a build fails.
+  } catch (error) {
+    process.stderr.write(
+      `build-net-probe: cannot write ${LOG}, so outbound calls are no longer observed: ` +
+        `${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exit(1);
   }
 }
 
 /**
- * Host and path only. Query strings are dropped rather than trimmed: the earlier
- * throwaway version of this probe logged a Sentry envelope URL complete with its
- * `sentry_key`, and a CI log is a public artefact.
+ * Protocol and host, nothing else.
+ *
+ * The checker only ever compares hosts, so the path serves no assertion, and an
+ * identifier or a token can be embedded in a path the day the log is published for
+ * diagnosis. Query strings were already dropped: a throwaway version of this probe
+ * logged a Sentry envelope URL complete with its `sentry_key`.
  */
 function record(kind, rawUrl) {
   if (typeof rawUrl !== "string" || rawUrl === "") return;
@@ -39,7 +62,7 @@ function record(kind, rawUrl) {
   if (rawUrl.startsWith("data:") || rawUrl.startsWith("blob:")) return;
   try {
     const url = new URL(rawUrl);
-    write(`${kind} ${url.protocol}//${url.host}${url.pathname}`);
+    write(`${kind} ${url.protocol}//${url.host}`);
   } catch {
     write(`${kind} unparseable`);
   }

--- a/scripts/build-net-probe.cjs
+++ b/scripts/build-net-probe.cjs
@@ -1,0 +1,99 @@
+/**
+ * Records every outbound host a `next build` reaches, so CI can fail on an unknown one.
+ *
+ * Loaded through NODE_OPTIONS=--require, which is what makes it land in the static
+ * generation workers Next forks: a probe living only in the parent process would miss
+ * the calls made while collecting pages, which is where they nearly all happen.
+ *
+ * It records and never blocks. The build genuinely needs some of these hosts (Google
+ * Fonts through next/font, Twemoji through next/og), so blocking would just break the
+ * build; the point is that a NEW dependency cannot appear unnoticed.
+ *
+ * CommonJS on purpose: --require cannot load an ES module.
+ */
+const fs = require("node:fs");
+const diagnostics = require("node:diagnostics_channel");
+
+const LOG = process.env.BUILD_NET_LOG;
+if (!LOG) {
+  throw new Error("build-net-probe: BUILD_NET_LOG is required, refusing to run blind");
+}
+
+function write(line) {
+  try {
+    // O_APPEND keeps the 13 workers from interleaving inside a line.
+    fs.appendFileSync(LOG, `${line}\n`);
+  } catch {
+    // A probe must never be the reason a build fails.
+  }
+}
+
+/**
+ * Host and path only. Query strings are dropped rather than trimmed: the earlier
+ * throwaway version of this probe logged a Sentry envelope URL complete with its
+ * `sentry_key`, and a CI log is a public artefact.
+ */
+function record(kind, rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl === "") return;
+  // Not network, and they can be megabytes long.
+  if (rawUrl.startsWith("data:") || rawUrl.startsWith("blob:")) return;
+  try {
+    const url = new URL(rawUrl);
+    write(`${kind} ${url.protocol}//${url.host}${url.pathname}`);
+  } catch {
+    write(`${kind} unparseable`);
+  }
+}
+
+// --- undici: covers globalThis.fetch AND the requests it makes when following a
+// redirect, which never pass back through the fetch wrapper below.
+try {
+  diagnostics.subscribe("undici:request:create", (event) => {
+    const request = event && event.request;
+    if (!request) return;
+    const origin = request.origin || "";
+    const path = request.path || "";
+    record("undici", `${origin}${path}`);
+  });
+} catch {
+  write("note undici-channel-unavailable");
+}
+
+// --- fetch, kept even though undici publishes the channel above: a runtime that does
+// not publish it must not turn into silent success.
+const originalFetch = globalThis.fetch;
+if (typeof originalFetch === "function") {
+  globalThis.fetch = function patchedFetch(input, init) {
+    const url =
+      typeof input === "string"
+        ? input
+        : input && typeof input === "object" && "url" in input
+          ? String(input.url)
+          : String(input);
+    record("fetch", url);
+    return originalFetch.call(this, input, init);
+  };
+}
+
+// --- node:http / node:https, for anything still using the classic client.
+for (const moduleName of ["http", "https"]) {
+  const lib = require(`node:${moduleName}`);
+  for (const fnName of ["request", "get"]) {
+    const original = lib[fnName];
+    if (typeof original !== "function") continue;
+    lib[fnName] = function patched(...args) {
+      const first = args[0];
+      if (typeof first === "string") {
+        record(moduleName, first);
+      } else if (first && typeof first === "object") {
+        const host = first.hostname || first.host || "unknown";
+        record(moduleName, `${moduleName}://${host}${first.path || ""}`);
+      }
+      return original.apply(this, args);
+    };
+  }
+}
+
+// Proof of loading, and the reason the checker cannot mistake an unloaded probe for a
+// build that called nothing.
+write(`probe-loaded ${process.pid}`);

--- a/scripts/check-build-network.mts
+++ b/scripts/check-build-network.mts
@@ -1,0 +1,99 @@
+#!/usr/bin/env tsx
+/**
+ * Fails when `next build` reached a host that is not on the allow-list.
+ *
+ * Reads what scripts/build-net-probe.cjs recorded during the build. Deliberately does
+ * NOT assert a number of calls: font and emoji fetches vary with what the pages happen
+ * to render, and a frozen count would fail on unrelated content changes while proving
+ * nothing extra. What matters is the SET of hosts.
+ *
+ * Usage: BUILD_NET_LOG=path npm run build:net-check
+ */
+import { readFileSync } from "node:fs";
+
+/**
+ * Hosts the build cannot do without today, each with the reason it is there. Adding a
+ * line to this list is a deliberate act: it says the production build now depends on
+ * one more third party being up.
+ */
+const ALLOWED_HOSTS = new Map([
+  [
+    "fonts.googleapis.com",
+    "next/font/google, the stylesheets for Outfit and Atkinson Hyperlegible",
+  ],
+  ["fonts.gstatic.com", "next/font/google, the font files themselves"],
+  ["cdn.jsdelivr.net", "next/og, the Twemoji SVGs used by the opengraph-image routes"],
+]);
+
+const logPath = process.env.BUILD_NET_LOG;
+if (!logPath) {
+  console.error("check-build-network: BUILD_NET_LOG is not set");
+  process.exit(1);
+}
+
+let raw: string;
+try {
+  raw = readFileSync(logPath, "utf8");
+} catch {
+  console.error(`check-build-network: cannot read ${logPath}`);
+  console.error("The probe writes it at load time, so an unreadable file means it never ran.");
+  process.exit(1);
+}
+
+const lines = raw.split("\n").filter((line) => line.trim() !== "");
+
+// Silence is not success. Without this, a probe that failed to load produces an empty
+// log and the check would happily report "no unknown host".
+const loaded = lines.filter((line) => line.startsWith("probe-loaded ")).length;
+if (loaded === 0) {
+  console.error("check-build-network: the probe never loaded, so nothing was observed.");
+  console.error("Expected NODE_OPTIONS to contain --require ./scripts/build-net-probe.cjs");
+  process.exit(1);
+}
+
+const hosts = new Map<string, number>();
+for (const line of lines) {
+  if (line.startsWith("probe-loaded ") || line.startsWith("note ")) continue;
+  const url = line.slice(line.indexOf(" ") + 1);
+  let host: string;
+  try {
+    host = new URL(url).host;
+  } catch {
+    host = "unparseable";
+  }
+  hosts.set(host, (hosts.get(host) ?? 0) + 1);
+}
+
+console.log(`Sonde chargée dans ${loaded} processus, ${lines.length} lignes enregistrées.`);
+// Le canal undici et l'enveloppe de fetch observent le même appel, donc un appel unique
+// compte souvent double. Les nombres ci-dessous sont indicatifs, seul l'ensemble des
+// hôtes est vérifié.
+console.log("Hôtes atteints pendant le build (compteurs indicatifs, doublés par sonde) :");
+for (const [host, count] of [...hosts].sort((a, b) => b[1] - a[1])) {
+  const reason = ALLOWED_HOSTS.get(host);
+  console.log(`  ${reason ? "autorisé" : "INCONNU "}  ${host}  (${count} appels)`);
+}
+
+const unknown = [...hosts.keys()].filter((host) => !ALLOWED_HOSTS.has(host));
+if (unknown.length > 0) {
+  console.error("");
+  console.error("Le build a joint des hôtes qui ne sont pas sur la liste blanche :");
+  for (const host of unknown) console.error(`  ${host}`);
+  console.error("");
+  console.error("Soit une dépendance vient d'ajouter un appel réseau au build, soit du code");
+  console.error("applicatif en fait un pendant la collecte des pages. Dans les deux cas la");
+  console.error("construction de production dépend désormais d'un tiers de plus : le décider,");
+  console.error(
+    "puis l'ajouter à ALLOWED_HOSTS avec sa raison, dans scripts/check-build-network.mts"
+  );
+  process.exit(1);
+}
+
+const missing = [...ALLOWED_HOSTS.keys()].filter((host) => !hosts.has(host));
+if (missing.length > 0) {
+  // Not a failure: a host can legitimately stop being called, and that is good news.
+  // Reported so the list can be trimmed instead of rotting.
+  console.log("");
+  console.log("Hôtes autorisés qui n'ont pas été appelés (liste à élaguer ?) :");
+  for (const host of missing) console.log(`  ${host}`);
+}


### PR DESCRIPTION
## Description

La CI vérifiait le lint, les types, le format et les tests. Elle ne construisait pas l'application, alors
que le dépôt vient de prendre des montées de `next`, `postcss`, `mjml`, `sharp` et `prisma`. Ce job ajoute
`npm run build` sur un PostgreSQL 17 **vide**, dans un checkout **sans `.env` ni secrets factices**.

Chantier volontairement séparé, et posé sur `main` avant la lecture publique des mesures : si le build
casse à cause des montées de dépendances, autant le découvrir sur un `main` nu que mêlé à une nouvelle
fonctionnalité.

## Pourquoi un préflight local n'aurait pas suffi

`next build` charge `.env` **lui-même**, indépendamment de `DOTENV_CONFIG_PATH` qui ne concerne que le
`dotenv` de `prisma.config.ts`. Une construction locale a donc toujours toutes les variables de
production sous la main, y compris le DSN Sentry et les clés d'API. Constaté en mesurant : un build lancé
avec un environnement que je croyais minimal a émis trente enveloppes vers `o1.ingest.sentry.io`, alors
que `src/instrumentation.ts` conditionne correctement son initialisation à la présence d'un DSN. Le DSN
venait de `.env`.

Autrement dit, « ça construit chez moi » ne teste pas que le build tient sans secrets. Un checkout de CI
est le seul endroit où cette question se pose vraiment, ce qui fait de la CI l'autorité et non un rappel.

## Ce que le job fait, et ce qu'il ne fait pas

Un service `postgres:17` vide. Le sonde de santé passe par `-h localhost`, donc en TCP : l'entrypoint de
l'image lance un serveur temporaire sur la socket Unix pendant ses scripts d'initialisation, et une sonde
socket se déclare prête contre celui-là.

Les extensions et les séquences viennent de **`docker/init-search.sql`**, le même fichier que le harnais
de test local alimente. Une seule source, donc aucune dérive possible entre les deux : `unaccent`, que les
requêtes de recherche appellent, et les dix séquences `poligraph_*_seq` qui ne sont pas dans le datamodel
et que `prisma db push` ne peut donc pas créer.

Le schéma est appliqué par `npx prisma db push` **sans `--accept-data-loss`**. La base est vide, il n'y a
rien à perdre, et un push qui exigerait le drapeau est un signal plutôt qu'une chose à forcer.

Aucune variable factice pour les intégrations externes, et aucune fixture. Les deux étaient prévues au
cahier des charges initial, les mesures les ont rendues inutiles : le build réussit sur une base vide, en
collectant 293 pages et en exécutant plus de 1800 transactions contre elle. Les dix `generateStaticParams`
qui interrogent la base renvoient simplement des listes vides.

## Le build a besoin du réseau, alors on le surveille au lieu de le bloquer

Le cahier des charges demandait d'empêcher tout appel réseau pendant la collecte des pages. Ce n'est pas
réalisable : le build en a besoin. Mesuré avec une sonde chargée par `NODE_OPTIONS`, donc présente aussi
dans les processus de collecte que Next dérive.

| Hôte                   | Origine                                                       | Nécessaire                  |
| ---------------------- | ------------------------------------------------------------- | --------------------------- |
| `fonts.googleapis.com` | `next/font/google` dans `layout.tsx`, les feuilles de style   | oui                         |
| `fonts.gstatic.com`    | `next/font/google`, les fichiers de police                    | oui                         |
| `cdn.jsdelivr.net`     | `next/og`, les SVG Twemoji des seize routes `opengraph-image` | oui                         |
| `checkpoint.prisma.io` | `prisma generate`                                             | non, `CHECKPOINT_DISABLE=1` |
| `o1.ingest.sentry.io`  | DSN présent dans l'environnement local                        | non, absent sans `.env`     |

Le fait dépasse la CI : **la construction de production dépend aujourd'hui de la disponibilité de Google
Fonts et de `cdn.jsdelivr.net`.**

Le job enregistre donc les hôtes atteints et **échoue sur tout hôte hors liste blanche**. Il ne fige
aucun nombre d'appels : celui-ci varie avec ce que les pages rendent, et une valeur figée casserait sur
un changement de contenu sans rien prouver de plus. C'est l'ensemble des hôtes qui compte.

`scripts/build-net-probe.cjs` observe le canal `undici:request:create`, ce qui couvre `globalThis.fetch`
**et les requêtes de suivi de redirection**, qui ne repassent jamais par une enveloppe de `fetch`. Il
enveloppe aussi `fetch`, pour qu'un runtime ne publiant pas ce canal ne se transforme pas en succès
silencieux, ainsi que `node:http` et `node:https` pour le client classique. Les `data:` et `blob:` sont
ignorés.

**Ce n'est pas un pare-feu**, et la distinction compte : un binaire enfant avec son propre client réseau,
ou une socket brute, n'apparaîtrait pas nécessairement.

Les lignes journalisées ne portent que **le protocole et l'hôte**. Le vérificateur ne compare que des
hôtes, donc le chemin ne sert aucune assertion et pourrait contenir un identifiant le jour où le journal
serait publié pour diagnostic. Les chaînes de requête étaient déjà écartées : une version jetable de cette
sonde avait écrit une URL d'enveloppe Sentry complète avec son `sentry_key`.

**Le silence ne vaut pas succès, et cela demande deux garanties, pas une.** La sonde écrit une ligne à son
chargement et le vérificateur refuse de conclure sans cette preuve : sans elle, une sonde non chargée
produit un journal vide et le contrôle rapporte tranquillement « aucun hôte inconnu ».

La preuve de chargement ne couvre pourtant pas tout, et la première version de cette PR laissait le trou
ouvert en avalant les erreurs d'écriture « pour qu'une sonde ne casse jamais un build » : première
écriture réussie, disque plein ensuite, appels suivants non enregistrés, et le contrôle retrouve sa preuve
de chargement pour conclure que tout va bien. **L'impossibilité d'observer fait donc échouer le build.**

Par sortie de processus et non par exception : ce code s'exécute à l'intérieur de l'appel `fetch` qu'il
enveloppe, et du code applicatif qui entoure son propre `fetch` d'un `try/catch` avalerait l'exception.
`process.exit` ne s'attrape pas. Ablation faite, journal rendu non inscriptible : sortie en code 1 avec
la raison.

Le contrôle tourne avec `if: always()` : un build mort à mi-chemin a pu joindre quelque chose de nouveau,
et c'est justement ce qu'on veut voir.

## Type de changement

- [x] CI/CD

## Issue liée

Aucune.

## Vérifications

La séquence complète a été rejouée en local dans un worktree **sans `.env`**, avec `node_modules` lié et
un conteneur PostgreSQL 17 jetable :

- `npx prisma db push` sans le drapeau destructeur, code 0 ;
- `npm run build`, code 0, 293 pages ;
- sonde chargée dans **26 processus**, 64 lignes enregistrées, trois hôtes, tous autorisés, contrôle en
  code 0.

Les trois refus du vérificateur ont été construits et constatés : journal absent, journal sans ligne de
chargement, et hôte inconnu. Ce dernier affiche la liste et sort en code 1.

`npx tsc --noEmit` en code 0 sur cache froid, Prettier propre, YAML relu par un analyseur. ESLint ignore
`scripts/**` par configuration, donc les deux nouveaux fichiers ne changent rien au job de lint.

## Ce que ce chantier ne contient pas

**Le durcissement hors-ligne du build.** Basculer sur `next/font/local` avec les fichiers de police dans
le dépôt, et fournir un chargeur d'emoji local à `ImageResponse`. C'est une modification du rendu, qui
demande une revue visuelle, et elle mérite son propre chantier. Ce job la rend simplement visible : le
jour où elle est faite, des lignes disparaissent de la liste blanche.

Correction d'une affirmation fausse d'une version précédente de cette description : `next/font/google`
télécharge les polices **pendant le build** puis les **auto-héberge** avec les ressources statiques. Les
navigateurs des visiteurs n'appellent donc **jamais** Google Fonts. Passer à `next/font/local`
supprimerait la dépendance **du build**, pas une dépendance des visiteurs, qui n'existe pas.

Reste à vérifier dans ce chantier, et non établi par cette mesure : les routes `opengraph-image`
**dynamiques** refont-elles l'appel Twemoji à la demande, côté serveur ? Le build ne le dit pas.

**Le coût.** Le job ajoute environ 3 min 40 par PR, en parallèle des autres contrôles. Il reste
obligatoire sur chaque PR : sur `main` seulement, la régression serait constatée après le merge, et
derrière une étiquette le contrôle deviendrait optionnel donc oublié.

Premier levier appliqué ici : un groupe de concurrence annule l'exécution devenue obsolète quand un
nouveau commit arrive sur la même PR, et **seulement** pour les PR, pour qu'aucun commit de `main` ou de
`staging` ne reste non vérifié. Second levier, laissé à un chantier séparé si le coût gêne encore : le
cache `.next/cache`, que les journaux signalent explicitement comme absent.
