### PR TITLE
Corriger le débordement mobile et faire réagir la synthèse de l'hémicycle

### DIFF
--- a/src/components/__tests__/sr-only-tables.test.ts
+++ b/src/components/__tests__/sr-only-tables.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { resolve, relative } from "path";
+
+const SRC = resolve(__dirname, "../..");
+
+function tsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "generated") continue;
+      out.push(...tsxFiles(full));
+    } else if (entry.name.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * `sr-only` sets `position: absolute; width: 1px`, but a table laid out with
+ * `table-layout: auto` sizes itself on its content and ignores that width. It
+ * then sticks out of the body and widens the document, which reads on mobile as
+ * a blank strip on the right of every page carrying such a table.
+ *
+ * The trap is invisible on review: nothing is visible on screen, and only
+ * `documentElement.scrollWidth` shows it.
+ */
+describe("screen-reader-only tables", () => {
+  it("all declare a fixed layout so they cannot widen the document", () => {
+    const offenders: string[] = [];
+
+    for (const file of tsxFiles(SRC)) {
+      const content = readFileSync(file, "utf-8");
+      for (const match of content.matchAll(/<table[^>]*className="([^"]*)"/g)) {
+        const classes = match[1]!;
+        if (!/\bsr-only\b/.test(classes)) continue;
+        if (/\btable-fixed\b/.test(classes)) continue;
+        offenders.push(`${relative(SRC, file)} -> className="${classes}"`);
+      }
+    }
+
+    expect(
+      offenders,
+      `These sr-only tables can widen the document. Add "table-fixed":\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
+});

--- a/src/components/elections/municipales/ParityChart.tsx
+++ b/src/components/elections/municipales/ParityChart.tsx
@@ -111,7 +111,7 @@ export function ParityChart({ data, title }: ParityChartProps) {
       </div>
 
       {/* Screen reader table */}
-      <table className="sr-only" id={descId}>
+      <table className="sr-only table-fixed" id={descId}>
         <caption>{title}</caption>
         <thead>
           <tr>

--- a/src/components/parlement/CompositionHemicycle.tsx
+++ b/src/components/parlement/CompositionHemicycle.tsx
@@ -242,7 +242,7 @@ export function CompositionHemicycle({ anGroups, senatGroups }: Props) {
       </div>
 
       {/* Accessible data table (hidden) */}
-      <table className="sr-only">
+      <table className="sr-only table-fixed">
         <caption>Composition {chamber === "AN" ? "de l'Assemblée nationale" : "du Sénat"}</caption>
         <thead>
           <tr>

--- a/src/components/stats/DonutChart.tsx
+++ b/src/components/stats/DonutChart.tsx
@@ -57,7 +57,7 @@ export function DonutChart({ segments, size = 200, title }: DonutChartProps) {
         </g>
       </svg>
       {/* Screen reader table */}
-      <table className="sr-only" id={descId}>
+      <table className="sr-only table-fixed" id={descId}>
         <caption>{title}</caption>
         <thead>
           <tr>

--- a/src/components/stats/GroupDynamics.tsx
+++ b/src/components/stats/GroupDynamics.tsx
@@ -81,7 +81,7 @@ function AlignmentSpectrum({
       </div>
 
       {/* Screen reader table */}
-      <table className="sr-only" id={descId}>
+      <table className="sr-only table-fixed" id={descId}>
         <caption>Concordance des votes par groupe - {chamberLabel}</caption>
         <thead>
           <tr>

--- a/src/components/stats/Hemicycle.tsx
+++ b/src/components/stats/Hemicycle.tsx
@@ -30,7 +30,7 @@ export function Hemicycle({ groups }: HemicycleProps) {
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
   const [highlightGroup, setHighlightGroup] = useState<string | null>(null);
 
-  const { seats, deputyMap, totalMisEnCause, totalCondamnes, totalDeputies } = useMemo(() => {
+  const { seats, deputyMap } = useMemo(() => {
     const activeGroups = groups.filter((g) => g.deputies.length > 0);
     const groupInputs = activeGroups.map((g) => ({
       code: g.code,
@@ -78,21 +78,30 @@ export function Hemicycle({ groups }: HemicycleProps) {
       }
     }
 
-    const total = seatPositions.length;
-    const deputies = [...dMap.values()];
-    const misEnCause = deputies.filter((d) => d.deputy.activeAffairCount > 0).length;
-    const condamnes = deputies.filter(
-      (d) => d.deputy.maxCertaintyLevel === "ETABLI" || d.deputy.maxCertaintyLevel === "PRONONCE"
-    ).length;
+    return { seats: seatPositions, deputyMap: dMap };
+  }, [groups]);
+
+  // Counts follow the legend: selecting a group without moving the numbers made
+  // the chart say "I am looking at one group" while the sentence below still
+  // described the whole chamber.
+  const summary = useMemo(() => {
+    const scoped = [...deputyMap.values()].filter(
+      (d) => !highlightGroup || d.groupCode === highlightGroup
+    );
+    const seatCount = highlightGroup
+      ? seats.filter((s) => s.groupCode === highlightGroup).length
+      : seats.length;
+    const selected = highlightGroup ? groups.find((g) => g.code === highlightGroup) : undefined;
 
     return {
-      seats: seatPositions,
-      deputyMap: dMap,
-      totalMisEnCause: misEnCause,
-      totalCondamnes: condamnes,
-      totalDeputies: total,
+      misEnCause: scoped.filter((d) => d.deputy.activeAffairCount > 0).length,
+      condamnes: scoped.filter(
+        (d) => d.deputy.maxCertaintyLevel === "ETABLI" || d.deputy.maxCertaintyLevel === "PRONONCE"
+      ).length,
+      seatCount,
+      groupLabel: selected ? selected.shortName || selected.code : null,
     };
-  }, [groups]);
+  }, [deputyMap, seats, highlightGroup, groups]);
 
   // Severity score → circle radius
   const radiusScale = useMemo(
@@ -138,7 +147,7 @@ export function Hemicycle({ groups }: HemicycleProps) {
         viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
         className="w-full h-auto"
         role="img"
-        aria-label={`Hémicycle de l'Assemblée nationale : ${totalMisEnCause} député${totalMisEnCause !== 1 ? "s" : ""} mis en cause dans une affaire judiciaire sur ${totalDeputies}`}
+        aria-label={`Hémicycle de l'Assemblée nationale : ${summary.misEnCause} député${summary.misEnCause !== 1 ? "s" : ""}${summary.groupLabel ? ` du groupe ${summary.groupLabel}` : ""} mis en cause dans une affaire judiciaire sur ${summary.seatCount}`}
         aria-describedby={descId}
       >
         {seats.map((seat, i) => {
@@ -252,6 +261,7 @@ export function Hemicycle({ groups }: HemicycleProps) {
             key={g.code}
             className="flex items-center gap-1.5 text-xs hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded-sm"
             style={{ opacity: !highlightGroup || highlightGroup === g.code ? 1 : 0.4 }}
+            aria-pressed={highlightGroup === g.code}
             onClick={() => setHighlightGroup((prev) => (prev === g.code ? null : g.code))}
           >
             <span
@@ -265,18 +275,36 @@ export function Hemicycle({ groups }: HemicycleProps) {
       </div>
 
       {/* Summary stat */}
-      <p className="text-center text-sm text-muted-foreground mt-2">
-        <span className="font-semibold text-amber-600 dark:text-amber-400">{totalMisEnCause}</span>{" "}
-        député{totalMisEnCause !== 1 ? "s" : ""} mis en cause dans au moins une affaire judiciaire
-        sur <span className="font-semibold">{totalDeputies}</span>
-        {totalCondamnes > 0 && (
+      <p
+        className="text-center text-sm text-muted-foreground mt-2"
+        data-testid="hemicycle-summary"
+        aria-live="polite"
+      >
+        <span className="font-semibold text-amber-600 dark:text-amber-400">
+          {summary.misEnCause}
+        </span>{" "}
+        député{summary.misEnCause !== 1 ? "s" : ""}
+        {summary.groupLabel && ` du groupe ${summary.groupLabel}`} mis en cause dans au moins une
+        affaire judiciaire sur <span className="font-semibold">{summary.seatCount}</span>
+        {summary.condamnes > 0 && (
           <>
             {" "}
-            dont <span className="font-semibold">{totalCondamnes}</span> condamné
-            {totalCondamnes !== 1 ? "s" : ""}
+            dont <span className="font-semibold">{summary.condamnes}</span> condamné
+            {summary.condamnes !== 1 ? "s" : ""}
           </>
         )}
       </p>
+
+      {highlightGroup && (
+        <div className="mt-2 text-center">
+          <button
+            className="text-xs text-primary hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded-sm"
+            onClick={() => setHighlightGroup(null)}
+          >
+            Voir tous les groupes
+          </button>
+        </div>
+      )}
 
       {/* SR-only accessible table */}
       <table className="sr-only table-fixed" id={descId}>

--- a/src/components/stats/HorizontalBars.tsx
+++ b/src/components/stats/HorizontalBars.tsx
@@ -62,7 +62,7 @@ export function HorizontalBars({ bars, title, maxValue: globalMax }: HorizontalB
         })}
       </div>
       {/* Screen reader table */}
-      <table className="sr-only" id={descId}>
+      <table className="sr-only table-fixed" id={descId}>
         <caption>{title}</caption>
         <thead>
           <tr>

--- a/src/components/stats/ProportionBar.tsx
+++ b/src/components/stats/ProportionBar.tsx
@@ -72,7 +72,7 @@ export function ProportionBar({ breakdown, showLabels: _showLabels = false }: Pr
           );
         })}
       </div>
-      <table className="sr-only" id={descId}>
+      <table className="sr-only table-fixed" id={descId}>
         <caption>Répartition des verdicts</caption>
         <thead>
           <tr>

--- a/src/components/stats/__tests__/Hemicycle.test.tsx
+++ b/src/components/stats/__tests__/Hemicycle.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { Hemicycle } from "../Hemicycle";
+import type { HemicycleGroup, HemicycleDeputy } from "@/lib/data/hemicycle";
+
+function deputy(over: Partial<HemicycleDeputy> & { id: string }): HemicycleDeputy {
+  return {
+    slug: `d-${over.id}`,
+    firstName: "Jean",
+    lastName: `Nom${over.id}`,
+    photoUrl: null,
+    severityScore: 0,
+    maxCertaintyLevel: null,
+    activeAffairCount: 0,
+    ...over,
+  };
+}
+
+/** Two groups: RED has one convicted and one accused, BLUE has nobody. */
+const groups: HemicycleGroup[] = [
+  {
+    code: "RED",
+    name: "Groupe Rouge",
+    shortName: "RGE",
+    color: "#ff0000",
+    politicalPosition: null,
+    deputies: [
+      deputy({ id: "1", severityScore: 8, maxCertaintyLevel: "ETABLI", activeAffairCount: 2 }),
+      deputy({ id: "2", severityScore: 2, maxCertaintyLevel: "EN_COURS", activeAffairCount: 1 }),
+      deputy({ id: "3" }),
+    ],
+  },
+  {
+    code: "BLUE",
+    name: "Groupe Bleu",
+    shortName: "BLU",
+    color: "#0000ff",
+    politicalPosition: null,
+    deputies: [deputy({ id: "4" }), deputy({ id: "5" })],
+  },
+];
+
+/** The visible summary line, screen-reader table excluded. */
+function summary() {
+  return screen.getByTestId("hemicycle-summary").textContent?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+describe("Hemicycle summary", () => {
+  it("counts the whole chamber when no group is selected", () => {
+    render(<Hemicycle groups={groups} />);
+
+    expect(summary()).toContain("2 députés mis en cause");
+    expect(summary()).toContain("sur 5");
+    expect(summary()).toContain("1 condamné");
+  });
+
+  it("counts only the selected group and names it", () => {
+    render(<Hemicycle groups={groups} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /RGE/ }));
+
+    expect(summary()).toContain("RGE");
+    expect(summary()).toContain("2 députés");
+    expect(summary()).toContain("sur 3");
+    expect(summary()).toContain("1 condamné");
+  });
+
+  it("reads correctly for a group with nobody in trouble", () => {
+    render(<Hemicycle groups={groups} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /BLU/ }));
+
+    expect(summary()).toContain("BLU");
+    expect(summary()).toContain("0 député");
+    expect(summary()).toContain("sur 2");
+    // Nothing to say about convictions when there are none.
+    expect(summary()).not.toContain("condamné");
+  });
+
+  it("offers a way back to the whole chamber", () => {
+    render(<Hemicycle groups={groups} />);
+    fireEvent.click(screen.getByRole("button", { name: /RGE/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: /tous les groupes/i }));
+
+    expect(summary()).toContain("sur 5");
+    expect(screen.queryByRole("button", { name: /tous les groupes/i })).toBeNull();
+  });
+
+  it("announces the selected group to assistive technology", () => {
+    render(<Hemicycle groups={groups} />);
+    const legend = screen.getByRole("button", { name: /RGE/ });
+
+    expect(legend).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(legend);
+    expect(legend).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps the screen-reader table on the whole chamber", () => {
+    render(<Hemicycle groups={groups} />);
+    fireEvent.click(screen.getByRole("button", { name: /RGE/ }));
+
+    // The table is a full data alternative to the chart, not a view of it.
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("BLU")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Deux retours d'une utilisatrice sur mobile, sur la même capture d'écran.

## Une bande vide à droite sur mobile (#665)

Le contenu n'occupait qu'une partie de la largeur, avec un vide à droite. Mesuré sur
`/statistiques` en 412px de large :

```
clientWidth  : 412
scrollWidth  : 580   <- 168px de trop
body.scrollWidth : 412   <- le flux normal allait bien
```

Le body était à la bonne largeur, donc le débordement venait d'un élément en
`position: absolute` échappé. Le coupable : une `<table class="sr-only">` de 540px.

`sr-only` pose `width: 1px`, mais une table en `table-layout: auto` se dimensionne sur
son contenu et ignore cette largeur. Le `white-space: nowrap` du même utilitaire
empêche en plus le texte de se replier, ce qui étale encore les colonnes.

Six tables étaient concernées, sur trois pages publiques (`/statistiques`,
`/parlement`, la page parité des municipales). La septième, celle de l'hémicycle,
portait déjà `table-fixed` : le contournement existait, appliqué à un seul endroit.

Le piège est invisible à la relecture, puisque rien ne dépasse à l'écran et que seul
`scrollWidth` le révèle. Un test parcourt donc les `.tsx` et échoue si une
`<table className="sr-only">` apparaît sans disposition fixe.

Mesure après correction, sur les trois pages : `scrollWidth` égale `clientWidth`.

## Les chiffres ne suivaient pas le groupe cliqué (#666)

> « Dans les stats générales quand tu cliques sur un parti ça serait bien que les
> chiffres en dessous se mettent à jour que sur le parti concerné »

La légende de l'hémicycle était déjà cliquable et estompait les sièges des autres
groupes, mais la ligne de synthèse ne bougeait pas : les totaux venaient d'un `useMemo`
qui ne dépendait que de `groups`. Le graphique disait « je regarde le RN », la phrase
en dessous décrivait toute l'Assemblée.

Les compteurs suivent maintenant la sélection, nomment le groupe, et un lien « Voir
tous les groupes » ramène à la vue d'ensemble sans avoir à deviner qu'il faut
recliquer la même pastille. Les boutons de légende portent `aria-pressed`, et
l'`aria-label` du graphique dit désormais la même chose que le texte affiché.

Vérifié au navigateur sur les données réelles :

```
avant  : 50 députés mis en cause ... sur 577 dont 30 condamnés
clic RN: 21 députés du groupe RN mis en cause ... sur 123 dont 13 condamnés
retour : 50 députés mis en cause ... sur 577 dont 30 condamnés
```

Les cartes « Élus condamnés » et « Élus mis en cause » plus bas restent globales, et
c'est voulu : elles comptent tous les élus, maires et sénateurs compris. Un maire n'a
pas de groupe à l'Assemblée, donc les filtrer par groupe parlementaire donnerait un
chiffre qui ne répond pas à la question posée.

## Vérification

Suite complète : 3409 tests passés (3402 avant), 0 échec. `tsc --noEmit` et
`next build` propres. `eslint` ne remonte que 4 avertissements pré-existants dans
`CumulTable.tsx`, fichier non touché ici.

Closes #665
Closes #666
