### PR TITLE
Corriger la dette de fraîcheur et de compteurs du hub présidentielle

### DIFF
--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -90,6 +90,7 @@ else
     src/lib/data/__tests__/hub.integration.test.ts \
     src/lib/data/__tests__/latest-review-date.integration.test.ts \
     src/lib/data/__tests__/measures.integration.test.ts \
+    src/lib/data/__tests__/pending-review-and-review-date.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
     src/lib/data/__tests__/priorites.integration.test.ts \
     src/lib/data/__tests__/subject-page.integration.test.ts \

--- a/src/app/api/admin/candidats/[id]/route.ts
+++ b/src/app/api/admin/candidats/[id]/route.ts
@@ -5,13 +5,16 @@ import { withValidation } from "@/lib/security/validate";
 import { updateCandidatePresidentialSchema } from "@/lib/security/schemas";
 import { getRequestMeta } from "@/lib/security/audit";
 import { invalidateEntity } from "@/lib/cache";
+import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 
 export const PATCH = withAdminAuth(
   withValidation(updateCandidatePresidentialSchema, async (request, context, body) => {
     const { id } = await context.params;
     const existing = await db.candidacyPresidential.findUnique({
       where: { id },
-      select: { id: true, candidacyId: true },
+      // electionId comes along on the existence check rather than in a second query: the hub
+      // reads are tagged per election and need it to be invalidated.
+      select: { id: true, candidacyId: true, candidacy: { select: { electionId: true } } },
     });
     if (!existing) {
       return NextResponse.json({ error: "Métadonnées candidature non trouvées" }, { status: 404 });
@@ -42,6 +45,9 @@ export const PATCH = withAdminAuth(
       },
     });
     invalidateEntity("election");
+    // A PATCH can flip publicationStatus, which is exactly what opens or closes the four hub
+    // surfaces. `invalidateEntity("election")` purges the `elections` tag and never reaches them.
+    invalidatePresidentialCandidacyTags(existing.candidacy.electionId);
     return NextResponse.json(updated);
   })
 );
@@ -50,7 +56,9 @@ export const DELETE = withAdminAuth(async (request, context) => {
   const { id } = await context.params;
   const existing = await db.candidacyPresidential.findUnique({
     where: { id },
-    select: { id: true, candidacyId: true },
+    // Read before the delete, because the row is gone afterwards and the election id would need
+    // a second query through the candidacy.
+    select: { id: true, candidacyId: true, candidacy: { select: { electionId: true } } },
   });
   if (!existing) {
     return NextResponse.json({ error: "Métadonnées candidature non trouvées" }, { status: 404 });
@@ -71,5 +79,8 @@ export const DELETE = withAdminAuth(async (request, context) => {
     },
   });
   invalidateEntity("election");
+  // Deleting a PUBLISHED extension removes a candidacy from the subject pages, which can close a
+  // subject that was open. Same tag as publication, same reason.
+  invalidatePresidentialCandidacyTags(existing.candidacy.electionId);
   return NextResponse.json({ success: true });
 });

--- a/src/app/api/admin/candidats/route.ts
+++ b/src/app/api/admin/candidats/route.ts
@@ -6,6 +6,7 @@ import { createCandidacyPresidentialFromPickerSchema } from "@/lib/security/sche
 import { getRequestMeta } from "@/lib/security/audit";
 import { getCandidates2027ForModeration } from "@/lib/data/candidates";
 import { invalidateEntity } from "@/lib/cache";
