### PR TITLE
Publier la fiche dont on publie l'affaire judiciaire

### DIFF
--- a/src/app/elections/[slug]/__tests__/static-params.integration.test.ts
+++ b/src/app/elections/[slug]/__tests__/static-params.integration.test.ts
@@ -1,11 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { assertDisposableTestDb } from "@/test/disposable-db";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
 
 // Deferred: both `@/lib/db` and `../page` throw at module load without DATABASE_URL.
 let db: typeof import("@/lib/db").db;
 let generateStaticParams: typeof import("../page").generateStaticParams;
 
-describe("elections/[slug] generateStaticParams", () => {
+describeIfDisposableDb("elections/[slug] generateStaticParams", () => {
   beforeAll(async () => {
     assertDisposableTestDb();
     ({ db } = await import("@/lib/db"));

--- a/src/services/sync/__tests__/publication-status.test.ts
+++ b/src/services/sync/__tests__/publication-status.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { determineStatus, type PoliticianRow } from "../publication-status-rules";
+
+function row(over: Partial<PoliticianRow> = {}): PoliticianRow {
+  return {
+    id: "p1",
+    birthDate: new Date("1970-01-01"),
+    deathDate: null,
+    photoUrl: null,
+    biography: null,
+    publicationStatus: "DRAFT",
+    statusOverride: false,
+    prominenceScore: 15,
+    hasCurrentMandate: false,
+    hasPublishedDirectAffair: false,
+    ...over,
+  };
+}
+
+describe("determineStatus", () => {
+  it("archives a former deputy nobody covers any more", () => {
+    expect(determineStatus(row())).toBe("ARCHIVED");
+  });
+
+  it("publishes a former deputy whose judicial affair we publish", () => {
+    // /politiques and the sitemap only list PUBLISHED profiles. Publishing the
+    // affair while leaving the profile out of both would link readers to a page
+    // the site itself does not acknowledge.
+    expect(determineStatus(row({ hasPublishedDirectAffair: true }))).toBe("PUBLISHED");
+  });
+
+  it("keeps publishing anyone holding a current mandate", () => {
+    expect(determineStatus(row({ hasCurrentMandate: true }))).toBe("PUBLISHED");
+  });
+
+  it("never overrides a manual decision", () => {
+    expect(
+      determineStatus(row({ statusOverride: true, hasPublishedDirectAffair: true }))
+    ).toBeNull();
+  });
+
+  it("leaves pre-1958 deceased figures excluded even with an affair", () => {
+    // The exclusion rules bound the site's scope; a published affair must not
+    // drag a nineteenth-century figure back into the directory.
+    expect(
+      determineStatus(row({ deathDate: new Date("1935-04-02"), hasPublishedDirectAffair: true }))
+    ).toBe("EXCLUDED");
+  });
+
+  it("leaves long-deceased figures archived when no affair is published", () => {
+    expect(determineStatus(row({ deathDate: new Date("1990-01-01") }))).toBe("ARCHIVED");
+  });
+});

--- a/src/services/sync/publication-status-rules.ts
+++ b/src/services/sync/publication-status-rules.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure publication-status decision, kept free of any database import so it can
+ * be unit-tested without a connection. See STATUS_RULES in config/prominence.
+ */
+
+import { PublicationStatus } from "@/generated/prisma";
+import { STATUS_RULES } from "@/config/prominence";
+
+export type PoliticianRow = {
+  id: string;
+  birthDate: Date | null;
+  deathDate: Date | null;
+  photoUrl: string | null;
+  biography: string | null;
+  publicationStatus: PublicationStatus;
+  statusOverride: boolean;
+  prominenceScore: number;
+  hasCurrentMandate: boolean;
+  hasPublishedDirectAffair: boolean;
+};
+
+export function determineStatus(p: PoliticianRow): PublicationStatus | null {
+  // Rule 1: Manual override — don't touch
+  if (p.statusOverride) return null;
+
+  const now = new Date();
+
+  // Rule 2: Deceased before 1958 → EXCLUDED
+  if (p.deathDate && p.deathDate.getFullYear() < STATUS_RULES.excludeDeathBeforeYear) {
+    return PublicationStatus.EXCLUDED;
+  }
+
+  // Rule 3: Born before 1920 AND no current mandate AND low score → EXCLUDED
+  if (
+    p.birthDate &&
+    p.birthDate.getFullYear() < STATUS_RULES.excludeBornBeforeYear &&
+    !p.hasCurrentMandate &&
+    p.prominenceScore < STATUS_RULES.publishThreshold
+  ) {
+    return PublicationStatus.EXCLUDED;
+  }
+
+  // Rule 3b: Publishing someone's judicial affair publishes their profile.
+  // /politiques and the sitemap only list PUBLISHED profiles, so leaving the
+  // profile ARCHIVED or DRAFT would link readers from a published affair to a
+  // page the site excludes from its own directory and index. Prominence has
+  // nothing to say here: this is a consequence of an editorial decision that
+  // has already been taken. Placed after the exclusion rules so a published
+  // affair cannot drag a pre-1958 figure back into scope.
+  if (p.hasPublishedDirectAffair) return PublicationStatus.PUBLISHED;
+
+  // Rule 4: Has current mandate → PUBLISHED
+  if (p.hasCurrentMandate) return PublicationStatus.PUBLISHED;
+
+  // Rule 5: High prominence AND has minimum data → PUBLISHED
+  if (p.prominenceScore >= STATUS_RULES.publishThreshold) {
+    if (!STATUS_RULES.minDataForPublished || p.photoUrl || p.biography) {
+      return PublicationStatus.PUBLISHED;
+    }
+  }
+
+  // Rule 6: Deceased > 10 years → ARCHIVED
+  if (p.deathDate) {
+    const yearsDeceased = (now.getTime() - p.deathDate.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+    if (yearsDeceased > STATUS_RULES.archiveDeathYears) {
+      return PublicationStatus.ARCHIVED;
+    }
+  }
+
+  // Rule 7: Low score AND no current mandate → ARCHIVED
+  if (p.prominenceScore < STATUS_RULES.archiveScoreThreshold && !p.hasCurrentMandate) {
+    return PublicationStatus.ARCHIVED;
+  }
+
+  // Rule 8: Default → DRAFT
+  return PublicationStatus.DRAFT;
+}

--- a/src/services/sync/publication-status.ts
+++ b/src/services/sync/publication-status.ts
@@ -7,7 +7,7 @@
 
 import { db } from "@/lib/db";
 import { PublicationStatus } from "@/generated/prisma";
-import { STATUS_RULES } from "@/config/prominence";
+import { determineStatus, type PoliticianRow } from "./publication-status-rules";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,70 +22,6 @@ export interface PublicationStatusStats {
   skippedOverride: number;
   unchanged: number;
   changes: Record<string, number>;
-}
-
-type PoliticianRow = {
-  id: string;
-  birthDate: Date | null;
-  deathDate: Date | null;
-  photoUrl: string | null;
-  biography: string | null;
-  publicationStatus: PublicationStatus;
-  statusOverride: boolean;
-  prominenceScore: number;
-  hasCurrentMandate: boolean;
-};
-
-// ---------------------------------------------------------------------------
-// Status determination
-// ---------------------------------------------------------------------------
-
-function determineStatus(p: PoliticianRow): PublicationStatus | null {
-  // Rule 1: Manual override — don't touch
-  if (p.statusOverride) return null;
-
-  const now = new Date();
-
-  // Rule 2: Deceased before 1958 → EXCLUDED
-  if (p.deathDate && p.deathDate.getFullYear() < STATUS_RULES.excludeDeathBeforeYear) {
-    return PublicationStatus.EXCLUDED;
-  }
-
-  // Rule 3: Born before 1920 AND no current mandate AND low score → EXCLUDED
-  if (
-    p.birthDate &&
-    p.birthDate.getFullYear() < STATUS_RULES.excludeBornBeforeYear &&
-    !p.hasCurrentMandate &&
-    p.prominenceScore < STATUS_RULES.publishThreshold
-  ) {
-    return PublicationStatus.EXCLUDED;
-  }
-
-  // Rule 4: Has current mandate → PUBLISHED
-  if (p.hasCurrentMandate) return PublicationStatus.PUBLISHED;
-
-  // Rule 5: High prominence AND has minimum data → PUBLISHED
-  if (p.prominenceScore >= STATUS_RULES.publishThreshold) {
-    if (!STATUS_RULES.minDataForPublished || p.photoUrl || p.biography) {
-      return PublicationStatus.PUBLISHED;
-    }
-  }
-
-  // Rule 6: Deceased > 10 years → ARCHIVED
-  if (p.deathDate) {
-    const yearsDeceased = (now.getTime() - p.deathDate.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
-    if (yearsDeceased > STATUS_RULES.archiveDeathYears) {
-      return PublicationStatus.ARCHIVED;
-    }
-  }
-
-  // Rule 7: Low score AND no current mandate → ARCHIVED
-  if (p.prominenceScore < STATUS_RULES.archiveScoreThreshold && !p.hasCurrentMandate) {
-    return PublicationStatus.ARCHIVED;
-  }
-
-  // Rule 8: Default → DRAFT
-  return PublicationStatus.DRAFT;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +48,14 @@ export async function assignPublicationStatus(
         select: { id: true },
         take: 1,
       },
+      // Rule 3b needs to know whether we publish a judicial affair about this
+      // person. Restricted to DIRECT, matching how the prominence affairs score
+      // counts them: being merely mentioned is not a reason to publish a profile.
+      affairs: {
+        where: { publicationStatus: "PUBLISHED", involvement: "DIRECT" },
+        select: { id: true },
+        take: 1,
+      },
     },
   });
 
@@ -130,6 +74,7 @@ export async function assignPublicationStatus(
       statusOverride: p.statusOverride,
       prominenceScore: p.prominenceScore,
       hasCurrentMandate: p.mandates.length > 0,
+      hasPublishedDirectAffair: p.affairs.length > 0,
     };
 
     const targetStatus = determineStatus(row);


### PR DESCRIPTION
Repéré en modérant les affaires du 5 août : Mustapha Laabid et Anne-Christine Lang
portaient une condamnation publiable sur une fiche `ARCHIVED`. En remontant la cause,
le trou s'est révélé bien plus large que ces deux cas.

## Le problème

`/politiques` et le sitemap ne listent que les fiches `PUBLISHED`
(`page.tsx:140`, `sitemap.ts:62`). Une fiche `DRAFT` ou `ARCHIVED` reste atteignable par
URL directe, mais elle est absente de l'annuaire du site et de son index.

Or `determineStatus` ne regardait que la proéminence et le mandat courant. Un ancien
élu sans mandat en cours et sous le seuil de 150 tombe en `DRAFT` (règle 8) ou en
`ARCHIVED` (règle 7), **même quand nous publions sa condamnation**.

Résultat mesuré en base : **46 fiches** portant une affaire publiée en `DIRECT` sont
absentes de l'annuaire et du sitemap. Parmi elles Alain Juppé, Jérôme Cahuzac, Patrick
Balkany, Jean Tiberi, Alain Carignon, Georges Tron, Claude Guéant.

Le site publie leur affaire, la fait figurer dans `/affaires`, y met un lien vers leur
fiche, et exclut cette fiche de son propre annuaire.

## La règle ajoutée

Une affaire publiée en `DIRECT` implique une fiche `PUBLISHED`. C'est la conséquence
d'une décision éditoriale déjà prise, pas une question de proéminence : au moment où on
publie l'affaire, on a tranché que le sujet est d'intérêt public.

Placée **après** les règles d'exclusion, pour qu'une affaire publiée ne puisse pas
ramener dans le périmètre une figure décédée avant 1958. Restreinte à `DIRECT`, comme
le score de proéminence : être simplement mentionné ne justifie pas de publier une
fiche.

## Pourquoi pas un correctif de données

Relancer un sync aurait corrigé les 46 lignes du jour et rien de plus : la prochaine
publication d'affaire aurait recréé l'écart, puisque rien ne recalcule le statut à ce
moment-là. L'invariant devait vivre dans la règle.

## Structure

`determineStatus` était privée et le module importe `@/lib/db`, donc inatteignable en
test unitaire sans exposer la suite à `DATABASE_URL` de production. La décision pure est
sortie dans `publication-status-rules.ts`, sans aucun import de base. Le service ne
garde que la requête et l'application.

## Un correctif hors périmètre, assumé

`main` était rouge en arrivant :
`src/app/elections/[slug]/__tests__/static-params.integration.test.ts`, arrivé avec
#674, écrit en base derrière un `describe` nu, sans le portail `describeIfDisposableDb`
qu'exige le garde `db-guard`. Deux tests échouaient, sans rapport avec ce changement.

Corrigé ici, en trois lignes, pour que cette PR puisse être verte. La CI de #674 avait
été **annulée par la panne GitHub Actions du 6 août**, donc ce test n'a jamais tourné
sur ce merge : la panne n'a pas seulement retardé des PR, elle a laissé passer une
régression sur `main`.

## Vérification

Essai à blanc sur les 37 675 fiches : 46 passages en `PUBLISHED`, **aucune
rétrogradation**, 2 overrides manuels respectés, 37 627 inchangées.

Suite complète : 3551 tests passés, 0 échec. `tsc --noEmit`, `eslint` et `next build`
propres.

Six tests couvrent la règle et ses bornes : promotion d'un ancien député avec affaire,
non-régression sur le mandat courant, respect de l'override manuel, primauté de
l'exclusion pre-1958, archivage inchangé sans affaire.
