### PR TITLE
Rejouer des fixtures dans le contrat d'analyse RSS

### DIFF
--- a/src/lib/api/__fixtures__/rss/bfmtv-politique.xml
+++ b/src/lib/api/__fixtures__/rss/bfmtv-politique.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Home Politique - actualités</title>
+        <link>https://www.bfmtv.com/politique/</link>
+        <description>Suivez toute l'actualité politique en France en direct : élections, gouvernement, Parlement, Élysée, partis politique, sondages, analyses et décryptages sur BFM</description>
+        <lastBuildDate>Wed, 05 Aug 2026 23:34:59 GMT</lastBuildDate>
+        <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+        <generator>BFMTV</generator>
+        <language>fr</language>
+        <image>
+            <title>Home Politique - actualités</title>
+            <url>https://www.bfmtv.com/assets/v24/images/BFMTV_default_16x9.20e7113082d8a27cea24f2ade5a4d03e.jpg</url>
+            <link>https://www.bfmtv.com/politique/</link>
+        </image>
+        <copyright>Copyright BFMTV</copyright>
+        <category>Home Politique - actualités</category>
+        <atom:link href="https://www.bfmtv.com/politique/" rel="self" type="application/rss+xml"/>
+        <item>
+            <title><![CDATA[Campagne présidentielle: Gabriel Attal ciblé par des ingérences russes]]></title>
+            <link>https://www.bfmtv.com/politique/video-campagne-presidentielle-gabriel-attal-cible-par-des-ingerences-russes_VN-202608050546.html</link>
+            <guid>https://www.bfmtv.com/politique/video-campagne-presidentielle-gabriel-attal-cible-par-des-ingerences-russes_VN-202608050546.html</guid>
+            <pubDate>Wed, 05 Aug 2026 21:57:34 GMT</pubDate>
+            <description><![CDATA[Après Raphaël Glucksmann, Gabriel Attal a également été ciblé par une campagne de désinformation lancée par de nouvelles ingérences russes. Ces faux contenus publiés sur les réseaux sociaux ont notamment usurpé l’identité visuelle de BFMTV, qui a engagé des démarches pour obtenir leur retrait. Une action en justice est par ailleurs en cours.<br /><br /><img src="https://images.bfmtv.com/TT-0pmOeA18w0ISdJ_Q1DiRFIns=/0x0:1280x720/800x0/images/Campagne-presidentielle-Gabriel-Attal-cible-par-des-ingerences-russes-2329276.jpg" />]]></description>
+            <enclosure url="https://images.bfmtv.com/TT-0pmOeA18w0ISdJ_Q1DiRFIns=/0x0:1280x720/800x0/images/Campagne-presidentielle-Gabriel-Attal-cible-par-des-ingerences-russes-2329276.jpg" length="0" type="image/jpg"/>
+        </item>
+<item>
+            <title><![CDATA[Présidentielle: Gabriel Attal visé par "une ingérence en provenance de la Russie"]]></title>
+            <link>https://www.bfmtv.com/politique/elections/presidentielle/presidentielle-gabriel-attal-vise-par-une-ingerence-en-provenance-de-la-russie_AN-202608050544.html</link>
+            <guid>https://www.bfmtv.com/politique/elections/presidentielle/presidentielle-gabriel-attal-vise-par-une-ingerence-en-provenance-de-la-russie_AN-202608050544.html</guid>
+            <pubDate>Wed, 05 Aug 2026 21:55:02 GMT</pubDate>
+            <description><![CDATA[Le candidat Renaissance à la présidentielle a été victime d'une "ingérance" russe. Une tentativate de déstabilisation qui a déjà visé l'ex-Premier ministre et candidat Édouard Philippe, ainsi que le candidat putatif Raphaël Glucksmann.<br /><br /><img src="https://images.bfmtv.com/WcOp64ySuzt9dfckcrZsS9Jrdu4=/0x106:2048x1258/800x0/images/Gabriel-Attal-lors-de-son-premier-meeting-de-campagne-a-Paris-ce-samedi-30-mai-2026-2294930.jpg" />]]></description>
+            <enclosure url="https://images.bfmtv.com/WcOp64ySuzt9dfckcrZsS9Jrdu4=/0x106:2048x1258/800x0/images/Gabriel-Attal-lors-de-son-premier-meeting-de-campagne-a-Paris-ce-samedi-30-mai-2026-2294930.jpg" length="0" type="image/jpg"/>
+        </item>
+<item>
+            <title><![CDATA[Primaire socialiste: le député Philippe Brun dénonce l'idée de payer 15 euros pour voter et propose une "caisse populaire"]]></title>
+            <link>https://www.bfmtv.com/politique/parti-socialiste/primaire-socialiste-le-depute-philippe-brun-denonce-l-idee-de-payer-15-euros-pour-voter-et-propose-une-caisse-populaire_AN-202608050388.html</link>
+            <guid>https://www.bfmtv.com/politique/parti-socialiste/primaire-socialiste-le-depute-philippe-brun-denonce-l-idee-de-payer-15-euros-pour-voter-et-propose-une-caisse-populaire_AN-202608050388.html</guid>
+            <pubDate>Wed, 05 Aug 2026 15:01:30 GMT</pubDate>
+            <description><![CDATA[Le député de l'Eure Philippe Brun a dénoncé ce mercredi 5 août le droit de vote à quinze euros, proposé pour la primaire socialiste en vue de l'élection présidentielle, à laquelle il est candidat. Si cette idée est maintenue, il propose la mise en place d'une "caisse populaire" pour financer les électeurs les moins aisés.<br /><br /><img src="https://images.bfmtv.com/32sl7nt6m47TcivMcmCna2hc-rs=/0x0:2032x1143/800x0/images/Le-depute-socialiste-Philippe-Brun-a-l-Assemblee-nationale-le-18-novembre-2025-2217877.jpg" />]]></description>
+            <enclosure url="https://images.bfmtv.com/32sl7nt6m47TcivMcmCna2hc-rs=/0x0:2032x1143/800x0/images/Le-depute-socialiste-Philippe-Brun-a-l-Assemblee-nationale-le-18-novembre-2025-2217877.jpg" length="0" type="image/jpg"/>
+        </item>
+    </channel>
+</rss>

--- a/src/lib/api/__fixtures__/rss/entites-et-dates.xml
+++ b/src/lib/api/__fixtures__/rss/entites-et-dates.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Entités HTML dans un titre, et deux formats de date. Le second item porte une date ISO 8601 : les
+  flux français mélangent les deux, et une date non analysée ressort en Invalid Date sans rien casser
+  d'autre, donc en silence.
+-->
+<rss version="2.0">
+  <channel>
+    <title>Entités et dates</title>
+    <link>https://example.org/</link>
+    <description>Contrat d'analyse</description>
+    <item>
+      <title>Budget &amp; fiscalit&eacute; : ce qui change</title>
+      <link>https://example.org/budget</link>
+      <pubDate>Tue, 04 Aug 2026 18:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Retraites &#8211; le calendrier</title>
+      <link>https://example.org/retraites</link>
+      <pubDate>2026-08-03T07:15:00Z</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/src/lib/api/__fixtures__/rss/un-seul-item.xml
+++ b/src/lib/api/__fixtures__/rss/un-seul-item.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Un flux à UN SEUL item, et c'est le cas limite qui compte : fast-xml-parser rend `item` comme un
+  objet quand il n'y en a qu'un, et comme un tableau au-delà. Un parseur qui suppose toujours un
+  tableau perd silencieusement le seul article d'un flux calme.
+-->
+<rss version="2.0">
+  <channel>
+    <title>Flux à un seul article</title>
+    <link>https://example.org/</link>
+    <description>Cas limite du parseur XML</description>
+    <item>
+      <title><![CDATA[Un titre entre CDATA avec une apostrophe d'essai]]></title>
+      <link>https://example.org/article-unique</link>
+      <pubDate>Wed, 05 Aug 2026 09:30:00 +0200</pubDate>
+      <description><![CDATA[Un chapô contenant &amp; une entité et <strong>du balisage</strong>.]]></description>
+    </item>
+  </channel>
+</rss>

--- a/src/lib/api/rss.test.ts
+++ b/src/lib/api/rss.test.ts
@@ -1,84 +1,142 @@
-import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { RSSClient, type RSSFeedConfig } from "./rss";
 
 /**
- * Parse contract tests for Q3 2026 candidate RSS feeds.
+ * Parse contract for the RSS feeds.
  *
- * Verifies each candidate feed can be fetched and parsed into items
- * carrying a title, an http(s) link, and a publication date.
+ * **Rejoue des fixtures, n'appelle plus le réseau** (issue #643). Le test s'appelle « parse contract »,
+ * donc son objet est l'analyse, pas la disponibilité de Mediacités : il était rouge quand un site tiers
+ * tombait, quelle que soit la modification testée. Un rouge dont la cause est hors du dépôt apprend à
+ * ignorer le rouge, et c'est par là qu'une vraie régression finit par passer pour un aléa.
  *
- * Network-bound: set SKIP_NETWORK_TESTS=1 to bypass in offline CI.
- * Task 12 only validates the contract; Task 13 will wire approved feeds
- * into RSS_FEEDS.
+ * Trois fixtures, deux natures :
+ *
+ * - `bfmtv-politique.xml` est **capturé** d'un vrai flux, tronqué à trois items. Il garantit que les
+ *   formes testées ici sont celles du monde réel et pas celles que j'imagine.
+ * - les deux autres sont **écrites à la main** pour couvrir des cas limites que les flux du jour
+ *   n'exhibent pas forcément, dont celui qui casse le plus souvent un parseur XML.
+ *
+ * Vérifier qu'un flux n'a pas changé de forme reste possible, à la demande : `RSS_NETWORK_CHECK=1`.
  */
 
-interface CandidateFeed extends RSSFeedConfig {
-  skipReason?: string;
+const FIXTURES = join(process.cwd(), "src/lib/api/__fixtures__/rss");
+
+function fixture(name: string): string {
+  return readFileSync(join(FIXTURES, `${name}.xml`), "utf8");
 }
 
-const CANDIDATE_FEEDS: CandidateFeed[] = [
+function feed(id: string): RSSFeedConfig {
+  return { id, name: id, url: `https://example.org/${id}.xml`, priority: 2 };
+}
+
+/** Serves the fixture instead of the network, so nothing here depends on a third party. */
+function serve(xml: string): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(xml, { status: 200, headers: { "content-type": "application/rss+xml" } })
+    )
+  );
+}
+
+describe("RSS parse contract", () => {
+  const client = new RSSClient({ timeout: 5_000, retries: 0 });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("analyse un vrai flux capturé en items titre, lien, date", async () => {
+    serve(fixture("bfmtv-politique"));
+
+    const result = await client.fetchFeed(feed("bfmtv-politique"));
+
+    expect(result.items.length).toBe(3);
+    for (const item of result.items) {
+      expect(item.title.length).toBeGreaterThan(0);
+      expect(item.link).toMatch(/^https?:\/\//);
+      expect(item.pubDate).toBeInstanceOf(Date);
+      expect(Number.isNaN(item.pubDate.getTime())).toBe(false);
+    }
+  });
+
+  it("ne perd pas l'article d'un flux qui n'en a qu'un", async () => {
+    // Le cas limite qui compte : fast-xml-parser rend `item` comme un objet quand il n'y en a qu'un et
+    // comme un tableau au-delà. Un parseur qui suppose toujours un tableau perd en silence le seul
+    // article d'un flux calme.
+    serve(fixture("un-seul-item"));
+
+    const result = await client.fetchFeed(feed("un-seul-item"));
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.title).toContain("Un titre entre CDATA");
+    expect(result.items[0]?.link).toBe("https://example.org/article-unique");
+  });
+
+  it("décode les entités HTML d'un titre", async () => {
+    serve(fixture("entites-et-dates"));
+
+    const result = await client.fetchFeed(feed("entites-et-dates"));
+
+    // Une entité non décodée s'afficherait telle quelle sur le site, et l'accent français est
+    // exactement ce que ce dépôt refuse de perdre.
+    expect(result.items[0]?.title).toContain("fiscalité");
+    expect(result.items[0]?.title).not.toContain("&amp;");
+    expect(result.items[0]?.title).not.toContain("&eacute;");
+  });
+
+  it("analyse les deux formats de date que les flux mélangent", async () => {
+    // Une date non analysée ressort en Invalid Date sans rien casser d'autre, donc en silence.
+    serve(fixture("entites-et-dates"));
+
+    const result = await client.fetchFeed(feed("entites-et-dates"));
+
+    expect(result.items).toHaveLength(2);
+    for (const item of result.items) {
+      expect(Number.isNaN(item.pubDate.getTime())).toBe(false);
+    }
+    expect(result.items[1]?.pubDate.toISOString()).toBe("2026-08-03T07:15:00.000Z");
+  });
+});
+
+/**
+ * La vérification de forme des vrais flux, sortie de la suite par défaut.
+ *
+ * C'est la seule chose que l'ancienne version testait vraiment : que le site répond aujourd'hui. Elle a
+ * sa valeur, une fois de temps en temps, à la demande, jamais en CI.
+ */
+const networkCheck = process.env.RSS_NETWORK_CHECK === "1";
+
+const LIVE_FEEDS: RSSFeedConfig[] = [
   {
     id: "reporterre",
     name: "Reporterre",
     url: "https://reporterre.net/spip.php?page=backend",
     priority: 2,
   },
-  {
-    id: "mediacites",
-    name: "Mediacités",
-    url: "https://www.mediacites.fr/feed/",
-    priority: 2,
-  },
-  {
-    id: "afpnews-politique",
-    name: "AFP politique",
-    url: "https://www.afp.com/fr/news-hub/4106/rss",
-    priority: 2,
-    skipReason: "HTTP 404 on /fr/news-hub/4106/rss; no public politics-only RSS confirmed",
-  },
+  { id: "mediacites", name: "Mediacités", url: "https://www.mediacites.fr/feed/", priority: 2 },
   {
     id: "bfmtv-politique",
     name: "BFM politique",
     url: "https://www.bfmtv.com/rss/politique/",
     priority: 2,
   },
-  {
-    id: "lacroix-politique",
-    name: "La Croix politique",
-    url: "https://www.la-croix.com/rss/Politique",
-    priority: 2,
-    skipReason: "HTTP 404 on /rss/Politique; la-croix.com only exposes universe-level feeds",
-  },
 ];
 
-const skipNetwork = process.env.SKIP_NETWORK_TESTS === "1";
-
-describe.skipIf(skipNetwork)("RSS feed parse contract - Q3 2026 candidates", () => {
+describe.skipIf(!networkCheck)("RSS : forme des flux réels (RSS_NETWORK_CHECK=1)", () => {
   const client = new RSSClient({ timeout: 25_000, retries: 1 });
 
-  for (const feed of CANDIDATE_FEEDS) {
-    const runner = feed.skipReason ? it.skip : it;
-    const title = feed.skipReason
-      ? `parses ${feed.id} into items with title, url, publishedAt (skipped: ${feed.skipReason})`
-      : `parses ${feed.id} into items with title, url, publishedAt`;
+  for (const config of LIVE_FEEDS) {
+    it(`${config.id} répond et garde sa forme`, async () => {
+      const result = await client.fetchFeed(config);
 
-    runner(
-      title,
-      async () => {
-        const result = await client.fetchFeed(feed);
-
-        expect(result.items.length).toBeGreaterThan(0);
-
-        const first = result.items[0];
-        expect(first).toBeDefined();
-        if (!first) return;
-        expect(typeof first.title).toBe("string");
-        expect(first.title.length).toBeGreaterThan(0);
-        expect(first.link).toMatch(/^https?:\/\//);
-        expect(first.pubDate).toBeInstanceOf(Date);
-        expect(Number.isNaN(first.pubDate.getTime())).toBe(false);
-      },
-      30_000
-    );
+      expect(result.items.length).toBeGreaterThan(0);
+      const first = result.items[0];
+      expect(first?.link).toMatch(/^https?:\/\//);
+      expect(Number.isNaN(first?.pubDate.getTime() ?? NaN)).toBe(false);
+    }, 30_000);
   }
 });


### PR DESCRIPTION
## Description

`src/lib/api/rss.test.ts` appelait de vrais flux RSS tiers. Il rougissait donc quand un site externe
tombait, quelle que soit la modification testée, et un rouge dont la cause est hors du dépôt apprend à
ignorer le rouge.

Le test s'appelle « parse contract » : son objet est l'analyse, pas la disponibilité de Mediacités. Il
rejoue maintenant des fixtures.

## Trois fixtures, deux natures

- **`bfmtv-politique.xml` est capturé** d'un vrai flux, tronqué à trois items. Il garantit que les formes
  testées sont celles du monde réel et pas celles que j'imagine. 5 Ko au lieu de 45 : le contrat porte
  sur la forme, et un fichier que personne ne relit ne sert à rien.
- **Deux fixtures écrites à la main** pour des cas limites que les flux du jour n'exhibent pas
  forcément :
  - **un flux à un seul item.** `fast-xml-parser` rend `item` comme un objet quand il n'y en a qu'un et
    comme un tableau au-delà : un parseur qui suppose toujours un tableau perd en silence le seul
    article d'un flux calme.
  - **entités HTML et deux formats de date.** Une entité non décodée s'affiche telle quelle, et une date
    non analysée ressort en `Invalid Date` sans rien casser d'autre, donc en silence.

## La vérification réseau reste possible, à la demande

`RSS_NETWORK_CHECK=1` relance les trois flux réels. C'est la seule chose que l'ancienne version testait
vraiment, elle garde sa valeur de temps en temps, jamais en CI.

## Type de changement

- [x] Correction

## Issue liée

Closes #643

## Vérifications

4 tests verts, 3 sautés (les flux réels). **Ablation** : en retirant le stub de `fetch`, les quatre
tests partent sur le réseau et échouent en `HTTP 404`, ce qui prouve qu'ils passent bien par les
fixtures et non par une requête sortante.

Suite complète du dossier : 50 verts.