### PR TITLE
Hub présidentielle lot 4B : index des sujets, hub racine, état fermé

### DIFF
--- a/scripts/seed-presidentielle-hub-demo.ts
+++ b/scripts/seed-presidentielle-hub-demo.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env tsx
+/**
+ * Seeds a fictional demo corpus for the presidential 2027 hub, so the public routes
+ * /elections/presidentielle-2027, /elections/presidentielle-2027/sujets and
+ * /elections/presidentielle-2027/sujets/numerique-tech can be reviewed in a browser
+ * (responsive + axe).
+ *
+ * The seeding itself lives in src/lib/data/__tests__/presidentielle-hub-demo.ts (a test fixture,
+ * where writing PUBLISHED directly is allowed); this script is the thin, guarded entry point.
+ *
+ * Refuses to run against anything but the disposable container, and that refusal is the point:
+ * `.env` and `.env.prod` point at the same Supabase database.
+ *
+ * Usage, with the container from docker-compose.test-search.yml running and its schema pushed:
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
+ *     npx tsx scripts/seed-presidentielle-hub-demo.ts
+ */
+import { assertDisposableTestDb } from "@/test/disposable-db";
+
+async function main(): Promise<void> {
+  // First statement, before any import that opens a connection: the guard is the safety net.
+  assertDisposableTestDb();
+
+  const { seedPresidentielleHubDemo } =
+    await import("@/lib/data/__tests__/presidentielle-hub-demo");
+  const { db } = await import("@/lib/db");
+
+  const { electionId } = await seedPresidentielleHubDemo(db);
+  console.log(`[seed:presidentielle-hub] élection presidentielle-2027 (${electionId})`);
+  console.log(
+    "[seed:presidentielle-hub] champ : 2 candidatures sourcées sans extension, 2 fiches " +
+      "publiées avec mesure Logement, 1 fiche publiée avec mesure Numérique (sous le seuil)"
+  );
+
+  await db.$disconnect();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/seed-presidentielle-hub-demo.ts
+++ b/scripts/seed-presidentielle-hub-demo.ts
@@ -11,6 +11,10 @@
  * Refuses to run against anything but the disposable container, and that refusal is the point:
  * `.env` and `.env.prod` point at the same Supabase database.
  *
+ * Expects a fresh database: this and scripts/seed-presidentielle-sujet-demo.ts both create the
+ * `presidentielle-2027` election, so running one after the other on the same container fails on
+ * the slug's unique constraint.
+ *
  * Usage, with the container from docker-compose.test-search.yml running and its schema pushed:
  *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
  *     npx tsx scripts/seed-presidentielle-hub-demo.ts

--- a/scripts/seed-presidentielle-sujet-demo.ts
+++ b/scripts/seed-presidentielle-sujet-demo.ts
@@ -9,6 +9,10 @@
  * Refuses to run against anything but the disposable container, and that refusal is the point:
  * `.env` and `.env.prod` point at the same Supabase database.
  *
+ * Expects a fresh database: this and scripts/seed-presidentielle-hub-demo.ts both create the
+ * `presidentielle-2027` election, so running one after the other on the same container fails on
+ * the slug's unique constraint.
+ *
  * Usage, with the container from docker-compose.test-search.yml running and its schema pushed:
  *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
  *     npx tsx scripts/seed-presidentielle-sujet-demo.ts

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -91,6 +91,7 @@ else
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
     src/lib/data/__tests__/subject-page.integration.test.ts \
+    src/lib/data/__tests__/themes-index.integration.test.ts \
     src/lib/search \
     src/lib/measures \
     src/app/admin/mesures \

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -87,6 +87,7 @@ else
   # the disposable container, so running it outside this harness proves half the guard.
   echo "[test:db:search] running the suites that need the disposable container"
   npx vitest run --no-file-parallelism \
+    src/lib/data/__tests__/latest-review-date.integration.test.ts \
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
     src/lib/data/__tests__/subject-page.integration.test.ts \

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -87,6 +87,7 @@ else
   # the disposable container, so running it outside this harness proves half the guard.
   echo "[test:db:search] running the suites that need the disposable container"
   npx vitest run --no-file-parallelism \
+    src/lib/data/__tests__/hub.integration.test.ts \
     src/lib/data/__tests__/latest-review-date.integration.test.ts \
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -24,8 +24,9 @@ export default async function AdminCandidatsPage() {
       <CandidatesListClient initialCandidates={candidates} />
 
       <p className="text-xs text-muted-foreground">
-        Note : cette page est admin-only. La surface publique <code>/presidentielle-2027</code>{" "}
-        arrivera en Q1.
+        Note : cette page est admin-only. La surface publique{" "}
+        <code>/elections/presidentielle-2027</code> existe, et elle reste hors des index tant que
+        ses seuils de publication ne sont pas franchis.
       </p>
     </div>
   );

--- a/src/app/elections/[slug]/__tests__/static-params.integration.test.ts
+++ b/src/app/elections/[slug]/__tests__/static-params.integration.test.ts
@@ -1,11 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { assertDisposableTestDb } from "@/test/disposable-db";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
 
 // Deferred: both `@/lib/db` and `../page` throw at module load without DATABASE_URL.
 let db: typeof import("@/lib/db").db;
 let generateStaticParams: typeof import("../page").generateStaticParams;
 
-describe("elections/[slug] generateStaticParams", () => {
+describeIfDisposableDb("elections/[slug] generateStaticParams", () => {
   beforeAll(async () => {
     assertDisposableTestDb();
     ({ db } = await import("@/lib/db"));

--- a/src/app/elections/presidentielle-2027/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/__tests__/page.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubMeasureContext } from "@/lib/data/hub";
+
+// Mocked so importing the page pulls no @/lib/db: the data authorities are exercised in their
+// own integration tests. Here we only check the metadata mapping.
+vi.mock("@/lib/data/hub", () => ({
+  getHubCandidacyField: vi.fn(),
+  getHubMeasureContext: vi.fn(),
+}));
+
+import { getHubMeasureContext } from "@/lib/data/hub";
+import { generateMetadata } from "../page";
+
+const mockGetContext = vi.mocked(getHubMeasureContext);
+
+function context(over: Partial<HubMeasureContext> = {}): HubMeasureContext {
+  return {
+    electionTitle: "Présidentielle 2027",
+    round1Date: new Date("2027-04-11"),
+    publishableSubjectPageCount: 0,
+    hubPublishable: false,
+    verifiedMeasureCount: 0,
+    lastReviewedAt: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockGetContext.mockReset();
+});
+
+describe("generateMetadata du hub présidentielle", () => {
+  it("titre correct", async () => {
+    mockGetContext.mockResolvedValue(context({ hubPublishable: true }));
+    const meta = await generateMetadata();
+    expect(String(meta.title)).toMatch(
+      /Présidentielle 2027 : programmes, votes, bilans \| Poligraph/
+    );
+  });
+
+  it("noindex quand le hub n'est pas encore publiable", async () => {
+    mockGetContext.mockResolvedValue(context({ hubPublishable: false }));
+    const meta = await generateMetadata();
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("indexable une fois le hub publiable", async () => {
+    mockGetContext.mockResolvedValue(context({ hubPublishable: true }));
+    const meta = await generateMetadata();
+    expect(meta.robots).toBeUndefined();
+  });
+
+  it("noindex quand l'élection n'existe pas", async () => {
+    mockGetContext.mockResolvedValue(null);
+    const meta = await generateMetadata();
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/elections/presidentielle-2027/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/__tests__/page.test.ts
@@ -17,6 +17,9 @@ function context(over: Partial<HubMeasureContext> = {}): HubMeasureContext {
   return {
     electionTitle: "Présidentielle 2027",
     round1Date: new Date("2027-04-11"),
+    round2Date: new Date("2027-04-25"),
+    dateConfirmed: true,
+    electionDescription: null,
     publishableSubjectPageCount: 0,
     hubPublishable: false,
     verifiedMeasureCount: 0,
@@ -54,5 +57,11 @@ describe("generateMetadata du hub présidentielle", () => {
     mockGetContext.mockResolvedValue(null);
     const meta = await generateMetadata();
     expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("canonical pointe vers l'URL du hub", async () => {
+    mockGetContext.mockResolvedValue(context({ hubPublishable: true }));
+    const meta = await generateMetadata();
+    expect(meta.alternates?.canonical).toBe("/elections/presidentielle-2027");
   });
 });

--- a/src/app/elections/presidentielle-2027/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/__tests__/page.test.ts
@@ -41,7 +41,7 @@ describe("generateMetadata du hub présidentielle", () => {
   it("noindex quand le hub n'est pas encore publiable", async () => {
     mockGetContext.mockResolvedValue(context({ hubPublishable: false }));
     const meta = await generateMetadata();
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 
   it("indexable une fois le hub publiable", async () => {
@@ -53,6 +53,6 @@ describe("generateMetadata du hub présidentielle", () => {
   it("noindex quand l'élection n'existe pas", async () => {
     mockGetContext.mockResolvedValue(null);
     const meta = await generateMetadata();
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 });

--- a/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
+++ b/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+/**
+ * What the hub is built from, and where to check the method. No claim of neutrality here
+ * (no "sans jugement", no "nous ne classons pas") : the provenance and the dates carry that
+ * weight on their own.
+ */
+export function DataProvenance() {
+  return (
+    <section aria-labelledby="provenance-heading" className="rounded-lg border border-border p-4">
+      <h2 id="provenance-heading" className="text-base font-semibold">
+        D&apos;où viennent les données
+      </h2>
+      <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+        <li>Programmes officiels publiés par les candidatures.</li>
+        <li>Scrutins publics à l&apos;Assemblée nationale et au Sénat.</li>
+        <li>Rapports publics et déclarations sourcées.</li>
+      </ul>
+      <p className="mt-3 text-sm">
+        <Link href="/methodologie" className="underline hover:text-primary">
+          Méthode et sources
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
+++ b/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 /**
  * What the hub is built from, and where to check the method. No claim of neutrality here
- * (no "sans jugement", no "nous ne classons pas") : the provenance and the dates carry that
- * weight on their own.
+ * (no "sans jugement", no "nous ne classons pas") : the provenance carries that weight on
+ * its own.
  */
 export function DataProvenance() {
   return (

--- a/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
@@ -1,0 +1,39 @@
+import { CandidacyCard, type CandidacyCardData } from "@/components/elections/CandidacyCard";
+import type { HubCandidacy } from "@/lib/data/hub";
+
+/**
+ * The whole field, not the published fiches: every sourced candidacy, pressenti/envisagé
+ * included. `constituencyName`/`isElected`/`round1Pct`/`round2Pct` have no meaning before a
+ * first round exists, so they map to their neutral values rather than to a guess.
+ */
+function toCandidacyCardData(candidacy: HubCandidacy): CandidacyCardData {
+  return {
+    id: candidacy.id,
+    candidateName: candidacy.candidateName,
+    partyLabel: candidacy.partyLabel,
+    constituencyName: null,
+    isElected: false,
+    round1Pct: null,
+    round2Pct: null,
+    status: candidacy.status,
+    sourceUrl: candidacy.sourceUrl,
+    sourceLabel: candidacy.sourceLabel,
+    politician: candidacy.politicianSlug !== null ? { slug: candidacy.politicianSlug } : null,
+    party: candidacy.partyColor !== null ? { color: candidacy.partyColor } : null,
+  };
+}
+
+export function HubCandidacyField({ candidacies }: { candidacies: HubCandidacy[] }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Candidatures classées par ordre alphabétique du nom.
+      </p>
+      <div className="space-y-2">
+        {candidacies.map((candidacy) => (
+          <CandidacyCard key={candidacy.id} candidacy={toCandidacyCardData(candidacy)} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
@@ -51,7 +51,7 @@ export function HubEntryCards() {
         </Card>
       </a>
 
-      <Card className="h-full opacity-70">
+      <Card className="h-full border-dashed">
         <CardContent className="flex items-start gap-3 p-4">
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
             <Radio className="h-5 w-5" aria-hidden="true" />

--- a/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { ChevronRight, ListChecks, Radio, UserSearch } from "lucide-react";
+
+/**
+ * Three entry points into the hub. The third, "Suivi et questions", is deliberately not a
+ * link: there is nothing behind it yet, and pointing it at /sujets would pass off the themes
+ * index as a substitute for a feature that doesn't exist (arbitrage #13). It stays a plain,
+ * non-interactive card labelled "à venir".
+ */
+export function HubEntryCards() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Link href="/elections/presidentielle-2027/sujets" prefetch={false}>
+        <Card className="group h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-md">
+          <CardContent className="flex items-start gap-3 p-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <ListChecks className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold leading-tight">Partir d&apos;un sujet</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                Le logement, la santé, l&apos;environnement et les mesures documentées par thème.
+              </div>
+            </div>
+            <ChevronRight
+              className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
+              aria-hidden="true"
+            />
+          </CardContent>
+        </Card>
+      </Link>
+
+      <a href="#candidatures">
+        <Card className="group h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-md">
+          <CardContent className="flex items-start gap-3 p-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <UserSearch className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold leading-tight">Chercher une personne</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                Les candidatures sourcées, avec leur statut et leur origine.
+              </div>
+            </div>
+            <ChevronRight
+              className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
+              aria-hidden="true"
+            />
+          </CardContent>
+        </Card>
+      </a>
+
+      <Card className="h-full opacity-70">
+        <CardContent className="flex items-start gap-3 p-4">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <Radio className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold leading-tight">Suivi et questions</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">À venir.</div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/HubStats.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubStats.tsx
@@ -1,0 +1,37 @@
+/**
+ * Launch-honest reporting (spec §4.3): a count of verified measures and the date they were last
+ * reviewed, never a percentage. There is no denominator that would make a "100 %" true at launch,
+ * so the component never computes one. At zero, it says so plainly instead of hiding the section.
+ */
+
+interface HubStatsProps {
+  verifiedMeasureCount: number;
+  lastReviewedAt: Date | null;
+}
+
+function formatDateFr(date: Date): string {
+  return date.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+export function HubStats({ verifiedMeasureCount, lastReviewedAt }: HubStatsProps) {
+  if (verifiedMeasureCount === 0 && lastReviewedAt === null) {
+    return (
+      <section className="rounded-lg border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+        Aucune mesure vérifiée pour l&apos;instant.
+      </section>
+    );
+  }
+
+  const countLabel = `${verifiedMeasureCount} mesure${verifiedMeasureCount === 1 ? "" : "s"} vérifiée${verifiedMeasureCount === 1 ? "" : "s"}`;
+
+  return (
+    <section className="rounded-lg border border-border p-4 text-sm">
+      <p className="font-medium">{countLabel}</p>
+      {lastReviewedAt !== null && (
+        <p className="mt-1 text-muted-foreground">
+          Dernière revue le {formatDateFr(lastReviewedAt)}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/HubStats.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubStats.tsx
@@ -1,3 +1,5 @@
+import { formatDate } from "@/lib/utils";
+
 /**
  * Launch-honest reporting (spec §4.3): a count of verified measures and the date they were last
  * reviewed, never a percentage. There is no denominator that would make a "100 %" true at launch,
@@ -9,14 +11,13 @@ interface HubStatsProps {
   lastReviewedAt: Date | null;
 }
 
-function formatDateFr(date: Date): string {
-  return date.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
-}
-
 export function HubStats({ verifiedMeasureCount, lastReviewedAt }: HubStatsProps) {
   if (verifiedMeasureCount === 0 && lastReviewedAt === null) {
     return (
-      <section className="rounded-lg border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+      <section
+        aria-label="Mesures vérifiées"
+        className="rounded-lg border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
+      >
         Aucune mesure vérifiée pour l&apos;instant.
       </section>
     );
@@ -25,12 +26,10 @@ export function HubStats({ verifiedMeasureCount, lastReviewedAt }: HubStatsProps
   const countLabel = `${verifiedMeasureCount} mesure${verifiedMeasureCount === 1 ? "" : "s"} vérifiée${verifiedMeasureCount === 1 ? "" : "s"}`;
 
   return (
-    <section className="rounded-lg border border-border p-4 text-sm">
+    <section aria-label="Mesures vérifiées" className="rounded-lg border border-border p-4 text-sm">
       <p className="font-medium">{countLabel}</p>
       {lastReviewedAt !== null && (
-        <p className="mt-1 text-muted-foreground">
-          Dernière revue le {formatDateFr(lastReviewedAt)}
-        </p>
+        <p className="mt-1 text-muted-foreground">Dernière revue le {formatDate(lastReviewedAt)}</p>
       )}
     </section>
   );

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { HubCandidacy } from "@/lib/data/hub";
+import { HubCandidacyField } from "../HubCandidacyField";
+
+function candidacy(over: Partial<HubCandidacy> = {}): HubCandidacy {
+  return {
+    id: "c1",
+    candidateName: "Alix Dupont",
+    politicianSlug: null,
+    status: "PRESSENTI",
+    sourceUrl: "https://example.org/source",
+    sourceLabel: "Le Monde",
+    partyLabel: "Parti Test",
+    partyColor: "#ff0000",
+    ...over,
+  };
+}
+
+describe("HubCandidacyField", () => {
+  it("rend une carte par candidature avec son statut honnête et le lien vers la fiche", () => {
+    const candidacies: HubCandidacy[] = [
+      candidacy({
+        id: "c1",
+        candidateName: "Alix Dupont",
+        status: "PRESSENTI",
+        politicianSlug: "alix-dupont",
+      }),
+      candidacy({
+        id: "c2",
+        candidateName: "Bruno Martin",
+        status: "ENVISAGE",
+        politicianSlug: null,
+      }),
+    ];
+
+    render(<HubCandidacyField candidacies={candidacies} />);
+
+    expect(screen.getByText("Alix Dupont")).toBeInTheDocument();
+    expect(screen.getByText("Bruno Martin")).toBeInTheDocument();
+    expect(screen.getByText("Candidature pressentie")).toBeInTheDocument();
+    expect(screen.getByText("Candidature évoquée")).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "Alix Dupont" });
+    expect(link).toHaveAttribute("href", "/politiques/alix-dupont");
+  });
+
+  it("annonce l'ordre alphabétique du champ", () => {
+    render(<HubCandidacyField candidacies={[candidacy()]} />);
+    expect(screen.getByText(/ordre alphabétique/)).toBeInTheDocument();
+  });
+});

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubStats.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubStats.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HubStats } from "../HubStats";
+
+describe("HubStats", () => {
+  it("montre le compte de mesures vérifiées et la date de dernière revue, jamais un 100 %", () => {
+    render(<HubStats verifiedMeasureCount={12} lastReviewedAt={new Date("2026-08-02")} />);
+    expect(screen.getByText(/12 mesures vérifiées/)).toBeInTheDocument();
+    expect(screen.getByText(/Dernière revue/)).toBeInTheDocument();
+    expect(screen.queryByText(/100 %/)).not.toBeInTheDocument();
+  });
+
+  it("rend un état de lancement honnête quand rien n'est vérifié", () => {
+    render(<HubStats verifiedMeasureCount={0} lastReviewedAt={null} />);
+    expect(screen.getByText(/Aucune mesure vérifiée pour l'instant/)).toBeInTheDocument();
+    expect(screen.queryByText(/100 %/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { getHubCandidacyField, getHubMeasureContext } from "@/lib/data/hub";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { DataProvenance } from "./_components/DataProvenance";
+import { HubCandidacyField } from "./_components/HubCandidacyField";
+import { HubEntryCards } from "./_components/HubEntryCards";
+import { HubStats } from "./_components/HubStats";
+
+// ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
+export const revalidate = 86400;
+
+function formatDateFr(date: Date): string {
+  return date.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const context = await getHubMeasureContext(PRESIDENTIELLE_2027_SLUG);
+  // The hub stays out of search results until the themes index clears its own publication
+  // gate (spec §4): below the gate there is nothing to send readers to yet.
+  const publishable = context !== null && context.hubPublishable;
+
+  return {
+    title: "Présidentielle 2027 : programmes, votes, bilans | Poligraph",
+    description:
+      "Les candidatures à la présidentielle 2027, leurs mesures documentées par sujet et les votes qui les éclairent.",
+    robots: publishable ? undefined : { index: false, follow: false },
+  };
+}
+
+export default async function PresidentialHubPage() {
+  const [field, context] = await Promise.all([
+    getHubCandidacyField(PRESIDENTIELLE_2027_SLUG),
+    getHubMeasureContext(PRESIDENTIELLE_2027_SLUG),
+  ]);
+  if (context === null) notFound();
+
+  const now = new Date();
+  const daysUntil = context.round1Date
+    ? Math.ceil((context.round1Date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+    : null;
+
+  return (
+    <div className="container mx-auto px-4 pt-4 pb-8 space-y-8">
+      <Breadcrumb items={[{ label: "Présidentielle" }]} />
+
+      <header className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          {context.electionTitle}
+          {daysUntil !== null && daysUntil > 0 && (
+            <>
+              {" · "}
+              <span className="font-semibold text-primary">J-{daysUntil}</span>
+            </>
+          )}
+          {context.round1Date && <> · 1er tour le {formatDateFr(context.round1Date)}</>}
+        </p>
+        <h1 className="text-3xl font-display font-extrabold tracking-tight">
+          Qu&apos;est-ce qui changerait pour vous ?
+        </h1>
+      </header>
+
+      <HubEntryCards />
+
+      <section id="candidatures" className="space-y-3">
+        <h2 className="text-xl font-display font-bold tracking-tight">Les candidatures</h2>
+        <HubCandidacyField candidacies={field} />
+      </section>
+
+      <DataProvenance />
+
+      <HubStats
+        verifiedMeasureCount={context.verifiedMeasureCount}
+        lastReviewedAt={context.lastReviewedAt}
+      />
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { Card, CardContent } from "@/components/ui/card";
+import { AddToCalendar } from "@/components/elections/AddToCalendar";
+import { EventJsonLd } from "@/components/seo/JsonLd";
 import { getHubCandidacyField, getHubMeasureContext } from "@/lib/data/hub";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
 import { formatDate } from "@/lib/utils";
+import { SITE_URL } from "@/config/site";
 import { DataProvenance } from "./_components/DataProvenance";
 import { HubCandidacyField } from "./_components/HubCandidacyField";
 import { HubEntryCards } from "./_components/HubEntryCards";
@@ -23,6 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
     description:
       "Les candidatures à la présidentielle 2027, leurs mesures documentées par sujet et les votes qui les éclairent.",
     robots: publishable ? undefined : { index: false, follow: true },
+    alternates: { canonical: "/elections/presidentielle-2027" },
   };
 }
 
@@ -39,38 +44,65 @@ export default async function PresidentialHubPage() {
     : null;
 
   return (
-    <div className="container mx-auto px-4 pt-4 pb-8 space-y-8">
-      <Breadcrumb items={[{ label: "Présidentielle" }]} />
+    <>
+      {context.round1Date && (
+        <EventJsonLd
+          name={context.electionTitle}
+          description={context.electionDescription || undefined}
+          startDate={context.round1Date.toISOString()}
+          location="France"
+          url={`${SITE_URL}/elections/${PRESIDENTIELLE_2027_SLUG}`}
+        />
+      )}
+      <div className="container mx-auto px-4 pt-4 pb-8 space-y-8">
+        <Breadcrumb items={[{ label: "Présidentielle" }]} />
 
-      <header className="space-y-2">
-        <p className="text-sm text-muted-foreground">
-          {context.electionTitle}
-          {daysUntil !== null && daysUntil > 0 && (
-            <>
-              {" · "}
-              <span className="font-semibold text-primary">J-{daysUntil}</span>
-            </>
-          )}
-          {context.round1Date && <> · 1er tour le {formatDate(context.round1Date)}</>}
-        </p>
-        <h1 className="text-3xl font-display font-extrabold tracking-tight">
-          Qu&apos;est-ce qui changerait pour vous ?
-        </h1>
-      </header>
+        <header className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {context.electionTitle}
+            {daysUntil !== null && daysUntil > 0 && (
+              <>
+                {" · "}
+                <span className="font-semibold text-primary">J-{daysUntil}</span>
+              </>
+            )}
+            {context.round1Date && <> · 1er tour le {formatDate(context.round1Date)}</>}
+            {context.round2Date && <> · 2d tour le {formatDate(context.round2Date)}</>}
+          </p>
+          <h1 className="text-3xl font-display font-extrabold tracking-tight">
+            Qu&apos;est-ce qui changerait pour vous ?
+          </h1>
+        </header>
 
-      <HubEntryCards />
+        {context.round1Date && (
+          <Card>
+            <CardContent className="pt-6">
+              <h2 className="text-lg font-semibold mb-3">Ajouter au calendrier</h2>
+              <AddToCalendar
+                title={context.electionTitle}
+                round1Date={context.round1Date}
+                round2Date={context.round2Date}
+                slug={PRESIDENTIELLE_2027_SLUG}
+                dateConfirmed={context.dateConfirmed}
+              />
+            </CardContent>
+          </Card>
+        )}
 
-      <section id="candidatures" className="space-y-3">
-        <h2 className="text-xl font-display font-bold tracking-tight">Les candidatures</h2>
-        <HubCandidacyField candidacies={field} />
-      </section>
+        <HubEntryCards />
 
-      <DataProvenance />
+        <section id="candidatures" className="space-y-3">
+          <h2 className="text-xl font-display font-bold tracking-tight">Les candidatures</h2>
+          <HubCandidacyField candidacies={field} />
+        </section>
 
-      <HubStats
-        verifiedMeasureCount={context.verifiedMeasureCount}
-        lastReviewedAt={context.lastReviewedAt}
-      />
-    </div>
+        <DataProvenance />
+
+        <HubStats
+          verifiedMeasureCount={context.verifiedMeasureCount}
+          lastReviewedAt={context.lastReviewedAt}
+        />
+      </div>
+    </>
   );
 }

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { getHubCandidacyField, getHubMeasureContext } from "@/lib/data/hub";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { formatDate } from "@/lib/utils";
 import { DataProvenance } from "./_components/DataProvenance";
 import { HubCandidacyField } from "./_components/HubCandidacyField";
 import { HubEntryCards } from "./_components/HubEntryCards";
@@ -10,10 +11,6 @@ import { HubStats } from "./_components/HubStats";
 
 // ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
 export const revalidate = 86400;
-
-function formatDateFr(date: Date): string {
-  return date.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
-}
 
 export async function generateMetadata(): Promise<Metadata> {
   const context = await getHubMeasureContext(PRESIDENTIELLE_2027_SLUG);
@@ -25,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: "Présidentielle 2027 : programmes, votes, bilans | Poligraph",
     description:
       "Les candidatures à la présidentielle 2027, leurs mesures documentées par sujet et les votes qui les éclairent.",
-    robots: publishable ? undefined : { index: false, follow: false },
+    robots: publishable ? undefined : { index: false, follow: true },
   };
 }
 
@@ -54,7 +51,7 @@ export default async function PresidentialHubPage() {
               <span className="font-semibold text-primary">J-{daysUntil}</span>
             </>
           )}
-          {context.round1Date && <> · 1er tour le {formatDateFr(context.round1Date)}</>}
+          {context.round1Date && <> · 1er tour le {formatDate(context.round1Date)}</>}
         </p>
         <h1 className="text-3xl font-display font-extrabold tracking-tight">
           Qu&apos;est-ce qui changerait pour vous ?

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/__tests__/page.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
 describe("generateMetadata de la page sujet", () => {
   it("noindex et titre explicite pour un thème inconnu, sans lire les données", async () => {
     const meta = await generateMetadata(props("pas-un-theme"));
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
     expect(String(meta.title)).toMatch(/introuvable/i);
     expect(mockGet).not.toHaveBeenCalled();
   });
@@ -35,12 +35,12 @@ describe("generateMetadata de la page sujet", () => {
   it("noindex tant que le seuil n'est pas franchi", async () => {
     mockGet.mockResolvedValue({ publishable: false } as never);
     const meta = await generateMetadata(props("logement-urbanisme"));
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 
   it("noindex quand l'élection n'existe pas", async () => {
     mockGet.mockResolvedValue(null);
     const meta = await generateMetadata(props("sante"));
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 });

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -11,6 +11,7 @@ import type { ThemeCategory } from "@/generated/prisma";
 import type { PublicMeasure } from "@/lib/data/measures";
 import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
+import { formatDate } from "@/lib/utils";
 import { SubjectGate } from "./SubjectGate";
 
 /**
@@ -20,10 +21,6 @@ import { SubjectGate } from "./SubjectGate";
  * on the theme gets a qualified absence. Below the publication gate the page renders an explicit closed
  * state.
  */
-
-function formatDateFr(date: Date): string {
-  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
-}
 
 function composeVoteBasis(reference: PublicVoteReference): string {
   const parts: string[] = [];
@@ -36,7 +33,7 @@ function composeVoteBasis(reference: PublicVoteReference): string {
   if (reference.legislatureScope.length > 0) {
     parts.push(`législature ${reference.legislatureScope.join(", ")}`);
   }
-  parts.push(`vérifié le ${formatDateFr(reference.checkedAt)}`);
+  parts.push(`vérifié le ${formatDate(reference.checkedAt)}`);
   return parts.join(" · ");
 }
 
@@ -60,7 +57,7 @@ function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
           {" · "}
           {SOURCE_TIER_LABELS[source.tier]}
           {" · "}
-          {formatDateFr(source.publishedAt)}
+          {formatDate(source.publishedAt)}
         </li>
       ))}
     </ul>
@@ -98,7 +95,7 @@ function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme
               <MeasureSources sources={measure.sources} />
               {measure.withdrawal !== null && (
                 <p className="text-xs text-muted-foreground">
-                  Mesure retirée le {formatDateFr(measure.withdrawal.withdrawnAt)}
+                  Mesure retirée le {formatDate(measure.withdrawal.withdrawnAt)}
                   {measure.withdrawal.sourceUrl !== null &&
                     measure.withdrawal.sourceLabel !== null && (
                       <>

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -11,6 +11,7 @@ import type { ThemeCategory } from "@/generated/prisma";
 import type { PublicMeasure } from "@/lib/data/measures";
 import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
+import { SubjectGate } from "./SubjectGate";
 
 /**
  * A public subject page: for one theme, the candidates and their measures, side by side.
@@ -139,19 +140,7 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
       </header>
 
       {!data.publishable ? (
-        <section
-          aria-labelledby="gate-heading"
-          className="rounded-lg border border-border bg-muted/40 p-4"
-        >
-          <h2 id="gate-heading" className="text-base font-semibold">
-            Comparaison pas encore disponible sur ce sujet
-          </h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Une comparaison n&apos;est publiée que lorsqu&apos;au moins deux candidatures portent
-            une mesure vérifiée sur ce sujet. Ce seuil n&apos;est pas encore atteint, la page reste
-            hors des index tant qu&apos;il ne l&apos;est pas.
-          </p>
-        </section>
+        <SubjectGate data={data} />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {data.candidates.map((entry) => (

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -15,10 +15,9 @@ import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-
 /**
  * A public subject page: for one theme, the candidates and their measures, side by side.
  *
- * No ranking and no proximity score: candidates come in the alphabetical order the authority returns, and
- * the page says so. A candidate with no published measure on the theme is not silent, it gets a qualified
- * absence. Below the publication gate the page renders an explicit state, never a one-candidate comparison
- * dressed up as a comparison.
+ * Candidates come in the alphabetical order the authority returns. A candidate with no published measure
+ * on the theme gets a qualified absence. Below the publication gate the page renders an explicit closed
+ * state.
  */
 
 function formatDateFr(date: Date): string {
@@ -135,7 +134,7 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
         <p className="text-sm text-muted-foreground">Présidentielle 2027</p>
         <h1 className="font-display text-2xl font-bold tracking-tight">{themeLabel}</h1>
         <p className="text-sm text-muted-foreground">
-          Candidats par ordre alphabétique, sans classement ni score de proximité.
+          Les candidatures sont présentées par ordre alphabétique.
         </p>
       </header>
 

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { SubjectPageData } from "@/lib/data/subject-page";
+import { formatDate } from "@/lib/utils";
 
 /**
  * The closed state of a subject page (spec §4.1): what is missing to compare, laid out as
@@ -7,13 +8,16 @@ import type { SubjectPageData } from "@/lib/data/subject-page";
  * counters are out of scope here and render "—" with an explicit note, never a misleading zero.
  */
 
-function formatDateFr(date: Date): string {
-  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
-}
-
+/**
+ * `covered` (candidacies with a verified measure, published-extension only) is not a subset of
+ * `total` (sourced candidacies of the election, extension not required): nothing forces the
+ * source fields to publish an extension. So the ratio can exceed 100 %, which this clamps, and
+ * at a zero denominator this renders "—" like the ProgramEdition counters beside it, never a
+ * misleading "0 %".
+ */
 function formatCoverageRate(covered: number, total: number): string {
-  const rate = total > 0 ? Math.round((covered / total) * 100) : 0;
-  return `${rate} %`;
+  if (total === 0) return "—";
+  return `${Math.min(100, Math.round((covered / total) * 100))} %`;
 }
 
 export function SubjectGate({ data }: { data: SubjectPageData }) {
@@ -56,7 +60,7 @@ export function SubjectGate({ data }: { data: SubjectPageData }) {
           <div>
             <dt>Dernière revue publique</dt>
             <dd className="font-medium text-foreground">
-              {data.lastReviewedAt !== null ? formatDateFr(data.lastReviewedAt) : "jamais relu"}
+              {data.lastReviewedAt !== null ? formatDate(data.lastReviewedAt) : "jamais relu"}
             </dd>
           </div>
           <div>

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import type { SubjectPageData } from "@/lib/data/subject-page";
+
+/**
+ * The closed state of a subject page (spec §4.1): what is missing to compare, laid out as
+ * distinct counters rather than a single placeholder sentence. The two `ProgramEdition`-backed
+ * counters are out of scope here and render "—" with an explicit note, never a misleading zero.
+ */
+
+function formatDateFr(date: Date): string {
+  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
+}
+
+function formatCoverageRate(covered: number, total: number): string {
+  const rate = total > 0 ? Math.round((covered / total) * 100) : 0;
+  return `${rate} %`;
+}
+
+export function SubjectGate({ data }: { data: SubjectPageData }) {
+  const measureWord =
+    data.pendingReviewMeasureCount === 1 ? "mesure extraite" : "mesures extraites";
+
+  return (
+    <section
+      aria-labelledby="gate-heading"
+      className="rounded-lg border border-border bg-muted/40 p-4"
+    >
+      <h2 id="gate-heading" className="text-base font-semibold">
+        Comparaison pas encore disponible sur ce sujet
+      </h2>
+      <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Ce qui manque pour comparer</p>
+        <dl className="grid gap-2 sm:grid-cols-2">
+          <div>
+            <dt>Candidatures avec mesure vérifiée</dt>
+            <dd className="font-medium text-foreground">
+              {data.candidaciesWithVerifiedMeasure} sur{" "}
+              {data.requiredCandidaciesWithVerifiedMeasure} requises
+            </dd>
+          </div>
+          <div>
+            <dt>Taux de couverture</dt>
+            <dd className="font-medium text-foreground">
+              {formatCoverageRate(
+                data.candidaciesWithVerifiedMeasure,
+                data.totalSourcedCandidacies
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt>Relecture en attente</dt>
+            <dd className="font-medium text-foreground">
+              {data.pendingReviewMeasureCount} {measureWord} en attente de relecture
+            </dd>
+          </div>
+          <div>
+            <dt>Dernière revue publique</dt>
+            <dd className="font-medium text-foreground">
+              {data.lastReviewedAt !== null ? formatDateFr(data.lastReviewedAt) : "jamais relu"}
+            </dd>
+          </div>
+          <div>
+            <dt>Éditions de programme ne couvrant pas ce sujet</dt>
+            <dd className="font-medium text-foreground">—</dd>
+          </div>
+          <div>
+            <dt>Candidatures sans programme publié</dt>
+            <dd className="font-medium text-foreground">—</dd>
+          </div>
+        </dl>
+        <p className="text-xs">
+          Donnée programme à venir : ces deux derniers compteurs dépendent des éditions de
+          programme, pas encore disponibles.
+        </p>
+      </div>
+      {data.fallbackPublishableTheme !== null && (
+        <p className="mt-4 text-sm">
+          Un sujet est comparable aujourd&apos;hui :{" "}
+          <Link
+            href={`/elections/presidentielle-2027/sujets/${data.fallbackPublishableTheme.slug}`}
+            className="underline"
+          >
+            {data.fallbackPublishableTheme.label}
+          </Link>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -83,9 +83,9 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
 }
 
 describe("SubjectComparison", () => {
-  it("annonce l'ordre alphabétique et l'absence de classement", () => {
+  it("annonce l'ordre alphabétique d'affichage", () => {
     render(<SubjectComparison data={data()} />);
-    expect(screen.getByText(/ordre alphabétique, sans classement/i)).toBeInTheDocument();
+    expect(screen.getByText(/présentées par ordre alphabétique/i)).toBeInTheDocument();
   });
 
   it("rend une absence qualifiée, jamais une cellule vide, pour un candidat sans mesure", () => {

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -78,6 +78,11 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
     candidates: [],
     candidaciesWithVerifiedMeasure: 2,
     publishable: true,
+    requiredCandidaciesWithVerifiedMeasure: 2,
+    totalSourcedCandidacies: 3,
+    pendingReviewMeasureCount: 0,
+    lastReviewedAt: null,
+    fallbackPublishableTheme: null,
     ...over,
   };
 }

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SubjectPageData } from "@/lib/data/subject-page";
+import { SubjectGate } from "../SubjectGate";
+
+function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
+  return {
+    theme: "LOGEMENT_URBANISME",
+    electionSlug: "presidentielle-2027",
+    candidates: [],
+    candidaciesWithVerifiedMeasure: 1,
+    publishable: false,
+    requiredCandidaciesWithVerifiedMeasure: 2,
+    totalSourcedCandidacies: 4,
+    pendingReviewMeasureCount: 3,
+    lastReviewedAt: new Date("2027-02-10T00:00:00Z"),
+    fallbackPublishableTheme: null,
+    ...over,
+  };
+}
+
+describe("SubjectGate", () => {
+  it("nomme l'état et affiche le compte de candidatures avec mesure vérifiée sur le seuil requis", () => {
+    render(<SubjectGate data={data()} />);
+    expect(screen.getByText(/Comparaison pas encore disponible/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 sur 2 requises/)).toBeInTheDocument();
+  });
+
+  it("calcule le taux de couverture à partir des candidatures sourcées", () => {
+    render(
+      <SubjectGate data={data({ candidaciesWithVerifiedMeasure: 1, totalSourcedCandidacies: 4 })} />
+    );
+    expect(screen.getByText("25 %")).toBeInTheDocument();
+  });
+
+  it("garde le taux à 0 % sans division par zéro quand aucune candidature n'est sourcée", () => {
+    render(
+      <SubjectGate data={data({ candidaciesWithVerifiedMeasure: 0, totalSourcedCandidacies: 0 })} />
+    );
+    expect(screen.getByText("0 %")).toBeInTheDocument();
+  });
+
+  it("affiche le nombre de mesures extraites en attente de relecture", () => {
+    render(<SubjectGate data={data({ pendingReviewMeasureCount: 3 })} />);
+    expect(screen.getByText(/3 mesures extraites en attente de relecture/)).toBeInTheDocument();
+  });
+
+  it("accorde au singulier quand une seule mesure est en attente", () => {
+    render(<SubjectGate data={data({ pendingReviewMeasureCount: 1 })} />);
+    expect(screen.getByText(/1 mesure extraite en attente de relecture/)).toBeInTheDocument();
+  });
+
+  it("affiche la date de dernière revue publique, au format français", () => {
+    render(<SubjectGate data={data({ lastReviewedAt: new Date("2027-02-10T00:00:00Z") })} />);
+    expect(screen.getByText(/10 février 2027/)).toBeInTheDocument();
+  });
+
+  it("affiche « jamais relu » quand aucune revue publique n'a eu lieu", () => {
+    render(<SubjectGate data={data({ lastReviewedAt: null })} />);
+    expect(screen.getByText(/jamais relu/i)).toBeInTheDocument();
+  });
+
+  it("rend les deux compteurs ProgramEdition en tiret, jamais en zéro trompeur", () => {
+    render(<SubjectGate data={data()} />);
+    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getByText(/donnée programme à venir/i)).toBeInTheDocument();
+  });
+
+  it("propose un renvoi vers un sujet comparable quand fallbackPublishableTheme est fourni", () => {
+    render(
+      <SubjectGate data={data({ fallbackPublishableTheme: { slug: "sante", label: "Santé" } })} />
+    );
+    const link = screen.getByRole("link", { name: "Santé" });
+    expect(link).toHaveAttribute("href", "/elections/presidentielle-2027/sujets/sante");
+  });
+
+  it("n'affiche aucun lien de renvoi quand fallbackPublishableTheme est nul", () => {
+    render(<SubjectGate data={data({ fallbackPublishableTheme: null })} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
@@ -33,11 +33,20 @@ describe("SubjectGate", () => {
     expect(screen.getByText("25 %")).toBeInTheDocument();
   });
 
-  it("garde le taux à 0 % sans division par zéro quand aucune candidature n'est sourcée", () => {
+  it("rend un tiret, jamais un faux 0 %, quand aucune candidature n'est sourcée", () => {
     render(
       <SubjectGate data={data({ candidaciesWithVerifiedMeasure: 0, totalSourcedCandidacies: 0 })} />
     );
-    expect(screen.getByText("0 %")).toBeInTheDocument();
+    expect(screen.queryByText("0 %")).not.toBeInTheDocument();
+    // Three dashes now: the coverage rate joins the two ProgramEdition placeholders.
+    expect(screen.getAllByText("—")).toHaveLength(3);
+  });
+
+  it("borne le taux à 100 % quand le numérateur dépasse le dénominateur", () => {
+    render(
+      <SubjectGate data={data({ candidaciesWithVerifiedMeasure: 5, totalSourcedCandidacies: 3 })} />
+    );
+    expect(screen.getByText("100 %")).toBeInTheDocument();
   });
 
   it("affiche le nombre de mesures extraites en attente de relecture", () => {

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/page.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (theme === null) {
     return {
       title: "Sujet introuvable | Présidentielle 2027",
-      robots: { index: false, follow: false },
+      robots: { index: false, follow: true },
     };
   }
 
@@ -31,7 +31,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${label} : les mesures des candidats | Présidentielle 2027`,
     description: `Ce que les candidats à la présidentielle 2027 proposent sur le thème ${label}.`,
-    robots: publishable ? undefined : { index: false, follow: false },
+    robots: publishable ? undefined : { index: false, follow: true },
   };
 }
 
@@ -43,5 +43,9 @@ export default async function SubjectPage({ params }: PageProps) {
   const data = await getSubjectPageData(PRESIDENTIELLE_2027_SLUG, theme);
   if (data === null) notFound();
 
-  return <SubjectComparison data={data} />;
+  return (
+    <div className="container mx-auto px-4 pt-4 pb-8">
+      <SubjectComparison data={data} />
+    </div>
+  );
 }

--- a/src/app/elections/presidentielle-2027/sujets/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/sujets/__tests__/page.test.ts
@@ -31,7 +31,7 @@ describe("generateMetadata de l'index des sujets", () => {
       publishableSubjectPageCount: 0,
     });
     const meta = await generateMetadata();
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 
   it("indexable une fois au moins une page sujet publiable", async () => {
@@ -47,6 +47,6 @@ describe("generateMetadata de l'index des sujets", () => {
   it("noindex quand l'élection n'existe pas", async () => {
     mockGet.mockResolvedValue(null);
     const meta = await generateMetadata();
-    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.robots).toEqual({ index: false, follow: true });
   });
 });

--- a/src/app/elections/presidentielle-2027/sujets/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/sujets/__tests__/page.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocked so importing the page pulls no @/lib/db: the data authority is exercised in its own
+// integration test. Here we only check the metadata mapping.
+vi.mock("@/lib/data/themes-index", () => ({ getThemesIndex: vi.fn() }));
+
+import { getThemesIndex } from "@/lib/data/themes-index";
+import { generateMetadata } from "../page";
+
+const mockGet = vi.mocked(getThemesIndex);
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("generateMetadata de l'index des sujets", () => {
+  it("titre correct", async () => {
+    mockGet.mockResolvedValue({
+      electionSlug: "presidentielle-2027",
+      themes: [],
+      publishableSubjectPageCount: 1,
+    });
+    const meta = await generateMetadata();
+    expect(String(meta.title)).toMatch(/Les 13 sujets de la présidentielle 2027 \| Poligraph/);
+  });
+
+  it("noindex quand aucune page sujet n'est publiable", async () => {
+    mockGet.mockResolvedValue({
+      electionSlug: "presidentielle-2027",
+      themes: [],
+      publishableSubjectPageCount: 0,
+    });
+    const meta = await generateMetadata();
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("indexable une fois au moins une page sujet publiable", async () => {
+    mockGet.mockResolvedValue({
+      electionSlug: "presidentielle-2027",
+      themes: [],
+      publishableSubjectPageCount: 1,
+    });
+    const meta = await generateMetadata();
+    expect(meta.robots).toBeUndefined();
+  });
+
+  it("noindex quand l'élection n'existe pas", async () => {
+    mockGet.mockResolvedValue(null);
+    const meta = await generateMetadata();
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/elections/presidentielle-2027/sujets/_components/ThemesIndexList.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/_components/ThemesIndexList.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import type { ThemesIndexData } from "@/lib/data/themes-index";
+import { THEME_CATEGORY_COLORS } from "@/config/labels";
+
+interface ThemesIndexListProps {
+  data: ThemesIndexData;
+}
+
+export function ThemesIndexList({ data }: ThemesIndexListProps) {
+  return (
+    <ul className="divide-y divide-border rounded-lg border border-border">
+      {data.themes.map((entry) => {
+        const n = entry.documentedMeasureCount;
+        const countLabel =
+          n === 0
+            ? "Aucune mesure documentée"
+            : `${n} mesure${n > 1 ? "s" : ""} documentée${n > 1 ? "s" : ""}`;
+
+        return (
+          <li key={entry.theme}>
+            <Link
+              href={`/elections/presidentielle-2027/sujets/${entry.slug}`}
+              className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors"
+            >
+              <span
+                className={`h-2.5 w-2.5 rounded-full border shrink-0 ${THEME_CATEGORY_COLORS[entry.theme]}`}
+                aria-hidden="true"
+              />
+              <span className="font-medium">{entry.label}</span>
+              <span className="ml-auto text-sm text-muted-foreground">{countLabel}</span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/app/elections/presidentielle-2027/sujets/_components/__tests__/ThemesIndexList.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/_components/__tests__/ThemesIndexList.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ThemesIndexData } from "@/lib/data/themes-index";
+import { ThemesIndexList } from "../ThemesIndexList";
+
+function data(over: Partial<ThemesIndexData> = {}): ThemesIndexData {
+  return {
+    electionSlug: "presidentielle-2027",
+    publishableSubjectPageCount: 1,
+    themes: [
+      {
+        theme: "LOGEMENT_URBANISME",
+        label: "Logement & Urbanisme",
+        slug: "logement-urbanisme",
+        documentedMeasureCount: 3,
+        currentlyDefendedMeasureCount: 3,
+        candidaciesWithVerifiedMeasure: 2,
+        publishable: true,
+      },
+      {
+        theme: "NUMERIQUE_TECH",
+        label: "Numérique & Tech",
+        slug: "numerique-tech",
+        documentedMeasureCount: 0,
+        currentlyDefendedMeasureCount: 0,
+        candidaciesWithVerifiedMeasure: 0,
+        publishable: false,
+      },
+    ],
+    ...over,
+  };
+}
+
+describe("ThemesIndexList", () => {
+  it("lie chaque thème à sa page sujet avec son compte de mesures documentées", () => {
+    render(<ThemesIndexList data={data()} />);
+
+    const logement = screen.getByRole("link", { name: /Logement & Urbanisme/ });
+    expect(logement).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/sujets/logement-urbanisme"
+    );
+    expect(logement).toHaveTextContent("3 mesures documentées");
+  });
+
+  it("garde un thème à zéro mesure dans la liste, pour la navigation", () => {
+    render(<ThemesIndexList data={data()} />);
+
+    const numerique = screen.getByRole("link", { name: /Numérique & Tech/ });
+    expect(numerique).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/sujets/numerique-tech"
+    );
+    expect(numerique).toHaveTextContent("Aucune mesure documentée");
+  });
+});

--- a/src/app/elections/presidentielle-2027/sujets/page.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { getThemesIndex } from "@/lib/data/themes-index";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { ThemesIndexList } from "./_components/ThemesIndexList";
+
+// ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
+export const revalidate = 86400;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await getThemesIndex(PRESIDENTIELLE_2027_SLUG);
+  // The index stays out of search results until at least one subject page clears its
+  // publication gate: below that, there is nothing to send readers to yet.
+  const publishable = data !== null && data.publishableSubjectPageCount > 0;
+
+  return {
+    title: "Les 13 sujets de la présidentielle 2027 | Poligraph",
+    description:
+      "Le logement, la santé, l'environnement et les autres sujets de la présidentielle 2027, avec les mesures documentées de chaque candidature.",
+    robots: publishable ? undefined : { index: false, follow: false },
+  };
+}
+
+export default async function ThemesIndexPage() {
+  const data = await getThemesIndex(PRESIDENTIELLE_2027_SLUG);
+  if (data === null) notFound();
+
+  return (
+    <div className="container mx-auto px-4 pt-4 pb-8">
+      <Breadcrumb
+        items={[
+          { label: "Présidentielle", href: "/elections/presidentielle-2027" },
+          { label: "Sujets" },
+        ]}
+      />
+
+      <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">
+        Quel sujet vous concerne ?
+      </h1>
+      <p className="text-muted-foreground mb-6">
+        Le chiffre affiché sous chaque sujet correspond au nombre de mesures documentées pour ce
+        thème, à date.
+      </p>
+
+      <ThemesIndexList data={data} />
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/sujets/page.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { getThemesIndex } from "@/lib/data/themes-index";
+import { isHubPublishable } from "@/config/publication-gates";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
 import { ThemesIndexList } from "./_components/ThemesIndexList";
 
@@ -12,13 +13,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const data = await getThemesIndex(PRESIDENTIELLE_2027_SLUG);
   // The index stays out of search results until at least one subject page clears its
   // publication gate: below that, there is nothing to send readers to yet.
-  const publishable = data !== null && data.publishableSubjectPageCount > 0;
+  const publishable = data !== null && isHubPublishable(data.publishableSubjectPageCount);
 
   return {
     title: "Les 13 sujets de la présidentielle 2027 | Poligraph",
     description:
       "Le logement, la santé, l'environnement et les autres sujets de la présidentielle 2027, avec les mesures documentées de chaque candidature.",
-    robots: publishable ? undefined : { index: false, follow: false },
+    robots: publishable ? undefined : { index: false, follow: true },
   };
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,9 @@ import { DEPARTMENTS, getDepartmentSlug } from "@/config/departments";
 import { getAllThemeSlugs } from "@/lib/theme-utils";
 import { SITE_URL } from "@/config/site";
 import { getWeekStart, getISOWeekString } from "@/lib/data/recap";
+import { loadThemesIndex } from "@/lib/data/themes-index";
+import { isHubPublishable } from "@/config/publication-gates";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
 import {
   SIGNIFICANT_MANDATE_TYPES,
   MAIRE_MIN_COMMUNE_POPULATION,
@@ -361,10 +364,24 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
       select: { slug: true, updatedAt: true },
     }),
     db.election.findMany({
-      select: { slug: true, updatedAt: true },
+      select: { id: true, slug: true, updatedAt: true },
       orderBy: { round1Date: "desc" },
     }),
   ]);
+
+  // The presidentielle-2027 hub is noindex,follow until it clears its own publication gate
+  // (spec §4, PUBLICATION_GATES.hub): below the gate there is nothing indexable to send
+  // crawlers to, so announcing the URL here would spend crawl budget to reach a noindex.
+  // Calls the plain loader rather than the cached getThemesIndex (the same choice
+  // loadHubMeasureContext makes for the same authority), and imports isHubPublishable rather
+  // than re-deriving its threshold.
+  const presidentielle2027 = elections.find((e) => e.slug === PRESIDENTIELLE_2027_SLUG);
+  const presidentielleHubPublishable =
+    presidentielle2027 !== undefined &&
+    isHubPublishable(
+      (await loadThemesIndex(presidentielle2027.id, PRESIDENTIELLE_2027_SLUG))
+        .publishableSubjectPageCount
+    );
 
   const affairPages: MetadataRoute.Sitemap = affairs.map((a) => ({
     url: `${SITE_URL}/affaires/${a.slug}`,
@@ -391,12 +408,14 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
       priority: 0.7,
     }));
 
-  const electionPages: MetadataRoute.Sitemap = elections.map((e) => ({
-    url: `${SITE_URL}/elections/${e.slug}`,
-    lastModified: e.updatedAt,
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
-  }));
+  const electionPages: MetadataRoute.Sitemap = elections
+    .filter((e) => e.slug !== PRESIDENTIELLE_2027_SLUG || presidentielleHubPublishable)
+    .map((e) => ({
+      url: `${SITE_URL}/elections/${e.slug}`,
+      lastModified: e.updatedAt,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    }));
 
   const departmentPages: MetadataRoute.Sitemap = Object.values(DEPARTMENTS).map((dept) => ({
     url: `${SITE_URL}/departements/${getDepartmentSlug(dept.name)}`,

--- a/src/lib/data/__tests__/hub-fixture.ts
+++ b/src/lib/data/__tests__/hub-fixture.ts
@@ -1,0 +1,154 @@
+import type { ThemeCategory } from "@/generated/prisma";
+
+/**
+ * Seeds the fixture for the `hub` read authorities test.
+ *
+ * Two populations coexist on purpose:
+ * - Alpha and Bravo carry a PUBLISHED `CandidacyPresidential` extension plus a defended
+ *   LOGEMENT_URBANISME measure each, so the subject page reaches its two-candidacy gate and
+ *   `getHubMeasureContext` reports `hubPublishable: true`.
+ * - Charlie is PRESSENTI, has a complete source (`sourceUrl` + `sourceLabel`) and NO extension
+ *   at all. The hub field shows the whole race, not just published fiches, so Charlie must
+ *   still surface from `getHubCandidacyField`.
+ * - Delta has a source URL but no `sourceLabel`: an incomplete source, which must stay absent
+ *   from the field.
+ *
+ * Statuses are assigned so that alphabetical order (by `candidateName`) and status order (by
+ * `status`, alphabetically DECLARE < ENVISAGE < PRESSENTI < RETIRE) disagree: Alpha is
+ * PRESSENTI, Bravo is DECLARE, Charlie is ENVISAGE. Sorting by name gives Alpha, Bravo,
+ * Charlie; sorting by status gives Bravo, Charlie, Alpha. This is what makes the "sorted by
+ * status instead of name" ablation actually turn the ordering test red.
+ */
+
+const THEME_LOGEMENT: ThemeCategory = "LOGEMENT_URBANISME";
+
+export async function seedHubFixture(
+  db: typeof import("@/lib/db").db,
+  options: { electionSlug: string }
+): Promise<string> {
+  const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
+    await import("@/lib/measures/transitions");
+
+  const election = await db.election.create({
+    data: {
+      slug: options.electionSlug,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Élection de test — hub",
+    },
+  });
+
+  async function politician(name: string) {
+    return db.politician.create({
+      data: {
+        slug: `${options.electionSlug}-${name.toLowerCase()}`,
+        firstName: name,
+        lastName: "Fixture",
+        fullName: `${name} Fixture`,
+      },
+    });
+  }
+
+  async function candidacyWithPublishedExtension(
+    name: string,
+    status: "PRESSENTI" | "DECLARE"
+  ): Promise<{ candidacyId: string; politicianId: string }> {
+    const pol = await politician(name);
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: pol.id,
+        candidateName: `${name} Fixture`,
+        status,
+        sourceUrl: "https://example.org/source",
+        sourceLabel: "Source",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED" },
+    });
+    return { candidacyId: candidacy.id, politicianId: pol.id };
+  }
+
+  async function publishMeasure(
+    politicianId: string,
+    candidacyId: string,
+    theme: ThemeCategory,
+    text: string
+  ) {
+    const seeded = await createMeasure({
+      politicianId,
+      electionId: election.id,
+      candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    await reviewMeasureRevision({ ...seeded, reviewedBy: "fixture" });
+    await publishMeasureRevision(seeded);
+    return seeded;
+  }
+
+  const alpha = await candidacyWithPublishedExtension("Alpha", "PRESSENTI");
+  const bravo = await candidacyWithPublishedExtension("Bravo", "DECLARE");
+
+  await publishMeasure(
+    alpha.politicianId,
+    alpha.candidacyId,
+    THEME_LOGEMENT,
+    "Encadrer les loyers dans les zones tendues."
+  );
+  await publishMeasure(
+    bravo.politicianId,
+    bravo.candidacyId,
+    THEME_LOGEMENT,
+    "Construire 500 000 logements sociaux sur le quinquennat."
+  );
+
+  // Charlie: pressenti, source complète, SANS extension CandidacyPresidential. Doit apparaître
+  // au champ du hub (le champ ≠ les fiches publiées).
+  const charlie = await politician("Charlie");
+  await db.candidacy.create({
+    data: {
+      electionId: election.id,
+      politicianId: charlie.id,
+      candidateName: "Charlie Fixture",
+      status: "ENVISAGE",
+      sourceUrl: "https://example.org/rumeur",
+      sourceLabel: "Presse",
+    },
+  });
+
+  // Delta: source incomplète (pas de sourceLabel). Doit rester absente du champ.
+  const delta = await politician("Delta");
+  await db.candidacy.create({
+    data: {
+      electionId: election.id,
+      politicianId: delta.id,
+      candidateName: "Delta Fixture",
+      status: "ENVISAGE",
+      sourceUrl: "https://example.org/rumeur-delta",
+      sourceLabel: null,
+    },
+  });
+
+  return election.id;
+}

--- a/src/lib/data/__tests__/hub-fixture.ts
+++ b/src/lib/data/__tests__/hub-fixture.ts
@@ -1,15 +1,18 @@
 import type { ThemeCategory } from "@/generated/prisma";
+import { assertDisposableTestDb } from "@/test/disposable-db";
 
 /**
  * Seeds the fixture for the `hub` read authorities test.
  *
- * Two populations coexist on purpose:
+ * Three populations coexist on purpose:
  * - Alpha and Bravo carry a PUBLISHED `CandidacyPresidential` extension plus a defended
  *   LOGEMENT_URBANISME measure each, so the subject page reaches its two-candidacy gate and
  *   `getHubMeasureContext` reports `hubPublishable: true`.
- * - Charlie is PRESSENTI, has a complete source (`sourceUrl` + `sourceLabel`) and NO extension
- *   at all. The hub field shows the whole race, not just published fiches, so Charlie must
- *   still surface from `getHubCandidacyField`.
+ * - Charlie is ENVISAGE, has a complete source (`sourceUrl` + `sourceLabel`), and a DRAFT
+ *   `CandidacyPresidential` extension carrying a published LOGEMENT_URBANISME measure. The hub
+ *   field shows the whole race, not just published fiches, so Charlie must still surface from
+ *   `getHubCandidacyField`, but the DRAFT extension means the measure is unreachable from any
+ *   subject page, so `verifiedMeasureCount` must not count it either (I7).
  * - Delta has a source URL but no `sourceLabel`: an incomplete source, which must stay absent
  *   from the field.
  *
@@ -26,6 +29,10 @@ export async function seedHubFixture(
   db: typeof import("@/lib/db").db,
   options: { electionSlug: string }
 ): Promise<string> {
+  // Defense in depth: the callers of this fixture already gate on the disposable container,
+  // but the fixture writes on its own, so it checks again rather than trusting them.
+  assertDisposableTestDb();
+
   const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
     await import("@/lib/measures/transitions");
 
@@ -34,7 +41,7 @@ export async function seedHubFixture(
       slug: options.electionSlug,
       type: "PRESIDENTIELLE",
       scope: "NATIONAL",
-      title: "Élection de test — hub",
+      title: "Élection de test (hub)",
     },
   });
 
@@ -123,10 +130,12 @@ export async function seedHubFixture(
     "Construire 500 000 logements sociaux sur le quinquennat."
   );
 
-  // Charlie: pressenti, source complète, SANS extension CandidacyPresidential. Doit apparaître
-  // au champ du hub (le champ ≠ les fiches publiées).
+  // Charlie: envisagé, complete source, DRAFT CandidacyPresidential extension carrying a
+  // published measure. Must surface in the hub field (the field != the published fiches), but
+  // the measure must not count in verifiedMeasureCount: the extension never publishes, so no
+  // subject page can ever reach it (I7).
   const charlie = await politician("Charlie");
-  await db.candidacy.create({
+  const charlieCandidacy = await db.candidacy.create({
     data: {
       electionId: election.id,
       politicianId: charlie.id,
@@ -136,8 +145,17 @@ export async function seedHubFixture(
       sourceLabel: "Presse",
     },
   });
+  await db.candidacyPresidential.create({
+    data: { candidacyId: charlieCandidacy.id, publicationStatus: "DRAFT" },
+  });
+  await publishMeasure(
+    charlie.id,
+    charlieCandidacy.id,
+    THEME_LOGEMENT,
+    "Mesure logement rattachée à une candidature non publiée."
+  );
 
-  // Delta: source incomplète (pas de sourceLabel). Doit rester absente du champ.
+  // Delta: incomplete source (no sourceLabel). Must stay absent from the field.
   const delta = await politician("Delta");
   await db.candidacy.create({
     data: {

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -13,7 +13,9 @@ const SLUG = "hub-test";
  * The hub field is the whole race (every sourced candidacy, pressenti/envisagé included),
  * never routed through `getPublicPresidentialCandidates` — that population is the published
  * fiches, and it would empty the hub at launch. The measure context, by contrast, mirrors the
- * subject-page gate exactly, because it summarizes the same subject pages.
+ * subject-page gate exactly, because it summarizes the same subject pages: Charlie's
+ * DRAFT-extension candidacy carries a published measure that must surface in the field but
+ * never in `verifiedMeasureCount` (I7).
  */
 describeIfDisposableDb("hub", () => {
   let electionId: string;
@@ -62,6 +64,21 @@ describeIfDisposableDb("hub", () => {
       expect(context.publishableSubjectPageCount).toBeGreaterThanOrEqual(1);
       expect(context.verifiedMeasureCount).toBe(2);
       expect(context.lastReviewedAt).not.toBeNull();
+    });
+
+    it("ne compte pas la mesure de Charlie, dont l'extension CandidacyPresidential est DRAFT (I7)", async () => {
+      // The measure genuinely exists and is PUBLISHED: this is not a fixture that forgot to
+      // create it, it is one whose owning candidacy never clears the extension gate.
+      const charlieMeasure = await db.measure.findFirst({
+        where: { election: { slug: SLUG }, candidacy: { candidateName: "Charlie Fixture" } },
+        select: { publicationStatus: true },
+      });
+      expect(charlieMeasure?.publicationStatus).toBe("PUBLISHED");
+
+      // Alpha and Bravo each defend one measure; Charlie's is unreachable from any subject
+      // page, so the context reports 2, never 3.
+      const context = await loadHubMeasureContext(electionId, SLUG);
+      expect(context.verifiedMeasureCount).toBe(2);
     });
 
     it("rend null pour une élection inconnue (getHubMeasureContext, avant la frontière cache)", async () => {

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -85,5 +85,23 @@ describeIfDisposableDb("hub", () => {
       const context = await getHubMeasureContext("inconnue");
       expect(context).toBeNull();
     });
+
+    it("remonte round2Date, dateConfirmed et electionDescription", async () => {
+      const round2Date = new Date("2027-04-25T00:00:00Z");
+      await db.election.update({
+        where: { id: electionId },
+        data: {
+          round2Date,
+          dateConfirmed: true,
+          description: "Élection de test (hub) pour le second tour.",
+        },
+      });
+
+      const context = await loadHubMeasureContext(electionId, SLUG);
+
+      expect(context.round2Date).toEqual(round2Date);
+      expect(context.dateConfirmed).toBe(true);
+      expect(context.electionDescription).toBe("Élection de test (hub) pour le second tour.");
+    });
   });
 });

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value, which throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let getHubCandidacyField: typeof import("../hub").getHubCandidacyField;
+let getHubMeasureContext: typeof import("../hub").getHubMeasureContext;
+let loadHubMeasureContext: typeof import("../hub").loadHubMeasureContext;
+
+const SLUG = "hub-test";
+
+/**
+ * The hub field is the whole race (every sourced candidacy, pressenti/envisagé included),
+ * never routed through `getPublicPresidentialCandidates` — that population is the published
+ * fiches, and it would empty the hub at launch. The measure context, by contrast, mirrors the
+ * subject-page gate exactly, because it summarizes the same subject pages.
+ */
+describeIfDisposableDb("hub", () => {
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getHubCandidacyField, getHubMeasureContext, loadHubMeasureContext } =
+      await import("../hub"));
+    const { seedHubFixture } = await import("./hub-fixture");
+    electionId = await seedHubFixture(db, { electionSlug: SLUG });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  describe("getHubCandidacyField", () => {
+    it("rend les candidatures sourcées triées par nom, pressenties sans extension comprises, source incomplète exclue", async () => {
+      const field = await getHubCandidacyField(SLUG);
+
+      expect(field.map((c) => c.candidateName)).toEqual([
+        "Alpha Fixture",
+        "Bravo Fixture",
+        "Charlie Fixture",
+      ]);
+      expect(field.some((c) => c.candidateName === "Delta Fixture")).toBe(false);
+
+      const charlie = field.find((c) => c.candidateName === "Charlie Fixture");
+      expect(charlie?.status).toBe("ENVISAGE");
+      expect(charlie?.sourceUrl).toBe("https://example.org/rumeur");
+      expect(charlie?.sourceLabel).toBe("Presse");
+    });
+  });
+
+  describe("getHubMeasureContext / loadHubMeasureContext", () => {
+    it("est publiable, compte les mesures défendues et porte la date de dernière revue", async () => {
+      // Le corps non caché, exactement comme loadThemesIndex/loadSubjectPageData : la frontière
+      // "use cache" de getHubMeasureContext lève hors d'un contexte Next.
+      const context = await loadHubMeasureContext(electionId, SLUG);
+
+      expect(context.hubPublishable).toBe(true);
+      expect(context.publishableSubjectPageCount).toBeGreaterThanOrEqual(1);
+      expect(context.verifiedMeasureCount).toBe(2);
+      expect(context.lastReviewedAt).not.toBeNull();
+    });
+
+    it("rend null pour une élection inconnue (getHubMeasureContext, avant la frontière cache)", async () => {
+      const context = await getHubMeasureContext("inconnue");
+      expect(context).toBeNull();
+    });
+  });
+});

--- a/src/lib/data/__tests__/latest-review-date.integration.test.ts
+++ b/src/lib/data/__tests__/latest-review-date.integration.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import type { ThemeCategory } from "@/generated/prisma";
+
+// Deferred: both `../measures` and the transitions module import `@/lib/db` as a value, which
+// throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let getLatestPublicReviewDate: typeof import("../measures").getLatestPublicReviewDate;
+let transitions: typeof import("@/lib/measures/transitions");
+
+const SLUG = "lrd-test";
+
+/**
+ * getLatestPublicReviewDate answers hub stat 4.3 ("when was the most recent public measure
+ * reviewed"). It reuses PUBLIC_MEASURE_WHERE rather than a hand-rolled predicate, so what is
+ * worth testing here is the aggregation on top of it: the result is a real max (not "the
+ * first row found"), the theme filter narrows it, an election with nothing public answers
+ * null, and a measure whose publishedRevision carries a LATER reviewedAt than any public one
+ * still stays invisible once publicationStatus has moved away from PUBLISHED.
+ */
+describeIfDisposableDb("getLatestPublicReviewDate", () => {
+  let mainElectionId: string;
+  let emptyElectionId: string;
+  let depubElectionId: string;
+  let logementReviewedAt: { l1: Date; l2: Date };
+  let transportsReviewedAt: Date;
+  let depubPublicReviewedAt: Date;
+  let depubHiddenReviewedAt: Date;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getLatestPublicReviewDate } = await import("../measures"));
+    transitions = await import("@/lib/measures/transitions");
+
+    async function politician(name: string): Promise<string> {
+      const slug = `${SLUG}-${name}`;
+      const row = await db.politician.create({
+        data: { slug, firstName: name, lastName: "Test", fullName: `${name} Test` },
+      });
+      return row.id;
+    }
+
+    /** Creates, reviews and publishes a measure, then returns its id and revision's real reviewedAt. */
+    async function publish(
+      politicianId: string,
+      electionId: string,
+      theme: ThemeCategory,
+      text: string
+    ): Promise<{ measureId: string; reviewedAt: Date }> {
+      const seeded = await transitions.createMeasure({
+        politicianId,
+        electionId,
+        candidacyId: null,
+        programEditionId: null,
+        attribution: "PERSONAL",
+        theme,
+        precedingMeasureId: null,
+        revision: {
+          text,
+          precision: "OBJECTIF_SANS_CHIFFRE",
+          validFrom: new Date("2027-01-01T00:00:00Z"),
+          extractionMethod: "MANUAL",
+          extractionConfidence: null,
+          extractorVersion: null,
+        },
+        sources: [
+          {
+            sourceKind: "DISCOURS_CAMPAGNE",
+            tier: "PRIMARY",
+            url: "https://example.org/meeting",
+            page: null,
+            publishedAt: new Date("2027-01-01T00:00:00Z"),
+          },
+        ],
+      });
+      await transitions.reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+      await transitions.publishMeasureRevision(seeded);
+      const revision = await db.measureRevision.findUniqueOrThrow({
+        where: { id: seeded.revisionId },
+        select: { reviewedAt: true },
+      });
+      if (!revision.reviewedAt) throw new Error("La révision publiée devrait porter reviewedAt");
+      return { measureId: seeded.measureId, reviewedAt: revision.reviewedAt };
+    }
+
+    // --- Main election: two published LOGEMENT_URBANISME measures, one published TRANSPORTS
+    // measure, and one never-reviewed draft. SANTE is never touched here, on purpose, so it
+    // stays the theme with zero public measures.
+    const mainElection = await db.election.create({
+      data: { slug: SLUG, type: "PRESIDENTIELLE", scope: "NATIONAL", title: "Élection test" },
+    });
+    mainElectionId = mainElection.id;
+
+    const l1 = await politician("l1");
+    const l1Published = await publish(
+      l1,
+      mainElectionId,
+      "LOGEMENT_URBANISME",
+      "Encadrer les loyers dans les zones tendues."
+    );
+    const l2 = await politician("l2");
+    const l2Published = await publish(
+      l2,
+      mainElectionId,
+      "LOGEMENT_URBANISME",
+      "Construire 500 000 logements sociaux."
+    );
+    logementReviewedAt = { l1: l1Published.reviewedAt, l2: l2Published.reviewedAt };
+
+    // A draft that is never reviewed nor published: it must not be able to surface, and
+    // PUBLIC_MEASURE_WHERE excludes it via publishedRevisionId alone before reviewedAt or
+    // ordering even come into play.
+    const draftPolitician = await politician("draft");
+    await transitions.createMeasure({
+      politicianId: draftPolitician,
+      electionId: mainElectionId,
+      candidacyId: null,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: "LOGEMENT_URBANISME",
+      precedingMeasureId: null,
+      revision: {
+        text: "Brouillon jamais relu.",
+        precision: null,
+        validFrom: new Date("2027-01-05T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "ARTICLE_PRESSE",
+          tier: "SECONDARY",
+          url: "https://example.org/article",
+          page: null,
+          publishedAt: new Date("2027-01-05T00:00:00Z"),
+        },
+      ],
+    });
+
+    const t1 = await politician("t1");
+    transportsReviewedAt = (
+      await publish(t1, mainElectionId, "TRANSPORTS", "Rendre gratuits les transports scolaires.")
+    ).reviewedAt;
+
+    // --- Empty election: no measure at all.
+    const emptyElection = await db.election.create({
+      data: {
+        slug: `${SLUG}-vide`,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Élection vide",
+      },
+    });
+    emptyElectionId = emptyElection.id;
+
+    // --- Depublication election: one public measure, and one measure published then
+    // depublished with a STRICTLY LATER reviewedAt. depublishMeasure() never touches
+    // publishedRevisionId, publishedAt, supersededAt or reviewedAt: only publicationStatus
+    // moves away from PUBLISHED, so the later date really does stay on the row, and only the
+    // publicationStatus condition of PUBLIC_MEASURE_WHERE is what keeps it out.
+    const depubElection = await db.election.create({
+      data: {
+        slug: `${SLUG}-depub`,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Élection dépublication",
+      },
+    });
+    depubElectionId = depubElection.id;
+
+    const p1 = await politician("p1");
+    const p1Published = await publish(
+      p1,
+      depubElectionId,
+      "LOGEMENT_URBANISME",
+      "Mesure publique de référence."
+    );
+    depubPublicReviewedAt = p1Published.reviewedAt;
+
+    const p2 = await politician("p2");
+    const p2Published = await publish(
+      p2,
+      depubElectionId,
+      "LOGEMENT_URBANISME",
+      "Mesure dépubliée après relecture."
+    );
+    depubHiddenReviewedAt = p2Published.reviewedAt;
+    await transitions.depublishMeasure({
+      measureId: p2Published.measureId,
+      reason: "Vérification en cours, pour le test.",
+    });
+  });
+
+  afterAll(async () => {
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.$disconnect();
+  });
+
+  it("renvoie le max des reviewedAt sur les mesures publiques d'un thème, ignore le brouillon jamais relu", async () => {
+    const expected = Math.max(logementReviewedAt.l1.getTime(), logementReviewedAt.l2.getTime());
+    const result = await getLatestPublicReviewDate(mainElectionId, "LOGEMENT_URBANISME");
+    expect(result).not.toBeNull();
+    expect(result?.getTime()).toBe(expected);
+  });
+
+  it("agrège tous les thèmes de l'élection quand aucun thème n'est demandé", async () => {
+    const expected = Math.max(
+      logementReviewedAt.l1.getTime(),
+      logementReviewedAt.l2.getTime(),
+      transportsReviewedAt.getTime()
+    );
+    const result = await getLatestPublicReviewDate(mainElectionId);
+    expect(result?.getTime()).toBe(expected);
+  });
+
+  it("filtre par thème : renvoie la date de la mesure publique de ce thème", async () => {
+    const result = await getLatestPublicReviewDate(mainElectionId, "TRANSPORTS");
+    expect(result?.getTime()).toBe(transportsReviewedAt.getTime());
+  });
+
+  it("filtre par thème : renvoie null si aucune mesure publique n'existe sur ce thème", async () => {
+    expect(await getLatestPublicReviewDate(mainElectionId, "SANTE")).toBeNull();
+  });
+
+  it("renvoie null sur une élection sans mesure publiée", async () => {
+    expect(await getLatestPublicReviewDate(emptyElectionId)).toBeNull();
+  });
+
+  it("ignore une mesure dépubliée même si sa révision a été relue plus récemment que la mesure publique", async () => {
+    // Guard: if this stops holding, the scenario no longer bites and the assertion below
+    // would pass for the wrong reason (there would be nothing later to wrongly ignore).
+    expect(depubHiddenReviewedAt.getTime()).toBeGreaterThan(depubPublicReviewedAt.getTime());
+
+    const result = await getLatestPublicReviewDate(depubElectionId, "LOGEMENT_URBANISME");
+    expect(result?.getTime()).toBe(depubPublicReviewedAt.getTime());
+  });
+});

--- a/src/lib/data/__tests__/presidentielle-hub-demo.ts
+++ b/src/lib/data/__tests__/presidentielle-hub-demo.ts
@@ -122,11 +122,11 @@ export async function seedPresidentielleHubDemo(
     return candidacy.id;
   }
 
-  // Le champ : sourcées, sans extension, visibles au hub avant toute fiche publiée.
+  // The field: sourced, no extension, visible at the hub before any fiche is published.
   await sourcedCandidacy("A", "PRESSENTI");
   await sourcedCandidacy("B", "ENVISAGE");
 
-  // La page sujet publiable : deux candidatures publiées défendent chacune une mesure Logement.
+  // The publishable subject page: two published candidacies each defend a Logement measure.
   await publishedCandidacyWithMeasure(
     "C",
     THEME_LOGEMENT,
@@ -138,7 +138,7 @@ export async function seedPresidentielleHubDemo(
     "Construire 500 000 logements sociaux sur le quinquennat."
   );
 
-  // La page sujet sous seuil : une seule candidature publiée défend une mesure Numérique.
+  // The subject page below threshold: only one published candidacy defends a Numérique measure.
   await publishedCandidacyWithMeasure(
     "E",
     THEME_NUMERIQUE,

--- a/src/lib/data/__tests__/presidentielle-hub-demo.ts
+++ b/src/lib/data/__tests__/presidentielle-hub-demo.ts
@@ -1,0 +1,149 @@
+import { assertDisposableTestDb } from "@/test/disposable-db";
+
+/**
+ * Seeds a fictional demo corpus for the presidential 2027 hub and its two downstream surfaces
+ * (the themes index and a subject page), so all three can be reviewed in a browser (responsive +
+ * axe) in one pass.
+ *
+ * It lives in a __tests__ folder on purpose: it writes `publicationStatus: "PUBLISHED"` directly on
+ * CandidacyPresidential, which has no transition of its own, so that literal belongs where the
+ * publication guard allows it, alongside the integration fixtures. Modeled on
+ * `presidentielle-subject-demo.ts` (the subject-page-only counterpart) and on
+ * `hub-fixture.ts`/`themes-index-fixture.ts` (the transition + extension patterns), consumed by
+ * `scripts/seed-presidentielle-hub-demo.ts`.
+ *
+ * The corpus has three parts, each proving a different gate:
+ * - the field: two sourced candidacies (PRESSENTI, ENVISAGE), no `CandidacyPresidential` extension
+ *   at all. The hub field shows the whole race, not just published fiches, so both must surface
+ *   from `getHubCandidacyField`.
+ * - a publishable subject page: two candidacies with a PUBLISHED extension, each defending one
+ *   LOGEMENT_URBANISME measure. That clears the page-sujet gate (2 candidacies with a verified
+ *   measure), so `hubPublishable` is true and `/sujets/logement-urbanisme` renders the open state.
+ * - a subject page under threshold: one candidacy with a PUBLISHED extension defending one
+ *   NUMERIQUE_TECH measure. One is short of the gate, so `/sujets/numerique-tech` renders the
+ *   closed state (`SubjectGate`).
+ *
+ * assertDisposableTestDb() is the safety net: `.env` and `.env.prod` share the same database, so an
+ * ungated run would fabricate candidacies and measures in production.
+ */
+
+const ELECTION_SLUG = "presidentielle-2027";
+const THEME_LOGEMENT = "LOGEMENT_URBANISME" as const;
+const THEME_NUMERIQUE = "NUMERIQUE_TECH" as const;
+
+export async function seedPresidentielleHubDemo(
+  db: typeof import("@/lib/db").db
+): Promise<{ electionId: string }> {
+  assertDisposableTestDb();
+
+  const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
+    await import("@/lib/measures/transitions");
+
+  const election = await db.election.create({
+    data: {
+      slug: ELECTION_SLUG,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Présidentielle 2027",
+    },
+  });
+
+  async function politician(name: string) {
+    const slug = `presidentielle-hub-demo-${name.toLowerCase()}`;
+    return db.politician.create({
+      data: { slug, firstName: "Candidat·e", lastName: name, fullName: `Candidat·e ${name}` },
+    });
+  }
+
+  async function sourcedCandidacy(name: string, status: "PRESSENTI" | "ENVISAGE"): Promise<string> {
+    const pol = await politician(name);
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: pol.id,
+        candidateName: `Candidat·e ${name}`,
+        status,
+        sourceUrl: "https://example.org/rumeur",
+        sourceLabel: "Presse",
+      },
+    });
+    return candidacy.id;
+  }
+
+  async function publishedCandidacyWithMeasure(
+    name: string,
+    theme: typeof THEME_LOGEMENT | typeof THEME_NUMERIQUE,
+    text: string
+  ): Promise<string> {
+    const pol = await politician(name);
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: pol.id,
+        candidateName: `Candidat·e ${name}`,
+        status: "DECLARE",
+        sourceUrl: "https://example.org/annonce",
+        sourceLabel: "Discours de déclaration",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED", slogan: `Slogan ${name}` },
+    });
+
+    const seeded = await createMeasure({
+      politicianId: pol.id,
+      electionId: election.id,
+      candidacyId: candidacy.id,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    await reviewMeasureRevision({ ...seeded, reviewedBy: "relecteur" });
+    await publishMeasureRevision(seeded);
+
+    return candidacy.id;
+  }
+
+  // Le champ : sourcées, sans extension, visibles au hub avant toute fiche publiée.
+  await sourcedCandidacy("A", "PRESSENTI");
+  await sourcedCandidacy("B", "ENVISAGE");
+
+  // La page sujet publiable : deux candidatures publiées défendent chacune une mesure Logement.
+  await publishedCandidacyWithMeasure(
+    "C",
+    THEME_LOGEMENT,
+    "Encadrer les loyers dans les zones tendues."
+  );
+  await publishedCandidacyWithMeasure(
+    "D",
+    THEME_LOGEMENT,
+    "Construire 500 000 logements sociaux sur le quinquennat."
+  );
+
+  // La page sujet sous seuil : une seule candidature publiée défend une mesure Numérique.
+  await publishedCandidacyWithMeasure(
+    "E",
+    THEME_NUMERIQUE,
+    "Créer un service public du numérique responsable."
+  );
+
+  return { electionId: election.id };
+}

--- a/src/lib/data/__tests__/subject-page.integration.test.ts
+++ b/src/lib/data/__tests__/subject-page.integration.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { themeToSlug } from "@/lib/theme-utils";
 
 // Deferred: these modules import @/lib/db as a value, which throws at module load without DATABASE_URL.
 let db: typeof import("@/lib/db").db;
@@ -9,6 +11,9 @@ let createMeasureVoteLink: typeof import("@/lib/measures/vote-links").createMeas
 
 const SLUG = "presidentielle-sujet-test";
 const THEME = "LOGEMENT_URBANISME" as const;
+// Below the gate throughout this fixture: no measure is ever attached to this theme, other
+// than the one draft added below to exercise pendingReviewMeasureCount.
+const OTHER_THEME = "SANTE" as const;
 
 /**
  * The subject page reads only through public authorities. The violation is built first: a DRAFT-extension
@@ -153,6 +158,35 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
       ],
     });
 
+    // A draft measure on a different theme, never reviewed nor published: exercises
+    // pendingReviewMeasureCount on a theme that otherwise carries no measure at all.
+    await transitions.createMeasure({
+      politicianId: a.politicianId,
+      electionId,
+      candidacyId: a.candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: OTHER_THEME,
+      precedingMeasureId: null,
+      revision: {
+        text: "Brouillon santé non publié.",
+        precision: null,
+        validFrom: new Date("2027-01-06T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "ARTICLE_PRESSE",
+          tier: "SECONDARY",
+          url: "https://example.org/article-sante",
+          page: null,
+          publishedAt: new Date("2027-01-06T00:00:00Z"),
+        },
+      ],
+    });
+
     // Bruno: one defended measure, so the gate reaches two candidacies.
     bruno = await publishedCandidate("Bruno");
     await publishMeasure(bruno.politicianId, bruno.candidacyId, "Construire 500 000 logements.");
@@ -224,5 +258,46 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
     // Alix and Bruno each defend a measure; Chloe has none; the withdrawn one does not count.
     expect(data.candidaciesWithVerifiedMeasure).toBe(2);
     expect(data.publishable).toBe(true);
+  });
+
+  it("expose le seuil requis et le total de candidatures sourcées de l'élection", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    expect(data.requiredCandidaciesWithVerifiedMeasure).toBe(2);
+    // Alix, Bruno and Chloe are sourced (status + sourceUrl + sourceLabel); Dora (DRAFT
+    // extension, no source) is not. The count is election-wide, not scoped to the theme.
+    expect(data.totalSourcedCandidacies).toBe(3);
+  });
+
+  it("compte les mesures en attente de relecture d'un thème sous le seuil, sans exposer leur texte", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
+    expect(data.candidaciesWithVerifiedMeasure).toBe(0);
+    expect(data.publishable).toBe(false);
+    expect(data.pendingReviewMeasureCount).toBe(1);
+    expect(JSON.stringify(data)).not.toContain("Brouillon santé non publié.");
+  });
+
+  it("date la dernière revue publique du thème, et jamais relu quand aucune n'existe", async () => {
+    const onTheme = await loadSubjectPageData(electionId, SLUG, THEME);
+    const brunoRevision = await db.measureRevision.findFirst({
+      where: { measure: { candidacyId: bruno.candidacyId } },
+      select: { reviewedAt: true },
+    });
+    expect(onTheme.lastReviewedAt?.getTime()).toBe(brunoRevision?.reviewedAt?.getTime());
+
+    const otherTheme = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
+    expect(otherTheme.lastReviewedAt).toBeNull();
+  });
+
+  it("sous le seuil, renvoie un thème publiable différent du thème courant", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
+    expect(data.fallbackPublishableTheme).toEqual({
+      slug: themeToSlug(THEME),
+      label: THEME_CATEGORY_LABELS[THEME],
+    });
+  });
+
+  it("au-dessus du seuil, ne propose aucun renvoi quand aucun autre thème n'est publiable", async () => {
+    const data = await loadSubjectPageData(electionId, SLUG, THEME);
+    expect(data.fallbackPublishableTheme).toBeNull();
   });
 });

--- a/src/lib/data/__tests__/subject-page.integration.test.ts
+++ b/src/lib/data/__tests__/subject-page.integration.test.ts
@@ -191,6 +191,42 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
     bruno = await publishedCandidate("Bruno");
     await publishMeasure(bruno.politicianId, bruno.candidacyId, "Construire 500 000 logements.");
 
+    // A measure published on OTHER_THEME, then depublished for cause (I3): publicationStatus
+    // falls back to DRAFT, exactly like a never-published draft, but this is a retraction, not
+    // a submission awaiting a first review. pendingReviewMeasureCount must not count it.
+    const depublishedSeed = await transitions.createMeasure({
+      politicianId: bruno.politicianId,
+      electionId,
+      candidacyId: bruno.candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: OTHER_THEME,
+      precedingMeasureId: null,
+      revision: {
+        text: "Mesure santé publiée puis retirée pour motif factuel.",
+        precision: null,
+        validFrom: new Date("2027-01-07T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "ARTICLE_PRESSE",
+          tier: "SECONDARY",
+          url: "https://example.org/article-sante-retiree",
+          page: null,
+          publishedAt: new Date("2027-01-07T00:00:00Z"),
+        },
+      ],
+    });
+    await transitions.reviewMeasureRevision({ ...depublishedSeed, reviewedBy: "relecteur" });
+    await transitions.publishMeasureRevision(depublishedSeed);
+    await transitions.depublishMeasure({
+      measureId: depublishedSeed.measureId,
+      reason: "Information inexacte, retirée après vérification.",
+    });
+
     // Chloe: a published candidacy with no measure on the theme, so a qualified absence.
     await publishedCandidate("Chloe");
 
@@ -274,6 +310,16 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
     expect(data.publishable).toBe(false);
     expect(data.pendingReviewMeasureCount).toBe(1);
     expect(JSON.stringify(data)).not.toContain("Brouillon santé non publié.");
+  });
+
+  it("ne compte pas une mesure publiée puis dépubliée dans pendingReviewMeasureCount", async () => {
+    // The draft SANTE measure alone brings the count to 1: depublishMeasure() also leaves
+    // publicationStatus at DRAFT, and without depublishedAt in the filter this would read 2.
+    const data = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
+    expect(data.pendingReviewMeasureCount).toBe(1);
+    expect(JSON.stringify(data)).not.toContain(
+      "Mesure santé publiée puis retirée pour motif factuel."
+    );
   });
 
   it("date la dernière revue publique du thème, et jamais relu quand aucune n'existe", async () => {

--- a/src/lib/data/__tests__/themes-index-fixture.ts
+++ b/src/lib/data/__tests__/themes-index-fixture.ts
@@ -1,4 +1,5 @@
 import type { ThemeCategory } from "@/generated/prisma";
+import { assertDisposableTestDb } from "@/test/disposable-db";
 
 /**
  * Seeds the fixture for the `themes-index` parity test.
@@ -26,6 +27,10 @@ export async function seedThemesIndexFixture(
   db: typeof import("@/lib/db").db,
   options: { electionSlug: string }
 ): Promise<string> {
+  // Defense in depth: the callers of this fixture already gate on the disposable container,
+  // but the fixture writes on its own, so it checks again rather than trusting them.
+  assertDisposableTestDb();
+
   const { createMeasure, reviewMeasureRevision, publishMeasureRevision, withdrawMeasure } =
     await import("@/lib/measures/transitions");
 
@@ -34,7 +39,7 @@ export async function seedThemesIndexFixture(
       slug: options.electionSlug,
       type: "PRESIDENTIELLE",
       scope: "NATIONAL",
-      title: "Élection de test — index des sujets",
+      title: "Élection de test (index des sujets)",
     },
   });
 

--- a/src/lib/data/__tests__/themes-index-fixture.ts
+++ b/src/lib/data/__tests__/themes-index-fixture.ts
@@ -1,0 +1,154 @@
+import type { ThemeCategory } from "@/generated/prisma";
+
+/**
+ * Seeds the fixture for the `themes-index` parity test.
+ *
+ * Modeled on `presidentielle-subject-demo.ts` and the setup of
+ * `subject-page.integration.test.ts`: candidacies + `CandidacyPresidential` extensions +
+ * measures created through the real transitions (`createMeasure`, `reviewMeasureRevision`,
+ * `publishMeasureRevision`, `withdrawMeasure`). The literal `publicationStatus: "PUBLISHED"`
+ * is deliberate here, in a `__tests__` file: `CandidacyPresidential` has no publishing
+ * transition of its own.
+ *
+ * The population this builds is exactly the one the invariant under test cares about:
+ * - Alpha and Bravo have a PUBLISHED extension, so they are in the subject-page population.
+ * - Charlie has a DRAFT extension: its LOGEMENT_URBANISME measure is published, but the
+ *   candidacy itself must never surface, and `themes-index` must not count it either.
+ * - Alpha also carries a withdrawn LOGEMENT_URBANISME measure (documented but not defended)
+ *   and a defended SANTE measure (to prove one candidacy short of the page-sujet gate on a
+ *   different theme).
+ */
+
+const THEME_LOGEMENT: ThemeCategory = "LOGEMENT_URBANISME";
+const THEME_SANTE: ThemeCategory = "SANTE";
+
+export async function seedThemesIndexFixture(
+  db: typeof import("@/lib/db").db,
+  options: { electionSlug: string }
+): Promise<string> {
+  const { createMeasure, reviewMeasureRevision, publishMeasureRevision, withdrawMeasure } =
+    await import("@/lib/measures/transitions");
+
+  const election = await db.election.create({
+    data: {
+      slug: options.electionSlug,
+      type: "PRESIDENTIELLE",
+      scope: "NATIONAL",
+      title: "Élection de test — index des sujets",
+    },
+  });
+
+  async function candidate(
+    name: string,
+    publicationStatus: "PUBLISHED" | "DRAFT"
+  ): Promise<{ candidacyId: string; politicianId: string }> {
+    const slug = `${options.electionSlug}-${name.toLowerCase()}`;
+    const politician = await db.politician.create({
+      data: { slug, firstName: name, lastName: "Fixture", fullName: `${name} Fixture` },
+    });
+    const candidacy = await db.candidacy.create({
+      data: {
+        electionId: election.id,
+        politicianId: politician.id,
+        candidateName: `${name} Fixture`,
+        status: "DECLARE",
+        sourceUrl: "https://example.org/source",
+        sourceLabel: "Source",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candidacy.id, publicationStatus },
+    });
+    return { candidacyId: candidacy.id, politicianId: politician.id };
+  }
+
+  async function publishMeasure(
+    politicianId: string,
+    candidacyId: string,
+    theme: ThemeCategory,
+    text: string
+  ): Promise<{ measureId: string; revisionId: string }> {
+    const seeded = await createMeasure({
+      politicianId,
+      electionId: election.id,
+      candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    await reviewMeasureRevision({ ...seeded, reviewedBy: "fixture" });
+    await publishMeasureRevision(seeded);
+    return seeded;
+  }
+
+  const alpha = await candidate("Alpha", "PUBLISHED");
+  const bravo = await candidate("Bravo", "PUBLISHED");
+  const charlie = await candidate("Charlie", "DRAFT");
+
+  // Alpha: one defended LOGEMENT measure, one withdrawn LOGEMENT measure, one defended SANTE measure.
+  await publishMeasure(
+    alpha.politicianId,
+    alpha.candidacyId,
+    THEME_LOGEMENT,
+    "Encadrer les loyers dans les zones tendues."
+  );
+  const withdrawn = await publishMeasure(
+    alpha.politicianId,
+    alpha.candidacyId,
+    THEME_LOGEMENT,
+    "Geler les loyers un an."
+  );
+  const before = await db.measure.findUniqueOrThrow({
+    where: { id: withdrawn.measureId },
+    select: { updatedAt: true },
+  });
+  await withdrawMeasure({
+    measureId: withdrawn.measureId,
+    withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+    sourceUrl: "https://example.org/retrait",
+    sourceLabel: "Communiqué de retrait",
+    expectedUpdatedAt: before.updatedAt,
+  });
+  await publishMeasure(
+    alpha.politicianId,
+    alpha.candidacyId,
+    THEME_SANTE,
+    "Recruter des soignants dans les hôpitaux publics."
+  );
+
+  // Bravo: one defended LOGEMENT measure, so the gate reaches two candidacies on this theme.
+  await publishMeasure(
+    bravo.politicianId,
+    bravo.candidacyId,
+    THEME_LOGEMENT,
+    "Construire 500 000 logements sociaux sur le quinquennat."
+  );
+
+  // Charlie: a published LOGEMENT measure, but the extension is DRAFT — must never count.
+  await publishMeasure(
+    charlie.politicianId,
+    charlie.candidacyId,
+    THEME_LOGEMENT,
+    "Mesure logement rattachée à une candidature non publiée."
+  );
+
+  return election.id;
+}

--- a/src/lib/data/__tests__/themes-index-fixture.ts
+++ b/src/lib/data/__tests__/themes-index-fixture.ts
@@ -147,7 +147,7 @@ export async function seedThemesIndexFixture(
     "Construire 500 000 logements sociaux sur le quinquennat."
   );
 
-  // Charlie: a published LOGEMENT measure, but the extension is DRAFT — must never count.
+  // Charlie: a published LOGEMENT measure, but the extension is DRAFT, so it must never count.
   await publishMeasure(
     charlie.politicianId,
     charlie.candidacyId,

--- a/src/lib/data/__tests__/themes-index.integration.test.ts
+++ b/src/lib/data/__tests__/themes-index.integration.test.ts
@@ -42,8 +42,8 @@ describeIfDisposableDb("loadThemesIndex", () => {
 
     expect(logement?.candidaciesWithVerifiedMeasure).toBe(2);
     expect(logement?.publishable).toBe(true);
-    // Alpha défendue + Alpha retirée + Bravo défendue = 3. La mesure de Charlie est exclue car
-    // sa candidature n'est pas dans la population publique.
+    // Alpha defended + Alpha withdrawn + Bravo defended = 3. Charlie's measure is excluded
+    // because its candidacy is not in the public population.
     expect(logement?.documentedMeasureCount).toBe(3);
     expect(logement?.currentlyDefendedMeasureCount).toBe(2);
   });

--- a/src/lib/data/__tests__/themes-index.integration.test.ts
+++ b/src/lib/data/__tests__/themes-index.integration.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import type { ThemeCategory } from "@/generated/prisma";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value, which throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let loadThemesIndex: typeof import("../themes-index").loadThemesIndex;
+let loadSubjectPageData: typeof import("@/lib/data/subject-page").loadSubjectPageData;
+
+const SLUG = "themes-index-test";
+const THEME_LOGEMENT: ThemeCategory = "LOGEMENT_URBANISME";
+
+/**
+ * The whole point of this authority is that it counts publiability on the SAME population as
+ * the real subject page: candidacies whose `CandidacyPresidential` extension is PUBLISHED. A
+ * measure on a DRAFT-extension candidacy (Charlie) must inflate neither the documented count
+ * nor the gate, or `themes-index` would advertise a page as open while the page itself renders
+ * a closed state.
+ */
+describeIfDisposableDb("loadThemesIndex", () => {
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ loadThemesIndex } = await import("../themes-index"));
+    ({ loadSubjectPageData } = await import("@/lib/data/subject-page"));
+    const { seedThemesIndexFixture } = await import("./themes-index-fixture");
+    electionId = await seedThemesIndexFixture(db, { electionSlug: SLUG });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  it("compte la population de porte sur LOGEMENT_URBANISME : Alpha et Bravo, jamais Charlie (extension DRAFT)", async () => {
+    const data = await loadThemesIndex(electionId, SLUG);
+    const logement = data.themes.find((t) => t.theme === THEME_LOGEMENT);
+
+    expect(logement?.candidaciesWithVerifiedMeasure).toBe(2);
+    expect(logement?.publishable).toBe(true);
+    // Alpha défendue + Alpha retirée + Bravo défendue = 3. La mesure de Charlie est exclue car
+    // sa candidature n'est pas dans la population publique.
+    expect(logement?.documentedMeasureCount).toBe(3);
+    expect(logement?.currentlyDefendedMeasureCount).toBe(2);
+  });
+
+  it("est en parité avec loadSubjectPageData sur chaque thème", async () => {
+    const data = await loadThemesIndex(electionId, SLUG);
+
+    for (const entry of data.themes) {
+      const subjectPage = await loadSubjectPageData(electionId, SLUG, entry.theme);
+      expect(entry.publishable).toBe(subjectPage.publishable);
+      expect(entry.candidaciesWithVerifiedMeasure).toBe(subjectPage.candidaciesWithVerifiedMeasure);
+    }
+  });
+
+  it("compte une seule page sujet publiable (LOGEMENT_URBANISME)", async () => {
+    const data = await loadThemesIndex(electionId, SLUG);
+    expect(data.publishableSubjectPageCount).toBe(1);
+  });
+});

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -4,7 +4,7 @@ import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
 import { loadThemesIndex } from "./themes-index";
-import { getPublicMeasuresByElection, getLatestPublicReviewDate } from "./measures";
+import { getLatestPublicReviewDate } from "./measures";
 
 /**
  * The two read authorities for the presidential hub page.
@@ -47,8 +47,10 @@ export type HubMeasureContext = {
 };
 
 /**
- * Not cached: ~11 rows today, and candidacy status/source edits have no invalidation path yet.
- * Freshness matters more than a 24h cache backstop here.
+ * Not cached: ~11 rows today, and candidacy status/source edits have no invalidation path yet, so
+ * caching this read would have nothing to bust it on a write. Real freshness still tops out at the
+ * page's own `revalidate = 86400`: this function itself always reads live, but the rendered page
+ * that calls it is only as fresh as its ISR backstop.
  */
 export async function getHubCandidacyField(electionSlug: string): Promise<HubCandidacy[]> {
   const rows = await db.candidacy.findMany({
@@ -93,22 +95,30 @@ export async function loadHubMeasureContext(
   electionId: string,
   electionSlug: string
 ): Promise<HubMeasureContext> {
-  const [election, themesIndex, defended, lastReviewedAt] = await Promise.all([
+  const [election, themesIndex, lastReviewedAt] = await Promise.all([
     db.election.findUniqueOrThrow({
       where: { id: electionId },
       select: { title: true, round1Date: true },
     }),
     loadThemesIndex(electionId, electionSlug),
-    getPublicMeasuresByElection(electionId),
     getLatestPublicReviewDate(electionId),
   ]);
+
+  // Derived from the themes index rather than a fresh getPublicMeasuresByElection() read: the
+  // subject pages are the only surface that renders a measure, and only for candidacies with a
+  // PUBLISHED extension. A measure on a DRAFT-extension candidacy is unreachable there, so
+  // counting it here would announce more measures than the hub can actually lead a reader to.
+  const verifiedMeasureCount = themesIndex.themes.reduce(
+    (n, t) => n + t.currentlyDefendedMeasureCount,
+    0
+  );
 
   return {
     electionTitle: election.title,
     round1Date: election.round1Date,
     publishableSubjectPageCount: themesIndex.publishableSubjectPageCount,
     hubPublishable: isHubPublishable(themesIndex.publishableSubjectPageCount),
-    verifiedMeasureCount: defended.length,
+    verifiedMeasureCount,
     lastReviewedAt,
   };
 }

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -40,6 +40,9 @@ export type HubCandidacy = {
 export type HubMeasureContext = {
   electionTitle: string;
   round1Date: Date | null;
+  round2Date: Date | null;
+  dateConfirmed: boolean;
+  electionDescription: string | null;
   publishableSubjectPageCount: number;
   hubPublishable: boolean;
   verifiedMeasureCount: number;
@@ -98,7 +101,13 @@ export async function loadHubMeasureContext(
   const [election, themesIndex, lastReviewedAt] = await Promise.all([
     db.election.findUniqueOrThrow({
       where: { id: electionId },
-      select: { title: true, round1Date: true },
+      select: {
+        title: true,
+        round1Date: true,
+        round2Date: true,
+        dateConfirmed: true,
+        description: true,
+      },
     }),
     loadThemesIndex(electionId, electionSlug),
     getLatestPublicReviewDate(electionId),
@@ -116,6 +125,9 @@ export async function loadHubMeasureContext(
   return {
     electionTitle: election.title,
     round1Date: election.round1Date,
+    round2Date: election.round2Date,
+    dateConfirmed: election.dateConfirmed,
+    electionDescription: election.description,
     publishableSubjectPageCount: themesIndex.publishableSubjectPageCount,
     hubPublishable: isHubPublishable(themesIndex.publishableSubjectPageCount),
     verifiedMeasureCount,

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -1,0 +1,139 @@
+import "server-only";
+import { cacheLife, cacheTag } from "next/cache";
+import type { CandidacyStatus } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { isHubPublishable } from "@/config/publication-gates";
+import { loadThemesIndex } from "./themes-index";
+import { getPublicMeasuresByElection, getLatestPublicReviewDate } from "./measures";
+
+/**
+ * The two read authorities for the presidential hub page.
+ *
+ * The candidacy field and the published fiches are two different populations, and this file
+ * exists to keep them that way. `getHubCandidacyField` shows the whole race — every sourced
+ * candidacy (status + `sourceUrl` + `sourceLabel` non-null), pressenti/envisagé included,
+ * extension NOT required — because the hub has to show the field before anyone has a published
+ * fiche. Routing it through `getPublicPresidentialCandidates` (the PUBLISHED-extension
+ * population used by the subject pages) would empty the hub at launch.
+ *
+ * `getHubMeasureContext`, by contrast, summarizes the same subject pages the themes index
+ * gates: it is cached under the same `election-measures:${electionId}` tag as the measure
+ * authorities, so a measure write busts it exactly when it busts the pages it summarizes.
+ *
+ * `loadHubMeasureContext` is the plain async body, integration-testable the same way
+ * `loadThemesIndex`/`loadSubjectPageData` are: a `"use cache"` boundary throws outside a Next
+ * request/build context, so tests exercise the uncached loader and pages call the cached
+ * wrapper.
+ */
+
+export type HubCandidacy = {
+  id: string;
+  candidateName: string;
+  politicianSlug: string | null;
+  status: CandidacyStatus | null;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+  partyLabel: string | null;
+  partyColor: string | null;
+};
+
+export type HubMeasureContext = {
+  electionTitle: string;
+  round1Date: Date | null;
+  publishableSubjectPageCount: number;
+  hubPublishable: boolean;
+  verifiedMeasureCount: number;
+  lastReviewedAt: Date | null;
+};
+
+/**
+ * Not cached: ~11 rows today, and candidacy status/source edits have no invalidation path yet.
+ * Freshness matters more than a 24h cache backstop here.
+ */
+export async function getHubCandidacyField(electionSlug: string): Promise<HubCandidacy[]> {
+  const rows = await db.candidacy.findMany({
+    // The field is the race, not the published fiches: sourced candidacies (status + both
+    // source fields non-null), no extension required. Alphabetical order.
+    where: {
+      election: { slug: electionSlug },
+      status: { not: null },
+      sourceUrl: { not: null },
+      sourceLabel: { not: null },
+    },
+    select: {
+      id: true,
+      candidateName: true,
+      status: true,
+      sourceUrl: true,
+      sourceLabel: true,
+      partyLabel: true,
+      politician: { select: { slug: true } },
+      party: { select: { color: true } },
+    },
+    orderBy: { candidateName: "asc" },
+  });
+
+  return rows.map((c) => ({
+    id: c.id,
+    candidateName: c.candidateName,
+    politicianSlug: c.politician?.slug ?? null,
+    status: c.status,
+    sourceUrl: c.sourceUrl,
+    sourceLabel: c.sourceLabel,
+    partyLabel: c.partyLabel,
+    partyColor: c.party?.color ?? null,
+  }));
+}
+
+/**
+ * Plain async, integration-testable. Callers on a page use `getHubMeasureContext`, which
+ * caches this.
+ */
+export async function loadHubMeasureContext(
+  electionId: string,
+  electionSlug: string
+): Promise<HubMeasureContext> {
+  const [election, themesIndex, defended, lastReviewedAt] = await Promise.all([
+    db.election.findUniqueOrThrow({
+      where: { id: electionId },
+      select: { title: true, round1Date: true },
+    }),
+    loadThemesIndex(electionId, electionSlug),
+    getPublicMeasuresByElection(electionId),
+    getLatestPublicReviewDate(electionId),
+  ]);
+
+  return {
+    electionTitle: election.title,
+    round1Date: election.round1Date,
+    publishableSubjectPageCount: themesIndex.publishableSubjectPageCount,
+    hubPublishable: isHubPublishable(themesIndex.publishableSubjectPageCount),
+    verifiedMeasureCount: defended.length,
+    lastReviewedAt,
+  };
+}
+
+export async function getHubMeasureContext(
+  electionSlug: string
+): Promise<HubMeasureContext | null> {
+  const election = await db.election.findUnique({
+    where: { slug: electionSlug },
+    select: { id: true },
+  });
+  if (election === null) return null;
+  return getHubMeasureContextCached(election.id, electionSlug);
+}
+
+/**
+ * Cached read for the hub page. Tagged the same as the measure authorities, so a measure write
+ * busts it exactly when it busts the subject pages it summarizes.
+ */
+async function getHubMeasureContextCached(
+  electionId: string,
+  electionSlug: string
+): Promise<HubMeasureContext> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheLife("synced");
+  return loadHubMeasureContext(electionId, electionSlug);
+}

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -173,6 +173,27 @@ export async function getMeasureForModeration(measureId: string) {
 }
 
 /**
+ * Hub stat 4.3: when the most recently reviewed public measure was reviewed, on an
+ * election and optionally narrowed to one theme.
+ *
+ * Orders on `publishedRevision.reviewedAt`, which PUBLIC_MEASURE_WHERE already requires to
+ * be non-null on every row this can select: a depublished or discarded measure can carry a
+ * later reviewedAt on its (former) published revision, and reusing the predicate rather than
+ * a hand-rolled one is what keeps it out.
+ */
+export async function getLatestPublicReviewDate(
+  electionId: string,
+  theme?: ThemeCategory
+): Promise<Date | null> {
+  const row = await db.measure.findFirst({
+    where: { electionId, ...(theme ? { theme } : {}), ...PUBLIC_MEASURE_WHERE },
+    orderBy: { publishedRevision: { reviewedAt: "desc" } },
+    select: { publishedRevision: { select: { reviewedAt: true } } },
+  });
+  return row?.publishedRevision?.reviewedAt ?? null;
+}
+
+/**
  * The revision publicly in force on a given day. The condition on publishedAt is not
  * optional: without it the query can select a draft that was never published, and make the
  * site report a text it never displayed.

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -20,10 +20,13 @@ import { loadThemesIndex } from "./themes-index";
  * The data of a public subject page: for one theme, each publicly visible candidacy and its published
  * measures on that theme, with the measure's relation to recorded votes.
  *
- * Every read goes through a public authority: `getPublicPresidentialCandidates` (drops DRAFT/missing
+ * Content reads go through a public authority: `getPublicPresidentialCandidates` (drops DRAFT/missing
  * extensions), `getPublicMeasuresByTheme` (the single measure authority), and `getPublicMeasureVoteRelation`
- * (which never selects `rationale`/`reviewedBy`). Nothing here reads `db.measure`/`db.candidacy` directly.
- * The only direct read is the election slug -> id resolution, which is not gated.
+ * (which never selects `rationale`/`reviewedBy`). Two direct reads bypass those authorities, but only to
+ * produce a number, never content: `db.candidacy.count` (sourced candidacies of the election, the coverage
+ * denominator) and `db.measure.count` (draft measures of the theme, for `pendingReviewMeasureCount`). The
+ * election slug -> id resolution is a third direct read, and is not gated. No unpublished text ever crosses
+ * this surface.
  *
  * `publishable` is the section 4 gate, not a rendering detail: below it the page shows an explicit state
  * and is noindex, never a silently degraded one-candidate "comparison".
@@ -89,8 +92,12 @@ export async function loadSubjectPageData(
         sourceLabel: { not: null },
       },
     }),
-    // Count only: never expose the text of an unpublished revision here.
-    db.measure.count({ where: { electionId, theme, publicationStatus: { not: "PUBLISHED" } } }),
+    // Count only: never expose the text of an unpublished revision here. DRAFT and never
+    // depublished, not merely "not PUBLISHED": depublishMeasure() also sets publicationStatus
+    // back to DRAFT, and a measure we withdrew for cause is not "awaiting review".
+    db.measure.count({
+      where: { electionId, theme, publicationStatus: "DRAFT", depublishedAt: null },
+    }),
     getLatestPublicReviewDate(electionId, theme),
     loadThemesIndex(electionId, electionSlug),
   ]);

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -2,14 +2,19 @@ import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import type { ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
-import { isSubjectPagePublishable } from "@/config/publication-gates";
+import { PUBLICATION_GATES, isSubjectPagePublishable } from "@/config/publication-gates";
 import { getPublicMeasureVoteRelations, type PublicVoteReference } from "@/lib/measures/vote-links";
 import type { VoteRelation } from "@/lib/measures/vote-relation";
-import { getPublicMeasuresByTheme, type PublicMeasure } from "./measures";
+import {
+  getLatestPublicReviewDate,
+  getPublicMeasuresByTheme,
+  type PublicMeasure,
+} from "./measures";
 import {
   getPublicPresidentialCandidates,
   type PublicPresidentialCandidate,
 } from "./presidential-candidates-public";
+import { loadThemesIndex } from "./themes-index";
 
 /**
  * The data of a public subject page: for one theme, each publicly visible candidacy and its published
@@ -44,6 +49,16 @@ export type SubjectPageData = {
   /** Candidacies with at least one currently-defended (non-withdrawn) published measure on the theme. */
   candidaciesWithVerifiedMeasure: number;
   publishable: boolean;
+  /** The publication gate this theme is measured against (spec §4, `PUBLICATION_GATES.pageSujet`). */
+  requiredCandidaciesWithVerifiedMeasure: number;
+  /** Candidacies of the election with a sourced editorial status, the denominator of the coverage rate. */
+  totalSourcedCandidacies: number;
+  /** Measures of the theme not yet published (count only: never the draft text itself). */
+  pendingReviewMeasureCount: number;
+  /** When the most recently reviewed public measure on this theme was reviewed, if any. */
+  lastReviewedAt: Date | null;
+  /** Another theme that already clears the gate, to redirect to when this one does not. */
+  fallbackPublishableTheme: { slug: string; label: string } | null;
 };
 
 /**
@@ -54,12 +69,34 @@ export async function loadSubjectPageData(
   electionSlug: string,
   theme: ThemeCategory
 ): Promise<SubjectPageData> {
-  const [candidates, measures] = await Promise.all([
+  const [
+    candidates,
+    measures,
+    totalSourcedCandidacies,
+    pendingReviewMeasureCount,
+    lastReviewedAt,
+    themesIndex,
+  ] = await Promise.all([
     getPublicPresidentialCandidates(electionSlug),
     // Withdrawn measures stay visible on a subject page (a dropped position is still information), so the
     // read includes them; the gate below counts only the ones still defended.
     getPublicMeasuresByTheme(electionId, theme, { includeWithdrawn: true }),
+    db.candidacy.count({
+      where: {
+        electionId,
+        status: { not: null },
+        sourceUrl: { not: null },
+        sourceLabel: { not: null },
+      },
+    }),
+    // Count only: never expose the text of an unpublished revision here.
+    db.measure.count({ where: { electionId, theme, publicationStatus: { not: "PUBLISHED" } } }),
+    getLatestPublicReviewDate(electionId, theme),
+    loadThemesIndex(electionId, electionSlug),
   ]);
+
+  const fallback = themesIndex.themes.find((t) => t.publishable && t.theme !== theme) ?? null;
+  const fallbackPublishableTheme = fallback ? { slug: fallback.slug, label: fallback.label } : null;
 
   const measuresByCandidacy = new Map<string, PublicMeasure[]>();
   for (const measure of measures) {
@@ -103,6 +140,12 @@ export async function loadSubjectPageData(
     candidates: entries,
     candidaciesWithVerifiedMeasure,
     publishable: isSubjectPagePublishable(candidaciesWithVerifiedMeasure),
+    requiredCandidaciesWithVerifiedMeasure:
+      PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure,
+    totalSourcedCandidacies,
+    pendingReviewMeasureCount,
+    lastReviewedAt,
+    fallbackPublishableTheme,
   };
 }
 

--- a/src/lib/data/themes-index.ts
+++ b/src/lib/data/themes-index.ts
@@ -1,0 +1,105 @@
+import "server-only";
+import { cacheLife, cacheTag } from "next/cache";
+import type { ThemeCategory } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { isSubjectPagePublishable } from "@/config/publication-gates";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { THEMES_IN_ORDER, themeToSlug } from "@/lib/presidentielle/themes";
+import { getPublicMeasuresByElection, type PublicMeasure } from "./measures";
+import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
+
+/**
+ * The read authority for the themes index / hub gate.
+ *
+ * `loadSubjectPageData` (in `./subject-page.ts`) counts `candidaciesWithVerifiedMeasure` by
+ * iterating `getPublicPresidentialCandidates` — candidacies whose `CandidacyPresidential`
+ * extension is PUBLISHED — and counting the ones with at least one currently-defended measure
+ * on the theme. This authority MUST count on that same population, or it would advertise a
+ * subject page as publishable while the page itself renders closed. A measure attached to a
+ * DRAFT-extension candidacy therefore never counts here either, which is why every measure is
+ * intersected against `publicIds` before being bucketed by theme.
+ */
+
+export type ThemeIndexEntry = {
+  theme: ThemeCategory;
+  label: string;
+  slug: string;
+  documentedMeasureCount: number;
+  currentlyDefendedMeasureCount: number;
+  candidaciesWithVerifiedMeasure: number;
+  publishable: boolean;
+};
+
+export type ThemesIndexData = {
+  electionSlug: string;
+  themes: ThemeIndexEntry[];
+  publishableSubjectPageCount: number;
+};
+
+/**
+ * Plain async, integration-testable. Callers on a page use `getThemesIndex`, which caches this.
+ */
+export async function loadThemesIndex(
+  electionId: string,
+  electionSlug: string
+): Promise<ThemesIndexData> {
+  const [measures, publicCandidates] = await Promise.all([
+    getPublicMeasuresByElection(electionId, { includeWithdrawn: true }),
+    getPublicPresidentialCandidates(electionSlug), // the subject-page population
+  ]);
+  const publicIds = new Set(publicCandidates.map((c) => c.id));
+
+  const byTheme = new Map<ThemeCategory, PublicMeasure[]>();
+  for (const m of measures) {
+    // The intersection with publicIds is the whole point: a measure on a DRAFT-extension
+    // candidacy must not inflate the documented count or the gate.
+    if (m.candidacyId === null || !publicIds.has(m.candidacyId)) continue;
+    const list = byTheme.get(m.theme) ?? [];
+    list.push(m);
+    byTheme.set(m.theme, list);
+  }
+
+  const themes: ThemeIndexEntry[] = THEMES_IN_ORDER.map((theme) => {
+    const onTheme = byTheme.get(theme) ?? [];
+    const defended = onTheme.filter((m) => m.withdrawal === null);
+    const candidacies = new Set(defended.map((m) => m.candidacyId as string));
+    return {
+      theme,
+      label: THEME_CATEGORY_LABELS[theme],
+      slug: themeToSlug(theme),
+      documentedMeasureCount: onTheme.length,
+      currentlyDefendedMeasureCount: defended.length,
+      candidaciesWithVerifiedMeasure: candidacies.size,
+      publishable: isSubjectPagePublishable(candidacies.size),
+    };
+  });
+
+  return {
+    electionSlug,
+    themes,
+    publishableSubjectPageCount: themes.filter((t) => t.publishable).length,
+  };
+}
+
+export async function getThemesIndex(electionSlug: string): Promise<ThemesIndexData | null> {
+  const election = await db.election.findUnique({
+    where: { slug: electionSlug },
+    select: { id: true },
+  });
+  if (election === null) return null;
+  return getThemesIndexCached(election.id, electionSlug);
+}
+
+/**
+ * Cached read for the hub page. Tagged the same as the measure authorities, so a measure
+ * write busts it exactly when it busts the subject pages it summarizes.
+ */
+async function getThemesIndexCached(
+  electionId: string,
+  electionSlug: string
+): Promise<ThemesIndexData> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheLife("synced");
+  return loadThemesIndex(electionId, electionSlug);
+}

--- a/src/lib/presidentielle/themes.ts
+++ b/src/lib/presidentielle/themes.ts
@@ -4,7 +4,7 @@ export { themeToSlug, themeFromSlug as parseThemeSlug } from "@/lib/theme-utils"
 
 export const PRESIDENTIELLE_2027_SLUG = "presidentielle-2027";
 
-/** Editorial display order of the 13 themes (topical, announced as such, not a ranking). */
+/** Ordre éditorial d'affichage des 13 thèmes. */
 export const THEMES_IN_ORDER: ThemeCategory[] = [
   "LOGEMENT_URBANISME",
   "SANTE",

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -279,6 +279,41 @@ describe("doctrine — sitemap shares the indexability thresholds (no drift)", (
   });
 });
 
+describe("doctrine — presidentielle-2027 hub stays out of the sitemap while unpublishable", () => {
+  const src = readFileSync(join(process.cwd(), "src/app/sitemap.ts"), "utf8");
+
+  it("imports isHubPublishable rather than a hardcoded threshold", () => {
+    expect(src).toContain('from "@/config/publication-gates"');
+    expect(src).toContain("isHubPublishable");
+  });
+
+  // Scoped to the shard, comments stripped, the same guard as the scrutin shard above: the
+  // election shard must actually gate the URL on isHubPublishable, not merely import it.
+  const electionShard = (() => {
+    const start = src.indexOf("async function buildAffairsPartiesElectionsDepartmentsSitemap");
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf("\nasync function", start + 1);
+    return src
+      .slice(start, end)
+      .split("\n")
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .join("\n");
+  })();
+
+  it("filters the election shard on isHubPublishable before mapping to URLs", () => {
+    expect(electionShard).toContain("PRESIDENTIELLE_2027_SLUG");
+    expect(electionShard).toContain("isHubPublishable(");
+    // Scoped past `const electionPages`: parties and partiesWithAffairs above it also
+    // filter-then-map, so an unscoped search would pass on the wrong pair.
+    const electionPagesAt = electionShard.indexOf("const electionPages");
+    expect(electionPagesAt).toBeGreaterThan(-1);
+    const filterAt = electionShard.indexOf(".filter(", electionPagesAt);
+    const mapAt = electionShard.indexOf(".map(", electionPagesAt);
+    expect(filterAt).toBeGreaterThan(electionPagesAt);
+    expect(mapAt).toBeGreaterThan(filterAt);
+  });
+});
+
 describe("doctrine — opengraph-image assets stay noindexed", () => {
   const require = createRequire(import.meta.url);
   const { pathToRegexp } = require("next/dist/compiled/path-to-regexp") as {

--- a/tests/visual/presidentielle-hub.spec.ts
+++ b/tests/visual/presidentielle-hub.spec.ts
@@ -1,0 +1,65 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Accessibility and responsive checks for the public presidential hub, its themes index, and one
+ * subject page below the publication gate.
+ *
+ * Needs the disposable container seeded with the fictional hub fixtures, and a dev server pointed
+ * at it (never production: `.env` and `.env.prod` share the same Supabase database):
+ *
+ *   docker compose -f docker-compose.test-search.yml up -d
+ *   DATABASE_URL=postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test?sslmode=disable \
+ *     npx prisma db push --url "$DATABASE_URL" --accept-data-loss
+ *   DATABASE_URL=... npx tsx scripts/seed-presidentielle-hub-demo.ts
+ *   DATABASE_URL=... npm run dev
+ *   npx playwright test presidentielle-hub --project=chromium
+ *
+ * Every page is public, so no session is forged: each is read exactly as a visitor sees it.
+ */
+
+const WCAG = ["wcag2a", "wcag2aa", "wcag21aa"];
+const WIDTHS = [375, 768, 1440];
+
+const PAGES = [
+  { name: "hub", path: "/elections/presidentielle-2027" },
+  { name: "index des sujets", path: "/elections/presidentielle-2027/sujets" },
+  {
+    name: "page sujet sous seuil (numérique & tech)",
+    path: "/elections/presidentielle-2027/sujets/numerique-tech",
+  },
+];
+
+/**
+ * How far the PAGE can actually be scrolled sideways, not `scrollWidth - clientWidth` (which also counts
+ * content clipped by overflow:hidden and legitimate inner scrollers). Asking the browser to scroll and
+ * reading back where it landed measures what a visitor experiences.
+ */
+async function horizontalScroll(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    window.scrollTo(2000, 0);
+    const x = window.scrollX;
+    window.scrollTo(0, 0);
+    return x;
+  });
+}
+
+for (const { name, path } of PAGES) {
+  test.describe(`${name} (présidentielle 2027)`, () => {
+    for (const width of WIDTHS) {
+      test(`répond 200, sans violation WCAG AA ni débordement horizontal à ${width}px`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width, height: 900 });
+        const response = await page.goto(path);
+        expect(response?.status()).toBe(200);
+        await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+        expect(await horizontalScroll(page)).toBe(0);
+
+        const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+        expect(results.violations).toEqual([]);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Description

Deuxième PR du lot 4. Elle ouvre les deux surfaces publiques manquantes du hub présidentielle et complète l'état fermé de la page sujet. Aucune surface n'est indexable tant que ses seuils de publication ne sont pas franchis : au lancement, tout rend un état explicite et reste en `noindex, follow`.

**Surfaces**

- Index des sujets `/elections/presidentielle-2027/sujets` : les 13 thèmes, chacun avec son nombre de mesures documentées. Un thème à zéro reste dans la navigation et le dit.
- Hub racine `/elections/presidentielle-2027` : bandeau d'élection (dates, compte à rebours, ajout au calendrier, données structurées), trois portes d'entrée, champ des candidatures sourcées avec leur statut réel, provenance des données, et les deux statistiques de la spec (mesures vérifiées, date de dernière revue).
- Page sujet sous son seuil : le bloc « ce qui manque pour comparer » (candidatures avec mesure vérifiée sur le seuil requis, taux de couverture, mesures en attente de relecture, date de dernière revue) et un renvoi vers un sujet déjà comparable, extrait dans un composant `SubjectGate`.

**Couche données**

Trois autorités de lecture, sur le patron du lot 3 (fonction nue testable + enveloppe `"use cache"` taguée `election-measures:<electionId>`, le tag que bustent déjà les écritures de mesure) : l'index des thèmes, le contexte du hub, et un helper de date de dernière revue qui réutilise le prédicat public existant.

Deux populations sont tenues volontairement distinctes : le **champ** du hub montre toutes les candidatures sourcées de la course (pressenties comprises), tandis que la **publiabilité** d'une page sujet se calcule sur les seules candidatures à extension éditoriale publiée. Un test de parité vérifie thème par thème que l'index et la page sujet concluent la même chose, et son ablation le prouve.

**Correctifs portés**

- Une régression héritée de la PR précédente : un test d'intégration échappait à la garde `db-guard` faute du bon portail.
- La note de l'admin candidats citait une URL périmée et promettait une date ; elle décrit maintenant la règle réelle (ouverture au franchissement du seuil).

## Vérification

- Suite complète verte, `typecheck` code 0, garde de publication propre, eslint sans erreur sur les fichiers changés.
- Sweep Playwright + axe sur le rendu réel (conteneur jetable seedé) : hub, index et page sujet sous seuil, à 375, 768 et 1440 px. Il a trouvé une vraie violation de contraste, corrigée puis reprouvée.
- Le rendu réel confirme les règles éditoriales : aucune statistique en dur, aucun faux zéro sur les compteurs qui dépendent d'un modèle non livré (rendus « — » avec une note), `noindex` sous les seuils.

## Note

`/elections/presidentielle-2027` est désormais servie par le hub et non plus par la page élection générique, qui continue de servir toutes les autres élections. Les éléments que cette URL portait (données structurées, canonical, date du second tour, ajout au calendrier) ont été rapatriés dans le hub.

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Bug fix

## Issue liée

Fixes #

## Checklist

- [x] Le code suit les conventions du projet
- [ ] `npm run lint` : vérifié en CI (bornée à `src/`)
- [ ] `npm run build` : vérifié par le job CI Build
- [x] Les changements sont testés
- [x] Pas de données sensibles (fixtures synthétiques et anonymisées, gardées par le conteneur jetable)
