### PR TITLE
Lot 3 : tranche verticale du hub présidentielle (relation aux votes, rattachement, page sujet)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -962,6 +962,7 @@ model Scrutin {
   importance        ScrutinImportance?
   groupPositions    ScrutinGroupPosition[]
   analysis          ScrutinAnalysis?
+  measureVoteLinks  MeasureVoteLink[]
   debateTranscripts DebateTranscript[]
 
   // Policy-title feature
@@ -2838,6 +2839,7 @@ model Measure {
   followingMeasures  Measure[] @relation("MeasureLineage")
 
   revisions MeasureRevision[] @relation("MeasureRevisions")
+  voteLinks MeasureVoteLink[] @relation("MeasureVoteLinks")
 
   latestRevision      MeasureRevision? @relation("MeasureLatest", fields: [latestRevisionId], references: [id], onDelete: SetNull)
   latestRevisionId    String?          @unique
@@ -2893,10 +2895,11 @@ model MeasureRevision {
   extractionConfidence Float?
   extractorVersion     String?
 
-  sources        MeasureSource[]
-  qualifications MeasureQualification[]
-  assessments    MeasureSimilarityAssessment[]
-  equivalentOf   MeasureSimilarityMatch[]      @relation("EquivalentRevision")
+  sources             MeasureSource[]
+  qualifications      MeasureQualification[]
+  assessments         MeasureSimilarityAssessment[]
+  equivalentOf        MeasureSimilarityMatch[]      @relation("EquivalentRevision")
+  applicableVoteLinks MeasureVoteLink[]             @relation("ApplicableRevisionVoteLinks")
 
   latestOf    Measure? @relation("MeasureLatest")
   publishedOf Measure? @relation("MeasurePublished")
@@ -2907,6 +2910,57 @@ model MeasureRevision {
   @@index([measureId, validFrom])
   @@index([measureId, supersededAt])
   @@index([measureId, discardedAt])
+}
+
+enum MeasureVoteLinkKind {
+  SAME_OBJECT
+  BROADER_TEXT
+  NO_VOTE_IDENTIFIED
+}
+
+// The candidate's relation to the measure on a scrutin, RECORDED by the reviewer, never derived from
+// the raw vote: on a suppression amendment, voting POUR is DEFAVORABLE to the measure. This field is
+// beyond the minimal §5.8 table and exists precisely for the polarity trap the spec flags. Manual by
+// design (§5.8: the attachment is an editorial judgment made explicit by rationale).
+enum MeasureVoteRelation {
+  FAVORABLE
+  DEFAVORABLE
+  ABSTENTION
+  ABSENCE
+}
+
+// The link between a measure and a scrutin (spec 5.8). Rattached to the Measure, but applicableRevisionId
+// records the formulation the link was judged applicable to. Written only in admin, never by a script.
+model MeasureVoteLink {
+  id String @id @default(cuid())
+
+  measure   Measure @relation("MeasureVoteLinks", fields: [measureId], references: [id], onDelete: Cascade)
+  measureId String
+
+  applicableRevision   MeasureRevision @relation("ApplicableRevisionVoteLinks", fields: [applicableRevisionId], references: [id], onDelete: Cascade)
+  applicableRevisionId String
+
+  scrutin   Scrutin? @relation(fields: [scrutinId], references: [id], onDelete: SetNull)
+  scrutinId String?
+
+  linkKind MeasureVoteLinkKind
+  // Set only on a SAME_OBJECT link tied to a scrutin. Reviewer-recorded, never derived.
+  relation    MeasureVoteRelation?
+  isReference Boolean              @default(false)
+
+  rationale        String    @db.Text
+  checkedAt        DateTime
+  institutionScope Chamber[]
+  legislatureScope String[]
+  searchMethod     String
+  reviewedBy       String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([measureId])
+  @@index([applicableRevisionId])
+  @@index([scrutinId])
 }
 
 // Attached to the revision and not to the measure: this is what represents the ordinary

--- a/scripts/seed-presidentielle-sujet-demo.ts
+++ b/scripts/seed-presidentielle-sujet-demo.ts
@@ -3,9 +3,11 @@
  * Seeds a fictional, publishable subject page for the presidential 2027 hub, so the public route
  * /presidentielle-2027/sujets/logement-urbanisme can be reviewed in a browser (responsive + axe).
  *
+ * The seeding itself lives in src/lib/data/__tests__/presidentielle-subject-demo.ts (a test fixture,
+ * where writing PUBLISHED directly is allowed); this script is the thin, guarded entry point.
+ *
  * Refuses to run against anything but the disposable container, and that refusal is the point:
- * `.env` and `.env.prod` point at the same Supabase database, so an ungated run with the default
- * environment would write fabricated candidacies and measures into production.
+ * `.env` and `.env.prod` point at the same Supabase database.
  *
  * Usage, with the container from docker-compose.test-search.yml running and its schema pushed:
  *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
@@ -13,100 +15,19 @@
  */
 import { assertDisposableTestDb } from "@/test/disposable-db";
 
-const ELECTION_SLUG = "presidentielle-2027";
-const THEME = "LOGEMENT_URBANISME" as const;
-
 async function main(): Promise<void> {
   // First statement, before any import that opens a connection: the guard is the safety net.
   assertDisposableTestDb();
 
+  const { seedPresidentielleSubjectDemo } =
+    await import("@/lib/data/__tests__/presidentielle-subject-demo");
   const { db } = await import("@/lib/db");
-  const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
-    await import("@/lib/measures/transitions");
 
-  const election = await db.election.create({
-    data: {
-      slug: ELECTION_SLUG,
-      type: "PRESIDENTIELLE",
-      scope: "NATIONAL",
-      title: "Présidentielle 2027",
-    },
-  });
-
-  async function publishedCandidate(name: string, text: string, sourced: boolean): Promise<void> {
-    const slug = `demo-${name.toLowerCase()}`;
-    const politician = await db.politician.create({
-      data: { slug, firstName: name, lastName: "Démo", fullName: `${name} Démo` },
-    });
-    const candidacy = await db.candidacy.create({
-      data: {
-        electionId: election.id,
-        politicianId: politician.id,
-        candidateName: `${name} Démo`,
-        status: "DECLARE",
-        sourceUrl: sourced ? "https://example.org/annonce" : null,
-        sourceLabel: sourced ? "Discours de déclaration" : null,
-      },
-    });
-    await db.candidacyPresidential.create({
-      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED", slogan: `Slogan ${name}` },
-    });
-    const seeded = await createMeasure({
-      politicianId: politician.id,
-      electionId: election.id,
-      candidacyId: candidacy.id,
-      programEditionId: null,
-      attribution: "PERSONAL",
-      theme: THEME,
-      precedingMeasureId: null,
-      revision: {
-        text,
-        precision: "OBJECTIF_SANS_CHIFFRE",
-        validFrom: new Date("2027-01-01T00:00:00Z"),
-        extractionMethod: "MANUAL",
-        extractionConfidence: null,
-        extractorVersion: null,
-      },
-      sources: [
-        {
-          sourceKind: "DISCOURS_CAMPAGNE",
-          tier: "PRIMARY",
-          url: "https://example.org/meeting",
-          page: null,
-          publishedAt: new Date("2027-01-01T00:00:00Z"),
-        },
-      ],
-    });
-    await reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
-    await publishMeasureRevision(seeded);
-  }
-
-  // Two candidacies with a defended measure clear the page-sujet gate; a third has none (absence).
-  await publishedCandidate("Alix", "Encadrer les loyers dans les zones tendues.", true);
-  await publishedCandidate(
-    "Bruno",
-    "Construire 500 000 logements sociaux sur le quinquennat.",
-    true
+  const { electionId } = await seedPresidentielleSubjectDemo();
+  console.log(`[seed:presidentielle-sujet] élection presidentielle-2027 (${electionId})`);
+  console.log(
+    "[seed:presidentielle-sujet] 3 candidatures publiées, 2 avec mesure sur LOGEMENT_URBANISME"
   );
-  const chloePol = await db.politician.create({
-    data: { slug: "demo-chloe", firstName: "Chloé", lastName: "Démo", fullName: "Chloé Démo" },
-  });
-  const chloe = await db.candidacy.create({
-    data: {
-      electionId: election.id,
-      politicianId: chloePol.id,
-      candidateName: "Chloé Démo",
-      status: "DECLARE",
-      sourceUrl: "https://example.org/annonce",
-      sourceLabel: "Discours de déclaration",
-    },
-  });
-  await db.candidacyPresidential.create({
-    data: { candidacyId: chloe.id, publicationStatus: "PUBLISHED" },
-  });
-
-  console.log(`[seed:presidentielle-sujet] élection ${ELECTION_SLUG} (${election.id})`);
-  console.log(`[seed:presidentielle-sujet] 3 candidatures publiées, 2 avec mesure sur ${THEME}`);
 
   await db.$disconnect();
 }

--- a/scripts/seed-presidentielle-sujet-demo.ts
+++ b/scripts/seed-presidentielle-sujet-demo.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+/**
+ * Seeds a fictional, publishable subject page for the presidential 2027 hub, so the public route
+ * /presidentielle-2027/sujets/logement-urbanisme can be reviewed in a browser (responsive + axe).
+ *
+ * Refuses to run against anything but the disposable container, and that refusal is the point:
+ * `.env` and `.env.prod` point at the same Supabase database, so an ungated run with the default
+ * environment would write fabricated candidacies and measures into production.
+ *
+ * Usage, with the container from docker-compose.test-search.yml running and its schema pushed:
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
+ *     npx tsx scripts/seed-presidentielle-sujet-demo.ts
+ */
+import { assertDisposableTestDb } from "@/test/disposable-db";
+
+const ELECTION_SLUG = "presidentielle-2027";
+const THEME = "LOGEMENT_URBANISME" as const;
+
+async function main(): Promise<void> {
+  // First statement, before any import that opens a connection: the guard is the safety net.
+  assertDisposableTestDb();
+
+  const { db } = await import("@/lib/db");
+  const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
+    await import("@/lib/measures/transitions");
+
+  const election = await db.election.create({
+    data: {
+      slug: ELECTION_SLUG,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Présidentielle 2027",
+    },
+  });
+
+  async function publishedCandidate(name: string, text: string, sourced: boolean): Promise<void> {
+    const slug = `demo-${name.toLowerCase()}`;
+    const politician = await db.politician.create({
+      data: { slug, firstName: name, lastName: "Démo", fullName: `${name} Démo` },
+    });
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: politician.id,
+        candidateName: `${name} Démo`,
+        status: "DECLARE",
+        sourceUrl: sourced ? "https://example.org/annonce" : null,
+        sourceLabel: sourced ? "Discours de déclaration" : null,
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED", slogan: `Slogan ${name}` },
+    });
+    const seeded = await createMeasure({
+      politicianId: politician.id,
+      electionId: election.id,
+      candidacyId: candidacy.id,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: THEME,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    await reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+    await publishMeasureRevision(seeded);
+  }
+
+  // Two candidacies with a defended measure clear the page-sujet gate; a third has none (absence).
+  await publishedCandidate("Alix", "Encadrer les loyers dans les zones tendues.", true);
+  await publishedCandidate(
+    "Bruno",
+    "Construire 500 000 logements sociaux sur le quinquennat.",
+    true
+  );
+  const chloePol = await db.politician.create({
+    data: { slug: "demo-chloe", firstName: "Chloé", lastName: "Démo", fullName: "Chloé Démo" },
+  });
+  const chloe = await db.candidacy.create({
+    data: {
+      electionId: election.id,
+      politicianId: chloePol.id,
+      candidateName: "Chloé Démo",
+      status: "DECLARE",
+      sourceUrl: "https://example.org/annonce",
+      sourceLabel: "Discours de déclaration",
+    },
+  });
+  await db.candidacyPresidential.create({
+    data: { candidacyId: chloe.id, publicationStatus: "PUBLISHED" },
+  });
+
+  console.log(`[seed:presidentielle-sujet] élection ${ELECTION_SLUG} (${election.id})`);
+  console.log(`[seed:presidentielle-sujet] 3 candidatures publiées, 2 avec mesure sur ${THEME}`);
+
+  await db.$disconnect();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -89,6 +89,7 @@ else
   npx vitest run --no-file-parallelism \
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
+    src/lib/data/__tests__/subject-page.integration.test.ts \
     src/lib/search \
     src/lib/measures \
     src/app/admin/mesures \

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -88,6 +88,7 @@ else
   echo "[test:db:search] running the suites that need the disposable container"
   npx vitest run --no-file-parallelism \
     src/lib/data/__tests__/measures.integration.test.ts \
+    src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
     src/lib/search \
     src/lib/measures \
     src/app/admin/mesures \

--- a/src/app/admin/mesures/[id]/page.tsx
+++ b/src/app/admin/mesures/[id]/page.tsx
@@ -2,7 +2,10 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import {
   CANDIDACY_STATUS_LABELS,
+  CHAMBER_SHORT_LABELS,
   MEASURE_ATTRIBUTION_LABELS,
+  MEASURE_VOTE_LINK_KIND_LABELS,
+  MEASURE_VOTE_RELATION_LABELS,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
 import { isAuthenticated } from "@/lib/auth";
@@ -14,8 +17,10 @@ import { MeasureMetadataPanel } from "../_components/MeasureMetadataPanel";
 import { ModerationStateBadge } from "../_components/ModerationStateBadge";
 import { PublicVisibilityCard } from "../_components/PublicVisibilityCard";
 import { RevisionTimeline } from "../_components/RevisionTimeline";
+import { VoteLinkForm } from "../_components/VoteLinkForm";
 import { availableActions, hasAmbiguousPointers } from "../_data/available-actions";
 import { getMeasureContext } from "../_data/detail-query";
+import { getMeasureVoteLinksForModeration } from "../_data/vote-links-query";
 
 export const metadata = {
   title: "Fiche de modération d'une mesure (admin) | Poligraph",
@@ -55,6 +60,10 @@ function toRow(measure: ModerationRead): ModerationMeasureRow {
   };
 }
 
+function shorten(text: string): string {
+  return text.length > 70 ? `${text.slice(0, 70)}…` : text;
+}
+
 export default async function AdminMeasureDetailPage({ params }: PageProps) {
   if (!(await isAuthenticated())) redirect("/admin/login");
 
@@ -62,10 +71,11 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
 
   // Three reads, three different questions: the moderation read applies no filter, the public
   // read applies both, and the context read carries who and which election.
-  const [measure, context, publicMeasure] = await Promise.all([
+  const [measure, context, publicMeasure, voteLinks] = await Promise.all([
     getMeasureForModeration(id),
     getMeasureContext(id),
     getPublicMeasure(id),
+    getMeasureVoteLinksForModeration(id),
   ]);
 
   if (measure === null || context === null) notFound();
@@ -214,6 +224,94 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
             revisions={measure.revisions}
             publishedRevisionId={measure.publishedRevisionId}
             latestRevisionId={measure.latestRevisionId}
+          />
+        </div>
+      </section>
+
+      <section aria-labelledby="votelinks-heading">
+        <h2 id="votelinks-heading" className="text-base font-semibold">
+          Rattachement à des scrutins
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            manuel, jamais dérivé d&apos;un vote automatiquement
+          </span>
+        </h2>
+
+        <div className="mt-3 space-y-4">
+          {voteLinks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Aucun scrutin rattaché. Tant qu&apos;aucun lien n&apos;existe, la relation aux votes
+              s&apos;affiche comme « recherche non effectuée ».
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {voteLinks.map((link) => (
+                <li key={link.id} className="rounded border border-border p-3 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">
+                      {MEASURE_VOTE_LINK_KIND_LABELS[link.linkKind]}
+                    </span>
+                    {link.relation !== null && (
+                      <span className="text-muted-foreground">
+                        · {MEASURE_VOTE_RELATION_LABELS[link.relation]}
+                      </span>
+                    )}
+                    {link.isReference && (
+                      <span className="rounded bg-muted px-2 py-0.5 text-xs font-medium">
+                        référence
+                      </span>
+                    )}
+                  </div>
+                  <dl className="mt-2 grid gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+                    {link.scrutinId !== null && (
+                      <div className="flex gap-2">
+                        <dt className="font-medium">Scrutin</dt>
+                        <dd>{link.scrutinId}</dd>
+                      </div>
+                    )}
+                    <div className="flex gap-2">
+                      <dt className="font-medium">Révision visée</dt>
+                      <dd>
+                        {shorten(
+                          revisionTexts[link.applicableRevisionId] ?? link.applicableRevisionId
+                        )}
+                      </dd>
+                    </div>
+                    <div className="flex gap-2">
+                      <dt className="font-medium">Vérifié le</dt>
+                      <dd>{dateFormat.format(link.checkedAt)}</dd>
+                    </div>
+                    <div className="flex gap-2">
+                      <dt className="font-medium">Chambres</dt>
+                      <dd>
+                        {link.institutionScope.map((c) => CHAMBER_SHORT_LABELS[c]).join(", ") ||
+                          "—"}
+                      </dd>
+                    </div>
+                    {link.legislatureScope.length > 0 && (
+                      <div className="flex gap-2">
+                        <dt className="font-medium">Législatures</dt>
+                        <dd>{link.legislatureScope.join(", ")}</dd>
+                      </div>
+                    )}
+                    <div className="flex gap-2">
+                      <dt className="font-medium">Méthode</dt>
+                      <dd>{link.searchMethod}</dd>
+                    </div>
+                  </dl>
+                  <p className="mt-2 text-xs text-muted-foreground">{link.rationale}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <VoteLinkForm
+            measureId={id}
+            defaultRevisionId={referenceRevisionId}
+            revisions={measure.revisions.map((revision) => ({
+              id: revision.id,
+              text: revision.text,
+              validFrom: dateFormat.format(revision.validFrom),
+            }))}
           />
         </div>
       </section>

--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -49,6 +49,10 @@ vi.mock("../_data/detail-query", () => ({
   getMeasureContext: vi.fn(async () => null),
 }));
 
+vi.mock("../_data/vote-links-query", () => ({
+  getMeasureVoteLinksForModeration: vi.fn(async () => []),
+}));
+
 vi.mock("../_data/candidacies-query", () => ({
   listPresidentialCandidacies: vi.fn(async () => []),
 }));

--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chamber } from "@/generated/prisma";
 import { MeasureConcurrencyError, MeasureValidationError } from "@/lib/measures/errors";
 
 /**
@@ -40,6 +41,12 @@ const eligibilityMock = {
   assertHubMeasureCandidacy: vi.fn(async () => ({ electionId: "e-1", politicianId: "p-1" })),
 };
 vi.mock("../_data/candidacy-eligibility", () => eligibilityMock);
+
+// The measure vote-link writer (#662). Mocked so importing actions does not pull the real @/lib/db.
+const voteLinksMock = {
+  createMeasureVoteLink: vi.fn(async () => ({ id: "vl-1" })),
+};
+vi.mock("@/lib/measures/vote-links", () => voteLinksMock);
 
 const REVISION = {
   text: "Encadrer les loyers dans les zones tendues.",
@@ -447,5 +454,124 @@ describe("conclusions éditoriales : pas de jeton de version, une révision expl
       ok: false,
       message: "Une conclusion EQUIVALENT_FOUND exige au moins un équivalent identifié",
     });
+  });
+});
+
+describe("attachVoteLinkAction : rattachement manuel à un scrutin (#662)", () => {
+  const base = {
+    measureId: "m-1",
+    applicableRevisionId: "rev-1",
+    rationale: "Vérifié sur les scrutins d'amendement du texte.",
+    checkedAt: "2026-05-20T00:00:00.000Z",
+    institutionScope: ["AN"] as Chamber[],
+    legislatureScope: ["17"],
+    searchMethod: "Filtre par thème",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAuthenticatedMock.mockResolvedValue(true);
+  });
+
+  it("refuse sans session, sans rien écrire", async () => {
+    isAuthenticatedMock.mockResolvedValue(false);
+    const { attachVoteLinkAction } = await actions();
+
+    await expect(
+      attachVoteLinkAction({ ...base, situation: { kind: "NO_VOTE_IDENTIFIED" } })
+    ).rejects.toThrow("Non autorisé");
+    expect(voteLinksMock.createMeasureVoteLink).not.toHaveBeenCalled();
+  });
+
+  it("« aucun vote identifié » n'écrit ni scrutin ni relation", async () => {
+    const { attachVoteLinkAction } = await actions();
+
+    const result = await attachVoteLinkAction({
+      ...base,
+      situation: { kind: "NO_VOTE_IDENTIFIED" },
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(voteLinksMock.createMeasureVoteLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linkKind: "NO_VOTE_IDENTIFIED",
+        scrutinId: null,
+        relation: null,
+        isReference: false,
+        checkedAt: new Date("2026-05-20T00:00:00.000Z"),
+        reviewedBy: "admin",
+      })
+    );
+  });
+
+  it("une absence est une relation ABSENCE sur un scrutin sur le même objet", async () => {
+    const { attachVoteLinkAction } = await actions();
+
+    await attachVoteLinkAction({
+      ...base,
+      situation: {
+        kind: "SAME_OBJECT",
+        scrutinId: "s-42",
+        relation: "ABSENCE",
+        isReference: false,
+      },
+    });
+
+    expect(voteLinksMock.createMeasureVoteLink).toHaveBeenCalledWith(
+      expect.objectContaining({ linkKind: "SAME_OBJECT", scrutinId: "s-42", relation: "ABSENCE" })
+    );
+  });
+
+  it("un texte plus large ne porte aucune relation", async () => {
+    const { attachVoteLinkAction } = await actions();
+
+    await attachVoteLinkAction({ ...base, situation: { kind: "BROADER_TEXT", scrutinId: "s-7" } });
+
+    expect(voteLinksMock.createMeasureVoteLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linkKind: "BROADER_TEXT",
+        scrutinId: "s-7",
+        relation: null,
+        isReference: false,
+      })
+    );
+  });
+
+  it("rend l'erreur métier du backend au lieu de la jeter", async () => {
+    voteLinksMock.createMeasureVoteLink.mockRejectedValueOnce(
+      new MeasureValidationError("Une référence existe déjà pour cette révision applicable")
+    );
+    const { attachVoteLinkAction } = await actions();
+
+    const result = await attachVoteLinkAction({
+      ...base,
+      situation: {
+        kind: "SAME_OBJECT",
+        scrutinId: "s-1",
+        relation: "FAVORABLE",
+        isReference: true,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Une référence existe déjà pour cette révision applicable",
+    });
+  });
+
+  it("refuse une date de vérification invalide avant d'écrire", async () => {
+    const { attachVoteLinkAction } = await actions();
+
+    const result = await attachVoteLinkAction({
+      ...base,
+      checkedAt: "pas une date",
+      situation: { kind: "NO_VOTE_IDENTIFIED" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "La date de vérification n'est pas une date valide",
+    });
+    expect(voteLinksMock.createMeasureVoteLink).not.toHaveBeenCalled();
   });
 });

--- a/src/app/admin/mesures/_components/VoteLinkForm.tsx
+++ b/src/app/admin/mesures/_components/VoteLinkForm.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import {
+  CHAMBER_LABELS,
+  MEASURE_VOTE_LINK_KIND_LABELS,
+  MEASURE_VOTE_RELATION_LABELS,
+} from "@/config/labels";
+import type { Chamber, MeasureVoteLinkKind, MeasureVoteRelation } from "@/generated/prisma";
+import { attachVoteLinkAction, type ActionResult, type VoteLinkSituation } from "../actions";
+
+/**
+ * The manual attachment of a measure to a scrutin (spec §5.8).
+ *
+ * The one rule this form exists to make unbreakable: the reviewer must never file "no scrutin found" as
+ * "the person was absent", nor the reverse. So the top-level choice is a single radio over three
+ * mutually exclusive situations, and the fields that only make sense for one situation are rendered ONLY
+ * for it:
+ *
+ * - NO_VOTE_IDENTIFIED: no scrutin, no relation. A dated constat that the documented perimeter held no
+ *   relevant vote. Not an absence.
+ * - SAME_OBJECT: a scrutin is chosen, and the reviewer records the candidate's relation to the measure,
+ *   ABSENCE (did not take part) being one of the four values, alongside favorable/défavorable/abstention.
+ * - BROADER_TEXT: a scrutin is chosen, but no position is attributable, so no relation field appears.
+ *
+ * A relation therefore cannot exist without a chosen scrutin, and ABSENCE is a relation on a scrutin, one
+ * click away from "no scrutin found" but never the same control. `attachVoteLinkAction` and, beneath it,
+ * `createMeasureVoteLink` re-check all of this: the form is the reviewer's guardrail, not the only one.
+ */
+
+const BUTTON =
+  "inline-flex min-h-11 items-center justify-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50";
+const FIELD = "mt-1 min-h-11 w-full rounded border border-border bg-background px-3 py-2 text-sm";
+const LABEL = "text-xs font-semibold uppercase tracking-wide text-muted-foreground";
+const LEGEND = "text-xs font-semibold uppercase tracking-wide text-muted-foreground";
+
+const SITUATION_KINDS = Object.keys(MEASURE_VOTE_LINK_KIND_LABELS) as MeasureVoteLinkKind[];
+const RELATIONS = Object.keys(MEASURE_VOTE_RELATION_LABELS) as MeasureVoteRelation[];
+const CHAMBERS = Object.keys(CHAMBER_LABELS) as Chamber[];
+
+export type VoteLinkRevisionOption = { id: string; text: string; validFrom: string };
+
+function shorten(text: string): string {
+  return text.length > 70 ? `${text.slice(0, 70)}…` : text;
+}
+
+export function VoteLinkForm({
+  measureId,
+  revisions,
+  defaultRevisionId,
+}: {
+  measureId: string;
+  revisions: VoteLinkRevisionOption[];
+  defaultRevisionId: string | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [situation, setSituation] = useState<MeasureVoteLinkKind>("SAME_OBJECT");
+  const [failure, setFailure] = useState<string | null>(null);
+
+  function run(action: () => Promise<ActionResult>): void {
+    setFailure(null);
+    startTransition(async () => {
+      const result = await action();
+      if (result.ok) {
+        setOpen(false);
+        router.refresh();
+        return;
+      }
+      setFailure(result.message);
+    });
+  }
+
+  if (revisions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aucune révision à rattacher : un lien à un scrutin porte sur une formulation précise de la
+        mesure.
+      </p>
+    );
+  }
+
+  function buildSituation(data: FormData): VoteLinkSituation | { error: string } {
+    if (situation === "NO_VOTE_IDENTIFIED") {
+      return { kind: "NO_VOTE_IDENTIFIED" };
+    }
+    const scrutinId = String(data.get("scrutinId") ?? "").trim();
+    if (scrutinId === "") {
+      return { error: "Renseignez l'identifiant du scrutin." };
+    }
+    if (situation === "BROADER_TEXT") {
+      return { kind: "BROADER_TEXT", scrutinId };
+    }
+    const relation = String(data.get("relation") ?? "");
+    if (!RELATIONS.includes(relation as MeasureVoteRelation)) {
+      return { error: "Choisissez la relation du candidat à la mesure sur ce scrutin." };
+    }
+    return {
+      kind: "SAME_OBJECT",
+      scrutinId,
+      relation: relation as MeasureVoteRelation,
+      isReference: data.get("isReference") !== null,
+    };
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border p-4">
+      {failure !== null && (
+        <p
+          role="alert"
+          aria-live="polite"
+          className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+        >
+          {failure}
+        </p>
+      )}
+
+      <button
+        type="button"
+        className={BUTTON}
+        disabled={pending}
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+      >
+        Rattacher un scrutin
+      </button>
+
+      {open && (
+        <form
+          className="space-y-4 rounded border border-border p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const data = new FormData(event.currentTarget);
+            const built = buildSituation(data);
+            if ("error" in built) {
+              setFailure(built.error);
+              return;
+            }
+            const chambers = data.getAll("institutionScope").map(String) as Chamber[];
+            if (chambers.length === 0) {
+              setFailure("Indiquez au moins une chambre examinée.");
+              return;
+            }
+            const legislatures = String(data.get("legislatureScope") ?? "")
+              .split(/[\s,]+/)
+              .map((value) => value.trim())
+              .filter((value) => value !== "");
+            run(() =>
+              attachVoteLinkAction({
+                measureId,
+                applicableRevisionId: String(data.get("applicableRevisionId")),
+                situation: built,
+                rationale: String(data.get("rationale") ?? ""),
+                checkedAt: String(data.get("checkedAt") ?? ""),
+                institutionScope: chambers,
+                legislatureScope: legislatures,
+                searchMethod: String(data.get("searchMethod") ?? ""),
+              })
+            );
+          }}
+        >
+          <div>
+            <label htmlFor="votelink-revision" className={LABEL}>
+              Révision concernée
+            </label>
+            <select
+              id="votelink-revision"
+              name="applicableRevisionId"
+              required
+              defaultValue={defaultRevisionId ?? ""}
+              className={FIELD}
+            >
+              {revisions.map((revision) => (
+                <option key={revision.id} value={revision.id}>
+                  {revision.validFrom} · {shorten(revision.text)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className={LEGEND}>Situation</legend>
+            {SITUATION_KINDS.map((kind) => (
+              <label key={kind} className="flex items-start gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="situation"
+                  value={kind}
+                  checked={situation === kind}
+                  onChange={() => setSituation(kind)}
+                  className="mt-1"
+                />
+                <span>{MEASURE_VOTE_LINK_KIND_LABELS[kind]}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          {situation === "NO_VOTE_IDENTIFIED" && (
+            <p className="rounded border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+              La recherche a bien eu lieu et n&apos;a rien trouvé dans le périmètre documenté. Ce
+              n&apos;est pas une absence au scrutin : il n&apos;y a pas de scrutin à rattacher.
+            </p>
+          )}
+
+          {(situation === "SAME_OBJECT" || situation === "BROADER_TEXT") && (
+            <div>
+              <label htmlFor="votelink-scrutin" className={LABEL}>
+                Identifiant du scrutin
+              </label>
+              <input
+                id="votelink-scrutin"
+                name="scrutinId"
+                type="text"
+                required
+                className={FIELD}
+                placeholder="Collé à la main pour l'instant ; une recherche viendra plus tard"
+              />
+            </div>
+          )}
+
+          {situation === "SAME_OBJECT" && (
+            <>
+              <fieldset className="space-y-2">
+                <legend className={LEGEND}>Relation du candidat à la mesure</legend>
+                {RELATIONS.map((relation) => (
+                  <label key={relation} className="flex items-start gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="relation"
+                      value={relation}
+                      required
+                      className="mt-1"
+                    />
+                    <span>{MEASURE_VOTE_RELATION_LABELS[relation]}</span>
+                  </label>
+                ))}
+                <p className="text-xs text-muted-foreground">
+                  « Absent(e) au scrutin » suppose un scrutin identifié auquel la personne n&apos;a
+                  pas pris part. C&apos;est une relation sur un scrutin, distincte de « aucun
+                  scrutin trouvé ».
+                </p>
+              </fieldset>
+
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" name="isReference" />
+                <span>Scrutin de référence pour cette révision (au plus un)</span>
+              </label>
+            </>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label htmlFor="votelink-checked" className={LABEL}>
+                Date de vérification
+              </label>
+              <input
+                id="votelink-checked"
+                name="checkedAt"
+                type="date"
+                required
+                className={FIELD}
+              />
+            </div>
+            <div>
+              <label htmlFor="votelink-legislatures" className={LABEL}>
+                Législatures examinées
+              </label>
+              <input
+                id="votelink-legislatures"
+                name="legislatureScope"
+                type="text"
+                className={FIELD}
+                placeholder="17, 16 (séparées par des espaces ou des virgules)"
+              />
+            </div>
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className={LEGEND}>Chambres examinées</legend>
+            <div className="flex flex-wrap gap-4">
+              {CHAMBERS.map((chamber) => (
+                <label key={chamber} className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" name="institutionScope" value={chamber} />
+                  <span>{CHAMBER_LABELS[chamber]}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div>
+            <label htmlFor="votelink-method" className={LABEL}>
+              Méthode de recherche
+            </label>
+            <input
+              id="votelink-method"
+              name="searchMethod"
+              type="text"
+              required
+              className={FIELD}
+              placeholder="Requête, filtre, source consultée"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="votelink-rationale" className={LABEL}>
+              Justification / constat
+            </label>
+            <textarea
+              id="votelink-rationale"
+              name="rationale"
+              required
+              rows={3}
+              className={FIELD}
+            />
+          </div>
+
+          <button type="submit" className={BUTTON} disabled={pending}>
+            Enregistrer le rattachement
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
@@ -22,6 +22,7 @@ function state(over: Partial<ModerationState> = {}): ModerationState {
 function publicMeasure(over: Partial<PublicMeasure> = {}): PublicMeasure {
   return {
     id: "m-1",
+    publishedRevisionId: "rev-1",
     text: "Encadrer les loyers dans les zones tendues.",
     precision: "OBJECTIF_SANS_CHIFFRE",
     theme: "LOGEMENT_URBANISME",

--- a/src/app/admin/mesures/_components/__tests__/VoteLinkForm.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/VoteLinkForm.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VoteLinkForm } from "../VoteLinkForm";
+
+const attachVoteLinkAction = vi.fn(async (_input: unknown) => ({ ok: true }) as const);
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("../../actions", () => ({
+  attachVoteLinkAction: (input: unknown) => attachVoteLinkAction(input),
+}));
+
+const REVISIONS = [
+  {
+    id: "rev-1",
+    text: "Encadrer les loyers dans les zones tendues.",
+    validFrom: "15 janvier 2027",
+  },
+];
+
+function open() {
+  render(<VoteLinkForm measureId="m-1" revisions={REVISIONS} defaultRevisionId="rev-1" />);
+  fireEvent.click(screen.getByRole("button", { name: "Rattacher un scrutin" }));
+}
+
+function fillCommonFields() {
+  fireEvent.change(screen.getByLabelText("Date de vérification"), {
+    target: { value: "2026-05-20" },
+  });
+  fireEvent.click(screen.getByRole("checkbox", { name: "Assemblée nationale" }));
+  fireEvent.change(screen.getByLabelText("Méthode de recherche"), {
+    target: { value: "Filtre par thème sur les scrutins de la 17e législature" },
+  });
+  fireEvent.change(screen.getByLabelText("Justification / constat"), {
+    target: { value: "Vérifié sur les scrutins d'amendement du texte." },
+  });
+}
+
+function submit() {
+  fireEvent.submit(
+    screen.getByLabelText("Méthode de recherche").closest("form") as HTMLFormElement
+  );
+}
+
+beforeEach(() => {
+  attachVoteLinkAction.mockClear();
+});
+
+describe("VoteLinkForm", () => {
+  it("ne montre le formulaire qu'après la demande", () => {
+    render(<VoteLinkForm measureId="m-1" revisions={REVISIONS} defaultRevisionId="rev-1" />);
+    expect(screen.queryByLabelText("Méthode de recherche")).not.toBeInTheDocument();
+  });
+
+  it("explique une mesure sans révision au lieu d'un formulaire vide", () => {
+    render(<VoteLinkForm measureId="m-1" revisions={[]} defaultRevisionId={null} />);
+    expect(screen.getByText(/un lien à un scrutin porte sur une formulation/)).toBeInTheDocument();
+  });
+
+  // The whole point of the screen: "no scrutin found" and "absent from the scrutin" are different
+  // controls in different groups. You can never file one as the other.
+  it("sépare « aucun scrutin trouvé » et « absent au scrutin » en deux contrôles distincts", () => {
+    open();
+    // Same-object is the default, so both the situation option and the relation option exist and differ.
+    const noVote = screen.getByRole("radio", {
+      name: "Aucun scrutin pertinent trouvé dans le périmètre",
+    });
+    const absence = screen.getByRole("radio", { name: "Absent(e) au scrutin" });
+    expect(noVote).toBeInTheDocument();
+    expect(absence).toBeInTheDocument();
+    expect(noVote).not.toBe(absence);
+    expect((noVote as HTMLInputElement).name).toBe("situation");
+    expect((absence as HTMLInputElement).name).toBe("relation");
+  });
+
+  it("cache le scrutin et la relation quand aucun scrutin n'est identifié", () => {
+    open();
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Aucun scrutin pertinent trouvé dans le périmètre" })
+    );
+    expect(screen.queryByLabelText("Identifiant du scrutin")).not.toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "Absent(e) au scrutin" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Ce n'est pas une absence au scrutin/)).toBeInTheDocument();
+  });
+
+  it("montre le scrutin mais pas de relation pour un texte plus large", () => {
+    open();
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Scrutin sur un texte plus large contenant la mesure" })
+    );
+    expect(screen.getByLabelText("Identifiant du scrutin")).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "Favorable à la mesure" })).not.toBeInTheDocument();
+  });
+
+  it("transmet un « aucun vote identifié » sans scrutin ni relation", () => {
+    open();
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Aucun scrutin pertinent trouvé dans le périmètre" })
+    );
+    fillCommonFields();
+    submit();
+
+    expect(attachVoteLinkAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        measureId: "m-1",
+        applicableRevisionId: "rev-1",
+        situation: { kind: "NO_VOTE_IDENTIFIED" },
+        institutionScope: ["AN"],
+      })
+    );
+  });
+
+  it("transmet une absence comme une relation sur un scrutin identifié", () => {
+    open();
+    fireEvent.change(screen.getByLabelText("Identifiant du scrutin"), {
+      target: { value: "scrutin-42" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Absent(e) au scrutin" }));
+    fillCommonFields();
+    submit();
+
+    expect(attachVoteLinkAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        situation: {
+          kind: "SAME_OBJECT",
+          scrutinId: "scrutin-42",
+          relation: "ABSENCE",
+          isReference: false,
+        },
+      })
+    );
+  });
+
+  it("refuse un scrutin sur le même objet sans identifiant de scrutin", () => {
+    open();
+    fireEvent.click(screen.getByRole("radio", { name: "Favorable à la mesure" }));
+    fillCommonFields();
+    submit();
+
+    expect(attachVoteLinkAction).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/identifiant du scrutin/i);
+  });
+
+  it("exige au moins une chambre examinée", () => {
+    open();
+    fireEvent.change(screen.getByLabelText("Identifiant du scrutin"), {
+      target: { value: "scrutin-42" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Favorable à la mesure" }));
+    fireEvent.change(screen.getByLabelText("Date de vérification"), {
+      target: { value: "2026-05-20" },
+    });
+    fireEvent.change(screen.getByLabelText("Méthode de recherche"), {
+      target: { value: "Filtre par thème" },
+    });
+    fireEvent.change(screen.getByLabelText("Justification / constat"), {
+      target: { value: "Constat." },
+    });
+    submit();
+
+    expect(attachVoteLinkAction).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/au moins une chambre/i);
+  });
+});

--- a/src/app/admin/mesures/_data/vote-links-query.ts
+++ b/src/app/admin/mesures/_data/vote-links-query.ts
@@ -1,0 +1,34 @@
+import { db } from "@/lib/db";
+
+/**
+ * The vote links already attached to a measure, for the moderation surface.
+ *
+ * Admin-only, so it deliberately carries `rationale` and `reviewedBy`: unlike the public
+ * `getPublicMeasureVoteRelation()`, this is the internal editorial view of what has been recorded and by
+ * whom. It never derives a public state; it lists the raw rows so the reviewer can audit them.
+ */
+export async function getMeasureVoteLinksForModeration(measureId: string) {
+  return db.measureVoteLink.findMany({
+    where: { measureId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      scrutinId: true,
+      linkKind: true,
+      relation: true,
+      isReference: true,
+      applicableRevisionId: true,
+      rationale: true,
+      checkedAt: true,
+      institutionScope: true,
+      legislatureScope: true,
+      searchMethod: true,
+      reviewedBy: true,
+      createdAt: true,
+    },
+  });
+}
+
+export type ModerationVoteLink = Awaited<
+  ReturnType<typeof getMeasureVoteLinksForModeration>
+>[number];

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -3,10 +3,12 @@
 import { revalidatePath } from "next/cache";
 import { QUALIFICATION_KIND_LABELS } from "@/config/labels";
 import type {
+  Chamber,
   MeasureAttribution,
   MeasureExtractionMethod,
   MeasurePrecision,
   MeasureSourceKind,
+  MeasureVoteRelation,
   QualificationKind,
   SimilarityConclusion,
   SourceTier,
@@ -15,6 +17,7 @@ import type {
 import { isAuthenticated } from "@/lib/auth";
 import { createQualification, createSimilarityAssessment } from "@/lib/measures/assessments";
 import { MeasureConcurrencyError, MeasureValidationError } from "@/lib/measures/errors";
+import { createMeasureVoteLink } from "@/lib/measures/vote-links";
 import {
   createMeasure,
   depublishMeasure,
@@ -351,6 +354,87 @@ export async function createSimilarityAssessmentAction(input: {
     });
     revalidate(input.measureId);
     return { ok: true };
+  } catch (error) {
+    return toFailure(error);
+  }
+}
+
+/**
+ * The manual attachment of the measure to a scrutin (spec §5.8), the only writer of MeasureVoteLink from
+ * the UI. The input is a discriminated `situation`, so the three cases the reviewer must keep apart are
+ * unrepresentable as a mix: "no scrutin found" carries neither a scrutinId nor a relation, an absence is a
+ * relation on a chosen scrutin, and a broader-text vote carries no relation at all. createMeasureVoteLink
+ * re-checks every one of these in its transaction: the type here is convenience, the transaction is the law.
+ */
+export type VoteLinkSituation =
+  | { kind: "NO_VOTE_IDENTIFIED" }
+  | { kind: "SAME_OBJECT"; scrutinId: string; relation: MeasureVoteRelation; isReference: boolean }
+  | { kind: "BROADER_TEXT"; scrutinId: string };
+
+export async function attachVoteLinkAction(input: {
+  measureId: string;
+  applicableRevisionId: string;
+  situation: VoteLinkSituation;
+  rationale: string;
+  /** ISO date of the review that produced this link. */
+  checkedAt: string;
+  institutionScope: Chamber[];
+  legislatureScope: string[];
+  searchMethod: string;
+}): Promise<ActionResult> {
+  await assertAuthenticated();
+
+  try {
+    const base = {
+      measureId: input.measureId,
+      applicableRevisionId: input.applicableRevisionId,
+      rationale: input.rationale,
+      checkedAt: parseDate(input.checkedAt, "La date de vérification"),
+      institutionScope: input.institutionScope,
+      legislatureScope: input.legislatureScope,
+      searchMethod: input.searchMethod,
+      reviewedBy: ACTOR,
+    };
+
+    switch (input.situation.kind) {
+      case "NO_VOTE_IDENTIFIED":
+        await createMeasureVoteLink({
+          ...base,
+          linkKind: "NO_VOTE_IDENTIFIED",
+          scrutinId: null,
+          relation: null,
+          isReference: false,
+        });
+        break;
+      case "SAME_OBJECT":
+        await createMeasureVoteLink({
+          ...base,
+          linkKind: "SAME_OBJECT",
+          scrutinId: input.situation.scrutinId,
+          relation: input.situation.relation,
+          isReference: input.situation.isReference,
+        });
+        break;
+      case "BROADER_TEXT":
+        await createMeasureVoteLink({
+          ...base,
+          linkKind: "BROADER_TEXT",
+          scrutinId: input.situation.scrutinId,
+          relation: null,
+          isReference: false,
+        });
+        break;
+      default: {
+        // Exhaustiveness: a new situation kind must add its branch here, not fall through silently.
+        const exhaustive: never = input.situation;
+        throw new MeasureValidationError(
+          `Situation de rattachement inconnue : ${JSON.stringify(exhaustive)}`
+        );
+      }
+    }
+
+    revalidate(input.measureId);
+    return { ok: true, measureId: input.measureId };
   } catch (error) {
     return toFailure(error);
   }

--- a/src/app/presidentielle-2027/sujets/[theme]/__tests__/page.test.ts
+++ b/src/app/presidentielle-2027/sujets/[theme]/__tests__/page.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocked so importing the page pulls no @/lib/db: the data authority is exercised in its own
+// integration test. Here we only check the metadata mapping and the theme-param parsing.
+vi.mock("@/lib/data/subject-page", () => ({ getSubjectPageData: vi.fn() }));
+
+import { getSubjectPageData } from "@/lib/data/subject-page";
+import { generateMetadata } from "../page";
+
+const mockGet = vi.mocked(getSubjectPageData);
+
+function props(theme: string) {
+  return { params: Promise.resolve({ theme }) };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("generateMetadata de la page sujet", () => {
+  it("noindex et titre explicite pour un thème inconnu, sans lire les données", async () => {
+    const meta = await generateMetadata(props("pas-un-theme"));
+    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(String(meta.title)).toMatch(/introuvable/i);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("indexable une fois le seuil de page sujet franchi", async () => {
+    mockGet.mockResolvedValue({ publishable: true } as never);
+    const meta = await generateMetadata(props("logement-urbanisme"));
+    expect(meta.robots).toBeUndefined();
+    expect(String(meta.title)).toMatch(/Présidentielle 2027/);
+  });
+
+  it("noindex tant que le seuil n'est pas franchi", async () => {
+    mockGet.mockResolvedValue({ publishable: false } as never);
+    const meta = await generateMetadata(props("logement-urbanisme"));
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("noindex quand l'élection n'existe pas", async () => {
+    mockGet.mockResolvedValue(null);
+    const meta = await generateMetadata(props("sante"));
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -1,11 +1,14 @@
 import {
   CANDIDACY_STATUS_LABELS,
   CHAMBER_SHORT_LABELS,
+  MEASURE_SOURCE_KIND_LABELS,
+  SOURCE_TIER_LABELS,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
 import { QualifiedEmptyCell } from "@/components/measures/QualifiedEmptyCell";
 import { VoteRelationBadge } from "@/components/measures/VoteRelationBadge";
 import type { ThemeCategory } from "@/generated/prisma";
+import type { PublicMeasure } from "@/lib/data/measures";
 import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
 
@@ -37,6 +40,33 @@ function composeVoteBasis(reference: PublicVoteReference): string {
   return parts.join(" · ");
 }
 
+/**
+ * The evidence behind a measure: its sources, primary first (the doctrine's reference source), each with
+ * its nature, its primary/secondary tier and its publication date, and a clickable link. A measure text
+ * without its sources on screen would ask the reader to trust it; the whole point is that they don't have to.
+ */
+function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
+  if (sources.length === 0) return null;
+  const ordered = [...sources].sort(
+    (a, b) => (a.tier === "PRIMARY" ? 0 : 1) - (b.tier === "PRIMARY" ? 0 : 1)
+  );
+  return (
+    <ul aria-label="Sources de la mesure" className="space-y-1 text-xs text-muted-foreground">
+      {ordered.map((source) => (
+        <li key={source.id}>
+          <a href={source.url} className="underline" rel="nofollow noopener">
+            {MEASURE_SOURCE_KIND_LABELS[source.sourceKind]}
+          </a>
+          {" · "}
+          {SOURCE_TIER_LABELS[source.tier]}
+          {" · "}
+          {formatDateFr(source.publishedAt)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
   const { candidate, measures } = entry;
   const statusLabel = candidate.status === null ? null : CANDIDACY_STATUS_LABELS[candidate.status];
@@ -49,6 +79,14 @@ function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme
       {statusLabel !== null && (
         <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{statusLabel}</p>
       )}
+      {candidate.sourceUrl !== null && candidate.sourceLabel !== null && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Candidature :{" "}
+          <a href={candidate.sourceUrl} className="underline" rel="nofollow noopener">
+            {candidate.sourceLabel}
+          </a>
+        </p>
+      )}
 
       <div className="mt-3 space-y-4">
         {measures.length === 0 ? (
@@ -57,6 +95,7 @@ function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme
           measures.map(({ measure, voteRelation, voteReference }) => (
             <div key={measure.id} className="space-y-2">
               <p className="text-sm">{measure.text}</p>
+              <MeasureSources sources={measure.sources} />
               {measure.withdrawal !== null && (
                 <p className="text-xs text-muted-foreground">
                   Mesure retirée le {formatDateFr(measure.withdrawal.withdrawnAt)}

--- a/src/app/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -1,0 +1,126 @@
+import {
+  CANDIDACY_STATUS_LABELS,
+  CHAMBER_SHORT_LABELS,
+  THEME_CATEGORY_LABELS,
+} from "@/config/labels";
+import { QualifiedEmptyCell } from "@/components/measures/QualifiedEmptyCell";
+import { VoteRelationBadge } from "@/components/measures/VoteRelationBadge";
+import type { ThemeCategory } from "@/generated/prisma";
+import type { PublicVoteReference } from "@/lib/measures/vote-links";
+import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
+
+/**
+ * A public subject page: for one theme, the candidates and their measures, side by side.
+ *
+ * No ranking and no proximity score: candidates come in the alphabetical order the authority returns, and
+ * the page says so. A candidate with no published measure on the theme is not silent, it gets a qualified
+ * absence. Below the publication gate the page renders an explicit state, never a one-candidate comparison
+ * dressed up as a comparison.
+ */
+
+function formatDateFr(date: Date): string {
+  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
+}
+
+function composeVoteBasis(reference: PublicVoteReference): string {
+  const parts: string[] = [];
+  if (reference.scrutinId !== null) parts.push(`scrutin ${reference.scrutinId}`);
+  if (reference.institutionScope.length > 0) {
+    parts.push(
+      reference.institutionScope.map((chamber) => CHAMBER_SHORT_LABELS[chamber]).join(", ")
+    );
+  }
+  if (reference.legislatureScope.length > 0) {
+    parts.push(`législature ${reference.legislatureScope.join(", ")}`);
+  }
+  parts.push(`vérifié le ${formatDateFr(reference.checkedAt)}`);
+  return parts.join(" · ");
+}
+
+function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
+  const { candidate, measures } = entry;
+  const statusLabel = candidate.status === null ? null : CANDIDACY_STATUS_LABELS[candidate.status];
+
+  return (
+    <article className="rounded-lg border border-border p-4">
+      <h2 className="font-display text-lg font-semibold tracking-tight">
+        {candidate.candidateName}
+      </h2>
+      {statusLabel !== null && (
+        <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{statusLabel}</p>
+      )}
+
+      <div className="mt-3 space-y-4">
+        {measures.length === 0 ? (
+          <QualifiedEmptyCell absence={{ kind: "no_measure_published", theme }} />
+        ) : (
+          measures.map(({ measure, voteRelation, voteReference }) => (
+            <div key={measure.id} className="space-y-2">
+              <p className="text-sm">{measure.text}</p>
+              {measure.withdrawal !== null && (
+                <p className="text-xs text-muted-foreground">
+                  Mesure retirée le {formatDateFr(measure.withdrawal.withdrawnAt)}
+                  {measure.withdrawal.sourceUrl !== null &&
+                    measure.withdrawal.sourceLabel !== null && (
+                      <>
+                        {" · "}
+                        <a
+                          href={measure.withdrawal.sourceUrl}
+                          className="underline"
+                          rel="nofollow noopener"
+                        >
+                          {measure.withdrawal.sourceLabel}
+                        </a>
+                      </>
+                    )}
+                </p>
+              )}
+              <VoteRelationBadge
+                relation={voteRelation}
+                basisDetails={voteReference !== null ? composeVoteBasis(voteReference) : undefined}
+              />
+            </div>
+          ))
+        )}
+      </div>
+    </article>
+  );
+}
+
+export function SubjectComparison({ data }: { data: SubjectPageData }) {
+  const themeLabel = THEME_CATEGORY_LABELS[data.theme];
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm text-muted-foreground">Présidentielle 2027</p>
+        <h1 className="font-display text-2xl font-bold tracking-tight">{themeLabel}</h1>
+        <p className="text-sm text-muted-foreground">
+          Candidats par ordre alphabétique, sans classement ni score de proximité.
+        </p>
+      </header>
+
+      {!data.publishable ? (
+        <section
+          aria-labelledby="gate-heading"
+          className="rounded-lg border border-border bg-muted/40 p-4"
+        >
+          <h2 id="gate-heading" className="text-base font-semibold">
+            Comparaison pas encore disponible sur ce sujet
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Une comparaison n&apos;est publiée que lorsqu&apos;au moins deux candidatures portent
+            une mesure vérifiée sur ce sujet. Ce seuil n&apos;est pas encore atteint, la page reste
+            hors des index tant qu&apos;il ne l&apos;est pas.
+          </p>
+        </section>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data.candidates.map((entry) => (
+            <CandidateColumn key={entry.candidate.id} entry={entry} theme={data.theme} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PublicMeasure } from "@/lib/data/measures";
+import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
+import type { VoteRelation } from "@/lib/measures/vote-relation";
+import { SubjectComparison } from "../SubjectComparison";
+
+function measure(over: Partial<PublicMeasure> = {}): PublicMeasure {
+  return {
+    id: "m-1",
+    publishedRevisionId: "rev-1",
+    text: "Encadrer les loyers.",
+    precision: "OBJECTIF_SANS_CHIFFRE",
+    theme: "LOGEMENT_URBANISME",
+    attribution: "PERSONAL",
+    politicianId: "p-1",
+    candidacyId: "c-1",
+    withdrawal: null,
+    sources: [],
+    qualifications: [],
+    ...over,
+  };
+}
+
+function candidate(name: string): SubjectCandidateEntry["candidate"] {
+  return {
+    id: `cand-${name}`,
+    candidateName: name,
+    politicianSlug: null,
+    status: "DECLARE",
+    sourceUrl: null,
+    sourceLabel: null,
+    slogan: null,
+    accentColor: null,
+    declaredAt: null,
+  };
+}
+
+function entry(name: string, measures: SubjectCandidateEntry["measures"]): SubjectCandidateEntry {
+  return { candidate: candidate(name), measures };
+}
+
+function subjectMeasure(
+  m: PublicMeasure,
+  relation: VoteRelation
+): SubjectCandidateEntry["measures"][number] {
+  return { measure: m, voteRelation: relation, voteReference: null };
+}
+
+function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
+  return {
+    theme: "LOGEMENT_URBANISME",
+    electionSlug: "presidentielle-2027",
+    candidates: [],
+    candidaciesWithVerifiedMeasure: 2,
+    publishable: true,
+    ...over,
+  };
+}
+
+describe("SubjectComparison", () => {
+  it("annonce l'ordre alphabétique et l'absence de classement", () => {
+    render(<SubjectComparison data={data()} />);
+    expect(screen.getByText(/ordre alphabétique, sans classement/i)).toBeInTheDocument();
+  });
+
+  it("rend une absence qualifiée, jamais une cellule vide, pour un candidat sans mesure", () => {
+    const { container } = render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ id: "m-a" }), "SEARCH_NOT_DONE")]),
+            entry("Chloe", []),
+          ],
+        })}
+      />
+    );
+    const absence = container.querySelector('[data-absence-kind="no_measure_published"]');
+    expect(absence).not.toBeNull();
+  });
+
+  it("garde une mesure retirée visible, avec sa source quand les deux champs sont là", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(
+                measure({
+                  id: "m-w",
+                  text: "Geler les loyers.",
+                  withdrawal: {
+                    withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+                    sourceUrl: "https://example.org/retrait",
+                    sourceLabel: "Communiqué de retrait",
+                  },
+                }),
+                "SEARCH_NOT_DONE"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText(/Mesure retirée le/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Communiqué de retrait" })).toBeInTheDocument();
+  });
+
+  it("n'affiche pas de lien de source de retrait quand le libellé manque", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(
+                measure({
+                  id: "m-w2",
+                  withdrawal: {
+                    withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+                    sourceUrl: "https://example.org/retrait",
+                    sourceLabel: null,
+                  },
+                }),
+                "SEARCH_NOT_DONE"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText(/Mesure retirée le/)).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("rend un état explicite sous le seuil, sans comparaison à un seul candidat", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          publishable: false,
+          candidaciesWithVerifiedMeasure: 1,
+          candidates: [entry("Alix", [subjectMeasure(measure(), "SEARCH_NOT_DONE")])],
+        })}
+      />
+    );
+    expect(screen.getByText(/Comparaison pas encore disponible/i)).toBeInTheDocument();
+    // Under the gate, no candidate column is rendered at all.
+    expect(screen.queryByRole("heading", { level: 2, name: "Alix" })).not.toBeInTheDocument();
+  });
+
+  it("rend le libellé de base de la relation aux votes", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ id: "m-x" }), "NO_VOTE_IN_SCOPE")]),
+            entry("Bruno", [subjectMeasure(measure({ id: "m-y" }), "SEARCH_NOT_DONE")]),
+          ],
+        })}
+      />
+    );
+    const alix = screen.getByRole("heading", { level: 2, name: "Alix" }).closest("article");
+    expect(
+      within(alix as HTMLElement).getByText(/périmètre examiné sans résultat/)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -22,7 +22,26 @@ function measure(over: Partial<PublicMeasure> = {}): PublicMeasure {
   };
 }
 
-function candidate(name: string): SubjectCandidateEntry["candidate"] {
+function source(
+  over: Partial<PublicMeasure["sources"][number]> = {}
+): PublicMeasure["sources"][number] {
+  return {
+    id: "s-1",
+    measureRevisionId: "rev-1",
+    sourceKind: "PROGRAMME_PARTI",
+    tier: "PRIMARY",
+    url: "https://example.org/programme.pdf",
+    page: null,
+    publishedAt: new Date("2027-01-15T00:00:00Z"),
+    createdAt: new Date("2027-01-16T00:00:00Z"),
+    ...over,
+  };
+}
+
+function candidate(
+  name: string,
+  over: Partial<SubjectCandidateEntry["candidate"]> = {}
+): SubjectCandidateEntry["candidate"] {
   return {
     id: `cand-${name}`,
     candidateName: name,
@@ -33,11 +52,16 @@ function candidate(name: string): SubjectCandidateEntry["candidate"] {
     slogan: null,
     accentColor: null,
     declaredAt: null,
+    ...over,
   };
 }
 
-function entry(name: string, measures: SubjectCandidateEntry["measures"]): SubjectCandidateEntry {
-  return { candidate: candidate(name), measures };
+function entry(
+  name: string,
+  measures: SubjectCandidateEntry["measures"],
+  candidateOver: Partial<SubjectCandidateEntry["candidate"]> = {}
+): SubjectCandidateEntry {
+  return { candidate: candidate(name, candidateOver), measures };
 }
 
 function subjectMeasure(
@@ -162,5 +186,43 @@ describe("SubjectComparison", () => {
     expect(
       within(alix as HTMLElement).getByText(/périmètre examiné sans résultat/)
     ).toBeInTheDocument();
+  });
+
+  it("affiche les preuves d'une mesure : source cliquable, nature, niveau et date", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(measure({ id: "m-s", sources: [source()] }), "SEARCH_NOT_DONE"),
+            ]),
+          ],
+        })}
+      />
+    );
+    const link = screen.getByRole("link", { name: "Programme de parti" });
+    expect(link).toHaveAttribute("href", "https://example.org/programme.pdf");
+    const li = link.closest("li");
+    expect(li).toHaveTextContent("Source primaire");
+    expect(li).toHaveTextContent(/janvier 2027/);
+  });
+
+  it("rend la source de déclaration de la candidature depuis sa colonne", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure(), "SEARCH_NOT_DONE")], {
+              sourceUrl: "https://example.org/annonce",
+              sourceLabel: "Discours du 1er mars",
+            }),
+          ],
+        })}
+      />
+    );
+    expect(screen.getByRole("link", { name: "Discours du 1er mars" })).toHaveAttribute(
+      "href",
+      "https://example.org/annonce"
+    );
   });
 });

--- a/src/app/presidentielle-2027/sujets/[theme]/page.tsx
+++ b/src/app/presidentielle-2027/sujets/[theme]/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { getSubjectPageData } from "@/lib/data/subject-page";
+import { SubjectComparison } from "./_components/SubjectComparison";
+
+// ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
+export const revalidate = 86400;
+
+const ELECTION_SLUG = "presidentielle-2027";
+
+/** URL slug (logement-urbanisme) <-> enum (LOGEMENT_URBANISME), deterministic in both directions. */
+function parseThemeParam(param: string): ThemeCategory | null {
+  const candidate = param.toUpperCase().replace(/-/g, "_");
+  return candidate in THEME_CATEGORY_LABELS ? (candidate as ThemeCategory) : null;
+}
+
+interface PageProps {
+  params: Promise<{ theme: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { theme: themeParam } = await params;
+  const theme = parseThemeParam(themeParam);
+  if (theme === null) {
+    return {
+      title: "Sujet introuvable | Présidentielle 2027",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const data = await getSubjectPageData(ELECTION_SLUG, theme);
+  const label = THEME_CATEGORY_LABELS[theme];
+  // The subject page stays out of the index until it clears its publication gate (spec §4): below the
+  // gate there is no comparison to index, only an explicit "not yet available" state.
+  const publishable = data?.publishable ?? false;
+
+  return {
+    title: `${label} : les mesures des candidats | Présidentielle 2027`,
+    description: `Ce que les candidats à la présidentielle 2027 proposent sur le thème ${label}.`,
+    robots: publishable ? undefined : { index: false, follow: false },
+  };
+}
+
+export default async function SubjectPage({ params }: PageProps) {
+  const { theme: themeParam } = await params;
+  const theme = parseThemeParam(themeParam);
+  if (theme === null) notFound();
+
+  const data = await getSubjectPageData(ELECTION_SLUG, theme);
+  if (data === null) notFound();
+
+  return <SubjectComparison data={data} />;
+}

--- a/src/components/measures/QualifiedEmptyCell.stories.tsx
+++ b/src/components/measures/QualifiedEmptyCell.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { QualifiedEmptyCell, type MeasureAbsence } from "./QualifiedEmptyCell";
+
+const meta: Meta<typeof QualifiedEmptyCell> = {
+  title: "Measures/QualifiedEmptyCell",
+  component: QualifiedEmptyCell,
+};
+export default meta;
+
+type Story = StoryObj<typeof QualifiedEmptyCell>;
+
+const ALL: MeasureAbsence[] = [
+  {
+    kind: "no_vote_identified",
+    checkedAt: new Date("2026-08-04T00:00:00Z"),
+    scope: "à l'Assemblée, législatures 16 et 17",
+  },
+  { kind: "never_sat" },
+  { kind: "never_held_office" },
+  { kind: "no_measure_published", theme: "LOGEMENT_URBANISME" },
+  { kind: "not_reviewed" },
+  { kind: "insufficient_context" },
+  { kind: "not_applicable", reason: "Le sujet ne concerne pas cette candidature" },
+];
+
+export const NoVoteIdentified: Story = { args: { absence: ALL[0] } };
+export const NeverSat: Story = { args: { absence: ALL[1] } };
+export const NoMeasurePublished: Story = { args: { absence: ALL[3] } };
+export const NotApplicable: Story = { args: { absence: ALL[6] } };
+
+export const AllVariants: Story = {
+  render: () => (
+    <ul className="space-y-2">
+      {ALL.map((absence) => (
+        <li key={absence.kind}>
+          <QualifiedEmptyCell absence={absence} />
+        </li>
+      ))}
+    </ul>
+  ),
+};

--- a/src/components/measures/QualifiedEmptyCell.test.tsx
+++ b/src/components/measures/QualifiedEmptyCell.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { QualifiedEmptyCell, type MeasureAbsence } from "./QualifiedEmptyCell";
+
+const ALL: MeasureAbsence[] = [
+  {
+    kind: "no_vote_identified",
+    checkedAt: new Date("2026-08-04T00:00:00Z"),
+    scope: "à l'Assemblée, législatures 16 et 17",
+  },
+  { kind: "never_sat" },
+  { kind: "never_held_office" },
+  { kind: "no_measure_published", theme: "LOGEMENT_URBANISME" },
+  { kind: "not_reviewed" },
+  { kind: "insufficient_context" },
+  { kind: "not_applicable", reason: "Le sujet ne concerne pas cette candidature" },
+];
+
+describe("QualifiedEmptyCell", () => {
+  it("rend un libellé non vide pour chacune des sept absences", () => {
+    for (const absence of ALL) {
+      const { container, unmount } = render(<QualifiedEmptyCell absence={absence} />);
+      const text = container.textContent?.trim() ?? "";
+      expect(text.length).toBeGreaterThan(1);
+      // Jamais une cellule vide ni un tiret seul.
+      expect(text).not.toBe("-");
+      expect(text).not.toBe("—");
+      unmount();
+    }
+  });
+
+  it("no_vote_identified porte son périmètre et sa date, jamais une vérité intemporelle", () => {
+    render(
+      <QualifiedEmptyCell
+        absence={{
+          kind: "no_vote_identified",
+          checkedAt: new Date("2026-08-04T00:00:00Z"),
+          scope: "à l'Assemblée, législatures 16 et 17",
+        }}
+      />
+    );
+    expect(screen.getByText(/à l'Assemblée, législatures 16 et 17/)).toBeInTheDocument();
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("no_measure_published nomme le thème", () => {
+    render(
+      <QualifiedEmptyCell absence={{ kind: "no_measure_published", theme: "LOGEMENT_URBANISME" }} />
+    );
+    // Le libellé du thème vient de THEME_CATEGORY_LABELS, pas d'un littéral.
+    expect(screen.getByText(/logement/i)).toBeInTheDocument();
+  });
+
+  it("not_applicable affiche sa raison", () => {
+    render(
+      <QualifiedEmptyCell
+        absence={{ kind: "not_applicable", reason: "Le sujet ne concerne pas cette candidature" }}
+      />
+    );
+    expect(screen.getByText(/ne concerne pas cette candidature/)).toBeInTheDocument();
+  });
+});

--- a/src/components/measures/QualifiedEmptyCell.tsx
+++ b/src/components/measures/QualifiedEmptyCell.tsx
@@ -1,0 +1,59 @@
+import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+
+/**
+ * The seven typed absences (spec §9.1). The point of this component is that an empty cell is never
+ * ambiguous: "personne n'a encore regardé" and "on a regardé, rien trouvé" are different facts and get
+ * different labels. Adding a `kind` without handling it below is a compile error (the `never` default),
+ * the same guarantee as the non-`Partial` Record on affair statuses.
+ */
+export type MeasureAbsence =
+  | { kind: "no_vote_identified"; checkedAt: Date; scope: string }
+  | { kind: "never_sat" }
+  | { kind: "never_held_office" }
+  | { kind: "no_measure_published"; theme: ThemeCategory }
+  | { kind: "not_reviewed" }
+  | { kind: "insufficient_context" }
+  | { kind: "not_applicable"; reason: string };
+
+function formatDateFr(date: Date): string {
+  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
+}
+
+export function measureAbsenceLabel(absence: MeasureAbsence): string {
+  switch (absence.kind) {
+    case "no_vote_identified":
+      return `Aucun vote identifié ${absence.scope}, vérifié le ${formatDateFr(absence.checkedAt)}`;
+    case "never_sat":
+      return "N'a jamais siégé";
+    case "never_held_office":
+      return "N'a jamais exercé de mandat";
+    case "no_measure_published":
+      return `Aucune mesure publiée sur ${THEME_CATEGORY_LABELS[absence.theme]}`;
+    case "not_reviewed":
+      return "Pas encore relu";
+    case "insufficient_context":
+      return "Pas assez d'éléments publiés";
+    case "not_applicable":
+      return absence.reason;
+    default: {
+      const exhaustive: never = absence;
+      return exhaustive;
+    }
+  }
+}
+
+export function QualifiedEmptyCell({
+  absence,
+  className,
+}: {
+  absence: MeasureAbsence;
+  className?: string;
+}) {
+  const base = "text-sm text-muted-foreground";
+  return (
+    <span className={className ? `${base} ${className}` : base} data-absence-kind={absence.kind}>
+      {measureAbsenceLabel(absence)}
+    </span>
+  );
+}

--- a/src/components/measures/VoteRelationBadge.stories.tsx
+++ b/src/components/measures/VoteRelationBadge.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { VoteRelation } from "@/lib/measures/vote-relation";
+import { VoteRelationBadge } from "./VoteRelationBadge";
+
+const meta: Meta<typeof VoteRelationBadge> = {
+  title: "Measures/VoteRelationBadge",
+  component: VoteRelationBadge,
+};
+export default meta;
+
+type Story = StoryObj<typeof VoteRelationBadge>;
+
+const ALL: VoteRelation[] = [
+  "FAVORABLE_SAME_OBJECT",
+  "DEFAVORABLE_SAME_OBJECT",
+  "ABSTENTION_SAME_OBJECT",
+  "ABSENCE_SAME_OBJECT",
+  "DIFFERENT_POSITIONS",
+  "BROADER_TEXT",
+  "NOT_RECHECKED_SINCE_REFORMULATION",
+  "NO_VOTE_IN_SCOPE",
+  "SEARCH_NOT_DONE",
+];
+
+export const Favorable: Story = {
+  args: {
+    relation: "FAVORABLE_SAME_OBJECT",
+    basisDetails: "scrutin no 1234, Assemblée, législature 17, vérifié le 4 août 2026",
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <ul className="space-y-3">
+      {ALL.map((relation) => (
+        <li key={relation}>
+          <VoteRelationBadge relation={relation} />
+        </li>
+      ))}
+    </ul>
+  ),
+};

--- a/src/components/measures/VoteRelationBadge.test.tsx
+++ b/src/components/measures/VoteRelationBadge.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { VoteRelation } from "@/lib/measures/vote-relation";
+import { VoteRelationBadge } from "./VoteRelationBadge";
+
+const ALL: VoteRelation[] = [
+  "FAVORABLE_SAME_OBJECT",
+  "DEFAVORABLE_SAME_OBJECT",
+  "ABSTENTION_SAME_OBJECT",
+  "ABSENCE_SAME_OBJECT",
+  "DIFFERENT_POSITIONS",
+  "BROADER_TEXT",
+  "NOT_RECHECKED_SINCE_REFORMULATION",
+  "NO_VOTE_IN_SCOPE",
+  "SEARCH_NOT_DONE",
+];
+
+describe("VoteRelationBadge", () => {
+  it("rend chacun des neuf états sans cellule vide ni tiret seul", () => {
+    for (const relation of ALL) {
+      const { container, unmount } = render(<VoteRelationBadge relation={relation} />);
+      const text = container.textContent?.trim() ?? "";
+      expect(text.length).toBeGreaterThan(1);
+      expect(text).not.toBe("-");
+      expect(text).not.toBe("—");
+      unmount();
+    }
+  });
+
+  it("un état de position sur le même objet porte une pastille de position et sa base", () => {
+    const { container } = render(<VoteRelationBadge relation="FAVORABLE_SAME_OBJECT" />);
+    expect(container.querySelector("[data-vote-position]")).not.toBeNull();
+    expect(screen.getByText("Pour")).toBeInTheDocument();
+    expect(screen.getByText(/même objet/)).toBeInTheDocument();
+  });
+
+  it("un état sans position ne porte aucune pastille de position", () => {
+    const { container } = render(<VoteRelationBadge relation="BROADER_TEXT" />);
+    expect(container.querySelector("[data-vote-position]")).toBeNull();
+    expect(screen.getByText(/texte plus large/)).toBeInTheDocument();
+  });
+
+  it("ni abstention ni absence ne rendent le libellé Contre", () => {
+    const abst = render(<VoteRelationBadge relation="ABSTENTION_SAME_OBJECT" />);
+    expect(abst.queryByText("Contre")).toBeNull();
+    abst.unmount();
+    const abs = render(<VoteRelationBadge relation="ABSENCE_SAME_OBJECT" />);
+    expect(abs.queryByText("Contre")).toBeNull();
+  });
+
+  it("recherche non effectuée s'affiche comme périmètre non examiné, jamais comme une position", () => {
+    const { container } = render(<VoteRelationBadge relation="SEARCH_NOT_DONE" />);
+    expect(container.querySelector("[data-vote-position]")).toBeNull();
+    expect(screen.getByText(/périmètre non examiné/)).toBeInTheDocument();
+  });
+
+  it("le détail sourcé est rendu quand il est fourni", () => {
+    render(
+      <VoteRelationBadge
+        relation="FAVORABLE_SAME_OBJECT"
+        basisDetails="scrutin no 1234, Assemblée, législature 17, vérifié le 4 août 2026"
+      />
+    );
+    expect(screen.getByText(/scrutin no 1234/)).toBeInTheDocument();
+  });
+});

--- a/src/components/measures/VoteRelationBadge.tsx
+++ b/src/components/measures/VoteRelationBadge.tsx
@@ -1,0 +1,45 @@
+import type { VoteRelation } from "@/lib/measures/vote-relation";
+import {
+  VOTE_RELATION_BASIS_LABELS,
+  VOTE_RELATION_PILL_CLASS,
+  VOTE_RELATION_POSITION_LABELS,
+} from "@/config/labels";
+
+/**
+ * The nine states of `deriveVoteRelation()` on two axes (spec §9.2): a short position pill (only when
+ * there is a position to state) and a longer, sourced basis line. Keeping the two on separate lines is
+ * what let the column fit; the decomposition does not change the nine states.
+ *
+ * `basisDetails` carries the sourced detail (scrutin number, chamber, legislatures, verification date).
+ * It is composed by the caller from the reference link, since `deriveVoteRelation()` is pure and does
+ * not carry link metadata.
+ */
+export function VoteRelationBadge({
+  relation,
+  basisDetails,
+  className,
+}: {
+  relation: VoteRelation;
+  basisDetails?: string;
+  className?: string;
+}) {
+  const position = VOTE_RELATION_POSITION_LABELS[relation];
+  const basis = VOTE_RELATION_BASIS_LABELS[relation];
+  const pill = VOTE_RELATION_PILL_CLASS[relation];
+
+  return (
+    <span className={className ? `flex flex-col gap-0.5 ${className}` : "flex flex-col gap-0.5"}>
+      {position !== null && (
+        <span
+          data-vote-position
+          className={`inline-flex w-fit items-center rounded-full px-2 py-0.5 text-xs font-medium ${pill}`}
+        >
+          {position}
+        </span>
+      )}
+      <span className="text-xs text-muted-foreground">
+        {basisDetails ? `${basis} : ${basisDetails}` : basis}
+      </span>
+    </span>
+  );
+}

--- a/src/config/__tests__/publication-gates.test.ts
+++ b/src/config/__tests__/publication-gates.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLICATION_GATES,
+  isFicheCandidatPublishable,
+  isHubPublishable,
+  isSubjectPagePublishable,
+} from "../publication-gates";
+
+/**
+ * Policy v1 locked. These are validated editorial thresholds, not proposals: a change here changes what
+ * gets published and indexed, so the values are asserted verbatim to make any drift a deliberate,
+ * reviewed edit.
+ */
+describe("publication-gates : politique v1 verrouillée", () => {
+  it("porte exactement les seuils arbitrés", () => {
+    expect(PUBLICATION_GATES.ficheCandidat.minVerifiedMeasuresWithPrimarySource).toBe(1);
+    expect(PUBLICATION_GATES.ficheCandidat.requiresSourcedStatus).toBe(true);
+    expect(PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure).toBe(2);
+    expect(PUBLICATION_GATES.priorites.minVerifiedMeasures).toBe(15);
+    expect(PUBLICATION_GATES.priorites.minThemesCovered).toBe(5);
+    expect(PUBLICATION_GATES.priorites.totalThemes).toBe(13);
+    expect(PUBLICATION_GATES.priorites.minPrimarySourceShare).toBe(0.6);
+    expect(PUBLICATION_GATES.priorites.maxCoverageRatio).toBe(3);
+    expect(PUBLICATION_GATES.questions.minReviewedQuestions).toBe(30);
+    expect(PUBLICATION_GATES.hub.minPublishableSubjectPages).toBe(1);
+  });
+});
+
+describe("publication-gates : évaluateurs au seuil et en dessous", () => {
+  it("page sujet : publiable à 2 candidatures, pas à 1", () => {
+    expect(isSubjectPagePublishable(2)).toBe(true);
+    expect(isSubjectPagePublishable(1)).toBe(false);
+    expect(isSubjectPagePublishable(0)).toBe(false);
+  });
+
+  it("fiche candidat : exige un statut sourcé ET une mesure vérifiée à source primaire", () => {
+    expect(
+      isFicheCandidatPublishable({ statusSourced: true, verifiedMeasuresWithPrimarySource: 1 })
+    ).toBe(true);
+    expect(
+      isFicheCandidatPublishable({ statusSourced: false, verifiedMeasuresWithPrimarySource: 3 })
+    ).toBe(false);
+    expect(
+      isFicheCandidatPublishable({ statusSourced: true, verifiedMeasuresWithPrimarySource: 0 })
+    ).toBe(false);
+  });
+
+  it("hub : publiable dès une page sujet publiable", () => {
+    expect(isHubPublishable(1)).toBe(true);
+    expect(isHubPublishable(0)).toBe(false);
+  });
+});

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -43,6 +43,7 @@ import type {
   PublicationState,
   VisibilityBlocker,
 } from "@/lib/measures/moderation-state";
+import type { VoteRelation } from "@/lib/measures/vote-relation";
 
 // Nombre de sièges à l'Assemblée nationale (XVIIe législature)
 export const AN_SEAT_COUNT = 577;
@@ -645,6 +646,50 @@ export const VOTE_POSITION_DOT_COLORS: Record<VotePosition, string> = {
   ABSTENTION: "bg-yellow-500",
   NON_VOTANT: "bg-gray-500",
   ABSENT: "bg-gray-400",
+};
+
+// ============================================
+// MEASURE VOTE RELATION (VoteRelationBadge, spec §9.2)
+// ============================================
+
+// Two axes, one label each, per the nine states of deriveVoteRelation(). The position axis is short and
+// null when there is nothing to assert. The basis axis is always present.
+export const VOTE_RELATION_POSITION_LABELS: Record<VoteRelation, string | null> = {
+  FAVORABLE_SAME_OBJECT: "Pour",
+  DEFAVORABLE_SAME_OBJECT: "Contre",
+  ABSTENTION_SAME_OBJECT: "Abstention",
+  ABSENCE_SAME_OBJECT: "Absence",
+  DIFFERENT_POSITIONS: "Positions différentes",
+  BROADER_TEXT: null,
+  NOT_RECHECKED_SINCE_REFORMULATION: null,
+  NO_VOTE_IN_SCOPE: null,
+  SEARCH_NOT_DONE: null,
+};
+
+export const VOTE_RELATION_BASIS_LABELS: Record<VoteRelation, string> = {
+  FAVORABLE_SAME_OBJECT: "même objet",
+  DEFAVORABLE_SAME_OBJECT: "même objet",
+  ABSTENTION_SAME_OBJECT: "même objet",
+  ABSENCE_SAME_OBJECT: "même objet",
+  DIFFERENT_POSITIONS: "même objet, plusieurs scrutins",
+  BROADER_TEXT: "texte plus large",
+  NOT_RECHECKED_SINCE_REFORMULATION: "reformulée depuis",
+  NO_VOTE_IN_SCOPE: "périmètre examiné sans résultat",
+  SEARCH_NOT_DONE: "périmètre non examiné",
+};
+
+// Solid pill, white text. Hex values are the AA-verified variants of spec §9.2 (ratios >= 4,5:1 on white
+// text): #3d7a4e (5,13), #9e5454 (5,45), #6b7078 (4,98). Empty for the states with no position pill.
+export const VOTE_RELATION_PILL_CLASS: Record<VoteRelation, string> = {
+  FAVORABLE_SAME_OBJECT: "bg-[#3d7a4e] text-white",
+  DEFAVORABLE_SAME_OBJECT: "bg-[#9e5454] text-white",
+  ABSTENTION_SAME_OBJECT: "bg-[#6b7078] text-white",
+  ABSENCE_SAME_OBJECT: "bg-[#6b7078] text-white",
+  DIFFERENT_POSITIONS: "bg-[#6b7078] text-white",
+  BROADER_TEXT: "",
+  NOT_RECHECKED_SINCE_REFORMULATION: "",
+  NO_VOTE_IN_SCOPE: "",
+  SEARCH_NOT_DONE: "",
 };
 
 export const VOTING_RESULT_LABELS: Record<VotingResult, string> = {

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -34,6 +34,8 @@ import type {
   MeasureExtractionMethod,
   MeasurePrecision,
   MeasureSourceKind,
+  MeasureVoteLinkKind,
+  MeasureVoteRelation,
   QualificationKind,
   SimilarityConclusion,
   SourceTier,
@@ -690,6 +692,24 @@ export const VOTE_RELATION_PILL_CLASS: Record<VoteRelation, string> = {
   NOT_RECHECKED_SINCE_REFORMULATION: "",
   NO_VOTE_IN_SCOPE: "",
   SEARCH_NOT_DONE: "",
+};
+
+// The reviewer-recorded relation of the candidate to the measure on an identified scrutin (raw
+// MeasureVoteRelation, spec §5.8), for the admin attachment screen. ABSENCE means "an existing scrutin
+// on the same object, in which the person did not take part": it is a relation on a chosen scrutin,
+// never "no scrutin found". That other case is a MeasureVoteLinkKind (NO_VOTE_IDENTIFIED), not a relation.
+export const MEASURE_VOTE_RELATION_LABELS: Record<MeasureVoteRelation, string> = {
+  FAVORABLE: "Favorable à la mesure",
+  DEFAVORABLE: "Défavorable à la mesure",
+  ABSTENTION: "Abstention",
+  ABSENCE: "Absent(e) au scrutin",
+};
+
+// The object relationship between a scrutin and the measure (MeasureVoteLinkKind, spec §5.8).
+export const MEASURE_VOTE_LINK_KIND_LABELS: Record<MeasureVoteLinkKind, string> = {
+  SAME_OBJECT: "Scrutin sur le même objet que la mesure",
+  BROADER_TEXT: "Scrutin sur un texte plus large contenant la mesure",
+  NO_VOTE_IDENTIFIED: "Aucun scrutin pertinent trouvé dans le périmètre",
 };
 
 export const VOTING_RESULT_LABELS: Record<VotingResult, string> = {

--- a/src/config/publication-gates.ts
+++ b/src/config/publication-gates.ts
@@ -1,0 +1,62 @@
+/**
+ * Publication gates, policy v1 (spec §4, arbitrated by Lamine on 2026-08-06).
+ *
+ * One place, evaluated by the data layer. A surface below its gate renders an explicit state and is
+ * `robots: noindex`; it never renders a silently degraded comparison. These are validated values, not
+ * proposals: changing one changes editorial policy, so it belongs here and nowhere else.
+ */
+
+export const PUBLICATION_GATES = {
+  /** Fiche candidat : sourced status and at least one verified measure backed by a primary source. */
+  ficheCandidat: {
+    requiresSourcedStatus: true,
+    minVerifiedMeasuresWithPrimarySource: 1,
+  },
+  /** Page sujet comparable : at least two candidacies with a verified measure on the subject. */
+  pageSujet: {
+    minCandidaciesWithVerifiedMeasure: 2,
+  },
+  /** Page priorités : the four cumulative conditions per included candidacy. */
+  priorites: {
+    minVerifiedMeasures: 15,
+    minThemesCovered: 5,
+    totalThemes: 13,
+    minPrimarySourceShare: 0.6,
+    /** Ratio between the best and least documented candidacy included. */
+    maxCoverageRatio: 3,
+  },
+  /** Questions : reviewed count, validated search test set, applied retention policy. */
+  questions: {
+    minReviewedQuestions: 30,
+    requiresValidatedTestSet: true,
+    requiresRetentionPolicy: true,
+  },
+  /** Hub racine : publishable as soon as at least one subject page is. */
+  hub: {
+    minPublishableSubjectPages: 1,
+  },
+} as const;
+
+/** A subject page is comparable once enough candidacies have a verified measure on the subject. */
+export function isSubjectPagePublishable(candidaciesWithVerifiedMeasure: number): boolean {
+  return (
+    candidaciesWithVerifiedMeasure >= PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure
+  );
+}
+
+/** A candidate fiche exists once the status is sourced and at least one primary-sourced measure is verified. */
+export function isFicheCandidatPublishable(params: {
+  statusSourced: boolean;
+  verifiedMeasuresWithPrimarySource: number;
+}): boolean {
+  return (
+    params.statusSourced &&
+    params.verifiedMeasuresWithPrimarySource >=
+      PUBLICATION_GATES.ficheCandidat.minVerifiedMeasuresWithPrimarySource
+  );
+}
+
+/** The root hub is publishable once at least one subject page is. */
+export function isHubPublishable(publishableSubjectPages: number): boolean {
+  return publishableSubjectPages >= PUBLICATION_GATES.hub.minPublishableSubjectPages;
+}

--- a/src/lib/data/__tests__/presidential-candidates-public.integration.test.ts
+++ b/src/lib/data/__tests__/presidential-candidates-public.integration.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred so the file skips cleanly without the container: @/lib/db throws at module load when
+// DATABASE_URL is unset, and describe.skip does not undo a static import.
+let db: typeof import("@/lib/db").db;
+let getPublicPresidentialCandidates: typeof import("@/lib/data/presidential-candidates-public").getPublicPresidentialCandidates;
+
+const SLUG = "presidentielle-test-cand-public";
+
+/**
+ * The sensitive invariant of this authority: a candidacy whose presidential extension is missing or
+ * DRAFT never surfaces publicly. The test builds the violation (a DRAFT candidacy and one with no
+ * extension both exist alongside a published one) and asserts only the published one comes back.
+ */
+describeIfDisposableDb("autorité de lecture publique des candidatures présidentielles", () => {
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getPublicPresidentialCandidates } =
+      await import("@/lib/data/presidential-candidates-public"));
+
+    const election = await db.election.create({
+      data: {
+        slug: SLUG,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Test candidatures publiques",
+      },
+    });
+    electionId = election.id;
+
+    const polPub = await db.politician.create({
+      data: { slug: `${SLUG}-a`, firstName: "Alix", lastName: "Publiee", fullName: "Alix Publiee" },
+    });
+    const polDraft = await db.politician.create({
+      data: { slug: `${SLUG}-b`, firstName: "Bo", lastName: "Brouillon", fullName: "Bo Brouillon" },
+    });
+    const polNoExt = await db.politician.create({
+      data: { slug: `${SLUG}-c`, firstName: "Cam", lastName: "Sansext", fullName: "Cam Sansext" },
+    });
+
+    const candPub = await db.candidacy.create({
+      data: {
+        electionId,
+        politicianId: polPub.id,
+        candidateName: "Alix Publiee",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/a",
+        sourceLabel: "Source A",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candPub.id, publicationStatus: "PUBLISHED", slogan: "Slogan A" },
+    });
+
+    const candDraft = await db.candidacy.create({
+      data: {
+        electionId,
+        politicianId: polDraft.id,
+        candidateName: "Bo Brouillon",
+        status: "DECLARE",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candDraft.id, publicationStatus: "DRAFT" },
+    });
+
+    // Une candidature sans extension éditoriale du tout : elle ne doit jamais sortir non plus.
+    await db.candidacy.create({
+      data: {
+        electionId,
+        politicianId: polNoExt.id,
+        candidateName: "Cam Sansext",
+        status: "DECLARE",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  it("ne renvoie que les candidatures dont l'extension est PUBLISHED", async () => {
+    const result = await getPublicPresidentialCandidates(SLUG);
+    expect(result.map((c) => c.candidateName)).toEqual(["Alix Publiee"]);
+  });
+
+  it("expose slogan et source, jamais un brouillon ni une candidature sans extension", async () => {
+    const result = await getPublicPresidentialCandidates(SLUG);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.slogan).toBe("Slogan A");
+    expect(result[0]?.sourceLabel).toBe("Source A");
+    expect(result[0]?.status).toBe("DECLARE");
+  });
+});

--- a/src/lib/data/__tests__/presidentielle-subject-demo.ts
+++ b/src/lib/data/__tests__/presidentielle-subject-demo.ts
@@ -1,0 +1,92 @@
+import { assertDisposableTestDb } from "@/test/disposable-db";
+
+/**
+ * Seeds a fictional, publishable subject page for the presidential 2027 hub.
+ *
+ * It lives in a __tests__ folder on purpose: it writes `publicationStatus: "PUBLISHED"` directly on
+ * CandidacyPresidential, which has no transition of its own, so that literal belongs where the publication
+ * guard allows it, alongside the integration fixtures. It is the demo counterpart of
+ * `subject-page.integration.test.ts`, consumed by scripts/seed-presidentielle-sujet-demo.ts for a live
+ * responsive/axe review.
+ *
+ * assertDisposableTestDb() is the safety net: `.env` and `.env.prod` share the same database, so an
+ * ungated run would fabricate candidacies and measures in production.
+ */
+
+const ELECTION_SLUG = "presidentielle-2027";
+const THEME = "LOGEMENT_URBANISME" as const;
+
+export async function seedPresidentielleSubjectDemo(): Promise<{ electionId: string }> {
+  assertDisposableTestDb();
+
+  const { db } = await import("@/lib/db");
+  const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
+    await import("@/lib/measures/transitions");
+
+  const election = await db.election.create({
+    data: {
+      slug: ELECTION_SLUG,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Présidentielle 2027",
+    },
+  });
+
+  async function publishedCandidate(name: string, text: string | null): Promise<void> {
+    const slug = `demo-${name.toLowerCase()}`;
+    const politician = await db.politician.create({
+      data: { slug, firstName: name, lastName: "Démo", fullName: `${name} Démo` },
+    });
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: politician.id,
+        candidateName: `${name} Démo`,
+        status: "DECLARE",
+        sourceUrl: "https://example.org/annonce",
+        sourceLabel: "Discours de déclaration",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED", slogan: `Slogan ${name}` },
+    });
+
+    if (text === null) return;
+
+    const seeded = await createMeasure({
+      politicianId: politician.id,
+      electionId: election.id,
+      candidacyId: candidacy.id,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: THEME,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    await reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+    await publishMeasureRevision(seeded);
+  }
+
+  // Two candidacies with a defended measure clear the page-sujet gate; a third has none (absence).
+  await publishedCandidate("Alix", "Encadrer les loyers dans les zones tendues.");
+  await publishedCandidate("Bruno", "Construire 500 000 logements sociaux sur le quinquennat.");
+  await publishedCandidate("Chloé", null);
+
+  return { electionId: election.id };
+}

--- a/src/lib/data/__tests__/subject-page.integration.test.ts
+++ b/src/lib/data/__tests__/subject-page.integration.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value, which throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let loadSubjectPageData: typeof import("@/lib/data/subject-page").loadSubjectPageData;
+let transitions: typeof import("@/lib/measures/transitions");
+let createMeasureVoteLink: typeof import("@/lib/measures/vote-links").createMeasureVoteLink;
+
+const SLUG = "presidentielle-sujet-test";
+const THEME = "LOGEMENT_URBANISME" as const;
+
+/**
+ * The subject page reads only through public authorities. The violation is built first: a DRAFT-extension
+ * candidacy and an unpublished (draft) measure both exist, and neither may surface. Alongside them, two
+ * candidacies with a defended published measure clear the gate, one candidacy has none (a qualified
+ * absence), and a withdrawn measure stays visible.
+ */
+describeIfDisposableDb("page sujet publique : agrégation des données", () => {
+  let electionId: string;
+  const alix = { candidacyId: "", politicianId: "", defendedMeasureId: "", defendedRevisionId: "" };
+  let bruno = { candidacyId: "", politicianId: "" };
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ loadSubjectPageData } = await import("@/lib/data/subject-page"));
+    transitions = await import("@/lib/measures/transitions");
+    ({ createMeasureVoteLink } = await import("@/lib/measures/vote-links"));
+
+    const election = await db.election.create({
+      data: { slug: SLUG, type: "PRESIDENTIELLE", scope: "NATIONAL", title: "Sujet test" },
+    });
+    electionId = election.id;
+
+    async function publishedCandidate(name: string) {
+      const slug = `${SLUG}-${name.toLowerCase()}`;
+      const politician = await db.politician.create({
+        data: { slug, firstName: name, lastName: "Test", fullName: `${name} Test` },
+      });
+      const candidacy = await db.candidacy.create({
+        data: {
+          electionId,
+          politicianId: politician.id,
+          candidateName: `${name} Test`,
+          status: "DECLARE",
+          sourceUrl: "https://example.org/source",
+          sourceLabel: "Source",
+        },
+      });
+      await db.candidacyPresidential.create({
+        data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED" },
+      });
+      return { candidacyId: candidacy.id, politicianId: politician.id };
+    }
+
+    async function publishMeasure(politicianId: string, candidacyId: string, text: string) {
+      const seeded = await transitions.createMeasure({
+        politicianId,
+        electionId,
+        candidacyId,
+        programEditionId: null,
+        attribution: "PERSONAL",
+        theme: THEME,
+        precedingMeasureId: null,
+        revision: {
+          text,
+          precision: "OBJECTIF_SANS_CHIFFRE",
+          validFrom: new Date("2027-01-01T00:00:00Z"),
+          extractionMethod: "MANUAL",
+          extractionConfidence: null,
+          extractorVersion: null,
+        },
+        sources: [
+          {
+            sourceKind: "DISCOURS_CAMPAGNE",
+            tier: "PRIMARY",
+            url: "https://example.org/meeting",
+            page: null,
+            publishedAt: new Date("2027-01-01T00:00:00Z"),
+          },
+        ],
+      });
+      await transitions.reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+      await transitions.publishMeasureRevision(seeded);
+      return seeded;
+    }
+
+    // Alix: a defended measure (with a NO_VOTE_IDENTIFIED link) AND a withdrawn one AND a draft one.
+    const a = await publishedCandidate("Alix");
+    alix.candidacyId = a.candidacyId;
+    alix.politicianId = a.politicianId;
+    const defended = await publishMeasure(a.politicianId, a.candidacyId, "Encadrer les loyers.");
+    alix.defendedMeasureId = defended.measureId;
+    alix.defendedRevisionId = defended.revisionId;
+    await createMeasureVoteLink({
+      measureId: defended.measureId,
+      applicableRevisionId: defended.revisionId,
+      linkKind: "NO_VOTE_IDENTIFIED",
+      scrutinId: null,
+      relation: null,
+      isReference: false,
+      rationale: "Aucun scrutin pertinent dans le périmètre.",
+      checkedAt: new Date("2027-02-01T00:00:00Z"),
+      institutionScope: ["AN"],
+      legislatureScope: ["17"],
+      searchMethod: "Filtre par thème",
+      reviewedBy: "relecteur",
+    });
+
+    const withdrawn = await publishMeasure(
+      a.politicianId,
+      a.candidacyId,
+      "Geler les loyers un an."
+    );
+    const before = await db.measure.findUniqueOrThrow({
+      where: { id: withdrawn.measureId },
+      select: { updatedAt: true },
+    });
+    await transitions.withdrawMeasure({
+      measureId: withdrawn.measureId,
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait",
+      sourceLabel: "Communiqué de retrait",
+      expectedUpdatedAt: before.updatedAt,
+    });
+
+    // A draft measure that is never reviewed nor published: it must not surface.
+    await transitions.createMeasure({
+      politicianId: a.politicianId,
+      electionId,
+      candidacyId: a.candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: THEME,
+      precedingMeasureId: null,
+      revision: {
+        text: "Brouillon non publié.",
+        precision: null,
+        validFrom: new Date("2027-01-05T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "ARTICLE_PRESSE",
+          tier: "SECONDARY",
+          url: "https://example.org/article",
+          page: null,
+          publishedAt: new Date("2027-01-05T00:00:00Z"),
+        },
+      ],
+    });
+
+    // Bruno: one defended measure, so the gate reaches two candidacies.
+    bruno = await publishedCandidate("Bruno");
+    await publishMeasure(bruno.politicianId, bruno.candidacyId, "Construire 500 000 logements.");
+
+    // Chloe: a published candidacy with no measure on the theme, so a qualified absence.
+    await publishedCandidate("Chloe");
+
+    // Dora: a DRAFT-extension candidacy. The authority must never surface it.
+    const doraSlug = `${SLUG}-dora`;
+    const dora = await db.politician.create({
+      data: { slug: doraSlug, firstName: "Dora", lastName: "Test", fullName: "Dora Test" },
+    });
+    const doraCandidacy = await db.candidacy.create({
+      data: { electionId, politicianId: dora.id, candidateName: "Dora Test", status: "DECLARE" },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: doraCandidacy.id, publicationStatus: "DRAFT" },
+    });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  it("ne renvoie que les candidatures publiées, en ordre alphabétique, sans le brouillon Dora", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    expect(data.candidates.map((c) => c.candidate.candidateName)).toEqual([
+      "Alix Test",
+      "Bruno Test",
+      "Chloe Test",
+    ]);
+  });
+
+  it("rend une absence (aucune mesure) plutôt qu'un candidat silencieux", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    const chloe = data.candidates.find((c) => c.candidate.candidateName === "Chloe Test");
+    expect(chloe?.measures).toEqual([]);
+  });
+
+  it("garde une mesure retirée visible, et exclut le brouillon non publié", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    const alixEntry = data.candidates.find((c) => c.candidate.candidateName === "Alix Test");
+    // Two public measures (defended + withdrawn), never the draft.
+    expect(alixEntry?.measures).toHaveLength(2);
+    expect(alixEntry?.measures.some((m) => m.measure.withdrawal !== null)).toBe(true);
+    expect(alixEntry?.measures.some((m) => m.measure.text === "Brouillon non publié.")).toBe(false);
+  });
+
+  it("dérive la relation aux votes par mesure, sans jamais exposer de rationale", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    const alixEntry = data.candidates.find((c) => c.candidate.candidateName === "Alix Test");
+    const defended = alixEntry?.measures.find((m) => m.measure.id === alix.defendedMeasureId);
+    // A NO_VOTE_IDENTIFIED link is a dated constat, never "search not done".
+    expect(defended?.voteRelation).toBe("NO_VOTE_IN_SCOPE");
+    expect(defended?.voteReference).toBeNull();
+    // The public shape carries no editorial rationale field at all.
+    expect(defended && "rationale" in defended).toBe(false);
+
+    const bruno = data.candidates.find((c) => c.candidate.candidateName === "Bruno Test");
+    // No link at all is the only path to "search not done".
+    expect(bruno?.measures[0]?.voteRelation).toBe("SEARCH_NOT_DONE");
+  });
+
+  it("compte deux candidatures avec mesure défendue et ouvre le seuil de page sujet", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    // Alix and Bruno each defend a measure; Chloe has none; the withdrawn one does not count.
+    expect(data.candidaciesWithVerifiedMeasure).toBe(2);
+    expect(data.publishable).toBe(true);
+  });
+});

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -59,6 +59,8 @@ export type MeasureWithdrawal = {
  */
 export type PublicMeasure = {
   id: string;
+  /** The published revision this measure points at. Non-null here: the where clause requires it. */
+  publishedRevisionId: string;
   text: string;
   precision: PublishedRevision["precision"];
   theme: MeasureRow["theme"];
@@ -78,6 +80,7 @@ function toPublicMeasure(row: MeasureRow): PublicMeasure | null {
 
   return {
     id: row.id,
+    publishedRevisionId: revision.id,
     text: revision.text,
     precision: revision.precision,
     theme: row.theme,

--- a/src/lib/data/presidential-candidates-public.ts
+++ b/src/lib/data/presidential-candidates-public.ts
@@ -1,0 +1,60 @@
+import "server-only";
+import { db } from "@/lib/db";
+import type { CandidacyStatus, Prisma } from "@/generated/prisma";
+
+/**
+ * Public read authority for presidential candidacies.
+ *
+ * Mirrors `src/lib/data/measures.ts`: the visibility rule lives here and nowhere else, and a page must
+ * read through this function, never `db.candidacy.*` directly. The one rule that matters is that a
+ * candidacy whose editorial extension (`CandidacyPresidential`) is missing or `DRAFT` never surfaces.
+ * `getPresidentielle2027Candidates()` does NOT apply this filter and is admin-only.
+ *
+ * Plain async on purpose (no "use cache"), so it stays integration-testable; the page wraps its reads
+ * in a cached function, as the measures authority is wrapped.
+ */
+
+// A candidacy is publicly visible only when its presidential extension exists and is PUBLISHED. The
+// `is` filter excludes candidacies with no extension row, which is the common case today (11 rows exist
+// with zero published extensions).
+export const PUBLIC_CANDIDACY_WHERE = {
+  presidentialData: { is: { publicationStatus: "PUBLISHED" } },
+} satisfies Prisma.CandidacyWhereInput;
+
+export type PublicPresidentialCandidate = {
+  id: string;
+  candidateName: string;
+  politicianSlug: string | null;
+  status: CandidacyStatus | null;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+  slogan: string | null;
+  accentColor: string | null;
+  declaredAt: Date | null;
+};
+
+export async function getPublicPresidentialCandidates(
+  electionSlug: string
+): Promise<PublicPresidentialCandidate[]> {
+  const rows = await db.candidacy.findMany({
+    where: { election: { slug: electionSlug }, ...PUBLIC_CANDIDACY_WHERE },
+    include: {
+      presidentialData: true,
+      politician: { select: { slug: true } },
+    },
+    // Alphabetical by candidate name. No ranking, no proximity score.
+    orderBy: { candidateName: "asc" },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    candidateName: row.candidateName,
+    politicianSlug: row.politician?.slug ?? null,
+    status: row.status,
+    sourceUrl: row.sourceUrl,
+    sourceLabel: row.sourceLabel,
+    slogan: row.presidentialData?.slogan ?? null,
+    accentColor: row.presidentialData?.accentColor ?? null,
+    declaredAt: row.presidentialData?.declaredAt ?? null,
+  }));
+}

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -3,7 +3,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import type { ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isSubjectPagePublishable } from "@/config/publication-gates";
-import { getPublicMeasureVoteRelation, type PublicVoteReference } from "@/lib/measures/vote-links";
+import { getPublicMeasureVoteRelations, type PublicVoteReference } from "@/lib/measures/vote-links";
 import type { VoteRelation } from "@/lib/measures/vote-relation";
 import { getPublicMeasuresByTheme, type PublicMeasure } from "./measures";
 import {
@@ -70,20 +70,27 @@ export async function loadSubjectPageData(
     measuresByCandidacy.set(measure.candidacyId, list);
   }
 
+  // One batched read for every measure's vote relation, instead of one query per measure (N+1).
+  const relations = await getPublicMeasureVoteRelations(
+    measures.map((measure) => ({
+      measureId: measure.id,
+      publishedRevisionId: measure.publishedRevisionId,
+    }))
+  );
+
   const entries: SubjectCandidateEntry[] = [];
   let candidaciesWithVerifiedMeasure = 0;
 
   for (const candidate of candidates) {
     const candidateMeasures = measuresByCandidacy.get(candidate.id) ?? [];
-    const subjectMeasures: SubjectMeasure[] = [];
-    for (const measure of candidateMeasures) {
-      const relation = await getPublicMeasureVoteRelation(measure.id, measure.publishedRevisionId);
-      subjectMeasures.push({
+    const subjectMeasures: SubjectMeasure[] = candidateMeasures.map((measure) => {
+      const relation = relations.get(measure.id);
+      return {
         measure,
-        voteRelation: relation.relation,
-        voteReference: relation.reference,
-      });
-    }
+        voteRelation: relation?.relation ?? "SEARCH_NOT_DONE",
+        voteReference: relation?.reference ?? null,
+      };
+    });
     if (candidateMeasures.some((measure) => measure.withdrawal === null)) {
       candidaciesWithVerifiedMeasure += 1;
     }

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -1,0 +1,127 @@
+import "server-only";
+import { cacheLife, cacheTag } from "next/cache";
+import type { ThemeCategory } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { isSubjectPagePublishable } from "@/config/publication-gates";
+import { getPublicMeasureVoteRelation, type PublicVoteReference } from "@/lib/measures/vote-links";
+import type { VoteRelation } from "@/lib/measures/vote-relation";
+import { getPublicMeasuresByTheme, type PublicMeasure } from "./measures";
+import {
+  getPublicPresidentialCandidates,
+  type PublicPresidentialCandidate,
+} from "./presidential-candidates-public";
+
+/**
+ * The data of a public subject page: for one theme, each publicly visible candidacy and its published
+ * measures on that theme, with the measure's relation to recorded votes.
+ *
+ * Every read goes through a public authority: `getPublicPresidentialCandidates` (drops DRAFT/missing
+ * extensions), `getPublicMeasuresByTheme` (the single measure authority), and `getPublicMeasureVoteRelation`
+ * (which never selects `rationale`/`reviewedBy`). Nothing here reads `db.measure`/`db.candidacy` directly.
+ * The only direct read is the election slug -> id resolution, which is not gated.
+ *
+ * `publishable` is the section 4 gate, not a rendering detail: below it the page shows an explicit state
+ * and is noindex, never a silently degraded one-candidate "comparison".
+ */
+
+export type SubjectMeasure = {
+  measure: PublicMeasure;
+  voteRelation: VoteRelation;
+  /** The sourced basis of the reference link, if any. Never carries rationale. */
+  voteReference: PublicVoteReference | null;
+};
+
+export type SubjectCandidateEntry = {
+  candidate: PublicPresidentialCandidate;
+  /** Empty when the candidacy has no published measure on this theme: the page renders a qualified absence. */
+  measures: SubjectMeasure[];
+};
+
+export type SubjectPageData = {
+  theme: ThemeCategory;
+  electionSlug: string;
+  candidates: SubjectCandidateEntry[];
+  /** Candidacies with at least one currently-defended (non-withdrawn) published measure on the theme. */
+  candidaciesWithVerifiedMeasure: number;
+  publishable: boolean;
+};
+
+/**
+ * Plain async, integration-testable. Callers on a page use `getSubjectPageData`, which caches this.
+ */
+export async function loadSubjectPageData(
+  electionId: string,
+  electionSlug: string,
+  theme: ThemeCategory
+): Promise<SubjectPageData> {
+  const [candidates, measures] = await Promise.all([
+    getPublicPresidentialCandidates(electionSlug),
+    // Withdrawn measures stay visible on a subject page (a dropped position is still information), so the
+    // read includes them; the gate below counts only the ones still defended.
+    getPublicMeasuresByTheme(electionId, theme, { includeWithdrawn: true }),
+  ]);
+
+  const measuresByCandidacy = new Map<string, PublicMeasure[]>();
+  for (const measure of measures) {
+    // A measure not tied to a candidacy has no column on a candidate comparison.
+    if (measure.candidacyId === null) continue;
+    const list = measuresByCandidacy.get(measure.candidacyId) ?? [];
+    list.push(measure);
+    measuresByCandidacy.set(measure.candidacyId, list);
+  }
+
+  const entries: SubjectCandidateEntry[] = [];
+  let candidaciesWithVerifiedMeasure = 0;
+
+  for (const candidate of candidates) {
+    const candidateMeasures = measuresByCandidacy.get(candidate.id) ?? [];
+    const subjectMeasures: SubjectMeasure[] = [];
+    for (const measure of candidateMeasures) {
+      const relation = await getPublicMeasureVoteRelation(measure.id, measure.publishedRevisionId);
+      subjectMeasures.push({
+        measure,
+        voteRelation: relation.relation,
+        voteReference: relation.reference,
+      });
+    }
+    if (candidateMeasures.some((measure) => measure.withdrawal === null)) {
+      candidaciesWithVerifiedMeasure += 1;
+    }
+    entries.push({ candidate, measures: subjectMeasures });
+  }
+
+  return {
+    theme,
+    electionSlug,
+    candidates: entries,
+    candidaciesWithVerifiedMeasure,
+    publishable: isSubjectPagePublishable(candidaciesWithVerifiedMeasure),
+  };
+}
+
+/**
+ * Cached read for the page. The election id is resolved uncached (cheap), then the heavy reads run inside
+ * a `"use cache"` boundary tagged `election-measures:${electionId}`, the same tag the measure writes bust.
+ */
+export async function getSubjectPageData(
+  electionSlug: string,
+  theme: ThemeCategory
+): Promise<SubjectPageData | null> {
+  const election = await db.election.findUnique({
+    where: { slug: electionSlug },
+    select: { id: true },
+  });
+  if (election === null) return null;
+  return getSubjectPageDataCached(election.id, electionSlug, theme);
+}
+
+async function getSubjectPageDataCached(
+  electionId: string,
+  electionSlug: string,
+  theme: ThemeCategory
+): Promise<SubjectPageData> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheLife("synced");
+  return loadSubjectPageData(electionId, electionSlug, theme);
+}

--- a/src/lib/measures/__tests__/vote-links.integration.test.ts
+++ b/src/lib/measures/__tests__/vote-links.integration.test.ts
@@ -1,0 +1,193 @@
+import { beforeAll, afterAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { publishSeededMeasure, seedMeasureWithDraft, uniqueSlug } from "./helpers";
+
+// Deferred: vote-links.ts imports @/lib/db as a value, which throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let createMeasureVoteLink: typeof import("../vote-links").createMeasureVoteLink;
+let getPublicMeasureVoteRelation: typeof import("../vote-links").getPublicMeasureVoteRelation;
+
+const base = {
+  rationale: "Le scrutin portait sur le même objet que la mesure.",
+  checkedAt: new Date("2026-08-04T00:00:00Z"),
+  institutionScope: ["AN" as const],
+  legislatureScope: ["17"],
+  searchMethod: "Recherche par dossier législatif",
+  reviewedBy: "admin",
+};
+
+describeIfDisposableDb("MeasureVoteLink : contraintes d'écriture et lecture publique", () => {
+  let scrutinId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ createMeasureVoteLink, getPublicMeasureVoteRelation } = await import("../vote-links"));
+
+    const scrutin = await db.scrutin.create({
+      data: {
+        externalId: uniqueSlug("scrutin"),
+        title: "Scrutin de test",
+        votingDate: new Date("2026-03-01T00:00:00Z"),
+        legislature: 17,
+        votesFor: 200,
+        votesAgainst: 150,
+        votesAbstain: 10,
+        result: "ADOPTED",
+      },
+    });
+    scrutinId = scrutin.id;
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("contrainte 1 : refuse un lien dont la révision appartient à une autre mesure", async () => {
+    const a = await publishSeededMeasure();
+    const b = await seedMeasureWithDraft();
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: a.measureId,
+        applicableRevisionId: b.revisionId,
+        scrutinId,
+        linkKind: "SAME_OBJECT",
+        relation: "FAVORABLE",
+      })
+    ).rejects.toThrow(/n'appartient pas à cette mesure/);
+  });
+
+  it("contrainte 3 : refuse un NO_VOTE_IDENTIFIED porteur d'un scrutin", async () => {
+    const m = await publishSeededMeasure();
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: m.measureId,
+        applicableRevisionId: m.revisionId,
+        scrutinId,
+        linkKind: "NO_VOTE_IDENTIFIED",
+      })
+    ).rejects.toThrow(/aucun vote identifié/);
+  });
+
+  it("relation : exige une relation sur un lien SAME_OBJECT rattaché à un scrutin", async () => {
+    const m = await publishSeededMeasure();
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: m.measureId,
+        applicableRevisionId: m.revisionId,
+        scrutinId,
+        linkKind: "SAME_OBJECT",
+        relation: null,
+      })
+    ).rejects.toThrow(/doit porter la relation/);
+  });
+
+  it("relation : refuse une relation sur un lien BROADER_TEXT", async () => {
+    const m = await publishSeededMeasure();
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: m.measureId,
+        applicableRevisionId: m.revisionId,
+        scrutinId,
+        linkKind: "BROADER_TEXT",
+        relation: "FAVORABLE",
+      })
+    ).rejects.toThrow(/Seul un lien sur le même objet/);
+  });
+
+  it("contrainte 2 : refuse isReference sur un lien sans scrutin", async () => {
+    const m = await publishSeededMeasure();
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: m.measureId,
+        applicableRevisionId: m.revisionId,
+        scrutinId: null,
+        linkKind: "SAME_OBJECT",
+        isReference: true,
+      })
+    ).rejects.toThrow(/peut être la référence/);
+  });
+
+  it("contrainte 4 : refuse une seconde référence sur la même révision applicable", async () => {
+    const m = await publishSeededMeasure();
+    await createMeasureVoteLink({
+      ...base,
+      measureId: m.measureId,
+      applicableRevisionId: m.revisionId,
+      scrutinId,
+      linkKind: "SAME_OBJECT",
+      relation: "FAVORABLE",
+      isReference: true,
+    });
+    await expect(
+      createMeasureVoteLink({
+        ...base,
+        measureId: m.measureId,
+        applicableRevisionId: m.revisionId,
+        scrutinId,
+        linkKind: "SAME_OBJECT",
+        relation: "DEFAVORABLE",
+        isReference: true,
+      })
+    ).rejects.toThrow(/référence existe déjà/);
+  });
+
+  it("cas nominal : crée un lien de référence favorable", async () => {
+    const m = await publishSeededMeasure();
+    const link = await createMeasureVoteLink({
+      ...base,
+      measureId: m.measureId,
+      applicableRevisionId: m.revisionId,
+      scrutinId,
+      linkKind: "SAME_OBJECT",
+      relation: "FAVORABLE",
+      isReference: true,
+    });
+    expect(link.isReference).toBe(true);
+    expect(link.relation).toBe("FAVORABLE");
+  });
+
+  it("lecture publique : un lien de référence favorable donne FAVORABLE_SAME_OBJECT et sa base sourcée", async () => {
+    const m = await publishSeededMeasure();
+    await createMeasureVoteLink({
+      ...base,
+      measureId: m.measureId,
+      applicableRevisionId: m.revisionId,
+      scrutinId,
+      linkKind: "SAME_OBJECT",
+      relation: "FAVORABLE",
+      isReference: true,
+    });
+
+    const result = await getPublicMeasureVoteRelation(m.measureId, m.revisionId);
+    expect(result.relation).toBe("FAVORABLE_SAME_OBJECT");
+    expect(result.reference?.scrutinId).toBe(scrutinId);
+    expect(result.reference?.legislatureScope).toEqual(["17"]);
+    // Draft-leak invariant: the public shape never carries the internal judgment.
+    expect(result.reference && "rationale" in result.reference).toBeFalsy();
+    expect(result.reference && "reviewedBy" in result.reference).toBeFalsy();
+  });
+
+  it("lecture publique : un lien hors de la révision publiée ne donne jamais de position", async () => {
+    const m = await publishSeededMeasure();
+    await createMeasureVoteLink({
+      ...base,
+      measureId: m.measureId,
+      applicableRevisionId: m.revisionId,
+      scrutinId,
+      linkKind: "SAME_OBJECT",
+      relation: "FAVORABLE",
+      isReference: true,
+    });
+
+    // Une reformulation a fait bouger la révision publiée : le lien porte sur l'ancienne.
+    const result = await getPublicMeasureVoteRelation(m.measureId, "une-autre-revision-publiee");
+    expect(result.relation).toBe("NOT_RECHECKED_SINCE_REFORMULATION");
+    expect(result.reference).toBeNull();
+  });
+});

