### PR TITLE
Auditer les invariants des mesures (lot 1, PR D)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build --webpack",
     "build:net-check": "tsx scripts/check-build-network.mts",
+    "measures:audit": "tsx scripts/audit-measures.ts",
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/scripts/audit-measures.ts
+++ b/scripts/audit-measures.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env tsx
+/**
+ * npm run measures:audit
+ *
+ * Exits non-zero when an invariant is violated, so it can be wired into CI or a cron
+ * without being interpreted by hand.
+ */
+import { db } from "@/lib/db";
+import { auditMeasures } from "@/lib/measures/audit";
+
+async function main(): Promise<void> {
+  const violations = await auditMeasures();
+
+  if (violations.length === 0) {
+    console.log("[measures:audit] aucun invariant violé");
+    return;
+  }
+
+  const byRule = new Map<string, number>();
+  for (const v of violations) {
+    byRule.set(v.rule, (byRule.get(v.rule) ?? 0) + 1);
+    console.error(`[${v.rule}] mesure=${v.measureId ?? "-"} ${v.detail}`);
+  }
+
+  console.error(`\n[measures:audit] ${violations.length} violation(s) :`);
+  for (const [rule, count] of [...byRule].sort((a, b) => b[1] - a[1])) {
+    console.error(`  ${count.toString().padStart(5)}  ${rule}`);
+  }
+  process.exitCode = 1;
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/lib/measures/__tests__/audit-command.integration.test.ts
+++ b/src/lib/measures/__tests__/audit-command.integration.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { publishSeededMeasure } from "./helpers";
+
+// Deferred: the transitions reached through the fixtures import `@/lib/db` as a value.
+let db: typeof import("@/lib/db").db;
+
+/**
+ * The exit code is what will let the command be wired into CI, so it is verified by running
+ * the script, not by calling auditMeasures() again.
+ */
+function runAudit(): { code: number; output: string } {
+  try {
+    const output = execFileSync("npx", ["tsx", "scripts/audit-measures.ts"], {
+      env: { ...process.env, DOTENV_CONFIG_PATH: "/dev/null" },
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { code: 0, output };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, output: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+const AUDIT_TIMEOUT_MS = 60_000;
+
+describeIfDisposableDb("measures:audit exit code", () => {
+  // The command audits the whole database, so this file cannot tolerate the violations the
+  // other files build on purpose. Truncating first makes it order-independent instead of
+  // relying on "run it last", which nobody remembers six months later. Safe because the gate
+  // guarantees a disposable container.
+  //
+  // ONE hook, and the order inside it matters. A first version of this plan truncated in one
+  // beforeAll and resolved the deferred import in a second: hooks run in declaration order,
+  // so the truncation reached `db` before it was assigned.
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+
+    await db.searchDocument.deleteMany({});
+    await db.measure.deleteMany({}); // revisions, sources, qualifications cascade
+    await db.programEdition.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it(
+    "exits 0 when every invariant holds",
+    async () => {
+      await publishSeededMeasure();
+
+      const { code, output } = runAudit();
+
+      expect(code).toBe(0);
+      expect(output).toContain("aucun invariant violé");
+    },
+    AUDIT_TIMEOUT_MS
+  );
+
+  it(
+    "exits 1 and names the rule when an invariant is violated",
+    async () => {
+      const { measureId } = await publishSeededMeasure();
+      await db.measure.update({ where: { id: measureId }, data: { withdrawnAt: new Date() } });
+
+      const { code, output } = runAudit();
+
+      // Exiting 0 on a violation is worse than not having the command: CI would go green on
+      // a database that contradicts the model.
+      expect(code).toBe(1);
+      expect(output).toContain("withdrawn_without_source");
+    },
+    AUDIT_TIMEOUT_MS
+  );
+});

--- a/src/lib/measures/__tests__/audit.integration.test.ts
+++ b/src/lib/measures/__tests__/audit.integration.test.ts
@@ -1,0 +1,299 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { publishSeededMeasure, seedElection, seedMeasureWithDraft, seedParty } from "./helpers";
+
+// Deferred: both `../audit` and `../transitions` import `@/lib/db` as a value, which throws
+// at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let auditMeasures: typeof import("../audit").auditMeasures;
+let discardMeasureRevision: typeof import("../transitions").discardMeasureRevision;
+
+/**
+ * One rule, one constructed violation. A rule with no test is not verified, it is assumed.
+ *
+ * EVERY case in this file writes directly to the database, and that is the nature of the
+ * exercise: these violations are no longer reachable through the public functions, since the
+ * transitions prevent them. The audit exists for the states produced by a past import, a
+ * script, or a manual correction in the database.
+ */
+async function violationsFor(measureId: string): Promise<string[]> {
+  const all = await auditMeasures();
+  return all.filter((v) => v.measureId === measureId).map((v) => v.rule);
+}
+
+async function allRules(): Promise<string[]> {
+  return (await auditMeasures()).map((v) => v.rule);
+}
+
+describeIfDisposableDb("auditMeasures", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ auditMeasures } = await import("../audit"));
+    ({ discardMeasureRevision } = await import("../transitions"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("reports nothing on a correctly published measure", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    expect(await violationsFor(measureId)).toEqual([]);
+  });
+
+  it("detects a published revision belonging to another measure", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const other = await seedMeasureWithDraft();
+    await db.measure.update({
+      where: { id: measureId },
+      data: { publishedRevisionId: other.revisionId },
+    });
+
+    expect(await violationsFor(measureId)).toContain("published_revision_foreign");
+  });
+
+  it("detects two published non-superseded revisions", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measureRevision.create({
+      data: {
+        measureId,
+        text: "Deuxième version publiée par erreur.",
+        validFrom: new Date("2027-02-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        reviewedAt: new Date(),
+        reviewedBy: "relecteur",
+        publishedAt: new Date(),
+      },
+    });
+
+    // The state two concurrent publications produce without FOR UPDATE.
+    expect(await violationsFor(measureId)).toContain("multiple_published_revisions");
+  });
+
+  it("detects publishedRevisionId pointing at an unreviewed revision", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { reviewedAt: null, reviewedBy: null },
+    });
+
+    expect(await violationsFor(measureId)).toContain("published_revision_unreviewed");
+  });
+
+  it("detects publishedRevisionId pointing at a superseded revision", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { supersededAt: new Date() },
+    });
+
+    expect(await violationsFor(measureId)).toContain("published_revision_superseded");
+  });
+
+  it("detects publishedRevisionId pointing at a revision with no publishedAt", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureRevision.update({ where: { id: revisionId }, data: { publishedAt: null } });
+
+    expect(await violationsFor(measureId)).toContain("published_revision_unpublished");
+  });
+
+  it("detects latestRevisionId pointing at another measure's revision", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const other = await seedMeasureWithDraft();
+
+    // latestRevisionId is @unique, so the foreign revision has to be released first. That is
+    // exactly what makes this state reachable: the constraint stops two measures from
+    // sharing a pointer, it does not stop one from pointing at a foreign revision.
+    await db.measure.update({ where: { id: other.measureId }, data: { latestRevisionId: null } });
+    await db.measure.update({
+      where: { id: measureId },
+      data: { latestRevisionId: other.revisionId },
+    });
+
+    expect(await violationsFor(measureId)).toContain("latest_revision_foreign");
+  });
+
+  it("detects an active draft that latestRevisionId does not designate", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measureRevision.create({
+      data: {
+        measureId,
+        text: "Brouillon orphelin.",
+        validFrom: new Date("2027-02-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+      },
+    });
+
+    expect(await violationsFor(measureId)).toContain("orphan_active_draft");
+  });
+
+  it("detects latestRevisionId on a discarded draft", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { discardedAt: new Date() },
+    });
+
+    expect(await violationsFor(measureId)).toContain("latest_revision_discarded");
+  });
+
+  it("detects a candidacy that belongs to another politician", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const other = await seedMeasureWithDraft();
+    const otherMeasure = await db.measure.findUniqueOrThrow({ where: { id: other.measureId } });
+    const foreign = await db.candidacy.create({
+      data: {
+        electionId: otherMeasure.electionId,
+        politicianId: otherMeasure.politicianId,
+        candidateName: "Autre candidat",
+      },
+    });
+    await db.measure.update({ where: { id: measureId }, data: { candidacyId: foreign.id } });
+
+    expect(await violationsFor(measureId)).toContain("candidacy_politician_mismatch");
+  });
+
+  it("detects a program edition attached to another election", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
+    // Seeded here rather than looked up: the plan wrote findFirstOrThrow on Party and
+    // Election, which relies on rows left behind by other test files. The fixtures never
+    // create a Party, so this file failed when run alone, and would have kept failing
+    // depending on execution order.
+    const otherElectionId = await seedElection();
+    const partyId = await seedParty();
+    expect(otherElectionId).not.toBe(measure.electionId);
+    const edition = await db.programEdition.create({
+      data: {
+        electionId: otherElectionId,
+        ownerType: "PARTY",
+        partyId,
+        label: "Programme d'une autre élection",
+        version: 99,
+        publishedAt: new Date(),
+        documentUrl: "https://example.org/autre.pdf",
+      },
+    });
+    await db.measure.update({ where: { id: measureId }, data: { programEditionId: edition.id } });
+
+    expect(await violationsFor(measureId)).toContain("program_edition_election_mismatch");
+  });
+
+  it("detects a withdrawn measure with no withdrawal source", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measure.update({ where: { id: measureId }, data: { withdrawnAt: new Date() } });
+
+    expect(await violationsFor(measureId)).toContain("withdrawn_without_source");
+  });
+
+  it("detects withdrawal fields set with no withdrawnAt", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measure.update({
+      where: { id: measureId },
+      data: {
+        withdrawnSourceUrl: "https://example.org/retrait",
+        withdrawnSourceLabel: "Le Monde",
+      },
+    });
+
+    expect(await violationsFor(measureId)).toContain("withdrawal_source_without_date");
+  });
+
+  it("detects a published revision with no source", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureSource.deleteMany({ where: { measureRevisionId: revisionId } });
+
+    expect(await violationsFor(measureId)).toContain("published_revision_without_source");
+  });
+
+  it("detects a measure with a reference revision and no search document at all", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.searchDocument.deleteMany({ where: { entityType: "MEASURE", entityId: measureId } });
+
+    // The two visibility and staleness rules are both guarded by "if a document exists", so
+    // without this rule a measure that was never indexed passes silently: invisible in
+    // search, and reported as healthy.
+    expect(await violationsFor(measureId)).toContain("search_document_missing");
+  });
+
+  it("does not demand a document for a measure with no reference revision", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await discardMeasureRevision({ measureId, revisionId });
+
+    // No published revision and no active draft: there is nothing to index, and
+    // syncSearchDocument removed the row on purpose.
+    const rules = await violationsFor(measureId);
+    expect(rules).not.toContain("search_document_missing");
+    expect(rules).not.toContain("search_document_stale");
+  });
+
+  it("detects a PUBLIC search document whose measure is no longer published", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measure.update({ where: { id: measureId }, data: { publicationStatus: "DRAFT" } });
+
+    expect(await violationsFor(measureId)).toContain("search_document_visibility_mismatch");
+  });
+
+  it("detects a search document aligned on the wrong revision", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.searchDocument.update({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+      data: { sourceRevisionId: "revision-inexistante" },
+    });
+
+    expect(await violationsFor(measureId)).toContain("search_document_stale");
+  });
+
+  // The last three rules carry no measureId, so they are checked on the whole result.
+
+  it("detects an EQUIVALENT_FOUND assessment with no match", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+    await db.measureSimilarityAssessment.create({
+      data: {
+        measureRevisionId: revisionId,
+        comparedCorpusVersion: "2027-01",
+        assessedAt: new Date(),
+        assessedBy: "relecteur",
+        conclusion: "EQUIVALENT_FOUND",
+        rationale: "Écrit directement en base pour construire la violation.",
+      },
+    });
+
+    expect(await allRules()).toContain("similarity_conclusion_mismatch");
+  });
+
+  it("detects a qualification with half a source", async () => {
+    const { revisionId } = await seedMeasureWithDraft();
+    await db.measureQualification.create({
+      data: {
+        measureRevisionId: revisionId,
+        kind: "DEJA_TENTEE",
+        label: "Déjà tentée",
+        rationale: "Écrit directement en base.",
+        sourceUrl: "https://example.org/2018",
+        assessedAt: new Date(),
+        assessedBy: "relecteur",
+      },
+    });
+
+    expect(await allRules()).toContain("qualification_half_source");
+  });
+
+  it("detects a program edition with zero or two owners", async () => {
+    const electionId = await seedElection();
+    await db.programEdition.create({
+      data: {
+        electionId,
+        ownerType: "PARTY",
+        label: "Édition sans propriétaire",
+        version: 98,
+        publishedAt: new Date(),
+        documentUrl: "https://example.org/orphan.pdf",
+      },
+    });
+
+    expect(await allRules()).toContain("program_edition_owner_count");
+  });
+});

