### PR TITLE
Livrer les métadonnées éditoriales et la lecture publique (lot 1, PR C)

### DIFF
--- a/docs/editorial/qualifications-mesures.md
+++ b/docs/editorial/qualifications-mesures.md
@@ -1,0 +1,154 @@
+# Qualificatifs des mesures : définitions opposables
+
+Ce document est la condition pour que l'enum `QualificationKind` garantisse quelque chose. Un enum fermé
+sans définitions ne garantit rien : deux relecteurs appliqueraient le même qualificatif sur des critères
+différents, et personne ne pourrait contester l'un sans contester l'autre.
+
+Chaque qualificatif est une **conclusion éditoriale datée** sur **une formulation**, jamais une propriété
+de la mesure. Il est rattaché à la révision examinée, porte la date de l'examen et le nom de son auteur.
+Une reformulation n'hérite d'aucune conclusion.
+
+Le **corpus examiné** est la partie la plus importante de chaque définition. « Financement non précisé »
+donne trois réponses différentes selon qu'on a lu la seule révision, ses sources primaires, ou le
+programme entier du candidat. Sans corpus explicite, le qualificatif ne dit pas ce qu'il constate.
+
+Le **cas limite** de chaque section n'est pas décoratif : c'est lui qui empêche deux lectures divergentes.
+Une définition sans cas limite se réduit à son intitulé.
+
+Les exemples ci-dessous sont **construits**, le corpus réel n'existant pas encore. À remplacer par des cas
+tirés du corpus dès qu'il y en a, en gardant la structure.
+
+---
+
+## FINANCEMENT_NON_PRECISE
+
+**Ce que le qualificatif affirme.** La formulation examinée ne dit pas d'où vient l'argent, ni combien
+elle coûte.
+
+**Corpus examiné.** La révision concernée **et** ses sources primaires, rien de plus. Pas le programme
+entier du candidat : un chiffrage qui figure dans un autre document ne rend pas cette formulation
+précise, et aller le chercher reviendrait à réécrire la mesure à la place de son auteur.
+
+**Deux exemples positifs.**
+
+1. « Doubler l'allocation de rentrée scolaire. » Aucun montant, aucune ressource, aucune source primaire
+   qui en parle.
+2. « Créer 10 000 places de crèche. » Un volume chiffré mais aucun coût ni financement, et la source
+   primaire est un discours qui n'aborde pas le budget.
+
+**Deux exemples négatifs, dont un cas limite.**
+
+1. « Créer 10 000 places de crèche, financées par le redéploiement du crédit d'impôt famille. » Le
+   financement est nommé. Qu'il soit suffisant est une autre question, qui n'est pas celle-ci.
+2. **Cas limite.** « Doubler l'allocation de rentrée scolaire, coût estimé à 1,2 milliard d'euros. » Le
+   coût est chiffré, la ressource ne l'est pas. Le qualificatif ne s'applique **pas** : il porte sur
+   l'absence d'information et non sur son insuffisance. Pour ce cas, `PERIMETRE_INCERTAIN` ne convient pas
+   non plus. Aucun qualificatif n'est posé.
+
+**Ce que le qualificatif n'affirme pas.** Ni que la mesure est infinançable, ni qu'elle est coûteuse, ni
+que le candidat a été évasif. Il constate une absence dans un texte, à une date.
+
+---
+
+## DEJA_TENTEE
+
+**Ce que le qualificatif affirme.** Un dispositif de même objet et de même mécanisme a déjà été mis en
+œuvre en France, et cette mise en œuvre est documentée.
+
+**Corpus examiné.** La révision concernée, plus **au moins une source secondaire vérifiable** attestant la
+tentative antérieure : texte au Journal officiel, rapport d'évaluation publique, ou travail parlementaire.
+Une ressemblance repérée de mémoire ne suffit pas, et ce qualificatif est le seul des quatre qui exige une
+source rattachée.
+
+**Deux exemples positifs.**
+
+1. « Instaurer une taxe sur les transactions financières. » Un dispositif de ce nom existe depuis 2012,
+   son périmètre et son rendement sont documentés.
+2. « Rétablir l'encadrement des loyers dans les zones tendues. » Encadré de 2014 à 2017 puis rétabli à
+   Paris en 2019, avec des évaluations publiques disponibles.
+
+**Deux exemples négatifs, dont un cas limite.**
+
+1. « Créer un revenu universel versé à tous les résidents. » Des expérimentations locales ont eu lieu
+   ailleurs, aucun dispositif national de même mécanisme en France.
+2. **Cas limite.** « Supprimer la taxe d'habitation sur les résidences secondaires. » La taxe
+   d'habitation sur les résidences **principales** a bien été supprimée, mais l'objet diffère : même nom,
+   autre assiette, autres bénéficiaires. Le qualificatif ne s'applique pas. Une ressemblance de vocabulaire
+   n'est pas une identité de dispositif.
+
+**Ce que le qualificatif n'affirme pas.** Ni que la mesure a échoué, ni qu'elle échouera, ni qu'elle est
+inutile. Un dispositif déjà tenté peut avoir été abandonné pour des raisons politiques et non pour son
+inefficacité. Le qualificatif situe une proposition dans une histoire, il ne la juge pas.
+
+---
+
+## CALENDRIER_PRECISE
+
+**Ce que le qualificatif affirme.** La formulation examinée engage une échéance vérifiable : une date, une
+durée, ou un rattachement explicite à un exercice budgétaire.
+
+**Corpus examiné.** La révision concernée seule. Le calendrier fait partie de ce qui est dit ou n'en fait
+pas partie, et un calendrier annoncé ailleurs n'engage pas cette formulation.
+
+C'est le seul des quatre qualificatifs qui constate une **présence** et non une absence. Il ne signale
+donc pas un défaut, et l'interface ne doit pas le rendre comme un reproche.
+
+**Deux exemples positifs.**
+
+1. « Porter le SMIC à 1 600 euros nets dès le 1er juillet 2027. » Une date, une valeur cible.
+2. « Recruter 10 000 enseignants sur les trois premiers budgets de la mandature. » Une durée rattachée à
+   des exercices identifiables.
+
+**Deux exemples négatifs, dont un cas limite.**
+
+1. « Augmenter significativement le SMIC. » Ni date, ni durée, ni exercice.
+2. **Cas limite.** « Engager la réforme dès le début du mandat. » Une intention de rapidité, pas une
+   échéance : « le début du mandat » ne se vérifie pas. Le qualificatif ne s'applique pas. La frontière est
+   la vérifiabilité, pas la présence d'un mot de temps.
+
+**Ce que le qualificatif n'affirme pas.** Ni que l'échéance est réaliste, ni qu'elle sera tenue, ni que la
+mesure est prioritaire. Le suivi de l'exécution est un autre chantier, avec ses propres sources.
+
+---
+
+## PERIMETRE_INCERTAIN
+
+**Ce que le qualificatif affirme.** La formulation examinée ne permet pas de dire **à qui** ou **à quoi**
+elle s'applique, à un degré qui empêcherait de la mettre en œuvre telle quelle.
+
+**Corpus examiné.** La révision concernée **et** ses sources primaires. Une précision apportée en
+interview compte, elle fait partie de ce que le candidat a dit.
+
+**Deux exemples positifs.**
+
+1. « Exonérer les classes moyennes d'impôt sur le revenu. » « Classes moyennes » n'a pas de définition
+   opposable, et aucune source primaire n'en donne de bornes.
+2. « Réguler les plateformes numériques. » Ni les plateformes visées, ni la nature de la régulation ne
+   sont identifiables.
+
+**Deux exemples négatifs, dont un cas limite.**
+
+1. « Exonérer d'impôt sur le revenu les foyers dont le revenu fiscal de référence est inférieur à 30 000
+   euros. » Le périmètre est une règle applicable.
+2. **Cas limite.** « Réguler les plateformes numériques de plus de 45 millions d'utilisateurs mensuels
+   dans l'Union. » Le seuil renvoie à une catégorie juridique existante, celle des très grandes plateformes
+   au sens du règlement européen sur les services numériques. Le périmètre est donc déterminable même s'il
+   n'est pas énuméré. Le qualificatif ne s'applique pas : un renvoi à une norme existante est une
+   définition, pas un flou.
+
+**Ce que le qualificatif n'affirme pas.** Ni que la mesure est vague par calcul, ni qu'elle est
+irréalisable. Beaucoup de propositions de campagne sont formulées avant leur rédaction juridique, ce qui
+est une étape normale et non une faute. Le qualificatif dit qu'à cette date, sur ce texte, le périmètre
+n'est pas déterminable.
+
+---
+
+## Ce que ce document ne couvre pas
+
+L'**unicité** d'une mesure n'est pas un qualificatif. Elle est portée par
+`MeasureSimilarityAssessment`, avec la version du corpus comparé et la date, parce qu'une mesure paraît
+unique jusqu'à la publication du programme suivant. Un qualificatif « mesure unique » serait faux quelques
+semaines après avoir été posé.
+
+Les **drapeaux de relecture** internes, qui signalent au relecteur ce qu'il faut regarder, ne sont pas des
+qualificatifs publics et n'appartiennent pas à cet enum.

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -87,6 +87,7 @@ else
   # the disposable container, so running it outside this harness proves half the guard.
   echo "[test:db:search] running the suites that need the disposable container"
   npx vitest run --no-file-parallelism \
