### PR TITLE
Corriger #660 : périmètre 2027/DECLARE/sourcée à la création de mesure

### DIFF
--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -34,6 +34,13 @@ const assessmentsMock = {
 };
 vi.mock("@/lib/measures/assessments", () => assessmentsMock);
 
+// The hub candidacy gate (#660). Default impl returns the everyAction table's e-1/p-1 so the
+// authenticated table test still succeeds; individual tests override it. clearAllMocks keeps the impl.
+const eligibilityMock = {
+  assertHubMeasureCandidacy: vi.fn(async () => ({ electionId: "e-1", politicianId: "p-1" })),
+};
+vi.mock("../_data/candidacy-eligibility", () => eligibilityMock);
+
 const REVISION = {
   text: "Encadrer les loyers dans les zones tendues.",
   precision: "OBJECTIF_SANS_CHIFFRE" as const,
@@ -152,6 +159,58 @@ describe("actions éditoriales : la session", () => {
     for (const [name, mock] of Object.entries(transitionsMock)) {
       expect(mock, name).toHaveBeenCalledTimes(1);
     }
+  });
+});
+
+describe("createMeasureAction : garde de candidature du hub (#660)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAuthenticatedMock.mockResolvedValue(true);
+  });
+
+  const call = (a: Awaited<ReturnType<typeof actions>>) =>
+    a.createMeasureAction({
+      candidacyId: "c-1",
+      politicianId: "p-1",
+      electionId: "e-1",
+      theme: "LOGEMENT_URBANISME",
+      attribution: "PERSONAL",
+      revision: REVISION,
+      sources: SOURCES,
+    });
+
+  it("crée la mesure avec l'élection et le politicien lus SUR la candidature", async () => {
+    eligibilityMock.assertHubMeasureCandidacy.mockResolvedValue({
+      electionId: "e-1",
+      politicianId: "p-1",
+    });
+    const result = await call(await actions());
+
+    expect(result).toEqual({ ok: true, measureId: "m-1" });
+    expect(transitionsMock.createMeasure).toHaveBeenCalledWith(
+      expect.objectContaining({ electionId: "e-1", politicianId: "p-1", candidacyId: "c-1" })
+    );
+  });
+
+  it("refuse et n'écrit rien quand la garde rejette la candidature", async () => {
+    eligibilityMock.assertHubMeasureCandidacy.mockRejectedValue(
+      new MeasureValidationError("La candidature doit être déclarée pour porter une mesure.")
+    );
+    const result = await call(await actions());
+
+    expect(result.ok).toBe(false);
+    expect(transitionsMock.createMeasure).not.toHaveBeenCalled();
+  });
+
+  it("refuse quand l'élection de la candidature ne correspond pas au formulaire", async () => {
+    eligibilityMock.assertHubMeasureCandidacy.mockResolvedValue({
+      electionId: "autre-election",
+      politicianId: "p-1",
+    });
+    const result = await call(await actions());
+
+    expect(result.ok).toBe(false);
+    expect(transitionsMock.createMeasure).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/admin/mesures/_data/__tests__/hub-candidacy-scope.integration.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/hub-candidacy-scope.integration.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { seedPolitician, uniqueSlug } from "@/lib/measures/__tests__/helpers";
+
+// Deferred: these modules import @/lib/db as a value.
+let db: typeof import("@/lib/db").db;
+let listPresidentialCandidacies: typeof import("../candidacies-query").listPresidentialCandidacies;
+let assertHubMeasureCandidacy: typeof import("../candidacy-eligibility").assertHubMeasureCandidacy;
+
+const HUB_SLUG = "presidentielle-2027";
+
+/**
+ * The 2027-hub candidacy scope (#660), proven on both sides: the selector and the server gate. Both
+ * must accept only a 2027 + DECLARE + sourced candidacy. The other three candidacies are the violations
+ * built first: unsourced DECLARE, sourced PRESSENTI, and a DECLARE on another presidential election.
+ */
+describeIfDisposableDb("périmètre des candidatures du hub 2027", () => {
+  let hubElectionId: string;
+  let otherElectionId: string;
+  const politicianIds: string[] = [];
+  const ids: Record<"declSourced" | "declUnsourced" | "pressenti" | "otherElection", string> = {
+    declSourced: "",
+    declUnsourced: "",
+    pressenti: "",
+    otherElection: "",
+  };
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ listPresidentialCandidacies } = await import("../candidacies-query"));
+    ({ assertHubMeasureCandidacy } = await import("../candidacy-eligibility"));
+
+    const hub = await db.election.create({
+      data: {
+        slug: HUB_SLUG,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Présidentielle 2027",
+      },
+    });
+    hubElectionId = hub.id;
+    const other = await db.election.create({
+      data: {
+        slug: uniqueSlug("presidentielle-autre"),
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Présidentielle antérieure",
+      },
+    });
+    otherElectionId = other.id;
+
+    async function candidacy(
+      key: keyof typeof ids,
+      electionId: string,
+      status: "DECLARE" | "PRESSENTI",
+      sourced: boolean
+    ): Promise<void> {
+      const politicianId = await seedPolitician();
+      politicianIds.push(politicianId);
+      const row = await db.candidacy.create({
+        data: {
+          electionId,
+          politicianId,
+          candidateName: `Candidat ${key}`,
+          status,
+          sourceUrl: sourced ? "https://example.org/source" : null,
+          sourceLabel: sourced ? "Source" : null,
+        },
+      });
+      ids[key] = row.id;
+    }
+
+    await candidacy("declSourced", hubElectionId, "DECLARE", true);
+    await candidacy("declUnsourced", hubElectionId, "DECLARE", false);
+    await candidacy("pressenti", hubElectionId, "PRESSENTI", true);
+    await candidacy("otherElection", otherElectionId, "DECLARE", true);
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({
+      where: { electionId: { in: [hubElectionId, otherElectionId] } },
+    });
+    await db.politician.deleteMany({ where: { id: { in: politicianIds } } });
+    await db.election.deleteMany({ where: { id: { in: [hubElectionId, otherElectionId] } } });
+    await db.$disconnect();
+  });
+
+  it("le sélecteur ne propose que la candidature 2027 DECLARE et sourcée", async () => {
+    const offered = new Set((await listPresidentialCandidacies()).map((c) => c.id));
+    expect(offered.has(ids.declSourced)).toBe(true);
+    expect(offered.has(ids.declUnsourced)).toBe(false);
+    expect(offered.has(ids.pressenti)).toBe(false);
+    expect(offered.has(ids.otherElection)).toBe(false);
+  });
+
+  it("la garde accepte la candidature éligible et rend son élection et son politicien", async () => {
+    const result = await assertHubMeasureCandidacy(ids.declSourced);
+    expect(result.electionId).toBe(hubElectionId);
+    expect(politicianIds).toContain(result.politicianId);
+  });
+
+  it("la garde refuse une candidature DECLARE non sourcée", async () => {
+    await expect(assertHubMeasureCandidacy(ids.declUnsourced)).rejects.toThrow(/sourcée/);
+  });
+
+  it("la garde refuse une candidature seulement pressentie", async () => {
+    await expect(assertHubMeasureCandidacy(ids.pressenti)).rejects.toThrow(/déclarée/);
+  });
+
+  it("la garde refuse une candidature d'une autre élection présidentielle", async () => {
+    await expect(assertHubMeasureCandidacy(ids.otherElection)).rejects.toThrow(
+      /présidentielle 2027/
+    );
+  });
+
+  it("la garde refuse un identifiant inconnu", async () => {
+    await expect(assertHubMeasureCandidacy("inexistant")).rejects.toThrow(/introuvable/);
+  });
+});

