### PR TITLE
Saisir l'historique des affiliations partisanes dans l'admin

### DIFF
--- a/src/app/admin/politiques/[id]/page.tsx
+++ b/src/app/admin/politiques/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { db } from "@/lib/db";
+import { OPEN_MEMBERSHIP_ORDER_BY } from "@/services/politician";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -57,7 +58,7 @@ async function getPolitician(id: string) {
         },
       },
       partyHistory: {
-        orderBy: { startDate: "desc" },
+        orderBy: OPEN_MEMBERSHIP_ORDER_BY,
         include: {
           party: {
             select: { id: true, name: true, shortName: true, color: true },

--- a/src/app/api/admin/politiques/[id]/party-membership/__tests__/create-route.test.ts
+++ b/src/app/api/admin/politiques/[id]/party-membership/__tests__/create-route.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Creating a history row is the only write in the admin that can rewrite another row
+// (a succession closes the previous affiliation), so the refusals matter more than usual.
+
+const h = vi.hoisted(() => ({
+  politicianFindUnique: vi.fn(),
+  membershipFindMany: vi.fn(),
+  membershipCreate: vi.fn(),
+  auditCreate: vi.fn(),
+  setCurrentParty: vi.fn(),
+  findCurrentOpenMembership: vi.fn(),
+  invalidateEntity: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    politician: { findUnique: h.politicianFindUnique },
+    partyMembership: { findMany: h.membershipFindMany, create: h.membershipCreate },
+    auditLog: { create: h.auditCreate },
+  },
+}));
+vi.mock("@/services/politician", () => ({
+  setCurrentParty: h.setCurrentParty,
+  findCurrentOpenMembership: h.findCurrentOpenMembership,
+}));
+vi.mock("@/lib/cache", () => ({ invalidateEntity: h.invalidateEntity }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (fn: (req: unknown, ctx: unknown) => unknown) => (req: unknown, ctx: unknown) =>
+    fn(req, ctx),
+}));
+vi.mock("@/lib/security", () => ({
+  withValidation:
+    (_s: unknown, fn: (req: unknown, ctx: unknown, body: unknown) => unknown) =>
+    async (req: { json: () => Promise<unknown> }, ctx: unknown) =>
+      fn(req, ctx, await req.json()),
+  getRequestMeta: () => ({ ip: "203.0.113.1", userAgent: "test-agent" }),
+}));
+
+import { POST } from "@/app/api/admin/politiques/[id]/party-membership/route";
+
+function call(body: unknown) {
+  return POST(
+    { json: async () => body } as never,
+    { params: Promise.resolve({ id: "pol_1" }) } as never
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.politicianFindUnique.mockResolvedValue({
+    id: "pol_1",
+    slug: "jeanne-exemple",
+    currentPartyId: "p_tdp",
+  });
+  h.membershipFindMany.mockResolvedValue([]);
+  h.membershipCreate.mockResolvedValue({ id: "m_new" });
+  h.findCurrentOpenMembership.mockResolvedValue({
+    id: "m_tdp",
+    partyId: "p_tdp",
+    startDate: new Date("2020-01-01"),
+  });
+  h.setCurrentParty.mockResolvedValue({ membershipId: "m_new", closedMembershipId: "m_tdp" });
+});
+
+describe("POST party-membership — creation", () => {
+  it("creates a closed affiliation without touching the current party", async () => {
+    const response = await call({
+      mode: "closed",
+      partyId: "p_ps",
+      startDate: "1997-06-03",
+      endDate: "2018-01-01",
+      role: "MEMBRE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, warnings: [] });
+    expect(h.setCurrentParty).not.toHaveBeenCalled();
+    expect(h.membershipCreate).toHaveBeenCalledWith({
+      data: {
+        politicianId: "pol_1",
+        partyId: "p_ps",
+        startDate: new Date("1997-06-03"),
+        endDate: new Date("2018-01-01"),
+        role: "MEMBRE",
+      },
+    });
+    expect(h.invalidateEntity).toHaveBeenCalledWith("politician", "jeanne-exemple");
+  });
+
+  it("delegates a succession to setCurrentParty, role included", async () => {
+    const response = await call({
+      mode: "succeeds",
+      partyId: "p_ps",
+      startDate: "2026-01-01",
+      role: "FONDATEUR",
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.setCurrentParty).toHaveBeenCalledWith("pol_1", "p_ps", {
+      startDate: new Date("2026-01-01"),
+      role: "FONDATEUR",
+    });
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a parallel affiliation without touching the current party", async () => {
+    const response = await call({ mode: "parallel", partyId: "p_ps", startDate: "2022-01-01" });
+
+    expect(response.status).toBe(200);
+    expect(h.setCurrentParty).not.toHaveBeenCalled();
+    expect(h.membershipCreate).toHaveBeenCalledWith({
+      data: {
+        politicianId: "pol_1",
+        partyId: "p_ps",
+        startDate: new Date("2022-01-01"),
+        endDate: null,
+      },
+    });
+  });
+
+  it("returns 404 for an unknown politician", async () => {
+    h.politicianFindUnique.mockResolvedValue(null);
+
+    expect((await call({ mode: "parallel", partyId: "p_ps" })).status).toBe(404);
+  });
+});
+
+describe("POST party-membership — refusals", () => {
+  it("refuses a start date on or after the end date", async () => {
+    const response = await call({
+      mode: "closed",
+      partyId: "p_ps",
+      startDate: "2018-01-01",
+      endDate: "2018-01-01",
+    });
+
+    expect(response.status).toBe(400);
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+  });
+
+  it("refuses closed mode without an end date", async () => {
+    expect((await call({ mode: "closed", partyId: "p_ps", startDate: "1997-06-03" })).status).toBe(
+      400
+    );
+  });
+
+  it("refuses an end date in an open mode", async () => {
+    expect(
+      (
+        await call({
+          mode: "parallel",
+          partyId: "p_ps",
+          startDate: "2022-01-01",
+          endDate: "2024-01-01",
+        })
+      ).status
+    ).toBe(400);
+  });
+
+  it("refuses a succession without a start date", async () => {
+    expect((await call({ mode: "succeeds", partyId: "p_ps" })).status).toBe(400);
+    expect(h.setCurrentParty).not.toHaveBeenCalled();
+  });
+
+  it("refuses succeeding to the party that is already current", async () => {
+    expect(
+      (await call({ mode: "succeeds", partyId: "p_tdp", startDate: "2026-01-01" })).status
+    ).toBe(400);
+    expect(h.setCurrentParty).not.toHaveBeenCalled();
+  });
+
+  it("refuses a succession starting before the affiliation it would close", async () => {
+    expect(
+      (await call({ mode: "succeeds", partyId: "p_ps", startDate: "1999-01-01" })).status
+    ).toBe(400);
+    expect(h.setCurrentParty).not.toHaveBeenCalled();
+  });
+
+  it("refuses parallel mode when there is no current party", async () => {
+    h.politicianFindUnique.mockResolvedValue({
+      id: "pol_1",
+      slug: "jeanne-exemple",
+      currentPartyId: null,
+    });
+
+    expect(
+      (await call({ mode: "parallel", partyId: "p_ps", startDate: "2022-01-01" })).status
+    ).toBe(400);
+  });
+});
+
+describe("POST party-membership — warnings and audit", () => {
+  it("reports an overlap without blocking the creation", async () => {
+    h.membershipFindMany.mockResolvedValue([
+      {
+        id: "m_ps",
+        partyId: "p_ps",
+        startDate: new Date("1997-06-03"),
+        endDate: new Date("2018-01-01"),
+        party: { shortName: "PS" },
+      },
+    ]);
+
+    const response = await call({
+      mode: "closed",
+      partyId: "p_lr",
+      startDate: "2010-01-01",
+      endDate: "2015-01-01",
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.warnings).toHaveLength(1);
+    expect(payload.warnings[0]).toMatchObject({ type: "OVERLAP", partyShortName: "PS" });
+    expect(h.membershipCreate).toHaveBeenCalled();
+  });
+
+  // The affiliation being closed still looks open before the write. Without projecting the
+  // post-write state, every single party change would raise a warning.
+  it("reports no overlap for a clean succession", async () => {
+    h.membershipFindMany.mockResolvedValue([
+      {
+        id: "m_tdp",
+        partyId: "p_tdp",
+        startDate: new Date("2020-01-01"),
+        endDate: null,
+        party: { shortName: "TDP" },
+      },
+    ]);
+
+    const response = await call({ mode: "succeeds", partyId: "p_ps", startDate: "2026-01-01" });
+
+    expect(await response.json()).toEqual({ success: true, warnings: [] });
+  });
+
+  it("records the closed membership in the audit entry", async () => {
+    await call({ mode: "succeeds", partyId: "p_ps", startDate: "2026-01-01" });
+
+    expect(h.auditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "CREATE",
+          entityType: "PartyMembership",
+          entityId: "m_new",
+          changes: expect.objectContaining({
+            mode: "succeeds",
+            partyId: "p_ps",
+            closedMembershipId: "m_tdp",
+            previousCurrentPartyId: "p_tdp",
+            currentPartyChanged: true,
+          }),
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/admin/politiques/[id]/party-membership/__tests__/create-route.test.ts
+++ b/src/app/api/admin/politiques/[id]/party-membership/__tests__/create-route.test.ts
@@ -63,7 +63,7 @@ beforeEach(() => {
   h.setCurrentParty.mockResolvedValue({ membershipId: "m_new", closedMembershipId: "m_tdp" });
 });
 
-describe("POST party-membership — creation", () => {
+describe("POST party-membership: creation", () => {
   it("creates a closed affiliation without touching the current party", async () => {
     const response = await call({
       mode: "closed",
@@ -122,11 +122,14 @@ describe("POST party-membership — creation", () => {
   it("returns 404 for an unknown politician", async () => {
     h.politicianFindUnique.mockResolvedValue(null);
 
-    expect((await call({ mode: "parallel", partyId: "p_ps" })).status).toBe(404);
+    const response = await call({ mode: "parallel", partyId: "p_ps" });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Politicien non trouvé" });
   });
 });
 
-describe("POST party-membership — refusals", () => {
+describe("POST party-membership: refusals", () => {
   it("refuses a start date on or after the end date", async () => {
     const response = await call({
       mode: "closed",
@@ -136,45 +139,68 @@ describe("POST party-membership — refusals", () => {
     });
 
     expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "La date de début doit être antérieure à la date de fin",
+    });
     expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses closed mode without an end date", async () => {
-    expect((await call({ mode: "closed", partyId: "p_ps", startDate: "1997-06-03" })).status).toBe(
-      400
-    );
+    const response = await call({ mode: "closed", partyId: "p_ps", startDate: "1997-06-03" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Une affiliation close exige une date de fin",
+    });
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses an end date in an open mode", async () => {
-    expect(
-      (
-        await call({
-          mode: "parallel",
-          partyId: "p_ps",
-          startDate: "2022-01-01",
-          endDate: "2024-01-01",
-        })
-      ).status
-    ).toBe(400);
+    const response = await call({
+      mode: "parallel",
+      partyId: "p_ps",
+      startDate: "2022-01-01",
+      endDate: "2024-01-01",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Une affiliation en cours ne peut pas porter de date de fin",
+    });
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses a succession without a start date", async () => {
-    expect((await call({ mode: "succeeds", partyId: "p_ps" })).status).toBe(400);
+    const response = await call({ mode: "succeeds", partyId: "p_ps" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Une succession exige une date de début",
+    });
     expect(h.setCurrentParty).not.toHaveBeenCalled();
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses succeeding to the party that is already current", async () => {
-    expect(
-      (await call({ mode: "succeeds", partyId: "p_tdp", startDate: "2026-01-01" })).status
-    ).toBe(400);
+    const response = await call({ mode: "succeeds", partyId: "p_tdp", startDate: "2026-01-01" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Ce parti est déjà l'affiliation actuelle",
+    });
     expect(h.setCurrentParty).not.toHaveBeenCalled();
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses a succession starting before the affiliation it would close", async () => {
-    expect(
-      (await call({ mode: "succeeds", partyId: "p_ps", startDate: "1999-01-01" })).status
-    ).toBe(400);
+    const response = await call({ mode: "succeeds", partyId: "p_ps", startDate: "1999-01-01" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "La succession ne peut pas commencer avant l'affiliation qu'elle remplace",
+    });
     expect(h.setCurrentParty).not.toHaveBeenCalled();
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 
   it("refuses parallel mode when there is no current party", async () => {
@@ -184,13 +210,17 @@ describe("POST party-membership — refusals", () => {
       currentPartyId: null,
     });
 
-    expect(
-      (await call({ mode: "parallel", partyId: "p_ps", startDate: "2022-01-01" })).status
-    ).toBe(400);
+    const response = await call({ mode: "parallel", partyId: "p_ps", startDate: "2022-01-01" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Une affiliation en parallèle exige un parti actuel. Utilisez la succession.",
+    });
+    expect(h.membershipCreate).not.toHaveBeenCalled();
   });
 });
 
-describe("POST party-membership — warnings and audit", () => {
+describe("POST party-membership: warnings and audit", () => {
   it("reports an overlap without blocking the creation", async () => {
     h.membershipFindMany.mockResolvedValue([
       {
@@ -227,6 +257,32 @@ describe("POST party-membership — warnings and audit", () => {
         startDate: new Date("2020-01-01"),
         endDate: null,
         party: { shortName: "TDP" },
+      },
+    ]);
+
+    const response = await call({ mode: "succeeds", partyId: "p_ps", startDate: "2026-01-01" });
+
+    expect(await response.json()).toEqual({ success: true, warnings: [] });
+  });
+
+  // setCurrentParty promotes an already-open affiliation for the target party instead of
+  // creating a new row, so that row IS the candidate after the write, not a coexisting
+  // one. Without dropping it from the projection, every promotion would collide with itself.
+  it("reports no overlap for a succession onto a party with an already-open affiliation", async () => {
+    h.membershipFindMany.mockResolvedValue([
+      {
+        id: "m_tdp",
+        partyId: "p_tdp",
+        startDate: new Date("2020-01-01"),
+        endDate: null,
+        party: { shortName: "TDP" },
+      },
+      {
+        id: "m_ps",
+        partyId: "p_ps",
+        startDate: new Date("2022-01-01"),
+        endDate: null,
+        party: { shortName: "PS" },
       },
     ]);
 

--- a/src/app/api/admin/politiques/[id]/party-membership/route.ts
+++ b/src/app/api/admin/politiques/[id]/party-membership/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { withValidation, getRequestMeta } from "@/lib/security";
+import { createPartyMembershipSchema } from "@/lib/security/schemas/party";
+import { invalidateEntity } from "@/lib/cache";
+import { setCurrentParty, findCurrentOpenMembership } from "@/services/politician";
+import { findOverlaps, type AffiliationInterval } from "@/lib/politicians/party-overlap";
+import type { z } from "zod/v4";
+
+type CreateBody = z.infer<typeof createPartyMembershipSchema>;
+
+function bad(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+export const POST = withAdminAuth(
+  withValidation(createPartyMembershipSchema, async (request, context, body: CreateBody) => {
+    const { id } = await context.params;
+
+    const politician = await db.politician.findUnique({
+      where: { id },
+      select: { id: true, slug: true, currentPartyId: true },
+    });
+
+    if (!politician) {
+      return NextResponse.json({ error: "Politicien non trouvé" }, { status: 404 });
+    }
+
+    const startDate = body.startDate ? new Date(body.startDate) : null;
+    const endDate = body.endDate ? new Date(body.endDate) : null;
+    const isOpen = body.mode !== "closed";
+
+    if (startDate && endDate && startDate >= endDate) {
+      return bad("La date de début doit être antérieure à la date de fin");
+    }
+    if (body.mode === "closed" && !endDate) {
+      return bad("Une affiliation close exige une date de fin");
+    }
+    if (isOpen && endDate) {
+      return bad("Une affiliation en cours ne peut pas porter de date de fin");
+    }
+
+    // The affiliation currentPartyId points at. A politician can hold several open
+    // affiliations, so this is not simply the most recent open one.
+    const currentMembership = await findCurrentOpenMembership(
+      politician.id,
+      politician.currentPartyId
+    );
+
+    if (body.mode === "succeeds") {
+      if (!startDate) {
+        return bad("Une succession exige une date de début");
+      }
+      if (politician.currentPartyId === body.partyId) {
+        return bad("Ce parti est déjà l'affiliation actuelle");
+      }
+      if (currentMembership?.startDate && startDate < currentMembership.startDate) {
+        return bad("La succession ne peut pas commencer avant l'affiliation qu'elle remplace");
+      }
+    }
+
+    if (body.mode === "parallel" && !politician.currentPartyId) {
+      return bad("Une affiliation en parallèle exige un parti actuel. Utilisez la succession.");
+    }
+
+    // Overlaps are computed on the state that will exist after the write: in a
+    // succession the affiliation about to be closed is projected with its future
+    // endDate, so a clean party change reports nothing.
+    const existing = await db.partyMembership.findMany({
+      where: { politicianId: politician.id },
+      select: {
+        id: true,
+        partyId: true,
+        startDate: true,
+        endDate: true,
+        party: { select: { shortName: true } },
+      },
+    });
+
+    const projected: AffiliationInterval[] = existing.map((membership) => ({
+      partyId: membership.partyId,
+      partyShortName: membership.party.shortName,
+      startDate: membership.startDate,
+      endDate:
+        body.mode === "succeeds" && membership.id === currentMembership?.id
+          ? startDate
+          : membership.endDate,
+    }));
+
+    const warnings = findOverlaps(
+      {
+        partyId: body.partyId,
+        partyShortName: "",
+        startDate,
+        endDate,
+      },
+      projected
+    );
+
+    let membershipId: string | null = null;
+    let closedMembershipId: string | null = null;
+
+    if (body.mode === "succeeds") {
+      const result = await setCurrentParty(politician.id, body.partyId, {
+        startDate: startDate!,
+        ...(body.role && { role: body.role }),
+      });
+      membershipId = result.membershipId;
+      closedMembershipId = result.closedMembershipId;
+    } else {
+      const created = await db.partyMembership.create({
+        data: {
+          politicianId: politician.id,
+          partyId: body.partyId,
+          startDate,
+          endDate,
+          ...(body.role && { role: body.role }),
+        },
+      });
+      membershipId = created.id;
+    }
+
+    const meta = getRequestMeta(request);
+    await db.auditLog.create({
+      data: {
+        action: "CREATE",
+        entityType: "PartyMembership",
+        entityId: membershipId!,
+        changes: {
+          mode: body.mode,
+          partyId: body.partyId,
+          role: body.role ?? null,
+          startDate: body.startDate ?? null,
+          endDate: body.endDate ?? null,
+          closedMembershipId,
+          previousCurrentPartyId: politician.currentPartyId,
+          currentPartyChanged: body.mode === "succeeds",
+        },
+        ipAddress: meta.ip,
+        userAgent: meta.userAgent,
+      },
+    });
+
+    invalidateEntity("politician", politician.slug);
+
+    return NextResponse.json({ success: true, warnings });
+  })
+);

--- a/src/app/api/admin/politiques/[id]/party-membership/route.ts
+++ b/src/app/api/admin/politiques/[id]/party-membership/route.ts
@@ -78,15 +78,28 @@ export const POST = withAdminAuth(
       },
     });
 
-    const projected: AffiliationInterval[] = existing.map((membership) => ({
-      partyId: membership.partyId,
-      partyShortName: membership.party.shortName,
-      startDate: membership.startDate,
-      endDate:
-        body.mode === "succeeds" && membership.id === currentMembership?.id
-          ? startDate
-          : membership.endDate,
-    }));
+    // In a succession, an open membership already sitting on body.partyId is not a
+    // separate affiliation that will coexist with the candidate: it IS the candidate
+    // after the write (setCurrentParty promotes it). Drop it from the projection
+    // entirely rather than giving it a projected bound.
+    const projected: AffiliationInterval[] = existing
+      .filter(
+        (membership) =>
+          !(
+            body.mode === "succeeds" &&
+            membership.partyId === body.partyId &&
+            membership.endDate === null
+          )
+      )
+      .map((membership) => ({
+        partyId: membership.partyId,
+        partyShortName: membership.party.shortName,
+        startDate: membership.startDate,
+        endDate:
+          body.mode === "succeeds" && membership.id === currentMembership?.id
+            ? startDate
+            : membership.endDate,
+      }));
 
     const warnings = findOverlaps(
       {

--- a/src/components/admin/EditablePartyCard.tsx
+++ b/src/components/admin/EditablePartyCard.tsx
@@ -256,8 +256,8 @@ export function EditablePartyCard({
           >
             <p className="font-medium">Chevauchements détectés</p>
             <ul className="mt-1 list-disc pl-5">
-              {warnings.map((warning) => (
-                <li key={`${warning.partyId}-${warning.startDate ?? "start"}`}>
+              {warnings.map((warning, index) => (
+                <li key={index}>
                   {warning.partyShortName} (
                   {formatStartDate(warning.startDate ? new Date(warning.startDate) : null)} à{" "}
                   {formatEndDate(warning.endDate ? new Date(warning.endDate) : null)})

--- a/src/components/admin/EditablePartyCard.tsx
+++ b/src/components/admin/EditablePartyCard.tsx
@@ -507,7 +507,7 @@ export function EditablePartyCard({
                       <span>
                         Affiliation en parallèle
                         <span className="block text-xs text-muted-foreground">
-                          Le parti affiché reste {currentParty.shortName || currentParty.name}, rien
+                          Le parti actuel reste {currentParty.shortName || currentParty.name}, rien
                           n&apos;est clôturé.
                         </span>
                       </span>

--- a/src/components/admin/EditablePartyCard.tsx
+++ b/src/components/admin/EditablePartyCard.tsx
@@ -47,6 +47,24 @@ const EMPTY_PARTY_FORM = {
 };
 const EMPTY_MEMBERSHIP_FORM = { startDate: "", endDate: "", role: "" };
 
+interface OverlapWarning {
+  type: "OVERLAP";
+  partyId: string;
+  partyShortName: string;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+type AffiliationMode = "closed" | "succeeds" | "parallel";
+
+const EMPTY_ADD_FORM = {
+  partyId: "",
+  startDate: "",
+  endDate: "",
+  role: "",
+  openMode: "succeeds" as Exclude<AffiliationMode, "closed">,
+};
+
 function formatStartDate(date: Date | null): string {
   if (!date) return "—";
   return new Date(date).toLocaleDateString("fr-FR");
@@ -92,6 +110,12 @@ export function EditablePartyCard({
 
   const [partyForm, setPartyForm] = useState({ ...EMPTY_PARTY_FORM });
   const [membershipForm, setMembershipForm] = useState({ ...EMPTY_MEMBERSHIP_FORM });
+
+  const [isAddingAffiliation, setIsAddingAffiliation] = useState(false);
+  const [addForm, setAddForm] = useState({ ...EMPTY_ADD_FORM });
+  // Kept out of `status`: useAdminMutation auto-clears status after 3 seconds, and an
+  // overlap notice has to outlive the green banner.
+  const [warnings, setWarnings] = useState<OverlapWarning[]>([]);
 
   // --- Section A: Change current party ---
 
@@ -170,6 +194,39 @@ export function EditablePartyCard({
     setConfirmDeleteMembershipId(null);
   }
 
+  const addMode: AffiliationMode = addForm.endDate ? "closed" : addForm.openMode;
+  const canSubmitAdd =
+    Boolean(addForm.partyId) && (addMode !== "succeeds" || Boolean(addForm.startDate));
+
+  function cancelAddAffiliation() {
+    setIsAddingAffiliation(false);
+    setAddForm({ ...EMPTY_ADD_FORM });
+  }
+
+  async function handleAddAffiliation() {
+    setWarnings([]);
+
+    const body: Record<string, string> = { mode: addMode, partyId: addForm.partyId };
+    if (addForm.startDate) body.startDate = addForm.startDate;
+    if (addForm.endDate) body.endDate = addForm.endDate;
+    if (addForm.role) body.role = addForm.role;
+
+    const response = await mutate(`/api/admin/politiques/${politicianId}/party-membership`, {
+      method: "POST",
+      body: JSON.stringify(body),
+      successMessage: "Affiliation ajoutée",
+    });
+
+    if (!response) return;
+
+    const payload = (await response.json().catch(() => ({ warnings: [] }))) as {
+      warnings?: OverlapWarning[];
+    };
+    setWarnings(payload.warnings ?? []);
+    setIsAddingAffiliation(false);
+    setAddForm({ ...EMPTY_ADD_FORM });
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -188,6 +245,29 @@ export function EditablePartyCard({
             }
           >
             {status.message}
+          </div>
+        )}
+
+        {warnings.length > 0 && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-md bg-amber-50 p-3 text-sm text-amber-900"
+          >
+            <p className="font-medium">Chevauchements détectés</p>
+            <ul className="mt-1 list-disc pl-5">
+              {warnings.map((warning) => (
+                <li key={`${warning.partyId}-${warning.startDate ?? "start"}`}>
+                  {warning.partyShortName} (
+                  {formatStartDate(warning.startDate ? new Date(warning.startDate) : null)} à{" "}
+                  {formatEndDate(warning.endDate ? new Date(warning.endDate) : null)})
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1">
+              L&apos;affiliation a bien été enregistrée. Vérifiez les dates si ce n&apos;est pas
+              voulu.
+            </p>
           </div>
         )}
 
@@ -310,9 +390,151 @@ export function EditablePartyCard({
 
         {/* Section B: Historique des affiliations */}
         <div>
-          <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-            Historique des affiliations
-          </h2>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              Historique des affiliations
+            </h2>
+            {!isAddingAffiliation && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setIsAddingAffiliation(true);
+                  setWarnings([]);
+                  clearStatus();
+                }}
+              >
+                Ajouter une affiliation
+              </Button>
+            )}
+          </div>
+
+          {isAddingAffiliation && (
+            <div className="mb-4 space-y-3 rounded-lg border p-4">
+              <div>
+                <Label htmlFor="add-party">Parti de l&apos;affiliation</Label>
+                <Select
+                  id="add-party"
+                  value={addForm.partyId}
+                  onChange={(e) => setAddForm((prev) => ({ ...prev, partyId: e.target.value }))}
+                >
+                  <option value="">— Sélectionner un parti —</option>
+                  {allParties.map((party) => (
+                    <option key={party.id} value={party.id}>
+                      {party.shortName} — {party.name}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <Label htmlFor="add-start">Date de début de l&apos;affiliation</Label>
+                  <Input
+                    id="add-start"
+                    type="date"
+                    value={addForm.startDate}
+                    onChange={(e) => setAddForm((prev) => ({ ...prev, startDate: e.target.value }))}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="add-end">Date de fin de l&apos;affiliation</Label>
+                  <Input
+                    id="add-end"
+                    type="date"
+                    value={addForm.endDate}
+                    onChange={(e) => setAddForm((prev) => ({ ...prev, endDate: e.target.value }))}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Laisser vide si l&apos;affiliation est toujours en cours.
+                  </p>
+                </div>
+                <div>
+                  <Label htmlFor="add-role">Rôle dans l&apos;affiliation</Label>
+                  <Select
+                    id="add-role"
+                    value={addForm.role}
+                    onChange={(e) => setAddForm((prev) => ({ ...prev, role: e.target.value }))}
+                  >
+                    <option value="">— Aucun —</option>
+                    {Object.entries(PARTY_ROLE_LABELS).map(([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              </div>
+
+              {!addForm.endDate && (
+                <fieldset className="space-y-2 rounded-md border p-3">
+                  <legend className="px-1 text-xs font-medium text-muted-foreground">
+                    Affiliation en cours
+                  </legend>
+                  <label className="flex items-start gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="add-open-mode"
+                      value="succeeds"
+                      checked={addForm.openMode === "succeeds"}
+                      onChange={() => setAddForm((prev) => ({ ...prev, openMode: "succeeds" }))}
+                      className="mt-1"
+                    />
+                    <span>
+                      Ce parti devient le parti actuel
+                      {currentParty && (
+                        <span className="block text-xs text-muted-foreground">
+                          L&apos;affiliation à {currentParty.shortName || currentParty.name} sera
+                          clôturée
+                          {addForm.startDate
+                            ? ` le ${new Date(addForm.startDate).toLocaleDateString("fr-FR")}`
+                            : ""}
+                          .
+                        </span>
+                      )}
+                    </span>
+                  </label>
+                  {currentParty && (
+                    <label className="flex items-start gap-2 text-sm">
+                      <input
+                        type="radio"
+                        name="add-open-mode"
+                        value="parallel"
+                        checked={addForm.openMode === "parallel"}
+                        onChange={() => setAddForm((prev) => ({ ...prev, openMode: "parallel" }))}
+                        className="mt-1"
+                      />
+                      <span>
+                        Affiliation en parallèle
+                        <span className="block text-xs text-muted-foreground">
+                          Le parti affiché reste {currentParty.shortName || currentParty.name}, rien
+                          n&apos;est clôturé.
+                        </span>
+                      </span>
+                    </label>
+                  )}
+                </fieldset>
+              )}
+
+              <div className="flex items-center gap-3">
+                <Button
+                  size="sm"
+                  onClick={handleAddAffiliation}
+                  disabled={loading || !canSubmitAdd}
+                >
+                  {loading ? "Enregistrement..." : "Ajouter"}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={cancelAddAffiliation}
+                  disabled={loading}
+                >
+                  Annuler
+                </Button>
+              </div>
+            </div>
+          )}
 
           {partyHistory.length === 0 ? (
             <p className="py-4 text-center text-sm text-muted-foreground">

--- a/src/components/admin/EditablePartyCard.tsx
+++ b/src/components/admin/EditablePartyCard.tsx
@@ -47,7 +47,12 @@ const EMPTY_PARTY_FORM = {
 };
 const EMPTY_MEMBERSHIP_FORM = { startDate: "", endDate: "", role: "" };
 
-function formatDateDisplay(date: Date | null): string {
+function formatStartDate(date: Date | null): string {
+  if (!date) return "—";
+  return new Date(date).toLocaleDateString("fr-FR");
+}
+
+function formatEndDate(date: Date | null): string {
   if (!date) return "En cours";
   return new Date(date).toLocaleDateString("fr-FR");
 }
@@ -458,8 +463,8 @@ function MembershipRow({
       <td className="py-2 pr-3">
         <Badge variant="outline">{roleLabel}</Badge>
       </td>
-      <td className="py-2 pr-3">{formatDateDisplay(membership.startDate)}</td>
-      <td className="py-2 pr-3">{formatDateDisplay(membership.endDate)}</td>
+      <td className="py-2 pr-3">{formatStartDate(membership.startDate)}</td>
+      <td className="py-2 pr-3">{formatEndDate(membership.endDate)}</td>
       <td className="py-2">
         <div className="flex gap-1">
           <Button variant="ghost" size="sm" onClick={onEdit} className="h-7 text-xs">

--- a/src/components/admin/__tests__/EditablePartyCard.test.tsx
+++ b/src/components/admin/__tests__/EditablePartyCard.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), back: vi.fn() }),
@@ -43,6 +44,8 @@ beforeEach(() => {
   );
 });
 
+afterEach(() => vi.unstubAllGlobals());
+
 describe("EditablePartyCard — affiliation dates", () => {
   it("renders an ongoing affiliation as such", () => {
     setup();
@@ -68,5 +71,140 @@ describe("EditablePartyCard — affiliation dates", () => {
 
     expect(screen.getByText("—")).toBeInTheDocument();
     expect(screen.queryByText("En cours")).not.toBeInTheDocument();
+  });
+});
+
+describe("EditablePartyCard — add affiliation form", () => {
+  it("opens the form even when the history is empty", async () => {
+    setup({ partyHistory: [] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+
+    expect(screen.getByLabelText("Parti de l'affiliation")).toBeInTheDocument();
+  });
+
+  it("shows the mode choice only when the end date is empty", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+
+    expect(screen.getByRole("radio", { name: /parti actuel/i })).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
+
+    expect(screen.queryByRole("radio", { name: /parti actuel/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the parallel option when there is no current party", async () => {
+    setup({ currentParty: null, partyHistory: [] });
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+
+    expect(screen.queryByRole("radio", { name: /en parallèle/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps the submit button disabled in succession mode without a start date", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+
+    expect(screen.getByRole("button", { name: "Ajouter" })).toBeDisabled();
+  });
+
+  it("posts the body matching the chosen mode", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+    await userEvent.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+    await userEvent.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
+    await userEvent.selectOptions(screen.getByLabelText("Rôle dans l'affiliation"), "MEMBRE");
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter" }));
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(url).toBe("/api/admin/politiques/pol_1/party-membership");
+    expect(JSON.parse(init.body)).toEqual({
+      mode: "closed",
+      partyId: "p_ps",
+      startDate: "1997-06-03",
+      endDate: "2018-01-01",
+      role: "MEMBRE",
+    });
+  });
+
+  it("shows returned warnings alongside the success message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          warnings: [
+            {
+              type: "OVERLAP",
+              // A party not already present in the fixtures (TDP is the current party
+              // badge, PS is an <option> in both selects): both already render their
+              // own text elsewhere on screen, which would make the assertion below
+              // match more than one element.
+              partyId: "p_modem",
+              partyShortName: "MODEM",
+              startDate: new Date("2020-01-01").toISOString(),
+              endDate: null,
+            },
+          ],
+        }),
+      }))
+    );
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+    await userEvent.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+    await userEvent.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter" }));
+
+    expect(await screen.findByText(/Chevauchements détectés/)).toBeInTheDocument();
+    expect(screen.getByText(/MODEM/)).toBeInTheDocument();
+    expect(screen.getByText("Affiliation ajoutée")).toBeInTheDocument();
+  });
+
+  it("clears previous warnings on the next submission", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          warnings: [
+            {
+              type: "OVERLAP",
+              partyId: "p_tdp",
+              partyShortName: "TDP",
+              startDate: null,
+              endDate: null,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, warnings: [] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    setup();
+
+    async function submitClosed(partyId: string) {
+      await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+      await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), partyId);
+      await userEvent.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+      await userEvent.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
+      await userEvent.click(screen.getByRole("button", { name: "Ajouter" }));
+    }
+
+    await submitClosed("p_ps");
+    expect(await screen.findByText(/Chevauchements détectés/)).toBeInTheDocument();
+
+    await submitClosed("p_tdp");
+    expect(screen.queryByText(/Chevauchements détectés/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/admin/__tests__/EditablePartyCard.test.tsx
+++ b/src/components/admin/__tests__/EditablePartyCard.test.tsx
@@ -148,6 +148,23 @@ describe("EditablePartyCard — add affiliation form", () => {
     });
   });
 
+  it("posts mode parallel when the end date is empty and parallel affiliation is chosen", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+    await userEvent.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+    await userEvent.click(screen.getByRole("radio", { name: /en parallèle/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter" }));
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(url).toBe("/api/admin/politiques/pol_1/party-membership");
+    expect(JSON.parse(init.body)).toEqual({
+      mode: "parallel",
+      partyId: "p_ps",
+      startDate: "1997-06-03",
+    });
+  });
+
   it("shows returned warnings alongside the success message", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/components/admin/__tests__/EditablePartyCard.test.tsx
+++ b/src/components/admin/__tests__/EditablePartyCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("next/navigation", () => ({
@@ -44,7 +44,10 @@ beforeEach(() => {
   );
 });
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
 
 describe("EditablePartyCard — affiliation dates", () => {
   it("renders an ongoing affiliation as such", () => {
@@ -87,11 +90,11 @@ describe("EditablePartyCard — add affiliation form", () => {
     setup();
     await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
 
-    expect(screen.getByRole("radio", { name: /parti actuel/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^Ce parti devient/i })).toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
 
-    expect(screen.queryByRole("radio", { name: /parti actuel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: /^Ce parti devient/i })).not.toBeInTheDocument();
   });
 
   it("hides the parallel option when there is no current party", async () => {
@@ -126,6 +129,22 @@ describe("EditablePartyCard — add affiliation form", () => {
       startDate: "1997-06-03",
       endDate: "2018-01-01",
       role: "MEMBRE",
+    });
+  });
+
+  it("posts mode succeeds when the end date is empty and succession is chosen", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await userEvent.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+    await userEvent.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+    await userEvent.click(screen.getByRole("button", { name: "Ajouter" }));
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(url).toBe("/api/admin/politiques/pol_1/party-membership");
+    expect(JSON.parse(init.body)).toEqual({
+      mode: "succeeds",
+      partyId: "p_ps",
+      startDate: "1997-06-03",
     });
   });
 
@@ -206,5 +225,50 @@ describe("EditablePartyCard — add affiliation form", () => {
 
     await submitClosed("p_tdp");
     expect(screen.queryByText(/Chevauchements détectés/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the amber banner past the 3-second status auto-clear", async () => {
+    // shouldAdvanceTime is required here: plain fake timers make userEvent's
+    // internal pointer/keyboard mechanics hang (no way to make them progress).
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          warnings: [
+            {
+              type: "OVERLAP",
+              partyId: "p_modem",
+              partyShortName: "MODEM",
+              startDate: null,
+              endDate: null,
+            },
+          ],
+        }),
+      }))
+    );
+    setup();
+    await user.click(screen.getByRole("button", { name: "Ajouter une affiliation" }));
+    await user.selectOptions(screen.getByLabelText("Parti de l'affiliation"), "p_ps");
+    await user.type(screen.getByLabelText("Date de début de l'affiliation"), "1997-06-03");
+    await user.type(screen.getByLabelText("Date de fin de l'affiliation"), "2018-01-01");
+    await user.click(screen.getByRole("button", { name: "Ajouter" }));
+
+    expect(screen.getByText(/Chevauchements détectés/)).toBeInTheDocument();
+    expect(screen.getByText("Affiliation ajoutée")).toBeInTheDocument();
+
+    // vi.advanceTimersByTimeAsync does not reliably fire the pending timer once
+    // shouldAdvanceTime is on (silently no-ops); wrapping a sync advance in act()
+    // does.
+    await act(async () => {
+      vi.advanceTimersByTime(3100);
+    });
+
+    expect(screen.getByText(/Chevauchements détectés/)).toBeInTheDocument();
+    expect(screen.queryByText("Affiliation ajoutée")).not.toBeInTheDocument();
   });
 });

--- a/src/components/admin/__tests__/EditablePartyCard.test.tsx
+++ b/src/components/admin/__tests__/EditablePartyCard.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), back: vi.fn() }),
+}));
+
+import { EditablePartyCard } from "@/components/admin/EditablePartyCard";
+
+const TDP = { id: "p_tdp", name: "Territoires de progrès", shortName: "TDP", color: "#e91e63" };
+const PS = { id: "p_ps", name: "Parti socialiste", shortName: "PS", color: "#ff8080" };
+
+function setup(overrides: Partial<Parameters<typeof EditablePartyCard>[0]> = {}) {
+  return render(
+    <EditablePartyCard
+      politicianId="pol_1"
+      currentParty={TDP}
+      partyHistory={[
+        {
+          id: "m_tdp",
+          partyId: "p_tdp",
+          role: "MEMBRE",
+          startDate: new Date("2020-01-01"),
+          endDate: null,
+          party: TDP,
+        },
+      ]}
+      allParties={[TDP, PS]}
+      {...overrides}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, warnings: [] }),
+    }))
+  );
+});
+
+describe("EditablePartyCard — affiliation dates", () => {
+  it("renders an ongoing affiliation as such", () => {
+    setup();
+
+    expect(screen.getByText("En cours")).toBeInTheDocument();
+  });
+
+  // A null startDate used to render "En cours" in the Début column, which states
+  // something false.
+  it("renders an unknown start date as a dash, not as ongoing", () => {
+    setup({
+      partyHistory: [
+        {
+          id: "m_ps",
+          partyId: "p_ps",
+          role: "MEMBRE",
+          startDate: null,
+          endDate: new Date("2018-01-01"),
+          party: PS,
+        },
+      ],
+    });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText("En cours")).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/politicians/__tests__/party-overlap.test.ts
+++ b/src/lib/politicians/__tests__/party-overlap.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { findOverlaps, type AffiliationInterval } from "@/lib/politicians/party-overlap";
+
+function interval(
+  partyId: string,
+  startDate: string | null,
+  endDate: string | null
+): AffiliationInterval {
+  return {
+    partyId,
+    partyShortName: partyId.toUpperCase(),
+    startDate: startDate ? new Date(startDate) : null,
+    endDate: endDate ? new Date(endDate) : null,
+  };
+}
+
+describe("findOverlaps", () => {
+  it("reports an affiliation covering the candidate period", () => {
+    const result = findOverlaps(interval("ps", "2000-01-01", "2010-01-01"), [
+      interval("lr", "2005-01-01", "2015-01-01"),
+    ]);
+
+    expect(result).toEqual([
+      {
+        type: "OVERLAP",
+        partyId: "lr",
+        partyShortName: "LR",
+        startDate: new Date("2005-01-01").toISOString(),
+        endDate: new Date("2015-01-01").toISOString(),
+      },
+    ]);
+  });
+
+  // Intervals are half-open, [start, end[. A succession sets the previous endDate to the
+  // new startDate, and that seam must not read as a conflict.
+  it("does not report affiliations that meet edge to edge", () => {
+    expect(
+      findOverlaps(interval("tdp", "2020-01-01", null), [
+        interval("ps", "1997-06-03", "2020-01-01"),
+      ])
+    ).toEqual([]);
+  });
+
+  it("treats a null endDate as open ended", () => {
+    expect(
+      findOverlaps(interval("tdp", "2020-01-01", null), [interval("ps", "1997-06-03", null)])
+    ).toHaveLength(1);
+  });
+
+  it("treats a null startDate as reaching back indefinitely", () => {
+    expect(
+      findOverlaps(interval("ps", null, "2018-01-01"), [interval("lr", "1990-01-01", "1995-01-01")])
+    ).toHaveLength(1);
+  });
+
+  it("reports nothing for disjoint periods", () => {
+    expect(
+      findOverlaps(interval("ps", "1997-01-01", "2018-01-01"), [
+        interval("tdp", "2020-01-01", null),
+      ])
+    ).toEqual([]);
+  });
+
+  it("reports every conflicting affiliation", () => {
+    expect(
+      findOverlaps(interval("ps", null, null), [
+        interval("lr", "1990-01-01", "1995-01-01"),
+        interval("tdp", "2020-01-01", null),
+      ])
+    ).toHaveLength(2);
+  });
+
+  it("returns an empty list when there is nothing to compare against", () => {
+    expect(findOverlaps(interval("ps", "1997-01-01", null), [])).toEqual([]);
+  });
+});

--- a/src/lib/politicians/party-overlap.ts
+++ b/src/lib/politicians/party-overlap.ts
@@ -1,0 +1,54 @@
+/**
+ * Overlap detection between party affiliations.
+ *
+ * Overlaps are legitimate (a main party plus a micro-party) as often as they are typos
+ * (a wrong year), so this never blocks a write: it reports, and the admin reads.
+ *
+ * Callers pass the projected post-write state. In a succession the affiliation about to
+ * be closed must be supplied with its future endDate, otherwise every party change
+ * would report a conflict and the banner would become noise.
+ */
+
+export interface AffiliationInterval {
+  partyId: string;
+  partyShortName: string;
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+export interface OverlapWarning {
+  type: "OVERLAP";
+  partyId: string;
+  partyShortName: string;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+/**
+ * Intervals are half-open: [startDate, endDate[. A null startDate reads as -Infinity, a
+ * null endDate as +Infinity. Half-open is what makes a succession seam (previous end ==
+ * new start) come out clean.
+ */
+function overlaps(a: AffiliationInterval, b: AffiliationInterval): boolean {
+  const aStart = a.startDate?.getTime() ?? -Infinity;
+  const aEnd = a.endDate?.getTime() ?? Infinity;
+  const bStart = b.startDate?.getTime() ?? -Infinity;
+  const bEnd = b.endDate?.getTime() ?? Infinity;
+
+  return aStart < bEnd && bStart < aEnd;
+}
+
+export function findOverlaps(
+  candidate: AffiliationInterval,
+  existing: AffiliationInterval[]
+): OverlapWarning[] {
+  return existing
+    .filter((other) => overlaps(candidate, other))
+    .map((other) => ({
+      type: "OVERLAP" as const,
+      partyId: other.partyId,
+      partyShortName: other.partyShortName,
+      startDate: other.startDate?.toISOString() ?? null,
+      endDate: other.endDate?.toISOString() ?? null,
+    }));
+}

--- a/src/lib/security/schemas/party.ts
+++ b/src/lib/security/schemas/party.ts
@@ -43,6 +43,14 @@ export const addPartyMembershipSchema = z.object({
   role: z.enum(VALID_PARTY_ROLES).optional(),
 });
 
+export const createPartyMembershipSchema = z.object({
+  mode: z.enum(["closed", "succeeds", "parallel"]),
+  partyId: z.string().min(1),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  role: z.enum(VALID_PARTY_ROLES).nullable().optional(),
+});
+
 export const endPartyMembershipSchema = z.object({
   endDate: z.string().optional(),
 });

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -48,6 +48,7 @@ import {
   setCurrentParty,
   syncAllCurrentParties,
   auditPartyConsistency,
+  removeParty,
 } from "@/services/politician";
 
 beforeEach(() => {
@@ -295,5 +296,30 @@ describe("auditPartyConsistency", () => {
         expectedPartyName: "MICRO",
       },
     ]);
+  });
+});
+
+describe("removeParty", () => {
+  it("closes only the affiliation of the current party", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: "p_main" });
+
+    await removeParty("pol_1", new Date("2026-02-01"));
+
+    expect(h.membershipUpdateMany).toHaveBeenCalledWith({
+      where: { politicianId: "pol_1", partyId: "p_main", endDate: null },
+      data: { endDate: new Date("2026-02-01") },
+    });
+    expect(h.politicianUpdate).toHaveBeenCalledWith({
+      where: { id: "pol_1" },
+      data: { currentPartyId: null },
+    });
+  });
+
+  it("closes nothing when there is no current party", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
+
+    await removeParty("pol_1", new Date("2026-02-01"));
+
+    expect(h.membershipUpdateMany).not.toHaveBeenCalled();
   });
 });

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -194,6 +194,42 @@ describe("setCurrentParty", () => {
     });
   });
 
+  it("applies an explicit startDate and role to the promoted row, still without a create", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
+    // 1st findFirst: findCurrentOpenMembership fallback (no currentPartyId) -> none open.
+    // 2nd findFirst: existingOpenForParty for the target party -> the row to promote.
+    h.membershipFindFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "m_micro", partyId: "p_ps", startDate: new Date("2022-01-01") });
+
+    const result = await setCurrentParty("pol_1", "p_ps", {
+      startDate: new Date("2026-01-01"),
+      role: "FONDATEUR",
+    });
+
+    expect(h.membershipUpdate).toHaveBeenCalledWith({
+      where: { id: "m_micro" },
+      data: { startDate: new Date("2026-01-01"), role: "FONDATEUR" },
+    });
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+    expect(result.membershipId).toBe("m_micro");
+  });
+
+  // Protects the sync callers (deputes, senateurs, gouvernement, mep-parties, careers), which
+  // call setCurrentParty without a startDate. If the promotion overwrote it unconditionally,
+  // the daily sync would rewrite a sourced start date to today's every time it promotes a
+  // parallel affiliation.
+  it("does not call update on the promoted row when no startDate option is supplied", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
+    h.membershipFindFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "m_micro", partyId: "p_ps", startDate: new Date("2022-01-01") });
+
+    await setCurrentParty("pol_1", "p_ps");
+
+    expect(h.membershipUpdate).not.toHaveBeenCalled();
+  });
+
   it("creates nothing and closes nothing when the politician has no affiliation", async () => {
     h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
     h.membershipFindFirst.mockResolvedValue(null);

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Party affiliations can run in parallel (a main party plus a micro-party), so "the open
+// membership" is ambiguous. These tests pin down which one each function picks.
+
+const h = vi.hoisted(() => ({
+  membershipFindFirst: vi.fn(),
+  membershipUpdate: vi.fn(),
+  membershipCreate: vi.fn(),
+  membershipUpdateMany: vi.fn(),
+  politicianFindUnique: vi.fn(),
+  politicianFindMany: vi.fn(),
+  politicianUpdate: vi.fn(),
+}));
+
+function txClient() {
+  return {
+    politician: { findUnique: h.politicianFindUnique, update: h.politicianUpdate },
+    partyMembership: {
+      findFirst: h.membershipFindFirst,
+      update: h.membershipUpdate,
+      create: h.membershipCreate,
+      updateMany: h.membershipUpdateMany,
+    },
+  };
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    politician: {
+      findUnique: h.politicianFindUnique,
+      findMany: h.politicianFindMany,
+      update: h.politicianUpdate,
+    },
+    partyMembership: {
+      findFirst: h.membershipFindFirst,
+      update: h.membershipUpdate,
+      create: h.membershipCreate,
+      updateMany: h.membershipUpdateMany,
+    },
+    $transaction: (fn: (t: unknown) => unknown) => fn(txClient()),
+  },
+}));
+
+import { findCurrentOpenMembership, OPEN_MEMBERSHIP_ORDER_BY } from "@/services/politician";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("findCurrentOpenMembership", () => {
+  it("prefers the open membership matching currentPartyId", async () => {
+    h.membershipFindFirst.mockResolvedValueOnce({
+      id: "m_main",
+      partyId: "p_main",
+      startDate: new Date("2015-01-01"),
+    });
+
+    const result = await findCurrentOpenMembership("pol_1", "p_main");
+
+    expect(result?.id).toBe("m_main");
+    expect(h.membershipFindFirst).toHaveBeenCalledTimes(1);
+    expect(h.membershipFindFirst.mock.calls[0]?.[0].where).toEqual({
+      politicianId: "pol_1",
+      partyId: "p_main",
+      endDate: null,
+    });
+  });
+
+  it("falls back to the most recent open membership when currentPartyId is null", async () => {
+    h.membershipFindFirst.mockResolvedValueOnce({
+      id: "m_micro",
+      partyId: "p_micro",
+      startDate: new Date("2022-01-01"),
+    });
+
+    const result = await findCurrentOpenMembership("pol_1", null);
+
+    expect(result?.id).toBe("m_micro");
+    expect(h.membershipFindFirst.mock.calls[0]?.[0].where).toEqual({
+      politicianId: "pol_1",
+      endDate: null,
+    });
+  });
+
+  it("falls back when currentPartyId points at a closed affiliation", async () => {
+    h.membershipFindFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "m_micro", partyId: "p_micro", startDate: null });
+
+    const result = await findCurrentOpenMembership("pol_1", "p_gone");
+
+    expect(result?.id).toBe("m_micro");
+    expect(h.membershipFindFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when the politician has no open membership", async () => {
+    h.membershipFindFirst.mockResolvedValue(null);
+
+    expect(await findCurrentOpenMembership("pol_1", null)).toBeNull();
+  });
+
+  // Postgres sorts NULLS FIRST on a descending order, so an unknown startDate would
+  // otherwise win over a known one. Guards against a "simplification" back to
+  // { startDate: "desc" }.
+  it("orders unknown start dates last", async () => {
+    h.membershipFindFirst.mockResolvedValue(null);
+
+    await findCurrentOpenMembership("pol_1", null);
+
+    expect(h.membershipFindFirst.mock.calls[0]?.[0].orderBy).toEqual([
+      { startDate: { sort: "desc", nulls: "last" } },
+      { createdAt: "desc" },
+    ]);
+    expect(OPEN_MEMBERSHIP_ORDER_BY).toEqual([
+      { startDate: { sort: "desc", nulls: "last" } },
+      { createdAt: "desc" },
+    ]);
+  });
+});

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -137,6 +137,11 @@ describe("setCurrentParty", () => {
       startDate: new Date("2026-01-01"),
     });
 
+    expect(h.membershipFindFirst.mock.calls[0]?.[0].where).toEqual({
+      politicianId: "pol_1",
+      partyId: "p_main",
+      endDate: null,
+    });
     expect(h.membershipUpdate).toHaveBeenCalledWith({
       where: { id: "m_main" },
       data: { endDate: new Date("2026-01-01") },

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -42,7 +42,11 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { findCurrentOpenMembership, OPEN_MEMBERSHIP_ORDER_BY } from "@/services/politician";
+import {
+  findCurrentOpenMembership,
+  OPEN_MEMBERSHIP_ORDER_BY,
+  setCurrentParty,
+} from "@/services/politician";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -116,5 +120,80 @@ describe("findCurrentOpenMembership", () => {
       { startDate: { sort: "desc", nulls: "last" } },
       { createdAt: "desc" },
     ]);
+  });
+});
+
+describe("setCurrentParty", () => {
+  it("closes the affiliation matching currentPartyId, not a more recent parallel one", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: "p_main" });
+    // 1st findFirst: open membership for currentPartyId. 2nd: open membership for the
+    // incoming party, to avoid creating a duplicate.
+    h.membershipFindFirst
+      .mockResolvedValueOnce({ id: "m_main", partyId: "p_main", startDate: new Date("2015-01-01") })
+      .mockResolvedValueOnce(null);
+    h.membershipCreate.mockResolvedValue({ id: "m_new" });
+
+    const result = await setCurrentParty("pol_1", "p_new", {
+      startDate: new Date("2026-01-01"),
+    });
+
+    expect(h.membershipUpdate).toHaveBeenCalledWith({
+      where: { id: "m_main" },
+      data: { endDate: new Date("2026-01-01") },
+    });
+    expect(result).toEqual({ membershipId: "m_new", closedMembershipId: "m_main" });
+  });
+
+  it("promotes an existing open affiliation instead of duplicating it", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: "p_main" });
+    h.membershipFindFirst
+      .mockResolvedValueOnce({ id: "m_main", partyId: "p_main", startDate: new Date("2015-01-01") })
+      .mockResolvedValueOnce({
+        id: "m_micro",
+        partyId: "p_micro",
+        startDate: new Date("2022-01-01"),
+      });
+
+    const result = await setCurrentParty("pol_1", "p_micro", {
+      startDate: new Date("2026-01-01"),
+    });
+
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+    expect(result.membershipId).toBe("m_micro");
+    expect(h.politicianUpdate).toHaveBeenCalledWith({
+      where: { id: "pol_1" },
+      data: { currentPartyId: "p_micro" },
+    });
+  });
+
+  it("passes the role through to the created membership", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
+    h.membershipFindFirst.mockResolvedValue(null);
+    h.membershipCreate.mockResolvedValue({ id: "m_new" });
+
+    await setCurrentParty("pol_1", "p_new", {
+      startDate: new Date("2026-01-01"),
+      role: "FONDATEUR",
+    });
+
+    expect(h.membershipCreate).toHaveBeenCalledWith({
+      data: {
+        politicianId: "pol_1",
+        partyId: "p_new",
+        startDate: new Date("2026-01-01"),
+        role: "FONDATEUR",
+      },
+    });
+  });
+
+  it("creates nothing and closes nothing when the politician has no affiliation", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
+    h.membershipFindFirst.mockResolvedValue(null);
+
+    const result = await setCurrentParty("pol_1", null, { startDate: new Date("2026-01-01") });
+
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+    expect(h.membershipUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({ membershipId: null, closedMembershipId: null });
   });
 });

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -46,6 +46,8 @@ import {
   findCurrentOpenMembership,
   OPEN_MEMBERSHIP_ORDER_BY,
   setCurrentParty,
+  syncAllCurrentParties,
+  auditPartyConsistency,
 } from "@/services/politician";
 
 beforeEach(() => {
@@ -200,5 +202,98 @@ describe("setCurrentParty", () => {
     expect(h.membershipCreate).not.toHaveBeenCalled();
     expect(h.membershipUpdate).not.toHaveBeenCalled();
     expect(result).toEqual({ membershipId: null, closedMembershipId: null });
+  });
+});
+
+describe("syncAllCurrentParties", () => {
+  it("leaves a currentPartyId that matches an open affiliation alone", async () => {
+    h.politicianFindMany.mockResolvedValue([
+      {
+        id: "pol_1",
+        currentPartyId: "p_main",
+        partyHistory: [
+          { partyId: "p_micro", party: { shortName: "MICRO" } },
+          { partyId: "p_main", party: { shortName: "MAIN" } },
+        ],
+      },
+    ]);
+
+    const result = await syncAllCurrentParties();
+
+    expect(h.politicianUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({ updated: 0, errors: [] });
+  });
+
+  it("repairs a currentPartyId that no longer matches any open affiliation", async () => {
+    h.politicianFindMany.mockResolvedValue([
+      {
+        id: "pol_1",
+        currentPartyId: "p_gone",
+        partyHistory: [{ partyId: "p_micro", party: { shortName: "MICRO" } }],
+      },
+    ]);
+
+    const result = await syncAllCurrentParties();
+
+    expect(h.politicianUpdate).toHaveBeenCalledWith({
+      where: { id: "pol_1" },
+      data: { currentPartyId: "p_micro" },
+    });
+    expect(result.updated).toBe(1);
+  });
+
+  it("clears currentPartyId when no affiliation is open", async () => {
+    h.politicianFindMany.mockResolvedValue([
+      { id: "pol_1", currentPartyId: "p_gone", partyHistory: [] },
+    ]);
+
+    await syncAllCurrentParties();
+
+    expect(h.politicianUpdate).toHaveBeenCalledWith({
+      where: { id: "pol_1" },
+      data: { currentPartyId: null },
+    });
+  });
+});
+
+describe("auditPartyConsistency", () => {
+  it("does not flag a parallel affiliation as an inconsistency", async () => {
+    h.politicianFindMany.mockResolvedValue([
+      {
+        id: "pol_1",
+        fullName: "Jeanne Exemple",
+        currentPartyId: "p_main",
+        currentParty: { shortName: "MAIN" },
+        partyHistory: [
+          { partyId: "p_micro", party: { shortName: "MICRO" } },
+          { partyId: "p_main", party: { shortName: "MAIN" } },
+        ],
+      },
+    ]);
+
+    expect(await auditPartyConsistency()).toEqual([]);
+  });
+
+  it("flags a currentPartyId that matches no open affiliation", async () => {
+    h.politicianFindMany.mockResolvedValue([
+      {
+        id: "pol_1",
+        fullName: "Jeanne Exemple",
+        currentPartyId: "p_gone",
+        currentParty: { shortName: "GONE" },
+        partyHistory: [{ partyId: "p_micro", party: { shortName: "MICRO" } }],
+      },
+    ]);
+
+    expect(await auditPartyConsistency()).toEqual([
+      {
+        politicianId: "pol_1",
+        fullName: "Jeanne Exemple",
+        currentPartyId: "p_gone",
+        expectedPartyId: "p_micro",
+        currentPartyName: "GONE",
+        expectedPartyName: "MICRO",
+      },
+    ]);
   });
 });

--- a/src/services/__tests__/politician-party.test.ts
+++ b/src/services/__tests__/politician-party.test.ts
@@ -215,10 +215,11 @@ describe("setCurrentParty", () => {
     expect(result.membershipId).toBe("m_micro");
   });
 
-  // Protects the sync callers (deputes, senateurs, gouvernement, mep-parties, careers), which
-  // call setCurrentParty without a startDate. If the promotion overwrote it unconditionally,
-  // the daily sync would rewrite a sourced start date to today's every time it promotes a
-  // parallel affiliation.
+  // Protects the sync callers (deputes, senateurs, gouvernement, mep-parties), which call
+  // setCurrentParty without a startDate. If the promotion overwrote it unconditionally, the
+  // daily sync would rewrite a sourced start date to today's every time it promotes a
+  // parallel affiliation. Note: careers.ts DOES pass a startDate, so this guard alone does
+  // not protect that path; isPromotion (tested below) is what does.
   it("does not call update on the promoted row when no startDate option is supplied", async () => {
     h.politicianFindUnique.mockResolvedValue({ currentPartyId: null });
     h.membershipFindFirst
@@ -228,6 +229,33 @@ describe("setCurrentParty", () => {
     await setCurrentParty("pol_1", "p_ps");
 
     expect(h.membershipUpdate).not.toHaveBeenCalled();
+  });
+
+  // The critical case: careers.ts (and the admin route) always pass an explicit startDate,
+  // so hasExplicitStartDate is always true there. When the incoming party is already
+  // currentPartyId, existingOpenForParty is the very row backing it: this call must be a
+  // true no-op, or a sync/re-save would silently rewrite that row's sourced start date.
+  it("issues no update and no create when the incoming party is already the current one", async () => {
+    h.politicianFindUnique.mockResolvedValue({ currentPartyId: "p_main" });
+    // 1st findFirst: open membership for currentPartyId (found -> partyId === partyId, so
+    // nothing is closed). 2nd findFirst: existingOpenForParty for the incoming party -> the
+    // same row.
+    h.membershipFindFirst
+      .mockResolvedValueOnce({ id: "m_main", partyId: "p_main", startDate: new Date("1998-01-01") })
+      .mockResolvedValueOnce({
+        id: "m_main",
+        partyId: "p_main",
+        startDate: new Date("1998-01-01"),
+      });
+
+    const result = await setCurrentParty("pol_1", "p_main", {
+      startDate: new Date("2015-01-01"),
+      role: "FONDATEUR",
+    });
+
+    expect(h.membershipUpdate).not.toHaveBeenCalled();
+    expect(h.membershipCreate).not.toHaveBeenCalled();
+    expect(result).toEqual({ membershipId: "m_main", closedMembershipId: null });
   });
 
   it("creates nothing and closes nothing when the politician has no affiliation", async () => {

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -9,7 +9,7 @@
  */
 
 import { db } from "@/lib/db";
-import type { PartyRole } from "@/generated/prisma";
+import { Prisma, type PartyRole } from "@/generated/prisma";
 
 export interface SetPartyOptions {
   /** Start date of the new affiliation (defaults to now) */
@@ -18,6 +18,55 @@ export interface SetPartyOptions {
   endPreviousMembership?: boolean;
   /** Role in the party (defaults to MEMBRE) */
   role?: PartyRole;
+}
+
+/**
+ * Ordering used whenever we need "the most recent open affiliation".
+ *
+ * startDate is nullable and Postgres sorts NULLS FIRST on a descending order, so an
+ * affiliation with an unknown start date would otherwise be picked as the most recent
+ * one. createdAt breaks remaining ties deterministically.
+ */
+export const OPEN_MEMBERSHIP_ORDER_BY: Prisma.PartyMembershipOrderByWithRelationInput[] = [
+  { startDate: { sort: "desc", nulls: "last" } },
+  { createdAt: "desc" },
+];
+
+/** Minimal read surface, so this works with `db` and with a transaction client alike. */
+export type PartyMembershipReader = {
+  partyMembership: {
+    findFirst: (args: {
+      where: { politicianId: string; partyId?: string; endDate: null };
+      orderBy: Prisma.PartyMembershipOrderByWithRelationInput[];
+    }) => Promise<{ id: string; partyId: string; startDate: Date | null } | null>;
+  };
+};
+
+/**
+ * Which open affiliation is the one the current party points at.
+ *
+ * A politician can hold several open affiliations at once (a main party plus a
+ * micro-party). "The most recent open one" is therefore not a safe proxy for "the
+ * current party": promoting the wrong row silently rewrites a politician's displayed
+ * party. Deliberate editorial choices, carried by currentPartyId, win.
+ */
+export async function findCurrentOpenMembership(
+  politicianId: string,
+  currentPartyId: string | null,
+  client: PartyMembershipReader = db as unknown as PartyMembershipReader
+): Promise<{ id: string; partyId: string; startDate: Date | null } | null> {
+  if (currentPartyId) {
+    const matching = await client.partyMembership.findFirst({
+      where: { politicianId, partyId: currentPartyId, endDate: null },
+      orderBy: OPEN_MEMBERSHIP_ORDER_BY,
+    });
+    if (matching) return matching;
+  }
+
+  return client.partyMembership.findFirst({
+    where: { politicianId, endDate: null },
+    orderBy: OPEN_MEMBERSHIP_ORDER_BY,
+  });
 }
 
 /**

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -166,20 +166,31 @@ export async function setCurrentParty(
 }
 
 /**
- * Remove party affiliation from a politician.
+ * Remove the current party for a politician.
  *
- * This ends the current membership and sets currentPartyId to null.
+ * This closes the affiliation of the current party and sets currentPartyId to null.
+ * A politician can hold several open affiliations at once (a main party plus a
+ * micro-party), so we must specify partyId to close only the one backing currentPartyId.
  */
 export async function removeParty(politicianId: string, endDate: Date = new Date()): Promise<void> {
   await db.$transaction(async (tx) => {
-    // End current membership
-    await tx.partyMembership.updateMany({
-      where: {
-        politicianId,
-        endDate: null,
-      },
-      data: { endDate },
+    // Read inside the transaction: a politician can hold parallel open affiliations, and
+    // only the one backing currentPartyId is the party being removed.
+    const politician = await tx.politician.findUnique({
+      where: { id: politicianId },
+      select: { currentPartyId: true },
     });
+
+    if (politician?.currentPartyId) {
+      await tx.partyMembership.updateMany({
+        where: {
+          politicianId,
+          partyId: politician.currentPartyId,
+          endDate: null,
+        },
+        data: { endDate },
+      });
+    }
 
     // Clear currentPartyId
     await tx.politician.update({

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -69,6 +69,24 @@ export async function findCurrentOpenMembership(
   });
 }
 
+/**
+ * In-memory twin of findCurrentOpenMembership, for the two functions that sweep every
+ * politician in one query. Calling the query-based helper per politician would turn a
+ * single findMany into tens of thousands of round trips.
+ *
+ * `openMemberships` must already be ordered by OPEN_MEMBERSHIP_ORDER_BY.
+ */
+function pickCurrentOpenMembership<T extends { partyId: string }>(
+  openMemberships: T[],
+  currentPartyId: string | null
+): T | null {
+  if (currentPartyId) {
+    const matching = openMemberships.find((m) => m.partyId === currentPartyId);
+    if (matching) return matching;
+  }
+  return openMemberships[0] ?? null;
+}
+
 export interface SetCurrentPartyResult {
   /** The membership now backing currentPartyId, created or promoted. */
   membershipId: string | null;
@@ -228,8 +246,8 @@ export async function setPartyRole(
  * Sync currentPartyId from PartyMembership for all politicians.
  *
  * Use this to fix inconsistencies between the two.
- * The current party is determined by the membership with no endDate
- * (or the most recent one if multiple exist).
+ * The current party is the open affiliation matching currentPartyId, or failing that,
+ * the most recent open one.
  */
 export async function syncAllCurrentParties(): Promise<{
   updated: number;
@@ -241,8 +259,7 @@ export async function syncAllCurrentParties(): Promise<{
       currentPartyId: true,
       partyHistory: {
         where: { endDate: null },
-        orderBy: { startDate: "desc" },
-        take: 1,
+        orderBy: OPEN_MEMBERSHIP_ORDER_BY,
         select: { partyId: true },
       },
     },
@@ -252,7 +269,8 @@ export async function syncAllCurrentParties(): Promise<{
   const errors: string[] = [];
 
   for (const p of politicians) {
-    const expectedPartyId = p.partyHistory[0]?.partyId ?? null;
+    const expectedPartyId =
+      pickCurrentOpenMembership(p.partyHistory, p.currentPartyId)?.partyId ?? null;
 
     if (p.currentPartyId !== expectedPartyId) {
       try {
@@ -273,8 +291,9 @@ export async function syncAllCurrentParties(): Promise<{
 /**
  * Audit party consistency for all politicians.
  *
- * Returns a list of politicians where currentPartyId doesn't match
- * the current PartyMembership.
+ * Returns a list of politicians where currentPartyId doesn't match the current
+ * PartyMembership. The current party is the open affiliation matching currentPartyId,
+ * or failing that, the most recent open one.
  */
 export async function auditPartyConsistency(): Promise<
   Array<{
@@ -294,8 +313,7 @@ export async function auditPartyConsistency(): Promise<
       currentParty: { select: { shortName: true } },
       partyHistory: {
         where: { endDate: null },
-        orderBy: { startDate: "desc" },
-        take: 1,
+        orderBy: OPEN_MEMBERSHIP_ORDER_BY,
         select: {
           partyId: true,
           party: { select: { shortName: true } },
@@ -307,7 +325,8 @@ export async function auditPartyConsistency(): Promise<
   const inconsistencies = [];
 
   for (const p of politicians) {
-    const expectedPartyId = p.partyHistory[0]?.partyId ?? null;
+    const expected = pickCurrentOpenMembership(p.partyHistory, p.currentPartyId);
+    const expectedPartyId = expected?.partyId ?? null;
 
     if (p.currentPartyId !== expectedPartyId) {
       inconsistencies.push({
@@ -316,7 +335,7 @@ export async function auditPartyConsistency(): Promise<
         currentPartyId: p.currentPartyId,
         expectedPartyId,
         currentPartyName: p.currentParty?.shortName ?? null,
-        expectedPartyName: p.partyHistory[0]?.party.shortName ?? null,
+        expectedPartyName: expected?.party.shortName ?? null,
       });
     }
   }

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -69,13 +69,20 @@ export async function findCurrentOpenMembership(
   });
 }
 
+export interface SetCurrentPartyResult {
+  /** The membership now backing currentPartyId, created or promoted. */
+  membershipId: string | null;
+  /** The membership this call closed, if any. */
+  closedMembershipId: string | null;
+}
+
 /**
  * Set the current party for a politician.
  *
  * This function:
- * 1. Ends the current party membership (if any)
- * 2. Creates a new party membership
- * 3. Updates the politician's currentPartyId
+ * 1. Ends the open membership matching currentPartyId (if any), promoting an existing
+ *    parallel affiliation for the incoming party instead of duplicating it
+ * 2. Updates the politician's currentPartyId
  *
  * @example
  * await politicianService.setCurrentParty("politician-id", "party-id");
@@ -85,30 +92,42 @@ export async function setCurrentParty(
   politicianId: string,
   partyId: string | null,
   options: SetPartyOptions = {}
-): Promise<void> {
+): Promise<SetCurrentPartyResult> {
   const { startDate = new Date(), endPreviousMembership = true, role } = options;
 
-  await db.$transaction(async (tx) => {
-    // 1. Get current party membership
-    const currentMembership = await tx.partyMembership.findFirst({
-      where: {
-        politicianId,
-        endDate: null,
-      },
-      orderBy: { startDate: "desc" },
+  return db.$transaction(async (tx) => {
+    const politician = await tx.politician.findUnique({
+      where: { id: politicianId },
+      select: { currentPartyId: true },
     });
 
-    // 2. End current membership if different party
+    const currentMembership = await findCurrentOpenMembership(
+      politicianId,
+      politician?.currentPartyId ?? null,
+      tx as unknown as PartyMembershipReader
+    );
+
+    let closedMembershipId: string | null = null;
     if (endPreviousMembership && currentMembership && currentMembership.partyId !== partyId) {
       await tx.partyMembership.update({
         where: { id: currentMembership.id },
         data: { endDate: startDate },
       });
+      closedMembershipId = currentMembership.id;
     }
 
-    // 3. Create new membership if party is set and different
-    if (partyId && (!currentMembership || currentMembership.partyId !== partyId)) {
-      await tx.partyMembership.create({
+    // An open membership for the incoming party may already exist as a parallel
+    // affiliation. Promote it rather than adding a second open row for the same party.
+    const existingOpenForParty = partyId
+      ? await tx.partyMembership.findFirst({
+          where: { politicianId, partyId, endDate: null },
+          orderBy: OPEN_MEMBERSHIP_ORDER_BY,
+        })
+      : null;
+
+    let membershipId: string | null = existingOpenForParty?.id ?? null;
+    if (partyId && !existingOpenForParty) {
+      const created = await tx.partyMembership.create({
         data: {
           politicianId,
           partyId,
@@ -116,13 +135,15 @@ export async function setCurrentParty(
           ...(role && { role }),
         },
       });
+      membershipId = created.id;
     }
 
-    // 4. Update currentPartyId
     await tx.politician.update({
       where: { id: politicianId },
       data: { currentPartyId: partyId },
     });
+
+    return { membershipId, closedMembershipId };
   });
 }
 

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -111,6 +111,7 @@ export async function setCurrentParty(
   partyId: string | null,
   options: SetPartyOptions = {}
 ): Promise<SetCurrentPartyResult> {
+  const hasExplicitStartDate = options.startDate !== undefined;
   const { startDate = new Date(), endPreviousMembership = true, role } = options;
 
   return db.$transaction(async (tx) => {
@@ -144,7 +145,21 @@ export async function setCurrentParty(
       : null;
 
     let membershipId: string | null = existingOpenForParty?.id ?? null;
-    if (partyId && !existingOpenForParty) {
+    if (partyId && existingOpenForParty) {
+      // Promoting a parallel affiliation to main. Apply what the caller supplied, and
+      // nothing else: the sync callers pass no startDate, and overwriting a stored start
+      // date with today's would destroy sourced data.
+      const promotionData: Prisma.PartyMembershipUpdateInput = {};
+      if (hasExplicitStartDate) promotionData.startDate = startDate;
+      if (role) promotionData.role = role;
+
+      if (Object.keys(promotionData).length > 0) {
+        await tx.partyMembership.update({
+          where: { id: existingOpenForParty.id },
+          data: promotionData,
+        });
+      }
+    } else if (partyId) {
       const created = await tx.partyMembership.create({
         data: {
           politicianId,

--- a/src/services/politician.ts
+++ b/src/services/politician.ts
@@ -144,14 +144,21 @@ export async function setCurrentParty(
         })
       : null;
 
+    // Whether the incoming party is actually replacing the current one. When the
+    // incoming party already IS currentPartyId, existingOpenForParty is the very row
+    // backing it, and this call is a no-op for that row: applying startDate/role here
+    // would silently rewrite a sourced date on every no-op re-save.
+    const isPromotion = politician?.currentPartyId !== partyId;
+
     let membershipId: string | null = existingOpenForParty?.id ?? null;
     if (partyId && existingOpenForParty) {
       // Promoting a parallel affiliation to main. Apply what the caller supplied, and
-      // nothing else: the sync callers pass no startDate, and overwriting a stored start
-      // date with today's would destroy sourced data.
+      // nothing else: four of the five sync callers pass no startDate, but careers.ts
+      // does, so the hasExplicitStartDate guard alone is not sufficient. Gating on
+      // isPromotion as well is what protects the row when it is already current.
       const promotionData: Prisma.PartyMembershipUpdateInput = {};
-      if (hasExplicitStartDate) promotionData.startDate = startDate;
-      if (role) promotionData.role = role;
+      if (isPromotion && hasExplicitStartDate) promotionData.startDate = startDate;
+      if (isPromotion && role) promotionData.role = role;
 
       if (Object.keys(promotionData).length > 0) {
         await tx.partyMembership.update({
@@ -274,6 +281,11 @@ export async function setPartyRole(
  * Use this to fix inconsistencies between the two.
  * The current party is the open affiliation matching currentPartyId, or failing that,
  * the most recent open one.
+ *
+ * Invariant to keep in mind before wiring this into a scheduled job: after removeParty,
+ * a politician can hold open affiliations with a null currentPartyId, and in that state
+ * this function promotes the most recent open one, which may be a micro-party. The admin
+ * API refuses to create that same state deliberately, so revisit this fallback first.
  */
 export async function syncAllCurrentParties(): Promise<{
   updated: number;


### PR DESCRIPTION
## Description

L'admin ne permettait de modifier que le parti actuel. Aucun moyen de saisir une
affiliation passée, ni une double appartenance. Le cas déclencheur : François Pupponi,
membre du PS jusqu'en 2018, dont la base ne connaissait que Territoires de progrès.

Aucune modification de schéma : `PartyMembership` savait déjà tout représenter.

**Ce que la PR ajoute**

- `POST /api/admin/politiques/[id]/party-membership`, avec un champ `mode` explicite
  (`closed`, `succeeds`, `parallel`) plutôt qu'une intention devinée depuis la présence
  de `endDate`. Sept branches de refus 400 exprimant six règles.
- Un formulaire d'ajout dans la carte « Parti et affiliations », avec un choix entre
  succession et affiliation en parallèle quand aucune date de fin n'est saisie.
- Détection de chevauchement non bloquante : la route renvoie des avertissements
  structurés, l'UI les rend dans un bandeau ambre. Le calcul porte sur l'état
  post-écriture et les intervalles sont semi-ouverts, sinon chaque changement de parti
  signalerait un faux chevauchement.
- Une date de début inconnue s'affiche « — » et non plus « En cours ».

**Correctifs de service inclus**

Quatre fonctions de `src/services/politician.ts` confondaient « l'affiliation ouverte la
plus récente » et « l'affiliation du parti actuel ». Sans elles, ajouter une affiliation
parallèle laissait le prochain balayage promouvoir le micro-parti en parti affiché. Le
tri est aussi corrigé : `startDate` est nullable et Postgres trie `NULLS FIRST` en ordre
décroissant, donc une affiliation à date inconnue passait pour la plus récente.

`setCurrentParty` renvoie désormais `{ membershipId, closedMembershipId }` pour
l'audit. Ses cinq appelants de `src/services/sync/` ignorent la valeur de retour et
restent inchangés.

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Bug fix

## Issue liée

Aucune.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

## Vérifications

- `npx vitest run` : 3455 tests passés, 366 fichiers, 0 échec
- `npx tsc --noEmit` : propre hors `.next/`
- Vérification manuelle sur `/admin/politiques/<id>` : ouverture du formulaire, bascule
  du choix de mode, absence de débordement horizontal, bandeau ambre qui survit à la
  disparition du bandeau vert

## Points de vigilance pour la relecture

- Le mode `succeeds` clôture une affiliation existante, donc il réécrit une ligne
  qu'il n'a pas créée. La règle qui décide **laquelle** est clôturée est le cœur de la
  PR.
- La promotion d'une affiliation parallèle déjà ouverte applique la date et le rôle
  saisis, mais seulement quand un vrai changement de parti a lieu. Sans cette
  condition, le sync des présidents de parti écrasait la date d'adhésion avec la date
  de prise de présidence.
- `syncAllCurrentParties` et `auditPartyConsistency` n'ont aucun appelant en production
  aujourd'hui. Leurs correctifs sont préventifs, et un invariant est consigné en
  docstring pour quiconque les brancherait sur un cron.