+    src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/search \
     src/lib/measures \
     src/test/__tests__/db-guard.test.ts

--- a/src/lib/data/__tests__/measures.integration.test.ts
+++ b/src/lib/data/__tests__/measures.integration.test.ts
@@ -1,0 +1,266 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import {
+  draftInput,
+  publishSeededMeasure,
+  seedMeasureWithDraft,
+} from "@/lib/measures/__tests__/helpers";
+
+// Deferred: both `../measures` and the transitions import `@/lib/db` as a value, which
+// throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let reads: typeof import("../measures");
+let transitions: typeof import("@/lib/measures/transitions");
+
+describeIfDisposableDb("public measure filter", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    reads = await import("../measures");
+    transitions = await import("@/lib/measures/transitions");
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("hides a PUBLISHED measure whose pointed revision is not reviewed", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    // Built directly in the database on purpose: no public call can produce this state,
+    // which is exactly why the filter must not trust publicationStatus alone.
+    await db.measure.update({
+      where: { id: measureId },
+      data: { publicationStatus: "PUBLISHED", publishedRevisionId: revisionId },
+    });
+
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+  });
+
+  it("hides a PUBLISHED measure whose pointed revision has no publishedAt", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { reviewedAt: new Date(), reviewedBy: "relecteur" },
+    });
+    await db.measure.update({
+      where: { id: measureId },
+      data: { publicationStatus: "PUBLISHED", publishedRevisionId: revisionId },
+    });
+
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+  });
+
+  it("hides a PUBLISHED measure whose pointed revision is superseded", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { supersededAt: new Date() },
+    });
+
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+  });
+
+  it("hides a PUBLISHED measure whose pointed revision has no source", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureSource.deleteMany({ where: { measureRevisionId: revisionId } });
+
+    // An unsourced measure on a public page is exactly what this project exists not to
+    // publish.
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+  });
+
+  it("hides a depublished measure", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await transitions.depublishMeasure({ measureId, reason: "Erreur factuelle." });
+
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+  });
+
+  it("returns a published measure with its sources and qualifications", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    const measure = await reads.getPublicMeasure(measureId);
+
+    expect(measure).not.toBeNull();
+    expect(measure?.sources.length).toBeGreaterThan(0);
+    expect(measure?.withdrawal).toBeNull();
+  });
+
+  it("moderation reads see what the public filter hides", async () => {
+    const { measureId } = await seedMeasureWithDraft();
+
+    expect(await reads.getPublicMeasure(measureId)).toBeNull();
+    const moderation = await reads.getMeasureForModeration(measureId);
+    expect(moderation?.revisions).toHaveLength(1);
+  });
+});
+
+describeIfDisposableDb("withdrawn measures in the reads", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    reads = await import("../measures");
+    transitions = await import("@/lib/measures/transitions");
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  async function withdrawn() {
+    const seeded = await publishSeededMeasure();
+    await transitions.withdrawMeasure({
+      measureId: seeded.measureId,
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait",
+      sourceLabel: "Le Monde, 1er mars 2027",
+    });
+    return seeded;
+  }
+
+  it("keeps a withdrawn measure visible on its detail read, with its withdrawal state", async () => {
+    const { measureId } = await withdrawn();
+
+    const measure = await reads.getPublicMeasure(measureId);
+
+    // Not a filter: erasing a proposal a candidate carried then dropped would delete
+    // information that matters. The page shows the withdrawal, it does not hide the row.
+    expect(measure).not.toBeNull();
+    expect(measure?.withdrawal?.withdrawnAt).not.toBeNull();
+    expect(measure?.withdrawal?.sourceLabel).toBe("Le Monde, 1er mars 2027");
+    expect(measure?.withdrawal?.sourceUrl).toBe("https://example.org/retrait");
+  });
+
+  it("excludes a withdrawn measure from the lists by default", async () => {
+    const { measureId } = await withdrawn();
+    const election = await db.measure.findUniqueOrThrow({
+      where: { id: measureId },
+      select: { electionId: true, theme: true },
+    });
+
+    const byElection = await reads.getPublicMeasuresByElection(election.electionId);
+    const byTheme = await reads.getPublicMeasuresByTheme(election.electionId, election.theme);
+
+    // A list answers "which proposals are currently defended". Showing a dropped one there
+    // states something false about the candidate, and a caller who forgets the option must
+    // get the safe answer.
+    expect(byElection.map((m) => m.id)).not.toContain(measureId);
+    expect(byTheme.map((m) => m.id)).not.toContain(measureId);
+  });
+
+  it("returns it when the caller asks for withdrawn measures explicitly", async () => {
+    const { measureId } = await withdrawn();
+    const election = await db.measure.findUniqueOrThrow({
+      where: { id: measureId },
+      select: { electionId: true },
+    });
+
+    const all = await reads.getPublicMeasuresByElection(election.electionId, {
+      includeWithdrawn: true,
+    });
+
+    expect(all.map((m) => m.id)).toContain(measureId);
+  });
+
+  it("publishes a correction of a withdrawn measure without reactivating it", async () => {
+    const { measureId } = await withdrawn();
+    const before = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+
+    // Publishing a revision is an EDITORIAL act, withdrawing is the candidate's POLITICAL
+    // act. A historical correction must stay possible, and must never reactivate the
+    // proposal.
+    const { revisionId: correction } = await transitions.draftMeasureRevision(
+      draftInput(measureId, "Encadrer les loyers dans les zones tendues, formulation corrigée.")
+    );
+    await transitions.reviewMeasureRevision({
+      measureId,
+      revisionId: correction,
+      reviewedBy: "relecteur",
+    });
+    await transitions.publishMeasureRevision({ measureId, revisionId: correction });
+
+    const after = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    const measure = await reads.getPublicMeasure(measureId);
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // The public revision and the index follow the correction...
+    expect(after.publishedRevisionId).toBe(correction);
+    expect(measure?.text).toContain("formulation corrigée");
+    expect(doc.sourceRevisionId).toBe(correction);
+    expect(doc.body).toContain("formulation corrigée");
+
+    // ...and the three withdrawal fields are byte for byte what they were.
+    expect(after.withdrawnAt).toStrictEqual(before.withdrawnAt);
+    expect(after.withdrawnSourceUrl).toBe(before.withdrawnSourceUrl);
+    expect(after.withdrawnSourceLabel).toBe(before.withdrawnSourceLabel);
+    expect(measure?.withdrawal).not.toBeNull();
+  });
+
+  it("keeps a withdrawn measure in the search index, not hidden from it", async () => {
+    const { measureId } = await withdrawn();
+
+    const doc = await db.searchDocument.findUniqueOrThrow({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+    });
+
+    // The search keeps withdrawn measures; marking them visibly is the interface's job.
+    // Dropping them from the index would make a proposal a candidate publicly carried
+    // unfindable.
+    expect(doc.visibility).toBe("PUBLIC");
+  });
+});
+
+describeIfDisposableDb("getRevisionInForceAt", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    reads = await import("../measures");
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("returns nothing before the first published revision", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    expect(
+      await reads.getRevisionInForceAt(measureId, new Date("2020-01-01T00:00:00Z"))
+    ).toBeNull();
+  });
+
+  it("returns the published revision after its date", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+
+    const inForce = await reads.getRevisionInForceAt(measureId, new Date("2027-06-01T00:00:00Z"));
+
+    expect(inForce?.id).toBe(revisionId);
+  });
+
+  it("never returns a draft that was never published", async () => {
+    const { measureId, revisionId: published } = await publishSeededMeasure();
+    // validFrom AFTER the published revision's (2027-01-01) and before the query date.
+    // The plan put it in 2020 and explained that "the draft has the earliest validFrom, so
+    // an ordering without the publishedAt condition would pick it". That is backwards: with
+    // ORDER BY validFrom DESC the earliest sorts LAST, so the published revision won either
+    // way and the test stayed green with the guard removed. It has to be the most recent
+    // candidate to be the one a missing guard would select.
+    const draft = await db.measureRevision.create({
+      data: {
+        measureId,
+        text: "Brouillon jamais publié.",
+        validFrom: new Date("2027-03-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+      },
+    });
+
+    const inForce = await reads.getRevisionInForceAt(measureId, new Date("2027-06-01T00:00:00Z"));
+
+    // Both assertions: "not the draft" alone would also pass on null, which is not the
+    // behaviour wanted here.
+    expect(inForce?.id).not.toBe(draft.id);
+    expect(inForce?.id).toBe(published);
+  });
+});

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -1,0 +1,193 @@
+import type { Prisma, ThemeCategory } from "@/generated/prisma";
+import { db } from "@/lib/db";
+
+/**
+ * The two cumulative publication conditions, as a reusable predicate.
+ *
+ * publicationStatus alone is not enough, and that is the whole point: the second condition
+ * is about the state of the revision the pointer designates. A measure can be PUBLISHED
+ * while pointing at a revision that was never reviewed, never published, has been
+ * superseded, or carries no source, and each of those must stay invisible.
+ */
+const PUBLIC_MEASURE_WHERE = {
+  publicationStatus: "PUBLISHED",
+  publishedRevisionId: { not: null },
+  publishedRevision: {
+    reviewedAt: { not: null },
+    publishedAt: { not: null },
+    supersededAt: null,
+    discardedAt: null,
+    sources: { some: {} },
+  },
+} satisfies Prisma.MeasureWhereInput;
+
+const PUBLIC_MEASURE_INCLUDE = {
+  publishedRevision: {
+    include: {
+      sources: { orderBy: { publishedAt: "asc" } },
+      qualifications: { orderBy: { assessedAt: "desc" } },
+    },
+  },
+} satisfies Prisma.MeasureInclude;
+
+type MeasureRow = Prisma.MeasureGetPayload<{ include: typeof PUBLIC_MEASURE_INCLUDE }>;
+type PublishedRevision = NonNullable<MeasureRow["publishedRevision"]>;
+
+/**
+ * The withdrawal state, as one object rather than three loose fields.
+ *
+ * Its PRESENCE is the fact that the candidate dropped the proposal, and that fact must
+ * never be hidden: a page showing a withdrawn measure as if it were still defended is a
+ * factual error, which is worse than a missing source label.
+ *
+ * That is why the two source fields are nullable inside a non-null object, which is the one
+ * deviation from the shape asked for in review. withdrawMeasure() writes the three fields
+ * together or none, so a partial state can only come from a direct database write, and the
+ * audit reports it. Requiring both sources here would mean returning `withdrawal: null` on
+ * such a row, which hides a real withdrawal to protect a type.
+ */
+export type MeasureWithdrawal = {
+  withdrawnAt: Date;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+};
+
+/**
+ * What a public surface receives. `text` is non-nullable while Measure.publishedRevisionId
+ * is nullable, and that narrowing is the whole point of this layer: a component must never
+ * have to ask whether the revision it renders exists.
+ */
+export type PublicMeasure = {
+  id: string;
+  text: string;
+  precision: PublishedRevision["precision"];
+  theme: MeasureRow["theme"];
+  attribution: MeasureRow["attribution"];
+  politicianId: string;
+  candidacyId: string | null;
+  withdrawal: MeasureWithdrawal | null;
+  sources: PublishedRevision["sources"];
+  qualifications: PublishedRevision["qualifications"];
+};
+
+function toPublicMeasure(row: MeasureRow): PublicMeasure | null {
+  const revision = row.publishedRevision;
+  // Defensive and not redundant with the where clause: this is the only place that turns a
+  // nullable pointer into a non-nullable text, so the narrowing has to be here.
+  if (!revision) return null;
+
+  return {
+    id: row.id,
+    text: revision.text,
+    precision: revision.precision,
+    theme: row.theme,
+    attribution: row.attribution,
+    politicianId: row.politicianId,
+    candidacyId: row.candidacyId,
+    withdrawal: row.withdrawnAt
+      ? {
+          withdrawnAt: row.withdrawnAt,
+          sourceUrl: row.withdrawnSourceUrl,
+          sourceLabel: row.withdrawnSourceLabel,
+        }
+      : null,
+    sources: revision.sources,
+    qualifications: revision.qualifications,
+  };
+}
+
+/**
+ * Lists answer "which proposals are currently defended", so they exclude withdrawn
+ * measures BY DEFAULT. A caller who forgets the option gets the safe answer; showing a
+ * dropped proposal in a programme listing states something false about the candidate.
+ *
+ * Withdrawn measures stay reachable explicitly, for a history view. Detail reads never
+ * filter on withdrawal at all.
+ */
+export type MeasureListOptions = { includeWithdrawn?: boolean };
+
+function withdrawalFilter(options?: MeasureListOptions): Prisma.MeasureWhereInput {
+  return options?.includeWithdrawn ? {} : { withdrawnAt: null };
+}
+
+/**
+ * Detail read. Includes withdrawn measures on purpose: erasing a proposal a candidate
+ * publicly carried and then dropped would delete information that matters, and the page
+ * displays the withdrawal instead of hiding the row.
+ */
+export async function getPublicMeasure(measureId: string): Promise<PublicMeasure | null> {
+  const row = await db.measure.findFirst({
+    where: { id: measureId, ...PUBLIC_MEASURE_WHERE },
+    include: PUBLIC_MEASURE_INCLUDE,
+  });
+  return row ? toPublicMeasure(row) : null;
+}
+
+export async function getPublicMeasuresByElection(
+  electionId: string,
+  options?: MeasureListOptions
+): Promise<PublicMeasure[]> {
+  const rows = await db.measure.findMany({
+    where: { electionId, ...PUBLIC_MEASURE_WHERE, ...withdrawalFilter(options) },
+    include: PUBLIC_MEASURE_INCLUDE,
+    orderBy: { createdAt: "asc" },
+  });
+  return rows.map(toPublicMeasure).filter((m): m is PublicMeasure => m !== null);
+}
+
+export async function getPublicMeasuresByTheme(
+  electionId: string,
+  theme: ThemeCategory,
+  options?: MeasureListOptions
+): Promise<PublicMeasure[]> {
+  const rows = await db.measure.findMany({
+    where: { electionId, theme, ...PUBLIC_MEASURE_WHERE, ...withdrawalFilter(options) },
+    include: PUBLIC_MEASURE_INCLUDE,
+    orderBy: { createdAt: "asc" },
+  });
+  return rows.map(toPublicMeasure).filter((m): m is PublicMeasure => m !== null);
+}
+
+/**
+ * Moderation read. Applies NO filter, on purpose: the admin has to see drafts, discarded
+ * revisions and depublished measures, which is the whole reason the public and moderation
+ * reads are two different functions in the same file.
+ */
+export async function getMeasureForModeration(measureId: string) {
+  return db.measure.findUnique({
+    where: { id: measureId },
+    include: {
+      revisions: {
+        include: {
+          sources: true,
+          qualifications: true,
+          assessments: { include: { matches: true } },
+        },
+        orderBy: { validFrom: "desc" },
+      },
+    },
+  });
+}
+
+/**
+ * The revision publicly in force on a given day. The condition on publishedAt is not
+ * optional: without it the query can select a draft that was never published, and make the
+ * site report a text it never displayed.
+ */
+export async function getRevisionInForceAt(
+  measureId: string,
+  at: Date
+): Promise<{ id: string; text: string } | null> {
+  const rows = await db.measureRevision.findMany({
+    where: {
+      measureId,
+      publishedAt: { not: null, lte: at },
+      validFrom: { lte: at },
+      OR: [{ supersededAt: null }, { supersededAt: { gt: at } }],
+    },
+    orderBy: { validFrom: "desc" },
+    take: 1,
+    select: { id: true, text: true },
+  });
+  return rows[0] ?? null;
+}

