### PR TITLE
Couper les lignes recollées du CSV des gouvernements

### DIFF
--- a/scripts/test-data-quality.ts
+++ b/scripts/test-data-quality.ts
@@ -71,6 +71,32 @@ const CHECKS: QualityCheck[] = [
     },
   },
 
+  {
+    name: "mandate-titles-gluing-two-people",
+    description: "Titres de mandat recollant deux personnes (corruption de source)",
+    critical: false,
+    check: async () => {
+      // A lowercase letter immediately followed by an uppercase one never
+      // occurs in a real mandate title ("d'État" has an apostrophe,
+      // "Outre-mer" a hyphen). It does occur when an upstream row merges two
+      // people, as the data.gouv.fr government CSV did for Pierre Messmer
+      // (#664). The government importer now cuts at that boundary; this check
+      // catches the same corruption arriving through any other source.
+      const mandates = await db.$queryRaw<{ fullName: string; title: string }[]>`
+        SELECT p."fullName", m.title
+        FROM "Mandate" m
+        JOIN "Politician" p ON m."politicianId" = p.id
+        WHERE m.title ~ '[a-zà-ÿ][A-ZÀ-Ý]'
+        LIMIT 20
+      `;
+      return {
+        passed: mandates.length === 0,
+        count: mandates.length,
+        details: mandates.slice(0, 10).map((m) => `${m.fullName}: ${m.title.slice(0, 80)}`),
+      };
+    },
+  },
+
   // === IMPORTANT CHECKS ===
   {
     name: "deputies-without-photo",

--- a/src/services/sync/gouvernement.ts
+++ b/src/services/sync/gouvernement.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import { HTTPClient } from "@/lib/api/http-client";
 import { DATA_GOUV_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { upsertPoliticianExternalId } from "@/lib/prisma-helpers";
+import { sanitizeGovernmentTitle } from "./government-title";
 
 const client = new HTTPClient({ rateLimitMs: DATA_GOUV_RATE_LIMIT_MS });
 
@@ -182,7 +183,7 @@ async function syncGouvernementMember(
 
     const mandateData = {
       type: mandateType,
-      title: member.fonction,
+      title: sanitizeGovernmentTitle(member.fonction),
       institution: `Gouvernement ${member.gouvernement}`,
       startDate,
       endDate,

--- a/src/services/sync/government-title.test.ts
+++ b/src/services/sync/government-title.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeGovernmentTitle } from "./government-title";
+
+describe("sanitizeGovernmentTitle", () => {
+  it("drops the next person's entry glued onto a merged row", () => {
+    // Real value from the upstream CSV, row 350: Pierre Messmer's title runs
+    // straight into André Bettencourt's name and title, with no separator.
+    const glued =
+      "Premier ministre, Garde des sceaux, ministre de la justice par intérimAndré BettencourtMinistre délégué auprès du ministre des affaires étrangères, Ministre des affaires étrangères par intérim";
+
+    expect(sanitizeGovernmentTitle(glued)).toBe(
+      "Premier ministre, Garde des sceaux, ministre de la justice par intérim"
+    );
+  });
+
+  it("leaves an ordinary title untouched", () => {
+    expect(sanitizeGovernmentTitle("Ministre de l'agriculture et du développement rural")).toBe(
+      "Ministre de l'agriculture et du développement rural"
+    );
+  });
+
+  it("keeps a capital that follows an apostrophe", () => {
+    expect(sanitizeGovernmentTitle("Secrétaire d'État aux transports")).toBe(
+      "Secrétaire d'État aux transports"
+    );
+  });
+
+  it("keeps a capital that follows a hyphen", () => {
+    expect(sanitizeGovernmentTitle("Ministre des Outre-mer")).toBe("Ministre des Outre-mer");
+  });
+
+  it("keeps a capital that opens a new clause after a comma", () => {
+    expect(sanitizeGovernmentTitle("Ministre d'État, chargé de la défense nationale")).toBe(
+      "Ministre d'État, chargé de la défense nationale"
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeGovernmentTitle("  Premier ministre  ")).toBe("Premier ministre");
+  });
+
+  it("survives an empty value", () => {
+    expect(sanitizeGovernmentTitle("")).toBe("");
+  });
+});

--- a/src/services/sync/government-title.ts
+++ b/src/services/sync/government-title.ts
@@ -1,0 +1,20 @@
+/**
+ * The upstream data.gouv.fr CSV occasionally merges two rows into one
+ * `fonction` value: the next person's name and title run straight into the
+ * previous title with no separator, as in
+ * "...par intérimAndré BettencourtMinistre délégué...".
+ *
+ * A lowercase letter immediately followed by an uppercase one never occurs in
+ * a real French government title: "d'État" has an apostrophe in between,
+ * "Outre-mer" a hyphen, and a new clause opens after a comma and a space. That
+ * boundary is therefore a reliable marker of where the record actually ends.
+ * Measured on the full 2111-row source: one match, the corrupted row.
+ */
+const GLUED_ENTRY = /\p{Ll}\p{Lu}/u;
+
+export function sanitizeGovernmentTitle(raw: string): string {
+  const match = GLUED_ENTRY.exec(raw);
+  // The boundary sits between the two matched letters, so keep everything up
+  // to and including the lowercase one.
+  return (match ? raw.slice(0, match.index + 1) : raw).trim();
+}


### PR DESCRIPTION
Le CSV de data.gouv.fr lu par l'importeur des gouvernements fusionne parfois deux
personnes sur une seule ligne. `gouvernement.ts` faisait `title: member.fonction`,
donc recopiait la chaîne fausse telle quelle.

Ligne 350 du CSV source, la seule concernée :

```
58;Pierre Messmer n°1;PM;Pierre;Messmer;Premier ministre, Garde des sceaux, ministre de la justice par intérimAndré BettencourtMinistre délégué auprès du ministre des affaires étrangères, Ministre des affaires étrangères par intérim;jeudi 15 mars 1973;mercredi 28 mars 1973
```

Le titre de Messmer se prolonge sans séparateur par le nom et la fonction d'André
Bettencourt. Ce dernier a déjà sa propre ligne correcte pour la même période, donc le
fragment collé est un pur doublon : rien à récupérer, tout à couper.

## La règle de coupure

Une minuscule immédiatement suivie d'une majuscule n'existe pas dans un intitulé
gouvernemental français : « d'État » a une apostrophe, « Outre-mer » un trait d'union,
et une nouvelle proposition s'ouvre après une virgule et une espace. Cette frontière
marque donc de façon fiable la fin du vrai enregistrement.

Mesuré avant d'écrire la règle, pas après : `\p{Ll}\p{Lu}` matche **1 ligne sur les
2111** du CSV, et **1 enregistrement sur toute la table `Mandate`**, tous types
confondus. Zéro faux positif.

## Pourquoi le correctif est dans l'importeur

`gouvernement.ts:220-232` fait un `db.mandate.update` avec le `title` du CSV quand le
mandat existe déjà. Une correction en base seule aurait tenu jusqu'au prochain
`syncGouvernement`, pas plus.

## Garde-fou

`scripts/test-data-quality.ts` gagne le check `mandate-titles-gluing-two-people`, qui
balaie toute la table. L'importeur des gouvernements ne peut plus produire la
corruption ; ce check attrape la même chose arrivant par une autre source.

Vu rouge puis vert : `❌ (1)` avant la correction de la donnée, `✅ (0)` après.

## Donnée de production

L'enregistrement a été corrigé en base, valeur produite en appliquant
`sanitizeGovernmentTitle()` à la chaîne stockée plutôt que saisie à la main, donc
identique à ce que l'importeur écrira au prochain sync.

```
avant : 192 car.
après :  70 car. "Premier ministre, Garde des sceaux, ministre de la justice par intérim"
```

Relu en base après écriture, et 0 occurrence restante de la signature.

## Vérification

Suite complète : 3416 tests passés, 0 échec. `tsc --noEmit` et `eslint` propres.

## Note

L'erreur est dans le jeu de données amont. Elle mérite un signalement au producteur
sur data.gouv.fr, ce que cette PR ne fait pas.

Closes #664
