### PR TITLE
Dériver le statut d'une élection de ses dates de tour

### DIFF
--- a/src/app/api/elections/calendar/route.ts
+++ b/src/app/api/elections/calendar/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { buildIcsCalendar, type IcsEvent } from "@/lib/ics";
+import { isElectionOver } from "@/lib/elections/status";
 import { SITE_URL } from "@/config/site";
 import { withPublicRoute } from "@/lib/api/with-public-route";
 
 export const GET = withPublicRoute(async () => {
-  const elections = await db.election.findMany({
-    where: {
-      status: { not: "COMPLETED" },
-      round1Date: { not: null },
-    },
+  const rows = await db.election.findMany({
+    where: { round1Date: { not: null } },
     orderBy: { round1Date: "asc" },
     select: {
       slug: true,
@@ -19,8 +17,14 @@ export const GET = withPublicRoute(async () => {
       round2Date: true,
       dateConfirmed: true,
       scope: true,
+      status: true,
     },
   });
+
+  // The stored status lags behind reality, so filter on the resolved phase:
+  // a SQL `status != COMPLETED` still exports scrutins held months ago.
+  const now = new Date();
+  const elections = rows.filter((e) => !isElectionOver(e, now));
 
   const events: IcsEvent[] = [];
 

--- a/src/app/elections/page.tsx
+++ b/src/app/elections/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ElectionCountdown, ElectionTimeline } from "@/components/elections";
 import { ELECTION_TYPE_LABELS, ELECTION_TYPE_ICONS } from "@/config/labels";
 import { getElections, getTypeCounts } from "@/lib/data/elections";
+import { resolveElectionStatus } from "@/lib/elections/status";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import type { ElectionType } from "@/types";
@@ -28,10 +29,14 @@ export default async function ElectionsPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const typeFilter = params.type as ElectionType | undefined;
 
-  const [elections, typeCounts] = await Promise.all([getElections(typeFilter), getTypeCounts()]);
+  const [rawElections, typeCounts] = await Promise.all([getElections(typeFilter), getTypeCounts()]);
+
+  // The stored status never advances on its own, so resolve it here rather than
+  // inside getElections(), which is cached for a day and would freeze `now`.
+  const now = new Date();
+  const elections = rawElections.map((e) => ({ ...e, status: resolveElectionStatus(e, now) }));
 
   // Find next upcoming election
-  const now = new Date();
   const nextElection = elections.find(
     (e) => e.round1Date && e.round1Date > now && e.status !== "COMPLETED"
   );

--- a/src/components/elections/ElectionCard.tsx
+++ b/src/components/elections/ElectionCard.tsx
@@ -117,7 +117,7 @@ export function ElectionCard({
               {totalSeats} sièges
             </span>
           )}
-          {round1Date && (
+          {round1Date && status !== "COMPLETED" && (
             <AddToCalendar
               title={title}
               round1Date={round1Date}

--- a/src/components/elections/ElectionTimeline.tsx
+++ b/src/components/elections/ElectionTimeline.tsx
@@ -6,115 +6,141 @@ interface ElectionTimelineProps {
   elections: Election[];
 }
 
-export function ElectionTimeline({ elections }: ElectionTimelineProps) {
-  // Split elections with/without dates
-  const withDates = elections.filter((e) => e.round1Date !== null);
-  const withoutDates = elections.filter((e) => e.round1Date === null);
+function ElectionEntry({ election }: { election: Election }) {
+  return (
+    <div className="relative flex items-start">
+      <div className="absolute left-2 w-4 h-4 rounded-full border-2 border-primary bg-background flex items-center justify-center mt-1">
+        <span className="text-[8px]" aria-hidden="true">
+          {ELECTION_TYPE_ICONS[election.type]}
+        </span>
+      </div>
+      <div className="pl-12 w-full">
+        <ElectionCard
+          slug={election.slug}
+          type={election.type}
+          title={election.title}
+          shortTitle={election.shortTitle}
+          round1Date={election.round1Date}
+          round2Date={election.round2Date}
+          scope={election.scope}
+          totalSeats={election.totalSeats}
+          suffrage={election.suffrage}
+          status={election.status}
+          dateConfirmed={election.dateConfirmed}
+          description={election.description}
+        />
+      </div>
+    </div>
+  );
+}
 
-  // Pre-compute which elections start a new year section
-  const yearStarts = new Set<string>();
+/** Ids of the elections that open a new year block, in iteration order. */
+function yearStartIds(elections: Election[]): Set<string> {
+  const ids = new Set<string>();
   const seenYears = new Set<number>();
-  for (const election of withDates) {
+  for (const election of elections) {
     const year = election.round1Date!.getFullYear();
     if (!seenYears.has(year)) {
       seenYears.add(year);
-      yearStarts.add(election.id);
+      ids.add(election.id);
     }
   }
+  return ids;
+}
+
+interface TimelineSectionProps {
+  title: string;
+  elections: Election[];
+  /** Elections carrying no round date, grouped at the end of the section. */
+  undated?: Election[];
+  undatedLabel?: string;
+}
+
+function TimelineSection({
+  title,
+  elections,
+  undated = [],
+  undatedLabel = "Dates à confirmer",
+}: TimelineSectionProps) {
+  const yearStarts = yearStartIds(elections);
 
   return (
-    <div className="relative">
-      {/* Vertical line */}
-      <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" aria-hidden="true" />
+    <section>
+      <h2 className="text-lg font-display font-bold tracking-tight mb-4">{title}</h2>
+      <div className="relative">
+        {/* Vertical line */}
+        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" aria-hidden="true" />
 
-      <ol className="space-y-6">
-        {withDates.map((election) => {
-          const year = election.round1Date!.getFullYear();
-          const showYearSeparator = yearStarts.has(election.id);
-
-          return (
+        <ol className="space-y-6">
+          {elections.map((election) => (
             <li key={election.id}>
-              {/* Year separator */}
-              {showYearSeparator && (
+              {yearStarts.has(election.id) && (
                 <div className="relative flex items-center mb-4">
                   <div className="absolute left-1.5 w-5 h-5 rounded-full bg-primary flex items-center justify-center">
                     <span className="text-[10px] font-bold text-primary-foreground">
-                      {String(year).slice(-2)}
+                      {String(election.round1Date!.getFullYear()).slice(-2)}
                     </span>
                   </div>
-                  <span className="pl-12 text-sm font-semibold text-muted-foreground">{year}</span>
-                </div>
-              )}
-
-              {/* Election entry */}
-              <div className="relative flex items-start">
-                <div className="absolute left-2 w-4 h-4 rounded-full border-2 border-primary bg-background flex items-center justify-center mt-1">
-                  <span className="text-[8px]" aria-hidden="true">
-                    {ELECTION_TYPE_ICONS[election.type]}
+                  <span className="pl-12 text-sm font-semibold text-muted-foreground">
+                    {election.round1Date!.getFullYear()}
                   </span>
                 </div>
-                <div className="pl-12 w-full">
-                  <ElectionCard
-                    slug={election.slug}
-                    type={election.type}
-                    title={election.title}
-                    shortTitle={election.shortTitle}
-                    round1Date={election.round1Date}
-                    round2Date={election.round2Date}
-                    scope={election.scope}
-                    totalSeats={election.totalSeats}
-                    suffrage={election.suffrage}
-                    status={election.status}
-                    dateConfirmed={election.dateConfirmed}
-                    description={election.description}
-                  />
+              )}
+              <ElectionEntry election={election} />
+            </li>
+          ))}
+
+          {undated.length > 0 && (
+            <li>
+              <div className="relative flex items-center mb-4">
+                <div className="absolute left-1.5 w-5 h-5 rounded-full bg-muted flex items-center justify-center">
+                  <span className="text-[10px] font-bold text-muted-foreground">?</span>
                 </div>
+                <span className="pl-12 text-sm font-semibold text-muted-foreground">
+                  {undatedLabel}
+                </span>
+              </div>
+              <div className="space-y-4">
+                {undated.map((election) => (
+                  <ElectionEntry key={election.id} election={election} />
+                ))}
               </div>
             </li>
-          );
-        })}
+          )}
+        </ol>
+      </div>
+    </section>
+  );
+}
 
-        {/* Elections without dates */}
-        {withoutDates.length > 0 && (
-          <li>
-            <div className="relative flex items-center mb-4">
-              <div className="absolute left-1.5 w-5 h-5 rounded-full bg-muted flex items-center justify-center">
-                <span className="text-[10px] font-bold text-muted-foreground">?</span>
-              </div>
-              <span className="pl-12 text-sm font-semibold text-muted-foreground">
-                Dates à confirmer
-              </span>
-            </div>
-            <div className="space-y-4">
-              {withoutDates.map((election) => (
-                <div key={election.id} className="relative flex items-start">
-                  <div className="absolute left-2 w-4 h-4 rounded-full border-2 border-muted bg-background flex items-center justify-center mt-1">
-                    <span className="text-[8px]" aria-hidden="true">
-                      {ELECTION_TYPE_ICONS[election.type]}
-                    </span>
-                  </div>
-                  <div className="pl-12 w-full">
-                    <ElectionCard
-                      slug={election.slug}
-                      type={election.type}
-                      title={election.title}
-                      shortTitle={election.shortTitle}
-                      round1Date={election.round1Date}
-                      round2Date={election.round2Date}
-                      scope={election.scope}
-                      totalSeats={election.totalSeats}
-                      suffrage={election.suffrage}
-                      status={election.status}
-                      dateConfirmed={election.dateConfirmed}
-                      description={election.description}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </li>
-        )}
-      </ol>
+export function ElectionTimeline({ elections }: ElectionTimelineProps) {
+  // The page is a calendar: upcoming scrutins come first, chronologically.
+  // Past ones follow, most recent first — nobody scrolls to 2014 on purpose.
+  const upcoming = elections.filter((e) => e.status !== "COMPLETED" && e.round1Date !== null);
+  const undated = elections.filter((e) => e.status !== "COMPLETED" && e.round1Date === null);
+  const past = elections
+    .filter((e) => e.status === "COMPLETED" && e.round1Date !== null)
+    .sort((a, b) => b.round1Date!.getTime() - a.round1Date!.getTime());
+
+  // A completed election with no date at all has nowhere sensible to go on a
+  // timeline; keep it visible at the end rather than dropping it silently.
+  const pastUndated = elections.filter((e) => e.status === "COMPLETED" && e.round1Date === null);
+
+  // Heading wording note: "À venir" is taken — it is the UPCOMING badge printed
+  // on every card just below, and repeating it drains the word of meaning.
+  return (
+    <div className="space-y-10">
+      {(upcoming.length > 0 || undated.length > 0) && (
+        <TimelineSection title="Prochaines élections" elections={upcoming} undated={undated} />
+      )}
+      {(past.length > 0 || pastUndated.length > 0) && (
+        <TimelineSection
+          title="Élections passées"
+          elections={past}
+          undated={pastUndated}
+          undatedLabel="Dates inconnues"
+        />
+      )}
     </div>
   );
 }

--- a/src/components/elections/__tests__/ElectionTimeline.test.tsx
+++ b/src/components/elections/__tests__/ElectionTimeline.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { ElectionTimeline } from "@/components/elections/ElectionTimeline";
+import type { Election } from "@/types";
+
+function makeElection(overrides: Partial<Election> & Pick<Election, "id" | "slug">): Election {
+  return {
+    publicId: null,
+    type: "MUNICIPALES",
+    title: "Élection",
+    shortTitle: null,
+    description: null,
+    round1Date: null,
+    round2Date: null,
+    dateConfirmed: true,
+    registrationDeadline: null,
+    candidacyOpenDate: null,
+    candidacyDeadline: null,
+    campaignStartDate: null,
+    scope: "MUNICIPAL",
+    totalSeats: null,
+    suffrage: "DIRECT",
+    status: "UPCOMING",
+    featured: false,
+    decreeUrl: null,
+    sourceUrl: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Election;
+}
+
+const MUNICIPALES_2026 = makeElection({
+  id: "e-muni-2026",
+  slug: "municipales-2026",
+  title: "Élections municipales de 2026",
+  status: "COMPLETED",
+  round1Date: new Date("2026-03-15T00:00:00Z"),
+  round2Date: new Date("2026-03-22T00:00:00Z"),
+});
+
+const MUNICIPALES_2020 = makeElection({
+  id: "e-muni-2020",
+  slug: "municipales-2020",
+  title: "Élections municipales de 2020",
+  status: "COMPLETED",
+  round1Date: new Date("2020-03-15T00:00:00Z"),
+});
+
+const SENATORIALES_2026 = makeElection({
+  id: "e-senat-2026",
+  slug: "senatoriales-2026",
+  title: "Élections sénatoriales de 2026",
+  type: "SENATORIALES",
+  scope: "NATIONAL",
+  suffrage: "INDIRECT",
+  status: "UPCOMING",
+  round1Date: new Date("2026-09-28T00:00:00Z"),
+  dateConfirmed: false,
+});
+
+const REGIONALES_2028 = makeElection({
+  id: "e-regio-2028",
+  slug: "regionales-2028",
+  title: "Élections régionales de 2028",
+  type: "REGIONALES",
+  scope: "REGIONAL",
+  status: "UPCOMING",
+});
+
+function section(name: string) {
+  return screen.getByRole("heading", { name, level: 2 }).closest("section")!;
+}
+
+describe("ElectionTimeline", () => {
+  const elections = [MUNICIPALES_2020, MUNICIPALES_2026, SENATORIALES_2026, REGIONALES_2028];
+
+  it("range une élection terminée dans la section des scrutins passés", () => {
+    render(<ElectionTimeline elections={elections} />);
+
+    expect(
+      within(section("Élections passées")).getByText("Élections municipales de 2026")
+    ).toBeInTheDocument();
+    expect(
+      within(section("Prochaines élections")).queryByText("Élections municipales de 2026")
+    ).not.toBeInTheDocument();
+  });
+
+  it("place les scrutins à venir dans leur propre section, datés ou non", () => {
+    render(<ElectionTimeline elections={elections} />);
+
+    const upcoming = within(section("Prochaines élections"));
+    expect(upcoming.getByText("Élections sénatoriales de 2026")).toBeInTheDocument();
+    expect(upcoming.getByText("Élections régionales de 2028")).toBeInTheDocument();
+  });
+
+  it("affiche les élections passées de la plus récente à la plus ancienne", () => {
+    render(<ElectionTimeline elections={elections} />);
+
+    const titles = within(section("Élections passées"))
+      .getAllByRole("link")
+      .map((a) => a.textContent);
+
+    expect(titles).toEqual(["Élections municipales de 2026", "Élections municipales de 2020"]);
+  });
+
+  it("n'affiche pas de section vide quand tous les scrutins sont passés", () => {
+    render(<ElectionTimeline elections={[MUNICIPALES_2020, MUNICIPALES_2026]} />);
+
+    expect(screen.queryByRole("heading", { name: "Prochaines élections" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Élections passées" })).toBeInTheDocument();
+  });
+
+  it("propose « Ajouter au calendrier » sur les scrutins à venir seulement", () => {
+    render(<ElectionTimeline elections={elections} />);
+
+    // Seules les sénatoriales sont à venir ET datées.
+    expect(screen.getAllByLabelText("Ajouter au calendrier")).toHaveLength(1);
+    expect(
+      within(section("Élections passées")).queryByLabelText("Ajouter au calendrier")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/elections/__tests__/status.test.ts
+++ b/src/lib/elections/__tests__/status.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { resolveElectionStatus } from "../status";
+
+const AOUT_2026 = new Date("2026-08-07T10:00:00Z");
+
+describe("resolveElectionStatus", () => {
+  it("marque terminée une élection à deux tours dont les deux tours sont passés", () => {
+    // Cas réel : municipales 2026, restées bloquées sur CANDIDACIES en base
+    // parce que le sync candidatures a écrit ce statut la nuit du 1er tour.
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CANDIDACIES",
+          round1Date: new Date("2026-03-15T00:00:00Z"),
+          round2Date: new Date("2026-03-22T00:00:00Z"),
+        },
+        AOUT_2026
+      )
+    ).toBe("COMPLETED");
+  });
+
+  it("marque terminée une élection à un seul tour une fois le jour du scrutin écoulé", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CAMPAIGN",
+          round1Date: new Date("2026-09-28T00:00:00Z"),
+          round2Date: null,
+        },
+        new Date("2026-09-29T08:00:00Z")
+      )
+    ).toBe("COMPLETED");
+  });
+
+  it("laisse intact le statut stocké tant que le 1er tour n'a pas eu lieu", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "UPCOMING",
+          round1Date: new Date("2026-09-28T00:00:00Z"),
+          round2Date: null,
+        },
+        AOUT_2026
+      )
+    ).toBe("UPCOMING");
+  });
+
+  it("ne devine pas les phases de pré-campagne stockées manuellement", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CAMPAIGN",
+          round1Date: new Date("2027-04-11T00:00:00Z"),
+          round2Date: new Date("2027-04-25T00:00:00Z"),
+        },
+        AOUT_2026
+      )
+    ).toBe("CAMPAIGN");
+  });
+
+  it("renvoie ROUND_1 le jour du premier tour", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CAMPAIGN",
+          round1Date: new Date("2026-03-15T00:00:00Z"),
+          round2Date: new Date("2026-03-22T00:00:00Z"),
+        },
+        new Date("2026-03-15T18:00:00Z")
+      )
+    ).toBe("ROUND_1");
+  });
+
+  it("renvoie BETWEEN_ROUNDS entre les deux tours", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CANDIDACIES",
+          round1Date: new Date("2026-03-15T00:00:00Z"),
+          round2Date: new Date("2026-03-22T00:00:00Z"),
+        },
+        new Date("2026-03-18T12:00:00Z")
+      )
+    ).toBe("BETWEEN_ROUNDS");
+  });
+
+  it("renvoie ROUND_2 le jour du second tour", () => {
+    expect(
+      resolveElectionStatus(
+        {
+          status: "CANDIDACIES",
+          round1Date: new Date("2026-03-15T00:00:00Z"),
+          round2Date: new Date("2026-03-22T00:00:00Z"),
+        },
+        new Date("2026-03-22T09:00:00Z")
+      )
+    ).toBe("ROUND_2");
+  });
+
+  it("ne rétrograde jamais un statut stocké plus avancé que la date", () => {
+    // Un scrutin joué en un seul tour alors qu'un 2nd tour était programmé :
+    // la rédaction a saisi COMPLETED, les dates diraient BETWEEN_ROUNDS.
+    expect(
+      resolveElectionStatus(
+        {
+          status: "COMPLETED",
+          round1Date: new Date("2026-03-15T00:00:00Z"),
+          round2Date: new Date("2026-03-22T00:00:00Z"),
+        },
+        new Date("2026-03-18T12:00:00Z")
+      )
+    ).toBe("COMPLETED");
+  });
+
+  it("laisse intact le statut d'une élection sans date connue", () => {
+    expect(
+      resolveElectionStatus({ status: "UPCOMING", round1Date: null, round2Date: null }, AOUT_2026)
+    ).toBe("UPCOMING");
+  });
+
+  it("gère un 2nd tour renseigné sans 1er tour sans planter", () => {
+    expect(
+      resolveElectionStatus(
+        { status: "UPCOMING", round1Date: null, round2Date: new Date("2026-03-22T00:00:00Z") },
+        AOUT_2026
+      )
+    ).toBe("COMPLETED");
+  });
+});