--- a/src/lib/measures/audit.ts
+++ b/src/lib/measures/audit.ts
@@ -1,0 +1,236 @@
+import { db } from "@/lib/db";
+
+export type AuditViolation = {
+  rule: string;
+  measureId: string | null;
+  detail: string;
+};
+
+/**
+ * The invariants Prisma cannot express, checked in the database.
+ *
+ * Nineteen rules. Two rules of an earlier draft are deliberately absent: "orphan
+ * qualification" and "orphan assessment" queried `revision: { is: null }` on a required
+ * relation with cascade delete. The orphan is structurally impossible and the query is
+ * meaningless.
+ *
+ * Partial unique indexes would give some of these guarantees, but Prisma cannot declare
+ * them and `db:push` would erase them, hence a command.
+ *
+ * No side effect: this function reports, it never repairs. A repair would have to decide
+ * which of two published revisions is the real one, and that decision belongs to a human.
+ */
+export async function auditMeasures(): Promise<AuditViolation[]> {
+  const violations: AuditViolation[] = [];
+
+  const measures = await db.measure.findMany({
+    select: {
+      id: true,
+      electionId: true,
+      politicianId: true,
+      candidacyId: true,
+      programEditionId: true,
+      publicationStatus: true,
+      latestRevisionId: true,
+      publishedRevisionId: true,
+      withdrawnAt: true,
+      withdrawnSourceUrl: true,
+      withdrawnSourceLabel: true,
+      candidacy: { select: { politicianId: true } },
+      programEdition: { select: { electionId: true } },
+      publishedRevision: {
+        select: {
+          id: true,
+          measureId: true,
+          reviewedAt: true,
+          publishedAt: true,
+          supersededAt: true,
+          _count: { select: { sources: true } },
+        },
+      },
+      latestRevision: { select: { id: true, measureId: true, discardedAt: true } },
+      revisions: {
+        select: { id: true, publishedAt: true, supersededAt: true, discardedAt: true },
+      },
+    },
+  });
+
+  const documents = await db.searchDocument.findMany({
+    where: { entityType: "MEASURE" },
+    select: { entityId: true, visibility: true, sourceRevisionId: true },
+  });
+  const byEntity = new Map(documents.map((d) => [d.entityId, d]));
+
+  for (const m of measures) {
+    const published = m.publishedRevision;
+
+    if (published && published.measureId !== m.id) {
+      violations.push({
+        rule: "published_revision_foreign",
+        measureId: m.id,
+        detail: published.id,
+      });
+    }
+    if (published && !published.reviewedAt) {
+      violations.push({
+        rule: "published_revision_unreviewed",
+        measureId: m.id,
+        detail: published.id,
+      });
+    }
+    // Distinct from the unreviewed case: a revision can be reviewed and pointed at without
+    // ever having been published, and "the text in force at date D" would then select
+    // something the site never displayed.
+    if (published && !published.publishedAt) {
+      violations.push({
+        rule: "published_revision_unpublished",
+        measureId: m.id,
+        detail: published.id,
+      });
+    }
+    if (published && published.supersededAt) {
+      violations.push({
+        rule: "published_revision_superseded",
+        measureId: m.id,
+        detail: published.id,
+      });
+    }
+    if (published && published._count.sources === 0) {
+      violations.push({
+        rule: "published_revision_without_source",
+        measureId: m.id,
+        detail: published.id,
+      });
+    }
+
+    // The state two concurrent publications produce without FOR UPDATE. No public call can
+    // create it any more, which is exactly why the audit has to see it.
+    const currentPublished = m.revisions.filter((r) => r.publishedAt && !r.supersededAt);
+    if (currentPublished.length > 1) {
+      violations.push({
+        rule: "multiple_published_revisions",
+        measureId: m.id,
+        detail: currentPublished.map((r) => r.id).join(","),
+      });
+    }
+
+    const activeDrafts = m.revisions.filter((r) => !r.publishedAt && !r.discardedAt);
+    const orphans = activeDrafts.filter((r) => r.id !== m.latestRevisionId);
+    if (orphans.length > 0) {
+      violations.push({
+        rule: "orphan_active_draft",
+        measureId: m.id,
+        detail: orphans.map((r) => r.id).join(","),
+      });
+    }
+
+    if (m.latestRevision && m.latestRevision.measureId !== m.id) {
+      violations.push({
+        rule: "latest_revision_foreign",
+        measureId: m.id,
+        detail: m.latestRevision.id,
+      });
+    }
+    if (m.latestRevision?.discardedAt) {
+      violations.push({
+        rule: "latest_revision_discarded",
+        measureId: m.id,
+        detail: m.latestRevision.id,
+      });
+    }
+
+    if (m.candidacy && m.candidacy.politicianId !== m.politicianId) {
+      violations.push({
+        rule: "candidacy_politician_mismatch",
+        measureId: m.id,
+        detail: m.candidacyId ?? "",
+      });
+    }
+    if (m.programEdition && m.programEdition.electionId !== m.electionId) {
+      violations.push({
+        rule: "program_edition_election_mismatch",
+        measureId: m.id,
+        detail: m.programEditionId ?? "",
+      });
+    }
+
+    if (m.withdrawnAt && (!m.withdrawnSourceUrl || !m.withdrawnSourceLabel)) {
+      violations.push({ rule: "withdrawn_without_source", measureId: m.id, detail: "" });
+    }
+    if (!m.withdrawnAt && (m.withdrawnSourceUrl || m.withdrawnSourceLabel)) {
+      violations.push({ rule: "withdrawal_source_without_date", measureId: m.id, detail: "" });
+    }
+
+    const doc = byEntity.get(m.id);
+    const shouldBePublic = m.publicationStatus === "PUBLISHED" && m.publishedRevisionId !== null;
+
+    // A missing document is a violation, not a normal case. Without this rule the two
+    // checks below never fire on a measure that was never indexed at all, because both are
+    // guarded by `if (doc)`: total absence escaped the audit entirely.
+    //
+    // Only demanded when there IS a reference revision. A measure whose only draft was
+    // discarded has nothing to represent, and syncSearchDocument deletes its row on purpose.
+    const referenceRevisionId = m.publishedRevisionId ?? m.latestRevisionId;
+    if (!doc && referenceRevisionId !== null) {
+      violations.push({
+        rule: "search_document_missing",
+        measureId: m.id,
+        detail: referenceRevisionId,
+      });
+    }
+
+    if (doc && shouldBePublic !== (doc.visibility === "PUBLIC")) {
+      violations.push({
+        rule: "search_document_visibility_mismatch",
+        measureId: m.id,
+        detail: doc.visibility,
+      });
+    }
+    if (doc) {
+      // Staleness is measured against the reference revision of the document's visibility,
+      // and NEVER against Measure.updatedAt: drafting moves updatedAt without changing the
+      // public text, so the naive comparison reports every measure with a draft in progress
+      // as stale.
+      const reference = doc.visibility === "PUBLIC" ? m.publishedRevisionId : m.latestRevisionId;
+      if (doc.sourceRevisionId !== reference) {
+        violations.push({
+          rule: "search_document_stale",
+          measureId: m.id,
+          detail: `${doc.sourceRevisionId} != ${reference}`,
+        });
+      }
+    }
+  }
+
+  const assessments = await db.measureSimilarityAssessment.findMany({
+    select: { id: true, conclusion: true, _count: { select: { matches: true } } },
+  });
+  for (const a of assessments) {
+    const hasMatches = a._count.matches > 0;
+    if ((a.conclusion === "EQUIVALENT_FOUND") !== hasMatches) {
+      violations.push({ rule: "similarity_conclusion_mismatch", measureId: null, detail: a.id });
+    }
+  }
+
+  const qualifications = await db.measureQualification.findMany({
+    select: { id: true, sourceUrl: true, sourceLabel: true },
+  });
+  for (const q of qualifications) {
+    if (Boolean(q.sourceUrl) !== Boolean(q.sourceLabel)) {
+      violations.push({ rule: "qualification_half_source", measureId: null, detail: q.id });
+    }
+  }
+
+  const editions = await db.programEdition.findMany({
+    select: { id: true, ownerType: true, partyId: true, candidacyId: true },
+  });
+  for (const e of editions) {
+    const owners = [e.partyId, e.candidacyId].filter((id) => id !== null);
+    const declared = e.ownerType === "PARTY" ? e.partyId : e.candidacyId;
+    if (owners.length !== 1 || declared === null) {
+      violations.push({ rule: "program_edition_owner_count", measureId: null, detail: e.id });
+    }
+  }
+
+  return violations;
+}


