### PR TITLE
Envelopper les tables sr-only au lieu de les contraindre

### DIFF
--- a/src/components/__tests__/sr-only-tables.test.ts
+++ b/src/components/__tests__/sr-only-tables.test.ts
@@ -19,16 +19,27 @@ function tsxFiles(dir: string): string[] {
 }
 
 /**
- * `sr-only` sets `position: absolute; width: 1px`, but a table laid out with
- * `table-layout: auto` sizes itself on its content and ignores that width. It
- * then sticks out of the body and widens the document, which reads on mobile as
- * a blank strip on the right of every page carrying such a table.
+ * `sr-only` is meant for a container, never for a table.
  *
- * The trap is invisible on review: nothing is visible on screen, and only
- * `documentElement.scrollWidth` shows it.
+ * It sets `position: absolute; width: 1px; overflow: hidden; white-space: nowrap`,
+ * but a table cannot shrink below the intrinsic width its `<caption>` and its
+ * nowrap cells demand. `table-layout: fixed` does not help: the caption box sets
+ * a floor. The table then sticks out of the body and widens the document, which
+ * reads on mobile as a blank strip on the right.
+ *
+ * Wrapping the table in `<div className="sr-only">` settles it: the div is the
+ * 1px clipping box, and the table inside can be as wide as it likes without
+ * contributing to layout.
+ *
+ * Measured on /statistiques?tab=legislatif at 412px: 503px of document width
+ * with `sr-only table-fixed` on the table, 412px once wrapped.
+ *
+ * This guard replaced a weaker one that only demanded `table-fixed`. That
+ * version passed while the bug was live, because a table whose caption happens
+ * to be shorter than the viewport fits by luck.
  */
 describe("screen-reader-only tables", () => {
-  it("all declare a fixed layout so they cannot widen the document", () => {
+  it("are wrapped in an sr-only container rather than carrying the class themselves", () => {
     const offenders: string[] = [];
 
     for (const file of tsxFiles(SRC)) {
@@ -36,14 +47,13 @@ describe("screen-reader-only tables", () => {
       for (const match of content.matchAll(/<table[^>]*className="([^"]*)"/g)) {
         const classes = match[1]!;
         if (!/\bsr-only\b/.test(classes)) continue;
-        if (/\btable-fixed\b/.test(classes)) continue;
-        offenders.push(`${relative(SRC, file)} -> className="${classes}"`);
+        offenders.push(`${relative(SRC, file)} -> <table className="${classes}">`);
       }
     }
 
     expect(
       offenders,
-      `These sr-only tables can widen the document. Add "table-fixed":\n${offenders.join("\n")}`
+      `A table must not carry "sr-only" itself. Wrap it in <div className="sr-only">:\n${offenders.join("\n")}`
     ).toEqual([]);
   });
 });

--- a/src/components/elections/municipales/ParityChart.tsx
+++ b/src/components/elections/municipales/ParityChart.tsx
@@ -111,27 +111,29 @@ export function ParityChart({ data, title }: ParityChartProps) {
       </div>
 
       {/* Screen reader table */}
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>{title}</caption>
-        <thead>
-          <tr>
-            <th>Catégorie</th>
-            <th>Femmes (%)</th>
-            <th>Hommes (%)</th>
-            <th>Total</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((item) => (
-            <tr key={item.label}>
-              <td>{item.label}</td>
-              <td>{Math.round(item.femaleRate * 100)}%</td>
-              <td>{100 - Math.round(item.femaleRate * 100)}%</td>
-              <td>{item.totalCount}</td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>{title}</caption>
+          <thead>
+            <tr>
+              <th>Catégorie</th>
+              <th>Femmes (%)</th>
+              <th>Hommes (%)</th>
+              <th>Total</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {sorted.map((item) => (
+              <tr key={item.label}>
+                <td>{item.label}</td>
+                <td>{Math.round(item.femaleRate * 100)}%</td>
+                <td>{100 - Math.round(item.femaleRate * 100)}%</td>
+                <td>{item.totalCount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       {/* Legend */}
       <div className="flex items-center gap-4 mt-3 text-sm text-muted-foreground">

--- a/src/components/parlement/CompositionHemicycle.tsx
+++ b/src/components/parlement/CompositionHemicycle.tsx
@@ -242,23 +242,27 @@ export function CompositionHemicycle({ anGroups, senatGroups }: Props) {
       </div>
 
       {/* Accessible data table (hidden) */}
-      <table className="sr-only table-fixed">
-        <caption>Composition {chamber === "AN" ? "de l'Assemblée nationale" : "du Sénat"}</caption>
-        <thead>
-          <tr>
-            <th>Groupe</th>
-            <th>Sièges</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedGroups.map((g) => (
-            <tr key={g.code}>
-              <td>{g.name}</td>
-              <td>{g.seatCount}</td>
+      <div className="sr-only">
+        <table>
+          <caption>
+            Composition {chamber === "AN" ? "de l'Assemblée nationale" : "du Sénat"}
+          </caption>
+          <thead>
+            <tr>
+              <th>Groupe</th>
+              <th>Sièges</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {sortedGroups.map((g) => (
+              <tr key={g.code}>
+                <td>{g.name}</td>
+                <td>{g.seatCount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }

--- a/src/components/stats/DonutChart.tsx
+++ b/src/components/stats/DonutChart.tsx
@@ -57,25 +57,27 @@ export function DonutChart({ segments, size = 200, title }: DonutChartProps) {
         </g>
       </svg>
       {/* Screen reader table */}
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>{title}</caption>
-        <thead>
-          <tr>
-            <th>Catégorie</th>
-            <th>Nombre</th>
-            <th>Pourcentage</th>
-          </tr>
-        </thead>
-        <tbody>
-          {segments.map((s) => (
-            <tr key={s.label}>
-              <td>{s.label}</td>
-              <td>{s.value}</td>
-              <td>{total > 0 ? ((s.value / total) * 100).toFixed(1) : 0}%</td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>{title}</caption>
+          <thead>
+            <tr>
+              <th>Catégorie</th>
+              <th>Nombre</th>
+              <th>Pourcentage</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {segments.map((s) => (
+              <tr key={s.label}>
+                <td>{s.label}</td>
+                <td>{s.value}</td>
+                <td>{total > 0 ? ((s.value / total) * 100).toFixed(1) : 0}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       {/* Visual legend */}
       <div className="flex flex-wrap justify-center gap-3 mt-4">
         {segments.map((s) => (

--- a/src/components/stats/GroupDynamics.tsx
+++ b/src/components/stats/GroupDynamics.tsx
@@ -81,27 +81,29 @@ function AlignmentSpectrum({
       </div>
 
       {/* Screen reader table */}
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>Concordance des votes par groupe - {chamberLabel}</caption>
-        <thead>
-          <tr>
-            <th>Groupe</th>
-            <th>Concordance</th>
-            <th>Cohésion</th>
-            <th>Participation</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((g) => (
-            <tr key={g.groupId}>
-              <td>{g.groupName}</td>
-              <td>{g.governmentAlignmentPct.toFixed(1)}%</td>
-              <td>{g.cohesionPct.toFixed(1)}%</td>
-              <td>{g.averageParticipationPct.toFixed(1)}%</td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>Concordance des votes par groupe - {chamberLabel}</caption>
+          <thead>
+            <tr>
+              <th>Groupe</th>
+              <th>Concordance</th>
+              <th>Cohésion</th>
+              <th>Participation</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {sorted.map((g) => (
+              <tr key={g.groupId}>
+                <td>{g.groupName}</td>
+                <td>{g.governmentAlignmentPct.toFixed(1)}%</td>
+                <td>{g.cohesionPct.toFixed(1)}%</td>
+                <td>{g.averageParticipationPct.toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/stats/Hemicycle.tsx
+++ b/src/components/stats/Hemicycle.tsx
@@ -307,33 +307,35 @@ export function Hemicycle({ groups }: HemicycleProps) {
       )}
 
       {/* SR-only accessible table */}
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>Affaires judiciaires par groupe parlementaire</caption>
-        <thead>
-          <tr>
-            <th>Groupe</th>
-            <th>Députés</th>
-            <th>Mis en cause</th>
-            <th>Condamnés</th>
-          </tr>
-        </thead>
-        <tbody>
-          {groups.map((g) => (
-            <tr key={g.code}>
-              <td>{g.shortName || g.name}</td>
-              <td>{g.deputies.length}</td>
-              <td>{g.deputies.filter((d) => d.activeAffairCount > 0).length}</td>
-              <td>
-                {
-                  g.deputies.filter(
-                    (d) => d.maxCertaintyLevel === "ETABLI" || d.maxCertaintyLevel === "PRONONCE"
-                  ).length
-                }
-              </td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>Affaires judiciaires par groupe parlementaire</caption>
+          <thead>
+            <tr>
+              <th>Groupe</th>
+              <th>Députés</th>
+              <th>Mis en cause</th>
+              <th>Condamnés</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {groups.map((g) => (
+              <tr key={g.code}>
+                <td>{g.shortName || g.name}</td>
+                <td>{g.deputies.length}</td>
+                <td>{g.deputies.filter((d) => d.activeAffairCount > 0).length}</td>
+                <td>
+                  {
+                    g.deputies.filter(
+                      (d) => d.maxCertaintyLevel === "ETABLI" || d.maxCertaintyLevel === "PRONONCE"
+                    ).length
+                  }
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/stats/HorizontalBars.tsx
+++ b/src/components/stats/HorizontalBars.tsx
@@ -62,26 +62,28 @@ export function HorizontalBars({ bars, title, maxValue: globalMax }: HorizontalB
         })}
       </div>
       {/* Screen reader table */}
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>{title}</caption>
-        <thead>
-          <tr>
-            <th>Nom</th>
-            <th>Valeur</th>
-          </tr>
-        </thead>
-        <tbody>
-          {bars.map((b) => (
-            <tr key={b.label}>
-              <td>{b.label}</td>
-              <td>
-                {b.value}
-                {b.suffix || ""}
-              </td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>{title}</caption>
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Valeur</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {bars.map((b) => (
+              <tr key={b.label}>
+                <td>{b.label}</td>
+                <td>
+                  {b.value}
+                  {b.suffix || ""}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/stats/ProportionBar.tsx
+++ b/src/components/stats/ProportionBar.tsx
@@ -72,25 +72,27 @@ export function ProportionBar({ breakdown, showLabels: _showLabels = false }: Pr
           );
         })}
       </div>
-      <table className="sr-only table-fixed" id={descId}>
-        <caption>Répartition des verdicts</caption>
-        <thead>
-          <tr>
-            <th>Verdict</th>
-            <th>Nombre</th>
-            <th>Pourcentage</th>
-          </tr>
-        </thead>
-        <tbody>
-          {segments.map((s) => (
-            <tr key={s.key}>
-              <td>{s.label}</td>
-              <td>{s.value}</td>
-              <td>{((s.value / total) * 100).toFixed(1)}%</td>
+      <div className="sr-only">
+        <table id={descId}>
+          <caption>Répartition des verdicts</caption>
+          <thead>
+            <tr>
+              <th>Verdict</th>
+              <th>Nombre</th>
+              <th>Pourcentage</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {segments.map((s) => (
+              <tr key={s.key}>
+                <td>{s.label}</td>
+                <td>{s.value}</td>
+                <td>{((s.value / total) * 100).toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Suite de #665, qui n'avait corrigé le débordement que sur l'onglet par défaut de
`/statistiques`. Marion l'a signalé encore présent sur l'onglet Lois.

## Pourquoi le premier correctif ne suffisait pas

#665 ajoutait `table-fixed` aux tables `sr-only`. Mesuré sur
`/statistiques?tab=legislatif` en 412px de large, après déploiement :

```
clientWidth      : 412
scrollWidth      : 503   <- 91px de trop
body.scrollWidth : 412
```

Et le coupable portait déjà le correctif :

```
table cls="sr-only table-fixed" right=503 w=463 pos=absolute ws=nowrap
caption cls=""                  right=503 w=463 pos=static   ws=nowrap
```

`table-layout: fixed` répartit une largeur entre les colonnes, mais il ne descend pas
sous la largeur intrinsèque imposée par le `<caption>`. Un caption en
`white-space: nowrap`, hérité de `sr-only`, met un plancher à 463px. La table le suit.

Sur l'onglet Justice, les captions se trouvaient plus courts que 412px, donc les tables
passaient. Le correctif de #665 marchait par coïncidence de longueur de texte, pas par
construction, et le test vert le masquait.

## Le correctif

`sr-only` est fait pour un conteneur, pas pour une table dont la largeur intrinsèque
est incompressible. Les 7 tables sont désormais enveloppées :

```diff
-<table className="sr-only table-fixed" id={descId}>
+<div className="sr-only">
+  <table id={descId}>
```

Le `div` est la boîte de clipping de 1px, et la table à l'intérieur peut faire la
largeur qu'elle veut sans participer à la mise en page.

Cela inclut la table de l'hémicycle, qui ne débordait pas mais tenait pour la même
mauvaise raison.

## Garde-fou remplacé

L'ancienne règle demandait `table-fixed`. Elle était verte pendant que le bug était en
production, ce qui la disqualifie. La nouvelle interdit `sr-only` sur une `<table>`,
sans échappatoire : la seule façon de passer est d'envelopper.

## Vérification

Mesuré sur les 6 pages concernées en 412px de large, dont les 4 onglets de
`/statistiques` cette fois, et pas seulement celui par défaut :

```
ok  /statistiques?tab=judiciaire      client=412 scroll=412
ok  /statistiques?tab=factcheck       client=412 scroll=412
ok  /statistiques?tab=legislatif      client=412 scroll=412
ok  /statistiques?tab=participation   client=412 scroll=412
ok  /parlement                        client=412 scroll=412
ok  /elections/municipales-2026/parite client=412 scroll=412
```

Accessibilité vérifiée sur l'onglet Lois, puisque c'est le critère à ne pas casser :
4 tables présentes dans l'arbre d'accessibilité, `display: table`,
`visibility: visible`, caption et 12 lignes lisibles, `aria-describedby` qui résout.
C'est le conteneur qui clippe, pas la table qui est masquée.

Suite complète : 3539 tests passés, 0 échec. `tsc --noEmit` et `next build` propres.
`eslint` ne remonte que 4 avertissements pré-existants dans `CumulTable.tsx`, fichier
non touché ici.

## Leçon retenue

Le contenu des onglets n'est rendu qu'à la sélection. Mesurer une page à onglets sur
son seul onglet par défaut ne dit rien des autres, et c'est ce qui a laissé passer le
bug après #665.

Closes #672
