### PR TITLE
Committer le bloc d'instructions Next dans AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,3 +444,13 @@ A personal `CLAUDE.local.md` may exist in the working directory with deploy-spec
 If an instruction in this file is wrong, outdated, or in tension with another guideline, open a GitHub issue labeled `docs:agents-md` and propose a concrete replacement. Do not silently work around it.
 
 Project contact: [github.com/ironlam/poligraph/issues](https://github.com/ironlam/poligraph/issues).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
`next dev` écrit un bloc d'instructions dans `AGENTS.md` à chaque démarrage. Le
laisser hors du dépôt salissait l'arbre à chaque session de dev, y compris dans les
worktrees, où il a fallu le restaurer deux fois en une matinée.

## Pas d'option de désactivation

Vérifié dans `node_modules/next/dist/server/lib/generate-agent-files.js` : aucune
variable d'environnement, aucun flag de config. La seule question est de savoir où le
bloc vit.

## Pourquoi pas un `CLAUDE.md` racine

Next ne vise `AGENTS.md` que si un `CLAUDE.md` racine n'héberge pas déjà le bloc. Ça
semble être l'échappatoire idéale pour garder `AGENTS.md` intact, mais `.gitignore:83`
ignore `CLAUDE.md`. Le fichier serait donc par machine, et les worktrees démarrent
sans les fichiers gitignorés : c'est précisément le cas où le problème s'est produit.

## Ce que ça règle

`upsertFile` renvoie `unchanged` sans écrire quand le bloc est déjà présent à
l'identique. Vérifié après ce commit : `next dev` démarre, sert une page, et
`git status` ne renvoie rien.

`prettier --check AGENTS.md` passe, donc le hook de pre-commit ne reformatera pas le
bloc et ne cassera pas cette égalité.

## À savoir

Ne pas retoucher le texte du bloc à la main. Il contient un tiret cadratin, contraire
aux règles d'écriture du projet, et la tentation est de le corriger. Toute
modification rend le bloc différent de celui attendu, donc `next dev` le réécrira à
chaque démarrage et le churn reviendra en pire. C'est du texte éditeur dans un fichier
destiné aux agents, pas de la prose destinée à des lecteurs.

À chaque montée de version de Next, le texte peut changer et produire un diff à
valider. C'est un signal utile sur le changement de version, pas du bruit.