### PR DESCRIPTION
## Description

Dernière PR du lot 1 : `npm run measures:audit`, dix-neuf règles qui vérifient les invariants que Prisma
ne sait pas exprimer. Isolée en revue parce qu'elle contrôle rétrospectivement ce que les trois PR
précédentes promettent.

Les invariants portés par cette commande et non par le schéma le sont pour une raison : un index unique
partiel donnerait certaines de ces garanties, mais Prisma ne sait pas les déclarer et `db:push` les
effacerait. D'où une commande, avec un code de sortie non nul, pour qu'elle puisse être branchée en CI ou
en tâche planifiée sans être interprétée à la main.

**Aucun effet de bord : l'audit constate, il ne répare pas.** Une réparation devrait décider laquelle de
deux révisions publiées est la vraie, et cette décision appartient à un humain.

## Une règle, un test, une violation construite

Vingt-et-un tests : une violation par règle, plus le cas sain qui ne doit rien déclencher, plus le cas
d'une mesure sans révision de référence qui ne doit pas réclamer de document d'index. Une règle sans test
n'est pas vérifiée, elle est supposée.

**Chaque cas est écrit directement en base**, et c'est la nature de l'exercice : ces états ne sont plus
atteignables par les fonctions publiques, puisque les PR A à C les empêchent. L'audit existe pour ce qu'un
import passé, un script ou une correction manuelle a laissé derrière lui.