+import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 
 export const GET = withAdminAuth(async () => {
   const items = await getCandidates2027ForModeration();
@@ -104,6 +105,9 @@ export const POST = withAdminAuth(
     });
 
     invalidateEntity("election");
+    // The hub reads gate on the extension's publication status, and `invalidateEntity("election")`
+    // does not reach them. The election id comes from the row just created, so this costs no query.
+    invalidatePresidentialCandidacyTags(outcome.candidacy.electionId);
     return NextResponse.json(
       { candidacy: outcome.candidacy, presidential: outcome.presidential },
       { status: 201 }

--- a/src/app/elections/presidentielle-2027/_components/HubClosedState.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubClosedState.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { PUBLICATION_GATES } from "@/config/publication-gates";
+
+/**
+ * The hub below its own gate.
+ *
+ * `hubPublishable` drove only `robots: noindex`, so a reader landing on the page saw the entry
+ * cards and the field with nothing saying that no comparison is open yet. The state is now written
+ * on the page, not only in a meta tag.
+ *
+ * It adds a block and hides nothing: the field, the provenance and the route to the themes index
+ * all stay. The index is legitimate while closed, since it shows the coverage of each subject and
+ * what is missing.
+ */
+export function HubClosedState({
+  verifiedMeasureCount,
+  themeCount,
+}: {
+  verifiedMeasureCount: number;
+  themeCount: number;
+}) {
+  const required = PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure;
+
+  return (
+    <section
+      aria-labelledby="hub-closed"
+      className="rounded-lg border border-border bg-muted/40 p-4"
+    >
+      <h2 id="hub-closed" className="text-base font-semibold">
+        Les comparaisons ne sont pas encore ouvertes
+      </h2>
+      <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+        {verifiedMeasureCount === 0
+          ? "Aucune mesure vérifiée n'est encore publiée."
+          : `${verifiedMeasureCount} ${verifiedMeasureCount === 1 ? "mesure vérifiée" : "mesures vérifiées"} à ce jour.`}{" "}
+        Un sujet s&apos;ouvre à la comparaison quand {required} candidatures y portent une mesure
+        vérifiée, et aucun des {themeCount} sujets n&apos;atteint ce seuil.{" "}
+        <Link
+          href="/elections/presidentielle-2027/sujets"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          L&apos;index des sujets
+        </Link>{" "}
+        montre, pour chacun, ce qui manque.
+      </p>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubClosedState.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubClosedState.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PUBLICATION_GATES } from "@/config/publication-gates";
+import { HubClosedState } from "../HubClosedState";
+
+describe("HubClosedState", () => {
+  it("nomme l'état et renvoie vers l'index des sujets", () => {
+    render(<HubClosedState verifiedMeasureCount={0} themeCount={13} />);
+
+    expect(
+      screen.getByRole("heading", { name: /Les comparaisons ne sont pas encore ouvertes/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /index des sujets/i })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/sujets"
+    );
+  });
+
+  it("dit l'absence de mesure au lieu d'annoncer « 0 mesures vérifiées »", () => {
+    render(<HubClosedState verifiedMeasureCount={0} themeCount={13} />);
+    expect(screen.getByText(/Aucune mesure vérifiée n'est encore publiée/)).toBeInTheDocument();
+  });
+
+  it("accorde le singulier sur une seule mesure", () => {
+    render(<HubClosedState verifiedMeasureCount={1} themeCount={13} />);
+    expect(screen.getByText(/1 mesure vérifiée à ce jour/)).toBeInTheDocument();
+  });
+
+  it("lit le seuil dans PUBLICATION_GATES plutôt que de le coder en dur", () => {
+    render(<HubClosedState verifiedMeasureCount={4} themeCount={13} />);
+    const attendu = PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure;
+    expect(
+      screen.getByText(new RegExp(`quand ${attendu} candidatures y portent une mesure vérifiée`))
+    ).toBeInTheDocument();
+    expect(screen.getByText(/aucun des 13 sujets n'atteint ce seuil/)).toBeInTheDocument();
+  });
+
+  it("n'invoque ni neutralité ni absence de classement", () => {
+    // Le bloc dit un état de couverture, pas une posture éditoriale.
+    const { container } = render(<HubClosedState verifiedMeasureCount={0} themeCount={13} />);
+    const texte = (container.textContent ?? "").toLowerCase();
+    for (const mot of ["neutralit", "classement", "impartial", "objectivit"]) {
+      expect(texte).not.toContain(mot);
+    }
+  });
+});

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -11,6 +11,7 @@ import { formatDate } from "@/lib/utils";
 import { SITE_URL } from "@/config/site";
 import { DataProvenance } from "./_components/DataProvenance";
 import { HubCandidacyField } from "./_components/HubCandidacyField";
+import { HubClosedState } from "./_components/HubClosedState";
 import { HubEntryCards } from "./_components/HubEntryCards";
 import { HubStats } from "./_components/HubStats";
 
@@ -162,6 +163,14 @@ export default async function PresidentialHubPage() {
             </Card>
           </div>
         </header>
+
+        {/* Below the gate the body says so too, instead of leaving the state in a meta tag. */}
+        {!context.hubPublishable && (
+          <HubClosedState
+            verifiedMeasureCount={context.verifiedMeasureCount}
+            themeCount={themeCount}
+          />
+        )}
 
         <HubEntryCards />
 

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
@@ -21,8 +21,10 @@ function formatCoverageRate(covered: number, total: number): string {
 }
 
 export function SubjectGate({ data }: { data: SubjectPageData }) {
-  const measureWord =
-    data.pendingReviewMeasureCount === 1 ? "mesure extraite" : "mesures extraites";
+  // "révision" and not "mesure extraite": the counter is on the active revision, and a revision
+  // can be a correction to a measure that is already published. Saying "extraite" would also claim
+  // an extraction step that the number does not attest.
+  const revisionWord = data.pendingReviewRevisionCount === 1 ? "révision" : "révisions";
 
   return (
     <section
@@ -52,9 +54,9 @@ export function SubjectGate({ data }: { data: SubjectPageData }) {
             </dd>
           </div>
           <div>
-            <dt>Relecture en attente</dt>
+            <dt>Révisions en attente de relecture</dt>
             <dd className="font-medium text-foreground">
-              {data.pendingReviewMeasureCount} {measureWord} en attente de relecture
+              {data.pendingReviewRevisionCount} {revisionWord}
             </dd>
           </div>
           <div>
@@ -65,16 +67,16 @@ export function SubjectGate({ data }: { data: SubjectPageData }) {
           </div>
           <div>
             <dt>Éditions de programme ne couvrant pas ce sujet</dt>
-            <dd className="font-medium text-foreground">—</dd>
+            <dd className="font-medium text-foreground">Non calculable</dd>
           </div>
           <div>
             <dt>Candidatures sans programme publié</dt>
-            <dd className="font-medium text-foreground">—</dd>
+            <dd className="font-medium text-foreground">Non calculable</dd>
           </div>
         </dl>
         <p className="text-xs">
-          Donnée programme à venir : ces deux derniers compteurs dépendent des éditions de
-          programme, pas encore disponibles.
+          Ces deux compteurs restent non calculables tant que le suivi des programmes publiés
+          n&apos;est pas disponible.
         </p>
       </div>
       {data.fallbackPublishableTheme !== null && (

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -81,7 +81,7 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
     publishable: true,
     requiredCandidaciesWithVerifiedMeasure: 2,
     totalSourcedCandidacies: 3,
-    pendingReviewMeasureCount: 0,
+    pendingReviewRevisionCount: 0,
     lastReviewedAt: null,
     fallbackPublishableTheme: null,
     ...over,

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
@@ -12,7 +12,7 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
     publishable: false,
     requiredCandidaciesWithVerifiedMeasure: 2,
     totalSourcedCandidacies: 4,
-    pendingReviewMeasureCount: 3,
+    pendingReviewRevisionCount: 3,
     lastReviewedAt: new Date("2027-02-10T00:00:00Z"),
     fallbackPublishableTheme: null,
     ...over,
@@ -38,8 +38,10 @@ describe("SubjectGate", () => {
       <SubjectGate data={data({ candidaciesWithVerifiedMeasure: 0, totalSourcedCandidacies: 0 })} />
     );
     expect(screen.queryByText("0 %")).not.toBeInTheDocument();
-    // Three dashes now: the coverage rate joins the two ProgramEdition placeholders.
-    expect(screen.getAllByText("—")).toHaveLength(3);
+    // Un seul tiret désormais : les deux compteurs programme disent « Non calculable », qui ne
+    // veut pas la même chose. Le tiret signale un rapport sans dénominateur, pas une donnée
+    // qu'on ne sait pas produire.
+    expect(screen.getAllByText("—")).toHaveLength(1);
   });
 
   it("borne le taux à 100 % quand le numérateur dépasse le dénominateur", () => {
@@ -49,14 +51,26 @@ describe("SubjectGate", () => {
     expect(screen.getByText("100 %")).toBeInTheDocument();
   });
 
-  it("affiche le nombre de mesures extraites en attente de relecture", () => {
-    render(<SubjectGate data={data({ pendingReviewMeasureCount: 3 })} />);
-    expect(screen.getByText(/3 mesures extraites en attente de relecture/)).toBeInTheDocument();
+  it("compte des révisions, et n'affirme pas une extraction que le chiffre n'atteste pas", () => {
+    render(<SubjectGate data={data({ pendingReviewRevisionCount: 3 })} />);
+    expect(screen.getByText("Révisions en attente de relecture")).toBeInTheDocument();
+    expect(screen.getByText("3 révisions")).toBeInTheDocument();
+    // Le compteur porte sur la révision active : une correction sur une mesure déjà publiée y
+    // figure, et « mesure extraite » décrirait autre chose.
+    expect(screen.queryByText(/extraite/)).not.toBeInTheDocument();
   });
 
-  it("accorde au singulier quand une seule mesure est en attente", () => {
-    render(<SubjectGate data={data({ pendingReviewMeasureCount: 1 })} />);
-    expect(screen.getByText(/1 mesure extraite en attente de relecture/)).toBeInTheDocument();
+  it("accorde au singulier quand une seule révision est en attente", () => {
+    render(<SubjectGate data={data({ pendingReviewRevisionCount: 1 })} />);
+    expect(screen.getByText("1 révision")).toBeInTheDocument();
+  });
+
+  it("dit les deux compteurs programme non calculables, sans tiret ambigu", () => {
+    render(<SubjectGate data={data()} />);
+    expect(screen.getAllByText("Non calculable")).toHaveLength(2);
+    expect(
+      screen.getByText(/tant que le suivi des programmes publiés n'est pas disponible/)
+    ).toBeInTheDocument();
   });
 
   it("affiche la date de dernière revue publique, au format français", () => {
@@ -67,12 +81,6 @@ describe("SubjectGate", () => {
   it("affiche « jamais relu » quand aucune revue publique n'a eu lieu", () => {
     render(<SubjectGate data={data({ lastReviewedAt: null })} />);
     expect(screen.getByText(/jamais relu/i)).toBeInTheDocument();
-  });
-
-  it("rend les deux compteurs ProgramEdition en tiret, jamais en zéro trompeur", () => {
-    render(<SubjectGate data={data()} />);
-    expect(screen.getAllByText("—")).toHaveLength(2);
-    expect(screen.getByText(/donnée programme à venir/i)).toBeInTheDocument();
   });
 
   it("propose un renvoi vers un sujet comparable quand fallbackPublishableTheme est fourni", () => {

--- a/src/lib/data/__tests__/pending-review-and-review-date.integration.test.ts
+++ b/src/lib/data/__tests__/pending-review-and-review-date.integration.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ThemeCategory } from "@/generated/prisma";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value, which throws at module load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let transitions: typeof import("@/lib/measures/transitions");
+let loadSubjectPageData: typeof import("../subject-page").loadSubjectPageData;
+let loadHubMeasureContext: typeof import("../hub").loadHubMeasureContext;
+
+const SLUG = "pending-review-test";
+const THEME: ThemeCategory = "LOGEMENT_URBANISME";
+
+/**
+ * Two invariants of the lot 4-5 debt, on the same fixture because they share it.
+ *
+ * `pendingReviewRevisionCount` must describe the ACTIVE REVISION, not the measure's publication
+ * status: a published measure carrying an unreviewed correction is awaiting review, and a draft
+ * whose revision was already reviewed is not.
+ *
+ * `lastReviewedAt` on the hub must come from the population the subject pages can render. A
+ * measure behind a DRAFT extension, or attached to no candidacy, is unreachable there and must not
+ * move the date the hub displays next to a count derived from that same population.
+ */
+describeIfDisposableDb("pendingReviewRevisionCount et lastReviewedAt", () => {
+  let electionId: string;
+  let publicCandidacyId: string;
+  let publicPoliticianId: string;
+  let draftCandidacyId: string;
+  let draftPoliticianId: string;
+
+  async function seedMeasure(
+    politicianId: string,
+    candidacyId: string | null,
+    text: string,
+    theme: ThemeCategory = THEME
+  ) {
+    return transitions.createMeasure({
+      politicianId,
+      electionId,
+      candidacyId,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme,
+      precedingMeasureId: null,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-01-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/meeting",
+          page: null,
+          publishedAt: new Date("2027-01-01T00:00:00Z"),
+        },
+      ],
+    });
+  }
+
+  async function reviewAndPublish(seed: { measureId: string; revisionId: string }) {
+    await transitions.reviewMeasureRevision({ ...seed, reviewedBy: "relecteur" });
+    await transitions.publishMeasureRevision(seed);
+  }
+
+  async function newDraftOn(measureId: string, text: string) {
+    return transitions.draftMeasureRevision({
+      measureId,
+      revision: {
+        text,
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-02-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/correction",
+          page: null,
+          publishedAt: new Date("2027-02-01T00:00:00Z"),
+        },
+      ],
+    });
+  }
+
+  async function candidacy(name: string, extension: "PUBLISHED" | "DRAFT") {
+    const pol = await db.politician.create({
+      data: {
+        slug: `${SLUG}-${name.toLowerCase()}`,
+        firstName: name,
+        lastName: "Fixture",
+        fullName: `${name} Fixture`,
+        source: "MANUAL",
+      },
+      select: { id: true },
+    });
+    const cand = await db.candidacy.create({
+      data: {
+        electionId,
+        politicianId: pol.id,
+        candidateName: `${name} Fixture`,
+        status: "DECLARE",
+        sourceUrl: "https://example.org/source",
+        sourceLabel: "Source",
+      },
+      select: { id: true },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: cand.id, publicationStatus: extension },
+    });
+    return { politicianId: pol.id, candidacyId: cand.id };
+  }
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    transitions = await import("@/lib/measures/transitions");
+    ({ loadSubjectPageData } = await import("../subject-page"));
+    ({ loadHubMeasureContext } = await import("../hub"));
+
+    const election = await db.election.create({
+      data: {
+        slug: SLUG,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Élection de test (relecture)",
+      },
+      select: { id: true },
+    });
+    electionId = election.id;
+
+    ({ politicianId: publicPoliticianId, candidacyId: publicCandidacyId } = await candidacy(
+      "Publique",
+      "PUBLISHED"
+    ));
+    ({ politicianId: draftPoliticianId, candidacyId: draftCandidacyId } = await candidacy(
+      "Brouillon",
+      "DRAFT"
+    ));
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  describe("pendingReviewRevisionCount", () => {
+    async function pending(): Promise<number> {
+      const data = await loadSubjectPageData(electionId, SLUG, THEME);
+      return data.pendingReviewRevisionCount;
+    }
+
+    it("compte une mesure publiée dont la nouvelle révision n'est pas relue", async () => {
+      // Le cas que l'ancien prédicat manquait entièrement : la mesure reste PUBLISHED, donc
+      // publicationStatus vaut PUBLISHED, et pourtant une correction attend bien une relecture.
+      const avant = await pending();
+      const seed = await seedMeasure(publicPoliticianId, publicCandidacyId, "Encadrer les loyers.");
+      await reviewAndPublish(seed);
+      expect(await pending()).toBe(avant); // relue et publiée : rien en attente
+
+      await newDraftOn(seed.measureId, "Encadrer les loyers dans les zones tendues.");
+      expect(await pending()).toBe(avant + 1);
+
+      await db.measure.delete({ where: { id: seed.measureId } });
+    });
+
+    it("ne compte pas une mesure dépubliée dont la révision est relue", async () => {
+      const avant = await pending();
+      const seed = await seedMeasure(publicPoliticianId, publicCandidacyId, "Mesure dépubliée.");
+      await reviewAndPublish(seed);
+      await transitions.depublishMeasure({ measureId: seed.measureId, reason: "Erreur de source" });
+
+      expect(await pending()).toBe(avant);
+
+      await db.measure.delete({ where: { id: seed.measureId } });
+    });
+
+    it("ne compte pas une mesure dépubliée même quand sa révision active n'est pas relue", async () => {
+      // C'est ce cas qui justifie de garder `depublishedAt: null` à côté du prédicat de révision :
+      // le seul prédicat de révision ferait rentrer cette mesure, retirée pour cause.
+      const avant = await pending();
+      const seed = await seedMeasure(publicPoliticianId, publicCandidacyId, "Mesure retirée.");
+      await reviewAndPublish(seed);
+      await transitions.depublishMeasure({ measureId: seed.measureId, reason: "Motif juridique" });
+      await newDraftOn(seed.measureId, "Reformulation non relue.");
+
+      expect(await pending()).toBe(avant);
+
+      await db.measure.delete({ where: { id: seed.measureId } });
+    });
+
+    it("ne compte pas une révision abandonnée", async () => {
+      const avant = await pending();
+      const seed = await seedMeasure(publicPoliticianId, publicCandidacyId, "Brouillon abandonné.");
+      expect(await pending()).toBe(avant + 1); // brouillon actif, non relu
+
+      await transitions.discardMeasureRevision(seed);
+      expect(await pending()).toBe(avant);
+
+      await db.measure.delete({ where: { id: seed.measureId } });
+    });
+
+    it("ne compte pas une révision remplacée par une révision relue", async () => {
+      const avant = await pending();
+      const seed = await seedMeasure(publicPoliticianId, publicCandidacyId, "Première version.");
+      await reviewAndPublish(seed);
+
+      const suivante = await newDraftOn(seed.measureId, "Seconde version.");
+      await reviewAndPublish({ measureId: seed.measureId, revisionId: suivante.revisionId });
+
+      // La première révision porte désormais supersededAt, mais ce n'est plus la révision active :
+      // la mesure ne doit pas être comptée pour autant.
+      const premiere = await db.measureRevision.findUniqueOrThrow({
+        where: { id: seed.revisionId },
+        select: { supersededAt: true },
+      });
+      expect(premiere.supersededAt).not.toBeNull();
+      expect(await pending()).toBe(avant);
+
+      await db.measure.delete({ where: { id: seed.measureId } });
+    });
+  });
+
+  describe("lastReviewedAt du hub", () => {
+    it("ignore une mesure publique plus récente portée par une extension DRAFT", async () => {
+      const ancienne = await seedMeasure(
+        publicPoliticianId,
+        publicCandidacyId,
+        "Mesure de la candidature publiée."
+      );
+      await reviewAndPublish(ancienne);
+      const reference = (await loadHubMeasureContext(electionId, SLUG)).lastReviewedAt;
+      expect(reference).not.toBeNull();
+
+      // Relue APRÈS, donc elle gagnerait sur la date si la population n'était pas filtrée.
+      const cachee = await seedMeasure(
+        draftPoliticianId,
+        draftCandidacyId,
+        "Mesure derrière une extension DRAFT."
+      );
+      await reviewAndPublish(cachee);
+
+      const apres = await loadHubMeasureContext(electionId, SLUG);
+      expect(apres.lastReviewedAt).toEqual(reference);
+
+      await db.measure.deleteMany({
+        where: { id: { in: [ancienne.measureId, cachee.measureId] } },
+      });
+    });
+
+    it("ignore une mesure publique plus récente rattachée à aucune candidature", async () => {
+      const ancienne = await seedMeasure(
+        publicPoliticianId,
+        publicCandidacyId,
+        "Mesure rattachée à une candidature."
+      );
+      await reviewAndPublish(ancienne);
+      const reference = (await loadHubMeasureContext(electionId, SLUG)).lastReviewedAt;
+
+      const orpheline = await seedMeasure(publicPoliticianId, null, "Mesure sans candidature.");
+      await reviewAndPublish(orpheline);
+
+      const apres = await loadHubMeasureContext(electionId, SLUG);
+      expect(apres.lastReviewedAt).toEqual(reference);
+
+      await db.measure.deleteMany({
+        where: { id: { in: [ancienne.measureId, orpheline.measureId] } },
+      });
+    });
+  });
+});

--- a/src/lib/data/__tests__/subject-page.integration.test.ts
+++ b/src/lib/data/__tests__/subject-page.integration.test.ts
@@ -12,7 +12,7 @@ let createMeasureVoteLink: typeof import("@/lib/measures/vote-links").createMeas
 const SLUG = "presidentielle-sujet-test";
 const THEME = "LOGEMENT_URBANISME" as const;
 // Below the gate throughout this fixture: no measure is ever attached to this theme, other
-// than the one draft added below to exercise pendingReviewMeasureCount.
+// than the one draft added below to exercise pendingReviewRevisionCount.
 const OTHER_THEME = "SANTE" as const;
 
 /**
@@ -159,7 +159,7 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
     });
 
     // A draft measure on a different theme, never reviewed nor published: exercises
-    // pendingReviewMeasureCount on a theme that otherwise carries no measure at all.
+    // pendingReviewRevisionCount on a theme that otherwise carries no measure at all.
     await transitions.createMeasure({
       politicianId: a.politicianId,
       electionId,
@@ -193,7 +193,7 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
 
     // A measure published on OTHER_THEME, then depublished for cause (I3): publicationStatus
     // falls back to DRAFT, exactly like a never-published draft, but this is a retraction, not
-    // a submission awaiting a first review. pendingReviewMeasureCount must not count it.
+    // a submission awaiting a first review. pendingReviewRevisionCount must not count it.
     const depublishedSeed = await transitions.createMeasure({
       politicianId: bruno.politicianId,
       electionId,
@@ -308,15 +308,15 @@ describeIfDisposableDb("page sujet publique : agrégation des données", () => {
     const data = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
     expect(data.candidaciesWithVerifiedMeasure).toBe(0);
     expect(data.publishable).toBe(false);
-    expect(data.pendingReviewMeasureCount).toBe(1);
+    expect(data.pendingReviewRevisionCount).toBe(1);
     expect(JSON.stringify(data)).not.toContain("Brouillon santé non publié.");
   });
 
-  it("ne compte pas une mesure publiée puis dépubliée dans pendingReviewMeasureCount", async () => {
+  it("ne compte pas une mesure publiée puis dépubliée dans pendingReviewRevisionCount", async () => {
     // The draft SANTE measure alone brings the count to 1: depublishMeasure() also leaves
     // publicationStatus at DRAFT, and without depublishedAt in the filter this would read 2.
     const data = await loadSubjectPageData(electionId, SLUG, OTHER_THEME);
-    expect(data.pendingReviewMeasureCount).toBe(1);
+    expect(data.pendingReviewRevisionCount).toBe(1);
     expect(JSON.stringify(data)).not.toContain(
       "Mesure santé publiée puis retirée pour motif factuel."
     );

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -4,7 +4,7 @@ import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
 import { loadThemesIndex } from "./themes-index";
-import { getLatestPublicReviewDate } from "./measures";
+import { getLatestPresidentialReviewDate } from "./measures";
 
 /**
  * The two read authorities for the presidential hub page.
@@ -130,7 +130,7 @@ export async function loadHubMeasureContext(
       },
     }),
     loadThemesIndex(electionId, electionSlug),
-    getLatestPublicReviewDate(electionId),
+    getLatestPresidentialReviewDate(electionId),
   ]);
 
   // Derived from the themes index rather than a fresh getPublicMeasuresByElection() read: the
@@ -176,6 +176,9 @@ async function getHubMeasureContextCached(
 ): Promise<HubMeasureContext> {
   "use cache";
   cacheTag(`election-measures:${electionId}`);
+  // This read also filters on CandidacyPresidential.publicationStatus. Without this second tag,
+  // publishing an extension busted nothing here and the surface stayed closed for 24h.
+  cacheTag(`election-candidacies:${electionId}`);
   cacheLife("synced");
   return loadHubMeasureContext(electionId, electionSlug);
 }

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -1,5 +1,6 @@
 import type { Prisma, ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { PUBLIC_CANDIDACY_WHERE } from "./presidential-candidates-public";
 
 /**
  * The two cumulative publication conditions, as a reusable predicate.
@@ -194,6 +195,38 @@ export async function getLatestPublicReviewDate(
 ): Promise<Date | null> {
   const row = await db.measure.findFirst({
     where: { electionId, ...(theme ? { theme } : {}), ...PUBLIC_MEASURE_WHERE },
+    orderBy: { publishedRevision: { reviewedAt: "desc" } },
+    select: { publishedRevision: { select: { reviewedAt: true } } },
+  });
+  return row?.publishedRevision?.reviewedAt ?? null;
+}
+
+/**
+ * The same date, narrowed to the population the presidential surfaces can actually render.
+ *
+ * `getLatestPublicReviewDate` answers "the last reviewed public measure of this election", which is
+ * the right question for a generic election page and the wrong one for the hub: the hub already
+ * derives `verifiedMeasureCount` from candidacies whose `CandidacyPresidential` is PUBLISHED, so
+ * pairing it with a date drawn from a wider set states that a measure was reviewed on a day when
+ * nothing the reader can reach was. Two measures escape the hub's own count and used to move its
+ * date: one attached to a DRAFT extension, and one attached to no candidacy at all.
+ *
+ * Composed from the two existing predicates rather than a third hand-rolled one. Duplicating
+ * PUBLIC_MEASURE_WHERE is exactly how the count and the date drifted apart in the first place.
+ */
+export async function getLatestPresidentialReviewDate(
+  electionId: string,
+  theme?: ThemeCategory
+): Promise<Date | null> {
+  const row = await db.measure.findFirst({
+    where: {
+      electionId,
+      ...(theme ? { theme } : {}),
+      ...PUBLIC_MEASURE_WHERE,
+      // `is` and not a bare object: it also excludes measures with candidacyId null, which have no
+      // column on any comparison and must not carry the date either.
+      candidacy: { is: PUBLIC_CANDIDACY_WHERE },
+    },
     orderBy: { publishedRevision: { reviewedAt: "desc" } },
     select: { publishedRevision: { select: { reviewedAt: true } } },
   });

--- a/src/lib/data/priorites.ts
+++ b/src/lib/data/priorites.ts
@@ -8,7 +8,7 @@ import {
 } from "@/config/publication-gates";
 import { getHubCandidacyField } from "./hub";
 import {
-  getLatestPublicReviewDate,
+  getLatestPresidentialReviewDate,
   getPublicMeasuresByElection,
   type PublicMeasure,
 } from "./measures";
@@ -111,7 +111,7 @@ export async function loadPrioritesData(
       getPublicMeasuresByElection(electionId),
       getPublicPresidentialCandidates(electionSlug),
       loadThemesIndex(electionId, electionSlug),
-      getLatestPublicReviewDate(electionId),
+      getLatestPresidentialReviewDate(electionId),
       db.programEdition.findMany({
         where: { electionId, publicationStatus: "PUBLISHED" },
         select: { id: true },
@@ -246,6 +246,9 @@ async function getPrioritesDataCached(
 ): Promise<PrioritesData> {
   "use cache";
   cacheTag(`election-measures:${electionId}`);
+  // This read also filters on CandidacyPresidential.publicationStatus. Without this second tag,
+  // publishing an extension busted nothing here and the surface stayed closed for 24h.
+  cacheTag(`election-candidacies:${electionId}`);
   cacheLife("synced");
   return loadPrioritesData(electionId, electionSlug);
 }

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -6,7 +6,7 @@ import { PUBLICATION_GATES, isSubjectPagePublishable } from "@/config/publicatio
 import { getPublicMeasureVoteRelations, type PublicVoteReference } from "@/lib/measures/vote-links";
 import type { VoteRelation } from "@/lib/measures/vote-relation";
 import {
-  getLatestPublicReviewDate,
+  getLatestPresidentialReviewDate,
   getPublicMeasuresByTheme,
   type PublicMeasure,
 } from "./measures";
@@ -24,7 +24,8 @@ import { loadThemesIndex } from "./themes-index";
  * extensions), `getPublicMeasuresByTheme` (the single measure authority), and `getPublicMeasureVoteRelation`
  * (which never selects `rationale`/`reviewedBy`). Two direct reads bypass those authorities, but only to
  * produce a number, never content: `db.candidacy.count` (sourced candidacies of the election, the coverage
- * denominator) and `db.measure.count` (draft measures of the theme, for `pendingReviewMeasureCount`). The
+ * denominator) and `db.measure.count` (measures whose active revision awaits review, for
+ * `pendingReviewRevisionCount`). The
  * election slug -> id resolution is a third direct read, and is not gated. No unpublished text ever crosses
  * this surface.
  *
@@ -56,8 +57,12 @@ export type SubjectPageData = {
   requiredCandidaciesWithVerifiedMeasure: number;
   /** Candidacies of the election with a sourced editorial status, the denominator of the coverage rate. */
   totalSourcedCandidacies: number;
-  /** Measures of the theme not yet published (count only: never the draft text itself). */
-  pendingReviewMeasureCount: number;
+  /**
+   * Measures of the theme whose ACTIVE revision has not been reviewed yet: not reviewed, not
+   * discarded, not superseded, on a measure that was never depublished. One active revision per
+   * measure, so this counts measures and revisions alike. Count only, never the draft text.
+   */
+  pendingReviewRevisionCount: number;
   /** When the most recently reviewed public measure on this theme was reviewed, if any. */
   lastReviewedAt: Date | null;
   /** Another theme that already clears the gate, to redirect to when this one does not. */
@@ -76,7 +81,7 @@ export async function loadSubjectPageData(
     candidates,
     measures,
     totalSourcedCandidacies,
-    pendingReviewMeasureCount,
+    pendingReviewRevisionCount,
     lastReviewedAt,
     themesIndex,
   ] = await Promise.all([
@@ -92,13 +97,26 @@ export async function loadSubjectPageData(
         sourceLabel: { not: null },
       },
     }),
-    // Count only: never expose the text of an unpublished revision here. DRAFT and never
-    // depublished, not merely "not PUBLISHED": depublishMeasure() also sets publicationStatus
-    // back to DRAFT, and a measure we withdrew for cause is not "awaiting review".
+    // Count only: never expose the text of an unpublished revision here.
+    //
+    // The predicate is on the ACTIVE REVISION, not on the measure's publication status. Counting
+    // `publicationStatus: "DRAFT"` answered a different question and got both ends wrong: it
+    // missed a PUBLISHED measure carrying a new, unreviewed correction (the most common case of
+    // "awaiting review" once a subject is live), and it counted a DRAFT measure whose latest
+    // revision had already been reviewed and was merely waiting to be published.
+    //
+    // `depublishedAt: null` stays, and is not redundant with the revision predicate:
+    // depublishMeasure() sets publicationStatus back to DRAFT, and a measure we withdrew for
+    // cause is not "awaiting review" even when its active revision was never reviewed.
     db.measure.count({
-      where: { electionId, theme, publicationStatus: "DRAFT", depublishedAt: null },
+      where: {
+        electionId,
+        theme,
+        depublishedAt: null,
+        latestRevision: { is: { reviewedAt: null, discardedAt: null, supersededAt: null } },
+      },
     }),
-    getLatestPublicReviewDate(electionId, theme),
+    getLatestPresidentialReviewDate(electionId, theme),
     loadThemesIndex(electionId, electionSlug),
   ]);
 
@@ -150,7 +168,7 @@ export async function loadSubjectPageData(
     requiredCandidaciesWithVerifiedMeasure:
       PUBLICATION_GATES.pageSujet.minCandidaciesWithVerifiedMeasure,
     totalSourcedCandidacies,
-    pendingReviewMeasureCount,
+    pendingReviewRevisionCount,
     lastReviewedAt,
     fallbackPublishableTheme,
   };
@@ -179,6 +197,9 @@ async function getSubjectPageDataCached(
 ): Promise<SubjectPageData> {
   "use cache";
   cacheTag(`election-measures:${electionId}`);
+  // This read also filters on CandidacyPresidential.publicationStatus. Without this second tag,
+  // publishing an extension busted nothing here and the surface stayed closed for 24h.
+  cacheTag(`election-candidacies:${electionId}`);
   cacheLife("synced");
   return loadSubjectPageData(electionId, electionSlug, theme);
 }

--- a/src/lib/data/themes-index.ts
+++ b/src/lib/data/themes-index.ts
@@ -100,6 +100,9 @@ async function getThemesIndexCached(
 ): Promise<ThemesIndexData> {
   "use cache";
   cacheTag(`election-measures:${electionId}`);
+  // This read also filters on CandidacyPresidential.publicationStatus. Without this second tag,
+  // publishing an extension busted nothing here and the surface stayed closed for 24h.
+  cacheTag(`election-candidacies:${electionId}`);
   cacheLife("synced");
   return loadThemesIndex(electionId, electionSlug);
 }

--- a/src/lib/presidentielle/__tests__/candidacy-cache-policy.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-cache-policy.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The invalidation policy for `CandidacyPresidential`, guarded at the source level.
+ *
+ * Why a source guard and not a runtime one: `cacheTag` only does anything inside a Next
+ * request/build context, and `revalidateTag` talks to the hosting platform. Neither can be
+ * observed from vitest, so the invariant that actually protects us — "a cached read that filters
+ * on the extension status carries the tag that a mutation busts" — has to be asserted on the code.
+ *
+ * The defect this locks down: the four reads carried only `election-measures:<id>` while the
+ * mutations called `invalidateEntity("election")` (which purges the `elections` tag). The two sets
+ * never intersected, so publishing an extension busted nothing and the surfaces stayed closed for
+ * a full ISR period.
+ *
+ * Comments are stripped before matching, per AGENTS.md: a guard that greps a whole file stays green
+ * on a rule that only survives in the surrounding prose.
+ */
+
+const ROOT = join(__dirname, "..", "..", "..", "..");
+
+function sourceWithoutComments(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/**
+ * Every cached read whose result depends on `CandidacyPresidential.publicationStatus`, directly or
+ * through `getPublicPresidentialCandidates`. Adding a fifth one without its tag turns this red.
+ */
+const CACHED_READS = [
+  "src/lib/data/hub.ts",
+  "src/lib/data/themes-index.ts",
+  "src/lib/data/subject-page.ts",
+  "src/lib/data/priorites.ts",
+];
+
+const MUTATION_ROUTES = [
+  "src/app/api/admin/candidats/route.ts",
+  "src/app/api/admin/candidats/[id]/route.ts",
+];
+
+describe("politique d'invalidation des extensions présidentielles", () => {
+  it.each(CACHED_READS)("%s porte le tag des candidatures à côté de celui des mesures", (path) => {
+    const code = sourceWithoutComments(path);
+
+    // Prérequis du test lui-même : si ce fichier cesse d'être une lecture cachée sur les mesures,
+    // l'assertion suivante n'a plus de sens et il faut revoir la liste.
+    expect(code).toContain("cacheTag(`election-measures:${electionId}`)");
+    expect(code).toContain("cacheTag(`election-candidacies:${electionId}`)");
+  });
+
+  it.each(MUTATION_ROUTES)("%s invalide le tag des candidatures", (path) => {
+    const code = sourceWithoutComments(path);
+    expect(code).toContain("invalidatePresidentialCandidacyTags(");
+  });
+
+  it("chaque mutation d'extension invalide, pas seulement une sur trois", () => {
+    // POST dans le premier fichier, PATCH et DELETE dans le second : trois appels au total.
+    const total = MUTATION_ROUTES.map(sourceWithoutComments)
+      .join("\n")
+      .match(/invalidatePresidentialCandidacyTags\(/g);
+    expect(total).toHaveLength(3);
+  });
+
+  it("le dépouillement des commentaires ne laisse pas passer une mention en prose", () => {
+    // Garde de la garde : sans cette vérification, un commentaire citant le tag suffirait à faire
+    // passer les assertions ci-dessus après la suppression de l'appel réel.
+    const faux = "/* cacheTag(`election-candidacies:${electionId}`) */\nconst x = 1;\n";
+    const nettoye = faux.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/.*$/gm, "$1");
+    expect(nettoye).not.toContain("election-candidacies");
+  });
+});
+
+describe("invalidatePresidentialCandidacyTags", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("purge un seul tag ciblé, jamais le tag global", async () => {
+    const revalidateTags = vi.fn();
+    vi.doMock("@/lib/cache", () => ({ revalidateTags }));
+    const { invalidatePresidentialCandidacyTags } = await import("../candidacy-cache");
+
+    invalidatePresidentialCandidacyTags("elec-1");
+
+    expect(revalidateTags).toHaveBeenCalledExactlyOnceWith(["election-candidacies:elec-1"]);
+  });
+
+  it("journalise et n'interrompt pas l'appelant quand la plateforme refuse", async () => {
+    // La mutation est déjà validée en base quand on arrive ici : lever ferait croire à un échec.
+    const revalidateTags = vi.fn(() => {
+      throw new Error("plateforme indisponible");
+    });
+    vi.doMock("@/lib/cache", () => ({ revalidateTags }));
+    const { invalidatePresidentialCandidacyTags } = await import("../candidacy-cache");
+    const erreur = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => invalidatePresidentialCandidacyTags("elec-1")).not.toThrow();
+    expect(erreur).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/presidentielle/candidacy-cache.ts
+++ b/src/lib/presidentielle/candidacy-cache.ts
@@ -1,0 +1,29 @@
+import { revalidateTags } from "@/lib/cache";
+
+/**
+ * Invalidation for the surfaces that depend on a `CandidacyPresidential` publication status.
+ *
+ * Why a tag of its own, next to `election-measures:${electionId}`. The four cached reads of the
+ * hub (subject page, themes index, hub context, priorities) all filter on
+ * `CandidacyPresidential.publicationStatus`, directly or through `getPublicPresidentialCandidates`.
+ * They carried only the measures tag, while the extension mutations called
+ * `invalidateEntity("election")`, which purges the `elections` tag. Those two sets do not overlap
+ * at all, so a DRAFT -> PUBLISHED transition busted NONE of the four: they stayed closed until the
+ * 24h ISR backstop, with the data already in place.
+ *
+ * Same policy as `invalidateMeasureTags`: best effort, logged, no retry. `revalidateTag` is a call
+ * to the hosting platform, not SQL, so describing it as atomic with the transaction would be wrong,
+ * and throwing here would make the caller believe a committed mutation had failed.
+ */
+export function invalidatePresidentialCandidacyTags(electionId: string): void {
+  try {
+    // One targeted tag, never the global one: purging the global tag once blew through this
+    // project's hosting spend cap.
+    revalidateTags([`election-candidacies:${electionId}`]);
+  } catch (error) {
+    // The only trace of a lost invalidation, which leaves the surfaces closed until their
+    // cacheLife profile expires.
+    // eslint-disable-next-line no-console -- deliberate ops signal
+    console.error(`[presidentielle] cache invalidation failed for election ${electionId}`, error);
+  }
+}


### PR DESCRIPTION
Corrige cinq incohérences restées sur `main` après les lots 4 et 5 du hub présidentielle, autour des portes de publication, de la fraîcheur du cache et des compteurs publics. Aucun changement Prisma, aucun seuil éditorial modifié, aucune refonte visuelle.

## Le défaut principal

Les quatre lectures cachées du hub (page sujet, index des sujets, contexte du hub, priorités) filtrent toutes sur `CandidacyPresidential.publicationStatus`, directement ou via `getPublicPresidentialCandidates`. Elles ne portaient pourtant que le tag `election-measures:<id>`, tandis que les mutations d'extension appelaient `invalidateEntity("election")`, qui purge le tag `elections`.

Les deux ensembles ne se recoupent pas. Un passage `DRAFT → PUBLISHED` ne bustait donc **aucune** de ces quatre surfaces : elles restaient fermées jusqu'au filet ISR de 24 h alors que la donnée était prête.

Un tag `election-candidacies:<id>` est ajouté aux quatre lectures et invalidé par `POST`, `PATCH` et `DELETE`. L'identifiant d'élection est remonté depuis des lectures déjà présentes, simplement élargies : aucune requête supplémentaire.

## Les quatre autres

**Compteur de relecture.** Il comptait `publicationStatus: "DRAFT"`, ce qui ratait une mesure publiée portant une correction non relue et comptait un brouillon dont la révision était déjà relue. Le prédicat porte désormais sur la révision active. `depublishedAt: null` est conservé : sans lui, une mesure retirée pour cause avec un brouillon non relu rentrerait dans le compteur. Le champ devient `pendingReviewRevisionCount` et le libellé public « Révisions en attente de relecture », l'affirmation « mesures extraites » n'étant pas attestée par le chiffre.

**Date de dernière revue.** `getLatestPublicReviewDate` considérait toutes les mesures publiques de l'élection, y compris celles portées par une extension `DRAFT` ou rattachées à aucune candidature, donc inatteignables depuis une page sujet. `getLatestPresidentialReviewDate` compose les deux prédicats publics existants sans en écrire un troisième. Appliquée aussi à la page sujet, qui portait le même défaut et affiche la même donnée.

**État du hub sous son seuil.** `hubPublishable` ne pilotait que le `noindex`. Le corps nomme désormais l'état, avec les chiffres et le seuil lus dans `PUBLICATION_GATES`. Le champ des candidatures, la provenance et la carte vers l'index restent tous en place.

**Compteurs `ProgramEdition`.** « Non calculable » remplace le tiret sur les deux lignes qui ne le sont pas, le tiret restant réservé au taux de couverture sans dénominateur. Les deux se lisent différemment.

## Tests

Une garde de politique au niveau source, commentaires dépouillés comme l'exige `AGENTS.md`, qui échoue si une cinquième lecture cachée arrive sans son tag ou si une mutation cesse d'invalider. Deux tests unitaires sur l'invalidateur, dont le comportement en cas de refus de la plateforme. Cinq cas d'intégration sur le compteur de relecture, deux sur la date du hub, cinq de composant sur l'état fermé.

Ablations vérifiées : retirer un tag rend la garde rouge, remettre les deux anciens prédicats rend quatre tests d'intégration rouges sur sept. Les trois autres passent sous les deux versions, ce sont des gardes de non-régression et non des tests discriminants.

## Validation

`npm run typecheck` sorti à 0. Suite complète : 391 fichiers, 3635 tests, aucun échec. `npm run build` sorti à 0. Conteneur jetable : 5 fichiers, 54 tests, db-guard compris. Lint sans erreur.

## À savoir avant de merger

`SubjectComparison.test.tsx` est aussi modifié par la branche `fix-hub-wording`, sur des lignes voisines. Un conflit d'une ligne contre deux est probable selon l'ordre de merge, sans conséquence sémantique : cette branche ne référence pas le champ renommé ici.

## Dette laissée en connaissance de cause

Les deux compteurs `ProgramEdition` sont désormais calculables, le modèle existant et `priorites.ts` le lisant déjà. Ils ne sont pas implémentés ici, par choix de périmètre. La section 4.1 reste donc partiellement couverte sur ces deux lignes.

L'invalidation reste en meilleur effort sans reprise, comme celle des mesures : une invalidation perdue laisse la surface fermée jusqu'à l'expiration du cache. Le correctif propre est une table d'attente, qui n'appartient à aucun lot.
