### PR TITLE
Corriger deux retours utilisateur sur la fiche politique (mobile)

### DIFF
--- a/src/components/politicians/PoliticianSignals.tsx
+++ b/src/components/politicians/PoliticianSignals.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import {
   Vote,
   Landmark,
@@ -11,6 +10,7 @@ import {
   FileText,
 } from "lucide-react";
 import type { Signal, SignalIconKey, SignalTone } from "@/lib/politicians/signals";
+import { TabShortcutLink } from "./TabShortcutLink";
 
 const ICONS: Record<
   SignalIconKey,
@@ -43,11 +43,9 @@ export function PoliticianSignals({ signals }: { signals: Signal[] }) {
       {cards.map((s) => {
         const Icon = ICONS[s.iconKey];
         return (
-          <Link
+          <TabShortcutLink
             key={s.key}
             href={s.href}
-            prefetch={false}
-            scroll={false}
             className="flex min-h-11 flex-col justify-between rounded-lg border bg-card p-3 transition-colors hover:bg-muted/50"
           >
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -60,7 +58,7 @@ export function PoliticianSignals({ signals }: { signals: Signal[] }) {
                 →
               </span>
             </span>
-          </Link>
+          </TabShortcutLink>
         );
       })}
     </div>

--- a/src/components/politicians/PoliticianSummary.tsx
+++ b/src/components/politicians/PoliticianSummary.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { Signal, SignalIconKey, SignalTone } from "@/lib/politicians/signals";
 import type { SourceLink } from "@/lib/politicians/external-sources";
+import { TabShortcutLink } from "./TabShortcutLink";
 
 const ICONS: Record<
   SignalIconKey,
@@ -59,10 +60,8 @@ export function PoliticianSummary({
             const Icon = ICONS[s.iconKey];
             return (
               <li key={s.key}>
-                <Link
+                <TabShortcutLink
                   href={s.href}
-                  prefetch={false}
-                  scroll={false}
                   className="flex items-center justify-between gap-2 py-1 text-foreground hover:underline"
                 >
                   <span className="flex items-center gap-1.5">
@@ -70,7 +69,7 @@ export function PoliticianSummary({
                     {s.label}
                   </span>
                   <span className={`font-semibold ${TONE[s.tone]}`}>{s.value} ›</span>
-                </Link>
+                </TabShortcutLink>
               </li>
             );
           })}

--- a/src/components/politicians/ProfileTabs.tsx
+++ b/src/components/politicians/ProfileTabs.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import type { ReactNode } from "react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { User, Briefcase, Vote, Wallet, FileCheck, Scale } from "lucide-react";
+import { PROFILE_TABS_ANCHOR_ID } from "./profile-tabs-anchor";
 
 const VALID_TABS = ["profil", "carriere", "votes", "patrimoine", "factchecks", "affaires"] as const;
 type TabValue = (typeof VALID_TABS)[number];
@@ -82,51 +83,55 @@ function ProfileTabsInner({
   }
 
   return (
-    <Tabs value={tab} onValueChange={onTabChange}>
-      <TabsList variant="line" className="w-full justify-start">
-        <TabsTrigger value="profil">
-          <User className="size-4" />
-          Profil
-        </TabsTrigger>
-        <TabsTrigger value="carriere">
-          <Briefcase className="size-4" />
-          Carrière
-        </TabsTrigger>
-        {votesContent && (
-          <TabsTrigger value="votes">
-            <Vote className="size-4" />
-            Votes
+    // Target of the "En bref" shortcuts. Mounted once, unlike the summary that
+    // links here, so the id stays unique. scroll-mt clears the sticky header.
+    <div id={PROFILE_TABS_ANCHOR_ID} tabIndex={-1} className="scroll-mt-20 outline-none">
+      <Tabs value={tab} onValueChange={onTabChange}>
+        <TabsList variant="line" className="w-full justify-start">
+          <TabsTrigger value="profil">
+            <User className="size-4" />
+            Profil
           </TabsTrigger>
-        )}
-        {patrimoineContent && (
-          <TabsTrigger value="patrimoine">
-            <Wallet className="size-4" />
-            Patrimoine
+          <TabsTrigger value="carriere">
+            <Briefcase className="size-4" />
+            Carrière
           </TabsTrigger>
-        )}
-        {factchecksContent && (
-          <TabsTrigger value="factchecks">
-            <FileCheck className="size-4" />
-            Fact-checks
-          </TabsTrigger>
-        )}
-        <TabsTrigger value="affaires">
-          <Scale className="size-4" />
-          Affaires
-          {affairsCount != null && affairsCount > 0 && (
-            <span className="ml-1 inline-flex items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-xs font-medium min-w-[1.25rem] h-5 px-1.5">
-              {affairsCount}
-            </span>
+          {votesContent && (
+            <TabsTrigger value="votes">
+              <Vote className="size-4" />
+              Votes
+            </TabsTrigger>
           )}
-        </TabsTrigger>
-      </TabsList>
-      <TabsContent value="profil">{profileContent}</TabsContent>
-      <TabsContent value="carriere">{careerContent}</TabsContent>
-      {votesContent && <TabsContent value="votes">{votesContent}</TabsContent>}
-      {patrimoineContent && <TabsContent value="patrimoine">{patrimoineContent}</TabsContent>}
-      {factchecksContent && <TabsContent value="factchecks">{factchecksContent}</TabsContent>}
-      <TabsContent value="affaires">{affairsContent}</TabsContent>
-    </Tabs>
+          {patrimoineContent && (
+            <TabsTrigger value="patrimoine">
+              <Wallet className="size-4" />
+              Patrimoine
+            </TabsTrigger>
+          )}
+          {factchecksContent && (
+            <TabsTrigger value="factchecks">
+              <FileCheck className="size-4" />
+              Fact-checks
+            </TabsTrigger>
+          )}
+          <TabsTrigger value="affaires">
+            <Scale className="size-4" />
+            Affaires
+            {affairsCount != null && affairsCount > 0 && (
+              <span className="ml-1 inline-flex items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-xs font-medium min-w-[1.25rem] h-5 px-1.5">
+                {affairsCount}
+              </span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="profil">{profileContent}</TabsContent>
+        <TabsContent value="carriere">{careerContent}</TabsContent>
+        {votesContent && <TabsContent value="votes">{votesContent}</TabsContent>}
+        {patrimoineContent && <TabsContent value="patrimoine">{patrimoineContent}</TabsContent>}
+        {factchecksContent && <TabsContent value="factchecks">{factchecksContent}</TabsContent>}
+        <TabsContent value="affaires">{affairsContent}</TabsContent>
+      </Tabs>
+    </div>
   );
 }
 

--- a/src/components/politicians/TabShortcutLink.tsx
+++ b/src/components/politicians/TabShortcutLink.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { revealProfileTabs } from "./profile-tabs-anchor";
+
+/**
+ * Shortcut to one of the profile tabs. Selecting the tab is the job of `?tab=`
+ * in the href; this only makes sure the visitor ends up looking at the panel
+ * that just opened, which `scroll={false}` alone never did.
+ */
+export function TabShortcutLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  // A few shortcuts point at an in-page anchor (#dossiers) instead of a tab.
+  // The browser already scrolls those, and revealing the tabs would fight it.
+  const opensTab = /[?&]tab=/.test(href);
+
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      scroll={false}
+      className={className}
+      onClick={opensTab ? () => revealProfileTabs() : undefined}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/politicians/__tests__/PoliticianSignals.test.tsx
+++ b/src/components/politicians/__tests__/PoliticianSignals.test.tsx
@@ -1,7 +1,30 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { PoliticianSignals } from "@/components/politicians/PoliticianSignals";
 import type { Signal } from "@/lib/politicians/signals";
+import { mountTabsAnchor } from "./helpers";
+
+// Plain anchor: jsdom has no navigation, and the click has to reach our handler.
+vi.mock("next/link", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ children, href, onClick, ...props }: any) => (
+    <a
+      href={href}
+      onClick={(e: React.MouseEvent) => {
+        e.preventDefault();
+        onClick?.(e);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
 
 const signal = (over: Partial<Signal>): Signal => ({
   key: "mandats",
@@ -20,6 +43,15 @@ describe("PoliticianSignals", () => {
     const link = screen.getByRole("link", { name: /Mandats/ });
     expect(link).toHaveAttribute("href", "/politiques/x?tab=carriere");
     expect(link).toHaveTextContent("8");
+  });
+
+  it("brings the tabs into view when a card is clicked", () => {
+    const anchor = mountTabsAnchor();
+    render(<PoliticianSignals signals={[signal({})]} />);
+
+    fireEvent.click(screen.getByRole("link", { name: /Mandats/ }));
+
+    expect(anchor.scrollIntoView).toHaveBeenCalled();
   });
 
   it("does not render non-primary signals as cards", () => {

--- a/src/components/politicians/__tests__/PoliticianSummary.test.tsx
+++ b/src/components/politicians/__tests__/PoliticianSummary.test.tsx
@@ -1,8 +1,26 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
 import type { Signal } from "@/lib/politicians/signals";
 import type { SourceLink } from "@/lib/politicians/external-sources";
+import { mountTabsAnchor } from "./helpers";
+
+// Plain anchor: jsdom has no navigation, and the click has to reach our handler.
+vi.mock("next/link", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ children, href, onClick, ...props }: any) => (
+    <a
+      href={href}
+      onClick={(e: React.MouseEvent) => {
+        e.preventDefault();
+        onClick?.(e);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
 
 const signals: Signal[] = [
   {
@@ -16,6 +34,11 @@ const signals: Signal[] = [
   },
 ];
 const sources: SourceLink[] = [{ source: "HATVP", label: "HATVP", url: "https://www.hatvp.fr/x" }];
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
 
 describe("PoliticianSummary", () => {
   it("renders every signal as a link and the sources with a new-tab hint", () => {
@@ -31,6 +54,48 @@ describe("PoliticianSummary", () => {
     const hatvp = screen.getByRole("link", { name: /HATVP.*ouvre un nouvel onglet/i });
     expect(hatvp).toHaveAttribute("target", "_blank");
     expect(hatvp).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("brings the tabs into view when a shortcut is clicked", () => {
+    const anchor = mountTabsAnchor();
+    render(
+      <PoliticianSummary
+        signals={signals}
+        sources={sources}
+        relationsHref="/politiques/x/relations"
+        lastUpdated="19 juil. 2026"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /Mandats/ }));
+
+    expect(anchor.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("leaves in-page anchor shortcuts to the browser", () => {
+    const anchor = mountTabsAnchor();
+    render(
+      <PoliticianSummary
+        signals={[
+          {
+            key: "dossiers",
+            iconKey: "filetext",
+            label: "Propositions de loi",
+            value: "4",
+            href: "/politiques/x#dossiers",
+            tone: "neutral",
+            primary: false,
+          },
+        ]}
+        sources={sources}
+        relationsHref="/politiques/x/relations"
+        lastUpdated="19 juil. 2026"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /Propositions de loi/ }));
+
+    expect(anchor.scrollIntoView).not.toHaveBeenCalled();
   });
 
   it("generates no fixed HTML id (mounted twice)", () => {

--- a/src/components/politicians/__tests__/ProfileTabs.test.tsx
+++ b/src/components/politicians/__tests__/ProfileTabs.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProfileTabs } from "@/components/politicians/ProfileTabs";
+import { PROFILE_TABS_ANCHOR_ID } from "@/components/politicians/profile-tabs-anchor";
+
+// TabsList watches its own width to fade the horizontal scroll edges; jsdom
+// ships no ResizeObserver.
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+function renderTabs() {
+  return render(
+    <ProfileTabs
+      profileContent={<p>contenu profil</p>}
+      careerContent={<p>contenu carrière</p>}
+      votesContent={null}
+      patrimoineContent={null}
+      factchecksContent={null}
+      affairsContent={<p>contenu affaires</p>}
+    />
+  );
+}
+
+describe("ProfileTabs", () => {
+  it("exposes exactly one anchor for the shortcuts to target", () => {
+    const { container } = renderTabs();
+
+    expect(container.querySelectorAll(`#${PROFILE_TABS_ANCHOR_ID}`)).toHaveLength(1);
+  });
+
+  it("makes the anchor focusable without adding it to the tab order", () => {
+    const { container } = renderTabs();
+
+    expect(container.querySelector(`#${PROFILE_TABS_ANCHOR_ID}`)).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("keeps the anchor clear of the sticky header once scrolled to", () => {
+    const { container } = renderTabs();
+
+    // The site header is `sticky top-0` and 4rem tall, so an anchor aligned to
+    // the very top of the viewport would land underneath it.
+    expect(container.querySelector(`#${PROFILE_TABS_ANCHOR_ID}`)?.className).toMatch(/scroll-mt-/);
+  });
+
+  it("still renders the tab list", () => {
+    renderTabs();
+
+    expect(screen.getByRole("tab", { name: /Carrière/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Profil/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/politicians/__tests__/helpers.ts
+++ b/src/components/politicians/__tests__/helpers.ts
@@ -1,0 +1,27 @@
+import { vi } from "vitest";
+import { PROFILE_TABS_ANCHOR_ID } from "@/components/politicians/profile-tabs-anchor";
+
+/**
+ * Stand-in for the anchor `ProfileTabs` renders, plus the two browser APIs
+ * jsdom leaves out (`scrollIntoView`, `matchMedia`). Callers must clean the
+ * body and unstub globals afterwards.
+ */
+export function mountTabsAnchor({ reducedMotion = false } = {}) {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reducedMotion && query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+
+  const anchor = document.createElement("div");
+  anchor.id = PROFILE_TABS_ANCHOR_ID;
+  anchor.tabIndex = -1;
+  anchor.scrollIntoView = vi.fn();
+  document.body.appendChild(anchor);
+  return anchor;
+}

--- a/src/components/politicians/__tests__/profile-tabs-anchor.test.ts
+++ b/src/components/politicians/__tests__/profile-tabs-anchor.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { PROFILE_TABS_ANCHOR_ID, revealProfileTabs } from "../profile-tabs-anchor";
+
+function mountAnchor() {
+  const el = document.createElement("div");
+  el.id = PROFILE_TABS_ANCHOR_ID;
+  el.tabIndex = -1;
+  // jsdom implements neither scrollIntoView nor matchMedia.
+  el.scrollIntoView = vi.fn();
+  document.body.appendChild(el);
+  return el;
+}
+
+function stubReducedMotion(reduce: boolean) {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("revealProfileTabs", () => {
+  it("brings the tabs anchor into view", () => {
+    stubReducedMotion(false);
+    const el = mountAnchor();
+
+    revealProfileTabs();
+
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("moves focus to the anchor without a second jump", () => {
+    stubReducedMotion(false);
+    const el = mountAnchor();
+    const focus = vi.spyOn(el, "focus");
+
+    revealProfileTabs();
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(document.activeElement).toBe(el);
+  });
+
+  it("drops the animation when the visitor asked for reduced motion", () => {
+    stubReducedMotion(true);
+    const el = mountAnchor();
+
+    revealProfileTabs();
+
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: "auto", block: "start" });
+  });
+
+  it("stays silent when no tabs are mounted on the page", () => {
+    stubReducedMotion(false);
+
+    expect(() => revealProfileTabs()).not.toThrow();
+  });
+});

--- a/src/components/politicians/profile-tabs-anchor.ts
+++ b/src/components/politicians/profile-tabs-anchor.ts
@@ -1,0 +1,21 @@
+/**
+ * Anchor shared by the profile tabs and the shortcuts that open them.
+ *
+ * The "En bref" shortcuts change the active tab through `?tab=`, but on mobile
+ * they render above the tabs, so the panel they open is off screen and the
+ * click looks like a no-op. Both sides agree on this id so a shortcut can bring
+ * the tabs into view. It lives on `ProfileTabs`, mounted once, never on the
+ * summary, which is mounted twice.
+ */
+export const PROFILE_TABS_ANCHOR_ID = "fiche-onglets";
+
+export function revealProfileTabs() {
+  const anchor = document.getElementById(PROFILE_TABS_ANCHOR_ID);
+  if (!anchor) return;
+
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  anchor.scrollIntoView({ behavior: reduced ? "auto" : "smooth", block: "start" });
+  // Keyboard and screen reader users follow the same path as the pointer. The
+  // scroll above already did the moving, so focus must not redo it.
+  anchor.focus({ preventScroll: true });
+}

--- a/src/components/politicians/timeline/CareerTimeline.tsx
+++ b/src/components/politicians/timeline/CareerTimeline.tsx
@@ -8,7 +8,7 @@ import { AFFAIR_STATUS_MARKER_COLORS, getMandateRow, MANDATE_ROW_LABELS } from "
 import { formatDate } from "@/lib/utils";
 import type { CareerTimelineProps, TooltipData, TimelineAffair } from "./types";
 import { LEFT_MARGIN, RIGHT_MARGIN } from "./types";
-import { computeDuration, computeOverlapOffsets } from "./utils";
+import { computeDuration, computeOverlapOffsets, mandateAffiliation } from "./utils";
 import { DesktopTimeline } from "./DesktopTimeline";
 import { MobileTimeline } from "./MobileTimeline";
 
@@ -174,10 +174,12 @@ export function CareerTimeline({
 
   const handleMandateHover = useCallback(
     (mandate: (typeof mandates)[number], event: React.MouseEvent) => {
+      const affiliation = mandateAffiliation(mandate);
       showTooltip(
         event,
         <div className="text-left">
           <p className="font-semibold">{MANDATE_TYPE_LABELS[mandate.type]}</p>
+          {affiliation && <p className="text-xs">{affiliation}</p>}
           {mandate.constituency && (
             <p className="text-xs text-muted-foreground">{mandate.constituency}</p>
           )}

--- a/src/components/politicians/timeline/DesktopTimeline.tsx
+++ b/src/components/politicians/timeline/DesktopTimeline.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type { scaleTime } from "d3-scale";
-import type { SerializedMandate } from "@/types";
 import { MANDATE_TYPE_LABELS, AFFAIR_STATUS_LABELS } from "@/config/labels";
 import { MANDATE_TYPE_COLORS, AFFAIR_STATUS_MARKER_COLORS } from "@/config/timeline";
 import { formatDate } from "@/lib/utils";
-import type { CareerTimelineProps, TooltipData, TimelineAffair } from "./types";
+import type { CareerTimelineProps, TooltipData, TimelineAffair, TimelineMandate } from "./types";
+import { mandateAffiliation } from "./utils";
 import {
   LEFT_MARGIN,
   RIGHT_MARGIN,
@@ -41,11 +41,11 @@ export function DesktopTimeline({
   tooltip: TooltipData | null;
   xScale: ReturnType<typeof scaleTime<number, number>>;
   yearMarkers: number[];
-  mandates: SerializedMandate[];
+  mandates: TimelineMandate[];
   mandateRows: {
     row: number;
     label: string;
-    mandates: SerializedMandate[];
+    mandates: TimelineMandate[];
     overlapOffsets: Map<string, number>;
     maxLanes: number;
   }[];
@@ -54,7 +54,7 @@ export function DesktopTimeline({
   deathDate?: Date | null;
   minDate: Date;
   maxDate: Date;
-  onMandateHover: (mandate: SerializedMandate, e: React.MouseEvent) => void;
+  onMandateHover: (mandate: TimelineMandate, e: React.MouseEvent) => void;
   onAffairHover: (affair: TimelineAffair, e: React.MouseEvent) => void;
   onHideTooltip: () => void;
 }) {
@@ -198,6 +198,7 @@ export function DesktopTimeline({
               const endX = xScale(endDate);
               const width = Math.max(endX - startX, MIN_BAR_WIDTH);
               const color = MANDATE_TYPE_COLORS[mandate.type];
+              const affiliation = mandateAffiliation(mandate);
               const laneOffset = overlapOffsets.get(mandate.id) ?? 0;
               const top =
                 rowYPositions[rowIndex]! + laneOffset * ROW_HEIGHT + (ROW_HEIGHT - BAR_HEIGHT) / 2;
@@ -217,7 +218,7 @@ export function DesktopTimeline({
                   }}
                   role="button"
                   tabIndex={0}
-                  aria-label={`${MANDATE_TYPE_LABELS[mandate.type]}${mandate.constituency ? `, ${mandate.constituency}` : ""}, ${new Date(mandate.startDate).getFullYear()} - ${mandate.isCurrent ? "présent" : mandate.endDate ? new Date(mandate.endDate).getFullYear() : ""}`}
+                  aria-label={`${MANDATE_TYPE_LABELS[mandate.type]}${affiliation ? `, ${affiliation}` : ""}${mandate.constituency ? `, ${mandate.constituency}` : ""}, ${new Date(mandate.startDate).getFullYear()} - ${mandate.isCurrent ? "présent" : mandate.endDate ? new Date(mandate.endDate).getFullYear() : ""}`}
                   onMouseEnter={(e) => onMandateHover(mandate, e)}
                   onMouseLeave={onHideTooltip}
                 >

--- a/src/components/politicians/timeline/MobileTimeline.tsx
+++ b/src/components/politicians/timeline/MobileTimeline.tsx
@@ -2,11 +2,11 @@
 
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
-import type { SerializedMandate } from "@/types";
 import { MANDATE_TYPE_LABELS, AFFAIR_STATUS_LABELS } from "@/config/labels";
 import { MANDATE_TYPE_COLORS, AFFAIR_STATUS_MARKER_COLORS } from "@/config/timeline";
 import { formatDate } from "@/lib/utils";
-import type { CareerTimelineProps, TimelineAffair, MobileEvent } from "./types";
+import type { CareerTimelineProps, TimelineAffair, MobileEvent, TimelineMandate } from "./types";
+import { mandateAffiliation } from "./utils";
 import { TimelineLegend } from "./TimelineLegend";
 import { ScreenReaderSummary } from "./ScreenReaderSummary";
 
@@ -16,7 +16,7 @@ export function MobileTimeline({
   timelineAffairs,
   deathDate,
 }: {
-  mandates: SerializedMandate[];
+  mandates: TimelineMandate[];
   partyHistory: CareerTimelineProps["partyHistory"];
   timelineAffairs: TimelineAffair[];
   deathDate?: Date | null;
@@ -87,11 +87,13 @@ function MobileEventCard({ event }: { event: MobileEvent }) {
   switch (event.type) {
     case "mandate-start": {
       const color = MANDATE_TYPE_COLORS[event.mandate.type];
+      const affiliation = mandateAffiliation(event.mandate);
       return (
         <div className="relative">
           <DotMarker color={color} />
           <div className="text-sm">
             <p className="font-medium">Début : {MANDATE_TYPE_LABELS[event.mandate.type]}</p>
+            {affiliation && <p className="text-xs text-foreground/80">{affiliation}</p>}
             {event.mandate.constituency && (
               <p className="text-xs text-muted-foreground">{event.mandate.constituency}</p>
             )}
@@ -106,6 +108,7 @@ function MobileEventCard({ event }: { event: MobileEvent }) {
       );
     }
     case "mandate-end": {
+      const affiliation = mandateAffiliation(event.mandate);
       return (
         <div className="relative">
           <DotMarker color="#9ca3af" />
@@ -113,6 +116,7 @@ function MobileEventCard({ event }: { event: MobileEvent }) {
             <p className="font-medium text-muted-foreground">
               Fin : {MANDATE_TYPE_LABELS[event.mandate.type]}
             </p>
+            {affiliation && <p className="text-xs text-muted-foreground">{affiliation}</p>}
             {event.mandate.constituency && (
               <p className="text-xs text-muted-foreground">{event.mandate.constituency}</p>
             )}

--- a/src/components/politicians/timeline/ScreenReaderSummary.tsx
+++ b/src/components/politicians/timeline/ScreenReaderSummary.tsx
@@ -1,7 +1,7 @@
-import type { SerializedMandate } from "@/types";
 import { MANDATE_TYPE_LABELS, AFFAIR_STATUS_LABELS } from "@/config/labels";
 import { formatDate } from "@/lib/utils";
-import type { TimelineAffair } from "./types";
+import type { TimelineAffair, TimelineMandate } from "./types";
+import { mandateAffiliation } from "./utils";
 
 export function ScreenReaderSummary({
   mandates,
@@ -9,7 +9,7 @@ export function ScreenReaderSummary({
   minYear,
   maxYear,
 }: {
-  mandates: SerializedMandate[];
+  mandates: TimelineMandate[];
   timelineAffairs: TimelineAffair[];
   minYear: number;
   maxYear: number;
@@ -22,13 +22,17 @@ export function ScreenReaderSummary({
       </p>
       <h4>Mandats ({mandates.length})</h4>
       <ul>
-        {mandates.map((m) => (
-          <li key={m.id}>
-            {MANDATE_TYPE_LABELS[m.type]}
-            {m.constituency && `, ${m.constituency}`} : {new Date(m.startDate).getFullYear()} -{" "}
-            {m.isCurrent ? "présent" : m.endDate ? new Date(m.endDate).getFullYear() : ""}
-          </li>
-        ))}
+        {mandates.map((m) => {
+          const affiliation = mandateAffiliation(m);
+          return (
+            <li key={m.id}>
+              {MANDATE_TYPE_LABELS[m.type]}
+              {affiliation && `, ${affiliation}`}
+              {m.constituency && `, ${m.constituency}`} : {new Date(m.startDate).getFullYear()} -{" "}
+              {m.isCurrent ? "présent" : m.endDate ? new Date(m.endDate).getFullYear() : ""}
+            </li>
+          );
+        })}
       </ul>
       {timelineAffairs.length > 0 && (
         <>

--- a/src/components/politicians/timeline/__tests__/CareerTimeline.desktop.test.tsx
+++ b/src/components/politicians/timeline/__tests__/CareerTimeline.desktop.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CareerTimeline } from "../CareerTimeline";
+import { mandate } from "./factories";
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  // The desktop chart only renders above 1024px.
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: query.includes("min-width: 1024px"),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const deputy = mandate({
+  type: "DEPUTE",
+  constituency: "Essonne (1ère)",
+  parliamentaryData: { parliamentaryGroup: { name: "Les Démocrates" } },
+});
+
+function renderDesktop() {
+  return render(
+    <CareerTimeline mandates={[deputy]} partyHistory={[]} affairs={[]} deathDate={null} />
+  );
+}
+
+describe("CareerTimeline (desktop)", () => {
+  it("names the group in the accessible label of a mandate bar", () => {
+    renderDesktop();
+
+    expect(screen.getByRole("button", { name: /Groupe Les Démocrates/ })).toBeInTheDocument();
+  });
+
+  it("names the group in the hover tooltip", () => {
+    renderDesktop();
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /Député/ }));
+
+    expect(screen.getByText("Groupe Les Démocrates")).toBeInTheDocument();
+  });
+});

--- a/src/components/politicians/timeline/__tests__/MobileTimeline.test.tsx
+++ b/src/components/politicians/timeline/__tests__/MobileTimeline.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { MobileTimeline } from "../MobileTimeline";
+import { mandate } from "./factories";
+
+/** Text a sighted visitor actually reads, with the screen-reader summary out. */
+function visibleText(container: HTMLElement) {
+  const clone = container.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(".sr-only").forEach((el) => el.remove());
+  return clone.textContent ?? "";
+}
+
+function renderTimeline(mandates: ReturnType<typeof mandate>[]) {
+  return render(
+    <MobileTimeline mandates={mandates} partyHistory={[]} timelineAffairs={[]} deathDate={null} />
+  );
+}
+
+describe("MobileTimeline", () => {
+  it("says which party a party leader ran", () => {
+    const { container } = renderTimeline([
+      mandate({
+        type: "PRESIDENT_PARTI",
+        title: "Dirigeant(e) - En marche",
+        party: { name: "En marche" },
+      }),
+    ]);
+
+    expect(visibleText(container)).toContain("En marche");
+  });
+
+  it("says which group a deputy sat with", () => {
+    const { container } = renderTimeline([
+      mandate({
+        type: "DEPUTE",
+        constituency: "Essonne (1ère)",
+        parliamentaryData: { parliamentaryGroup: { name: "Ensemble pour la République" } },
+      }),
+    ]);
+
+    const text = visibleText(container);
+    expect(text).toContain("Groupe Ensemble pour la République");
+    expect(text).toContain("Essonne (1ère)");
+  });
+
+  it("repeats the affiliation on the end of a mandate", () => {
+    const { container } = renderTimeline([
+      mandate({
+        type: "DEPUTE",
+        isCurrent: false,
+        endDate: new Date("2024-06-09"),
+        parliamentaryData: { parliamentaryGroup: { name: "Les Démocrates" } },
+      }),
+    ]);
+
+    const text = visibleText(container);
+    expect(text).toContain("Fin : Député");
+    expect(text.match(/Groupe Les Démocrates/g)).toHaveLength(2);
+  });
+
+  it("adds nothing when the group is unknown", () => {
+    const { container } = renderTimeline([
+      mandate({ type: "DEPUTE", title: "Député de l'Essonne", constituency: "Essonne (1ère)" }),
+    ]);
+
+    expect(visibleText(container)).not.toContain("Groupe");
+  });
+});

--- a/src/components/politicians/timeline/__tests__/ScreenReaderSummary.test.tsx
+++ b/src/components/politicians/timeline/__tests__/ScreenReaderSummary.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScreenReaderSummary } from "../ScreenReaderSummary";
+import { mandate } from "./factories";
+
+describe("ScreenReaderSummary", () => {
+  it("names the group in the mandate list", () => {
+    render(
+      <ScreenReaderSummary
+        mandates={[
+          mandate({
+            type: "DEPUTE",
+            constituency: "Essonne (1ère)",
+            parliamentaryData: { parliamentaryGroup: { name: "Les Démocrates" } },
+          }),
+        ]}
+        timelineAffairs={[]}
+        minYear={2022}
+        maxYear={2026}
+      />
+    );
+
+    expect(screen.getByRole("listitem")).toHaveTextContent(
+      "Député, Groupe Les Démocrates, Essonne (1ère)"
+    );
+  });
+
+  it("skips the affiliation when it is unknown", () => {
+    render(
+      <ScreenReaderSummary
+        mandates={[mandate({ type: "DEPUTE", constituency: "Essonne (1ère)" })]}
+        timelineAffairs={[]}
+        minYear={2022}
+        maxYear={2026}
+      />
+    );
+
+    expect(screen.getByRole("listitem")).toHaveTextContent("Député, Essonne (1ère)");
+  });
+});

--- a/src/components/politicians/timeline/__tests__/factories.ts
+++ b/src/components/politicians/timeline/__tests__/factories.ts
@@ -1,0 +1,29 @@
+import type { MandateType } from "@/types";
+import type { TimelineMandate } from "../types";
+
+export function mandate(over: Partial<TimelineMandate> & { type: MandateType }): TimelineMandate {
+  return {
+    id: "m1",
+    publicId: "MA-000001",
+    politicianId: "p1",
+    title: "",
+    institution: "",
+    role: null,
+    constituency: null,
+    departmentCode: null,
+    startDate: new Date("2022-06-22"),
+    endDate: null,
+    isCurrent: true,
+    source: null,
+    partyId: null,
+    externalId: null,
+    sourceUrl: null,
+    officialUrl: null,
+    createdAt: new Date("2022-06-22"),
+    updatedAt: new Date("2022-06-22"),
+    party: null,
+    parliamentaryData: null,
+    europeanData: null,
+    ...over,
+  };
+}

--- a/src/components/politicians/timeline/__tests__/utils.test.ts
+++ b/src/components/politicians/timeline/__tests__/utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { mandateAffiliation } from "../utils";
+import { mandate } from "./factories";
+
+describe("mandateAffiliation", () => {
+  it("names the party behind a party leadership", () => {
+    const result = mandateAffiliation(
+      mandate({
+        type: "PRESIDENT_PARTI",
+        title: "Dirigeant(e) - La France insoumise",
+        party: { name: "La France insoumise" },
+      })
+    );
+
+    expect(result).toBe("La France insoumise");
+  });
+
+  it("names the parliamentary group of a deputy, flagged as a group", () => {
+    const result = mandateAffiliation(
+      mandate({
+        type: "DEPUTE",
+        parliamentaryData: { parliamentaryGroup: { name: "Ensemble pour la République" } },
+      })
+    );
+
+    // "Ensemble pour la République" is a group, not a party. Saying so keeps
+    // the two apart for the reader.
+    expect(result).toBe("Groupe Ensemble pour la République");
+  });
+
+  it("names the parliamentary group of a senator", () => {
+    const result = mandateAffiliation(
+      mandate({
+        type: "SENATEUR",
+        parliamentaryData: {
+          parliamentaryGroup: { name: "Socialiste, Écologiste et Républicain" },
+        },
+      })
+    );
+
+    expect(result).toBe("Groupe Socialiste, Écologiste et Républicain");
+  });
+
+  it("names the european group of an MEP", () => {
+    const result = mandateAffiliation(
+      mandate({
+        type: "DEPUTE_EUROPEEN",
+        europeanData: { europeanGroup: { name: "Renew Europe" } },
+      })
+    );
+
+    expect(result).toBe("Groupe Renew Europe");
+  });
+
+  it("gives the actual portfolio of a minister", () => {
+    const result = mandateAffiliation(
+      mandate({ type: "MINISTRE", title: "Garde des sceaux, ministre de la justice" })
+    );
+
+    expect(result).toBe("Garde des sceaux, ministre de la justice");
+  });
+
+  it("stays silent when a minister's title only repeats the generic label", () => {
+    const result = mandateAffiliation(
+      mandate({ type: "PREMIER_MINISTRE", title: "Premier ministre" })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("stays silent when a deputy has no recorded group", () => {
+    const result = mandateAffiliation(mandate({ type: "DEPUTE", title: "Député de l'Essonne" }));
+
+    expect(result).toBeNull();
+  });
+
+  it("stays silent for a mayor, whose commune is already displayed", () => {
+    const result = mandateAffiliation(
+      mandate({ type: "MAIRE", title: "Maire d'Agen", constituency: "Agen" })
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/components/politicians/timeline/types.ts
+++ b/src/components/politicians/timeline/types.ts
@@ -2,8 +2,21 @@ import type { SerializedMandate, SerializedAffairWithSources, AffairStatus } fro
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
+/**
+ * A mandate plus the relations the timeline needs to say who the person sat
+ * with. `PoliticianFull.mandates` is typed as a bare `Mandate`, which is how
+ * the group could be fetched by the page query and still never reach the
+ * screen. Required (though nullable) on purpose: a missing `include` has to be
+ * a compile error, not a silently empty line.
+ */
+export type TimelineMandate = SerializedMandate & {
+  party: { name: string } | null;
+  parliamentaryData: { parliamentaryGroup: { name: string } | null } | null;
+  europeanData: { europeanGroup: { name: string } | null } | null;
+};
+
 export interface CareerTimelineProps {
-  mandates: SerializedMandate[];
+  mandates: TimelineMandate[];
   partyHistory: {
     id: string;
     startDate: Date | null;
@@ -37,8 +50,8 @@ export interface TimelineAffair {
 
 /** A chronological event for the mobile vertical timeline. */
 export type MobileEvent =
-  | { type: "mandate-start"; date: Date; mandate: SerializedMandate }
-  | { type: "mandate-end"; date: Date; mandate: SerializedMandate }
+  | { type: "mandate-start"; date: Date; mandate: TimelineMandate }
+  | { type: "mandate-end"; date: Date; mandate: TimelineMandate }
   | {
       type: "party-change";
       date: Date;

--- a/src/components/politicians/timeline/utils.ts
+++ b/src/components/politicians/timeline/utils.ts
@@ -1,4 +1,47 @@
 import type { SerializedMandate } from "@/types";
+import { MANDATE_TYPE_LABELS } from "@/config/labels";
+import type { TimelineMandate } from "./types";
+
+/**
+ * Who the person sat with during a mandate, or what they were actually in
+ * charge of. "Député" alone says nothing about the group; "Dirigeant(e) de
+ * parti" says nothing about the party.
+ *
+ * Returns null whenever the data is missing, so the timeline silently falls
+ * back to the generic label rather than filling the gap with a guess.
+ */
+export function mandateAffiliation(mandate: TimelineMandate): string | null {
+  switch (mandate.type) {
+    case "PRESIDENT_PARTI":
+      return mandate.party?.name ?? null;
+
+    case "DEPUTE":
+    case "SENATEUR": {
+      const group = mandate.parliamentaryData?.parliamentaryGroup?.name;
+      return group ? `Groupe ${group}` : null;
+    }
+
+    case "DEPUTE_EUROPEEN": {
+      const group = mandate.europeanData?.europeanGroup?.name;
+      return group ? `Groupe ${group}` : null;
+    }
+
+    // Government titles carry the portfolio, which the mandate type does not.
+    // Restricted to these types on purpose: elsewhere the title only repeats
+    // the constituency already on screen ("Maire d'Agen").
+    case "PREMIER_MINISTRE":
+    case "MINISTRE":
+    case "MINISTRE_DELEGUE":
+    case "SECRETAIRE_ETAT": {
+      const title = mandate.title?.trim();
+      if (!title) return null;
+      return title.toLowerCase() === MANDATE_TYPE_LABELS[mandate.type].toLowerCase() ? null : title;
+    }
+
+    default:
+      return null;
+  }
+}
 
 export function computeDuration(startDate: string | Date, endDate: string | Date | null): string {
   const start = new Date(startDate);

--- a/src/lib/data/politicians.ts
+++ b/src/lib/data/politicians.ts
@@ -14,11 +14,21 @@ export const getPolitician = cache(async function getPolitician(slug: string) {
       mandates: {
         orderBy: { startDate: "desc" },
         include: {
+          // Who the person sat with, shown on the career timeline: the party
+          // for a party leadership, the group for a parliamentary mandate.
+          party: {
+            select: { name: true },
+          },
           parliamentaryData: {
             select: {
               parliamentaryGroup: {
                 select: { code: true, name: true, color: true },
               },
+            },
+          },
+          europeanData: {
+            select: {
+              europeanGroup: { select: { name: true } },
             },
           },
           // Commune population feeds the SEO richness predicate (politician-robots).


### PR DESCRIPTION
Deux retours d'une utilisatrice qui testait le site sur mobile le 06/08/2026.

## Les raccourcis « En bref » n'emmenaient nulle part (#658)

> « Quand tu cliques sur les flèches à droite ça devrait glisser vers le bas parce
> qu'on comprend pas que ça ouvre la bonne tab en dessous »

Les raccourcis passaient `scroll={false}` au `<Link href="?tab=...">`. Sur desktop
la carte est dans la colonne de droite, à hauteur du contenu, donc le changement se
devine. Sur mobile elle est rendue au-dessus du bloc à onglets : l'onglet s'ouvrait
hors écran et le clic passait pour cassé.

`ProfileTabs` expose maintenant une ancre unique (`#fiche-onglets`, `tabindex="-1"`,
`scroll-mt-20` pour passer sous le header sticky de 4rem), et un petit composant
client `TabShortcutLink` amène le visiteur dessus. Le focus suit le même chemin que
le pointeur, avec `preventScroll` pour ne pas annuler le défilement. Un visiteur qui
a désactivé les animations n'en a pas.

Le raccourci « Propositions de loi » pointe vers `#dossiers`, pas vers un onglet : il
est laissé au navigateur, sinon deux défilements se battaient.

## La timeline Carrière ne disait pas sous quelle étiquette (#659)

> « Et pour chaque politique tu vois que son dernier parti. Genre là sur l'historique
> ça serait bien de voir dirigeant de quel parti, ou pareil pour les députés »

Les événements de mandat n'affichaient que le libellé du type : « Début :
Dirigeant(e) de parti » sans le parti, « Début : Député » sans le groupe.

Un helper pur `mandateAffiliation()` résout le rattachement selon le type de mandat :
le parti pour une direction de parti, le groupe pour un mandat parlementaire (AN,
Sénat, Parlement européen), l'intitulé réel du portefeuille pour un poste
gouvernemental. Câblé sur les quatre surfaces : carte mobile, tooltip desktop,
`aria-label` des barres, résumé lecteur d'écran.

La donnée était déjà en base et, pour les groupes AN/Sénat, déjà chargée par la
requête de la page : elle n'arrivait simplement jamais à l'écran. `party` et
`europeanData` ont été ajoutés à l'`include`.

Deux points de conception valent d'être notés.

`TimelineMandate` déclare les trois relations comme **obligatoires** (nullables, mais
obligatoires). C'est exactement le trou qui a produit le bug : `PoliticianFull.mandates`
est typé `Mandate[]`, donc le groupe pouvait être chargé par la requête et rester
invisible sans que le compilateur bronche. Oublier un `include` est désormais une
erreur de type.

Le préfixe « Groupe » est volontaire. « Ensemble pour la République » est un groupe
parlementaire, pas un parti, et le projet tient cette distinction (deux modèles
Prisma séparés). Sans préfixe, un lecteur lit une étiquette partisane.

Quand la donnée manque, l'affichage retombe silencieusement sur l'ancien libellé, sans
texte de remplissage. Ce n'est pas un cas limite : la couverture des groupes est de
605/3412 pour les députés, 377/581 pour les sénateurs, 82/390 pour les MEP.

## Vérification

Suite complète : 3402 tests passés (3375 à la baseline), 0 échec. `tsc --noEmit`,
`eslint` et `next build` propres.

Mesuré au navigateur sur mobile (390x844) : au clic sur « Mandats », `scrollY` passe
de 0 à 749 et l'ancre se stabilise à 80px du haut, donc le header de 64px ne recouvre
rien. L'onglet actif devient bien « Carrière ».

Vu à l'écran sur deux fiches : une direction de parti affiche « Union des démocrates
et indépendants », un mandat de député en cours affiche « Groupe Horizons &
Indépendants », et les mandats de 2017 et 2022 sans groupe en base gardent l'ancien
libellé.

## À part

Un enregistrement ministériel sur 1773 a un `title` corrompu (un intitulé qui recolle
deux personnes, artefact de scraping). Il s'affichera tel quel. Le corriger dans la vue
le masquerait, donc ça mérite une issue data-quality à part plutôt qu'un contournement
ici.

Closes #658
Closes #659
