### PR TITLE
Livrer le cycle éditorial des mesures (lot 1, PR B)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,16 +26,24 @@ jobs:
             exit 1
           fi
 
-      - name: No direct PUBLISHED writes on Affair outside publish-guard
+      - name: No direct PUBLISHED writes outside an authorized publisher
         run: |
           # RGPD art. 10 : la publication d'une affaire passe exclusivement par
           # src/lib/affairs/publish-guard.ts. Ce step détecte les écritures
           # directes : un littéral `publicationStatus: "PUBLISHED"` dont le
           # contexte amont (12 lignes) contient `data:` plus près que `where:`.
           # scripts/ est couvert au même titre que src/.
+          #
+          # La détection est lexicale, donc aveugle au modèle : `PublicationStatus`
+          # est un enum partagé, et ce step attrape aussi la publication d'une
+          # mesure. La liste ci-dessous nomme donc UN fichier autorisé par modèle,
+          # jamais un répertoire : tout autre fichier qui publierait une mesure
+          # reste détecté, ce qui est bien l'invariant voulu.
           FOUND=0
           for f in $(grep -rl 'publicationStatus: "PUBLISHED"' src/ scripts/ --include='*.ts' --include='*.tsx' \
-            | grep -v 'src/lib/affairs/publish-guard.ts' | grep -v '__tests__' | grep -v '\.test\.'); do
+            | grep -v 'src/lib/affairs/publish-guard.ts' \
+            | grep -v 'src/lib/measures/transitions.ts' \
+            | grep -v '__tests__' | grep -v '\.test\.'); do
             while IFS=: read -r linenum rest; do
               START=$((linenum > 12 ? linenum - 12 : 1))
               CONTEXT=$(sed -n "${START},${linenum}p" "$f")

--- a/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
+++ b/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { publishSeededMeasure } from "./helpers";
+
+// Deferred: `../transitions` imports `@/lib/db` as a value, which throws at module load
+// without DATABASE_URL, so a static import fails the file instead of skipping the block.
+let db: typeof import("@/lib/db").db;
+let depublishMeasure: typeof import("../transitions").depublishMeasure;
+let withdrawMeasure: typeof import("../transitions").withdrawMeasure;
+
+describeIfDisposableDb("depublishMeasure", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ depublishMeasure } = await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("hides the document without deleting it", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    await depublishMeasure({ measureId, reason: "Erreur factuelle signalée." });
+
+    const doc = await db.searchDocument.findUnique({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+    // The vector is Unsupported("tsvector") so Prisma cannot read it. The plan asserted on
+    // a searchText column, which the lot 1B review removed.
+    const rows = await db.$queryRaw<{ lexemes: string | null }[]>`
+      SELECT "searchVector"::text AS lexemes
+      FROM "SearchDocument"
+      WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${measureId}
+    `;
+
+    // Deleting the row would force a full reindex to bring the measure back, and the
+    // indexed text is not reproducible from the index itself.
+    expect(doc).not.toBeNull();
+    expect(doc?.visibility).toBe("ADMIN_ONLY");
+    expect(rows[0]?.lexemes).not.toBeNull();
+  });
+
+  it("leaves a trace of why", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    await depublishMeasure({ measureId, reason: "Erreur factuelle signalée." });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    // Without these two fields, a depublished measure is indistinguishable from one that
+    // was never published, and nobody can tell why it left the site.
+    expect(measure.publicationStatus).toBe("DRAFT");
+    expect(measure.depublishedAt).not.toBeNull();
+    expect(measure.depublicationReason).toContain("Erreur factuelle");
+    // The revision is untouched: depublication is our act, not a change to what the
+    // candidate said.
+    const revision = await db.measureRevision.findUniqueOrThrow({
+      where: { id: measure.publishedRevisionId! },
+    });
+    expect(revision.supersededAt).toBeNull();
+  });
+
+  it("refuses a depublication with no stated reason", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    await expect(depublishMeasure({ measureId, reason: "  " })).rejects.toThrow(/motif/i);
+  });
+});
+
+describeIfDisposableDb("withdrawMeasure", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ withdrawMeasure } = await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses a withdrawal without both a source url and a source label", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const withdrawnAt = new Date("2027-03-01T00:00:00Z");
+
+    await expect(
+      withdrawMeasure({
+        measureId,
+        withdrawnAt,
+        sourceUrl: "https://example.org/retrait",
+        sourceLabel: "",
+      })
+    ).rejects.toThrow(/source/i);
+    await expect(
+      withdrawMeasure({ measureId, withdrawnAt, sourceUrl: "", sourceLabel: "Le Monde" })
+    ).rejects.toThrow(/source/i);
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    // The three fields are written together or not at all: a withdrawnAt with no source is
+    // an unsourced claim that a candidate dropped a proposal.
+    expect(measure.withdrawnAt).toBeNull();
+    expect(measure.withdrawnSourceUrl).toBeNull();
+    expect(measure.withdrawnSourceLabel).toBeNull();
+  });
+
+  it("keeps a withdrawn measure published and searchable", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+
+    await withdrawMeasure({
+      measureId,
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait",
+      sourceLabel: "Le Monde, 1er mars 2027",
+    });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // A withdrawn measure does not disappear. Erasing a proposal a candidate publicly
+    // carried and then dropped would delete information that matters.
+    expect(measure.withdrawnAt).not.toBeNull();
+    expect(measure.publicationStatus).toBe("PUBLISHED");
+    expect(measure.publishedRevisionId).toBe(revisionId);
+    expect(doc.visibility).toBe("PUBLIC");
+  });
+});

--- a/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
+++ b/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
-import { publishSeededMeasure } from "./helpers";
+import { publishSeededMeasure, withIndexingRejected } from "./helpers";
 
 // Deferred: `../transitions` imports `@/lib/db` as a value, which throws at module load
 // without DATABASE_URL, so a static import fails the file instead of skipping the block.
@@ -59,6 +59,31 @@ describeIfDisposableDb("depublishMeasure", () => {
       where: { id: measure.publishedRevisionId! },
     });
     expect(revision.supersededAt).toBeNull();