--- a/src/lib/measures/__tests__/vote-relation.test.ts
+++ b/src/lib/measures/__tests__/vote-relation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { deriveVoteRelation, type VoteRelationLink } from "../vote-relation";
+
+const PUB = "rev-published";
+const OLD = "rev-superseded";
+
+function link(over: Partial<VoteRelationLink> = {}): VoteRelationLink {
+  return {
+    linkKind: "SAME_OBJECT",
+    applicableRevisionId: PUB,
+    position: "FAVORABLE",
+    ...over,
+  };
+}
+
+/**
+ * The rule that matters most (spec §9.2): no available vote datum may render as "recherche non
+ * effectuée". That state is reserved for zero links. Written first, before the nominal cases.
+ */
+describe("deriveVoteRelation : aucune donnée ne se rend en recherche non effectuée", () => {
+  it("un NO_VOTE_IDENTIFIED sur la révision publiée donne NO_VOTE_IN_SCOPE", () => {
+    expect(
+      deriveVoteRelation([link({ linkKind: "NO_VOTE_IDENTIFIED", position: null })], PUB)
+    ).toBe("NO_VOTE_IN_SCOPE");
+  });
+
+  it("un lien uniquement sur une révision supersédée donne NOT_RECHECKED_SINCE_REFORMULATION", () => {
+    expect(deriveVoteRelation([link({ applicableRevisionId: OLD })], PUB)).toBe(
+      "NOT_RECHECKED_SINCE_REFORMULATION"
+    );
+  });
+
+  it("SEARCH_NOT_DONE seulement quand il n'y a aucun lien", () => {
+    expect(deriveVoteRelation([], PUB)).toBe("SEARCH_NOT_DONE");
+  });
+});
+
+describe("deriveVoteRelation : les neuf états", () => {
+  it("vote favorable sur le même objet", () => {
+    expect(deriveVoteRelation([link({ position: "FAVORABLE" })], PUB)).toBe(
+      "FAVORABLE_SAME_OBJECT"
+    );
+  });
+
+  it("vote défavorable sur le même objet", () => {
+    expect(deriveVoteRelation([link({ position: "DEFAVORABLE" })], PUB)).toBe(
+      "DEFAVORABLE_SAME_OBJECT"
+    );
+  });
+
+  it("abstention sur le même objet", () => {
+    expect(deriveVoteRelation([link({ position: "ABSTENTION" })], PUB)).toBe(
+      "ABSTENTION_SAME_OBJECT"
+    );
+  });
+
+  it("absence sur le même objet", () => {
+    expect(deriveVoteRelation([link({ position: "ABSENCE" })], PUB)).toBe("ABSENCE_SAME_OBJECT");
+  });
+
+  it("plusieurs SAME_OBJECT de positions distinctes donnent DIFFERENT_POSITIONS", () => {
+    expect(
+      deriveVoteRelation([link({ position: "FAVORABLE" }), link({ position: "DEFAVORABLE" })], PUB)
+    ).toBe("DIFFERENT_POSITIONS");
+  });
+
+  it("plusieurs SAME_OBJECT de MEME position ne sont pas des positions différentes", () => {
+    expect(
+      deriveVoteRelation(
+        [
+          link({ position: "FAVORABLE" }),
+          link({ position: "FAVORABLE" }),
+          link({ position: "FAVORABLE" }),
+        ],
+        PUB
+      )
+    ).toBe("FAVORABLE_SAME_OBJECT");
+  });
+
+  it("uniquement des liens BROADER_TEXT donnent BROADER_TEXT", () => {
+    expect(deriveVoteRelation([link({ linkKind: "BROADER_TEXT", position: null })], PUB)).toBe(
+      "BROADER_TEXT"
+    );
+  });
+
+  it("des liens existent mais aucun sur la révision publiée : NOT_RECHECKED_SINCE_REFORMULATION", () => {
+    expect(
+      deriveVoteRelation([link({ applicableRevisionId: OLD, position: "FAVORABLE" })], PUB)
+    ).toBe("NOT_RECHECKED_SINCE_REFORMULATION");
+  });
+
+  it("aucun lien : SEARCH_NOT_DONE", () => {
+    expect(deriveVoteRelation([], PUB)).toBe("SEARCH_NOT_DONE");
+  });
+});
+
+describe("deriveVoteRelation : priorité et bornes", () => {
+  it("SAME_OBJECT prime sur BROADER_TEXT sur la même révision", () => {
+    expect(
+      deriveVoteRelation(
+        [link({ position: "FAVORABLE" }), link({ linkKind: "BROADER_TEXT", position: null })],
+        PUB
+      )
+    ).toBe("FAVORABLE_SAME_OBJECT");
+  });
+
+  it("un SAME_OBJECT sur révision supersédée est ignoré au profit du SAME_OBJECT publié", () => {
+    expect(
+      deriveVoteRelation(
+        [
+          link({ applicableRevisionId: OLD, position: "DEFAVORABLE" }),
+          link({ position: "FAVORABLE" }),
+        ],
+        PUB
+      )
+    ).toBe("FAVORABLE_SAME_OBJECT");
+  });
+
+  it("ni abstention ni absence ne produisent défavorable", () => {
+    expect(deriveVoteRelation([link({ position: "ABSTENTION" })], PUB)).not.toBe(
+      "DEFAVORABLE_SAME_OBJECT"
+    );
+    expect(deriveVoteRelation([link({ position: "ABSENCE" })], PUB)).not.toBe(
+      "DEFAVORABLE_SAME_OBJECT"
+    );
+  });
+
+  it("un mélange BROADER_TEXT et NO_VOTE_IDENTIFIED sans SAME_OBJECT donne BROADER_TEXT", () => {
+    expect(
+      deriveVoteRelation(
+        [
+          link({ linkKind: "BROADER_TEXT", position: null }),
+          link({ linkKind: "NO_VOTE_IDENTIFIED", position: null }),
+        ],
+        PUB
+      )
+    ).toBe("BROADER_TEXT");
+  });
+});
+
+describe("deriveVoteRelation : indépendante de l'ordre", () => {
+  it("les mêmes liens dans trois ordres donnent le même état", () => {
+    const a = link({ position: "FAVORABLE" });
+    const b = link({ linkKind: "BROADER_TEXT", position: null });
+    const c = link({ applicableRevisionId: OLD, position: "DEFAVORABLE" });
+
+    const orders = [
+      [a, b, c],
+      [c, b, a],
+      [b, a, c],
+    ];
+    const results = orders.map((o) => deriveVoteRelation(o, PUB));
+
+    expect(new Set(results).size).toBe(1);
+    expect(results[0]).toBe("FAVORABLE_SAME_OBJECT");
+  });
+
+  it("positions contradictoires : même résultat quel que soit l'ordre", () => {
+    const fav = link({ position: "FAVORABLE" });
+    const def = link({ position: "DEFAVORABLE" });
+    expect(deriveVoteRelation([fav, def], PUB)).toBe("DIFFERENT_POSITIONS");
+    expect(deriveVoteRelation([def, fav], PUB)).toBe("DIFFERENT_POSITIONS");
+  });
+});