--- a/src/lib/elections/status.ts
+++ b/src/lib/elections/status.ts
@@ -1,0 +1,83 @@
+import type { ElectionStatus } from "@/types";
+
+/**
+ * Election.status is a stored column with no automatic transition: the only
+ * writer is the candidacy sync, which pins it to CANDIDACIES after an import.
+ * Once the ballot has been held the stored value rots, so the phases that dates
+ * alone can prove are derived at read time instead of being trusted from the DB.
+ *
+ * Only post-round phases are derived. Everything before the first round
+ * (REGISTRATION, CANDIDACIES, CAMPAIGN) stays editorially curated.
+ */
+
+const PHASE_ORDER: ElectionStatus[] = [
+  "UPCOMING",
+  "REGISTRATION",
+  "CANDIDACIES",
+  "CAMPAIGN",
+  "ROUND_1",
+  "BETWEEN_ROUNDS",
+  "ROUND_2",
+  "COMPLETED",
+];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface ElectionStatusInput {
+  status: ElectionStatus;
+  round1Date: Date | null;
+  round2Date: Date | null;
+}
+
+/**
+ * Round dates are stored at midnight UTC, so a polling day spans
+ * [date, date + 24h) in UTC — about 02:00 to 02:00 Paris time in summer.
+ * Day-level precision is what a status badge needs.
+ */
+function isPollingDay(now: Date, date: Date): boolean {
+  const start = date.getTime();
+  return now.getTime() >= start && now.getTime() < start + DAY_MS;
+}
+
+function isPast(now: Date, date: Date): boolean {
+  return now.getTime() >= date.getTime() + DAY_MS;
+}
+
+function deriveFromDates(election: ElectionStatusInput, now: Date): ElectionStatus | null {
+  const { round1Date, round2Date } = election;
+
+  if (round2Date) {
+    if (isPast(now, round2Date)) return "COMPLETED";
+    if (isPollingDay(now, round2Date)) return "ROUND_2";
+  }
+
+  if (round1Date) {
+    if (isPast(now, round1Date)) return round2Date ? "BETWEEN_ROUNDS" : "COMPLETED";
+    if (isPollingDay(now, round1Date)) return "ROUND_1";
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the phase actually reached by an election, combining what is stored
+ * with what its round dates prove. Never downgrades: an election flagged
+ * COMPLETED by an editor stays COMPLETED even if a second round was scheduled
+ * and never held.
+ */
+export function resolveElectionStatus(
+  election: ElectionStatusInput,
+  now: Date = new Date()
+): ElectionStatus {
+  const derived = deriveFromDates(election, now);
+  if (!derived) return election.status;
+
+  return PHASE_ORDER.indexOf(derived) > PHASE_ORDER.indexOf(election.status)
+    ? derived
+    : election.status;
+}
+
+/** An election is over once its resolved phase is COMPLETED. */
+export function isElectionOver(election: ElectionStatusInput, now: Date = new Date()): boolean {
+  return resolveElectionStatus(election, now) === "COMPLETED";
+}


### PR DESCRIPTION
## Le problème

Sur `/elections`, les municipales 2026 affichaient le badge « Candidatures » cinq mois après le second tour.

`Election.status` est une colonne stockée sans aucune transition automatique. Le seul code qui l'écrit est le sync candidatures (`src/services/sync/candidatures.ts:562`), qui la force à `CANDIDACIES` après un import. Il a tourné dans la nuit du 1er tour (`updatedAt: 2026-03-15 00:31`) et plus rien n'a fait avancer le statut depuis. Aucun cron, aucune dérivation par date.

Le même pourrissement était garanti sur les sénatoriales du 28 septembre, puis sur la présidentielle 2027.

Trois symptômes, une cause :

| Endroit                   | Symptôme                                                                           |
| ------------------------- | ---------------------------------------------------------------------------------- |
| `/elections`              | badge « Candidatures » sur un scrutin clos                                         |
| `/api/elections/calendar` | le flux ICS exportait encore le 15 mars 2026 comme événement à venir               |
| Timeline                  | tri croissant sans césure : une page « Calendrier électoral » qui démarre sur 2014 |

## Le correctif

**`resolveElectionStatus(election, now)`**, fonction pure dans `src/lib/elections/status.ts`. Elle ne dérive que les phases que les dates prouvent (`ROUND_1`, `BETWEEN_ROUNDS`, `ROUND_2`, `COMPLETED`) et laisse la pré-campagne à la saisie éditoriale. Elle ne rétrograde jamais : un `COMPLETED` saisi à la main tient face à un second tour programmé mais jamais joué.

Deux raisons de dériver plutôt que d'écrire en base :

- `getElections()` est derrière `"use cache"` avec `cacheLife("synced")`, soit revalidate 24h (`next.config.ts:17`). Un `new Date()` appelé dedans serait figé. La résolution se fait donc dans la page, pas dans la couche data.
- Un statut dérivé ne peut pas être écrasé au prochain import de candidatures.

**Timeline en deux sections.** « Prochaines élections » en ordre croissant, puis « Élections passées » en ordre décroissant. Le titre de section évite « À venir », qui est déjà le libellé du badge `UPCOMING` imprimé sur chaque carte juste en dessous.

**Bouton agenda retiré des scrutins terminés.** Il s'affichait sur les municipales 2014.

**Flux ICS** filtré sur le statut résolu au lieu du `status != COMPLETED` en SQL. Il passe de 5 à 3 événements.

## Rendu vérifié

HTML réellement servi par le dev server :

```
H1  Calendrier électoral
H2  Prochaines élections
      2026  Élections sénatoriales de 2026      [À venir]
      2027  Élection présidentielle de 2027     [À venir]
      Dates à confirmer
            européennes 2029, régionales 2028, départementales 2028, législatives 2029
H2  Élections passées
      2026  Élections municipales de 2026       [Terminée]
      2024  Élections législatives de 2024      [Terminée]
      2022  Élection présidentielle de 2022     [Terminée]
      2020  Elections municipales 2020          [Terminée]
      2014  Elections municipales 2014          [Terminée]
```

Hiérarchie de titres H1 puis H2, deux occurrences de `aria-label="Ajouter au calendrier"` contre sept avant.

## Tests

- `src/lib/elections/__tests__/status.test.ts` : 10 cas, dont le cas municipales 2026 exact, le non-rétrogradage, le scrutin à un seul tour, les bornes de jour de scrutin.
- `src/components/elections/__tests__/ElectionTimeline.test.tsx` : 5 cas de garde sur le rangement, l'ordre décroissant des passées, l'absence de section vide, le bouton agenda.

`tsc --noEmit` propre. `eslint` 0 erreur. Suite complète : 3588 tests passés, 49 fichiers skippés (gates DB).

## Hors périmètre, à trancher séparément

**La fiche `/elections/[slug]`** porte le même défaut : `showCountdown` et l'affichage des résultats sont gatés sur `election.status` brut (`page.tsx:152` et `:401`). Les sénatoriales afficheront un compte à rebours vers une date passée le 29 septembre. Même correctif à appliquer, mais ça touche la logique d'affichage d'une autre page.

**La valeur en base** reste `CANDIDACIES`. `getFeaturedElection()` et `getUpcomingElections()` filtrent en SQL, donc les municipales 2026 restent l'élection mise en avant sur la home. Le bandeau se dégrade proprement (pas de « J-x », il affiche « Résultats disponibles »), mais c'est un choix éditorial à valider.