+  });
+
+  it("rolls back the depublication when indexing fails", async () => {
+    // Seeded BEFORE arming the guard: publishSeededMeasure indexes twice on its way, so it
+    // would fail under the constraint itself.
+    const { measureId, revisionId } = await publishSeededMeasure();
+
+    await withIndexingRejected(async () => {
+      await expect(
+        depublishMeasure({ measureId, reason: "Motif qui ne doit pas survivre." })
+      ).rejects.toThrow();
+    });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // A partial rollback would be the worst of both: the measure marked depublished while
+    // the index still serves it as PUBLIC.
+    expect(measure.publicationStatus).toBe("PUBLISHED");
+    expect(measure.depublishedAt).toBeNull();
+    expect(measure.depublicationReason).toBeNull();
+    expect(doc.visibility).toBe("PUBLIC");
+    expect(doc.sourceRevisionId).toBe(revisionId);
   });
 
   it("refuses a depublication with no stated reason", async () => {

--- a/src/lib/measures/__tests__/draft-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/draft-revision.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
-import { draftInput, seedMeasureWithDraft } from "./helpers";
+import { draftInput, seedMeasureWithDraft, withIndexingRejected } from "./helpers";
 
 // Two deferred imports: `@/lib/db` throws at module load when DATABASE_URL is unset, and
 // `../transitions` imports it as a value, so a static import of either fails the whole
@@ -95,6 +95,26 @@ describeIfDisposableDb("draftMeasureRevision", () => {
     expect(document.visibility).toBe("PUBLIC");
     expect(document.sourceRevisionId).toBe(publishedId);
     expect(document.body).not.toContain("reformulation invisible");
+  });
+
+  it("rolls back the new draft and the discard when indexing fails", async () => {
+    const { measureId, revisionId: original } = await seedMeasureWithDraft();
+
+    await withIndexingRejected(async () => {
+      await expect(
+        draftMeasureRevision(draftInput(measureId, "Version qui ne doit pas survivre."))
+      ).rejects.toThrow();
+    });
+
+    const revisions = await db.measureRevision.findMany({ where: { measureId } });
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+
+    // Two writes precede the indexing here, the discard of the previous draft and the
+    // creation of the new one. Both must be gone: a partial rollback would leave the
+    // original draft discarded with nothing to replace it.
+    expect(revisions.map((r) => r.id)).toEqual([original]);
+    expect(revisions[0]?.discardedAt).toBeNull();
+    expect(measure.latestRevisionId).toBe(original);
   });
 
   it("refuses to draft on a measure that does not exist", async () => {

--- a/src/lib/measures/__tests__/draft-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/draft-revision.integration.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { draftInput, seedMeasureWithDraft } from "./helpers";
+
+// Two deferred imports: `@/lib/db` throws at module load when DATABASE_URL is unset, and
+// `../transitions` imports it as a value, so a static import of either fails the whole
+// file instead of skipping the block.
+let db: typeof import("@/lib/db").db;
+let draftMeasureRevision: typeof import("../transitions").draftMeasureRevision;
+
+describeIfDisposableDb("draftMeasureRevision", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ draftMeasureRevision } = await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("leaves at most one active draft after two successive calls", async () => {
+    const { measureId } = await seedMeasureWithDraft();
+
+    const first = await draftMeasureRevision(draftInput(measureId, "Deuxième version."));
+    const second = await draftMeasureRevision(draftInput(measureId, "Troisième version."));
+
+    const active = await db.measureRevision.findMany({
+      where: { measureId, discardedAt: null, publishedAt: null },
+      select: { id: true },
+    });
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+
+    // The violation revision 1 of the plan produced: three drafts, none discarded, and an
+    // orphan active draft on the very first audit run.
+    expect(active.map((r) => r.id)).toEqual([second.revisionId]);
+    expect(measure.latestRevisionId).toBe(second.revisionId);
+
+    const abandoned = await db.measureRevision.findUniqueOrThrow({
+      where: { id: first.revisionId },
+    });
+    expect(abandoned.discardedAt).not.toBeNull();
+    expect(abandoned.reviewedBy).toBeNull();
+  });
+
+  it("does not discard the published revision when drafting a correction", async () => {
+    const { measureId, revisionId: publishedId } = await seedMeasureWithDraft();
+
+    // Simulates the published state without going through publishMeasureRevision, which
+    // does not exist yet: what this test guards is the branch of draftMeasureRevision,
+    // not the publication path.
+    await db.measureRevision.update({
+      where: { id: publishedId },
+      data: { reviewedAt: new Date(), reviewedBy: "relecteur", publishedAt: new Date() },
+    });
+    await db.measure.update({
+      where: { id: measureId },
+      data: { publishedRevisionId: publishedId, publicationStatus: "PUBLISHED" },
+    });
+
+    await draftMeasureRevision(draftInput(measureId, "Correction en cours."));
+
+    const published = await db.measureRevision.findUniqueOrThrow({ where: { id: publishedId } });
+    const after = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+
+    // Discarding the published revision here would depublish valid public content on
+    // every correction, which is the effect two pointers exist to prevent.
+    expect(published.discardedAt).toBeNull();
+    expect(published.supersededAt).toBeNull();
+    expect(after.publishedRevisionId).toBe(publishedId);
+    expect(after.publicationStatus).toBe("PUBLISHED");
+  });
+
+  it("keeps the public document on the published revision while a draft is in flight", async () => {
+    const { measureId, revisionId: publishedId } = await seedMeasureWithDraft();
+    await db.measureRevision.update({
+      where: { id: publishedId },
+      data: { reviewedAt: new Date(), reviewedBy: "relecteur", publishedAt: new Date() },
+    });
+    await db.measure.update({
+      where: { id: measureId },
+      data: { publishedRevisionId: publishedId, publicationStatus: "PUBLISHED" },
+    });
+    // The index has to be re-derived after the hand-made publication above, otherwise
+    // this test would be asserting against the document left by createMeasure.
+    await draftMeasureRevision(draftInput(measureId, "Une reformulation invisible."));
+
+    const document = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // The visible half of the same invariant: a correction in progress must not reach the
+    // public index either. Asserting only on the pointers would leave the search free to
+    // expose a draft.
+    expect(document.visibility).toBe("PUBLIC");
+    expect(document.sourceRevisionId).toBe(publishedId);
+    expect(document.body).not.toContain("reformulation invisible");
+  });
+
+  it("refuses to draft on a measure that does not exist", async () => {
+    await expect(draftMeasureRevision(draftInput("mesure-inexistante", "Texte."))).rejects.toThrow(
+      /not found/i
+    );
+  });
+});

--- a/src/lib/measures/__tests__/helpers.ts
+++ b/src/lib/measures/__tests__/helpers.ts
@@ -169,3 +169,36 @@ export async function publishSeededMeasure(): Promise<{ measureId: string; revis
   await publishMeasureRevision(seeded);
   return seeded;
 }
+
+const REJECT_CONSTRAINT = "reject_measure_search_document_test";
+
+/**
+ * Runs `fn` while the database rejects every write to a MEASURE SearchDocument.
+ *
+ * The only way to observe atomicity. A test that reads the final state stays green if the
+ * indexing is moved after the commit, because the rows would still be there; making the
+ * indexing FAIL is what shows whether the rest of the transition rolled back with it.
+ *
+ * NOT VALID is required, not cosmetic: earlier tests of the same run have already written
+ * MEASURE documents, and without it the ALTER TABLE would fail on them instead of arming
+ * the guard.
+ */
+export async function withIndexingRejected<T>(fn: () => Promise<T>): Promise<T> {
+  const db = await client();
+  await db.$executeRaw`
+    ALTER TABLE "SearchDocument"
+    ADD CONSTRAINT "reject_measure_search_document_test"
+    CHECK ("entityType" <> 'MEASURE'::"SearchEntityType") NOT VALID
+  `;
+  try {
+    return await fn();
+  } finally {
+    await db.$executeRaw`
+      ALTER TABLE "SearchDocument" DROP CONSTRAINT IF EXISTS "reject_measure_search_document_test"
+    `;
+  }
+}
+
+// Named export of the constraint name so a failing test can be diagnosed without
+// searching for the string.
+export const INDEXING_REJECT_CONSTRAINT = REJECT_CONSTRAINT;

--- a/src/lib/measures/__tests__/helpers.ts
+++ b/src/lib/measures/__tests__/helpers.ts
@@ -9,6 +9,7 @@
  */
 
 import { assertDisposableTestDb } from "@/test/db-guard";
+import { createMeasure, type DraftMeasureRevisionInput } from "../transitions";
 
 /**
  * Deferred client. `@/lib/db` throws `DATABASE_URL environment variable is not set` at
@@ -88,4 +89,63 @@ export async function seedCandidacy(politicianId: string, electionId: string): P
     data: { electionId, politicianId, candidateName: `Candidat ${uniqueSlug("c")}` },
   });
   return row.id;
+}
+
+// The three fixtures below are shared by every task from the editorial cycle onwards, so
+// they live here rather than in one test file. Duplicating them means two definitions
+// that drift, and a test that then passes for a reason nobody intended.
+
+/** A measure with a single, never-published draft. The starting point of most scenarios. */
+export async function seedMeasureWithDraft(): Promise<{ measureId: string; revisionId: string }> {
+  const politicianId = await seedPolitician();
+  const electionId = await seedElection();
+  return createMeasure({
+    politicianId,
+    electionId,
+    candidacyId: null,
+    programEditionId: null,
+    attribution: "PERSONAL",
+    theme: "LOGEMENT_URBANISME",
+    precedingMeasureId: null,
+    revision: {
+      text: "Encadrer les loyers dans les zones tendues.",
+      precision: "OBJECTIF_SANS_CHIFFRE",
+      validFrom: new Date("2027-01-01T00:00:00Z"),
+      extractionMethod: "MANUAL",
+      extractionConfidence: null,
+      extractorVersion: null,
+    },
+    sources: [
+      {
+        sourceKind: "DISCOURS_CAMPAGNE",
+        tier: "PRIMARY",
+        url: "https://example.org/meeting",
+        page: null,
+        publishedAt: new Date("2027-01-01T00:00:00Z"),
+      },
+    ],
+  });
+}
+
+export function draftInput(measureId: string, text: string): DraftMeasureRevisionInput {
+  return {
+    measureId,
+    revision: {
+      text,
+      precision: null,
+      validFrom: new Date("2027-02-01T00:00:00Z"),
+      extractionMethod: "MANUAL",
+      extractionConfidence: null,
+      extractorVersion: null,
+    },
+    sources: [
+      {
+        sourceKind: "ARTICLE_PRESSE",
+        tier: "SECONDARY",
+        url: "https://example.org/article",
+        page: null,
+        publishedAt: new Date("2027-02-01T00:00:00Z"),
+      },
+    ],
+  };
 }

--- a/src/lib/measures/__tests__/helpers.ts
+++ b/src/lib/measures/__tests__/helpers.ts
@@ -9,7 +9,17 @@
  */
 
 import { assertDisposableTestDb } from "@/test/db-guard";
-import { createMeasure, type DraftMeasureRevisionInput } from "../transitions";
+// TYPE-ONLY, and that matters: `../transitions` imports `@/lib/db` as a value, which
+// throws at module load without DATABASE_URL. A value import here would fail every test
+// file that imports these fixtures, before any gate could skip a block. A type import is
+// erased at compile time, so it costs nothing.
+import type { DraftMeasureRevisionInput } from "../transitions";
+
+/** Deferred, for the same reason as client(): the module must not load at import time. */
+async function transitions(): Promise<typeof import("../transitions")> {
+  assertDisposableTestDb();
+  return import("../transitions");
+}
 
 /**
  * Deferred client. `@/lib/db` throws `DATABASE_URL environment variable is not set` at
@@ -97,6 +107,7 @@ export async function seedCandidacy(politicianId: string, electionId: string): P
 
 /** A measure with a single, never-published draft. The starting point of most scenarios. */
 export async function seedMeasureWithDraft(): Promise<{ measureId: string; revisionId: string }> {
+  const { createMeasure } = await transitions();
   const politicianId = await seedPolitician();
   const electionId = await seedElection();
   return createMeasure({
@@ -148,4 +159,13 @@ export function draftInput(measureId: string, text: string): DraftMeasureRevisio
       },
     ],
   };
+}
+
+/** A measure published through the real path: created, reviewed, then published. */
+export async function publishSeededMeasure(): Promise<{ measureId: string; revisionId: string }> {
+  const { publishMeasureRevision, reviewMeasureRevision } = await transitions();
+  const seeded = await seedMeasureWithDraft();
+  await reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+  await publishMeasureRevision(seeded);
+  return seeded;
 }

--- a/src/lib/measures/__tests__/publish-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/publish-revision.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, expect, expectTypeOf, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
 import type { publishMeasureRevision as PublishFn } from "../transitions";
-import { draftInput, seedMeasureWithDraft } from "./helpers";
+import { draftInput, seedMeasureWithDraft, withIndexingRejected } from "./helpers";
 
 // Deferred: `../transitions` imports `@/lib/db` as a value, which throws at module load
 // without DATABASE_URL. The type-only import above is erased, so it costs nothing.
@@ -239,6 +239,26 @@ describeIfDisposableDb("publishMeasureRevision guards", () => {
       where: { measureId, publishedAt: null, discardedAt: null, id: { not: draft } },
     });
     expect(orphans).toHaveLength(0);
+  });
+
+  it("rolls back the whole publication when indexing fails", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" });
+
+    await withIndexingRejected(async () => {
+      await expect(publishMeasureRevision({ measureId, revisionId })).rejects.toThrow();
+    });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    const revision = await db.measureRevision.findUniqueOrThrow({ where: { id: revisionId } });
+
+    // Three writes precede the indexing: publishedAt on the revision, the pointer, and
+    // publicationStatus. A partial rollback here would put the measure online while the
+    // index still describes a draft, which is the exact state the same-transaction rule
+    // exists to make impossible.
+    expect(measure.publicationStatus).toBe("DRAFT");
+    expect(measure.publishedRevisionId).toBeNull();
+    expect(revision.publishedAt).toBeNull();
   });
 
   it("leaves the index untouched when a guard refuses the publication", async () => {

--- a/src/lib/measures/__tests__/publish-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/publish-revision.integration.test.ts
@@ -1,0 +1,265 @@
+import { afterAll, beforeAll, expect, expectTypeOf, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import type { publishMeasureRevision as PublishFn } from "../transitions";
+import { draftInput, seedMeasureWithDraft } from "./helpers";
+
+// Deferred: `../transitions` imports `@/lib/db` as a value, which throws at module load
+// without DATABASE_URL. The type-only import above is erased, so it costs nothing.
+let db: typeof import("@/lib/db").db;
+let draftMeasureRevision: typeof import("../transitions").draftMeasureRevision;
+let publishMeasureRevision: typeof import("../transitions").publishMeasureRevision;
+let reviewMeasureRevision: typeof import("../transitions").reviewMeasureRevision;
+
+// A type-level assertion, and the invariant is about the SHAPE OF THE PARAMETER: the
+// moment publish accepts a review timestamp, it declares the review instead of verifying
+// it, and the "a published revision has been reviewed" guarantee becomes circular.
+//
+// Deliberately NOT an assertion on the function body. A first version of this plan checked
+// that the string "reviewedAt" is absent from publishMeasureRevision.toString(), which is
+// guaranteed red: the function MUST read revision.reviewedAt to verify the review. The
+// constraint is on what the caller can pass, not on what the body does.
+//
+// Erased at runtime: it is `npx tsc --noEmit` that fails on a violation.
+it("keeps the publication input free of any review field", () => {
+  expectTypeOf<Parameters<typeof PublishFn>[0]>().toEqualTypeOf<{
+    measureId: string;
+    revisionId: string;
+  }>();
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describeIfDisposableDb("publishMeasureRevision concurrency", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ publishMeasureRevision, reviewMeasureRevision } = await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("leaves exactly one current revision when two publications race", async () => {
+    // The plan proposed a timing test instead: hold the row with FOR UPDATE, start a
+    // publication, sleep, assert it has not settled. That test stays GREEN with the lock
+    // removed, so it proves nothing about the lock. The reason is that
+    // publishMeasureRevision ends with an UPDATE on the very row the outer transaction
+    // holds, so the call is blocked by the WRITE whether or not it locked first.
+    //
+    // What FOR UPDATE actually protects is the read-then-decide sequence. Without it, two
+    // concurrent publications both read "no published revision", and the second one writes
+    // a decision taken on a stale read. The observable violation is not a delay, it is two
+    // published revisions of which neither is superseded.
+    const { measureId, revisionId: first } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId: first, reviewedBy: "relecteur" });
+
+    // A second reviewed revision, built directly: draftMeasureRevision would discard the
+    // first one, and this test needs two publishable revisions at the same time. Building
+    // the violation by hand is the plan's own rule for invariants no public sequence can
+    // reach.
+    const second = await db.measureRevision.create({
+      data: {
+        measureId,
+        text: "Version concurrente.",
+        validFrom: new Date("2027-03-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        reviewedAt: new Date(),
+        reviewedBy: "relecteur",
+        sources: {
+          create: [
+            {
+              sourceKind: "ARTICLE_PRESSE",
+              tier: "SECONDARY",
+              url: "https://example.org/concurrent",
+              publishedAt: new Date("2027-03-01T00:00:00Z"),
+            },
+          ],
+        },
+      },
+    });
+
+    // Exactly two concurrent transactions, which is exactly the pool limit (max: 2). A
+    // third would deadlock on connection acquisition rather than on the row.
+    const results = await Promise.allSettled([
+      publishMeasureRevision({ measureId, revisionId: first }),
+      publishMeasureRevision({ measureId, revisionId: second.id }),
+    ]);
+
+    // Both are allowed to succeed: serialised by the lock, the second simply supersedes
+    // the first. What must never happen is two current revisions.
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(rejected).toHaveLength(0);
+
+    const current = await db.measureRevision.findMany({
+      where: { measureId, publishedAt: { not: null }, supersededAt: null },
+      select: { id: true },
+    });
+    expect(current).toHaveLength(1);
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    expect(current[0]?.id).toBe(measure.publishedRevisionId);
+  });
+
+  it("blocks while another transaction holds the measure row", async () => {
+    // Kept as a weaker, separate claim, and worded for what it actually shows: the call
+    // does not sail past a row another transaction holds. It does NOT distinguish the lock
+    // from the final UPDATE, which is why the race test above exists.
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" });
+
+    let settled = false;
+    let attempt: Promise<void> | undefined;
+
+    // The pool is max: 2 per process. This holds one connection and waits for a second,
+    // which is exactly the limit, so it must never open a third transaction.
+    await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT id FROM "Measure" WHERE id = ${measureId} FOR UPDATE`;
+
+      attempt = publishMeasureRevision({ measureId, revisionId }).then(() => {
+        settled = true;
+      });
+
+      await sleep(400);
+
+      expect(settled).toBe(false);
+    });
+
+    await attempt;
+    expect(settled).toBe(true);
+
+    const published = await db.measureRevision.findMany({
+      where: { measureId, publishedAt: { not: null }, supersededAt: null },
+    });
+    expect(published).toHaveLength(1);
+  });
+});
+
+describeIfDisposableDb("publishMeasureRevision guards", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ draftMeasureRevision, publishMeasureRevision, reviewMeasureRevision } =
+      await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses an unreviewed revision", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+
+    await expect(publishMeasureRevision({ measureId, revisionId })).rejects.toThrow(/non relue/i);
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    expect(measure.publicationStatus).toBe("DRAFT");
+    expect(measure.publishedRevisionId).toBeNull();
+  });
+
+  it("moves publicationStatus to PUBLISHED itself", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" });
+
+    await publishMeasureRevision({ measureId, revisionId });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    // The first version's tests set this field by hand, which hid the fact that no code
+    // path ever moved it: every measure would have stayed invisible forever.
+    expect(measure.publicationStatus).toBe("PUBLISHED");
+    expect(measure.publishedRevisionId).toBe(revisionId);
+  });
+
+  it("supersedes the previous published revision and leaves exactly one current", async () => {
+    const { measureId, revisionId: first } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId: first, reviewedBy: "relecteur" });
+    await publishMeasureRevision({ measureId, revisionId: first });
+
+    const { revisionId: second } = await draftMeasureRevision(
+      draftInput(measureId, "Nouvelle version.")
+    );
+    await reviewMeasureRevision({ measureId, revisionId: second, reviewedBy: "relecteur" });
+    await publishMeasureRevision({ measureId, revisionId: second });
+
+    const current = await db.measureRevision.findMany({
+      where: { measureId, publishedAt: { not: null }, supersededAt: null },
+      select: { id: true },
+    });
+    const superseded = await db.measureRevision.findUniqueOrThrow({ where: { id: first } });
+
+    // The invariant is "at most one PUBLISHED non-superseded revision", not "at most one
+    // non-superseded revision": a pending draft also has supersededAt null and that is the
+    // normal state. Conflating the two is what made the first version's test vacuous.
+    expect(current.map((r) => r.id)).toEqual([second]);
+    expect(superseded.supersededAt).not.toBeNull();
+    expect(superseded.publishedAt).not.toBeNull();
+  });
+
+  it("indexes the published text in the same transaction", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" });
+    await publishMeasureRevision({ measureId, revisionId });
+
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+    // The vector is Unsupported("tsvector"), so Prisma cannot read it: a raw read is the
+    // only way to prove the second statement of the upsert ran. The plan asserted on a
+    // searchText column, which the lot 1B review removed.
+    const rows = await db.$queryRaw<{ lexemes: string | null }[]>`
+      SELECT "searchVector"::text AS lexemes
+      FROM "SearchDocument"
+      WHERE "entityType" = 'MEASURE'::"SearchEntityType" AND "entityId" = ${measureId}
+    `;
+
+    expect(doc.visibility).toBe("PUBLIC");
+    expect(doc.sourceRevisionId).toBe(revisionId);
+    expect(rows[0]?.lexemes).not.toBeNull();
+    expect(rows[0]?.lexemes).toContain("loyers");
+  });
+
+  it("does not move latestRevisionId backwards when a draft is in flight", async () => {
+    const { measureId, revisionId: first } = await seedMeasureWithDraft();
+    await reviewMeasureRevision({ measureId, revisionId: first, reviewedBy: "relecteur" });
+    await publishMeasureRevision({ measureId, revisionId: first });
+
+    const { revisionId: draft } = await draftMeasureRevision(
+      draftInput(measureId, "Correction en cours.")
+    );
+
+    // Republishing the current revision while a correction is being written. Moving
+    // latestRevisionId back to `first` would orphan the draft.
+    await publishMeasureRevision({ measureId, revisionId: first });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    expect(measure.publishedRevisionId).toBe(first);
+    expect(measure.latestRevisionId).toBe(draft);
+
+    const orphans = await db.measureRevision.findMany({
+      where: { measureId, publishedAt: null, discardedAt: null, id: { not: draft } },
+    });
+    expect(orphans).toHaveLength(0);
+  });
+
+  it("leaves the index untouched when a guard refuses the publication", async () => {
+    const { measureId } = await seedMeasureWithDraft();
+    const { revisionId: unreviewed } = await draftMeasureRevision(
+      draftInput(measureId, "Brouillon non relu.")
+    );
+
+    await expect(publishMeasureRevision({ measureId, revisionId: unreviewed })).rejects.toThrow();
+
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // What this proves: a guard that refuses wrote nothing. The document is still the
+    // ADMIN_ONLY one that createMeasure and draftMeasureRevision produced, and it is NOT
+    // PUBLIC. What it does NOT prove is transactional atomicity: the review guard throws
+    // BEFORE any write, so an ablation moving the upsert out of the transaction would stay
+    // green here. The rollback is covered by the lot 1B test on the primitive and by
+    // createMeasure's own atomicity test.
+    expect(doc.visibility).toBe("ADMIN_ONLY");
+    expect(doc.sourceRevisionId).toBe(unreviewed);
+  });
+});

--- a/src/lib/measures/__tests__/review-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/review-revision.integration.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { seedMeasureWithDraft } from "./helpers";
+
+// Two deferred imports: `@/lib/db` throws at module load when DATABASE_URL is unset, and
+// `../transitions` imports it as a value, so a static import of either fails the whole
+// file instead of skipping the block.
+let db: typeof import("@/lib/db").db;
+let transitions: typeof import("../transitions");
+
+describeIfDisposableDb("reviewMeasureRevision", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    transitions = await import("../transitions");
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses a revision that belongs to another measure", async () => {
+    const first = await seedMeasureWithDraft();
+    const second = await seedMeasureWithDraft();
+
+    // Without this check, reviewing the wrong id silently marks a foreign revision as
+    // read, and the trace names a reviewer who never saw that text.
+    await expect(
+      transitions.reviewMeasureRevision({
+        measureId: first.measureId,
+        revisionId: second.revisionId,
+        reviewedBy: "relecteur",
+      })
+    ).rejects.toThrow(/autre mesure/i);
+  });
+
+  it("refuses a discarded revision", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await transitions.discardMeasureRevision({ measureId, revisionId });
+
+    await expect(
+      transitions.reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" })
+    ).rejects.toThrow(/abandonnée/i);
+  });
+
+  it("refuses an unidentified reviewer", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+
+    // reviewedBy is free text for now (no user model in this repo), so an empty string
+    // would produce a review with no accountable author.
+    await expect(
+      transitions.reviewMeasureRevision({ measureId, revisionId, reviewedBy: "   " })
+    ).rejects.toThrow(/relecteur/i);
+  });
+
+  it("records the reviewer and the date", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+
+    await transitions.reviewMeasureRevision({ measureId, revisionId, reviewedBy: "relecteur" });
+
+    const revision = await db.measureRevision.findUniqueOrThrow({ where: { id: revisionId } });
+    expect(revision.reviewedBy).toBe("relecteur");
+    expect(revision.reviewedAt).not.toBeNull();
+    // Review is not publication: the measure stays invisible until publish runs.
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    expect(measure.publishedRevisionId).toBeNull();
+    expect(measure.publicationStatus).toBe("DRAFT");
+  });
+});
+
+describeIfDisposableDb("discardMeasureRevision", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    transitions = await import("../transitions");
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses a revision that belongs to another measure", async () => {
+    const first = await seedMeasureWithDraft();
+    const second = await seedMeasureWithDraft();
+
+    // The lock is taken on measureId while the update targets revisionId. Without an
+    // ownership check, this call locks the first measure and discards a draft of the
+    // second one, which is neither locked nor what the caller asked for.
+    await expect(
+      transitions.discardMeasureRevision({
+        measureId: first.measureId,
+        revisionId: second.revisionId,
+      })
+    ).rejects.toThrow(/autre mesure/i);
+
+    const untouched = await db.measureRevision.findUniqueOrThrow({
+      where: { id: second.revisionId },
+    });
+    expect(untouched.discardedAt).toBeNull();
+  });
+
+  it("never leaves latestRevisionId on a discarded draft", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+
+    await transitions.discardMeasureRevision({ measureId, revisionId });
+
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    // The measure has no published revision here, so the pointer falls back to null
+    // rather than to a draft the audit would flag as abandoned-but-designated.
+    expect(measure.latestRevisionId).toBeNull();
+  });
+
+  it("removes the index document when the last draft of a never-published measure goes", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+
+    await transitions.discardMeasureRevision({ measureId, revisionId });
+
+    const document = await db.searchDocument.findUnique({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // Nothing is left to represent: no published revision, no active draft. Leaving an
+    // ADMIN_ONLY document behind would make the moderation search offer a measure whose
+    // text no longer exists anywhere, and the audit would report it as stale forever.
+    expect(document).toBeNull();
+  });
+});

--- a/src/lib/measures/cache.ts
+++ b/src/lib/measures/cache.ts
@@ -1,0 +1,33 @@
+import { revalidateTags } from "@/lib/cache";
+
+/**
+ * Cache invalidation is NOT part of the publication transaction: revalidateTag() is a
+ * call to the hosting platform, not SQL, and describing it as atomic with PostgreSQL
+ * would be wrong.
+ *
+ * Best effort with a log, and NO retry. A retry held in memory does not survive the end
+ * of the lambda, so it would buy the appearance of a guarantee and nothing else. A lost
+ * invalidation leaves the page stale until its cacheLife profile expires, which is a
+ * known and bounded defect. An outbox table is what fixes it properly, and it belongs to
+ * no lot yet.
+ *
+ * Throwing here would be worse than logging: the transaction is already committed, so the
+ * caller would believe the publication failed when it succeeded.
+ */
+export function invalidateMeasureTags(measureId: string, electionId: string): void {
+  try {
+    // Two specific tags, never a mass revalidation and never the global tag: purging the
+    // global tag once blew through this project's hosting spend cap.
+    //
+    // Delegates to src/lib/cache.ts rather than calling revalidateTag directly: on this
+    // Next version the second `profile` argument is mandatory, and that module already
+    // owns the default. A second invalidation mechanism next to it would be one more
+    // thing to keep in sync.
+    revalidateTags([`measure:${measureId}`, `election-measures:${electionId}`]);
+  } catch (error) {
+    // The only trace of a lost invalidation, which leaves a page stale until its
+    // cacheLife profile expires.
+    // eslint-disable-next-line no-console -- deliberate ops signal
+    console.error(`[measures] cache invalidation failed for ${measureId}`, error);
+  }
+}

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -7,6 +7,7 @@ import type {
   ThemeCategory,
 } from "@/generated/prisma";
 import { db, type DbTransactionClient } from "@/lib/db";
+import { invalidateMeasureTags } from "./cache";
 import { MeasureValidationError } from "./errors";
 import { lockMeasure } from "./lock";
 import { syncSearchDocument } from "./search-sync";
@@ -310,4 +311,193 @@ export async function discardMeasureRevision(input: {
 
     await syncSearchDocument(tx, input.measureId);
   });
+}
+
+/**
+ * Publishes a reviewed revision. Five writes in one PostgreSQL transaction, then the cache
+ * invalidation outside it.
+ *
+ * Note what this signature does NOT take: no reviewedAt, no reviewedBy. The review is
+ * verified here, never declared. A publish function that accepts a review timestamp makes
+ * the "a published revision has been reviewed" guarantee circular.
+ */
+export async function publishMeasureRevision(input: {
+  measureId: string;
+  revisionId: string;
+}): Promise<void> {
+  const { electionId } = await db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    const measure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: {
+        electionId: true,
+        publishedRevisionId: true,
+        latestRevisionId: true,
+      },
+    });
+
+    const revision = await tx.measureRevision.findUnique({
+      where: { id: input.revisionId },
+      select: {
+        measureId: true,
+        text: true,
+        reviewedAt: true,
+        discardedAt: true,
+        supersededAt: true,
+        _count: { select: { sources: true } },
+      },
+    });
+
+    if (!revision) throw new MeasureValidationError(`Révision ${input.revisionId} introuvable`);
+    if (revision.measureId !== input.measureId) {
+      throw new MeasureValidationError("La révision appartient à une autre mesure");
+    }
+    if (!revision.reviewedAt) {
+      throw new MeasureValidationError("Une révision non relue ne peut pas être publiée");
+    }
+    if (revision.discardedAt) {
+      throw new MeasureValidationError("Une révision abandonnée ne peut pas être publiée");
+    }
+    if (revision.supersededAt) {
+      throw new MeasureValidationError("Une révision remplacée ne peut pas être republiée");
+    }
+    if (revision._count.sources === 0) {
+      throw new MeasureValidationError("Une révision publiée doit porter au moins une source");
+    }
+
+    const now = new Date();
+
+    // Republishing the current revision while a draft is in flight must NOT move
+    // latestRevisionId: pointing it back at the published revision would leave the draft
+    // active with no pointer designating it, which the audit reports as an orphan.
+    // Reachable through an admin republish after a depublication.
+    const hasNewerDraft =
+      measure.latestRevisionId !== null &&
+      measure.latestRevisionId !== input.revisionId &&
+      measure.latestRevisionId !== measure.publishedRevisionId;
+
+    if (measure.publishedRevisionId && measure.publishedRevisionId !== input.revisionId) {
+      await tx.measureRevision.update({
+        where: { id: measure.publishedRevisionId },
+        data: { supersededAt: now },
+      });
+    }
+
+    await tx.measureRevision.update({
+      where: { id: input.revisionId },
+      data: { publishedAt: now },
+    });
+
+    await tx.measure.update({
+      where: { id: input.measureId },
+      data: {
+        publishedRevisionId: input.revisionId,
+        publicationStatus: "PUBLISHED",
+        depublishedAt: null,
+        depublicationReason: null,
+        // Publishing normally makes the revision the latest state too, unless a newer
+        // draft is in flight (see hasNewerDraft above).
+        ...(hasNewerDraft ? {} : { latestRevisionId: input.revisionId }),
+      },
+    });
+
+    // In the same transaction: the database must never expose a new revision while the
+    // index still holds the previous text. Called last, so it reads the pointers this
+    // transaction has just written.
+    await syncSearchDocument(tx, input.measureId);
+
+    return { electionId: measure.electionId };
+  });
+
+  invalidateMeasureTags(input.measureId, electionId);
+}
+
+/**
+ * Our act: removing a published measure from the site. Reserved for content that is
+ * legally or factually dangerous, which is why it demands a reason.
+ *
+ * Does not touch the revision: what the candidate said has not changed, only our decision
+ * to show it.
+ */
+export async function depublishMeasure(input: {
+  measureId: string;
+  reason: string;
+}): Promise<void> {
+  if (input.reason.trim() === "") {
+    throw new MeasureValidationError("Une dépublication exige un motif");
+  }
+
+  const { electionId } = await db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    const measure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: { electionId: true },
+    });
+
+    await tx.measure.update({
+      where: { id: input.measureId },
+      data: {
+        publicationStatus: "DRAFT",
+        depublishedAt: new Date(),
+        depublicationReason: input.reason,
+      },
+    });
+
+    // Re-derives rather than just flipping visibility. With a draft in flight, the
+    // reference revision becomes latestRevisionId, so the document must carry the draft
+    // text: only changing visibility would leave it aligned on the former published
+    // revision, which the staleness rule reports as stale. The row is kept either way, an
+    // upsert never deletes.
+    await syncSearchDocument(tx, input.measureId);
+
+    return { electionId: measure.electionId };
+  });
+
+  invalidateMeasureTags(input.measureId, electionId);
+}
+
+/**
+ * The candidate's act: dropping a proposal before the election. Not a revision, and not a
+ * depublication. The measure keeps its published revision and its sources, and its
+ * withdrawal state is displayed explicitly.
+ *
+ * The three withdrawal fields are written here and nowhere else, and never separately.
+ *
+ * No syncSearchDocument call, same as reviewMeasureRevision: neither changes the pointers,
+ * the visibility or the indexed text. A withdrawal is displayed by the page, it does not
+ * change the searchable content, so syncing here would be a write that changes nothing.
+ */
+export async function withdrawMeasure(input: {
+  measureId: string;
+  withdrawnAt: Date;
+  sourceUrl: string;
+  sourceLabel: string;
+}): Promise<void> {
+  if (input.sourceUrl.trim() === "" || input.sourceLabel.trim() === "") {
+    throw new MeasureValidationError("Un retrait exige une URL et un libellé de source, les deux");
+  }
+
+  const { electionId } = await db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    const measure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: { electionId: true },
+    });
+
+    await tx.measure.update({
+      where: { id: input.measureId },
+      data: {
+        withdrawnAt: input.withdrawnAt,
+        withdrawnSourceUrl: input.sourceUrl,
+        withdrawnSourceLabel: input.sourceLabel,
+      },
+    });
+
+    return { electionId: measure.electionId };
+  });
+
+  invalidateMeasureTags(input.measureId, electionId);
 }

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/generated/prisma";
 import { db, type DbTransactionClient } from "@/lib/db";
 import { MeasureValidationError } from "./errors";
+import { lockMeasure } from "./lock";
 import { syncSearchDocument } from "./search-sync";
 
 export type MeasureSourceInput = {
@@ -149,5 +150,74 @@ export async function createMeasure(
     await syncSearchDocument(tx, measure.id);
 
     return { measureId: measure.id, revisionId: revision.id };
+  });
+}
+
+export type DraftMeasureRevisionInput = {
+  measureId: string;
+  revision: MeasureRevisionInput;
+  sources: MeasureSourceInput[];
+};
+
+// No `discardedBy` and no `supersedesDraftBy`. A first version of this plan took a
+// `supersedesDraftBy` and never stored it anywhere, which is a parameter documenting an
+// intention the code does not honour. Attributing a discard needs a real column on
+// MeasureRevision, and the moderation admin is what will know whether it needs one.
+
+/**
+ * Creates a new revision in draft. The public keeps seeing publishedRevisionId, which
+ * this function never touches.
+ *
+ * Also discards the previous active draft, and that second write is the point: without
+ * it, two successive calls leave two active drafts while latestRevisionId designates only
+ * one of them. The other becomes an orphan no path can ever publish or clean up.
+ */
+export async function draftMeasureRevision(
+  input: DraftMeasureRevisionInput
+): Promise<{ revisionId: string }> {
+  assertRevisionIsUsable(input.revision, input.sources);
+
+  return db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    const measure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: { latestRevisionId: true, publishedRevisionId: true },
+    });
+
+    // The previous latest revision is an active draft only if it is not the published
+    // one: a published revision is superseded at publication time, never discarded.
+    if (measure.latestRevisionId && measure.latestRevisionId !== measure.publishedRevisionId) {
+      await tx.measureRevision.update({
+        where: { id: measure.latestRevisionId },
+        data: { discardedAt: new Date() },
+      });
+    }
+
+    const revision = await tx.measureRevision.create({
+      data: {
+        measureId: input.measureId,
+        text: input.revision.text,
+        precision: input.revision.precision,
+        validFrom: input.revision.validFrom,
+        extractionMethod: input.revision.extractionMethod,
+        extractionConfidence: input.revision.extractionConfidence,
+        extractorVersion: input.revision.extractorVersion,
+        sources: { create: input.sources },
+      },
+    });
+
+    await tx.measure.update({
+      where: { id: input.measureId },
+      data: { latestRevisionId: revision.id },
+    });
+
+    // Re-derives the document. On a public measure this changes nothing, because the
+    // reference stays publishedRevisionId: that is precisely how a correction in progress
+    // stays invisible. On a never-published or depublished measure, it moves the
+    // ADMIN_ONLY document onto the new draft.
+    await syncSearchDocument(tx, input.measureId);
+
+    return { revisionId: revision.id };
   });
 }

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -221,3 +221,93 @@ export async function draftMeasureRevision(
     return { revisionId: revision.id };
   });
 }
+
+/**
+ * Records that a human read this formulation. Separate from publication on purpose: a
+ * function that receives reviewedAt as a parameter declares the review rather than
+ * verifying it, which made the guarantee "a published revision has been reviewed"
+ * circular in the first version of this plan.
+ */
+export async function reviewMeasureRevision(input: {
+  measureId: string;
+  revisionId: string;
+  reviewedBy: string;
+}): Promise<void> {
+  if (input.reviewedBy.trim() === "") {
+    throw new MeasureValidationError("Le relecteur doit être identifié");
+  }
+
+  await db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    const revision = await tx.measureRevision.findUnique({
+      where: { id: input.revisionId },
+      select: { measureId: true, discardedAt: true, supersededAt: true },
+    });
+    if (!revision) throw new MeasureValidationError(`Révision ${input.revisionId} introuvable`);
+    if (revision.measureId !== input.measureId) {
+      throw new MeasureValidationError("La révision appartient à une autre mesure");
+    }
+    if (revision.discardedAt) {
+      throw new MeasureValidationError("Une révision abandonnée ne peut pas être relue");
+    }
+    if (revision.supersededAt) {
+      throw new MeasureValidationError("Une révision remplacée ne peut pas être relue");
+    }
+
+    await tx.measureRevision.update({
+      where: { id: input.revisionId },
+      data: { reviewedAt: new Date(), reviewedBy: input.reviewedBy },
+    });
+  });
+}
+
+/**
+ * Abandons a draft. If it was the latest, the pointer falls back to the published
+ * revision, so the measure never designates a discarded draft as its latest state.
+ */
+export async function discardMeasureRevision(input: {
+  measureId: string;
+  revisionId: string;
+}): Promise<void> {
+  await db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+
+    // Ownership check, not a formality: the lock is taken on input.measureId, and the
+    // update targets input.revisionId. Without this, a call can lock measure A and set
+    // discardedAt on a revision of measure B, which is both unlocked and untouched by the
+    // caller's intent.
+    const revision = await tx.measureRevision.findUnique({
+      where: { id: input.revisionId },
+      select: { measureId: true },
+    });
+    if (!revision) throw new MeasureValidationError(`Révision ${input.revisionId} introuvable`);
+    if (revision.measureId !== input.measureId) {
+      throw new MeasureValidationError("La révision appartient à une autre mesure");
+    }
+
+    const measure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: { latestRevisionId: true, publishedRevisionId: true },
+    });
+    if (input.revisionId === measure.publishedRevisionId) {
+      throw new MeasureValidationError(
+        "Une révision publiée ne s'abandonne pas, elle se dépublie ou se remplace"
+      );
+    }
+
+    await tx.measureRevision.update({
+      where: { id: input.revisionId },
+      data: { discardedAt: new Date() },
+    });
+
+    if (measure.latestRevisionId === input.revisionId) {
+      await tx.measure.update({
+        where: { id: input.measureId },
+        data: { latestRevisionId: measure.publishedRevisionId },
+      });
+    }
+
+    await syncSearchDocument(tx, input.measureId);
+  });
+}


### PR DESCRIPTION
## Description

PR B du lot 1 sur quatre : le cycle éditorial complet d'une mesure. La PR A permettait d'en créer une,
sans jamais la publier. Six fonctions s'ajoutent ici, et chacune suit la même forme :

```
db.$transaction()
  → lockMeasure()          verrou de ligne AVANT toute lecture
  → lecture de l'état
  → validation des préconditions
  → écritures
  → syncSearchDocument()   dans la même transaction
commit
  → invalidation ciblée du cache, seulement si l'état public a changé
```

`draftMeasureRevision()` crée une révision en brouillon **et abandonne le brouillon actif précédent**.
Cette seconde écriture est tout l'objet de la fonction : sans elle, deux appels successifs laissent deux
brouillons actifs alors que `latestRevisionId` n'en désigne qu'un, et l'autre devient un orphelin
qu'aucun chemin ne peut plus publier ni nettoyer. Elle ne touche jamais `publishedRevisionId` : c'est
ainsi qu'une correction en cours reste invisible.

`reviewMeasureRevision()` pose elle-même `reviewedAt`. L'appelant ne peut pas déclarer une date de
relecture, et la signature de `publishMeasureRevision()` n'accepte aucun champ de relecture. Sans cette
séparation, la garantie « une révision publiée a été relue » serait circulaire : vraie parce que la
fonction l'écrit.

`discardMeasureRevision()` n'abandonne qu'un brouillon, refuse une révision publiée, et ramène
`latestRevisionId` sur `publishedRevisionId` pour qu'une mesure ne désigne jamais un brouillon abandonné
comme son état courant.

`publishMeasureRevision()` exige une révision qui appartient à la mesure, relue, non abandonnée, non
remplacée et sourcée. Elle supersède l'ancienne version publique, pose `publishedAt`, repointe
`publishedRevisionId` et passe la mesure à `PUBLISHED`.

`depublishMeasure()` est **notre** acte : nous retirons un contenu, donc un motif est exigé. La révision
n'est pas touchée, ce que le candidat a dit n'a pas changé. `withdrawMeasure()` est l'acte **du
candidat** : il abandonne sa proposition. La mesure reste publiée et indexée, et son retrait est affiché.
Les trois champs de retrait s'écrivent ensemble ou pas du tout : un `withdrawnAt` sans source serait une
affirmation non sourcée sur ce qu'un candidat a abandonné.

Aucune de ces opérations ne modifie `candidacyId`, `programEditionId` ni aucun autre élément de contexte.

## Le défaut le plus important de cette PR n'était pas dans le code

Le test de concurrence prévu par le plan **restait vert avec `FOR UPDATE` retiré**. L'ablation l'a montré,
et la raison mérite d'être écrite : `publishMeasureRevision()` termine par un `UPDATE` sur la ligne que la
transaction concurrente tient déjà. L'appel est donc bloqué par **l'écriture**, pas par le verrou de
lecture. Le test mesurait un délai qui existe de toute façon.

Ce que `FOR UPDATE` protège, c'est la séquence lire-puis-décider. Sans lui, deux publications concurrentes
lisent toutes les deux « aucune révision publiée », et la seconde écrit une décision prise sur une lecture
périmée. La violation observable n'est pas un délai : c'est **deux révisions publiées dont aucune n'est
remplacée**.

Le test réécrit fait donc courir deux publications sur **deux révisions relues distinctes**, la seconde
construite directement en base puisque `draftMeasureRevision` abandonnerait la première. Avec le verrou :
une seule révision courante, égale à `publishedRevisionId`. Sans : `expected [ …(2) ] to have a length of 1
but got 2`.

Le test de délai est conservé, renommé et recommenté pour ce qu'il montre réellement, c'est-à-dire moins :
l'appel ne passe pas outre une ligne qu'une autre transaction tient. Il ne distingue pas le verrou de
l'`UPDATE` final.

## L'atomicité, prouvée transition par transition

Un test qui lit l'état final ne prouve rien de l'atomicité : déplacer l'indexation après le commit le
laisse vert. Il faut faire **échouer** l'indexation. Une contrainte `CHECK … NOT VALID` posée le temps du
test refuse toute écriture d'un `SearchDocument` de type `MEASURE`, et le `NOT VALID` est indispensable
puisque les tests précédents du même passage en ont déjà écrit.

Le helper `withIndexingRejected()` porte ce mécanisme, et trois tests l'utilisent :

- **brouillon** : deux écritures précèdent l'indexation, l'abandon du brouillon précédent et la création du
  nouveau. Un rollback partiel laisserait le brouillon d'origine abandonné sans rien pour le remplacer ;
- **publication** : trois écritures précèdent. Un rollback partiel mettrait la mesure en ligne alors que
  l'index décrit encore un brouillon, exactement l'état que la règle « même transaction » rend impossible ;
- **dépublication** : un rollback partiel serait le pire des deux, la mesure marquée dépubliée et l'index
  la servant encore en `PUBLIC`.

Ablation faite sur la publication : indexation sortie de la transaction, `expected 'PUBLISHED' to be
'DRAFT'`.

## Le cache, et ce qu'on ne prétend pas

`invalidateMeasureTags()` s'exécute **après** le commit, jamais dedans : un appel à la plateforme
d'hébergement n'est pas atomique avec PostgreSQL et le décrire ainsi serait faux. Deux étiquettes ciblées,
jamais l'étiquette globale, dont la purge avait une fois fait exploser le plafond de dépense.

Pas de table d'invalidation, pas de file d'attente, **pas de réessai**. Un réessai gardé en mémoire ne
survit pas à la fin de la lambda : il achèterait l'apparence d'une garantie et rien d'autre. Une
invalidation perdue laisse la page périmée jusqu'à l'expiration de son profil `cacheLife`, ce qui est un
défaut connu et borné. Le module délègue à `src/lib/cache.ts`, dont le `revalidateTags(tags, profile)`
connaît déjà le second argument obligatoire de cette version de Next.

## Trois choses trouvées en exécutant

**Un `select` mort.** Le plan faisait lire `withdrawnAt` à la publication sans jamais s'en servir, et
aucune règle du lot ne dit ce qu'une publication doit faire d'une mesure retirée. Je l'ai retiré plutôt que
d'inventer une garde absente de la spec. **Question ouverte** : peut-on publier une nouvelle révision d'une
mesure retirée ? Corriger une coquille dans un texte historique semble légitime, mais rien ne le tranche.

**Les fixtures cassaient les six fichiers sans base.** `helpers.ts` importait `../transitions` de façon
statique, donc la chaîne chargeait `@/lib/db` et tous les fichiers de mesures échouaient **au chargement**,
pas en assertion : la suite affiche alors « 6 files failed, 0 tests failed », ce qui n'est pas un échec de
test. Import différé dans les fixtures, `import type` là où le type suffit. Même piège que la PR A, par un
chemin transitif cette fois.

**Le journal d'invalidation demandait sa justification.** ESLint interdit `console` en avertissement, et le
dépôt a une convention pour les signaux d'exploitation délibérés. Directive posée sur la bonne ligne, ce
qui n'était pas le cas du premier essai : un commentaire de deux lignes place
`eslint-disable-next-line` devant la seconde ligne de commentaire, pas devant le code.

## Une garde de CI corrigée au passage

Le job Security a rougi sur cette PR, et c'était un faux positif. Sa règle cherche le littéral
`publicationStatus: "PUBLISHED"` hors de `src/lib/affairs/publish-guard.ts` : la détection est lexicale,
donc aveugle au modèle, et `PublicationStatus` est un enum partagé. Elle attrapait la publication d'une
mesure alors qu'elle vise la publication d'une affaire (RGPD art. 10).

Corrigé en nommant **un fichier autorisé par modèle**, jamais un répertoire : `publish-guard.ts` pour les
affaires, `transitions.ts` pour les mesures. Tout autre fichier qui publierait une mesure reste détecté,
ce qui est bien l'invariant voulu. Vérifié dans les deux sens en rejouant la règle en local : sans
l'exclusion, elle nomme `src/lib/measures/transitions.ts:396` ; avec, elle ne trouve rien.

## Un aléa de CI, sans rapport avec cette PR

Le job Unit Tests a échoué une première fois sur `src/lib/api/rss.test.ts`, avec
`Failed to fetch RSS feed Mediacités: TypeError: fetch failed`. Ce test fait un **appel réseau réel** vers
un site tiers, il est donc rouge quand ce site est indisponible. Il est passé au second essai. Cela
explique aussi un échec local isolé que je n'avais pas su nommer pendant la PR A, dont la durée anormale
collait à un délai réseau.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Aucune. Étape interne du chantier hub présidentielle, deuxième des quatre PR du lot 1.

## Vérifications

92 tests verts sous `npm run test:db:search`, dont 36 sur les mesures. Les mêmes en skip sous
`npx vitest run`, jamais en échec. Suite complète : 3165 verts. `npx tsc --noEmit` en code 0 sur cache
froid, ESLint propre sur `src/lib/measures` avec `--max-warnings=0`.

Onze ablations, chacune ayant produit l'échec annoncé avant d'être remise :

| Ce qu'on retire                                                 | Ce qui tombe                                                |
| --------------------------------------------------------------- | ----------------------------------------------------------- |
| l'abandon du brouillon précédent                                | l'unicité du brouillon actif, trois brouillons au lieu d'un |
| la condition « pas la révision publiée » sur cet abandon        | la révision publiée se retrouve abandonnée                  |
| l'appartenance dans `reviewMeasureRevision`                     | une révision étrangère est marquée relue                    |
| l'appartenance dans `discardMeasureRevision`                    | un brouillon d'une autre mesure est abandonné               |
| `FOR UPDATE` du verrou                                          | deux révisions publiées dont aucune remplacée               |
| le garde de relecture                                           | une révision non relue est publiée                          |
| l'indexation de la publication                                  | le document reste `ADMIN_ONLY` sur l'ancienne révision      |
| la condition `hasNewerDraft`                                    | le brouillon en cours est orphelin                          |
| la dépublication qui supprime le document au lieu de le masquer | le document disparaît                                       |
| le garde de source du retrait                                   | un retrait non sourcé est accepté                           |
| l'indexation sortie de la transaction de publication            | le rollback n'a plus lieu                                   |

Les deux ablations d'appartenance sont nécessaires séparément : les deux fonctions ont **la même faille
possible**, le verrou étant pris sur `measureId` tandis que l'écriture cible `revisionId`.

## Quatre tests ajoutés au plan

Le plan vérifiait les pointeurs, pas ce que la recherche expose, alors que c'est là que la fuite se
verrait.

- le document reste sur la révision publiée pendant qu'un brouillon est en cours, et son corps **ne
  contient pas** le texte du brouillon ;
- le document disparaît quand une mesure jamais publiée perd son unique brouillon : il ne reste rien à
  représenter, et le garder ferait proposer par la recherche de modération une mesure dont le texte
  n'existe plus nulle part ;
- les trois tests de rollback décrits plus haut, dont la liste de vérification attendait un par transition
  qui indexe.