Les dix-neuf règles, par famille :

**Le pointeur de publication** : `published_revision_foreign`, `published_revision_unreviewed`,
`published_revision_unpublished`, `published_revision_superseded`, `published_revision_without_source`,
`multiple_published_revisions`.

`published_revision_unpublished` est distincte de la non-relue, et la distinction compte : une révision
peut être relue et pointée sans avoir jamais été publiée, et « le texte en vigueur à la date D »
sélectionnerait alors quelque chose que le site n'a jamais affiché.

`multiple_published_revisions` décrit exactement l'état que deux publications concurrentes produisent sans
`FOR UPDATE`. Aucun appel public ne peut plus le créer, ce qui est précisément pourquoi l'audit doit le
voir.

**Le pointeur de brouillon** : `orphan_active_draft`, `latest_revision_foreign`,
`latest_revision_discarded`.

`latest_revision_foreign` méritait sa construction : `latestRevisionId` est `@unique`, donc la révision
étrangère doit d'abord être libérée. C'est ce qui rend l'état atteignable, la contrainte empêche deux
mesures de partager un pointeur, pas une mesure de pointer une révision étrangère.

**Le contexte** : `candidacy_politician_mismatch`, `program_edition_election_mismatch`.

**Le retrait** : `withdrawn_without_source`, `withdrawal_source_without_date`. Les deux sens, parce qu'un
`withdrawnAt` sans source est une affirmation non sourcée, et une source sans date est un retrait à moitié
écrit.