--- a/src/lib/measures/__tests__/assessments.integration.test.ts
+++ b/src/lib/measures/__tests__/assessments.integration.test.ts
@@ -1,0 +1,177 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { seedMeasureWithDraft } from "./helpers";
+
+// Deferred: `../assessments` imports `@/lib/db` as a value, which throws at module load
+// without DATABASE_URL, so a static import fails the file instead of skipping.
+let db: typeof import("@/lib/db").db;
+let createQualification: typeof import("../assessments").createQualification;
+let createSimilarityAssessment: typeof import("../assessments").createSimilarityAssessment;
+
+describeIfDisposableDb("createSimilarityAssessment", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ createSimilarityAssessment } = await import("../assessments"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses EQUIVALENT_FOUND with no equivalent identified", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+
+    // An EQUIVALENT_FOUND conclusion with no matches is neither usable nor auditable: the
+    // interface would state that an equivalent exists without being able to show it.
+    await expect(
+      createSimilarityAssessment({
+        measureRevisionId: revisionId,
+        comparedCorpusVersion: "2027-01",
+        conclusion: "EQUIVALENT_FOUND",
+        rationale: "Formulation proche.",
+        assessedBy: "relecteur",
+        equivalentRevisionIds: [],
+      })
+    ).rejects.toThrow(/équivalent/i);
+  });
+
+  it("refuses NO_EQUIVALENT_FOUND with equivalents attached", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+    const other = await seedMeasureWithDraft();
+
+    await expect(
+      createSimilarityAssessment({
+        measureRevisionId: revisionId,
+        comparedCorpusVersion: "2027-01",
+        conclusion: "NO_EQUIVALENT_FOUND",
+        rationale: "Aucun équivalent.",
+        assessedBy: "relecteur",
+        equivalentRevisionIds: [other.revisionId],
+      })
+    ).rejects.toThrow(/équivalent/i);
+  });
+
+  it("leaves no assessment behind when the matches cannot be written", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+
+    // The conclusion and its matches are one editorial statement, so they are written in
+    // one transaction. A dangling EQUIVALENT_FOUND with no match is exactly the state the
+    // first guard refuses at the door: this proves the door is not the only lock, because
+    // an unknown revision id fails at the foreign key, after the assessment row.
+    await expect(
+      createSimilarityAssessment({
+        measureRevisionId: revisionId,
+        comparedCorpusVersion: "2027-01",
+        conclusion: "EQUIVALENT_FOUND",
+        rationale: "Équivalent supposé.",
+        assessedBy: "relecteur",
+        equivalentRevisionIds: ["revision-inexistante"],
+      })
+    ).rejects.toThrow();
+
+    const assessments = await db.measureSimilarityAssessment.findMany({
+      where: { measureRevisionId: revisionId },
+    });
+    expect(assessments).toHaveLength(0);
+  });
+
+  it("stores the corpus version and the date with the conclusion", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+    const other = await seedMeasureWithDraft();
+
+    await createSimilarityAssessment({
+      measureRevisionId: revisionId,
+      comparedCorpusVersion: "2027-01",
+      conclusion: "EQUIVALENT_FOUND",
+      rationale: "Même objet, formulation différente.",
+      assessedBy: "relecteur",
+      equivalentRevisionIds: [other.revisionId],
+    });
+
+    const assessment = await db.measureSimilarityAssessment.findFirstOrThrow({
+      where: { measureRevisionId: revisionId },
+      include: { matches: true },
+    });
+
+    // The interface only ever displays "no equivalent found" with the date of the
+    // assessment: without the date and the corpus version, the conclusion is a claim about
+    // the present that was true in the past.
+    expect(assessment.comparedCorpusVersion).toBe("2027-01");
+    expect(assessment.assessedAt).not.toBeNull();
+    expect(assessment.matches).toHaveLength(1);
+  });
+});
+
+describeIfDisposableDb("createQualification", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ createQualification } = await import("../assessments"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("refuses a source url without its label, and the reverse", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+    const base = {
+      measureRevisionId: revisionId,
+      kind: "DEJA_TENTEE" as const,
+      label: "Déjà tentée en 2018",
+      rationale: "Un dispositif comparable a été adopté puis abrogé.",
+      assessedBy: "relecteur",
+    };
+
+    await expect(
+      createQualification({ ...base, sourceUrl: "https://example.org/2018", sourceLabel: null })
+    ).rejects.toThrow(/source/i);
+    await expect(
+      createQualification({ ...base, sourceUrl: null, sourceLabel: "Le Monde" })
+    ).rejects.toThrow(/source/i);
+  });
+
+  it("refuses an empty rationale", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+
+    // A qualification is an editorial conclusion. Without a rationale it is an unexplained
+    // judgement on a candidate's proposal.
+    await expect(
+      createQualification({
+        measureRevisionId: revisionId,
+        kind: "FINANCEMENT_NON_PRECISE",
+        label: "Financement non précisé",
+        rationale: "   ",
+        sourceUrl: null,
+        sourceLabel: null,
+        assessedBy: "relecteur",
+      })
+    ).rejects.toThrow(/justification/i);
+  });
+
+  it("records the author and the date of the judgement", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+
+    await createQualification({
+      measureRevisionId: revisionId,
+      kind: "FINANCEMENT_NON_PRECISE",
+      label: "Financement non précisé",
+      rationale: "Le programme ne chiffre ni le coût ni la recette associée.",
+      sourceUrl: null,
+      sourceLabel: null,
+      assessedBy: "relecteur",
+    });
+
+    const qualification = await db.measureQualification.findFirstOrThrow({
+      where: { measureRevisionId: revisionId },
+    });
+
+    // A qualification without its date and its author is a judgement nobody signs, on a
+    // formulation nobody can situate in time. It is attached to the REVISION, not to the
+    // measure, so a reformulation does not silently inherit the conclusion.
+    expect(qualification.assessedBy).toBe("relecteur");
+    expect(qualification.assessedAt).not.toBeNull();
+    expect(qualification.measureRevisionId).toBe(revisionId);
+  });
+});

