### PR TITLE
Corriger le contraste de la sidebar admin et retirer le scope axe

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -209,7 +209,9 @@ export function AdminSidebar() {
         {/* Collapse toggle — desktop only */}
         <button
           onClick={toggleCollapse}
-          className="hidden lg:flex w-full items-center gap-2 px-3 py-2 text-xs text-white/40 hover:text-white/70 rounded-md hover:bg-white/5 transition-colors"
+          // text-white/60 et pas /40 : sur le fond oklch(0.18 0.015 250), 40 % de blanc donne 4,06:1,
+          // sous le seuil AA de 4,5:1 pour du texte de 12 px. 60 % donne environ 7,9:1.
+          className="hidden lg:flex w-full items-center gap-2 px-3 py-2 text-xs text-white/60 hover:text-white/90 rounded-md hover:bg-white/5 transition-colors"
           aria-label={collapsed ? "Développer la sidebar" : "Réduire la sidebar"}
         >
           {collapsed ? (

--- a/tests/visual/mesures-moderation.spec.ts
+++ b/tests/visual/mesures-moderation.spec.ts
@@ -24,15 +24,13 @@ const PASSWORD = process.env.ADMIN_PASSWORD;
 const WCAG = ["wcag2a", "wcag2aa", "wcag21aa"];
 
 /**
- * The scan is scoped to the page content, not the whole document.
+ * Le document entier, plus aucun scope.
  *
- * The admin sidebar carries one WCAG AA contrast failure (#6e7174 on #0d1218, 3.82:1 in the
- * section labels), verified identical on /admin/policy-titles, /admin/promises and
- * /admin/affaires. It is layout debt these screens inherit, not something they introduce, and
- * it is tracked separately. Scoping states what this suite is responsible for instead of
- * silencing a rule.
+ * La sidebar admin portait un échec de contraste AA que ces écrans héritaient sans l'introduire, donc
+ * l'analyse était bornée à `#admin-main`. Corrigé par #648, vérifié sur le document complet de
+ * /admin/mesures, /admin/policy-titles et /admin/promises : le scope n'a plus de raison d'être, et le
+ * garder cacherait une régression future du layout.
  */
-const CONTENT = "#admin-main";
 
 async function signIn(context: BrowserContext, password: string): Promise<void> {
   const timestamp = Date.now();
@@ -100,7 +98,7 @@ test.describe("/admin/mesures — modération des mesures", () => {
     await page.goto("/admin/mesures");
     await expect(page.getByRole("table")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+    const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -108,7 +106,7 @@ test.describe("/admin/mesures — modération des mesures", () => {
   test("le détail n'a aucune violation WCAG AA", async ({ page }) => {
     await openFirstDetail(page);
 
-    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+    const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -276,7 +274,7 @@ test.describe("/admin/mesures — parcours éditorial", () => {
     await page.goto("/admin/mesures/nouvelle");
     await expect(page.getByRole("heading", { name: "Nouvelle mesure" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+    const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -288,7 +286,7 @@ test.describe("/admin/mesures — parcours éditorial", () => {
     // Formulaires ouverts : c'est dans cet état que les champs et leurs libellés existent.
     await page.getByRole("button", { name: "Ajouter une qualification" }).click();
 
-    const results = await new AxeBuilder({ page }).include(CONTENT).withTags(WCAG).analyze();
+    const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
 
     expect(results.violations).toEqual([]);
   });


### PR DESCRIPTION
## Description

Le bouton « Réduire » de la sidebar rendait du blanc à 40 % sur `oklch(0.18 0.015 250)`, soit **4,06:1**
calculé, sous le seuil AA de 4,5:1 pour du texte de 12 px. axe le signalait sur **toutes** les pages
admin, une violation par page, toujours la même.

Passé à 60 %, soit environ 7,9:1.

## Le scope de la suite axe disparaît avec la dette

La PR #646 bornait son analyse axe à `#admin-main` parce que ses écrans héritaient de cet échec sans
l'introduire. Le scope n'a plus de raison d'être, et le garder cacherait une régression future du
layout : il est retiré, la suite analyse le document entier.

## Ce qui est mesuré

axe WCAG 2.1 AA sur le **document complet**, serveur de dev, après correctif :

| Page | Violations |
| --- | --- |
| `/admin/mesures` | aucune |
| `/admin/policy-titles` | aucune |
| `/admin/promises` | aucune |

Puis les 17 vérifications Playwright des écrans de modération, sans scope : toutes vertes.

## Type de changement

- [x] Accessibilité

## Issue liée

Closes #648

## Vérifications

Suite complète : **3375 verts**, `tsc` code 0.