--- a/src/lib/measures/vote-links.ts
+++ b/src/lib/measures/vote-links.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/generated/prisma";
 import { lockMeasure } from "./lock";
 import { MeasureValidationError } from "./errors";
+import { invalidateMeasureTags } from "./cache";
 import { deriveVoteRelation, type VoteRelation } from "./vote-relation";
 
 /**
@@ -41,13 +42,14 @@ export async function createMeasureVoteLink(
   const isReference = input.isReference ?? false;
   const isSameObjectVote = input.linkKind === "SAME_OBJECT" && scrutinId !== null;
 
-  return db.$transaction(async (tx: DbTransactionClient) => {
+  const { link, electionId } = await db.$transaction(async (tx: DbTransactionClient) => {
     await lockMeasure(tx, input.measureId);
 
-    // Constraint 1: the link's measure must be the measure of the targeted revision.
+    // Constraint 1: the link's measure must be the measure of the targeted revision. The measure's
+    // electionId is read here too, to bust the public subject-page cache tag after the commit.
     const revision = await tx.measureRevision.findUnique({
       where: { id: input.applicableRevisionId },
-      select: { measureId: true },
+      select: { measureId: true, measure: { select: { electionId: true } } },
     });
     if (!revision) throw new MeasureValidationError("La révision applicable est introuvable");
     if (revision.measureId !== input.measureId) {
@@ -91,7 +93,7 @@ export async function createMeasureVoteLink(
       }
     }
 
-    return tx.measureVoteLink.create({
+    const created = await tx.measureVoteLink.create({
       data: {
         measureId: input.measureId,
         applicableRevisionId: input.applicableRevisionId,
@@ -107,7 +109,13 @@ export async function createMeasureVoteLink(
         reviewedBy: input.reviewedBy,
       },
     });
+    return { link: created, electionId: revision.measure.electionId };
   });
+
+  // Not part of the transaction: revalidateTag is a platform call, best effort, exactly as the lot 1
+  // transitions do. Without it, the public subject page keeps a stale badge until its 24h cacheLife.
+  invalidateMeasureTags(input.measureId, electionId);
+  return link;
 }
 
 /** The sourced basis of the reference link, safe to show publicly. Never carries rationale/reviewedBy. */