**L'index de recherche** : `search_document_missing`, `search_document_visibility_mismatch`,
`search_document_stale`.

`search_document_missing` existe pour une raison structurelle : les deux autres sont gardées par « si un
document existe », donc sans elle une mesure jamais indexée passe en silence, invisible dans la recherche
et déclarée saine. Elle n'est exigée que s'il y a une révision de référence : une mesure dont l'unique
brouillon a été abandonné n'a rien à représenter, et `syncSearchDocument` supprime sa ligne exprès.

**Les conclusions éditoriales** : `similarity_conclusion_mismatch`, `qualification_half_source`,
`program_edition_owner_count`. Ces trois-là ne portent pas de `measureId`, donc elles sont vérifiées sur
l'ensemble du résultat.

Deux règles d'une version antérieure du plan sont **délibérément absentes** : « qualification orpheline »
et « évaluation orpheline » interrogeaient `revision: { is: null }` sur une relation obligatoire avec
suppression en cascade. L'orphelin est structurellement impossible et la requête ne veut rien dire.

## Le code de sortie, vérifié à part

Le test des dix-neuf règles vérifie `auditMeasures()`, pas le script. Le code de sortie est ce qui
permettra de brancher la commande en CI, donc il se vérifie en lançant le script. Sortir en 0 sur une
violation serait pire que de ne pas avoir la commande : la CI passerait au vert sur une base qui contredit
le modèle.

