### PR TITLE
Borner l'audit de l'index aux mesures du test

### DIFF
--- a/src/lib/search/__tests__/maintenance.integration.test.ts
+++ b/src/lib/search/__tests__/maintenance.integration.test.ts
@@ -82,12 +82,17 @@ describeIfDisposableDb("maintenance de l'index de recherche", () => {
   });
 
   it("ne signale rien sur des mesures correctement indexées", async () => {
-    await publishSeededMeasure();
-    await seedMeasureWithDraft();
+    const published = await publishSeededMeasure();
+    const drafted = await seedMeasureWithDraft();
+    const mine = new Set([published.measureId, drafted.measureId]);
 
-    // Filtré sur les deux règles de cette commande : les autres fichiers du harnais construisent
-    // exprès des violations que `measures:audit` couvre.
-    const violations = await auditSearchDocuments();
+    // Filtré sur MES mesures, et ce n'est pas une commodité : le corpus lexical du lot 1B indexe des
+    // entités synthétiques (`insert-…`, `loyer-singulier-…`) qui n'ont jamais été des mesures, parce
+    // que le substrat est agnostique de l'entité par construction. Elles sont donc de vraies
+    // violations pour cette règle, dans une base partagée par tous les fichiers du harnais. Une
+    // assertion globale ici dépend de l'ordre d'exécution, ce qu'elle a fait : verte seule, rouge
+    // dans la suite complète.
+    const violations = (await auditSearchDocuments()).filter((v) => mine.has(v.entityId));
 
     expect(violations).toEqual([]);
   });


### PR DESCRIPTION
## Description

Le test « ne signale rien sur des mesures correctement indexées », ajouté par #653, assérait une
propriété **globale** de l'index dans une base que tous les fichiers du harnais partagent.

Or le corpus lexical du lot 1B indexe volontairement des entités synthétiques (`insert-…`,
`loyer-singulier-…`) qui n'ont jamais été des mesures, parce que le substrat est agnostique de l'entité
par construction. Pour la règle `document_without_entity`, ce sont donc de **vraies** violations.

Résultat : vert quand le fichier tourne seul, rouge dans la suite complète selon l'ordre d'exécution.
C'est l'assertion qui était fautive, pas la règle : en production, un document sans entité est bien un
problème, et le corpus lexical n'existe que dans le conteneur jetable.

L'assertion est désormais filtrée sur les deux mesures que le test crée lui-même, comme le font les
tests de `measures:audit`.

## Type de changement

- [x] Correction de test

## Vérifications

**Trois passages consécutifs du harnais complet** : 310 verts, 34 fichiers, à chaque fois. Le premier
diagnostic est parti de la violation réelle affichée, pas d'une supposition.