### PR TITLE
Vérifier le jeton de session admin dans le proxy

### DIFF
--- a/src/__tests__/admin-session-guard.test.ts
+++ b/src/__tests__/admin-session-guard.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { signSessionToken, verifySessionToken } from "@/lib/auth-token";
+import { hasValidAdminSession } from "../proxy";
+
+/**
+ * The admin session guard of `src/proxy.ts` (issue #647).
+ *
+ * Built violation first, and the violation is the one that was live: the proxy checked
+ * `session?.value`, so `admin_session=1` passed it. Only four admin pages out of thirty-seven called
+ * `isAuthenticated()` themselves, so the rest rendered for anyone who set any cookie.
+ *
+ * Note for the record: the earlier reading of this issue said there was no middleware at all. That was
+ * literally true of `middleware.ts` and wrong in substance, because Next 16 renamed the convention to
+ * `proxy.ts` and this repository has one.
+ */
+
+const PASSWORD = "mot-de-passe-de-test";
+
+function requestWith(cookie?: string) {
+  return {
+    cookies: {
+      get: (name: string) =>
+        name === "admin_session" && cookie !== undefined ? { name, value: cookie } : undefined,
+    },
+  } as unknown as Parameters<typeof hasValidAdminSession>[0];
+}
+
+describe("hasValidAdminSession", () => {
+  beforeEach(() => {
+    process.env.ADMIN_PASSWORD = PASSWORD;
+  });
+
+  it("refuse un cookie posé à la main, qui passait avant", () => {
+    expect(hasValidAdminSession(requestWith("1"))).toBe(false);
+  });
+
+  it("refuse une signature inventée", () => {
+    const token = `${Date.now()}.0000000000000000000000000000000000000000000000000000000000000000`;
+
+    expect(hasValidAdminSession(requestWith(token))).toBe(false);
+  });
+
+  it("refuse un jeton signé avec un autre mot de passe", () => {
+    const token = signSessionToken(Date.now());
+    process.env.ADMIN_PASSWORD = "un-autre-mot-de-passe";
+
+    expect(hasValidAdminSession(requestWith(token))).toBe(false);
+  });
+
+  it("refuse un jeton expiré", () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+    expect(hasValidAdminSession(requestWith(signSessionToken(eightDaysAgo)))).toBe(false);
+  });
+
+  it("refuse l'absence de cookie", () => {
+    expect(hasValidAdminSession(requestWith())).toBe(false);
+  });
+
+  it("accepte un jeton que nous avons signé", () => {
+    // Sans ce cas, une garde qui refuse tout passerait les cinq tests ci-dessus en rendant l'admin
+    // inutilisable.
+    expect(hasValidAdminSession(requestWith(signSessionToken(Date.now())))).toBe(true);
+  });
+});
+
+describe("verifySessionToken : les formes dégénérées", () => {
+  beforeEach(() => {
+    process.env.ADMIN_PASSWORD = PASSWORD;
+  });
+
+  it.each(["", ".", "sans-point", "12345", `${Date.now()}.`, ".signature-seule"])(
+    "refuse %o",
+    (token) => {
+      expect(verifySessionToken(token)).toBe(false);
+    }
+  );
+
+  it("refuse tout quand ADMIN_PASSWORD est absent", () => {
+    // Sinon une instance mal configurée signerait et vérifierait avec la clé vide, donc accepterait
+    // un jeton que n'importe qui peut calculer.
+    const token = signSessionToken(Date.now());
+    delete process.env.ADMIN_PASSWORD;
+
+    expect(verifySessionToken(token)).toBe(false);
+  });
+});

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,50 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * The admin session token, signing and verification, with NO request context.
+ *
+ * Split out of `src/lib/auth.ts` for one reason: `src/proxy.ts` needs to verify the token, and
+ * `auth.ts` imports `cookies` from `next/headers`, which does not belong in the proxy. Rewriting the
+ * HMAC check there would mean two implementations of the only thing standing between the admin and
+ * the public.
+ *
+ * Stateless on purpose: the signing key is ADMIN_PASSWORD, so a token can only be forged by someone
+ * who already knows the password.
+ */
+
+export const ADMIN_COOKIE_NAME = "admin_session";
+
+/** Seven days, in seconds. */
+export const SESSION_DURATION = 60 * 60 * 24 * 7;
+
+/** Format: "timestamp.hmac_signature". */
+export function signSessionToken(timestamp: number): string {
+  const secret = process.env.ADMIN_PASSWORD || "";
+  const signature = createHmac("sha256", secret).update(String(timestamp)).digest("hex");
+  return `${timestamp}.${signature}`;
+}
+
+/**
+ * Whether the token is one we issued and has not expired.
+ *
+ * Checking the mere PRESENCE of the cookie is not enough, and that was the real hole behind issue
+ * #647: `admin_session=1` passed the proxy, and every admin page without its own check then rendered.
+ */
+export function verifySessionToken(token: string): boolean {
+  const secret = process.env.ADMIN_PASSWORD;
+  if (!secret) return false;
+
+  const dotIndex = token.indexOf(".");
+  if (dotIndex === -1) return false;
+
+  const timestamp = token.substring(0, dotIndex);
+  const signature = token.substring(dotIndex + 1);
+
+  const expected = createHmac("sha256", secret).update(timestamp).digest("hex");
+  if (expected.length !== signature.length) return false;
+  if (!timingSafeEqual(Buffer.from(expected), Buffer.from(signature))) return false;
+
+  const created = parseInt(timestamp, 10);
+  if (isNaN(created)) return false;
+  return (Date.now() - created) / 1000 < SESSION_DURATION;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,15 @@
 import { cookies } from "next/headers";
-import { timingSafeEqual, createHmac } from "crypto";
+import { timingSafeEqual } from "crypto";
+import {
+  ADMIN_COOKIE_NAME,
+  SESSION_DURATION,
+  signSessionToken,
+  verifySessionToken,
+} from "@/lib/auth-token";
 
-const ADMIN_COOKIE_NAME = "admin_session";
-const SESSION_DURATION = 60 * 60 * 24 * 7; // 7 days in seconds
+// La signature et la vérification vivent dans @/lib/auth-token, sans next/headers, pour que
+// src/proxy.ts puisse vérifier le jeton sans réécrire le HMAC.
+export { verifySessionToken } from "@/lib/auth-token";
 
 /**
  * Simple admin authentication using ADMIN_PASSWORD env var
@@ -22,44 +29,11 @@ export async function verifyPassword(password: string): Promise<boolean> {
 }
 
 /**
- * Create a signed session token (stateless — no server-side store needed).
- * Format: "timestamp.hmac_signature"
- * The HMAC key is ADMIN_PASSWORD, so only someone who knows the password can forge a token.
- */
-function signToken(timestamp: number): string {
-  const secret = process.env.ADMIN_PASSWORD || "";
-  const sig = createHmac("sha256", secret).update(String(timestamp)).digest("hex");
-  return `${timestamp}.${sig}`;
-}
-
-function verifyToken(token: string): boolean {
-  const secret = process.env.ADMIN_PASSWORD;
-  if (!secret) return false;
-
-  const dotIndex = token.indexOf(".");
-  if (dotIndex === -1) return false;
-
-  const timestamp = token.substring(0, dotIndex);
-  const signature = token.substring(dotIndex + 1);
-
-  // Verify HMAC signature
-  const expected = createHmac("sha256", secret).update(timestamp).digest("hex");
-  if (expected.length !== signature.length) return false;
-  if (!timingSafeEqual(Buffer.from(expected), Buffer.from(signature))) return false;
-
-  // Check expiry
-  const created = parseInt(timestamp, 10);
-  if (isNaN(created)) return false;
-  const elapsed = (Date.now() - created) / 1000;
-  return elapsed < SESSION_DURATION;
-}
-
-/**
  * Create admin session with HMAC-signed cookie (stateless)
  */
 export async function createSession(): Promise<void> {
   const cookieStore = await cookies();
-  const token = signToken(Date.now());
+  const token = signSessionToken(Date.now());
 
   cookieStore.set(ADMIN_COOKIE_NAME, token, {
     httpOnly: true,
@@ -77,7 +51,7 @@ export async function isAuthenticated(): Promise<boolean> {
   const cookieStore = await cookies();
   const session = cookieStore.get(ADMIN_COOKIE_NAME);
   if (!session?.value) return false;
-  return verifyToken(session.value);
+  return verifySessionToken(session.value);
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/ratelimit/degraded-mode";
 import { getUpstashCredentials } from "@/lib/ratelimit/upstash-credentials";
 import { buildVotesListingRedirect } from "@/lib/parlement-votes-redirect";
+import { ADMIN_COOKIE_NAME, verifySessionToken } from "@/lib/auth-token";
 
 // ─── Rate limit tiers ────────────────────────────────────────────
 
@@ -288,6 +289,17 @@ async function applyApiRateLimit(
   return response;
 }
 
+/**
+ * Whether the request carries a session token WE issued, and that has not expired.
+ *
+ * `verifySessionToken` lives in `@/lib/auth-token`, which imports no `next/headers`: the proxy and
+ * `isAuthenticated()` then share one implementation of the HMAC check instead of two that drift.
+ */
+export function hasValidAdminSession(request: NextRequest): boolean {
+  const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+  return token !== undefined && verifySessionToken(token);
+}
+
 // ─── Proxy (Next 16 convention; the active middleware-like layer) ──
 
 export async function proxy(request: NextRequest, event: NextFetchEvent) {
@@ -331,18 +343,20 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
     }
   }
 
-  // Protect admin API routes (except auth endpoint)
+  // Protect admin API routes (except auth endpoint).
+  //
+  // The token is VERIFIED, not merely present (issue #647). Checking `session?.value` let
+  // `admin_session=1` through, and every admin page without its own isAuthenticated() call then
+  // rendered: four pages out of thirty-seven had one.
   if (pathname.startsWith("/api/admin") && !pathname.startsWith("/api/admin/auth")) {
-    const session = request.cookies.get("admin_session");
-    if (!session?.value) {
+    if (!hasValidAdminSession(request)) {
       return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
     }
   }
 
-  // Protect admin pages - check session cookie
+  // Protect admin pages.
   if (pathname.startsWith("/admin") && !pathname.startsWith("/admin/login")) {
-    const session = request.cookies.get("admin_session");
-    if (!session?.value) {
+    if (!hasValidAdminSession(request)) {
       return NextResponse.redirect(new URL("/admin/login", request.url));
     }
   }


### PR DESCRIPTION
## Description

Le proxy admin vérifiait la **présence** du cookie `admin_session`, pas sa signature. `admin_session=1`
suffisait donc à passer, et les pages sans garde propre se rendaient ensuite normalement, avec les
données de production dessus.

Le jeton est maintenant vérifié : HMAC et expiration, dans le proxy, pour les pages `/admin/*` comme
pour les routes `/api/admin/*`.

## Correction d'une analyse fausse

L'issue #647 disait « il n'y a pas de `middleware.ts` dans ce dépôt », et en concluait que les pages
admin étaient servies à n'importe qui. C'était littéralement vrai et faux sur le fond : **Next 16 a
renommé la convention en `proxy.ts`**, et ce dépôt en a un depuis longtemps, qui redirige déjà
`/admin/*` vers la connexion en l'absence de cookie.

Découvert en essayant d'ajouter un `middleware.ts` : Next refuse de démarrer quand les deux fichiers
coexistent, et c'est ce refus qui m'a fait lire `src/proxy.ts`.

La faille réelle est donc plus étroite que décrite, et bien réelle quand même : il fallait poser un
cookie, ce que n'importe qui fait en une ligne.

## Ce qui est mesuré, pas déduit

Serveur de dev, requêtes réelles, avant et après.

| Requête | Avant (présence seule) | Après (jeton vérifié) |
| --- | --- | --- |
| `Cookie: admin_session=1` sur `/admin/promises` | **200, page rendue** | 307 vers la connexion |
| `Cookie: admin_session=1` sur `/admin/politiques` | 200 | 307 |
| sans cookie sur `/admin/promises` | 307 | 307 |
| cookie signé valide sur `/admin/mesures` | 200 | 200 |
| `/admin/login` | 200 | 200 |
| `/` public | 200 | 200 |
| `Cookie: admin_session=1` sur `/api/admin/badges` | 401 | 401 |

La colonne « avant » vient d'une ablation faite sur le serveur en marche : j'ai remis la vérification
de présence seule et relancé les mêmes requêtes. Les routes API répondaient déjà 401 parce que
`with-admin-auth.ts` appelle `isAuthenticated()`, qui vérifie vraiment le jeton.

## Une seule implémentation du HMAC

`verifySessionToken` descend dans `src/lib/auth-token.ts`, qui n'importe pas `next/headers` : le proxy
ne peut pas importer `auth.ts` sans tirer le contexte de requête, et réécrire la vérification à côté
donnerait deux implémentations de la seule chose qui sépare l'admin du public. `auth.ts` délègue
désormais à ce module.

Les gardes par page restent en place. C'est de la défense en profondeur, pas un doublon à nettoyer :
une règle qu'il faut se rappeler dans chaque nouveau fichier est une règle qu'on oubliera dans un.

## Type de changement

- [x] Correction de sécurité

## Issue liée

Closes #647

## Vérifications

13 tests sur la garde, construits violation d'abord : cookie posé à la main, signature inventée, jeton
signé avec un autre mot de passe, jeton expiré, absence de cookie, plus le cas positif sans lequel une
garde qui refuse tout passerait les cinq autres. Et les formes dégénérées du jeton, dont
`ADMIN_PASSWORD` absent : une instance mal configurée signerait et vérifierait avec la clé vide, donc
accepterait un jeton que n'importe qui calcule.

Suite complète : **3370 verts, code 0**. `npx tsc --noEmit` code 0.
