### PR TITLE
Livrer la file de relecture des mesures (lot 2, PR 2A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "seed:communes": "npx dotenv -e .env -- npx tsx scripts/seed-communes.ts",
     "compute:municipales-stats": "npx dotenv -e .env -- npx tsx scripts/compute-election-stats.ts",
     "seed:elections": "tsx scripts/seed-elections.ts",
+    "seed:measures-demo": "tsx scripts/seed-measures-demo.ts",
     "seed:presidentielle-2027": "npx dotenv -e .env -- npx tsx scripts/seed-presidentielle-2027.ts",
     "seed:parliamentary-groups": "tsx scripts/seed-parliamentary-groups.ts",
     "trigger": "tsx scripts/trigger.ts",

--- a/scripts/seed-measures-demo.ts
+++ b/scripts/seed-measures-demo.ts
@@ -10,11 +10,11 @@
  * point: `.env` and `.env.prod` point at the same Supabase database, so an ungated run with
  * the default environment would write fabricated political positions into production.
  *
- * Usage, with the container from `npm run test:db:search` running:
- *   DATABASE_URL=postgresql://poligraph:poligraph@localhost:55433/poligraph_test \
+ * Usage, with the container from docker-compose.test-search.yml running:
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
  *     npx tsx scripts/seed-measures-demo.ts
  */
-import { assertDisposableTestDb } from "@/test/db-guard";
+import { assertDisposableTestDb } from "@/test/disposable-db";
 import { seedMeasuresDemoCorpus } from "@/test/fixtures/measures-demo";
 
 async function main(): Promise<void> {

--- a/scripts/seed-measures-demo.ts
+++ b/scripts/seed-measures-demo.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+/**
+ * npm run seed:measures-demo
+ *
+ * Seeds the demonstration corpus so the moderation screens can be reviewed against every
+ * state they claim to render. No measure exists in production, so there is nothing else to
+ * look at.
+ *
+ * Refuses to run against anything but the disposable container, and that refusal is the
+ * point: `.env` and `.env.prod` point at the same Supabase database, so an ungated run with
+ * the default environment would write fabricated political positions into production.
+ *
+ * Usage, with the container from `npm run test:db:search` running:
+ *   DATABASE_URL=postgresql://poligraph:poligraph@localhost:55433/poligraph_test \
+ *     npx tsx scripts/seed-measures-demo.ts
+ */
+import { assertDisposableTestDb } from "@/test/db-guard";
+import { seedMeasuresDemoCorpus } from "@/test/fixtures/measures-demo";
+
+async function main(): Promise<void> {
+  // First statement of the script, before any import that opens a connection.
+  assertDisposableTestDb();
+
+  const corpus = await seedMeasuresDemoCorpus();
+  const { db } = await import("@/lib/db");
+
+  console.log(`[seed:measures-demo] élection ${corpus.electionSlug} (${corpus.electionId})`);
+  for (const [key, id] of Object.entries(corpus.measureIds)) {
+    console.log(`  ${key.padEnd(24)} ${id}`);
+  }
+  console.log(
+    `[seed:measures-demo] ${Object.keys(corpus.measureIds).length} mesures, ` +
+      `${corpus.candidateIds.length} candidatures fictives`
+  );
+
+  await db.$disconnect();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -90,5 +90,7 @@ else
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/search \
     src/lib/measures \
+    src/app/admin/mesures \
+    src/test/fixtures/__tests__ \
     src/test/__tests__/db-guard.test.ts
 fi

--- a/src/app/admin/mesures/[id]/page.tsx
+++ b/src/app/admin/mesures/[id]/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import {
+  CANDIDACY_STATUS_LABELS,
+  MEASURE_ATTRIBUTION_LABELS,
+  THEME_CATEGORY_LABELS,
+} from "@/config/labels";
+import { isAuthenticated } from "@/lib/auth";
+import { getMeasureForModeration, getPublicMeasure } from "@/lib/data/measures";
+import { deriveModerationState, type ModerationMeasureRow } from "@/lib/measures/moderation-state";
+import { AnomalyList } from "../_components/AnomalyList";
+import { ModerationStateBadge } from "../_components/ModerationStateBadge";
+import { PublicVisibilityCard } from "../_components/PublicVisibilityCard";
+import { RevisionTimeline } from "../_components/RevisionTimeline";
+import { getMeasureContext } from "../_data/detail-query";
+
+export const metadata = {
+  title: "Fiche de modération d'une mesure (admin) | Poligraph",
+  robots: { index: false },
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+type ModerationRead = NonNullable<Awaited<ReturnType<typeof getMeasureForModeration>>>;
+
+/**
+ * The moderation read carries the full source rows, so the source count is their length. The
+ * shape is exhaustive by type, so adding a field to ModerationMeasureRow breaks this at compile
+ * time rather than silently deriving from a missing value.
+ */
+function toRow(measure: ModerationRead): ModerationMeasureRow {
+  return {
+    id: measure.id,
+    publicationStatus: measure.publicationStatus,
+    latestRevisionId: measure.latestRevisionId,
+    publishedRevisionId: measure.publishedRevisionId,
+    withdrawnAt: measure.withdrawnAt,
+    withdrawnSourceUrl: measure.withdrawnSourceUrl,
+    withdrawnSourceLabel: measure.withdrawnSourceLabel,
+    depublishedAt: measure.depublishedAt,
+    depublicationReason: measure.depublicationReason,
+    revisions: measure.revisions.map((revision) => ({
+      id: revision.id,
+      reviewedAt: revision.reviewedAt,
+      publishedAt: revision.publishedAt,
+      supersededAt: revision.supersededAt,
+      discardedAt: revision.discardedAt,
+      sourceCount: revision.sources.length,
+    })),
+  };
+}
+
+export default async function AdminMeasureDetailPage({ params }: PageProps) {
+  if (!(await isAuthenticated())) redirect("/admin/login");
+
+  const { id } = await params;
+
+  // Three reads, three different questions: the moderation read applies no filter, the public
+  // read applies both, and the context read carries who and which election.
+  const [measure, context, publicMeasure] = await Promise.all([
+    getMeasureForModeration(id),
+    getMeasureContext(id),
+    getPublicMeasure(id),
+  ]);
+
+  if (measure === null || context === null) notFound();
+
+  const state = deriveModerationState(toRow(measure));
+  const dateFormat = new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" });
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <Link href="/admin/mesures" prefetch={false} className="text-sm text-primary underline">
+          Retour à la file
+        </Link>
+        <h1 className="font-display text-2xl font-bold tracking-tight">
+          {context.politician.fullName}
+        </h1>
+        <ModerationStateBadge state={state} />
+      </header>
+
+      <section
+        aria-labelledby="context-heading"
+        className="rounded-lg border border-border p-4 text-sm"
+      >
+        <h2 id="context-heading" className="text-base font-semibold">
+          Contexte
+        </h2>
+        <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          <div className="flex gap-2">
+            <dt className="font-medium">Élection</dt>
+            <dd className="text-muted-foreground">{context.election.title}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Sujet</dt>
+            <dd className="text-muted-foreground">{THEME_CATEGORY_LABELS[context.theme]}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Attribution</dt>
+            <dd className="text-muted-foreground">
+              {MEASURE_ATTRIBUTION_LABELS[context.attribution]}
+            </dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Candidature</dt>
+            <dd className="text-muted-foreground">
+              {context.candidacy === null
+                ? "aucune candidature rattachée"
+                : // status is nullable: before the official filing, no one is formally a
+                  // candidate, and lot 0A kept that distinction rather than defaulting it.
+                  `${context.candidacy.candidateName} · ${
+                    context.candidacy.status === null
+                      ? "statut non renseigné"
+                      : CANDIDACY_STATUS_LABELS[context.candidacy.status]
+                  }`}
+            </dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Édition de programme</dt>
+            <dd className="text-muted-foreground">
+              {context.programEdition === null
+                ? "aucune édition rattachée"
+                : `${context.programEdition.label} (version ${context.programEdition.version})`}
+            </dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Saisie le</dt>
+            <dd className="text-muted-foreground">{dateFormat.format(context.createdAt)}</dd>
+          </div>
+        </dl>
+
+        {state.depublication !== null && (
+          <div className="mt-4 rounded border border-border bg-muted/40 p-3">
+            <p className="font-medium">Dépubliée le {dateFormat.format(state.depublication.at)}</p>
+            {state.depublication.reason === null ? (
+              <p className="mt-1 text-red-700 dark:text-red-400">
+                Aucun motif enregistré, alors que la dépublication en exige un.
+              </p>
+            ) : (
+              <p className="mt-1 text-muted-foreground">{state.depublication.reason}</p>
+            )}
+          </div>
+        )}
+      </section>
+
+      <PublicVisibilityCard state={state} publicMeasure={publicMeasure} />
+
+      <section aria-labelledby="anomalies-heading">
+        <h2 id="anomalies-heading" className="text-base font-semibold">
+          Anomalies
+        </h2>
+        <div className="mt-3">
+          <AnomalyList anomalies={state.anomalies} />
+        </div>
+      </section>
+
+      <section aria-labelledby="revisions-heading">
+        <h2 id="revisions-heading" className="text-base font-semibold">
+          {measure.revisions.length === 1 ? "1 révision" : `${measure.revisions.length} révisions`}
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            brouillons et révisions abandonnées comprises
+          </span>
+        </h2>
+        <div className="mt-3">
+          <RevisionTimeline
+            revisions={measure.revisions}
+            publishedRevisionId={measure.publishedRevisionId}
+            latestRevisionId={measure.latestRevisionId}
+          />
+        </div>
+      </section>
+
+      <p className="text-sm text-muted-foreground">
+        Cet écran est en lecture seule. Les actions éditoriales arrivent au lot suivant.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/mesures/[id]/page.tsx
+++ b/src/app/admin/mesures/[id]/page.tsx
@@ -70,15 +70,26 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
   const state = deriveModerationState(toRow(measure));
   const dateFormat = new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" });
 
+  // The published revision when there is one, the active draft otherwise. Same reference the
+  // queue shows, so the two screens name the measure identically.
+  const referenceRevisionId = measure.publishedRevisionId ?? measure.latestRevisionId;
+  const referenceText =
+    measure.revisions.find((revision) => revision.id === referenceRevisionId)?.text ?? null;
+
   return (
     <div className="space-y-6">
       <header className="space-y-3">
         <Link href="/admin/mesures" prefetch={false} className="text-sm text-primary underline">
           Retour à la file
         </Link>
+        {/* The measure is what this page is about, so it is the h1. Naming the politician
+            instead read as a page about the person, who carries many measures. */}
         <h1 className="font-display text-2xl font-bold tracking-tight">
-          {context.politician.fullName}
+          {referenceText ?? "Mesure sans révision saisie"}
         </h1>
+        <p className="text-sm text-muted-foreground">
+          {context.politician.fullName} · {context.election.title}
+        </p>
         <ModerationStateBadge state={state} />
       </header>
 

--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MeasureQueueResult } from "../_data/queue-query";
+
+/**
+ * The moderation screens show unreviewed editorial text, so they must not be reachable without
+ * a session.
+ *
+ * This is not a formality in this repository: `src/app/admin/layout.tsx` renders its children
+ * when the visitor is NOT authenticated, so that the login page can go through. A page that
+ * does not check for itself is therefore served to an anonymous request, and there is no
+ * `middleware.ts` behind it.
+ */
+
+const redirectMock = vi.fn((path: string) => {
+  // The real redirect() throws to unwind the render, so the mock does too.
+  throw new Error(`REDIRECT:${path}`);
+});
+const isAuthenticatedMock = vi.fn<() => Promise<boolean>>();
+
+const EMPTY_RESULT: MeasureQueueResult = {
+  rows: [],
+  total: 0,
+  counts: { EMPTY: 0, DRAFT: 0, REVIEWED: 0, PUBLISHED: 0, DEPUBLISHED: 0 },
+  anomalyCount: 0,
+  withdrawnCount: 0,
+  scanCapped: false,
+};
+
+const queryMeasureQueueMock = vi.fn(async () => EMPTY_RESULT);
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => redirectMock(path),
+  notFound: () => {
+    throw new Error("NOT_FOUND");
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: () => isAuthenticatedMock(),
+}));
+
+// Mocked so the pages load without DATABASE_URL, and so a page that queried before checking
+// the session would be visible in the call order.
+vi.mock("../_data/queue-query", () => ({
+  queryMeasureQueue: () => queryMeasureQueueMock(),
+}));
+
+vi.mock("../_data/detail-query", () => ({
+  getMeasureContext: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/data/measures", () => ({
+  getMeasureForModeration: vi.fn(async () => null),
+  getPublicMeasure: vi.fn(async () => null),
+}));
+
+describe("accès aux écrans de modération des mesures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirige la file vers la connexion en l'absence de session", async () => {
+    isAuthenticatedMock.mockResolvedValue(false);
+    const { default: QueuePage } = await import("../page");
+
+    await expect(QueuePage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "REDIRECT:/admin/login"
+    );
+    expect(redirectMock).toHaveBeenCalledWith("/admin/login");
+    expect(queryMeasureQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("redirige le détail vers la connexion en l'absence de session", async () => {
+    isAuthenticatedMock.mockResolvedValue(false);
+    const { default: DetailPage } = await import("../[id]/page");
+
+    await expect(DetailPage({ params: Promise.resolve({ id: "mesure-1" }) })).rejects.toThrow(
+      "REDIRECT:/admin/login"
+    );
+    expect(redirectMock).toHaveBeenCalledWith("/admin/login");
+  });
+
+  it("laisse passer la file avec une session valide", async () => {
+    // Without this case, a guard that redirected unconditionally would pass the two tests
+    // above while making the screen unusable.
+    isAuthenticatedMock.mockResolvedValue(true);
+    const { default: QueuePage } = await import("../page");
+
+    await QueuePage({ searchParams: Promise.resolve({}) });
+
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(queryMeasureQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("garde les deux écrans hors des index", async () => {
+    // A crawled admin page would publish unreviewed editorial text under our name.
+    const queue = await import("../page");
+    const detail = await import("../[id]/page");
+
+    expect(queue.metadata.robots).toEqual({ index: false });
+    expect(detail.metadata.robots).toEqual({ index: false });
+  });
+});

--- a/src/app/admin/mesures/_components/AnomalyList.tsx
+++ b/src/app/admin/mesures/_components/AnomalyList.tsx
@@ -1,0 +1,37 @@
+import { MODERATION_ANOMALY_LABELS } from "@/config/labels";
+import type { ModerationAnomaly } from "@/lib/measures/moderation-state";
+
+/**
+ * The anomalies of a measure, named with the same vocabulary as `npm run measures:audit`.
+ *
+ * Each entry carries the identifiers involved, so a moderator can go and fix the row instead
+ * of only knowing that something is wrong.
+ */
+export function AnomalyList({ anomalies }: { anomalies: ModerationAnomaly[] }) {
+  if (anomalies.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aucune anomalie détectée sur cette mesure et ses révisions.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {anomalies.map((anomaly) => (
+        <li
+          key={`${anomaly.code}-${anomaly.detail}`}
+          className="rounded border border-red-300 bg-red-50 p-3 text-sm dark:border-red-900 dark:bg-red-950/40"
+        >
+          <p className="font-medium text-red-800 dark:text-red-300">
+            {MODERATION_ANOMALY_LABELS[anomaly.code]}
+          </p>
+          <p className="mt-1 font-mono text-xs break-all text-red-700/80 dark:text-red-400/80">
+            {anomaly.code}
+            {anomaly.detail !== "" && ` · ${anomaly.detail}`}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/admin/mesures/_components/ModerationStateBadge.tsx
+++ b/src/app/admin/mesures/_components/ModerationStateBadge.tsx
@@ -1,0 +1,73 @@
+import { PUBLICATION_STATE_LABELS, PUBLICATION_STATUS_LABELS } from "@/config/labels";
+import type { ModerationState, PublicationState } from "@/lib/measures/moderation-state";
+
+/**
+ * The moderation state of a measure, as several chips rather than one label.
+ *
+ * One chip per fact, on purpose. A single badge would have to choose between "published" and
+ * "withdrawn" and "a correction is under review", and those coexist. The pair that matters
+ * most is "published" beside "invisible to the public": collapsing them would hide the case a
+ * moderator has to act on.
+ */
+
+const CHIP = "inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium";
+
+const STATE_STYLES: Record<PublicationState, string> = {
+  EMPTY:
+    "bg-slate-50 text-slate-600 border-slate-300 dark:bg-slate-900/40 dark:text-slate-300 dark:border-slate-700",
+  DRAFT:
+    "bg-amber-50 text-amber-700 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800",
+  REVIEWED:
+    "bg-sky-50 text-sky-700 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-800",
+  PUBLISHED:
+    "bg-emerald-50 text-emerald-700 border-emerald-300 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800",
+  DEPUBLISHED:
+    "bg-slate-100 text-slate-700 border-slate-400 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-600",
+};
+
+const WARNING =
+  "bg-red-50 text-red-700 border-red-300 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900";
+const NEUTRAL = "bg-muted text-muted-foreground border-border";
+
+export function ModerationStateBadge({ state }: { state: ModerationState }) {
+  const unexpectedlyHidden = state.publication === "PUBLISHED" && !state.publiclyVisible;
+  const statusDisagrees = state.declaredStatus !== "PUBLISHED" && state.declaredStatus !== "DRAFT";
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className={`${CHIP} ${STATE_STYLES[state.publication]}`}>
+        {PUBLICATION_STATE_LABELS[state.publication]}
+      </span>
+
+      {unexpectedlyHidden && (
+        <span className={`${CHIP} ${WARNING}`}>Publiée mais invisible du public</span>
+      )}
+
+      {statusDisagrees && (
+        <span className={`${CHIP} ${WARNING}`}>
+          Statut en base : {PUBLICATION_STATUS_LABELS[state.declaredStatus]}
+        </span>
+      )}
+
+      {state.withdrawal !== null && (
+        <span className={`${CHIP} ${NEUTRAL}`}>
+          {state.withdrawal.sourceUrl && state.withdrawal.sourceLabel
+            ? "Retirée, sourcée"
+            : "Retirée, source incomplète"}
+        </span>
+      )}
+
+      {state.pendingDraft !== null && (
+        <span className={`${CHIP} ${NEUTRAL}`}>
+          {state.pendingDraft.reviewed ? "Correction relue en attente" : "Correction en cours"}
+        </span>
+      )}
+
+      {state.anomalies.length > 0 && (
+        <span className={`${CHIP} ${WARNING}`}>
+          {state.anomalies.length === 1 ? "1 anomalie" : `${state.anomalies.length} anomalies`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
+++ b/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
@@ -1,0 +1,110 @@
+import {
+  MEASURE_SOURCE_KIND_LABELS,
+  SOURCE_TIER_LABELS,
+  VISIBILITY_BLOCKER_LABELS,
+} from "@/config/labels";
+import type { PublicMeasure } from "@/lib/data/measures";
+import type { ModerationState } from "@/lib/measures/moderation-state";
+
+/**
+ * What the public actually gets for this measure.
+ *
+ * `publicMeasure` is the real output of `getPublicMeasure()`, not a second derivation: the
+ * moderation screen shows the public function's answer, which is the strongest form of the
+ * separation between the two reads. When it is null, the blocker list says why, condition by
+ * condition.
+ */
+export function PublicVisibilityCard({
+  state,
+  publicMeasure,
+}: {
+  state: ModerationState;
+  publicMeasure: PublicMeasure | null;
+}) {
+  const dateFormat = new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" });
+
+  return (
+    <section
+      aria-labelledby="public-visibility-heading"
+      className="rounded-lg border border-border p-4"
+    >
+      <h2 id="public-visibility-heading" className="text-base font-semibold">
+        Ce que le public voit
+      </h2>
+
+      {publicMeasure === null ? (
+        <div className="mt-3 space-y-3">
+          <p className="text-sm font-medium">
+            Cette mesure ne sort d&apos;aucune lecture publique.
+          </p>
+          <ul className="space-y-1.5 text-sm text-muted-foreground">
+            {state.visibilityBlockers.map((blocker) => (
+              <li key={blocker} className="flex gap-2">
+                <span aria-hidden="true">·</span>
+                <span>{VISIBILITY_BLOCKER_LABELS[blocker]}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div className="mt-3 space-y-4">
+          <blockquote className="border-l-2 border-border pl-3 text-sm">
+            {publicMeasure.text}
+          </blockquote>
+
+          {publicMeasure.withdrawal !== null && (
+            <div className="rounded border border-border bg-muted/40 p-3 text-sm">
+              <p className="font-medium">
+                Retirée le {dateFormat.format(publicMeasure.withdrawal.withdrawnAt)}
+              </p>
+              {publicMeasure.withdrawal.sourceUrl && publicMeasure.withdrawal.sourceLabel ? (
+                <a
+                  href={publicMeasure.withdrawal.sourceUrl}
+                  className="mt-1 inline-block text-primary underline"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {publicMeasure.withdrawal.sourceLabel}
+                </a>
+              ) : (
+                // The withdrawal is shown either way. Hiding it to protect the missing source
+                // would state something false: that the candidate still defends the measure.
+                <p className="mt-1 text-red-700 dark:text-red-400">
+                  Retrait incomplet : la source n&apos;est pas renseignée, donc aucun lien
+                  n&apos;est affiché au public.
+                </p>
+              )}
+            </div>
+          )}
+
+          <div>
+            <h3 className="text-sm font-medium">
+              {publicMeasure.sources.length === 1
+                ? "1 source citée"
+                : `${publicMeasure.sources.length} sources citées`}
+            </h3>
+            <ul className="mt-2 space-y-1.5 text-sm">
+              {publicMeasure.sources.map((source) => (
+                <li key={source.id}>
+                  <a
+                    href={source.url}
+                    className="text-primary underline break-all"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {MEASURE_SOURCE_KIND_LABELS[source.sourceKind]}
+                  </a>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    · {SOURCE_TIER_LABELS[source.tier]} · {dateFormat.format(source.publishedAt)}
+                    {source.page !== null && ` · p. ${source.page}`}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/admin/mesures/_components/QueueFilters.tsx
+++ b/src/app/admin/mesures/_components/QueueFilters.tsx
@@ -1,0 +1,184 @@
+import Link from "next/link";
+import { PUBLICATION_STATE_LABELS, THEME_CATEGORY_LABELS } from "@/config/labels";
+import type { PublicationState } from "@/lib/measures/moderation-state";
+import type { ThemeCategory } from "@/generated/prisma";
+import type { MeasureQueueResult } from "../_data/queue-query";
+
+/**
+ * Filters as plain links, server-rendered.
+ *
+ * No `useSearchParams`, no client component: the page already reads its parameters from
+ * `searchParams` on the server, and a filter bar made of links keeps the route static and
+ * needs no Suspense boundary.
+ */
+
+export type QueueFilterState = {
+  publication: PublicationState[];
+  theme: ThemeCategory[];
+  anomaliesOnly: boolean;
+  withdrawn: "only" | "exclude" | undefined;
+  q: string | undefined;
+};
+
+const BASE_PATH = "/admin/mesures";
+
+// 44px minimum touch target, per the accessibility rules of the design.
+const TAB =
+  "inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm hover:bg-muted";
+const TAB_ACTIVE = "bg-muted font-medium";
+
+const PUBLICATION_ORDER: PublicationState[] = [
+  "DRAFT",
+  "REVIEWED",
+  "PUBLISHED",
+  "DEPUBLISHED",
+  "EMPTY",
+];
+
+function hrefWith(current: QueueFilterState, patch: Partial<QueueFilterState>): string {
+  const next = { ...current, ...patch };
+  const params = new URLSearchParams();
+
+  for (const state of next.publication) params.append("etat", state);
+  for (const theme of next.theme) params.append("theme", theme);
+  if (next.anomaliesOnly) params.set("anomalies", "1");
+  if (next.withdrawn) params.set("retrait", next.withdrawn);
+  if (next.q) params.set("q", next.q);
+
+  const query = params.toString();
+  return query === "" ? BASE_PATH : `${BASE_PATH}?${query}`;
+}
+
+function toggle<T>(values: T[], value: T): T[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+}
+
+export function QueueFilters({
+  current,
+  result,
+}: {
+  current: QueueFilterState;
+  result: MeasureQueueResult;
+}) {
+  const themeKeys = Object.keys(THEME_CATEGORY_LABELS) as ThemeCategory[];
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border p-4">
+      <fieldset>
+        <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Étape du cycle
+        </legend>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Link
+            href={hrefWith(current, { publication: [] })}
+            prefetch={false}
+            className={`${TAB} ${current.publication.length === 0 ? TAB_ACTIVE : ""}`}
+          >
+            Toutes
+          </Link>
+          {PUBLICATION_ORDER.map((state) => (
+            <Link
+              key={state}
+              href={hrefWith(current, { publication: toggle(current.publication, state) })}
+              prefetch={false}
+              className={`${TAB} ${current.publication.includes(state) ? TAB_ACTIVE : ""}`}
+              aria-pressed={current.publication.includes(state)}
+            >
+              {PUBLICATION_STATE_LABELS[state]}
+              <span className="ml-1.5 text-muted-foreground">{result.counts[state]}</span>
+            </Link>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Signalements
+        </legend>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Link
+            href={hrefWith(current, { anomaliesOnly: !current.anomaliesOnly })}
+            prefetch={false}
+            className={`${TAB} ${current.anomaliesOnly ? TAB_ACTIVE : ""}`}
+            aria-pressed={current.anomaliesOnly}
+          >
+            Anomalies seulement
+            <span className="ml-1.5 text-muted-foreground">{result.anomalyCount}</span>
+          </Link>
+          <Link
+            href={hrefWith(current, {
+              withdrawn: current.withdrawn === "only" ? undefined : "only",
+            })}
+            prefetch={false}
+            className={`${TAB} ${current.withdrawn === "only" ? TAB_ACTIVE : ""}`}
+            aria-pressed={current.withdrawn === "only"}
+          >
+            Retraits
+            <span className="ml-1.5 text-muted-foreground">{result.withdrawnCount}</span>
+          </Link>
+          <Link
+            href={hrefWith(current, {
+              withdrawn: current.withdrawn === "exclude" ? undefined : "exclude",
+            })}
+            prefetch={false}
+            className={`${TAB} ${current.withdrawn === "exclude" ? TAB_ACTIVE : ""}`}
+            aria-pressed={current.withdrawn === "exclude"}
+          >
+            Hors retraits
+          </Link>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Sujet
+        </legend>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {themeKeys.map((theme) => (
+            <Link
+              key={theme}
+              href={hrefWith(current, { theme: toggle(current.theme, theme) })}
+              prefetch={false}
+              className={`${TAB} ${current.theme.includes(theme) ? TAB_ACTIVE : ""}`}
+              aria-pressed={current.theme.includes(theme)}
+            >
+              {THEME_CATEGORY_LABELS[theme]}
+            </Link>
+          ))}
+        </div>
+      </fieldset>
+
+      <form action={BASE_PATH} method="get" className="flex flex-wrap items-end gap-2">
+        {/* A GET form submits only its own fields, so the active filters travel as hidden
+            inputs. Without them, searching would silently reset every other filter. */}
+        {current.publication.map((state) => (
+          <input key={state} type="hidden" name="etat" value={state} />
+        ))}
+        {current.theme.map((theme) => (
+          <input key={theme} type="hidden" name="theme" value={theme} />
+        ))}
+        {current.anomaliesOnly && <input type="hidden" name="anomalies" value="1" />}
+        {current.withdrawn && <input type="hidden" name="retrait" value={current.withdrawn} />}
+
+        <div className="flex-1">
+          <label
+            htmlFor="queue-search"
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Chercher dans le texte des révisions
+          </label>
+          <input
+            id="queue-search"
+            name="q"
+            type="search"
+            defaultValue={current.q ?? ""}
+            className="mt-2 min-h-11 w-full rounded border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <button type="submit" className={TAB}>
+          Chercher
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/mesures/_components/QueueFilters.tsx
+++ b/src/app/admin/mesures/_components/QueueFilters.tsx
@@ -82,7 +82,7 @@ export function QueueFilters({
               href={hrefWith(current, { publication: toggle(current.publication, state) })}
               prefetch={false}
               className={`${TAB} ${current.publication.includes(state) ? TAB_ACTIVE : ""}`}
-              aria-pressed={current.publication.includes(state)}
+              aria-current={current.publication.includes(state) ? "true" : undefined}
             >
               {PUBLICATION_STATE_LABELS[state]}
               <span className="ml-1.5 text-muted-foreground">{result.counts[state]}</span>
@@ -100,7 +100,7 @@ export function QueueFilters({
             href={hrefWith(current, { anomaliesOnly: !current.anomaliesOnly })}
             prefetch={false}
             className={`${TAB} ${current.anomaliesOnly ? TAB_ACTIVE : ""}`}
-            aria-pressed={current.anomaliesOnly}
+            aria-current={current.anomaliesOnly ? "true" : undefined}
           >
             Anomalies seulement
             <span className="ml-1.5 text-muted-foreground">{result.anomalyCount}</span>
@@ -111,7 +111,7 @@ export function QueueFilters({
             })}
             prefetch={false}
             className={`${TAB} ${current.withdrawn === "only" ? TAB_ACTIVE : ""}`}
-            aria-pressed={current.withdrawn === "only"}
+            aria-current={current.withdrawn === "only" ? "true" : undefined}
           >
             Retraits
             <span className="ml-1.5 text-muted-foreground">{result.withdrawnCount}</span>
@@ -122,7 +122,7 @@ export function QueueFilters({
             })}
             prefetch={false}
             className={`${TAB} ${current.withdrawn === "exclude" ? TAB_ACTIVE : ""}`}
-            aria-pressed={current.withdrawn === "exclude"}
+            aria-current={current.withdrawn === "exclude" ? "true" : undefined}
           >
             Hors retraits
           </Link>
@@ -140,7 +140,7 @@ export function QueueFilters({
               href={hrefWith(current, { theme: toggle(current.theme, theme) })}
               prefetch={false}
               className={`${TAB} ${current.theme.includes(theme) ? TAB_ACTIVE : ""}`}
-              aria-pressed={current.theme.includes(theme)}
+              aria-current={current.theme.includes(theme) ? "true" : undefined}
             >
               {THEME_CATEGORY_LABELS[theme]}
             </Link>

--- a/src/app/admin/mesures/_components/QueueTable.tsx
+++ b/src/app/admin/mesures/_components/QueueTable.tsx
@@ -25,7 +25,12 @@ export function QueueTable({ rows }: { rows: MeasureQueueRow[] }) {
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
+    // `relative` is load-bearing, not decoration. `sr-only` is position: absolute, so the
+    // hidden label in the last header cell is placed against the nearest positioned ancestor.
+    // Without it, that ancestor is outside the scroll container, the label lands at x=736 in
+    // the document, and the whole PAGE scrolls horizontally by 361px on a 375px viewport.
+    // Measured, then fixed.
+    <div className="relative overflow-x-auto rounded-lg border border-border">
       <table className="w-full text-sm">
         <caption className="sr-only">
           Mesures en attente de relecture, de la plus ancienne à la plus récente

--- a/src/app/admin/mesures/_components/QueueTable.tsx
+++ b/src/app/admin/mesures/_components/QueueTable.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import type { MeasureQueueRow } from "../_data/queue-query";
+import { ModerationStateBadge } from "./ModerationStateBadge";
+
+/**
+ * The queue itself.
+ *
+ * A real `<table>` with `<th scope="col">`, not a CSS grid: applying `display: grid` to a
+ * table destroys the tabular semantics screen readers rely on. Wide content scrolls inside its
+ * own container so the page never scrolls horizontally.
+ */
+export function QueueTable({ rows }: { rows: MeasureQueueRow[] }) {
+  const formatter = new Intl.DateTimeFormat("fr-FR", { dateStyle: "short" });
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-border p-8 text-center">
+        <p className="text-sm font-medium">Aucune mesure ne correspond à ces filtres.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Les compteurs ci-dessus indiquent ce que contiennent les autres étapes.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <caption className="sr-only">
+          Mesures en attente de relecture, de la plus ancienne à la plus récente
+        </caption>
+        <thead className="bg-muted/50">
+          <tr>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              Candidature
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              Texte de référence
+              <span className="block text-xs font-normal">
+                La révision publiée, ou le brouillon à défaut
+              </span>
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              Sujet
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              État
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              Saisie
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
+              <span className="sr-only">Ouvrir la fiche de modération</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.id} className="transition-colors hover:bg-muted/30">
+              <td className="px-3 py-3 align-top whitespace-nowrap">{row.politicianName}</td>
+              <td className="max-w-md px-3 py-3 align-top">
+                {row.referenceText === null ? (
+                  // Never an empty cell and never a lone dash: the absence carries its reason.
+                  <span className="text-muted-foreground">Aucune révision saisie</span>
+                ) : (
+                  <span className="line-clamp-3">{row.referenceText}</span>
+                )}
+              </td>
+              <td className="px-3 py-3 align-top whitespace-nowrap">
+                {THEME_CATEGORY_LABELS[row.theme]}
+              </td>
+              <td className="px-3 py-3 align-top">
+                <ModerationStateBadge state={row.state} />
+              </td>
+              <td className="px-3 py-3 align-top whitespace-nowrap text-muted-foreground">
+                {formatter.format(row.createdAt)}
+              </td>
+              <td className="px-3 py-3 align-top">
+                <Link
+                  href={`/admin/mesures/${row.id}`}
+                  prefetch={false}
+                  className="inline-flex min-h-11 items-center text-primary underline"
+                >
+                  Examiner
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/admin/mesures/_components/RevisionTimeline.tsx
+++ b/src/app/admin/mesures/_components/RevisionTimeline.tsx
@@ -1,0 +1,213 @@
+import {
+  MEASURE_EXTRACTION_METHOD_LABELS,
+  MEASURE_PRECISION_LABELS,
+  MEASURE_SOURCE_KIND_LABELS,
+  QUALIFICATION_KIND_LABELS,
+  SOURCE_TIER_LABELS,
+} from "@/config/labels";
+import type { getMeasureForModeration } from "@/lib/data/measures";
+
+type ModerationMeasure = NonNullable<Awaited<ReturnType<typeof getMeasureForModeration>>>;
+type ModerationRevision = ModerationMeasure["revisions"][number];
+
+/**
+ * Every revision of the measure, drafts and discarded ones included.
+ *
+ * The moderation read applies no filter, and this component shows all of it: a screen that
+ * only listed the published revision would make the editorial history invisible, which is the
+ * one thing versioning was introduced for.
+ */
+
+const CHIP = "inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium";
+
+function dateOf(formatter: Intl.DateTimeFormat, value: Date | null): string {
+  return value === null ? "non" : formatter.format(value);
+}
+
+function RevisionCard({
+  revision,
+  isPublished,
+  isLatest,
+  formatter,
+}: {
+  revision: ModerationRevision;
+  isPublished: boolean;
+  isLatest: boolean;
+  formatter: Intl.DateTimeFormat;
+}) {
+  const state = revision.discardedAt
+    ? "Abandonnée"
+    : revision.supersededAt
+      ? "Remplacée"
+      : revision.publishedAt
+        ? "Publiée"
+        : revision.reviewedAt
+          ? "Relue, non publiée"
+          : "Brouillon";
+
+  return (
+    <li className="rounded-lg border border-border p-4">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className={`${CHIP} bg-muted text-muted-foreground border-border`}>{state}</span>
+        {isPublished && (
+          <span
+            className={`${CHIP} border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300`}
+          >
+            Révision désignée comme publiée
+          </span>
+        )}
+        {isLatest && (
+          <span
+            className={`${CHIP} border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-800 dark:bg-sky-900/30 dark:text-sky-300`}
+          >
+            Dernière révision
+          </span>
+        )}
+      </div>
+
+      <p className="mt-3 text-sm">{revision.text}</p>
+
+      <dl className="mt-3 grid gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+        <div className="flex gap-1">
+          <dt className="font-medium">En vigueur au</dt>
+          <dd>{formatter.format(revision.validFrom)}</dd>
+        </div>
+        <div className="flex gap-1">
+          <dt className="font-medium">Précision</dt>
+          <dd>
+            {revision.precision === null
+              ? "non qualifiée"
+              : MEASURE_PRECISION_LABELS[revision.precision]}
+          </dd>
+        </div>
+        <div className="flex gap-1">
+          <dt className="font-medium">Extraction</dt>
+          <dd>
+            {MEASURE_EXTRACTION_METHOD_LABELS[revision.extractionMethod]}
+            {revision.extractionConfidence !== null &&
+              ` · confiance ${revision.extractionConfidence.toFixed(2)}`}
+            {revision.extractorVersion !== null && ` · ${revision.extractorVersion}`}
+          </dd>
+        </div>
+        <div className="flex gap-1">
+          <dt className="font-medium">Relue</dt>
+          <dd>
+            {dateOf(formatter, revision.reviewedAt)}
+            {revision.reviewedBy !== null && ` · ${revision.reviewedBy}`}
+          </dd>
+        </div>
+        <div className="flex gap-1">
+          <dt className="font-medium">Publiée</dt>
+          <dd>{dateOf(formatter, revision.publishedAt)}</dd>
+        </div>
+        <div className="flex gap-1">
+          <dt className="font-medium">Remplacée</dt>
+          <dd>{dateOf(formatter, revision.supersededAt)}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-3">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {revision.sources.length === 1 ? "1 source" : `${revision.sources.length} sources`}
+        </h4>
+        {revision.sources.length === 0 ? (
+          <p className="mt-1 text-xs text-red-700 dark:text-red-400">
+            Aucune source : cette révision ne peut pas être publiée.
+          </p>
+        ) : (
+          <ul className="mt-1 space-y-1 text-xs">
+            {revision.sources.map((source) => (
+              <li key={source.id}>
+                <a
+                  href={source.url}
+                  className="text-primary underline break-all"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {MEASURE_SOURCE_KIND_LABELS[source.sourceKind]}
+                </a>
+                <span className="text-muted-foreground">
+                  {" "}
+                  · {SOURCE_TIER_LABELS[source.tier]} · {formatter.format(source.publishedAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {revision.qualifications.length > 0 && (
+        <div className="mt-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Qualifications
+          </h4>
+          <ul className="mt-1 space-y-1 text-xs">
+            {revision.qualifications.map((qualification) => (
+              <li key={qualification.id}>
+                <span className="font-medium">{QUALIFICATION_KIND_LABELS[qualification.kind]}</span>
+                <span className="text-muted-foreground">
+                  {" "}
+                  · {formatter.format(qualification.assessedAt)} · {qualification.assessedBy}
+                </span>
+                <p className="text-muted-foreground">{qualification.rationale}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {revision.assessments.length > 0 && (
+        <div className="mt-3">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Évaluations de similarité
+          </h4>
+          <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+            {revision.assessments.map((assessment) => (
+              <li key={assessment.id}>
+                {assessment.conclusion} · corpus {assessment.comparedCorpusVersion} ·{" "}
+                {formatter.format(assessment.assessedAt)} ·{" "}
+                {assessment.matches.length === 1
+                  ? "1 rapprochement"
+                  : `${assessment.matches.length} rapprochements`}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function RevisionTimeline({
+  revisions,
+  publishedRevisionId,
+  latestRevisionId,
+}: {
+  revisions: ModerationRevision[];
+  publishedRevisionId: string | null;
+  latestRevisionId: string | null;
+}) {
+  const formatter = new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" });
+
+  if (revisions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Cette mesure n&apos;a aucune révision. Rien n&apos;a encore été saisi.
+      </p>
+    );
+  }
+
+  return (
+    <ol className="space-y-3">
+      {revisions.map((revision) => (
+        <RevisionCard
+          key={revision.id}
+          revision={revision}
+          isPublished={revision.id === publishedRevisionId}
+          isLatest={revision.id === latestRevisionId}
+          formatter={formatter}
+        />
+      ))}
+    </ol>
+  );
+}

--- a/src/app/admin/mesures/_components/__tests__/AnomalyList.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/AnomalyList.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AnomalyList } from "../AnomalyList";
+
+describe("AnomalyList", () => {
+  it("dit explicitement qu'il n'y a rien à signaler", () => {
+    render(<AnomalyList anomalies={[]} />);
+
+    expect(
+      screen.getByText("Aucune anomalie détectée sur cette mesure et ses révisions.")
+    ).toBeInTheDocument();
+  });
+
+  it("nomme le défaut et porte l'identifiant concerné", () => {
+    // The identifier is what lets a moderator go and fix the row instead of only knowing that
+    // something is wrong.
+    render(
+      <AnomalyList anomalies={[{ code: "published_revision_without_source", detail: "rev-42" }]} />
+    );
+
+    expect(screen.getByText("La révision publiée n'a plus aucune source")).toBeInTheDocument();
+    expect(screen.getByText(/published_revision_without_source · rev-42/)).toBeInTheDocument();
+  });
+
+  it("rend chaque anomalie d'une liste", () => {
+    render(
+      <AnomalyList
+        anomalies={[
+          { code: "withdrawn_without_source", detail: "m-1" },
+          { code: "orphan_active_draft", detail: "rev-7" },
+        ]}
+      />
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("Retrait sans source : ni URL ni libellé")).toBeInTheDocument();
+    expect(screen.getByText("Un brouillon actif qu'aucun pointeur ne désigne")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/mesures/_components/__tests__/ModerationStateBadge.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/ModerationStateBadge.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ModerationState } from "@/lib/measures/moderation-state";
+import { ModerationStateBadge } from "../ModerationStateBadge";
+
+function state(over: Partial<ModerationState> = {}): ModerationState {
+  return {
+    publication: "DRAFT",
+    declaredStatus: "DRAFT",
+    publiclyVisible: false,
+    visibilityBlockers: ["status_not_published"],
+    withdrawal: null,
+    depublication: null,
+    pendingDraft: null,
+    anomalies: [],
+    ...over,
+  };
+}
+
+const PUBLISHED = {
+  publication: "PUBLISHED",
+  declaredStatus: "PUBLISHED",
+  publiclyVisible: true,
+  visibilityBlockers: [],
+} satisfies Partial<ModerationState>;
+
+describe("ModerationStateBadge", () => {
+  it("rend l'étape du cycle", () => {
+    render(<ModerationStateBadge state={state({ publication: "REVIEWED" })} />);
+
+    expect(screen.getByText("Relue")).toBeInTheDocument();
+  });
+
+  it("ne crie rien sur une mesure publiée et visible", () => {
+    render(<ModerationStateBadge state={state(PUBLISHED)} />);
+
+    expect(screen.getByText("Publiée")).toBeInTheDocument();
+    expect(screen.queryByText(/invisible du public/i)).not.toBeInTheDocument();
+  });
+
+  it("signale une mesure publiée que le public ne voit pas", () => {
+    // The pair that matters: the stage says published, the visibility says otherwise, and both
+    // have to be on screen at once.
+    render(
+      <ModerationStateBadge
+        state={state({
+          ...PUBLISHED,
+          publiclyVisible: false,
+          visibilityBlockers: ["revision_without_source"],
+        })}
+      />
+    );
+
+    expect(screen.getByText("Publiée")).toBeInTheDocument();
+    expect(screen.getByText("Publiée mais invisible du public")).toBeInTheDocument();
+  });
+
+  it("distingue un retrait sourcé d'un retrait incomplet", () => {
+    const { unmount } = render(
+      <ModerationStateBadge
+        state={state({
+          ...PUBLISHED,
+          withdrawal: {
+            withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+            sourceUrl: "https://example.org/retrait",
+            sourceLabel: "Conférence de presse",
+          },
+        })}
+      />
+    );
+    expect(screen.getByText("Retirée, sourcée")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <ModerationStateBadge
+        state={state({
+          ...PUBLISHED,
+          withdrawal: {
+            withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+            sourceUrl: null,
+            sourceLabel: null,
+          },
+        })}
+      />
+    );
+    expect(screen.getByText("Retirée, source incomplète")).toBeInTheDocument();
+  });
+
+  it("montre la correction en cours au lieu de la cacher derrière l'étape", () => {
+    render(
+      <ModerationStateBadge
+        state={state({ ...PUBLISHED, pendingDraft: { id: "rev-2", reviewed: true } })}
+      />
+    );
+
+    expect(screen.getByText("Correction relue en attente")).toBeInTheDocument();
+  });
+
+  it("distingue une correction relue d'une correction en cours", () => {
+    render(
+      <ModerationStateBadge
+        state={state({ ...PUBLISHED, pendingDraft: { id: "rev-2", reviewed: false } })}
+      />
+    );
+
+    expect(screen.getByText("Correction en cours")).toBeInTheDocument();
+  });
+
+  it("accorde le compteur d'anomalies", () => {
+    const { unmount } = render(
+      <ModerationStateBadge
+        state={state({ anomalies: [{ code: "orphan_active_draft", detail: "rev-3" }] })}
+      />
+    );
+    expect(screen.getByText("1 anomalie")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <ModerationStateBadge
+        state={state({
+          anomalies: [
+            { code: "orphan_active_draft", detail: "rev-3" },
+            { code: "withdrawn_without_source", detail: "m-1" },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText("2 anomalies")).toBeInTheDocument();
+  });
+
+  it("affiche un statut en base que les transitions n'écrivent jamais", () => {
+    render(<ModerationStateBadge state={state({ declaredStatus: "EXCLUDED" })} />);
+
+    expect(screen.getByText("Statut en base : Exclu")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PublicMeasure } from "@/lib/data/measures";
+import type { ModerationState } from "@/lib/measures/moderation-state";
+import { PublicVisibilityCard } from "../PublicVisibilityCard";
+
+function state(over: Partial<ModerationState> = {}): ModerationState {
+  return {
+    publication: "PUBLISHED",
+    declaredStatus: "PUBLISHED",
+    publiclyVisible: true,
+    visibilityBlockers: [],
+    withdrawal: null,
+    depublication: null,
+    pendingDraft: null,
+    anomalies: [],
+    ...over,
+  };
+}
+
+function publicMeasure(over: Partial<PublicMeasure> = {}): PublicMeasure {
+  return {
+    id: "m-1",
+    text: "Encadrer les loyers dans les zones tendues.",
+    precision: "OBJECTIF_SANS_CHIFFRE",
+    theme: "LOGEMENT_URBANISME",
+    attribution: "PERSONAL",
+    politicianId: "p-1",
+    candidacyId: "c-1",
+    withdrawal: null,
+    sources: [
+      {
+        id: "s-1",
+        measureRevisionId: "rev-1",
+        sourceKind: "PROGRAMME_PARTI",
+        tier: "PRIMARY",
+        url: "https://example.org/programme.pdf",
+        page: "12",
+        publishedAt: new Date("2027-01-15T00:00:00Z"),
+        createdAt: new Date("2027-01-16T00:00:00Z"),
+      },
+    ],
+    qualifications: [],
+    ...over,
+  };
+}
+
+describe("PublicVisibilityCard", () => {
+  it("rend le texte et les sources que le public reçoit", () => {
+    render(<PublicVisibilityCard state={state()} publicMeasure={publicMeasure()} />);
+
+    expect(screen.getByText("Encadrer les loyers dans les zones tendues.")).toBeInTheDocument();
+    expect(screen.getByText("1 source citée")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Programme de parti" })).toHaveAttribute(
+      "href",
+      "https://example.org/programme.pdf"
+    );
+  });
+
+  it("énumère les raisons quand la lecture publique ne renvoie rien", () => {
+    // A moderator told "invisible" without the why cannot act. One line per unmet condition.
+    render(
+      <PublicVisibilityCard
+        state={state({
+          publiclyVisible: false,
+          visibilityBlockers: ["revision_unreviewed", "revision_without_source"],
+        })}
+        publicMeasure={null}
+      />
+    );
+
+    expect(screen.getByText("Cette mesure ne sort d'aucune lecture publique.")).toBeInTheDocument();
+    expect(screen.getByText("La révision désignée n'a pas été relue")).toBeInTheDocument();
+    expect(screen.getByText("La révision désignée n'a aucune source")).toBeInTheDocument();
+  });
+
+  it("affiche le lien de retrait quand les deux champs de source sont là", () => {
+    render(
+      <PublicVisibilityCard
+        state={state()}
+        publicMeasure={publicMeasure({
+          withdrawal: {
+            withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+            sourceUrl: "https://example.org/retrait",
+            sourceLabel: "Conférence de presse du 1er mars 2027",
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Retirée le 1 mars 2027/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Conférence de presse du 1er mars 2027" })
+    ).toHaveAttribute("href", "https://example.org/retrait");
+  });
+
+  it("montre le retrait sans lien quand la source manque, au lieu de masquer le retrait", () => {
+    // The arbitrated contract: the withdrawal is always displayed, the link only when both
+    // source fields are there. Hiding the withdrawal to protect the missing source would state
+    // that the candidate still defends the measure.
+    render(
+      <PublicVisibilityCard
+        state={state()}
+        publicMeasure={publicMeasure({
+          withdrawal: {
+            withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+            sourceUrl: null,
+            sourceLabel: null,
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Retirée le 1 mars 2027/)).toBeInTheDocument();
+    expect(screen.getByText(/Retrait incomplet/)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Conférence/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/mesures/_components/__tests__/QueueTable.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/QueueTable.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { MeasureQueueRow } from "../../_data/queue-query";
+import { QueueTable } from "../QueueTable";
+
+function row(over: Partial<MeasureQueueRow> = {}): MeasureQueueRow {
+  return {
+    id: "m-1",
+    theme: "LOGEMENT_URBANISME",
+    politicianName: "Alix Démonstration",
+    politicianSlug: "alix-demonstration",
+    electionTitle: "Élection de démonstration 2027",
+    createdAt: new Date("2027-01-15T00:00:00Z"),
+    referenceText: "Encadrer les loyers dans les zones tendues.",
+    state: {
+      publication: "PUBLISHED",
+      declaredStatus: "PUBLISHED",
+      publiclyVisible: true,
+      visibilityBlockers: [],
+      withdrawal: null,
+      depublication: null,
+      pendingDraft: null,
+      anomalies: [],
+    },
+    ...over,
+  };
+}
+
+describe("QueueTable", () => {
+  it("garde la sémantique tabulaire et des en-têtes de colonnes", () => {
+    // A CSS grid on a <table> destroys what screen readers use to navigate it.
+    render(<QueueTable rows={[row()]} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("columnheader").length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByRole("columnheader", { name: /Candidature/ })).toBeInTheDocument();
+  });
+
+  it("qualifie l'absence de texte au lieu de laisser une cellule vide", () => {
+    render(<QueueTable rows={[row({ referenceText: null })]} />);
+
+    expect(screen.getByText("Aucune révision saisie")).toBeInTheDocument();
+  });
+
+  it("ne rend jamais une cellule vide ni un tiret seul", () => {
+    const { container } = render(
+      <QueueTable
+        rows={[
+          row(),
+          row({ id: "m-2", referenceText: null, politicianName: "Camille Exemple" }),
+          row({
+            id: "m-3",
+            state: {
+              ...row().state,
+              publiclyVisible: false,
+              visibilityBlockers: ["revision_without_source"],
+              anomalies: [{ code: "published_revision_without_source", detail: "rev-9" }],
+            },
+          }),
+        ]}
+      />
+    );
+
+    const cells = Array.from(container.querySelectorAll("td"));
+    expect(cells.length).toBeGreaterThan(0);
+    for (const cell of cells) {
+      const text = cell.textContent?.trim() ?? "";
+      expect(text).not.toBe("");
+      expect(text).not.toBe("-");
+      expect(text).not.toBe("—");
+      expect(text).not.toBe("n/a");
+    }
+  });
+
+  it("explique un résultat vide au lieu de rendre un tableau nu", () => {
+    render(<QueueTable rows={[]} />);
+
+    expect(screen.getByText("Aucune mesure ne correspond à ces filtres.")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { seedMeasuresDemoCorpus, type DemoCorpus } from "@/test/fixtures/measures-demo";
+
+let db: typeof import("@/lib/db").db;
+let queryMeasureQueue: typeof import("../queue-query").queryMeasureQueue;
+let corpus: DemoCorpus;
+
+const SEED_TIMEOUT_MS = 120_000;
+
+/** Every query is scoped to the corpus election, so the counters are deterministic. */
+function scoped(filters: Partial<Parameters<typeof queryMeasureQueue>[0]> = {}) {
+  return queryMeasureQueue({ electionId: corpus.electionId, ...filters });
+}
+
+describeIfDisposableDb("queryMeasureQueue", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ queryMeasureQueue } = await import("../queue-query"));
+    corpus = await seedMeasuresDemoCorpus();
+  }, SEED_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("compte les dix états du corpus, un par étape du cycle", async () => {
+    const result = await scoped();
+
+    expect(result.counts).toEqual({
+      // published, published with a correction in flight, withdrawn, incomplete withdrawal,
+      // published with no source, orphan draft: all six are declared published.
+      PUBLISHED: 6,
+      DRAFT: 1,
+      REVIEWED: 1,
+      DEPUBLISHED: 1,
+      EMPTY: 1,
+    });
+    expect(result.total).toBe(10);
+    expect(result.scanCapped).toBe(false);
+  });
+
+  it("compte séparément les anomalies et les retraits", async () => {
+    const result = await scoped();
+
+    // Incomplete withdrawal, published with no source, orphan active draft.
+    expect(result.anomalyCount).toBe(3);
+    // Withdrawn (sourced) and withdrawn (unsourced): both are withdrawals.
+    expect(result.withdrawnCount).toBe(2);
+  });
+
+  it("borne la page sans jamais produire un LIMIT invalide", async () => {
+    // take: 0 and take: -5 must not reach the database as such. A negative LIMIT fails with
+    // P2010, and a zero one silently returns an empty page that reads like "no measures".
+    await expect(scoped({ take: 3 }).then((r) => r.rows.length)).resolves.toBe(3);
+    await expect(scoped({ take: 0 }).then((r) => r.rows.length)).resolves.toBe(1);
+    await expect(scoped({ take: -5 }).then((r) => r.rows.length)).resolves.toBe(1);
+    await expect(scoped({ take: 5000 }).then((r) => r.rows.length)).resolves.toBe(10);
+  });
+
+  it("pagine sans recouvrement et garde le total", async () => {
+    const first = await scoped({ take: 6, skip: 0 });
+    const second = await scoped({ take: 6, skip: 6 });
+
+    expect(first.rows).toHaveLength(6);
+    expect(second.rows).toHaveLength(4);
+    expect(first.total).toBe(10);
+    expect(second.total).toBe(10);
+
+    const overlap = first.rows.filter((row) => second.rows.some((other) => other.id === row.id));
+    expect(overlap).toEqual([]);
+  });
+
+  it("filtre sur une étape dérivée sans toucher aux compteurs", async () => {
+    const result = await scoped({ publication: ["DRAFT"] });
+
+    expect(result.rows.map((row) => row.id)).toEqual([corpus.measureIds.brouillon]);
+    expect(result.total).toBe(1);
+    // The counters keep showing the whole distribution: a filter chip that only counted the
+    // selected state would leave the moderator unable to see there is anything else.
+    expect(result.counts.PUBLISHED).toBe(6);
+  });
+
+  it("filtre sur les seules mesures porteuses d'une anomalie", async () => {
+    const result = await scoped({ anomaliesOnly: true });
+
+    expect(result.rows).toHaveLength(3);
+    expect(result.rows.every((row) => row.state.anomalies.length > 0)).toBe(true);
+    expect(result.rows.map((row) => row.id).sort()).toEqual(
+      [
+        corpus.measureIds.retrait_incomplet,
+        corpus.measureIds.publiee_sans_source,
+        corpus.measureIds.brouillon_orphelin,
+      ].sort()
+    );
+  });
+
+  it("filtre par thème", async () => {
+    const result = await scoped({ theme: ["TRANSPORTS"] });
+
+    expect(result.rows.map((row) => row.id).sort()).toEqual(
+      [corpus.measureIds.brouillon, corpus.measureIds.relue].sort()
+    );
+  });
+
+  it("isole ou exclut les retraits", async () => {
+    const only = await scoped({ withdrawn: "only" });
+    const excluded = await scoped({ withdrawn: "exclude" });
+
+    expect(only.rows.map((row) => row.id).sort()).toEqual(
+      [corpus.measureIds.retiree, corpus.measureIds.retrait_incomplet].sort()
+    );
+    expect(excluded.rows).toHaveLength(8);
+    expect(excluded.rows.every((row) => row.state.withdrawal === null)).toBe(true);
+  });
+
+  it("cherche une sous-chaîne sans tenir compte de la casse", async () => {
+    const exact = await scoped({ q: "fret ferroviaire" });
+    const shouted = await scoped({ q: "FRET FERROVIAIRE" });
+
+    expect(exact.rows.map((row) => row.id)).toEqual([corpus.measureIds.relue]);
+    expect(shouted.rows.map((row) => row.id)).toEqual([corpus.measureIds.relue]);
+  });
+
+  it("rend un résultat vide sans compteur fantôme", async () => {
+    const result = await scoped({ theme: ["IMMIGRATION"] });
+
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.counts).toEqual({
+      PUBLISHED: 0,
+      DRAFT: 0,
+      REVIEWED: 0,
+      DEPUBLISHED: 0,
+      EMPTY: 0,
+    });
+    expect(result.anomalyCount).toBe(0);
+  });
+
+  it("montre le texte public et signale la correction en cours, pas l'inverse", async () => {
+    const result = await scoped({ publication: ["PUBLISHED"] });
+    const row = result.rows.find((r) => r.id === corpus.measureIds.publiee_avec_correction);
+
+    // The reference text is the PUBLISHED one, because that is what the site displays. The
+    // pending draft is signalled beside it instead of quietly replacing it.
+    expect(row?.referenceText).toContain("sur la durée du mandat");
+    expect(row?.state.pendingDraft).toEqual({
+      id: expect.any(String),
+      reviewed: true,
+    });
+  });
+
+  it("n'invente pas de texte pour une mesure sans révision de référence", async () => {
+    const result = await scoped({ publication: ["EMPTY"] });
+
+    expect(result.rows.map((row) => row.id)).toEqual([corpus.measureIds.vide]);
+    expect(result.rows[0].referenceText).toBeNull();
+  });
+});

--- a/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
@@ -155,6 +155,7 @@ describeIfDisposableDb("queryMeasureQueue", () => {
     const result = await scoped({ publication: ["EMPTY"] });
 
     expect(result.rows.map((row) => row.id)).toEqual([corpus.measureIds.vide]);
-    expect(result.rows[0].referenceText).toBeNull();
+    // toBeNull() and not toBeUndefined(): the row is there, its reference text is not.
+    expect(result.rows[0]?.referenceText).toBeNull();
   });
 });

--- a/src/app/admin/mesures/_data/detail-query.ts
+++ b/src/app/admin/mesures/_data/detail-query.ts
@@ -1,0 +1,27 @@
+import { db } from "@/lib/db";
+
+/**
+ * The context of a measure, which `getMeasureForModeration()` does not carry.
+ *
+ * That function is the lot 1 moderation read and it answers "what has been said, and when".
+ * Who says it, for which election, under which candidacy is route-local presentation data, so
+ * it is fetched here rather than by widening the shared read.
+ */
+export async function getMeasureContext(measureId: string) {
+  return db.measure.findUnique({
+    where: { id: measureId },
+    select: {
+      theme: true,
+      attribution: true,
+      createdAt: true,
+      updatedAt: true,
+      politician: { select: { fullName: true, slug: true } },
+      election: { select: { title: true, slug: true } },
+      candidacy: { select: { candidateName: true, status: true } },
+      programEdition: { select: { label: true, version: true } },
+      precedingMeasureId: true,
+    },
+  });
+}
+
+export type MeasureContext = NonNullable<Awaited<ReturnType<typeof getMeasureContext>>>;

--- a/src/app/admin/mesures/_data/queue-query.ts
+++ b/src/app/admin/mesures/_data/queue-query.ts
@@ -1,0 +1,187 @@
+import type { Prisma, ThemeCategory } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import {
+  deriveModerationState,
+  MODERATION_MEASURE_SELECT,
+  toModerationMeasureRow,
+  type ModerationState,
+  type PublicationState,
+} from "@/lib/measures/moderation-state";
+
+/**
+ * The moderation queue for measures.
+ *
+ * Two of the filters, `publication` and `anomaliesOnly`, apply to DERIVED values and not to
+ * stored columns, so they cannot be a Prisma `where`. Expressing them in SQL would mean
+ * writing the derivation a second time in another language, and the two would drift.
+ *
+ * So: the SQL-expressible filters bound the scan, the derivation runs over the scanned rows,
+ * and the derived filters apply after it. The scan is capped, and `scanCapped` says so rather
+ * than letting the counters look exhaustive when they are not.
+ */
+
+const DEFAULT_TAKE = 25;
+const MAX_TAKE = 100;
+
+/**
+ * The ceiling on rows fed to the derivation in one call. At a few hundred measures it never
+ * bites; when it does, the caller is told instead of being handed truncated counters that
+ * read like totals.
+ */
+export const QUEUE_SCAN_CAP = 500;
+
+export type MeasureQueueFilters = {
+  publication?: PublicationState[];
+  theme?: ThemeCategory[];
+  electionId?: string;
+  politicianId?: string;
+  withdrawn?: "only" | "exclude";
+  anomaliesOnly?: boolean;
+  q?: string;
+  take?: number;
+  skip?: number;
+};
+
+const QUEUE_SELECT = {
+  ...MODERATION_MEASURE_SELECT,
+  createdAt: true,
+  theme: true,
+  attribution: true,
+  politician: { select: { fullName: true, slug: true } },
+  election: { select: { title: true, slug: true } },
+  // Extends the shared selection rather than replacing it: the derivation reads the same
+  // fields either way, and the queue needs the text and the date on top.
+  revisions: {
+    select: { ...MODERATION_MEASURE_SELECT.revisions.select, text: true, validFrom: true },
+    orderBy: MODERATION_MEASURE_SELECT.revisions.orderBy,
+  },
+} satisfies Prisma.MeasureSelect;
+
+type QueueDbRow = Prisma.MeasureGetPayload<{ select: typeof QUEUE_SELECT }>;
+
+export type MeasureQueueRow = {
+  id: string;
+  theme: ThemeCategory;
+  politicianName: string;
+  politicianSlug: string;
+  electionTitle: string;
+  createdAt: Date;
+  /**
+   * The text of the reference revision, published one first and active draft otherwise.
+   * Null only when the measure has no revision at all, which the EMPTY stage names.
+   */
+  referenceText: string | null;
+  state: ModerationState;
+};
+
+export type MeasureQueueResult = {
+  rows: MeasureQueueRow[];
+  /** Rows matching every filter, derived ones included. Not the page length. */
+  total: number;
+  counts: Record<PublicationState, number>;
+  anomalyCount: number;
+  withdrawnCount: number;
+  scanCapped: boolean;
+};
+
+function clampTake(take: number | undefined): number {
+  if (take === undefined || !Number.isFinite(take)) return DEFAULT_TAKE;
+  return Math.min(Math.max(Math.trunc(take), 1), MAX_TAKE);
+}
+
+function clampSkip(skip: number | undefined): number {
+  if (skip === undefined || !Number.isFinite(skip)) return 0;
+  return Math.max(Math.trunc(skip), 0);
+}
+
+function buildWhere(filters: MeasureQueueFilters): Prisma.MeasureWhereInput {
+  const where: Prisma.MeasureWhereInput = {};
+
+  if (filters.theme && filters.theme.length > 0) where.theme = { in: filters.theme };
+  if (filters.electionId) where.electionId = filters.electionId;
+  if (filters.politicianId) where.politicianId = filters.politicianId;
+  if (filters.withdrawn === "only") where.withdrawnAt = { not: null };
+  if (filters.withdrawn === "exclude") where.withdrawnAt = null;
+
+  if (filters.q && filters.q.trim() !== "") {
+    // Substring search on the moderation side, deliberately: the lexical index is built for
+    // the public search, and a moderator looking for a formulation they half remember needs
+    // the substring behaviour the index refuses to give.
+    const like = filters.q.trim();
+    where.revisions = { some: { text: { contains: like, mode: "insensitive" } } };
+  }
+
+  return where;
+}
+
+function referenceTextOf(row: QueueDbRow): string | null {
+  const referenceId = row.publishedRevisionId ?? row.latestRevisionId;
+  if (referenceId === null) return null;
+  return row.revisions.find((revision) => revision.id === referenceId)?.text ?? null;
+}
+
+function toQueueRow(row: QueueDbRow): MeasureQueueRow {
+  return {
+    id: row.id,
+    theme: row.theme,
+    politicianName: row.politician.fullName,
+    politicianSlug: row.politician.slug,
+    electionTitle: row.election.title,
+    createdAt: row.createdAt,
+    referenceText: referenceTextOf(row),
+    state: deriveModerationState(toModerationMeasureRow(row)),
+  };
+}
+
+function matchesDerivedFilters(row: MeasureQueueRow, filters: MeasureQueueFilters): boolean {
+  if (filters.publication && filters.publication.length > 0) {
+    if (!filters.publication.includes(row.state.publication)) return false;
+  }
+  if (filters.anomaliesOnly && row.state.anomalies.length === 0) return false;
+  return true;
+}
+
+function emptyCounts(): Record<PublicationState, number> {
+  return { EMPTY: 0, DRAFT: 0, REVIEWED: 0, PUBLISHED: 0, DEPUBLISHED: 0 };
+}
+
+export async function queryMeasureQueue(
+  filters: MeasureQueueFilters = {}
+): Promise<MeasureQueueResult> {
+  const take = clampTake(filters.take);
+  const skip = clampSkip(filters.skip);
+
+  const scanned = await db.measure.findMany({
+    where: buildWhere(filters),
+    select: QUEUE_SELECT,
+    // Oldest first: a queue that shows the newest extractions first leaves the oldest
+    // untreated measures at the bottom forever. The page states the order.
+    orderBy: { createdAt: "asc" },
+    take: QUEUE_SCAN_CAP + 1,
+  });
+
+  const scanCapped = scanned.length > QUEUE_SCAN_CAP;
+  const rows = scanned.slice(0, QUEUE_SCAN_CAP).map(toQueueRow);
+
+  // Counters are computed BEFORE the derived filters, so the filter chips show the whole
+  // distribution of the SQL-filtered set instead of only the state already selected.
+  const counts = emptyCounts();
+  let anomalyCount = 0;
+  let withdrawnCount = 0;
+  for (const row of rows) {
+    counts[row.state.publication] += 1;
+    if (row.state.anomalies.length > 0) anomalyCount += 1;
+    if (row.state.withdrawal !== null) withdrawnCount += 1;
+  }
+
+  const matching = rows.filter((row) => matchesDerivedFilters(row, filters));
+
+  return {
+    rows: matching.slice(skip, skip + take),
+    total: matching.length,
+    counts,
+    anomalyCount,
+    withdrawnCount,
+    scanCapped,
+  };
+}

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { PUBLICATION_STATE_LABELS, THEME_CATEGORY_LABELS } from "@/config/labels";
+import type { ThemeCategory } from "@/generated/prisma";
+import { isAuthenticated } from "@/lib/auth";
+import type { PublicationState } from "@/lib/measures/moderation-state";
+import { QueueFilters, type QueueFilterState } from "./_components/QueueFilters";
+import { QueueTable } from "./_components/QueueTable";
+import { queryMeasureQueue } from "./_data/queue-query";
+
+export const metadata = {
+  title: "Mesures : relecture (admin) | Poligraph",
+  robots: { index: false },
+};
+
+const PAGE_SIZE = 25;
+
+const PUBLICATION_KEYS = Object.keys(PUBLICATION_STATE_LABELS) as PublicationState[];
+const THEME_KEYS = Object.keys(THEME_CATEGORY_LABELS) as ThemeCategory[];
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function asArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function asString(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const first = Array.isArray(value) ? value[0] : value;
+  return first === "" ? undefined : first;
+}
+
+export default async function AdminMeasuresPage({ searchParams }: PageProps) {
+  // The admin layout renders its children when the visitor is not authenticated, so it can let
+  // the login page through. A page that does not check for itself is therefore served to
+  // anonymous requests, and this one shows unreviewed editorial text.
+  if (!(await isAuthenticated())) redirect("/admin/login");
+
+  const params = await searchParams;
+
+  const publication = asArray(params.etat).filter((value): value is PublicationState =>
+    PUBLICATION_KEYS.includes(value as PublicationState)
+  );
+  const theme = asArray(params.theme).filter((value): value is ThemeCategory =>
+    THEME_KEYS.includes(value as ThemeCategory)
+  );
+  const retrait = asString(params.retrait);
+  const withdrawn = retrait === "only" || retrait === "exclude" ? retrait : undefined;
+  const anomaliesOnly = asString(params.anomalies) === "1";
+  const q = asString(params.q);
+
+  const pageParam = Number(asString(params.page) ?? "1");
+  const page = Number.isFinite(pageParam) ? Math.max(1, Math.trunc(pageParam)) : 1;
+
+  const result = await queryMeasureQueue({
+    publication,
+    theme,
+    withdrawn,
+    anomaliesOnly,
+    q,
+    take: PAGE_SIZE,
+    skip: (page - 1) * PAGE_SIZE,
+  });
+
+  const current: QueueFilterState = { publication, theme, anomaliesOnly, withdrawn, q };
+  const totalPages = Math.max(1, Math.ceil(result.total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="font-display text-2xl font-bold tracking-tight">Mesures : relecture</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {result.total === 1
+            ? "1 mesure correspond aux filtres"
+            : `${result.total} mesures correspondent aux filtres`}
+          . Ordre : de la plus anciennement saisie à la plus récente.
+        </p>
+      </header>
+
+      {result.scanCapped && (
+        <p
+          role="status"
+          className="rounded border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/40"
+        >
+          Les compteurs et les filtres d&apos;étape portent sur les 500 premières mesures de la
+          sélection, pas sur la totalité. Restreindre par sujet ou par candidature pour retrouver
+          des chiffres complets.
+        </p>
+      )}
+
+      <QueueFilters current={current} result={result} />
+
+      <QueueTable rows={result.rows} />
+
+      {totalPages > 1 && (
+        <nav className="flex flex-wrap justify-center gap-2" aria-label="Pagination">
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map((number) => {
+            const query = new URLSearchParams();
+            for (const state of publication) query.append("etat", state);
+            for (const key of theme) query.append("theme", key);
+            if (anomaliesOnly) query.set("anomalies", "1");
+            if (withdrawn) query.set("retrait", withdrawn);
+            if (q) query.set("q", q);
+            query.set("page", String(number));
+
+            return (
+              <Link
+                key={number}
+                href={`/admin/mesures?${query.toString()}`}
+                prefetch={false}
+                className={`inline-flex min-h-11 items-center rounded border border-border px-3 py-2 ${
+                  number === page ? "bg-muted font-medium" : "hover:bg-muted"
+                }`}
+                aria-current={number === page ? "page" : undefined}
+              >
+                {number}
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -29,6 +29,7 @@ import {
   Vote,
   CopyCheck,
   GitPullRequestArrow,
+  ListChecks,
 } from "lucide-react";
 
 const STORAGE_KEY = "admin-sidebar-collapsed";
@@ -50,6 +51,7 @@ const contentItems: NavItem[] = [
   { href: "/admin/maires", label: "Maires", icon: Crown },
   { href: "/admin/dossiers", label: "Dossiers", icon: FileText },
   { href: "/admin/policy-titles", label: "Titres de scrutins", icon: Vote },
+  { href: "/admin/mesures", label: "Mesures", icon: ListChecks },
   { href: "/admin/affair-matching/review", label: "Liaison affaires", icon: Fingerprint },
   { href: "/admin/affair-matching/dashboard", label: "Liaison — activité", icon: BarChart3 },
 ];

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -29,6 +29,19 @@ import type {
   PromiseExtractionStatus,
   CandidacyStatus,
 } from "@/types";
+import type {
+  MeasureAttribution,
+  MeasureExtractionMethod,
+  MeasurePrecision,
+  MeasureSourceKind,
+  QualificationKind,
+  SourceTier,
+} from "@/generated/prisma";
+import type {
+  ModerationAnomalyCode,
+  PublicationState,
+  VisibilityBlocker,
+} from "@/lib/measures/moderation-state";
 
 // Nombre de sièges à l'Assemblée nationale (XVIIe législature)
 export const AN_SEAT_COUNT = 577;
@@ -1359,4 +1372,88 @@ export const CANDIDACY_STATUS_LABELS: Record<CandidacyStatus, string> = {
   PRESSENTI: "Candidature pressentie",
   ENVISAGE: "Candidature évoquée",
   RETIRE: "Candidature retirée",
+};
+
+// ---------------------------------------------------------------------------
+// Mesures : le modèle éditorial versionné du hub présidentielle (lot 1 et 2).
+// ---------------------------------------------------------------------------
+
+export const MEASURE_ATTRIBUTION_LABELS: Record<MeasureAttribution, string> = {
+  PERSONAL: "Formulée personnellement",
+  PARTY_PROGRAM: "Reprise du programme du parti",
+};
+
+export const MEASURE_PRECISION_LABELS: Record<MeasurePrecision, string> = {
+  CHIFFREE: "Chiffrée",
+  OBJECTIF_SANS_CHIFFRE: "Objectif sans chiffre",
+};
+
+export const MEASURE_EXTRACTION_METHOD_LABELS: Record<MeasureExtractionMethod, string> = {
+  MANUAL: "Saisie manuelle",
+  AI_ASSISTED: "Assistée par IA",
+  IMPORTED: "Importée",
+};
+
+export const MEASURE_SOURCE_KIND_LABELS: Record<MeasureSourceKind, string> = {
+  PROGRAMME_PARTI: "Programme de parti",
+  DISCOURS_CAMPAGNE: "Discours de campagne",
+  DEBAT_TELEVISE: "Débat télévisé",
+  DISCOURS_AN: "Discours à l'Assemblée nationale",
+  DISCOURS_SENAT: "Discours au Sénat",
+  INTERVIEW_PRESSE: "Interview de presse",
+  ARTICLE_PRESSE: "Article de presse",
+  PROPOSITION_LOI: "Proposition de loi",
+};
+
+export const SOURCE_TIER_LABELS: Record<SourceTier, string> = {
+  PRIMARY: "Source primaire",
+  SECONDARY: "Source secondaire",
+};
+
+// Les quatre qualificatifs opposables. Leurs définitions complètes, avec leur cas limite,
+// vivent dans docs/editorial/qualifications-mesures.md.
+export const QUALIFICATION_KIND_LABELS: Record<QualificationKind, string> = {
+  FINANCEMENT_NON_PRECISE: "Financement non précisé",
+  DEJA_TENTEE: "Déjà tentée",
+  CALENDRIER_PRECISE: "Calendrier précisé",
+  PERIMETRE_INCERTAIN: "Périmètre incertain",
+};
+
+// L'étape du cycle éditorial, dérivée. Distincte de PUBLICATION_STATUS_LABELS, qui nomme la
+// colonne : une mesure peut être déclarée PUBLISHED sans être visible du public.
+export const PUBLICATION_STATE_LABELS: Record<PublicationState, string> = {
+  EMPTY: "Sans révision",
+  DRAFT: "Brouillon",
+  REVIEWED: "Relue",
+  PUBLISHED: "Publiée",
+  DEPUBLISHED: "Dépubliée",
+};
+
+// Le vocabulaire est celui de measures:audit. Chaque libellé dit ce qui est cassé, pas
+// seulement qu'il y a un problème : un relecteur doit pouvoir agir.
+export const MODERATION_ANOMALY_LABELS: Record<ModerationAnomalyCode, string> = {
+  published_revision_foreign: "La révision publiée n'appartient pas à cette mesure",
+  published_revision_unreviewed: "La révision publiée n'a pas été relue",
+  published_revision_unpublished: "La révision pointée n'a jamais été publiée",
+  published_revision_superseded: "La révision publiée a été remplacée",
+  published_revision_without_source: "La révision publiée n'a plus aucune source",
+  multiple_published_revisions: "Deux révisions publiées et non remplacées",
+  orphan_active_draft: "Un brouillon actif qu'aucun pointeur ne désigne",
+  latest_revision_foreign: "Le pointeur de brouillon désigne une autre mesure",
+  latest_revision_discarded: "Le pointeur de brouillon désigne un brouillon abandonné",
+  withdrawn_without_source: "Retrait sans source : ni URL ni libellé",
+  withdrawal_source_without_date: "Source de retrait sans date de retrait",
+};
+
+// Pourquoi le public ne voit pas une mesure. Distinct des anomalies : une dépublication est
+// une raison sans être un défaut de données.
+export const VISIBILITY_BLOCKER_LABELS: Record<VisibilityBlocker, string> = {
+  status_not_published: "La mesure n'est pas au statut publié",
+  no_published_pointer: "Aucune révision n'est désignée comme publiée",
+  pointer_not_found: "La révision désignée est introuvable",
+  revision_unreviewed: "La révision désignée n'a pas été relue",
+  revision_never_published: "La révision désignée n'a jamais été publiée",
+  revision_superseded: "La révision désignée a été remplacée",
+  revision_discarded: "La révision désignée a été abandonnée",
+  revision_without_source: "La révision désignée n'a aucune source",
 };

--- a/src/lib/measures/__tests__/moderation-state.integration.test.ts
+++ b/src/lib/measures/__tests__/moderation-state.integration.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import {
+  deriveModerationState,
+  MODERATION_MEASURE_SELECT,
+  toModerationMeasureRow,
+} from "../moderation-state";
+import { publishSeededMeasure, seedMeasureWithDraft } from "./helpers";
+
+// `../moderation-state` is imported statically on purpose: it only imports types, so it
+// loads without DATABASE_URL. The two modules below reach the Prisma client as a value.
+let db: typeof import("@/lib/db").db;
+let getPublicMeasure: typeof import("@/lib/data/measures").getPublicMeasure;
+
+/**
+ * The invariant this file exists for: the moderation queue must say exactly what the public
+ * read decides, not what `publicationStatus` suggests.
+ *
+ * It is checked by CROSSING the two functions on the same row, never by re-reading the
+ * derivation. A test that only asserted `publiclyVisible === false` would stay green if the
+ * derivation and the public filter drifted apart in the same direction.
+ */
+async function crossCheck(measureId: string): Promise<{ derived: boolean; publicRead: boolean }> {
+  const row = await db.measure.findUniqueOrThrow({
+    where: { id: measureId },
+    select: MODERATION_MEASURE_SELECT,
+  });
+  return {
+    derived: deriveModerationState(toModerationMeasureRow(row)).publiclyVisible,
+    publicRead: (await getPublicMeasure(measureId)) !== null,
+  };
+}
+
+describeIfDisposableDb("publiclyVisible face à la lecture publique réelle", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getPublicMeasure } = await import("@/lib/data/measures"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("agrees on a correctly published measure", async () => {
+    const { measureId } = await publishSeededMeasure();
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(true);
+  });
+
+  it("agrees on a measure that only has a draft", async () => {
+    const { measureId } = await seedMeasureWithDraft();
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(false);
+  });
+
+  // The case the ablation targets. Removing `sourceCount > 0` from the derivation makes the
+  // queue announce this measure as publicly visible while getPublicMeasure() returns null.
+  it("agrees when the published revision lost its last source", async () => {
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureSource.deleteMany({ where: { measureRevisionId: revisionId } });
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(false);
+  });
+
+  it("agrees on a depublished measure", async () => {
+    const { measureId } = await publishSeededMeasure();
+    const { depublishMeasure } = await import("../transitions");
+    await depublishMeasure({ measureId, reason: "Formulation contestée par le candidat" });
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(false);
+  });
+
+  it.each([
+    ["unreviewed", { reviewedAt: null, reviewedBy: null }],
+    ["never published", { publishedAt: null }],
+    ["superseded", { supersededAt: new Date("2027-03-01T00:00:00Z") }],
+    ["discarded", { discardedAt: new Date("2027-03-01T00:00:00Z") }],
+  ])("agrees when the pointed revision is %s", async (_label, data) => {
+    // Written directly to the database: the transitions refuse to produce these states, and
+    // they are exactly what a past import or a manual correction leaves behind.
+    const { measureId, revisionId } = await publishSeededMeasure();
+    await db.measureRevision.update({ where: { id: revisionId }, data });
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(false);
+  });
+
+  it("agrees on a status the measure transitions never write", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measure.update({ where: { id: measureId }, data: { publicationStatus: "EXCLUDED" } });
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(false);
+  });
+
+  it("agrees that a withdrawn measure stays publicly visible", async () => {
+    // A withdrawal does not hide the measure, it is displayed on it. The detail read returns
+    // the row and the derivation must not pretend otherwise.
+    const { measureId } = await publishSeededMeasure();
+    const { withdrawMeasure } = await import("../transitions");
+    await withdrawMeasure({
+      measureId,
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait",
+      sourceLabel: "Le Monde, 1er mars 2027",
+    });
+
+    const { derived, publicRead } = await crossCheck(measureId);
+
+    expect(derived).toBe(publicRead);
+    expect(derived).toBe(true);
+  });
+
+  it("agrees that an incomplete withdrawal does not hide the measure either", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.measure.update({
+      where: { id: measureId },
+      data: { withdrawnAt: new Date("2027-03-01T00:00:00Z") },
+    });
+
+    const row = await db.measure.findUniqueOrThrow({
+      where: { id: measureId },
+      select: MODERATION_MEASURE_SELECT,
+    });
+    const state = deriveModerationState(toModerationMeasureRow(row));
+
+    expect(state.publiclyVisible).toBe((await getPublicMeasure(measureId)) !== null);
+    expect(state.publiclyVisible).toBe(true);
+    expect(state.anomalies.map((a) => a.code)).toContain("withdrawn_without_source");
+  });
+});

--- a/src/lib/measures/__tests__/moderation-state.test.ts
+++ b/src/lib/measures/__tests__/moderation-state.test.ts
@@ -85,13 +85,68 @@ describe("deriveModerationState : visibilité publique", () => {
   });
 
   it.each([
-    ["unreviewed", { reviewedAt: null }],
-    ["never published", { publishedAt: null }],
-    ["superseded", { supersededAt: T1 }],
-    ["discarded", { discardedAt: T1 }],
-    ["without source", { sourceCount: 0 }],
-  ])("hides a measure whose pointed revision is %s", (_label, over) => {
-    expect(deriveModerationState(publishedRow(over)).publiclyVisible).toBe(false);
+    ["unreviewed", { reviewedAt: null }, "revision_unreviewed"],
+    ["never published", { publishedAt: null }, "revision_never_published"],
+    ["superseded", { supersededAt: T1 }, "revision_superseded"],
+    ["discarded", { discardedAt: T1 }, "revision_discarded"],
+    ["without source", { sourceCount: 0 }, "revision_without_source"],
+  ])("hides a measure whose pointed revision is %s, and says why", (_label, over, blocker) => {
+    const state = deriveModerationState(publishedRow(over));
+
+    expect(state.publiclyVisible).toBe(false);
+    expect(state.visibilityBlockers).toContain(blocker);
+  });
+
+  it("keeps publiclyVisible and the blocker list in agreement", () => {
+    // The flag is DEFINED as "no blocker", so the two cannot disagree. This test states the
+    // contract rather than the implementation, and it is what makes the blocker list safe to
+    // render as the explanation of the flag.
+    for (const row of [
+      publishedRow(),
+      publishedRow({ sourceCount: 0 }),
+      measureRow(),
+      publishedRow({}, { publicationStatus: "DRAFT", depublishedAt: T1 }),
+    ]) {
+      const state = deriveModerationState(row);
+      expect(state.publiclyVisible).toBe(state.visibilityBlockers.length === 0);
+    }
+  });
+
+  it("explains a depublication that carries no anomaly at all", () => {
+    // A depublished measure is not broken data: nothing to report as an anomaly, and still a
+    // reason the public does not see it. Two different questions, two different lists.
+    const state = deriveModerationState(
+      publishedRow({}, { publicationStatus: "DRAFT", depublishedAt: T1, depublicationReason: "x" })
+    );
+
+    expect(state.anomalies).toEqual([]);
+    expect(state.visibilityBlockers).toEqual(["status_not_published"]);
+  });
+
+  it("explains a discarded published revision that no anomaly rule reports", () => {
+    // Found while writing the moderation card. PUBLIC_MEASURE_WHERE filters on
+    // `discardedAt: null` on the pointed revision, and neither measures:audit nor the anomaly
+    // list has a rule for it. The narrow case is what proves the gap: with the latest pointer
+    // on a separate live draft, `latest_revision_discarded` does not fire either, so the
+    // measure is invisible to the public and reported as healthy.
+    const published = revision({
+      id: "rev-pub",
+      reviewedAt: T0,
+      publishedAt: T0,
+      discardedAt: T1,
+    });
+    const draft = revision({ id: "rev-draft" });
+    const state = deriveModerationState(
+      measureRow({
+        publicationStatus: "PUBLISHED",
+        publishedRevisionId: published.id,
+        latestRevisionId: draft.id,
+        revisions: [published, draft],
+      })
+    );
+
+    expect(state.visibilityBlockers).toEqual(["revision_discarded"]);
+    expect(state.anomalies).toEqual([]);
   });
 
   it("carries the declared status through instead of folding it into the stage", () => {

--- a/src/lib/measures/__tests__/moderation-state.test.ts
+++ b/src/lib/measures/__tests__/moderation-state.test.ts
@@ -186,7 +186,9 @@ describe("deriveModerationState : les étapes du cycle", () => {
     );
 
     expect(state.publication).toBe("DRAFT");
-    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: false });
+    // No pending draft: nothing is published, so this draft IS the current state and not a
+    // correction waiting on top of one. Reporting both would claim two versions exist.
+    expect(state.pendingDraft).toBeNull();
   });
 
   it("reports REVIEWED on an active draft that has been read", () => {
@@ -196,7 +198,7 @@ describe("deriveModerationState : les étapes du cycle", () => {
     );
 
     expect(state.publication).toBe("REVIEWED");
-    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: true });
+    expect(state.pendingDraft).toBeNull();
     expect(state.publiclyVisible).toBe(false);
   });
 

--- a/src/lib/measures/__tests__/moderation-state.test.ts
+++ b/src/lib/measures/__tests__/moderation-state.test.ts
@@ -1,0 +1,356 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deriveModerationState,
+  MODERATION_ANOMALY_CODES,
+  type ModerationMeasureRow,
+  type ModerationRevisionRow,
+} from "../moderation-state";
+
+const T0 = new Date("2027-01-10T00:00:00Z");
+const T1 = new Date("2027-02-10T00:00:00Z");
+
+function revision(over: Partial<ModerationRevisionRow> = {}): ModerationRevisionRow {
+  return {
+    id: "rev-1",
+    reviewedAt: null,
+    publishedAt: null,
+    supersededAt: null,
+    discardedAt: null,
+    sourceCount: 1,
+    ...over,
+  };
+}
+
+function measureRow(over: Partial<ModerationMeasureRow> = {}): ModerationMeasureRow {
+  return {
+    id: "m-1",
+    publicationStatus: "DRAFT",
+    latestRevisionId: null,
+    publishedRevisionId: null,
+    withdrawnAt: null,
+    withdrawnSourceUrl: null,
+    withdrawnSourceLabel: null,
+    depublishedAt: null,
+    depublicationReason: null,
+    revisions: [],
+    ...over,
+  };
+}
+
+/** A correctly published measure: reviewed, published, not superseded, one source. */
+function publishedRow(
+  revisionOver: Partial<ModerationRevisionRow> = {},
+  measureOver: Partial<ModerationMeasureRow> = {}
+): ModerationMeasureRow {
+  const published = revision({
+    id: "rev-pub",
+    reviewedAt: T0,
+    publishedAt: T0,
+    ...revisionOver,
+  });
+  return measureRow({
+    publicationStatus: "PUBLISHED",
+    publishedRevisionId: published.id,
+    latestRevisionId: published.id,
+    revisions: [published],
+    ...measureOver,
+  });
+}
+
+function codes(row: ModerationMeasureRow): string[] {
+  return deriveModerationState(row).anomalies.map((a) => a.code);
+}
+
+describe("deriveModerationState : visibilité publique", () => {
+  // The violation first: a measure the admin would call "published" while the public read
+  // returns nothing for it. This is the failure this whole module exists to prevent.
+  it("does not report a measure as publicly visible when the pointed revision has no source", () => {
+    const state = deriveModerationState(publishedRow({ sourceCount: 0 }));
+
+    expect(state.publiclyVisible).toBe(false);
+    expect(state.anomalies.map((a) => a.code)).toContain("published_revision_without_source");
+  });
+
+  it("reports a correctly published measure as publicly visible, with no anomaly", () => {
+    const state = deriveModerationState(publishedRow());
+
+    expect(state.publication).toBe("PUBLISHED");
+    expect(state.publiclyVisible).toBe(true);
+    expect(state.anomalies).toEqual([]);
+    expect(state.pendingDraft).toBeNull();
+    expect(state.withdrawal).toBeNull();
+    expect(state.depublication).toBeNull();
+  });
+
+  it.each([
+    ["unreviewed", { reviewedAt: null }],
+    ["never published", { publishedAt: null }],
+    ["superseded", { supersededAt: T1 }],
+    ["discarded", { discardedAt: T1 }],
+    ["without source", { sourceCount: 0 }],
+  ])("hides a measure whose pointed revision is %s", (_label, over) => {
+    expect(deriveModerationState(publishedRow(over)).publiclyVisible).toBe(false);
+  });
+
+  it("carries the declared status through instead of folding it into the stage", () => {
+    // The enum is shared with affairs. The measure transitions never write EXCLUDED, but a
+    // direct write can, and deriving it away would show it as an ordinary draft.
+    const state = deriveModerationState(publishedRow({}, { publicationStatus: "EXCLUDED" }));
+
+    expect(state.declaredStatus).toBe("EXCLUDED");
+    expect(state.publiclyVisible).toBe(false);
+  });
+});
+
+describe("deriveModerationState : les étapes du cycle", () => {
+  it("reports EMPTY when the measure has no revision at all", () => {
+    const state = deriveModerationState(measureRow());
+
+    expect(state.publication).toBe("EMPTY");
+    expect(state.anomalies).toEqual([]);
+  });
+
+  it("reports EMPTY when the only draft was discarded and nothing was ever published", () => {
+    // The state discardMeasureRevision() leaves behind: the pointer falls back to
+    // publishedRevisionId, which is null here.
+    const state = deriveModerationState(
+      measureRow({ revisions: [revision({ discardedAt: T1 })], latestRevisionId: null })
+    );
+
+    expect(state.publication).toBe("EMPTY");
+    expect(state.pendingDraft).toBeNull();
+    expect(state.anomalies).toEqual([]);
+  });
+
+  it("reports DRAFT on an active draft that nobody has reviewed", () => {
+    const draft = revision({ id: "rev-draft" });
+    const state = deriveModerationState(
+      measureRow({ revisions: [draft], latestRevisionId: draft.id })
+    );
+
+    expect(state.publication).toBe("DRAFT");
+    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: false });
+  });
+
+  it("reports REVIEWED on an active draft that has been read", () => {
+    const draft = revision({ id: "rev-draft", reviewedAt: T1 });
+    const state = deriveModerationState(
+      measureRow({ revisions: [draft], latestRevisionId: draft.id })
+    );
+
+    expect(state.publication).toBe("REVIEWED");
+    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: true });
+    expect(state.publiclyVisible).toBe(false);
+  });
+
+  it("reports DEPUBLISHED with its reason, and keeps the pointer visible", () => {
+    // What depublishMeasure() writes: status DRAFT, the trace, and the published pointer
+    // left in place.
+    const state = deriveModerationState(
+      publishedRow(
+        {},
+        {
+          publicationStatus: "DRAFT",
+          depublishedAt: T1,
+          depublicationReason: "Mise en cause nominative retirée à la demande du conseil",
+        }
+      )
+    );
+
+    expect(state.publication).toBe("DEPUBLISHED");
+    expect(state.publiclyVisible).toBe(false);
+    expect(state.depublication).toEqual({
+      at: T1,
+      reason: "Mise en cause nominative retirée à la demande du conseil",
+    });
+  });
+
+  it("still reports the depublication when its reason is missing", () => {
+    // Same reasoning as the withdrawal shape: the presence of the object is the fact, and a
+    // missing reason must not hide the act. Only a direct write can produce this.
+    const state = deriveModerationState(
+      publishedRow({}, { publicationStatus: "DRAFT", depublishedAt: T1 })
+    );
+
+    expect(state.depublication).toEqual({ at: T1, reason: null });
+  });
+});
+
+describe("deriveModerationState : la correction en cours", () => {
+  it("keeps a published measure at PUBLISHED while exposing its reviewed pending draft", () => {
+    // The whole point of the two pointers: a correction under review changes nothing for
+    // the public, and must not disappear from the moderation view either.
+    const published = revision({ id: "rev-pub", reviewedAt: T0, publishedAt: T0 });
+    const draft = revision({ id: "rev-draft", reviewedAt: T1 });
+    const state = deriveModerationState(
+      measureRow({
+        publicationStatus: "PUBLISHED",
+        publishedRevisionId: published.id,
+        latestRevisionId: draft.id,
+        revisions: [published, draft],
+      })
+    );
+
+    expect(state.publication).toBe("PUBLISHED");
+    expect(state.publiclyVisible).toBe(true);
+    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: true });
+    expect(state.anomalies).toEqual([]);
+  });
+
+  it("marks a pending draft as not reviewed when it has not been read", () => {
+    const published = revision({ id: "rev-pub", reviewedAt: T0, publishedAt: T0 });
+    const draft = revision({ id: "rev-draft" });
+    const state = deriveModerationState(
+      measureRow({
+        publicationStatus: "PUBLISHED",
+        publishedRevisionId: published.id,
+        latestRevisionId: draft.id,
+        revisions: [published, draft],
+      })
+    );
+
+    expect(state.pendingDraft).toEqual({ id: "rev-draft", reviewed: false });
+  });
+});
+
+describe("deriveModerationState : le retrait", () => {
+  it("keeps a withdrawn measure published and publicly visible", () => {
+    // Spec 5.2: a withdrawn measure does not disappear. It keeps its published revision and
+    // its sources, and its withdrawal state is displayed.
+    const state = deriveModerationState(
+      publishedRow(
+        {},
+        {
+          withdrawnAt: T1,
+          withdrawnSourceUrl: "https://example.org/retrait",
+          withdrawnSourceLabel: "Le Monde, 1er mars 2027",
+        }
+      )
+    );
+
+    expect(state.publication).toBe("PUBLISHED");
+    expect(state.publiclyVisible).toBe(true);
+    expect(state.withdrawal).toEqual({
+      withdrawnAt: T1,
+      sourceUrl: "https://example.org/retrait",
+      sourceLabel: "Le Monde, 1er mars 2027",
+    });
+    expect(state.anomalies).toEqual([]);
+  });
+
+  it("reports an incomplete withdrawal AND still exposes the withdrawal", () => {
+    // Both halves matter. Reporting the anomaly while dropping the withdrawal would hide a
+    // real fact to protect a type; exposing the withdrawal without the anomaly would pass
+    // an unsourced claim off as a sourced one.
+    const state = deriveModerationState(publishedRow({}, { withdrawnAt: T1 }));
+
+    expect(state.anomalies.map((a) => a.code)).toContain("withdrawn_without_source");
+    expect(state.withdrawal).toEqual({ withdrawnAt: T1, sourceUrl: null, sourceLabel: null });
+  });
+
+  it("reports a withdrawal source with no date", () => {
+    const state = deriveModerationState(
+      publishedRow({}, { withdrawnSourceLabel: "Le Monde, 1er mars 2027" })
+    );
+
+    expect(state.anomalies.map((a) => a.code)).toContain("withdrawal_source_without_date");
+    expect(state.withdrawal).toBeNull();
+  });
+});
+
+describe("deriveModerationState : les anomalies, une par une", () => {
+  it("detects a published pointer that designates no revision of this measure", () => {
+    expect(codes(measureRow({ publishedRevisionId: "rev-ailleurs" }))).toContain(
+      "published_revision_foreign"
+    );
+  });
+
+  it("detects a published pointer on an unreviewed revision", () => {
+    expect(codes(publishedRow({ reviewedAt: null }))).toContain("published_revision_unreviewed");
+  });
+
+  it("detects a published pointer on a revision that was never published", () => {
+    expect(codes(publishedRow({ publishedAt: null }))).toContain("published_revision_unpublished");
+  });
+
+  it("detects a published pointer on a superseded revision", () => {
+    expect(codes(publishedRow({ supersededAt: T1 }))).toContain("published_revision_superseded");
+  });
+
+  it("detects two published non-superseded revisions", () => {
+    const first = revision({ id: "rev-a", reviewedAt: T0, publishedAt: T0 });
+    const second = revision({ id: "rev-b", reviewedAt: T1, publishedAt: T1 });
+    const row = measureRow({
+      publicationStatus: "PUBLISHED",
+      publishedRevisionId: second.id,
+      latestRevisionId: second.id,
+      revisions: [first, second],
+    });
+
+    expect(codes(row)).toContain("multiple_published_revisions");
+  });
+
+  it("detects an active draft that no pointer designates", () => {
+    const published = revision({ id: "rev-pub", reviewedAt: T0, publishedAt: T0 });
+    const orphan = revision({ id: "rev-orphan" });
+    const row = measureRow({
+      publicationStatus: "PUBLISHED",
+      publishedRevisionId: published.id,
+      latestRevisionId: published.id,
+      revisions: [published, orphan],
+    });
+
+    expect(codes(row)).toContain("orphan_active_draft");
+  });
+
+  it("detects a latest pointer that designates no revision of this measure", () => {
+    expect(codes(measureRow({ latestRevisionId: "rev-ailleurs" }))).toContain(
+      "latest_revision_foreign"
+    );
+  });
+
+  it("detects a latest pointer on a discarded draft", () => {
+    const discarded = revision({ id: "rev-discarded", discardedAt: T1 });
+    const row = measureRow({ revisions: [discarded], latestRevisionId: discarded.id });
+
+    expect(codes(row)).toContain("latest_revision_discarded");
+  });
+
+  it("decides the stage of orphan drafts without depending on row order", () => {
+    // Two active drafts and no pointer on either: already an anomaly, but the stage still
+    // has to be decided, and "the last one in the array" would make the answer depend on
+    // the ORDER BY of whatever query fed the derivation.
+    const reviewed = revision({ id: "rev-a", reviewedAt: T1 });
+    const plain = revision({ id: "rev-b" });
+
+    const forward = deriveModerationState(measureRow({ revisions: [reviewed, plain] }));
+    const backward = deriveModerationState(measureRow({ revisions: [plain, reviewed] }));
+
+    expect(forward.publication).toBe(backward.publication);
+    expect(forward.publication).toBe("REVIEWED");
+    expect(forward.anomalies.map((a) => a.code)).toContain("orphan_active_draft");
+  });
+
+  it("reports nothing on a measure whose only draft is active and designated", () => {
+    const draft = revision({ id: "rev-draft" });
+
+    expect(codes(measureRow({ revisions: [draft], latestRevisionId: draft.id }))).toEqual([]);
+  });
+});
+
+describe("MODERATION_ANOMALY_CODES", () => {
+  it("n'invente aucun code absent de la commande d'audit", () => {
+    // One vocabulary for the queue and for `measures:audit`. A lexical check rather than a
+    // shared constant, because typing audit.ts's rules would mean reopening lot 1 code for
+    // a guarantee this test already gives.
+    // process.cwd() is the repo root under vitest; import.meta.url is a vite URL here, not
+    // a file: one, so fileURLToPath refuses it.
+    const auditSource = readFileSync(join(process.cwd(), "src/lib/measures/audit.ts"), "utf8");
+
+    const missing = MODERATION_ANOMALY_CODES.filter((code) => !auditSource.includes(`"${code}"`));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/lib/measures/moderation-state.ts
+++ b/src/lib/measures/moderation-state.ts
@@ -1,0 +1,303 @@
+import type { Prisma, PublicationStatus } from "@/generated/prisma";
+import type { MeasureWithdrawal } from "@/lib/data/measures";
+
+/**
+ * What a moderator needs to know about a measure, derived from the measure and its
+ * revisions alone.
+ *
+ * Four independent axes rather than one enum. "Empty, draft, reviewed, published,
+ * depublished, withdrawn, inconsistent" are not seven mutually exclusive values: a
+ * withdrawn measure can stay published, a published measure can carry a correction under
+ * review, and inconsistency is not a stage but the presence of an anomaly. Flattening them
+ * would repeat the mixed-sentence defect, where a structure poorer than reality states
+ * something false without ever failing.
+ *
+ * Type-only imports on purpose: this module must stay loadable without DATABASE_URL, and
+ * `@/lib/data/measures` imports the Prisma client as a value.
+ */
+
+/** The stage of the editorial cycle, as opposed to the raw column value. */
+export type PublicationState = "EMPTY" | "DRAFT" | "REVIEWED" | "PUBLISHED" | "DEPUBLISHED";
+
+/**
+ * The anomaly vocabulary is the audit's vocabulary, deliberately: same strings as the rules
+ * of `src/lib/measures/audit.ts`, so the queue and the command name the same defect the same
+ * way. A test asserts every code below appears literally in that file.
+ *
+ * These eleven are the rules derivable from a measure and its revisions. The audit's other
+ * rules cross other tables (candidacy, programme edition, search index, qualifications,
+ * assessments); recomputing them here would duplicate the audit inside a page.
+ */
+export const MODERATION_ANOMALY_CODES = [
+  "published_revision_foreign",
+  "published_revision_unreviewed",
+  "published_revision_unpublished",
+  "published_revision_superseded",
+  "published_revision_without_source",
+  "multiple_published_revisions",
+  "orphan_active_draft",
+  "latest_revision_foreign",
+  "latest_revision_discarded",
+  "withdrawn_without_source",
+  "withdrawal_source_without_date",
+] as const;
+
+export type ModerationAnomalyCode = (typeof MODERATION_ANOMALY_CODES)[number];
+
+export type ModerationAnomaly = {
+  code: ModerationAnomalyCode;
+  /** The identifiers involved, so the moderator can act instead of only being warned. */
+  detail: string;
+};
+
+export type ModerationRevisionRow = {
+  id: string;
+  reviewedAt: Date | null;
+  publishedAt: Date | null;
+  supersededAt: Date | null;
+  discardedAt: Date | null;
+  sourceCount: number;
+};
+
+export type ModerationMeasureRow = {
+  id: string;
+  publicationStatus: PublicationStatus;
+  latestRevisionId: string | null;
+  publishedRevisionId: string | null;
+  withdrawnAt: Date | null;
+  withdrawnSourceUrl: string | null;
+  withdrawnSourceLabel: string | null;
+  depublishedAt: Date | null;
+  depublicationReason: string | null;
+  revisions: ModerationRevisionRow[];
+};
+
+/**
+ * Mirrors the shape arbitrated for withdrawal, for the same reason: the presence of the
+ * object is the fact, and a missing reason must not hide the depublication. Only
+ * depublishMeasure() writes these fields and it demands a reason, so a null reason can only
+ * come from a direct database write.
+ */
+export type MeasureDepublication = { at: Date; reason: string | null };
+
+export type ModerationState = {
+  publication: PublicationState;
+  /**
+   * The raw column, carried through rather than folded into `publication`. The enum is
+   * shared with affairs and holds ARCHIVED, EXCLUDED and REJECTED, which the measure
+   * transitions never produce but a direct write can. Deriving without exposing it would
+   * silently turn an EXCLUDED measure into a plain draft.
+   */
+  declaredStatus: PublicationStatus;
+  publiclyVisible: boolean;
+  withdrawal: MeasureWithdrawal | null;
+  depublication: MeasureDepublication | null;
+  /** The correction in flight, which the PUBLISHED stage would otherwise hide. */
+  pendingDraft: { id: string; reviewed: boolean } | null;
+  anomalies: ModerationAnomaly[];
+};
+
+/**
+ * The one selection every moderation read uses, so the queue and the tests cannot drift on
+ * what the derivation is fed. Kept next to the shape it produces rather than in the admin
+ * route, because the derivation is the consumer.
+ */
+export const MODERATION_MEASURE_SELECT = {
+  id: true,
+  publicationStatus: true,
+  latestRevisionId: true,
+  publishedRevisionId: true,
+  withdrawnAt: true,
+  withdrawnSourceUrl: true,
+  withdrawnSourceLabel: true,
+  depublishedAt: true,
+  depublicationReason: true,
+  revisions: {
+    select: {
+      id: true,
+      reviewedAt: true,
+      publishedAt: true,
+      supersededAt: true,
+      discardedAt: true,
+      _count: { select: { sources: true } },
+    },
+    orderBy: { validFrom: "asc" },
+  },
+} satisfies Prisma.MeasureSelect;
+
+export type ModerationMeasureDbRow = Prisma.MeasureGetPayload<{
+  select: typeof MODERATION_MEASURE_SELECT;
+}>;
+
+/** Flattens Prisma's `_count.sources` into the source count the derivation reads. */
+export function toModerationMeasureRow(row: ModerationMeasureDbRow): ModerationMeasureRow {
+  return {
+    id: row.id,
+    publicationStatus: row.publicationStatus,
+    latestRevisionId: row.latestRevisionId,
+    publishedRevisionId: row.publishedRevisionId,
+    withdrawnAt: row.withdrawnAt,
+    withdrawnSourceUrl: row.withdrawnSourceUrl,
+    withdrawnSourceLabel: row.withdrawnSourceLabel,
+    depublishedAt: row.depublishedAt,
+    depublicationReason: row.depublicationReason,
+    revisions: row.revisions.map((revision) => ({
+      id: revision.id,
+      reviewedAt: revision.reviewedAt,
+      publishedAt: revision.publishedAt,
+      supersededAt: revision.supersededAt,
+      discardedAt: revision.discardedAt,
+      sourceCount: revision._count.sources,
+    })),
+  };
+}
+
+function isActiveDraft(revision: ModerationRevisionRow): boolean {
+  return revision.publishedAt === null && revision.discardedAt === null;
+}
+
+function findRevision(row: ModerationMeasureRow, id: string | null): ModerationRevisionRow | null {
+  if (id === null) return null;
+  return row.revisions.find((r) => r.id === id) ?? null;
+}
+
+/**
+ * Echoes PUBLIC_MEASURE_WHERE of `src/lib/data/measures.ts`, condition by condition.
+ *
+ * That file is the authority on what the public sees; this is a read-side echo of it, and
+ * the two are crossed on the same rows by
+ * `__tests__/moderation-state.integration.test.ts`. Deriving from `publicationStatus`
+ * alone would make the queue announce a measure as visible while the public read returns
+ * nothing for it, which is exactly the case a moderator needs to be told about.
+ */
+function isPubliclyVisible(
+  row: ModerationMeasureRow,
+  published: ModerationRevisionRow | null
+): boolean {
+  return (
+    row.publicationStatus === "PUBLISHED" &&
+    row.publishedRevisionId !== null &&
+    published !== null &&
+    published.reviewedAt !== null &&
+    published.publishedAt !== null &&
+    published.supersededAt === null &&
+    published.discardedAt === null &&
+    published.sourceCount > 0
+  );
+}
+
+function derivePublication(
+  row: ModerationMeasureRow,
+  activeDrafts: ModerationRevisionRow[]
+): PublicationState {
+  // Declared published with a pointer: the stage is PUBLISHED even when the pointed
+  // revision is broken. publiclyVisible carries the disagreement; collapsing the two would
+  // lose one of the two facts.
+  if (row.publicationStatus === "PUBLISHED" && row.publishedRevisionId !== null) {
+    return "PUBLISHED";
+  }
+  // depublishedAt is the explicit trace, not a guess from "some revision was published
+  // once": a republication clears it, so it means "currently depublished".
+  if (row.depublishedAt !== null) return "DEPUBLISHED";
+  if (activeDrafts.length === 0) return "EMPTY";
+
+  const designated = activeDrafts.find((r) => r.id === row.latestRevisionId);
+  if (designated) return designated.reviewedAt !== null ? "REVIEWED" : "DRAFT";
+
+  // No pointer designates an active draft, which is orphan_active_draft. The stage still
+  // has to be decided, and it must not depend on the order the rows came back in: "a
+  // reviewed draft exists" is order-independent, "the last one in the array" is not.
+  return activeDrafts.some((r) => r.reviewedAt !== null) ? "REVIEWED" : "DRAFT";
+}
+
+function collectAnomalies(
+  row: ModerationMeasureRow,
+  published: ModerationRevisionRow | null,
+  activeDrafts: ModerationRevisionRow[]
+): ModerationAnomaly[] {
+  const anomalies: ModerationAnomaly[] = [];
+
+  if (row.publishedRevisionId !== null && published === null) {
+    anomalies.push({ code: "published_revision_foreign", detail: row.publishedRevisionId });
+  }
+  if (published !== null) {
+    if (published.reviewedAt === null) {
+      anomalies.push({ code: "published_revision_unreviewed", detail: published.id });
+    }
+    if (published.publishedAt === null) {
+      anomalies.push({ code: "published_revision_unpublished", detail: published.id });
+    }
+    if (published.supersededAt !== null) {
+      anomalies.push({ code: "published_revision_superseded", detail: published.id });
+    }
+    if (published.sourceCount === 0) {
+      anomalies.push({ code: "published_revision_without_source", detail: published.id });
+    }
+  }
+
+  const currentlyPublished = row.revisions.filter(
+    (r) => r.publishedAt !== null && r.supersededAt === null
+  );
+  if (currentlyPublished.length > 1) {
+    anomalies.push({
+      code: "multiple_published_revisions",
+      detail: currentlyPublished.map((r) => r.id).join(", "),
+    });
+  }
+
+  const orphans = activeDrafts.filter((r) => r.id !== row.latestRevisionId);
+  if (orphans.length > 0) {
+    anomalies.push({
+      code: "orphan_active_draft",
+      detail: orphans.map((r) => r.id).join(", "),
+    });
+  }
+
+  const latest = findRevision(row, row.latestRevisionId);
+  if (row.latestRevisionId !== null && latest === null) {
+    anomalies.push({ code: "latest_revision_foreign", detail: row.latestRevisionId });
+  }
+  if (latest?.discardedAt) {
+    anomalies.push({ code: "latest_revision_discarded", detail: latest.id });
+  }
+
+  if (row.withdrawnAt !== null && (!row.withdrawnSourceUrl || !row.withdrawnSourceLabel)) {
+    anomalies.push({ code: "withdrawn_without_source", detail: row.id });
+  }
+  if (row.withdrawnAt === null && (row.withdrawnSourceUrl || row.withdrawnSourceLabel)) {
+    anomalies.push({ code: "withdrawal_source_without_date", detail: row.id });
+  }
+
+  return anomalies;
+}
+
+export function deriveModerationState(row: ModerationMeasureRow): ModerationState {
+  const published = findRevision(row, row.publishedRevisionId);
+  const activeDrafts = row.revisions.filter(isActiveDraft);
+
+  const latest = findRevision(row, row.latestRevisionId);
+  const pendingDraft =
+    latest !== null && latest.id !== row.publishedRevisionId && isActiveDraft(latest)
+      ? { id: latest.id, reviewed: latest.reviewedAt !== null }
+      : null;
+
+  return {
+    publication: derivePublication(row, activeDrafts),
+    declaredStatus: row.publicationStatus,
+    publiclyVisible: isPubliclyVisible(row, published),
+    withdrawal:
+      row.withdrawnAt !== null
+        ? {
+            withdrawnAt: row.withdrawnAt,
+            sourceUrl: row.withdrawnSourceUrl,
+            sourceLabel: row.withdrawnSourceLabel,
+          }
+        : null,
+    depublication:
+      row.depublishedAt !== null
+        ? { at: row.depublishedAt, reason: row.depublicationReason }
+        : null,
+    pendingDraft,
+    anomalies: collectAnomalies(row, published, activeDrafts),
+  };
+}

--- a/src/lib/measures/moderation-state.ts
+++ b/src/lib/measures/moderation-state.ts
@@ -90,6 +90,8 @@ export type ModerationState = {
    */
   declaredStatus: PublicationStatus;
   publiclyVisible: boolean;
+  /** Empty exactly when `publiclyVisible` is true. Carries the why. */
+  visibilityBlockers: VisibilityBlocker[];
   withdrawal: MeasureWithdrawal | null;
   depublication: MeasureDepublication | null;
   /** The correction in flight, which the PUBLISHED stage would otherwise hide. */
@@ -162,28 +164,59 @@ function findRevision(row: ModerationMeasureRow, id: string | null): ModerationR
 }
 
 /**
- * Echoes PUBLIC_MEASURE_WHERE of `src/lib/data/measures.ts`, condition by condition.
+ * Every reason the public read would leave this measure out, one entry per unmet condition
+ * of PUBLIC_MEASURE_WHERE in `src/lib/data/measures.ts`.
  *
- * That file is the authority on what the public sees; this is a read-side echo of it, and
- * the two are crossed on the same rows by
- * `__tests__/moderation-state.integration.test.ts`. Deriving from `publicationStatus`
- * alone would make the queue announce a measure as visible while the public read returns
- * nothing for it, which is exactly the case a moderator needs to be told about.
+ * Reasons rather than a boolean, because "published but invisible" is useless to a moderator
+ * without the why. And they are NOT the anomaly list: an anomaly is data that should not
+ * exist, a blocker is a condition that is not met. A depublished measure has a blocker and
+ * no anomaly; a published revision carrying `discardedAt` has a blocker that the audit has
+ * no rule for at all.
  */
-function isPubliclyVisible(
+export const VISIBILITY_BLOCKERS = [
+  "status_not_published",
+  "no_published_pointer",
+  "pointer_not_found",
+  "revision_unreviewed",
+  "revision_never_published",
+  "revision_superseded",
+  "revision_discarded",
+  "revision_without_source",
+] as const;
+
+export type VisibilityBlocker = (typeof VISIBILITY_BLOCKERS)[number];
+
+/**
+ * Echoes PUBLIC_MEASURE_WHERE condition by condition. That file is the authority on what the
+ * public sees; this is a read-side echo of it, and the two are crossed on the same rows by
+ * `__tests__/moderation-state.integration.test.ts`.
+ *
+ * `publiclyVisible` is then defined as "no blocker", so the flag and the explanation cannot
+ * disagree: there is one list of conditions, not a boolean beside a list.
+ */
+function deriveVisibilityBlockers(
   row: ModerationMeasureRow,
   published: ModerationRevisionRow | null
-): boolean {
-  return (
-    row.publicationStatus === "PUBLISHED" &&
-    row.publishedRevisionId !== null &&
-    published !== null &&
-    published.reviewedAt !== null &&
-    published.publishedAt !== null &&
-    published.supersededAt === null &&
-    published.discardedAt === null &&
-    published.sourceCount > 0
-  );
+): VisibilityBlocker[] {
+  const blockers: VisibilityBlocker[] = [];
+
+  if (row.publicationStatus !== "PUBLISHED") blockers.push("status_not_published");
+  if (row.publishedRevisionId === null) {
+    blockers.push("no_published_pointer");
+    return blockers;
+  }
+  if (published === null) {
+    blockers.push("pointer_not_found");
+    return blockers;
+  }
+
+  if (published.reviewedAt === null) blockers.push("revision_unreviewed");
+  if (published.publishedAt === null) blockers.push("revision_never_published");
+  if (published.supersededAt !== null) blockers.push("revision_superseded");
+  if (published.discardedAt !== null) blockers.push("revision_discarded");
+  if (published.sourceCount === 0) blockers.push("revision_without_source");
+
+  return blockers;
 }
 
 function derivePublication(
@@ -281,10 +314,13 @@ export function deriveModerationState(row: ModerationMeasureRow): ModerationStat
       ? { id: latest.id, reviewed: latest.reviewedAt !== null }
       : null;
 
+  const visibilityBlockers = deriveVisibilityBlockers(row, published);
+
   return {
     publication: derivePublication(row, activeDrafts),
     declaredStatus: row.publicationStatus,
-    publiclyVisible: isPubliclyVisible(row, published),
+    publiclyVisible: visibilityBlockers.length === 0,
+    visibilityBlockers,
     withdrawal:
       row.withdrawnAt !== null
         ? {

--- a/src/lib/measures/moderation-state.ts
+++ b/src/lib/measures/moderation-state.ts
@@ -309,8 +309,16 @@ export function deriveModerationState(row: ModerationMeasureRow): ModerationStat
   const activeDrafts = row.revisions.filter(isActiveDraft);
 
   const latest = findRevision(row, row.latestRevisionId);
+  // A pending draft is a correction waiting ON TOP of a published text, so it only exists once
+  // something is published. Without that condition, a plain unpublished draft was reported as
+  // "a correction is in progress" beside the DRAFT stage, which says there are two versions
+  // when there is one. Found by looking at the rendered queue, not by the unit tests, which
+  // asserted the wrong semantics.
   const pendingDraft =
-    latest !== null && latest.id !== row.publishedRevisionId && isActiveDraft(latest)
+    row.publishedRevisionId !== null &&
+    latest !== null &&
+    latest.id !== row.publishedRevisionId &&
+    isActiveDraft(latest)
       ? { id: latest.id, reviewed: latest.reviewedAt !== null }
       : null;
 

--- a/src/test/__tests__/db-guard.test.ts
+++ b/src/test/__tests__/db-guard.test.ts
@@ -162,6 +162,19 @@ describe("assertDisposableTestDb", () => {
   });
 });
 
+describe("le module de garde reste utilisable hors de vitest", () => {
+  it("n'importe pas vitest dans disposable-db.ts", () => {
+    // Trouvé en exécutant scripts/seed-measures-demo.ts : quand assertDisposableTestDb()
+    // venait de db-guard.ts, le script tsx échouait sur « Vitest cannot be imported in a
+    // CommonJS module using require() ». Aucun test ne pouvait le voir, ils tournent tous
+    // sous vitest. La garde doit rester appelable par un script qui écrit en base.
+    const source = readFileSync(join(process.cwd(), "src/test/disposable-db.ts"), "utf8");
+
+    expect(source).not.toMatch(/from\s+"vitest"/);
+    expect(source).not.toMatch(/require\(\s*"vitest"/);
+  });
+});
+
 describe("describeIfDisposableDb", () => {
   it.skipIf(isDisposableTestDb())("n'est pas le describe ouvert hors du conteneur jetable", () => {
     expect(describeIfDisposableDb).not.toBe(describe);

--- a/src/test/db-guard.ts
+++ b/src/test/db-guard.ts
@@ -1,136 +1,40 @@
 /**
  * Gate for integration tests that write to a database (issue #547).
  *
- * `.env` and `.env.prod` both point at the same production Supabase: this project
- * has no separate development database. A gate on "is there a database?" therefore
- * turns every integration test into a production writer as soon as someone exports
- * `DATABASE_URL` in their shell. The gate has to be "is this a *local throwaway*
- * database?" instead.
+ * The predicates and the hard refusals live in `./disposable-db`, which imports no vitest: a
+ * seed script running under tsx has to be able to call `assertDisposableTestDb()`, and pulling
+ * `describe` in through it crashes. This module adds the two vitest gates and re-exports the
+ * rest, so `@/test/db-guard` stays the single import for tests.
  *
- * Skipping is deliberately preferred over throwing. A guard that throws inside
- * `beforeAll` still lets earlier writes in that same hook reach the database, and
- * the residue then outlives the run. A block that never starts writes nothing, so
- * there is nothing to clean up.
+ * Skipping is deliberately preferred over throwing. A guard that throws inside `beforeAll`
+ * still lets earlier writes in that same hook reach the database, and the residue then outlives
+ * the run. A block that never starts writes nothing, so there is nothing to clean up.
  *
- * Run these tests through the disposable harness (`npm run test:db:477`), which
- * exports a `@localhost` URL and tears the container down on exit.
+ * Run these tests through the disposable harness (`npm run test:db:search`), which exports a
+ * `@localhost` URL and tears the container down on exit.
  */
 
 import { describe } from "vitest";
+import { isDisposableTestDb, isLocalTestDb } from "./disposable-db";
 
-/** Hosts that can only be a throwaway database on the machine running the tests. */
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
-
-/**
- * Whether `DATABASE_URL` names a local database.
- *
- * Parses rather than pattern-matches, so both credentialed
- * (`postgresql://user:pass@localhost:5432/db`) and bare (`postgresql://localhost/db`)
- * forms are recognised. Anything unparseable counts as non-local: an unreadable URL
- * is not evidence of safety.
- */
-export function isLocalTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
-  if (!url) return false;
-  try {
-    // IPv6 hostnames come back bracketed ("[::1]"); compare the host itself.
-    const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").toLowerCase();
-    return LOCAL_HOSTS.has(hostname);
-  } catch {
-    return false;
-  }
-}
+export {
+  assertDisposableTestDb,
+  assertLocalTestDb,
+  isDisposableTestDb,
+  isLocalTestDb,
+} from "./disposable-db";
 
 /**
- * `describe` for suites that write to a database: runs against a local database,
- * skips everywhere else, including against production.
+ * `describe` for suites that write to a database: runs against a local database, skips
+ * everywhere else, including against production.
  *
- * Replaces the `process.env.DATABASE_URL ? describe : describe.skip` idiom, which
- * gated on the presence of a database rather than on which one.
+ * Replaces the `process.env.DATABASE_URL ? describe : describe.skip` idiom, which gated on the
+ * presence of a database rather than on which one.
  */
 export const describeIfLocalDb = isLocalTestDb() ? describe : describe.skip;
 
 /**
- * Hard refusal, for shared seed and cleanup helpers.
- *
- * Second layer behind {@link describeIfLocalDb}: a helper can be called from a
- * script or a future test that forgot the gate, and it must not depend on its
- * caller having been careful.
- */
-export function assertLocalTestDb(): void {
-  if (!isLocalTestDb()) {
-    throw new Error(
-      "Ces fixtures refusent de s'exécuter : DATABASE_URL ne désigne pas une base locale. " +
-        "Lancer les tests d'intégration via le harness jetable (npm run test:db:477)."
-    );
-  }
-}
-
-// --- Destructive suites: the exact disposable container ----------------------
-//
-// `isLocalTestDb` answers "is this a local database", which is the right question
-// for a suite that only writes rows. It is not enough for suites that run DDL:
-// "local" also describes a persistent development database or an SSH tunnel to a
-// remote one. Discovered concretely on the lot 1B search substrate, whose drift
-// test ran ALTER TABLE and `prisma db push --accept-data-loss`, and whose internal
-// URL check happened AFTER the first statement, so a refusal left the added column
-// behind on someone else's database.
-//
-// Deliberately pinned to the port 55433 container only, and NOT to the #477
-// harness on 55432: the two containers are created by different compose files with
-// different extensions, so "any disposable container" would be a claim this module
-// cannot verify. The cost of pinning is that a suite launched under the wrong
-// harness skips instead of running, which is the safe direction and is visible in
-// the vitest output.
-
-/** The container from docker-compose.test-search.yml, and nothing else. */
-const DISPOSABLE_TEST_DB = {
-  hostname: "localhost",
-  port: "55433",
-  database: "poligraph_test",
-} as const;
-
-/**
- * Whether `DATABASE_URL` names the disposable container of `npm run test:db:search`.
- *
- * Narrows {@link isLocalTestDb} rather than replacing it, so there stays a single
- * definition of "local" and a single definition of "the destructible container".
- * Parses rather than pattern-matches, so a credentialed URL and a bare one both
- * work and the expected values cannot be smuggled in through a password or a query
- * parameter. Anything unparseable counts as "not it": an unreadable URL is not
- * evidence of safety.
- */
-export function isDisposableTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
-  if (!url || !isLocalTestDb(url)) return false;
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.hostname.toLowerCase() === DISPOSABLE_TEST_DB.hostname &&
-      parsed.port === DISPOSABLE_TEST_DB.port &&
-      parsed.pathname.replace(/^\//, "") === DISPOSABLE_TEST_DB.database
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * `describe` for destructive suites: runs on the disposable container, skips
- * everywhere else, including on another local database.
+ * `describe` for destructive suites: runs on the disposable container, skips everywhere else,
+ * including on another local database.
  */
 export const describeIfDisposableDb = isDisposableTestDb() ? describe : describe.skip;
-
-/**
- * Hard refusal, second layer behind {@link describeIfDisposableDb}.
- *
- * Call it from every `beforeAll` of a destructive suite, and from fixture modules:
- * a block can be added later with the wrong `describe`, and a helper must not
- * depend on its caller having been careful.
- */
-export function assertDisposableTestDb(): void {
-  if (!isDisposableTestDb()) {
-    throw new Error(
-      "Ces tests refusent de s'exécuter : DATABASE_URL ne désigne pas le conteneur jetable " +
-        "(localhost:55433/poligraph_test). Lancer npm run test:db:search."
-    );
-  }
-}

--- a/src/test/disposable-db.ts
+++ b/src/test/disposable-db.ts
@@ -1,0 +1,115 @@
+/**
+ * Which database `DATABASE_URL` names, and the hard refusals built on the answer.
+ *
+ * **This module must never import vitest.** It is split out of `db-guard.ts` for exactly that
+ * reason: `assertDisposableTestDb()` is also called by `scripts/seed-measures-demo.ts`, which
+ * runs under tsx, and importing the `describe` helpers there fails with "Vitest cannot be
+ * imported in a CommonJS module using require()". The guard has to be usable by the callers
+ * that most need it, and a script that writes to a database is one of them.
+ *
+ * `db-guard.ts` re-exports everything here and adds the two vitest `describe` gates, so
+ * existing imports of `@/test/db-guard` keep working.
+ *
+ * Why the guard exists at all: `.env` and `.env.prod` both point at the same production
+ * Supabase, so this project has no separate development database. A check on "is there a
+ * database?" turns any seed helper into a production writer as soon as someone exports
+ * `DATABASE_URL` in their shell.
+ */
+
+/** Hosts that can only be a throwaway database on the machine running the code. */
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Whether `DATABASE_URL` names a local database.
+ *
+ * Parses rather than pattern-matches, so both credentialed
+ * (`postgresql://user:pass@localhost:5432/db`) and bare (`postgresql://localhost/db`) forms
+ * are recognised. Anything unparseable counts as non-local: an unreadable URL is not evidence
+ * of safety.
+ */
+export function isLocalTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
+  if (!url) return false;
+  try {
+    // IPv6 hostnames come back bracketed ("[::1]"); compare the host itself.
+    const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hard refusal, for shared seed and cleanup helpers.
+ *
+ * Second layer behind `describeIfLocalDb`: a helper can be called from a script or a future
+ * test that forgot the gate, and it must not depend on its caller having been careful.
+ */
+export function assertLocalTestDb(): void {
+  if (!isLocalTestDb()) {
+    throw new Error(
+      "Ces fixtures refusent de s'exécuter : DATABASE_URL ne désigne pas une base locale. " +
+        "Lancer les tests d'intégration via le harness jetable (npm run test:db:477)."
+    );
+  }
+}
+
+// --- Destructive suites: the exact disposable container ----------------------
+//
+// `isLocalTestDb` answers "is this a local database", which is the right question for a suite
+// that only writes rows. It is not enough for suites that run DDL: "local" also describes a
+// persistent development database or an SSH tunnel to a remote one. Discovered concretely on
+// the lot 1B search substrate, whose drift test ran ALTER TABLE and
+// `prisma db push --accept-data-loss`, and whose internal URL check happened AFTER the first
+// statement, so a refusal left the added column behind on someone else's database.
+//
+// Deliberately pinned to the port 55433 container only, and NOT to the #477 harness on 55432:
+// the two containers are created by different compose files with different extensions, so "any
+// disposable container" would be a claim this module cannot verify. The cost of pinning is that
+// a suite launched under the wrong harness skips instead of running, which is the safe
+// direction and is visible in the vitest output.
+
+/** The container from docker-compose.test-search.yml, and nothing else. */
+const DISPOSABLE_TEST_DB = {
+  hostname: "localhost",
+  port: "55433",
+  database: "poligraph_test",
+} as const;
+
+/**
+ * Whether `DATABASE_URL` names the disposable container of `npm run test:db:search`.
+ *
+ * Narrows {@link isLocalTestDb} rather than replacing it, so there stays a single definition of
+ * "local" and a single definition of "the destructible container". Parses rather than
+ * pattern-matches, so a credentialed URL and a bare one both work and the expected values
+ * cannot be smuggled in through a password or a query parameter. Anything unparseable counts as
+ * "not it".
+ */
+export function isDisposableTestDb(url: string | undefined = process.env.DATABASE_URL): boolean {
+  if (!url || !isLocalTestDb(url)) return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.toLowerCase() === DISPOSABLE_TEST_DB.hostname &&
+      parsed.port === DISPOSABLE_TEST_DB.port &&
+      parsed.pathname.replace(/^\//, "") === DISPOSABLE_TEST_DB.database
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hard refusal, second layer behind `describeIfDisposableDb`.
+ *
+ * Call it from every `beforeAll` of a destructive suite, from fixture modules, and from any
+ * script that writes: a block can be added later with the wrong `describe`, and a helper must
+ * not depend on its caller having been careful.
+ */
+export function assertDisposableTestDb(): void {
+  if (!isDisposableTestDb()) {
+    throw new Error(
+      "Ces tests refusent de s'exécuter : DATABASE_URL ne désigne pas le conteneur jetable " +
+        "(localhost:55433/poligraph_test). Lancer npm run test:db:search."
+    );
+  }
+}

--- a/src/test/fixtures/__tests__/measures-demo.test.ts
+++ b/src/test/fixtures/__tests__/measures-demo.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { seedMeasuresDemoCorpus } from "../measures-demo";
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+function restoreDatabaseUrl(): void {
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+    return;
+  }
+  process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+}
+
+describe("seedMeasuresDemoCorpus : la garde avant toute écriture", () => {
+  afterEach(restoreDatabaseUrl);
+
+  it("refuse une base de production", async () => {
+    // The corpus attributes invented positions to fictional candidates. Writing it into the
+    // production database would put fabricated political claims in front of the public, and
+    // `.env` points at production, so this refusal is the only thing standing between the two.
+    process.env.DATABASE_URL = "postgresql://postgres:secret@db.example.supabase.co:5432/postgres";
+
+    await expect(seedMeasuresDemoCorpus()).rejects.toThrow(/conteneur jetable/);
+  });
+
+  it("refuse une base locale qui n'est pas le conteneur jetable", async () => {
+    // A local database is not enough: the harness container is destroyed on exit, a local
+    // development database is not.
+    process.env.DATABASE_URL = "postgresql://poligraph:poligraph@localhost:5432/poligraph";
+
+    await expect(seedMeasuresDemoCorpus()).rejects.toThrow(/conteneur jetable/);
+  });
+
+  it("refuse une DATABASE_URL absente", async () => {
+    delete process.env.DATABASE_URL;
+
+    await expect(seedMeasuresDemoCorpus()).rejects.toThrow(/conteneur jetable/);
+  });
+});

--- a/src/test/fixtures/measures-demo.ts
+++ b/src/test/fixtures/measures-demo.ts
@@ -1,0 +1,324 @@
+/**
+ * A demonstration corpus of measures, covering every moderation state.
+ *
+ * No measure exists in production and the tables are not there yet, so the moderation
+ * screens have to be reviewed against fabricated data. Two consequences that are not
+ * negotiable:
+ *
+ * 1. **The candidates are fictional.** Attributing invented positions to a real politician
+ *    would put a false claim in the database, which is the exact failure mode this project
+ *    exists to prevent. The names below are explicitly made up, and so is the election.
+ * 2. **Writing is gated on the disposable container.** `.env` and `.env.prod` point at the
+ *    same Supabase database, so an ungated seed run with the default environment would write
+ *    fabricated political positions into production.
+ *
+ * States covered, one measure each: published, draft, reviewed, published with a correction
+ * in flight, depublished, withdrawn, incomplete withdrawal, published with no source, empty,
+ * and an orphan active draft.
+ */
+
+import type { ThemeCategory } from "@/generated/prisma";
+import { assertDisposableTestDb } from "@/test/db-guard";
+
+/** Deferred, same reason as the lot 1 fixtures: `@/lib/db` throws at module load. */
+async function client(): Promise<typeof import("@/lib/db").db> {
+  assertDisposableTestDb();
+  const { db } = await import("@/lib/db");
+  return db;
+}
+
+async function transitions(): Promise<typeof import("@/lib/measures/transitions")> {
+  assertDisposableTestDb();
+  return import("@/lib/measures/transitions");
+}
+
+/** Stable keys, so a test can name the measure it is asserting on. */
+export type DemoMeasureKey =
+  | "publiee"
+  | "brouillon"
+  | "relue"
+  | "publiee_avec_correction"
+  | "depubliee"
+  | "retiree"
+  | "retrait_incomplet"
+  | "publiee_sans_source"
+  | "vide"
+  | "brouillon_orphelin";
+
+export type DemoCorpus = {
+  electionId: string;
+  electionSlug: string;
+  candidateIds: string[];
+  measureIds: Record<DemoMeasureKey, string>;
+};
+
+const CORPUS_PREFIX = "demo-mesures";
+
+/** Fictional on purpose. See the note at the top of this file. */
+const CANDIDATES = [
+  { firstName: "Alix", lastName: "Démonstration" },
+  { firstName: "Camille", lastName: "Exemple" },
+] as const;
+
+type SeedContext = {
+  db: Awaited<ReturnType<typeof client>>;
+  electionId: string;
+  candidacyIds: string[];
+  politicianIds: string[];
+};
+
+function suffix(): string {
+  return `${process.pid}-${Date.now().toString(36)}`;
+}
+
+async function seedContext(): Promise<SeedContext> {
+  const db = await client();
+  const unique = suffix();
+
+  const election = await db.election.create({
+    data: {
+      slug: `${CORPUS_PREFIX}-election-${unique}`,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Élection de démonstration 2027",
+      round1Date: new Date("2027-04-11T00:00:00Z"),
+    },
+  });
+
+  const politicianIds: string[] = [];
+  const candidacyIds: string[] = [];
+  for (const [index, candidate] of CANDIDATES.entries()) {
+    const politician = await db.politician.create({
+      data: {
+        slug: `${CORPUS_PREFIX}-${candidate.firstName.toLowerCase()}-${unique}-${index}`,
+        firstName: candidate.firstName,
+        lastName: candidate.lastName,
+        fullName: `${candidate.firstName} ${candidate.lastName}`,
+      },
+    });
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: politician.id,
+        candidateName: `${candidate.firstName} ${candidate.lastName}`,
+      },
+    });
+    politicianIds.push(politician.id);
+    candidacyIds.push(candidacy.id);
+  }
+
+  return { db, electionId: election.id, candidacyIds, politicianIds };
+}
+
+type MeasureSeed = {
+  text: string;
+  theme: ThemeCategory;
+};
+
+function buildRevision(input: { text: string; chiffree: boolean; validFrom: Date }) {
+  return {
+    text: input.text,
+    precision: input.chiffree ? ("CHIFFREE" as const) : ("OBJECTIF_SANS_CHIFFRE" as const),
+    validFrom: input.validFrom,
+    extractionMethod: "AI_ASSISTED" as const,
+    extractionConfidence: 0.82,
+    extractorVersion: "demo-1",
+  };
+}
+
+const PRIMARY_SOURCE = {
+  sourceKind: "PROGRAMME_PARTI" as const,
+  tier: "PRIMARY" as const,
+  url: "https://example.org/programme-demonstration.pdf",
+  page: "12",
+  publishedAt: new Date("2027-01-15T00:00:00Z"),
+};
+
+const PRESS_SOURCE = {
+  sourceKind: "ARTICLE_PRESSE" as const,
+  tier: "SECONDARY" as const,
+  url: "https://example.org/article-demonstration",
+  page: null,
+  publishedAt: new Date("2027-02-02T00:00:00Z"),
+};
+
+async function createDemoMeasure(
+  context: SeedContext,
+  candidateIndex: number,
+  seed: MeasureSeed,
+  options: { chiffree?: boolean } = {}
+): Promise<{ measureId: string; revisionId: string }> {
+  const { createMeasure } = await transitions();
+  return createMeasure({
+    politicianId: context.politicianIds[candidateIndex],
+    electionId: context.electionId,
+    candidacyId: context.candidacyIds[candidateIndex],
+    programEditionId: null,
+    attribution: "PERSONAL",
+    theme: seed.theme,
+    precedingMeasureId: null,
+    revision: buildRevision({
+      text: seed.text,
+      chiffree: options.chiffree ?? false,
+      validFrom: new Date("2027-01-15T00:00:00Z"),
+    }),
+    sources: [PRIMARY_SOURCE],
+  });
+}
+
+/**
+ * Seeds the corpus and returns the identifiers.
+ *
+ * Everything reachable through the transitions goes through them. The four broken states are
+ * written directly, and that is the nature of the exercise: the transitions refuse to produce
+ * them, while a past import or a manual correction leaves exactly those behind. The
+ * moderation screens exist to show them.
+ */
+export async function seedMeasuresDemoCorpus(): Promise<DemoCorpus> {
+  const context = await seedContext();
+  const { db, electionId } = context;
+  const {
+    reviewMeasureRevision,
+    publishMeasureRevision,
+    draftMeasureRevision,
+    discardMeasureRevision,
+    depublishMeasure,
+    withdrawMeasure,
+  } = await transitions();
+
+  const election = await db.election.findUniqueOrThrow({
+    where: { id: electionId },
+    select: { slug: true },
+  });
+
+  // 1. Published, correctly.
+  const publiee = await createDemoMeasure(context, 0, {
+    text: "Encadrer les loyers dans les zones tendues et étendre le dispositif aux communes littorales.",
+    theme: "LOGEMENT_URBANISME",
+  });
+  await reviewMeasureRevision({ ...publiee, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(publiee);
+
+  // 2. Draft, nobody has read it.
+  const brouillon = await createDemoMeasure(context, 1, {
+    text: "Rendre gratuits les transports scolaires dans les départements ruraux.",
+    theme: "TRANSPORTS",
+  });
+
+  // 3. Reviewed, not published.
+  const relue = await createDemoMeasure(context, 0, {
+    text: "Porter la part du fret ferroviaire à 20 % du transport de marchandises en cinq ans.",
+    theme: "TRANSPORTS",
+  });
+  await reviewMeasureRevision({ ...relue, reviewedBy: "relecteur de démonstration" });
+
+  // 4. Published, with a reviewed correction in flight.
+  const avecCorrection = await createDemoMeasure(context, 1, {
+    text: "Créer 5 000 postes d'enseignants sur la durée du mandat.",
+    theme: "EDUCATION_CULTURE",
+  });
+  await reviewMeasureRevision({ ...avecCorrection, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(avecCorrection);
+  const correction = await draftMeasureRevision({
+    measureId: avecCorrection.measureId,
+    revision: buildRevision({
+      text: "Créer 5 000 postes d'enseignants dès la première année du mandat.",
+      chiffree: true,
+      validFrom: new Date("2027-02-20T00:00:00Z"),
+    }),
+    sources: [PRESS_SOURCE],
+  });
+  await reviewMeasureRevision({
+    measureId: avecCorrection.measureId,
+    revisionId: correction.revisionId,
+    reviewedBy: "relecteur de démonstration",
+  });
+
+  // 5. Depublished, with its reason.
+  const depubliee = await createDemoMeasure(context, 0, {
+    text: "Réformer le financement de l'audiovisuel public.",
+    theme: "INSTITUTIONS",
+  });
+  await reviewMeasureRevision({ ...depubliee, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(depubliee);
+  await depublishMeasure({
+    measureId: depubliee.measureId,
+    reason: "Formulation trop éloignée du texte source, à réextraire.",
+  });
+
+  // 6. Withdrawn, sourced.
+  const retiree = await createDemoMeasure(context, 1, {
+    text: "Supprimer la taxe d'habitation sur les résidences secondaires.",
+    theme: "ECONOMIE_BUDGET",
+  });
+  await reviewMeasureRevision({ ...retiree, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(retiree);
+  await withdrawMeasure({
+    measureId: retiree.measureId,
+    withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+    sourceUrl: "https://example.org/retrait-demonstration",
+    sourceLabel: "Conférence de presse du 1er mars 2027",
+  });
+
+  // 7. Anomaly: withdrawn with no source. Direct write, withdrawMeasure() refuses it.
+  const retraitIncomplet = await createDemoMeasure(context, 0, {
+    text: "Instaurer un revenu de base pour les 18-25 ans.",
+    theme: "SOCIAL_TRAVAIL",
+  });
+  await reviewMeasureRevision({ ...retraitIncomplet, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(retraitIncomplet);
+  await db.measure.update({
+    where: { id: retraitIncomplet.measureId },
+    data: { withdrawnAt: new Date("2027-03-05T00:00:00Z") },
+  });
+
+  // 8. Anomaly: published revision with no source left.
+  const sansSource = await createDemoMeasure(context, 1, {
+    text: "Doubler le budget de la rénovation énergétique des bâtiments publics.",
+    theme: "ENVIRONNEMENT_ENERGIE",
+  });
+  await reviewMeasureRevision({ ...sansSource, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(sansSource);
+  await db.measureSource.deleteMany({ where: { measureRevisionId: sansSource.revisionId } });
+
+  // 9. Empty: the only draft was discarded through the real path.
+  const vide = await createDemoMeasure(context, 0, {
+    text: "Généraliser la médiation numérique dans les maisons France Services.",
+    theme: "NUMERIQUE_TECH",
+  });
+  await discardMeasureRevision(vide);
+
+  // 10. Anomaly: an active draft no pointer designates.
+  const orphelin = await createDemoMeasure(context, 1, {
+    text: "Créer une agence publique du médicament essentiel.",
+    theme: "SANTE",
+  });
+  await reviewMeasureRevision({ ...orphelin, reviewedBy: "relecteur de démonstration" });
+  await publishMeasureRevision(orphelin);
+  await db.measureRevision.create({
+    data: {
+      measureId: orphelin.measureId,
+      text: "Créer une agence publique du médicament, périmètre à préciser.",
+      validFrom: new Date("2027-02-25T00:00:00Z"),
+      extractionMethod: "IMPORTED",
+    },
+  });
+
+  return {
+    electionId,
+    electionSlug: election.slug,
+    candidateIds: context.politicianIds,
+    measureIds: {
+      publiee: publiee.measureId,
+      brouillon: brouillon.measureId,
+      relue: relue.measureId,
+      publiee_avec_correction: avecCorrection.measureId,
+      depubliee: depubliee.measureId,
+      retiree: retiree.measureId,
+      retrait_incomplet: retraitIncomplet.measureId,
+      publiee_sans_source: sansSource.measureId,
+      vide: vide.measureId,
+      brouillon_orphelin: orphelin.measureId,
+    },
+  };
+}

--- a/src/test/fixtures/measures-demo.ts
+++ b/src/test/fixtures/measures-demo.ts
@@ -149,10 +149,16 @@ async function createDemoMeasure(
   options: { chiffree?: boolean } = {}
 ): Promise<{ measureId: string; revisionId: string }> {
   const { createMeasure } = await transitions();
+  const politicianId = context.politicianIds[candidateIndex];
+  const candidacyId = context.candidacyIds[candidateIndex];
+  if (politicianId === undefined || candidacyId === undefined) {
+    throw new Error(`Candidature de démonstration ${candidateIndex} absente du contexte`);
+  }
+
   return createMeasure({
-    politicianId: context.politicianIds[candidateIndex],
+    politicianId,
     electionId: context.electionId,
-    candidacyId: context.candidacyIds[candidateIndex],
+    candidacyId,
     programEditionId: null,
     attribution: "PERSONAL",
     theme: seed.theme,

--- a/src/test/fixtures/measures-demo.ts
+++ b/src/test/fixtures/measures-demo.ts
@@ -18,7 +18,10 @@
  */
 
 import type { ThemeCategory } from "@/generated/prisma";
-import { assertDisposableTestDb } from "@/test/db-guard";
+// From ./disposable-db and NOT @/test/db-guard: this module is also imported by
+// scripts/seed-measures-demo.ts under tsx, where pulling vitest in through the gate module
+// crashes the script.
+import { assertDisposableTestDb } from "@/test/disposable-db";
 
 /** Deferred, same reason as the lot 1 fixtures: `@/lib/db` throws at module load. */
 async function client(): Promise<typeof import("@/lib/db").db> {

--- a/tests/visual/mesures-moderation.spec.ts
+++ b/tests/visual/mesures-moderation.spec.ts
@@ -1,0 +1,153 @@
+import { createHmac } from "node:crypto";
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+/**
+ * Accessibility and responsive checks for the measure moderation screens.
+ *
+ * Needs the disposable container seeded with the demonstration corpus, and a dev server
+ * pointed at it:
+ *
+ *   docker compose -f docker-compose.test-search.yml up -d
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
+ *     npx prisma db push --url "$DATABASE_URL" --accept-data-loss
+ *   DATABASE_URL=... npx tsx scripts/seed-measures-demo.ts
+ *   DATABASE_URL=... ADMIN_PASSWORD=<choix local> npm run dev
+ *   ADMIN_PASSWORD=<le même> npx playwright test mesures-moderation --project=chromium
+ *
+ * The session cookie is forged rather than typed into the login form: it is the exact token
+ * `isAuthenticated()` verifies, so the test depends on the auth contract instead of on the
+ * markup of the login page.
+ */
+
+const PASSWORD = process.env.ADMIN_PASSWORD;
+const WCAG = ["wcag2a", "wcag2aa", "wcag21aa"];
+
+/**
+ * The scan is scoped to the page content, not the whole document.
+ *
+ * The admin sidebar carries one WCAG AA contrast failure (#6e7174 on #0d1218, 3.82:1 in the
+ * section labels), verified identical on /admin/policy-titles, /admin/promises and
+ * /admin/affaires. It is layout debt these screens inherit, not something they introduce, and
+ * it is tracked separately. Scoping states what this suite is responsible for instead of
+ * silencing a rule.
+ */
+const CONTENT = "#admin-main";
+
+async function signIn(context: BrowserContext, password: string): Promise<void> {
+  const timestamp = Date.now();
+  const signature = createHmac("sha256", password).update(String(timestamp)).digest("hex");
+  await context.addCookies([
+    {
+      name: "admin_session",
+      value: `${timestamp}.${signature}`,
+      domain: "localhost",
+      path: "/",
+    },
+  ]);
+}
+
+/**
+ * How far the PAGE can actually be scrolled sideways.
+ *
+ * Not `documentElement.scrollWidth - clientWidth`: that value also counts content clipped by
+ * `overflow: hidden` and content inside a legitimate horizontal scroller, so it reports an
+ * overflow the visitor never experiences. Asking the browser to scroll and reading back where
+ * it landed measures what a visitor gets.
+ */
+async function horizontalScroll(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    window.scrollTo(2000, 0);
+    const x = window.scrollX;
+    window.scrollTo(0, 0);
+    return x;
+  });
+}
+
+/**
+ * Opens the first measure of the filtered queue and waits for the URL to change.
+ *
+ * The URL assertion is the point: the queue and the detail both have an h1, so waiting on a
+ * level-1 heading let two tests run against the queue while claiming to test the detail.
+ */
+async function openFirstDetail(page: Page): Promise<void> {
+  await page.goto("/admin/mesures?anomalies=1");
+  await page.getByRole("link", { name: "Examiner" }).first().click();
+  await expect(page).toHaveURL(/\/admin\/mesures\/[A-Za-z0-9]+$/);
+  await expect(page.getByRole("link", { name: "Retour à la file" })).toBeVisible();
+}
+
+test.describe("/admin/mesures — modération des mesures", () => {
+  test.skip(!PASSWORD, "ADMIN_PASSWORD doit valoir le mot de passe du serveur de dev local");
+
+  test.beforeEach(async ({ context }) => {
+    await signIn(context, PASSWORD as string);
+  });
+
+  test("la file rend le corpus de démonstration", async ({ page }) => {
+    await page.goto("/admin/mesures");
+
+    await expect(page.getByRole("heading", { name: "Mesures : relecture" })).toBeVisible();
+    // Ten measures in the corpus, so ten rows plus the header row.
+    await expect(page.locator("tbody tr")).toHaveCount(10);
+    // The state that must never be smoothed over.
+    await expect(page.getByText("Publiée mais invisible du public").first()).toBeVisible();
+    await expect(page.getByText("Retirée, source incomplète").first()).toBeVisible();
+  });
+
+  test("la file n'a aucune violation WCAG AA", async ({ page }) => {
+    await page.goto("/admin/mesures");
+    await expect(page.getByRole("table")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("le détail n'a aucune violation WCAG AA", async ({ page }) => {
+    await openFirstDetail(page);
+
+    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("le détail montre les raisons quand le public ne voit rien", async ({ page }) => {
+    await openFirstDetail(page);
+
+    await expect(page.getByRole("heading", { name: "Ce que le public voit" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Anomalies" })).toBeVisible();
+  });
+
+  for (const [label, width, height] of [
+    ["mobile", 375, 812],
+    ["tablette", 768, 1024],
+    ["bureau", 1440, 900],
+  ] as const) {
+    test(`la file ne fait pas défiler la page horizontalement en ${label}`, async ({ page }) => {
+      await page.setViewportSize({ width, height });
+      await page.goto("/admin/mesures");
+      await expect(page.getByRole("table")).toBeVisible();
+
+      // The table scrolls inside its own container; the page must not.
+      expect(await horizontalScroll(page)).toBe(0);
+
+      await page.screenshot({
+        path: `tests/visual/test-results/mesures-file-${label}.png`,
+        fullPage: true,
+      });
+    });
+
+    test(`le détail ne fait pas défiler la page horizontalement en ${label}`, async ({ page }) => {
+      await page.setViewportSize({ width, height });
+      await openFirstDetail(page);
+
+      expect(await horizontalScroll(page)).toBe(0);
+
+      await page.screenshot({
+        path: `tests/visual/test-results/mesures-detail-${label}.png`,
+        fullPage: true,
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Description

Première PR du lot 2 : la file de relecture des mesures et la fiche de modération, en **lecture
seule**. Elle est construite sur les fonctions du lot 1 et n'en réécrit aucune. Les actions
éditoriales sont la PR 2B.

Deux écrans : `/admin/mesures` (file bornée, filtres, compteurs par état) et
`/admin/mesures/[id]` (toutes les révisions, sources, qualifications, évaluations, anomalies, et
un panneau « ce que le public voit »).

## Les sept états ne sont pas sept valeurs d'un enum

Une mesure retirée peut rester publiée, une mesure publiée peut porter une correction en
relecture, et « incohérent » n'est pas une étape mais la présence d'une anomalie. Les aplatir
aurait refait le défaut des peines mixtes : une structure plus pauvre que la réalité affirme du
faux sans jamais planter.

D'où des axes indépendants dans `deriveModerationState()` : `publication`, `declaredStatus`,
`publiclyVisible`, `visibilityBlockers`, `withdrawal`, `depublication`, `pendingDraft`,
`anomalies`.

**`publiclyVisible` est l'axe qui porte le poids.** Il ne peut pas être
`publicationStatus === "PUBLISHED"` : la publication est cumulative depuis le lot 1, statut plus
état de la révision pointée. Une file qui affiche « publiée » d'après le seul statut raconte au
relecteur un site qui n'existe pas, exactement dans le cas où il aurait besoin de savoir.

Le test ne relit donc pas la dérivation, il **croise** les deux fonctions sur les mêmes lignes :
`publiclyVisible === (getPublicMeasure(id) !== null)`, sur dix états construits en base.

## Les raisons plutôt qu'un booléen

`visibilityBlockers` liste une entrée par condition non remplie de `PUBLIC_MEASURE_WHERE`, et
`publiclyVisible` est **défini** comme « aucun bloqueur », donc le drapeau et son explication ne
peuvent pas se contredire.

Ce n'est pas la liste des anomalies, et la distinction compte : une dépublication est une raison
sans être un défaut de données. Et une révision publiée portant `discardedAt` est invisible du
public alors qu'**aucune règle de `measures:audit` ne la voit** (issue ouverte). Sans liste de
raisons, l'écran aurait affiché « publiée, invisible » sans dire pourquoi.

## Le vocabulaire d'anomalies est celui de l'audit

Onze codes, les mêmes chaînes que les règles de `src/lib/measures/audit.ts`, avec un test qui
vérifie que chacun y apparaît littéralement. Un vocabulaire parallèle est ainsi interdit sans
coupler les deux modules.

Les autres règles de l'audit croisent d'autres tables : les recalculer ici serait dupliquer
l'audit dans une page.

## Trois ablations, chacune ayant produit l'échec annoncé

| Ce qu'on retire                             | Ce qui tombe                                                                                                     |
| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| la condition de source de `publiclyVisible` | 3 tests, dont le croisé : `expected true to be false`, la file annonce visible ce que la lecture publique refuse |
| la détection du retrait sans source         | 4 tests sur 3 fichiers, dont les compteurs de la file : `expected 2 to be 3`                                     |
| la garde `isAuthenticated()` de la file     | `promise resolved instead of rejecting`, la page rend la file pour une requête anonyme                           |

## Une découverte de sécurité, et sa moitié hors périmètre

`src/app/admin/layout.tsx` appelle `isAuthenticated()`, et quand la réponse est fausse il rend
`{children}` **sans le chrome**, pour laisser passer la page de connexion. Il n'y a pas de
`middleware.ts`. Sur 37 pages sous `/admin`, quatre appellent la garde elles-mêmes. Les routes
`src/app/api/admin/*` sont correctement protégées par `with-admin-auth.ts` : c'est la couche page
qui est inégale.

Dans cette PR : mes deux écrans portent leur garde, et un test le vérifie dans les deux sens
(redirection sans session, et passage avec session, sinon une garde qui redirige toujours
passerait aussi). Les autres pages font l'objet d'une issue, sans correction en drive-by.

## Ce que seule la revue visuelle a trouvé

**Un défaut d'affichage que 33 tests unitaires laissaient passer.** Une mesure au brouillon
s'affichait « Brouillon + Correction en cours », alors qu'il n'y a aucune correction : c'est le
brouillon initial. Une correction en attente n'existe qu'**au-dessus** d'un texte publié. Mon test
encodait la mauvaise sémantique, il a fallu le corriger avec le code.

**Un débordement horizontal de 361 px en 375 px de large.** Cause exacte, mesurée puis corrigée :
le `<span class="sr-only">` de la dernière colonne est en `position: absolute`, la conteneuse
défilante n'établissait pas de bloc conteneur, donc le libellé masqué se plaçait à x=736 dans le
document et faisait défiler la page entière. `/admin/promises` n'a pas ce bug parce que son `<th>`
est vide, ce qui est pire pour l'accessibilité.

**`aria-pressed` sur un `<a>`** : 21 violations critiques signalées par axe. Remplacé par
`aria-current`.

**Mon propre test était faux.** Après le clic sur « Examiner », il attendait un `h1` visible, or la
file en a un aussi : les deux tests « détail » mesuraient la file. Ils vérifient maintenant l'URL.

**Ma mesure de débordement était fausse aussi.** `documentElement.scrollWidth - clientWidth` compte
le contenu clippé et celui d'un conteneur défilant légitime, donc il signale un débordement que le
visiteur ne subit pas. Remplacé par une mesure comportementale : demander au navigateur de défiler
et lire où il atterrit.

## Un bug trouvé en exécutant le script, qu'aucun test ne pouvait voir

`src/test/db-guard.ts` importe `describe` de vitest, donc `assertDisposableTestDb()` était
inutilisable depuis un script `tsx` : le seed échouait au chargement sur « Vitest cannot be
imported in a CommonJS module using require() ». Les prédicats et les refus sont sortis dans
`src/test/disposable-db.ts`, sans vitest, et `db-guard.ts` les réexporte. Une règle lexicale
interdit désormais le retour en arrière.

C'est la garde qui protège la production d'un seed de positions politiques fabriquées : elle doit
être appelable par le code qui écrit.

## Corpus de démonstration : candidatures fictives, obligatoirement

Aucune mesure n'existe en production, donc la revue visuelle se fait sur des données fabriquées.
Les candidats sont explicitement inventés (« Alix Démonstration », « Camille Exemple ») et
l'élection aussi : attribuer des positions inventées à une personne réelle mettrait une
affirmation fausse en base, ce que ce projet existe pour empêcher.

Dix mesures, une par état, dont quatre écrites directement en base parce que les transitions les
refusent. `npm run seed:measures-demo` refuse toute base autre que le conteneur jetable.

## Ce que la file fait des filtres dérivés

`publication` et `anomaliesOnly` portent sur du dérivé, pas sur des colonnes. Les exprimer en SQL
voudrait dire réécrire la dérivation dans un second langage. Les filtres SQL bornent donc le
balayage, la dérivation tourne sur les lignes balayées, les filtres dérivés s'appliquent après, et
`scanCapped` dit quand les compteurs ne portent pas sur la totalité. Pas de troncature muette.

## Type de changement

- [x] Nouvelle fonctionnalité

## Issue liée

Aucune. Première PR du lot 2.

## Vérifications

- **238 tests verts sous `npm run test:db:search`** (26 fichiers), dont 12 sur la file et 11 sur le
  croisement avec la lecture publique. Les mêmes en skip sans base.
- **Suite complète : 3313 verts, 275 skip, code 0.**
- `npx tsc --noEmit` en code 0, ESLint à zéro warning sur le périmètre.
- **10 vérifications Playwright vertes** : axe WCAG 2.1 AA sur les deux écrans, et absence de
  défilement horizontal aux trois largeurs (375, 768, 1440), mesurée par le comportement réel.
- Captures regardées aux trois largeurs sur les deux écrans.

L'analyse axe est scopée à `#admin-main`. La sidebar admin porte une violation de contraste AA
(#6e7174 sur #0d1218, 3,82:1), vérifiée identique sur `/admin/policy-titles`, `/admin/promises` et
`/admin/affaires` : dette de layout héritée, pas introduite ici, issue à part.

## Hors périmètre, tenu

Aucune mutation, aucune server action, `Promise` intouché, aucun `db:push` de production, aucun
branchement de `measures:audit` en CI ni en cron, aucune route publique, aucun composant de design
system ajouté.

## Observations pour la suite

- En mobile, la colonne « État » demande un défilement latéral dans le tableau. Acceptable pour un
  écran de modération, mais un rendu en cartes sous `sm` serait meilleur. Pas fait : hors du
  périmètre annoncé.
- Le seed journalise des erreurs d'invalidation de cache hors contexte de requête Next. C'est
  l'invalidation après commit du lot 1, journalisée et non fatale, comme prévu.
- `next dev` réinjecte un bloc `nextjs-agent-rules` dans `AGENTS.md`. Retiré ici, à trancher
  séparément.