@@ -124,19 +132,22 @@ export type PublicMeasureVoteRelation = {
 };
 
 /**
- * The public relation of a measure to recorded votes, and the sourced basis of its reference.
+ * The public vote relations of several measures at once, keyed by measureId.
  *
- * Constraint 5 (§5.8): the badge only uses links whose applicableRevisionId equals publishedRevisionId,
- * which deriveVoteRelation() enforces. The select deliberately omits `rationale` and `reviewedBy`: they
- * are internal editorial judgment and must never reach the public surface.
+ * One query for all the links (`measureId in [...]`), then the derivation runs in memory per measure:
+ * this is what a subject page with N measures needs, instead of N sequential reads. Constraint 5 (§5.8):
+ * only links whose applicableRevisionId equals a measure's publishedRevisionId count, which
+ * deriveVoteRelation() enforces. The select omits `rationale` and `reviewedBy`, internal editorial
+ * judgment that must never reach the public surface.
  */
-export async function getPublicMeasureVoteRelation(
-  measureId: string,
-  publishedRevisionId: string
-): Promise<PublicMeasureVoteRelation> {
+export async function getPublicMeasureVoteRelations(
+  inputs: { measureId: string; publishedRevisionId: string }[]
+): Promise<Map<string, PublicMeasureVoteRelation>> {
+  const measureIds = inputs.map((i) => i.measureId);
   const links = await db.measureVoteLink.findMany({
-    where: { measureId },
+    where: { measureId: { in: measureIds } },
     select: {
+      measureId: true,
       linkKind: true,
       applicableRevisionId: true,
       relation: true,
@@ -148,27 +159,52 @@ export async function getPublicMeasureVoteRelation(
     },
   });
 
-  const relation = deriveVoteRelation(
-    links.map((l) => ({
-      linkKind: l.linkKind,
-      applicableRevisionId: l.applicableRevisionId,
-      position: l.relation,
-    })),
-    publishedRevisionId
-  );
+  const linksByMeasure = new Map<string, typeof links>();
+  for (const link of links) {
+    const list = linksByMeasure.get(link.measureId) ?? [];
+    list.push(link);
+    linksByMeasure.set(link.measureId, list);
+  }
 
-  const ref =
-    links.find((l) => l.applicableRevisionId === publishedRevisionId && l.isReference) ?? null;
+  const result = new Map<string, PublicMeasureVoteRelation>();
+  for (const { measureId, publishedRevisionId } of inputs) {
+    const measureLinks = linksByMeasure.get(measureId) ?? [];
+    const relation = deriveVoteRelation(
+      measureLinks.map((l) => ({
+        linkKind: l.linkKind,
+        applicableRevisionId: l.applicableRevisionId,
+        position: l.relation,
+      })),
+      publishedRevisionId
+    );
+    const ref =
+      measureLinks.find((l) => l.applicableRevisionId === publishedRevisionId && l.isReference) ??
+      null;
+    result.set(measureId, {
+      relation,
+      reference: ref
+        ? {
+            scrutinId: ref.scrutinId,
+            institutionScope: ref.institutionScope,
+            legislatureScope: ref.legislatureScope,
+            checkedAt: ref.checkedAt,
+          }
+        : null,
+    });
+  }
 
-  return {
-    relation,
-    reference: ref
-      ? {
-          scrutinId: ref.scrutinId,
-          institutionScope: ref.institutionScope,
-          legislatureScope: ref.legislatureScope,
-          checkedAt: ref.checkedAt,
-        }
-      : null,
-  };
+  return result;
+}
+
+/**
+ * The public relation of a single measure to recorded votes. Delegates to the batched read so the
+ * derivation and the public projection have exactly one definition.
+ */
+export async function getPublicMeasureVoteRelation(
+  measureId: string,
+  publishedRevisionId: string
+): Promise<PublicMeasureVoteRelation> {
+  const relations = await getPublicMeasureVoteRelations([{ measureId, publishedRevisionId }]);
+  // Always present: getPublicMeasureVoteRelations sets one entry per input.
+  return relations.get(measureId)!;
 }

--- a/src/lib/measures/vote-links.ts
+++ b/src/lib/measures/vote-links.ts
@@ -1,0 +1,174 @@
+import { db, type DbTransactionClient } from "@/lib/db";
+import type {
+  Chamber,
+  MeasureVoteLink,
+  MeasureVoteLinkKind,
+  MeasureVoteRelation,
+} from "@/generated/prisma";
+import { lockMeasure } from "./lock";
+import { MeasureValidationError } from "./errors";
+import { deriveVoteRelation, type VoteRelation } from "./vote-relation";
+
+/**
+ * MeasureVoteLink: the manual attachment of a measure to a scrutin (spec §5.8).
+ *
+ * Written only from admin, never by a script, never by an automatic engine or confidence score
+ * (arbitrated 2026-08-06). The five write constraints of §5.8 are checked in the transaction, not only
+ * by the audit, because each of them, if skipped, lets a position state be produced from nothing.
+ */
+
+export type CreateMeasureVoteLinkInput = {
+  measureId: string;
+  applicableRevisionId: string;
+  scrutinId?: string | null;
+  linkKind: MeasureVoteLinkKind;
+  /** Reviewer-recorded relation to the measure; only on a SAME_OBJECT link tied to a scrutin. */
+  relation?: MeasureVoteRelation | null;
+  isReference?: boolean;
+  rationale: string;
+  checkedAt: Date;
+  institutionScope: Chamber[];
+  legislatureScope: string[];
+  searchMethod: string;
+  reviewedBy: string;
+};
+
+export async function createMeasureVoteLink(
+  input: CreateMeasureVoteLinkInput
+): Promise<MeasureVoteLink> {
+  const scrutinId = input.scrutinId ?? null;
+  const relation = input.relation ?? null;
+  const isReference = input.isReference ?? false;
+  const isSameObjectVote = input.linkKind === "SAME_OBJECT" && scrutinId !== null;
+
+  return db.$transaction(async (tx: DbTransactionClient) => {
+    await lockMeasure(tx, input.measureId);
+
+    // Constraint 1: the link's measure must be the measure of the targeted revision.
+    const revision = await tx.measureRevision.findUnique({
+      where: { id: input.applicableRevisionId },
+      select: { measureId: true },
+    });
+    if (!revision) throw new MeasureValidationError("La révision applicable est introuvable");
+    if (revision.measureId !== input.measureId) {
+      throw new MeasureValidationError("La révision applicable n'appartient pas à cette mesure");
+    }
+
+    // Constraint 3: NO_VOTE_IDENTIFIED is a constatation, not an attachment.
+    if (input.linkKind === "NO_VOTE_IDENTIFIED" && scrutinId !== null) {
+      throw new MeasureValidationError("Un lien « aucun vote identifié » ne porte pas de scrutin");
+    }
+
+    // Relation consistency: only a SAME_OBJECT link tied to a scrutin carries a relation, and it must.
+    if (isSameObjectVote && relation === null) {
+      throw new MeasureValidationError(
+        "Un lien sur le même objet doit porter la relation du candidat à la mesure"
+      );
+    }
+    if (!isSameObjectVote && relation !== null) {
+      throw new MeasureValidationError(
+        "Seul un lien sur le même objet rattaché à un scrutin porte une relation"
+      );
+    }
+
+    // Constraint 2: a reference must be a SAME_OBJECT link tied to a scrutin.
+    if (isReference && !isSameObjectVote) {
+      throw new MeasureValidationError(
+        "Seul un lien sur le même objet rattaché à un scrutin peut être la référence"
+      );
+    }
+
+    // Constraint 4: at most one reference per applicable revision. Partial constraint Prisma cannot
+    // declare; the row lock above serializes concurrent attempts, so the count is authoritative here.
+    if (isReference) {
+      const existing = await tx.measureVoteLink.count({
+        where: { applicableRevisionId: input.applicableRevisionId, isReference: true },
+      });
+      if (existing > 0) {
+        throw new MeasureValidationError(
+          "Une référence existe déjà pour cette révision applicable"
+        );
+      }
+    }
+
+    return tx.measureVoteLink.create({
+      data: {
+        measureId: input.measureId,
+        applicableRevisionId: input.applicableRevisionId,
+        scrutinId,
+        linkKind: input.linkKind,
+        relation,
+        isReference,
+        rationale: input.rationale,
+        checkedAt: input.checkedAt,
+        institutionScope: input.institutionScope,
+        legislatureScope: input.legislatureScope,
+        searchMethod: input.searchMethod,
+        reviewedBy: input.reviewedBy,
+      },
+    });
+  });
+}
+
+/** The sourced basis of the reference link, safe to show publicly. Never carries rationale/reviewedBy. */
+export type PublicVoteReference = {
+  scrutinId: string | null;
+  institutionScope: Chamber[];
+  legislatureScope: string[];
+  checkedAt: Date;
+};
+
+export type PublicMeasureVoteRelation = {
+  relation: VoteRelation;
+  reference: PublicVoteReference | null;
+};
+
+/**
+ * The public relation of a measure to recorded votes, and the sourced basis of its reference.
+ *
+ * Constraint 5 (§5.8): the badge only uses links whose applicableRevisionId equals publishedRevisionId,
+ * which deriveVoteRelation() enforces. The select deliberately omits `rationale` and `reviewedBy`: they
+ * are internal editorial judgment and must never reach the public surface.
+ */
+export async function getPublicMeasureVoteRelation(
+  measureId: string,
+  publishedRevisionId: string
+): Promise<PublicMeasureVoteRelation> {
+  const links = await db.measureVoteLink.findMany({
+    where: { measureId },
+    select: {
+      linkKind: true,
+      applicableRevisionId: true,
+      relation: true,
+      isReference: true,
+      scrutinId: true,
+      institutionScope: true,
+      legislatureScope: true,
+      checkedAt: true,
+    },
+  });
+
+  const relation = deriveVoteRelation(
+    links.map((l) => ({
+      linkKind: l.linkKind,
+      applicableRevisionId: l.applicableRevisionId,
+      position: l.relation,
+    })),
+    publishedRevisionId
+  );
+
+  const ref =
+    links.find((l) => l.applicableRevisionId === publishedRevisionId && l.isReference) ?? null;
+
+  return {
+    relation,
+    reference: ref
+      ? {
+          scrutinId: ref.scrutinId,
+          institutionScope: ref.institutionScope,
+          legislatureScope: ref.legislatureScope,
+          checkedAt: ref.checkedAt,
+        }
+      : null,
+  };
+}

--- a/src/lib/measures/vote-relation.ts
+++ b/src/lib/measures/vote-relation.ts
@@ -1,0 +1,74 @@
+/**
+ * `deriveVoteRelation()` : the nine descriptive states of a measure's relation to recorded votes.
+ *
+ * Authority: spec §9.2. This is a PURE aggregation over links that already carry a resolved position.
+ * It does NOT read a scrutin nor compute favorable/défavorable from a vote: that resolution (including
+ * the suppression-amendment polarity trap) happens upstream, at link creation in admin, and is written
+ * into `position`. Keeping it pure lets the render path stay fast and testable, and lets the attachment
+ * engine evolve without touching what the badge shows.
+ *
+ * The governing rule (§9.2): no available vote datum ever renders as "recherche non effectuée". That
+ * state is reserved for the case where no link exists in the database at all. The derivation is
+ * independent of the order of the links.
+ */
+
+export type MeasureVotePosition = "FAVORABLE" | "DEFAVORABLE" | "ABSTENTION" | "ABSENCE";
+export type MeasureVoteLinkKind = "SAME_OBJECT" | "BROADER_TEXT" | "NO_VOTE_IDENTIFIED";
+
+export type VoteRelationLink = {
+  linkKind: MeasureVoteLinkKind;
+  applicableRevisionId: string;
+  /** Resolved at write time for a SAME_OBJECT link tied to a scrutin; null otherwise. */
+  position: MeasureVotePosition | null;
+};
+
+export type VoteRelation =
+  | "FAVORABLE_SAME_OBJECT"
+  | "DEFAVORABLE_SAME_OBJECT"
+  | "ABSTENTION_SAME_OBJECT"
+  | "ABSENCE_SAME_OBJECT"
+  | "DIFFERENT_POSITIONS"
+  | "BROADER_TEXT"
+  | "NOT_RECHECKED_SINCE_REFORMULATION"
+  | "NO_VOTE_IN_SCOPE"
+  | "SEARCH_NOT_DONE";
+
+const POSITION_STATE: Record<MeasureVotePosition, VoteRelation> = {
+  FAVORABLE: "FAVORABLE_SAME_OBJECT",
+  DEFAVORABLE: "DEFAVORABLE_SAME_OBJECT",
+  ABSTENTION: "ABSTENTION_SAME_OBJECT",
+  ABSENCE: "ABSENCE_SAME_OBJECT",
+};
+
+export function deriveVoteRelation(
+  links: VoteRelationLink[],
+  publishedRevisionId: string
+): VoteRelation {
+  // Priority 1: zero links is the only path to "recherche non effectuée".
+  if (links.length === 0) return "SEARCH_NOT_DONE";
+
+  const applicable = links.filter((l) => l.applicableRevisionId === publishedRevisionId);
+  // Links exist, but none on the published revision: the measure was reformulated since.
+  if (applicable.length === 0) return "NOT_RECHECKED_SINCE_REFORMULATION";
+
+  // Priority 2-3: any SAME_OBJECT on the published revision decides, by its distinct positions.
+  const sameObject = applicable.filter((l) => l.linkKind === "SAME_OBJECT");
+  if (sameObject.length > 0) {
+    const positions = new Set<MeasureVotePosition>();
+    for (const l of sameObject) {
+      if (l.position !== null) positions.add(l.position);
+    }
+    if (positions.size >= 2) return "DIFFERENT_POSITIONS";
+    // Exactly one distinct position, whether it came from one link or several.
+    const [only] = positions;
+    if (only !== undefined) return POSITION_STATE[only];
+    // Degenerate input: SAME_OBJECT links without any resolved position. The write constraints
+    // (§5.8) forbid it, so treat it as no usable same-object signal and fall through.
+  }
+
+  // Priority 4: a vote on a broader text is a datum; it outranks a mere "no vote identified".
+  if (applicable.some((l) => l.linkKind === "BROADER_TEXT")) return "BROADER_TEXT";
+
+  // Priority 5: only NO_VOTE_IDENTIFIED remains, a bounded, dated constatation.
+  return "NO_VOTE_IN_SCOPE";
+}

--- a/tests/visual/presidentielle-sujet.spec.ts
+++ b/tests/visual/presidentielle-sujet.spec.ts
@@ -1,0 +1,66 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Accessibility and responsive checks for the public presidential subject page.
+ *
+ * Needs the disposable container seeded with the fictional subject fixtures, and a dev server pointed
+ * at it (never production: `.env` and `.env.prod` share the same Supabase database):
+ *
+ *   docker compose -f docker-compose.test-search.yml up -d
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
+ *     npx prisma db push --url "$DATABASE_URL" --accept-data-loss
+ *   DATABASE_URL=... npx tsx scripts/seed-presidentielle-sujet-demo.ts
+ *   DATABASE_URL=... npm run dev
+ *   npx playwright test presidentielle-sujet --project=chromium
+ *
+ * The page is public, so no session is forged: it is read exactly as a visitor sees it.
+ */
+
+const WCAG = ["wcag2a", "wcag2aa", "wcag21aa"];
+const SUBJECT_PATH = "/presidentielle-2027/sujets/logement-urbanisme";
+const WIDTHS = [375, 768, 1440];
+
+/**
+ * How far the PAGE can actually be scrolled sideways, not `scrollWidth - clientWidth` (which also counts
+ * content clipped by overflow:hidden and legitimate inner scrollers). Asking the browser to scroll and
+ * reading back where it landed measures what a visitor experiences.
+ */
+async function horizontalScroll(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    window.scrollTo(2000, 0);
+    const x = window.scrollX;
+    window.scrollTo(0, 0);
+    return x;
+  });
+}
+
+test.describe("page sujet publique de la présidentielle 2027", () => {
+  test("rend la comparaison seedée avec preuves et absence qualifiée", async ({ page }) => {
+    await page.goto(SUBJECT_PATH);
+
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Logement & Urbanisme");
+    await expect(page.getByRole("heading", { level: 2, name: "Alix Démo" })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2, name: "Bruno Démo" })).toBeVisible();
+    await expect(page.getByText("Encadrer les loyers dans les zones tendues.")).toBeVisible();
+    // The evidence is on screen, not hidden behind trust.
+    await expect(page.getByRole("link", { name: "Discours de campagne" }).first()).toBeVisible();
+    // Chloé has no measure on the theme: a qualified absence, never a silent blank.
+    await expect(page.locator('[data-absence-kind="no_measure_published"]').first()).toBeVisible();
+  });
+
+  for (const width of WIDTHS) {
+    test(`n'a aucune violation WCAG AA ni débordement horizontal à ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(SUBJECT_PATH);
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+      expect(await horizontalScroll(page)).toBe(0);
+
+      const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+      expect(results.violations).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Tranche verticale du hub présidentielle 2027 : de la donnée à une page publique comparant, sur un sujet, les mesures des candidats et leur relation aux votes. Le but est de valider le modèle de bout en bout sur des fixtures fictives avant de multiplier les routes.

**Draft assumé.** Les fixtures de démonstration ne sont jamais écrites en production ; le `db:push` de `MeasureVoteLink` en prod est une opération séparée, avec son propre diff et son propre consentement, hors de cette PR.

## Ce que livre la PR

- `deriveVoteRelation()` : dérivation **pure** des neuf états de la relation mesure-vote (spec §9.2). Elle agrège des positions déjà résolues portées par les liens ; le piège de polarité des amendements de suppression vit en amont, au rattachement admin, jamais dans la dérivation.
- Composants : `QualifiedEmptyCell` (sept absences typées, exhaustivité garantie à la compilation), `VoteRelationBadge` (deux axes, couleurs AA).
- `src/config/publication-gates.ts` : les seuils de publication v1.
- Autorité de lecture publique des candidatures (`getPublicPresidentialCandidates`) : une candidature dont l'extension éditoriale est absente ou `DRAFT` ne sort jamais.
- Modèle `MeasureVoteLink` + `createMeasureVoteLink()` (cinq contraintes d'écriture vérifiées dans la transaction) et son **écran de rattachement admin**. L'interface rend impossibles les combinaisons invalides : `NO_VOTE_IDENTIFIED` ne porte ni scrutin ni relation, `ABSENCE` est une relation sur un scrutin identifié, jamais présentée comme « aucun vote identifié ».
- Page sujet publique `/presidentielle-2027/sujets/[theme]` : lecture par les seules autorités publiques, mesures avec leurs sources (nature, niveau primaire/secondaire, date), source de déclaration de la candidature, mesure retirée signalée mais visible, absence qualifiée pour un candidat sans mesure. Sous le seuil de deux candidatures documentées, la page rend un état explicite et passe en `noindex`.

## Invariants tenus, chacun avec son ablation

- Aucune donnée disponible ne se rend en « recherche non effectuée » (réservé à zéro lien).
- `deriveVoteRelation` est indépendante de l'ordre des liens.
- La surface publique ne lit que par l'autorité : une candidature `DRAFT` ne sort jamais (test d'intégration).
- Une absence n'est jamais une position : une cellule sans mesure passe par `QualifiedEmptyCell`.
- `rationale` et `reviewedBy` ne franchissent jamais la frontière publique.

## Décisions arbitrées le 2026-08-06 (résolues, plus ouvertes)

1. `MeasureVoteLink` reste **100 % manuel** pour le lot 3 : aucun moteur de suggestion, aucun score de confiance, aucun rattachement automatique.
2. Les seuils de la section 4 sont **validés en politique v1**, dans `publication-gates.ts`, sans valeur provisoire.
3. `DECLARE` décrit une déclaration politique publique et sourcée, pas une validation administrative : aucun statut de parrainage ajouté maintenant.
4. Dans la chaîne du hub 2027, une mesure ne peut être créée que pour une candidature 2027 au statut `DECLARE` avec source. Règle de la chaîne, pas contrainte universelle du modèle `Measure`. Résout #660 (corrigé et mergé via #669).
5. `declaredAt` est facultatif pour une candidature déclarée, jamais synthétisé (doctrine #661, mergée).

## Retours de revue intégrés

- Les **preuves** des mesures sont affichées : source cliquable, date, nature, niveau primaire/secondaire, et la source de déclaration de la candidature.
- La page publique est **rafraîchie après un rattachement de vote** : `createMeasureVoteLink()` invalide `election-measures:${electionId}` après le commit, comme les transitions.
- La lecture N+1 des relations de vote est remplacée par une **lecture batchée** (`getPublicMeasureVoteRelations`), une seule requête pour toutes les mesures.

## Vérifications

- `tsc --noEmit` code 0 ; suite `vitest` complète verte ; tests d'intégration sur conteneur jetable (autorités, ablations, contraintes d'écriture, page sujet).
- Parcours **Playwright + axe** de la page sujet sur fixtures seedées : rendu correct et **aucune violation WCAG 2.1 AA ni débordement horizontal** à 375, 768 et 1440 px.
- Aucune donnée fictive en production, aucun `db:push` de production dans cette PR.

Plan local : `docs/superpowers/plans/2026-08-06-lot3-tranche-verticale.md`.