--- a/src/lib/measures/__tests__/program-editions.integration.test.ts
+++ b/src/lib/measures/__tests__/program-editions.integration.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { seedCandidacy, seedElection, seedParty, seedPolitician } from "./helpers";
+
+// Deferred: `../program-editions` imports `@/lib/db` as a value, which throws at module
+// load without DATABASE_URL, so a static import fails the file instead of skipping.
+let db: typeof import("@/lib/db").db;
+let createProgramEdition: typeof import("../program-editions").createProgramEdition;
+
+describeIfDisposableDb("createProgramEdition", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ createProgramEdition } = await import("../program-editions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  function base(electionId: string) {
+    return {
+      electionId,
+      label: "Programme 2027, édition de janvier",
+      version: 1,
+      publishedAt: new Date("2027-01-15T00:00:00Z"),
+      documentUrl: "https://example.org/programme.pdf",
+    };
+  }
+
+  it("refuses an edition with no owner", async () => {
+    const electionId = await seedElection();
+
+    // Exactly one owner, not at least one: an edition owned by nobody cannot be
+    // attributed and cannot be displayed.
+    await expect(
+      createProgramEdition({
+        ...base(electionId),
+        ownerType: "PARTY",
+        partyId: null,
+        candidacyId: null,
+      })
+    ).rejects.toThrow(/propriétaire/i);
+  });
+
+  it("refuses an edition with two owners", async () => {
+    const electionId = await seedElection();
+    const partyId = await seedParty();
+    const politicianId = await seedPolitician();
+    const candidacyId = await seedCandidacy(politicianId, electionId);
+
+    // Left open by an earlier revision of the spec, which made "whose programme is this"
+    // unanswerable.
+    await expect(
+      createProgramEdition({ ...base(electionId), ownerType: "PARTY", partyId, candidacyId })
+    ).rejects.toThrow(/propriétaire/i);
+  });
+
+  it("refuses an ownerType that disagrees with the field that is set", async () => {
+    const electionId = await seedElection();
+    const politicianId = await seedPolitician();
+    const candidacyId = await seedCandidacy(politicianId, electionId);
+
+    // ownerType is what says which field to read: if it lies, every consumer reads the
+    // wrong one and gets null.
+    await expect(
+      createProgramEdition({ ...base(electionId), ownerType: "PARTY", partyId: null, candidacyId })
+    ).rejects.toThrow(/propriétaire/i);
+  });
+
+  it("creates an edition with exactly one owner", async () => {
+    const electionId = await seedElection();
+    const partyId = await seedParty();
+
+    const { programEditionId } = await createProgramEdition({
+      ...base(electionId),
+      ownerType: "PARTY",
+      partyId,
+      candidacyId: null,
+    });
+
+    const edition = await db.programEdition.findUniqueOrThrow({ where: { id: programEditionId } });
+    expect(edition.partyId).toBe(partyId);
+    expect(edition.candidacyId).toBeNull();
+    // Creation never publishes, same rule as measures: an edition becomes visible through
+    // a deliberate act, not as a side effect of being recorded.
+    expect(edition.publicationStatus).toBe("DRAFT");
+  });
+});