--- a/src/app/admin/mesures/_data/candidacies-query.ts
+++ b/src/app/admin/mesures/_data/candidacies-query.ts
@@ -1,16 +1,24 @@
 import { db } from "@/lib/db";
 
 /**
- * The candidacies a measure can be created from.
+ * The candidacies a measure can be created from, in the 2027 hub.
  *
- * Bounded and filtered, not a full list: `Candidacy` also holds municipal candidacies (it carries a
- * `communeId`), and that table runs into the hundreds of thousands of rows. Loading it whole has
- * already produced a 19 MB page in this project.
+ * Scoped, not a full list (issue #660, decisions of 2026-08-06):
+ * - the presidential election 2027 only, by slug, not merely the PRESIDENTIELLE type (which also holds
+ *   2022 and earlier);
+ * - status `DECLARE` only: attaching a measure to a merely pressentie or envisagée candidacy would lend
+ *   a programme to someone who has not declared;
+ * - a sourced candidacy only (`sourceUrl` and `sourceLabel`), per the doctrine that a declared candidacy
+ *   is sourced.
  *
- * `politicianId` must be present. It is nullable on the model, and `createMeasure()` requires a
- * politician: a candidacy with no linked politician cannot carry a measure, so offering it would
- * only produce a failure at submit time.
+ * This is the display side of the rule. The server action re-checks the same conditions
+ * (`assertHubMeasureCandidacy`), because a selector filter is not an authorization.
+ *
+ * `politicianId` must be present: it is nullable on the model and `createMeasure()` requires a
+ * politician, so a candidacy without one would only fail at submit time. The bound stays because
+ * `Candidacy` also holds municipal rows and loading it whole has already produced a 19 MB page.
  */