Ce fichier tronque les mesures dans son `beforeAll`, parce que la commande audite la base entière et ne
peut pas tolérer les violations que les autres fichiers construisent exprès. Tronquer d'abord le rend
indépendant de l'ordre d'exécution, au lieu de reposer sur « le lancer en dernier », dont personne ne se
souvient six mois plus tard.

Un seul `beforeAll`, et l'ordre à l'intérieur compte : une version du plan tronquait dans un hook et
résolvait l'import différé dans un second, or les hooks s'exécutent dans l'ordre de déclaration, donc la
troncature atteignait `db` avant son affectation. Corrigé avant d'écrire le code.

## Une dépendance à l'ordre d'exécution, trouvée en exécutant

Le test de l'édition rattachée à une autre élection utilisait `db.party.findFirstOrThrow()` et
`db.election.findFirstOrThrow()`, donc il reposait sur des lignes laissées par d'autres fichiers de test.
Les fixtures ne créent jamais de `Party` : le fichier échouait lancé seul, et aurait continué d'échouer
selon l'ordre d'exécution. Il sème maintenant ses propres données.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Aucune. Quatrième et dernière PR du lot 1.

## Vérifications

155 tests verts sous `npm run test:db:search`, dont 21 sur les règles et 2 sur le code de sortie. Les mêmes
en skip sous `npx vitest run`, jamais en échec. Suite complète verte. `npx tsc --noEmit` en code 0 sur
cache froid, ESLint propre sur `src/lib/measures` et `src/lib/data` avec `--max-warnings=0`.