--- a/src/lib/measures/__tests__/qualification-definitions.test.ts
+++ b/src/lib/measures/__tests__/qualification-definitions.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { QualificationKind } from "@/generated/prisma";
+
+/**
+ * Unit test, no database: the plan checked this coverage with a manual grep, which holds
+ * exactly until someone adds a fifth enum value. A closed enum whose values have no
+ * opposable definition guarantees nothing, so the definitions are part of the contract and
+ * CI is where a missing one has to surface.
+ *
+ * Reading the enum from the generated client rather than a hardcoded list is the point: a
+ * new value fails this test until its section exists.
+ */
+const DOC = join(process.cwd(), "docs/editorial/qualifications-mesures.md");
+const source = readFileSync(DOC, "utf8");
+
+/** The five parts each definition must carry, per the editorial contract. */
+const REQUIRED_PARTS = [
+  "Ce que le qualificatif affirme",
+  "Corpus examiné",
+  "Deux exemples positifs",
+  "Deux exemples négatifs",
+  "Ce que le qualificatif n'affirme pas",
+];
+
+function sectionOf(value: string): string {
+  const start = source.indexOf(`## ${value}`);
+  if (start === -1) return "";
+  const rest = source.slice(start);
+  const end = rest.indexOf("\n---");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("définitions opposables des qualificatifs", () => {
+  const values = Object.values(QualificationKind);
+
+  it("couvre effectivement des valeurs, sinon la règle est vide", () => {
+    expect(values.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(values)("%s a sa section", (value) => {
+    expect(sectionOf(value)).not.toBe("");
+  });
+
+  it.each(values)("%s énonce ses cinq parties", (value) => {
+    const section = sectionOf(value);
+    for (const part of REQUIRED_PARTS) {
+      expect(section, `partie manquante dans ${value} : ${part}`).toContain(part);
+    }
+  });
+
+  it.each(values)("%s borne sa lecture par un cas limite", (value) => {
+    // Without a borderline case a definition reduces to its own title, and two reviewers
+    // apply it on different criteria. This is the part most likely to be skipped.
+    expect(sectionOf(value)).toContain("Cas limite");
+  });
+
+  it("est écrit sans tiret cadratin", () => {
+    // Repository-wide rule for human-facing text.
+    expect(source).not.toMatch(/[—–]/);
+  });
+});

--- a/src/lib/measures/assessments.ts
+++ b/src/lib/measures/assessments.ts
@@ -1,0 +1,101 @@
+import type { QualificationKind, SimilarityConclusion } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { MeasureValidationError } from "./errors";
+
+/**
+ * A dated editorial conclusion on one formulation. Never a field on the measure: an
+ * editorial conclusion stored as a fact goes stale silently, and "funding not specified"
+ * depends on the text that was analysed.
+ *
+ * Attached to the REVISION, so a reformulation does not inherit the conclusion.
+ */
+export async function createQualification(input: {
+  measureRevisionId: string;
+  kind: QualificationKind;
+  label: string;
+  rationale: string;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+  assessedBy: string;
+}): Promise<void> {
+  if (input.rationale.trim() === "") {
+    throw new MeasureValidationError("Une qualification exige une justification");
+  }
+  if (input.assessedBy.trim() === "") {
+    throw new MeasureValidationError("Une qualification exige un auteur identifié");
+  }
+  // Half a source is worse than none: a label with no link cannot be checked, and a link
+  // with no label cannot be displayed.
+  const hasUrl = (input.sourceUrl ?? "").trim() !== "";
+  const hasLabel = (input.sourceLabel ?? "").trim() !== "";
+  if (hasUrl !== hasLabel) {
+    throw new MeasureValidationError("Une source exige son URL et son libellé, les deux ou aucun");
+  }
+
+  await db.measureQualification.create({
+    data: {
+      measureRevisionId: input.measureRevisionId,
+      kind: input.kind,
+      label: input.label,
+      rationale: input.rationale,
+      sourceUrl: hasUrl ? input.sourceUrl : null,
+      sourceLabel: hasLabel ? input.sourceLabel : null,
+      assessedAt: new Date(),
+      assessedBy: input.assessedBy,
+    },
+  });
+}
+
+/**
+ * Uniqueness as a dated assessment on one formulation, with the state of the corpus it was
+ * compared against. A boolean isUnique would be wrong the day the next programme is
+ * published, and "equivalent" has no single definition.
+ *
+ * The conclusion and the matches are one editorial statement, so they are validated
+ * together and written in one transaction.
+ */
+export async function createSimilarityAssessment(input: {
+  measureRevisionId: string;
+  comparedCorpusVersion: string;
+  conclusion: SimilarityConclusion;
+  rationale: string;
+  assessedBy: string;
+  equivalentRevisionIds: string[];
+}): Promise<void> {
+  const hasMatches = input.equivalentRevisionIds.length > 0;
+  if (input.conclusion === "EQUIVALENT_FOUND" && !hasMatches) {
+    throw new MeasureValidationError(
+      "Une conclusion EQUIVALENT_FOUND exige au moins un équivalent identifié"
+    );
+  }
+  if (input.conclusion !== "EQUIVALENT_FOUND" && hasMatches) {
+    throw new MeasureValidationError(
+      `Une conclusion ${input.conclusion} ne peut pas porter d'équivalent identifié`
+    );
+  }
+  if (input.comparedCorpusVersion.trim() === "") {
+    throw new MeasureValidationError("L'évaluation exige la version du corpus comparé");
+  }
+
+  await db.$transaction(async (tx) => {
+    const assessment = await tx.measureSimilarityAssessment.create({
+      data: {
+        measureRevisionId: input.measureRevisionId,
+        comparedCorpusVersion: input.comparedCorpusVersion,
+        assessedAt: new Date(),
+        assessedBy: input.assessedBy,
+        conclusion: input.conclusion,
+        rationale: input.rationale,
+      },
+    });
+
+    if (hasMatches) {
+      await tx.measureSimilarityMatch.createMany({
+        data: input.equivalentRevisionIds.map((id) => ({
+          assessmentId: assessment.id,
+          equivalentMeasureRevisionId: id,
+        })),
+      });
+    }
+  });
+}

--- a/src/lib/measures/assessments.ts
+++ b/src/lib/measures/assessments.ts
@@ -8,6 +8,11 @@ import { MeasureValidationError } from "./errors";
  * depends on the text that was analysed.
  *
  * Attached to the REVISION, so a reformulation does not inherit the conclusion.
+ *
+ * Each QualificationKind value needs an opposable definition before it can be used. See
+ * docs/editorial/qualifications-mesures.md, which states the corpus to examine for each
+ * one: "funding not specified" gives three different answers depending on whether the
+ * reviewer read the revision alone, its primary sources, or the whole programme.
  */
 export async function createQualification(input: {
   measureRevisionId: string;

--- a/src/lib/measures/program-editions.ts
+++ b/src/lib/measures/program-editions.ts
@@ -1,0 +1,55 @@
+import type { ProgramOwnerType } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { MeasureValidationError } from "./errors";
+
+export type CreateProgramEditionInput = {
+  electionId: string;
+  ownerType: ProgramOwnerType;
+  partyId: string | null;
+  candidacyId: string | null;
+  label: string;
+  version: number;
+  publishedAt: Date;
+  documentUrl: string;
+};
+
+/**
+ * Exactly one owner, and ownerType must agree with the field that is set.
+ *
+ * The schema cannot express this: both columns are independently nullable, and the two
+ * unique constraints only bite once an owner is chosen. So the guard lives here, and this
+ * is the only authorized way to create an edition.
+ */
+export async function createProgramEdition(
+  input: CreateProgramEditionInput
+): Promise<{ programEditionId: string }> {
+  const owners = [input.partyId, input.candidacyId].filter((id) => id !== null);
+  if (owners.length !== 1) {
+    throw new MeasureValidationError(
+      "Une édition de programme doit avoir exactement un propriétaire, parti ou candidature"
+    );
+  }
+  // ownerType is what tells every consumer which column to read. If it disagrees with the
+  // column that is set, they all read the wrong one and get null.
+  const declared = input.ownerType === "PARTY" ? input.partyId : input.candidacyId;
+  if (declared === null) {
+    throw new MeasureValidationError(
+      `Le propriétaire déclaré (${input.ownerType}) ne correspond pas au champ renseigné`
+    );
+  }
+
+  const edition = await db.programEdition.create({
+    data: {
+      electionId: input.electionId,
+      ownerType: input.ownerType,
+      partyId: input.partyId,
+      candidacyId: input.candidacyId,
+      label: input.label,
+      version: input.version,
+      publishedAt: input.publishedAt,
+      documentUrl: input.documentUrl,
+    },
+  });
+
+  return { programEditionId: edition.id };
+}


### PR DESCRIPTION
## Description

PR C du lot 1 sur quatre : les métadonnées éditoriales, leurs définitions opposables, et la couche de
lecture publique. Ordre volontaire, décidé en revue : les définitions viennent **avant** la lecture, parce
qu'un enum sans définition ne garantit rien et que la lecture expose ces qualificatifs.

`createProgramEdition()` exige **exactement un** propriétaire, parti ou candidature, et que `ownerType`
soit d'accord avec la colonne renseignée. Le schéma ne peut pas l'exprimer : les deux colonnes sont
indépendamment nullables, et les deux contraintes d'unicité ne mordent qu'une fois un propriétaire choisi.
`ownerType` est ce qui dit à tous les consommateurs quelle colonne lire, donc s'il mentait ils liraient
tous la mauvaise et obtiendraient `null`.

`createQualification()` et `createSimilarityAssessment()` écrivent des **conclusions datées**, jamais des
faits. Une qualification exige une justification, un auteur, et une source complète ou pas de source du
tout : la moitié d'une source est pire que rien, un libellé sans lien ne se vérifie pas et un lien sans
libellé ne s'affiche pas. Une conclusion `EQUIVALENT_FOUND` exige au moins un équivalent identifié,
faute de quoi l'interface affirmerait qu'un équivalent existe sans pouvoir le montrer.

Les conclusions sont rattachées à la **révision**, pas à la mesure, donc une reformulation n'hérite
d'aucun jugement.

## Les définitions opposables, et pourquoi c'est du code

`docs/editorial/qualifications-mesures.md` donne pour chacune des quatre valeurs : ce que le qualificatif
affirme en une phrase que le candidat pourrait contester, le **corpus examiné**, deux exemples positifs,
deux négatifs dont un cas limite, et ce que le qualificatif n'affirme pas.

Le corpus examiné est la partie qui compte le plus. « Financement non précisé » donne trois réponses
différentes selon qu'on a lu la seule révision, ses sources primaires, ou le programme entier du candidat.
Sans corpus explicite, le qualificatif ne dit pas ce qu'il constate.

**La couverture est testée**, et c'est un ajout au plan qui prévoyait un `grep` manuel. Un `grep` tient
exactement jusqu'au jour où quelqu'un ajoute une cinquième valeur d'enum.
`qualification-definitions.test.ts` lit `QualificationKind` depuis le client généré et exige pour chaque
valeur sa section, ses cinq parties et son cas limite. Test unitaire, donc il tourne en CI sans base.
Ablation faite : section `CALENDRIER_PRECISE` retirée, trois tests tombent en la nommant.

## La lecture publique et ses deux conditions cumulatives

`publicationStatus` seul ne suffit pas, et c'est tout l'enjeu : la seconde condition porte sur l'état de
la **révision que le pointeur désigne**. Une mesure peut être `PUBLISHED` en pointant une révision jamais
relue, jamais publiée, remplacée, ou sans source. Chacun de ces quatre cas doit rester invisible, et
chacun est construit directement en base dans les tests, puisqu'aucun appel public ne peut les produire.

`getMeasureForModeration()` n'applique **aucun** filtre, délibérément : l'admin doit voir les brouillons,
les révisions abandonnées et les mesures dépubliées. C'est toute la raison pour laquelle lecture publique
et lecture de modération sont deux fonctions distinctes dans le même fichier.

## Le retrait, selon l'arbitrage de revue

Publication éditoriale et réactivation politique sont deux actes différents. La couche de lecture
applique la distinction :

- **détail** : inclut les mesures retirées, avec leur état de retrait. Effacer une proposition qu'un
  candidat a portée puis abandonnée supprimerait une information qui compte ;
- **listes** : excluent les mesures retirées **par défaut**. Une liste répond à « quelles propositions
  sont actuellement défendues », et y montrer une proposition abandonnée affirme quelque chose de faux sur
  le candidat. Un appelant qui oublie l'option obtient donc la réponse sûre, et
  `{ includeWithdrawn: true }` les ramène explicitement ;
- **recherche** : conserve les mesures retirées en `PUBLIC`. Les sortir de l'index rendrait introuvable
  une proposition publiquement portée.

Le test demandé en revue est là : publier une correction d'une mesure retirée met à jour la révision
publique **et** le `SearchDocument`, en conservant les trois métadonnées de retrait à l'identique.

### Une déviation de la forme demandée, et sa raison

La revue demandait `withdrawal: { withdrawnAt: Date; sourceUrl: string; sourceLabel: string } | null`.
J'ai livré les deux champs de source en `string | null` **à l'intérieur** de l'objet non nul.

La raison : la **présence** de l'objet est le fait que le candidat a abandonné la proposition, et ce fait
ne doit jamais être caché. Une page qui montrerait une mesure retirée comme encore défendue est une erreur
factuelle, plus grave qu'un libellé de source manquant. Avec des sources non nullables, une ligne au
retrait partiel forcerait à renvoyer `withdrawal: null`, donc à masquer un retrait réel pour préserver un
type.

`withdrawMeasure()` écrit les trois champs ensemble ou aucun, donc un état partiel ne peut venir que d'une
écriture directe en base, que l'audit de la PR D signalera. Si tu préfères la forme stricte, elle se
change en trois lignes.

## Le second test qui ne mordait pas

Comme pour la concurrence en PR B, une ablation a montré qu'un test du plan était vert pour la mauvaise
raison. Retirer `publishedAt: { not: null, lte: at }` de `getRevisionInForceAt` laissait les 15 tests
verts.

Le plan justifiait ainsi son cas de test : « le brouillon a le `validFrom` le plus ancien, donc un tri sans
la condition le choisirait ». C'est l'inverse. Avec `ORDER BY validFrom DESC`, le plus ancien est choisi
**en dernier** : la révision publiée du 2027-01-01 devançait toujours le brouillon du 2020-01-01, avec ou
sans la garde.

Corrigé en donnant au brouillon le `validFrom` le plus **récent** tout en restant antérieur à la date
interrogée. L'ablation tombe maintenant, et j'ai ajouté l'assertion positive : « pas le brouillon » seul
serait aussi vrai si la fonction renvoyait `null`.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Aucune. Troisième des quatre PR du lot 1.

## Vérifications

132 tests verts sous `npm run test:db:search`, dont 15 sur la couche de lecture et 11 sur les métadonnées.
Les mêmes en skip sous `npx vitest run`, jamais en échec, sauf les 14 tests de couverture des définitions
qui tournent sans base. Suite complète : verte. `npx tsc --noEmit` en code 0 sur cache froid, ESLint propre
sur `src/lib/measures` et `src/lib/data` avec `--max-warnings=0`.

Cinq ablations, chacune ayant produit l'échec annoncé :

| Ce qu'on retire                                      | Ce qui tombe                                    |
| ---------------------------------------------------- | ----------------------------------------------- |
| la garde du propriétaire unique                      | l'édition à deux propriétaires est acceptée     |
| la garde `EQUIVALENT_FOUND` sans équivalent          | une conclusion sans équivalent est acceptée     |
| une section du document de définitions               | trois tests de couverture, en nommant la valeur |
| la condition sur la révision pointée                 | les **quatre** tests de fuite du filtre public  |
| la condition `publishedAt` de `getRevisionInForceAt` | le brouillon jamais publié est renvoyé          |
| l'exclusion par défaut des mesures retirées          | une mesure retirée apparaît dans les listes     |

Une prédiction du plan corrigée : l'ablation de la garde du propriétaire unique ne fait tomber que « two
owners », pas « no owner ». Le cas sans propriétaire est rattrapé par la **seconde** garde, celle de
l'accord `ownerType`, donc les deux gardes se recouvrent sur ce cas. Le test reste utile comme test de
comportement, il n'isole simplement pas quelle garde refuse.

## Deux tests ajoutés au plan

- **la transaction des évaluations de similarité** : une conclusion et ses équivalents forment un seul
  énoncé éditorial. Le test passe un identifiant de révision inexistant, ce qui échoue à la clé étrangère
  **après** la création de l'évaluation, et vérifie qu'aucune évaluation orpheline ne subsiste. La garde
  d'entrée n'est donc pas le seul verrou ;
- **la date et l'auteur d'une qualification** : un jugement que personne ne signe, sur une formulation que
  personne ne peut situer dans le temps, n'est pas opposable.