+const HUB_ELECTION_SLUG = "presidentielle-2027";
 const MAX_CANDIDACIES = 200;
 
 export type CandidacyOption = {
@@ -23,7 +31,13 @@ export type CandidacyOption = {
 
 export async function listPresidentialCandidacies(): Promise<CandidacyOption[]> {
   const rows = await db.candidacy.findMany({
-    where: { election: { type: "PRESIDENTIELLE" }, politicianId: { not: null } },
+    where: {
+      election: { slug: HUB_ELECTION_SLUG },
+      status: "DECLARE",
+      sourceUrl: { not: null },
+      sourceLabel: { not: null },
+      politicianId: { not: null },
+    },
     select: {
       id: true,
       politicianId: true,

--- a/src/app/admin/mesures/_data/candidacy-eligibility.ts
+++ b/src/app/admin/mesures/_data/candidacy-eligibility.ts
@@ -1,0 +1,53 @@
+import { db } from "@/lib/db";
+import { MeasureValidationError } from "@/lib/measures/errors";
+
+const HUB_ELECTION_SLUG = "presidentielle-2027";
+
+export type EligibleCandidacy = { electionId: string; politicianId: string };
+
+/**
+ * Server-side gate for creating a measure in the 2027 hub (issue #660, decisions of 2026-08-06).
+ *
+ * A measure can only be created for a candidacy of the presidential election 2027, at status `DECLARE`,
+ * and sourced. This is a rule of the hub chain, not a universal constraint of the `Measure` model:
+ * `createMeasure()` stays general, this gate is what the admin action calls.
+ *
+ * Returns the election and politician read FROM the candidacy so the action can bind the measure to
+ * them rather than trusting a client payload. A selector filter is not an authorization: this runs even
+ * if the request never went through the selector.
+ */
+export async function assertHubMeasureCandidacy(candidacyId: string): Promise<EligibleCandidacy> {
+  const candidacy = await db.candidacy.findUnique({
+    where: { id: candidacyId },
+    select: {
+      status: true,
+      sourceUrl: true,
+      sourceLabel: true,
+      politicianId: true,
+      electionId: true,
+      election: { select: { slug: true } },
+    },
+  });
+
+  if (!candidacy) {
+    throw new MeasureValidationError("Candidature introuvable.");
+  }
+  if (candidacy.election.slug !== HUB_ELECTION_SLUG) {
+    throw new MeasureValidationError(
+      "Une mesure du hub ne peut viser qu'une candidature de la présidentielle 2027."
+    );
+  }
+  if (candidacy.status !== "DECLARE") {
+    throw new MeasureValidationError(
+      "La candidature doit être déclarée pour porter une mesure. Les autres statuts restent au suivi éditorial."
+    );
+  }
+  if (!candidacy.sourceUrl || !candidacy.sourceLabel) {
+    throw new MeasureValidationError("La candidature doit être sourcée (URL et libellé).");
+  }
+  if (!candidacy.politicianId) {
+    throw new MeasureValidationError("La candidature n'a pas de politicien associé.");
+  }
+
+  return { electionId: candidacy.electionId, politicianId: candidacy.politicianId };
+}

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -24,6 +24,7 @@ import {
   reviewMeasureRevision,
   withdrawMeasure,
 } from "@/lib/measures/transitions";
+import { assertHubMeasureCandidacy } from "./_data/candidacy-eligibility";
 
 /**
  * The editorial actions of the moderation admin.
@@ -139,9 +140,20 @@ export async function createMeasureAction(input: {
   await assertAuthenticated();
 
   try {
+    // Server-side gate (#660): the candidacy must be 2027 + DECLARE + sourced. The election and
+    // politician come FROM the candidacy, not from the payload, so a stale or tampered form cannot
+    // bind the measure elsewhere.
+    const eligible = await assertHubMeasureCandidacy(input.candidacyId);
+    if (eligible.electionId !== input.electionId || eligible.politicianId !== input.politicianId) {
+      return {
+        ok: false,
+        message:
+          "La candidature sélectionnée ne correspond plus à cette élection ou ce politicien. Rechargez la page.",
+      };
+    }
     const { measureId } = await createMeasure({
-      politicianId: input.politicianId,
-      electionId: input.electionId,
+      politicianId: eligible.politicianId,
+      electionId: eligible.electionId,
       candidacyId: input.candidacyId,
       programEditionId: null,
       attribution: input.attribution,

--- a/src/app/api/admin/candidats/route.ts
+++ b/src/app/api/admin/candidats/route.ts
@@ -54,6 +54,9 @@ export const POST = withAdminAuth(
           partyId: politician.currentPartyId,
           candidateName: politician.fullName,
           status: data.status,
+          // Required by the schema when status is DECLARE (#660), optional otherwise.
+          sourceUrl: data.sourceUrl,
+          sourceLabel: data.sourceLabel,
         },
       });
       const presidential = await tx.candidacyPresidential.create({
@@ -85,6 +88,8 @@ export const POST = withAdminAuth(
           electionSlug: data.electionSlug,
           politicianId: data.politicianId,
           status: data.status,
+          sourceUrl: data.sourceUrl,
+          sourceLabel: data.sourceLabel,
           slogan: data.slogan,
           accentColor: data.accentColor,
           declaredAt: data.declaredAt,

--- a/src/lib/security/schemas/__tests__/candidate.test.ts
+++ b/src/lib/security/schemas/__tests__/candidate.test.ts
@@ -55,3 +55,44 @@ describe("createCandidacyPresidentialFromPickerSchema : source exigée pour DECL
     ).toBe(false);
   });
 });
+
+const declareSourced = {
+  ...declare,
+  sourceUrl: "https://example.org/annonce",
+  sourceLabel: "Discours du 1er mars",
+};
+
+/**
+ * declaredAt is optional for a DECLARE candidacy (correction 2026-08-06): a sourced declaration stays valid
+ * even when the exact announcement date is unknown. The schema must never inject a date on its own, and the
+ * date, when given, is neither a substitute for the source nor silently dropped.
+ */
+describe("createCandidacyPresidentialFromPickerSchema : declaredAt facultatif (correction 2026-08-06)", () => {
+  it("accepte une DECLARE sourcée sans declaredAt et n'invente aucune date", () => {
+    const result = createCandidacyPresidentialFromPickerSchema.safeParse(declareSourced);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.declaredAt).toBeUndefined();
+    }
+  });
+
+  it("conserve declaredAt quand il est fourni au format ISO", () => {
+    const result = createCandidacyPresidentialFromPickerSchema.safeParse({
+      ...declareSourced,
+      declaredAt: "2026-03-01T10:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.declaredAt).toBe("2026-03-01T10:00:00.000Z");
+    }
+  });
+
+  it("refuse une DECLARE avec declaredAt mais sans source : la date ne remplace pas la source", () => {
+    expect(
+      createCandidacyPresidentialFromPickerSchema.safeParse({
+        ...declare,
+        declaredAt: "2026-03-01T10:00:00.000Z",
+      }).success
+    ).toBe(false);
+  });
+});

--- a/src/lib/security/schemas/__tests__/candidate.test.ts
+++ b/src/lib/security/schemas/__tests__/candidate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { createCandidacyPresidentialFromPickerSchema } from "../candidate";
+
+const declare = {
+  politicianId: "p1",
+  electionSlug: "presidentielle-2027",
+  status: "DECLARE" as const,
+};
+
+/**
+ * A DECLARE candidacy must be sourced (#660). Other statuses stay usable for editorial tracking without
+ * a source. Written violation-first: the rejection of an unsourced DECLARE is the point.
+ */
+describe("createCandidacyPresidentialFromPickerSchema : source exigée pour DECLARE", () => {
+  it("refuse une candidature DECLARE sans source", () => {
+    expect(createCandidacyPresidentialFromPickerSchema.safeParse(declare).success).toBe(false);
+  });
+
+  it("refuse une DECLARE avec URL mais sans libellé", () => {
+    expect(
+      createCandidacyPresidentialFromPickerSchema.safeParse({
+        ...declare,
+        sourceUrl: "https://example.org/annonce",
+      }).success
+    ).toBe(false);
+  });
+
+  it("accepte une candidature DECLARE sourcée", () => {
+    expect(
+      createCandidacyPresidentialFromPickerSchema.safeParse({
+        ...declare,
+        sourceUrl: "https://example.org/annonce",
+        sourceLabel: "Discours du 1er mars",
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepte une candidature PRESSENTI sans source", () => {
+    expect(
+      createCandidacyPresidentialFromPickerSchema.safeParse({
+        politicianId: "p1",
+        electionSlug: "presidentielle-2027",
+        status: "PRESSENTI",
+      }).success
+    ).toBe(true);
+  });
+
+  it("refuse une sourceUrl qui n'est pas une URL", () => {
+    expect(
+      createCandidacyPresidentialFromPickerSchema.safeParse({
+        ...declare,
+        sourceUrl: "pas-une-url",
+        sourceLabel: "Libellé",
+      }).success
+    ).toBe(false);
+  });
+});

--- a/src/lib/security/schemas/candidate.ts
+++ b/src/lib/security/schemas/candidate.ts
@@ -7,6 +7,7 @@ const SLOGAN_MAX = 200;
 const WITHDREW_REASON_MAX = 1000;
 const NOTES_MAX = 2000;
 const RANK_MAX = 999;
+const SOURCE_LABEL_MAX = 300;
 
 export const createCandidatePresidentialSchema = z.object({
   candidacyId: z.string().min(1),
@@ -32,15 +33,29 @@ export const updateCandidatePresidentialSchema = z.object({
 
 // Schéma combiné pour POST /api/admin/candidats : crée la Candidacy (via picker)
 // ET les métadonnées CandidacyPresidential dans une seule transaction.
-export const createCandidacyPresidentialFromPickerSchema = z.object({
-  politicianId: z.string().min(1),
-  electionSlug: z.string().min(1),
-  status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]).default("PRESSENTI"),
-  slogan: z.string().max(SLOGAN_MAX).optional(),
-  accentColor: z.string().regex(HEX_COLOR_RE).optional(),
-  declaredAt: z.string().datetime().optional(),
-  withdrewAt: z.string().datetime().optional(),
-  withdrewReason: z.string().max(WITHDREW_REASON_MAX).optional(),
-  rank: z.number().int().min(0).max(RANK_MAX).optional(),
-  notes: z.string().max(NOTES_MAX).optional(),
-});
+//
+// La source (sourceUrl + sourceLabel) est exigée quand le statut est DECLARE (#660, décisions du
+// 2026-08-06) : une candidature déclarée est sourcée. Elle reste facultative pour les autres statuts,
+// qui servent au suivi éditorial.
+export const createCandidacyPresidentialFromPickerSchema = z
+  .object({
+    politicianId: z.string().min(1),
+    electionSlug: z.string().min(1),
+    status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]).default("PRESSENTI"),
+    sourceUrl: z.string().url().optional(),
+    sourceLabel: z.string().min(1).max(SOURCE_LABEL_MAX).optional(),
+    slogan: z.string().max(SLOGAN_MAX).optional(),
+    accentColor: z.string().regex(HEX_COLOR_RE).optional(),
+    declaredAt: z.string().datetime().optional(),
+    withdrewAt: z.string().datetime().optional(),
+    withdrewReason: z.string().max(WITHDREW_REASON_MAX).optional(),
+    rank: z.number().int().min(0).max(RANK_MAX).optional(),
+    notes: z.string().max(NOTES_MAX).optional(),
+  })
+  .refine(
+    (data) => data.status !== "DECLARE" || (Boolean(data.sourceUrl) && Boolean(data.sourceLabel)),
+    {
+      message: "Une candidature déclarée exige une source : URL et libellé.",
+      path: ["sourceUrl"],
+    }
+  );


### PR DESCRIPTION
Corrige l'anomalie #660 : la création d'une mesure du hub ne peut viser qu'une candidature de la présidentielle 2027, au statut `DECLARE`, et sourcée. La source devient obligatoire quand une candidature est créée en `DECLARE`.

## Périmètre

- **Sélecteur** (`candidacies-query.ts`) borné à l'élection `presidentielle-2027`, statut `DECLARE`, `sourceUrl` et `sourceLabel` présents.
- **Garde serveur** `assertHubMeasureCandidacy()` (nouveau module) rejoue les mêmes conditions dans `createMeasureAction`. L'élection et le politicien sont lus **sur la candidature**, pas sur le formulaire : un payload périmé ou trafiqué ne peut pas rattacher la mesure ailleurs. Un filtre de sélecteur n'est pas une autorisation.
- **Schéma du picker** : `sourceUrl`/`sourceLabel`, exigés quand le statut est `DECLARE`. La route POST les écrit sur la `Candidacy` et dans la trace d'audit.
- Les autres statuts (`PRESSENTI`, `ENVISAGE`, `RETIRE`) restent au suivi éditorial mais ne peuvent pas porter de mesure.

## Ce qui n'est pas fait, volontairement

- Aucune donnée de production modifiée, aucune candidature existante basculée en `DECLARE`.
- Aucun chemin de transition de statut n'existe aujourd'hui (seule la création pose `DECLARE`). S'il en est ajouté un, il devra porter la même exigence de source.

## Tests

- Schéma (unitaire) : `DECLARE` sans source rejeté, `DECLARE` sourcée acceptée, `PRESSENTI` sans source acceptée, URL invalide rejetée.
- Serveur (`actions.test.ts`) : la garde est câblée ; sans candidature éligible, la création est refusée sans rien écrire ; l'élection non concordante est refusée.
- Intégration (conteneur jetable) : le sélecteur et la garde n'acceptent que 2027 + `DECLARE` + sourcée ; non sourcée, pressentie, autre élection et identifiant inconnu sont rejetés.

`tsc` code 0, suite complète verte. PR indépendante de #662.

Closes #660