Lancé tout le lot d'un bloc pour vérifier que la troncature couvre bien toutes les tables : vert, donc
`audit-command` ne dépend pas de sa position dans l'ordre.

Trois ablations, chacune ayant produit l'échec annoncé :

| Ce qu'on retire                                                                      | Ce qui tombe                              |
| ------------------------------------------------------------------------------------ | ----------------------------------------- |
| la règle `search_document_missing`                                                   | la mesure jamais indexée passe pour saine |
| la règle `multiple_published_revisions`                                              | deux révisions publiées ne sont plus vues |
| la péremption comparée à la révision de référence, remplacée par `Measure.updatedAt` | le cas sain est déclaré périmé            |

La troisième mérite une précision. Le plan annonçait qu'elle tomberait « parce que toute mesure avec un
brouillon en cours serait déclarée périmée ». C'est vrai, mais l'échec arrive avant : une mesure **sans**
aucun brouillon suffit, puisque l'`UPDATE` de publication déplace `Measure.updatedAt` après l'écriture de
la révision, donc `sourceUpdatedAt < updatedAt` dès la publication. La comparaison naïve est encore plus
fausse que le plan ne le disait.

## Rebasé sur `main` en cours de route

`main` a pris le pipeline portraits pendant l'écriture de cette PR. Rebasé, tests et typage rejoués après
coup : le diff ne contient que les cinq fichiers de l'audit.

## Ce que le lot 1 ne contient pas, et qui reste ouvert

- **L'admin de relecture** : lot 2. Ce lot livre les fonctions, pas les écrans.
- **`MeasureVoteLink`** et le rattachement aux scrutins : lot 3.
- **La table d'invalidation de cache** : aucun lot. L'invalidation après commit journalisée suffit tant
  qu'une invalidation perdue ne laisse pas une page périmée durablement.
- **`db:push` de production** pour les sept modèles du lot : à faire avant la mise en service, et il sera
  soumis au garde anti-agent de Prisma 7.9, avec son propre consentement explicite.
- **Brancher `measures:audit` en CI ou en cron** : la commande a le code de sortie qu'il faut, rien ne la
  déclenche encore. À décider quand des mesures existeront en production.
