### PR TITLE
Entrée en présidentielle : bandeau d'accueil, encart de candidature, fiche candidat

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRedirect = vi.fn((href: string) => {
+  throw new Error(`REDIRECT:${href}`);
+});
+const mockNotFound = vi.fn(() => {
+  throw new Error("NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  redirect: (href: string) => mockRedirect(href),
+  notFound: () => mockNotFound(),
+}));
+
+const mockGetCandidacy = vi.fn();
+vi.mock("@/lib/data/politician-candidacy", () => ({
+  getPoliticianPresidentialCandidacy: (id: string) => mockGetCandidacy(id),
+}));
+
+const mockGetPolitician = vi.fn();
+vi.mock("@/lib/data/politicians", () => ({
+  getPolitician: (slug: string) => mockGetPolitician(slug),
+}));
+
+const candidacy = (overrides: Record<string, unknown> = {}) => ({
+  electionSlug: "presidentielle-2027",
+  electionShortTitle: "Présidentielle 2027",
+  round1Date: new Date("2027-04-11T00:00:00.000Z"),
+  round2Date: new Date("2027-04-25T00:00:00.000Z"),
+  status: "DECLARE",
+  sourceUrl: "https://example.org/source",
+  sourceLabel: "Le Monde, 14 janvier 2026",
+  declaredAt: null,
+  withdrewAt: null,
+  publishedMeasureCount: 0,
+  themesCoveredCount: 0,
+  primarySourceMeasureCount: 0,
+  lastReviewedAt: null,
+  round1Pct: null,
+  round2Pct: null,
+  isElected: false,
+  ...overrides,
+});
+
+describe("page fiche candidat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPolitician.mockResolvedValue({
+      id: "p1",
+      slug: "camille-riviere",
+      fullName: "Camille Rivière",
+      civility: "Mme",
+    });
+  });
+
+  it("renvoie vers la fiche du politique quand la candidature est sous le seuil", async () => {
+    mockGetCandidacy.mockResolvedValue(candidacy());
+    const { default: Page } = await import("../page");
+
+    await expect(Page({ params: Promise.resolve({ slug: "camille-riviere" }) })).rejects.toThrow(
+      "REDIRECT:/politiques/camille-riviere"
+    );
+  });
+
+  it("renvoie vers la fiche du politique quand il n'y a aucune candidature", async () => {
+    mockGetCandidacy.mockResolvedValue(null);
+    const { default: Page } = await import("../page");
+
+    await expect(Page({ params: Promise.resolve({ slug: "camille-riviere" }) })).rejects.toThrow(
+      "REDIRECT:/politiques/camille-riviere"
+    );
+  });
+
+  it("rend 404 quand le politique n'existe pas", async () => {
+    mockGetPolitician.mockResolvedValue(null);
+    const { default: Page } = await import("../page");
+
+    await expect(Page({ params: Promise.resolve({ slug: "inconnu" }) })).rejects.toThrow(
+      "NOT_FOUND"
+    );
+  });
+
+  it("rend la fiche quand le seuil est franchi", async () => {
+    mockGetCandidacy.mockResolvedValue(
+      candidacy({ publishedMeasureCount: 27, themesCoveredCount: 9, primarySourceMeasureCount: 20 })
+    );
+    const { default: Page } = await import("../page");
+
+    const result = await Page({ params: Promise.resolve({ slug: "camille-riviere" }) });
+    expect(result).toBeDefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("reste hors des moteurs tant que la fiche n'est pas publiable", async () => {
+    mockGetCandidacy.mockResolvedValue(candidacy());
+    const { generateMetadata } = await import("../page");
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "camille-riviere" }),
+    });
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("laisse la fiche publiable entrer dans les moteurs", async () => {
+    mockGetCandidacy.mockResolvedValue(
+      candidacy({ publishedMeasureCount: 27, themesCoveredCount: 9, primarySourceMeasureCount: 20 })
+    );
+    const { generateMetadata } = await import("../page");
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "camille-riviere" }),
+    });
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  it("génère zéro paramètre statique : les fiches sortent à l'écriture éditoriale", async () => {
+    const { generateStaticParams } = await import("../page");
+    expect(await generateStaticParams()).toEqual([]);
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ExternalLink } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { CANDIDACY_STATUS_LABELS, candidacyRoleLabel } from "@/config/labels";
+import { isFicheCandidatPublishable } from "@/config/publication-gates";
+// Reuses the established politician authority rather than adding a second, lighter read for three
+// fields. It loads more than this page needs, but it is already cached under `politician:<slug>`.
+import { getPolitician } from "@/lib/data/politicians";
+import { getPoliticianPresidentialCandidacy } from "@/lib/data/politician-candidacy";
+import { formatDate } from "@/lib/utils";
+
+/**
+ * Candidate fiche for the presidential hub. `[slug]` is the POLITICIAN slug, consistent with
+ * `politicianSlug` everywhere in the hub data layer and with the link the notice emits.
+ *
+ * Below the publication gate the route redirects to `/politiques/[slug]`, which is what spec §4.1 of
+ * the hub design prescribes ("no fiche, the name points to /politiques/[slug]"). A redirect leaves no
+ * orphan page to maintain and no URL to de-index later.
+ *
+ * Above the gate it renders a MINIMAL fiche: identity, sourced status, measure volume linking to the
+ * subject pages, provenance. The full #D3 screen of the handoff is a separate lot and grows on top of
+ * this one.
+ */
+
+export const revalidate = 86400;
+
+/**
+ * No pre-generation. The publishable population changes with EDITORIAL WRITES, not with deployments:
+ * pre-generating at build time would freeze a list that a publication invalidates hours later, and
+ * would make a fiche's going live depend on a redeploy. Fiches are therefore generated on demand
+ * under ISR, and this reasoning survives the first publication.
+ */
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  return [];
+}
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/** Plural agreement: the gate opens at one measure, so "1 mesures" is reachable. */
+function plural(count: number, singular: string): string {
+  return `${count} ${singular}${count > 1 ? "s" : ""}`;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const politician = await getPolitician(slug);
+  if (!politician) return { robots: { index: false, follow: true } };
+
+  const candidacy = await getPoliticianPresidentialCandidacy(politician.id);
+  const publishable =
+    candidacy !== null &&
+    isFicheCandidatPublishable({
+      statusSourced: true,
+      verifiedMeasuresWithPrimarySource: candidacy.primarySourceMeasureCount,
+    });
+
+  return {
+    title: `${politician.fullName}, candidature à la présidentielle 2027 | Poligraph`,
+    description: `Les mesures documentées de ${politician.fullName} pour la présidentielle 2027, par sujet, avec leurs sources.`,
+    // A surface below its gate stays out of search results (spec §4.2). `follow: true` so the links
+    // out of the page keep their value.
+    robots: publishable ? undefined : { index: false, follow: true },
+    alternates: { canonical: `/elections/presidentielle-2027/candidats/${slug}` },
+  };
+}
+
+export default async function CandidateFichePage({ params }: PageProps) {
+  const { slug } = await params;
+  const politician = await getPolitician(slug);
+  if (!politician) notFound();
+
+  const candidacy = await getPoliticianPresidentialCandidacy(politician.id);
+  const publishable =
+    candidacy !== null &&
+    isFicheCandidatPublishable({
+      statusSourced: true,
+      verifiedMeasuresWithPrimarySource: candidacy.primarySourceMeasureCount,
+    });
+
+  if (!candidacy || !publishable) {
+    redirect(`/politiques/${slug}`);
+  }
+
+  return (
+    <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
+      <Breadcrumb
+        items={[
+          { label: "Présidentielle", href: `/elections/${candidacy.electionSlug}` },
+          { label: politician.fullName },
+        ]}
+      />
+
+      <header className="space-y-3">
+        <p className="text-xs font-bold uppercase tracking-widest text-brand">
+          {candidacy.electionShortTitle}
+        </p>
+        <h1 className="font-display text-3xl font-extrabold leading-tight tracking-tight md:text-4xl">
+          {politician.fullName}
+        </h1>
+        <p className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="font-semibold">{candidacyRoleLabel(politician.civility)}</span>
+          <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
+            {CANDIDACY_STATUS_LABELS[candidacy.status]}
+          </span>
+          <a
+            href={candidacy.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs underline hover:no-underline"
+          >
+            {candidacy.sourceLabel}
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        </p>
+      </header>
+
+      <section className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
+        <h2 className="font-display text-xl font-bold tracking-tight">Son programme par sujet</h2>
+        <p className="text-sm text-muted-foreground">
+          {plural(candidacy.publishedMeasureCount, "mesure")} publiée
+          {candidacy.publishedMeasureCount > 1 ? "s" : ""} sur{" "}
+          {plural(candidacy.themesCoveredCount, "sujet")}
+          {candidacy.lastReviewedAt && (
+            <> · dernière revue le {formatDate(candidacy.lastReviewedAt)}</>
+          )}
+          .
+        </p>
+        <p className="text-sm">
+          <Link
+            href={`/elections/${candidacy.electionSlug}/sujets`}
+            prefetch={false}
+            className="font-bold text-primary hover:underline"
+          >
+            Parcourir les sujets
+          </Link>
+        </p>
+      </section>
+
+      <section className="space-y-2 rounded-xl border bg-card p-4 text-sm text-muted-foreground md:p-6">
+        <h2 className="font-display text-base font-bold tracking-tight text-foreground">
+          D&apos;où viennent ces données
+        </h2>
+        <p>
+          Chaque mesure est extraite d&apos;un document daté, relue, et publiée avec sa source. Le
+          statut de la candidature vient de la source citée ci-dessus, à sa date. Aucun classement,
+          aucun score de proximité : l&apos;ordre des candidatures est alphabétique partout sur le
+          site.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,8 @@
   --color-destructive: var(--destructive);
   --color-brand-foreground: var(--brand-foreground);
   --color-brand: var(--brand);
+  --color-brand-on-surface: var(--brand-on-surface);
+  --color-muted-foreground-strong: var(--muted-foreground-strong);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -64,6 +66,13 @@
   --secondary-foreground: oklch(0.205 0.015 260);
   --muted: oklch(0.965 0.005 260);
   --muted-foreground: oklch(0.44 0 0);
+  /* Readable variants of --brand and --muted-foreground for SMALL TEXT sitting on --card or
+     --muted. Additive: the base tokens keep their value and their uses. In light mode both already
+     clear AA (measured 5.44:1 and 7.12:1), so these alias them; only the dark block diverges. Same
+     pattern the handoff asks for on VOTE_POSITION_COLORS: a second value per role for text, the
+     first staying valid as a flat fill. */
+  --brand-on-surface: oklch(0.55 0.22 25);
+  --muted-foreground-strong: oklch(0.44 0 0);
   --accent: oklch(0.97 0.01 80);
   --accent-foreground: oklch(0.25 0.05 250);
   --brand: oklch(0.55 0.22 25);
@@ -106,6 +115,12 @@
   --accent: oklch(0.22 0.01 250);
   --accent-foreground: oklch(0.85 0.02 250);
   --brand: oklch(0.6 0.2 25);
+  /* Measured, not guessed. On --card (oklch 0.205) the base --brand gives 4.11:1 at 12px bold, below
+     the 4.5:1 AA needs; this lightness gives 5.24:1. On --muted (oklch 0.269) the base
+     --muted-foreground gives 3.83:1 at 12px; this one gives 5.25:1. Script kept out of the repo, the
+     values are reproducible from the tokens above. */
+  --brand-on-surface: oklch(0.66 0.2 25);
+  --muted-foreground-strong: oklch(0.68 0 0);
   --brand-foreground: oklch(0.15 0 0);
   --destructive: oklch(0.65 0.2 25);
   --border: oklch(1 0 0 / 10%);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,17 +31,13 @@ export default async function HomePage() {
     getEnabledFlags(),
   ]);
 
-  const daysUntil = featuredElection?.round1Date
-    ? Math.ceil(
-        (new Date(featuredElection.round1Date).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
-      )
-    : null;
-
   return (
     <div className="container mx-auto px-4 py-8 space-y-10">
       <HomeHero />
 
-      {featuredElection && <ElectionBanner election={featuredElection} daysUntil={daysUntil} />}
+      {/* The banner derives its own temporal state: a day count computed here was the duplication
+          that kept the other four states invisible from this page. */}
+      {featuredElection && <ElectionBanner election={featuredElection} now={now} />}
 
       <HomeIntentGrid enabledFlags={enabledFlags} />
 

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -44,6 +44,7 @@ import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
 import { DeepLinkHighlighter } from "@/components/politicians/DeepLinkHighlighter";
 import { CandidacyNotice } from "@/components/politicians/CandidacyNotice";
 import { getPoliticianPresidentialCandidacy } from "@/lib/data/politician-candidacy";
+import { isFicheCandidatPublishable } from "@/config/publication-gates";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag
 
@@ -190,6 +191,16 @@ export default async function PoliticianPage({ params }: PageProps) {
   // the notice sayable: there is no "we are not sure" state, the block simply does not appear.
   const presidentialCandidacy = await getPoliticianPresidentialCandidacy(politician.id);
   const now = new Date();
+  // Null below the gate, where the fiche route redirects back here: the notice then points at the
+  // hub and drops its possessive wording rather than promising a page that bounces.
+  const ficheHref =
+    presidentialCandidacy !== null &&
+    isFicheCandidatPublishable({
+      statusSourced: true,
+      verifiedMeasuresWithPrimarySource: presidentialCandidacy.primarySourceMeasureCount,
+    })
+      ? `/elections/${presidentialCandidacy.electionSlug}/candidats/${politician.slug}`
+      : null;
 
   const currentMandate = politician.mandates.find((m) => m.isCurrent);
   const currentGroup = (
@@ -465,6 +476,7 @@ export default async function PoliticianPage({ params }: PageProps) {
               candidacy={presidentialCandidacy}
               civility={politician.civility}
               now={now}
+              ficheHref={ficheHref}
             />
           </div>
         )}

--- a/src/app/politiques/[slug]/page.tsx
+++ b/src/app/politiques/[slug]/page.tsx
@@ -42,6 +42,8 @@ import { PoliticianSignals } from "@/components/politicians/PoliticianSignals";
 import { PresumptionNotice } from "@/components/politicians/PresumptionNotice";
 import { PoliticianSummary } from "@/components/politicians/PoliticianSummary";
 import { DeepLinkHighlighter } from "@/components/politicians/DeepLinkHighlighter";
+import { CandidacyNotice } from "@/components/politicians/CandidacyNotice";
+import { getPoliticianPresidentialCandidacy } from "@/lib/data/politician-candidacy";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag
 
@@ -183,6 +185,11 @@ export default async function PoliticianPage({ params }: PageProps) {
   if (!politician) {
     notFound();
   }
+
+  // Returns null unless this person carries a SOURCED presidential candidacy, which is what makes
+  // the notice sayable: there is no "we are not sure" state, the block simply does not appear.
+  const presidentialCandidacy = await getPoliticianPresidentialCandidacy(politician.id);
+  const now = new Date();
 
   const currentMandate = politician.mandates.find((m) => m.isCurrent);
   const currentGroup = (
@@ -449,6 +456,18 @@ export default async function PoliticianPage({ params }: PageProps) {
             )}
           </div>
         </div>
+
+        {/* Full width, under the badges, above the tabs, at both widths. Never a badge in the
+            party/mandate row: there it would read as a qualification awarded by Poligraph. */}
+        {presidentialCandidacy && (
+          <div className="mb-8">
+            <CandidacyNotice
+              candidacy={presidentialCandidacy}
+              civility={politician.civility}
+              now={now}
+            />
+          </div>
+        )}
 
         {/* Summary before the tabbed body on mobile (DOM order matches reading order). */}
         <div className="lg:hidden mb-8">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,8 +9,10 @@ import { getAllThemeSlugs } from "@/lib/theme-utils";
 import { SITE_URL } from "@/config/site";
 import { getWeekStart, getISOWeekString } from "@/lib/data/recap";
 import { loadThemesIndex } from "@/lib/data/themes-index";
-import { isHubPublishable } from "@/config/publication-gates";
+import { isFicheCandidatPublishable, isHubPublishable } from "@/config/publication-gates";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { getPublicPresidentialCandidates } from "@/lib/data/presidential-candidates-public";
+import { getPublicMeasureStatsByCandidacy } from "@/lib/data/measures";
 import {
   SIGNIFICANT_MANDATE_TYPES,
   MAIRE_MIN_COMMUNE_POPULATION,
@@ -417,6 +419,36 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
       priority: 0.7,
     }));
 
+  // Candidate fiches, only above their own publication gate (spec §4.1, indexation §4.2). The route
+  // redirects to /politiques/[slug] below the gate, so announcing an unpublishable slug would spend
+  // crawl budget on a redirect.
+  //
+  // Known freshness limit, and NOT an oversight: SITEMAP_SHARD_TAGS[1] is
+  // ["affairs", "parties", "elections"], while publishing a measure or an extension busts
+  // `election-measures:<id>` / `election-candidacies:<id>`. Neither is in that list, so this shard
+  // refreshes on its cacheLife rather than on the write. The condition is pre-existing and identical
+  // for the hub URL above, whose `presidentielleHubPublishable` guard already reads the themes index.
+  // Fixing it means making a parameterised tag selectable, which is its own chantier.
+  const candidateFichePages: MetadataRoute.Sitemap = [];
+  if (presidentielle2027 !== undefined) {
+    const candidates = await getPublicPresidentialCandidates(PRESIDENTIELLE_2027_SLUG);
+    for (const candidate of candidates) {
+      if (candidate.politicianSlug === null) continue;
+      const stats = await getPublicMeasureStatsByCandidacy(candidate.id);
+      const publishable = isFicheCandidatPublishable({
+        statusSourced: candidate.sourceUrl !== null && candidate.sourceLabel !== null,
+        verifiedMeasuresWithPrimarySource: stats.primarySourceMeasureCount,
+      });
+      if (!publishable) continue;
+      candidateFichePages.push({
+        url: `${SITE_URL}/elections/${PRESIDENTIELLE_2027_SLUG}/candidats/${candidate.politicianSlug}`,
+        lastModified: stats.lastReviewedAt ?? new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      });
+    }
+  }
+
   const departmentPages: MetadataRoute.Sitemap = Object.values(DEPARTMENTS).map((dept) => ({
     url: `${SITE_URL}/departements/${getDepartmentSlug(dept.name)}`,
     lastModified: new Date(),
@@ -445,6 +477,7 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
     ...partyPages,
     ...partyAffairPages,
     ...electionPages,
+    ...candidateFichePages,
     ...departmentPages,
     ...themePages,
   ];

--- a/src/components/home/BannerCountdown.tsx
+++ b/src/components/home/BannerCountdown.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useIsMounted } from "@/hooks/useIsMounted";
+
+/**
+ * Countdown for the homepage election banner.
+ *
+ * Separate from `ElectionCountdown` on purpose: that one renders four fixed columns inside a
+ * gradient card and serves the election detail pages. Merging them would mean a component with
+ * five layout props for two callers.
+ *
+ * The homepage is ISR-cached for 300 s. A day count rendered on the server stays right, hours and
+ * minutes do not, so the values are computed after mount only. What differs from
+ * `ElectionCountdown` is that this one renders a same-size skeleton instead of null: the banner is
+ * the tallest card above the fold and collapsing it would shift the whole page at hydration.
+ */
+
+interface BannerCountdownProps {
+  /** ISO string. Serialising here makes the server-to-client contract explicit. */
+  targetDate: string;
+  showSeconds: boolean;
+  /** Accessible name of the timer, e.g. "Compte à rebours jusqu'au premier tour". */
+  label: string;
+}
+
+type Remaining = { days: number; hours: number; minutes: number; seconds: number };
+
+function computeRemaining(target: Date): Remaining {
+  const diff = Math.max(0, target.getTime() - Date.now());
+  return {
+    days: Math.floor(diff / 86_400_000),
+    hours: Math.floor(diff / 3_600_000) % 24,
+    minutes: Math.floor(diff / 60_000) % 60,
+    seconds: Math.floor(diff / 1_000) % 60,
+  };
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+export function BannerCountdown({ targetDate, showSeconds, label }: BannerCountdownProps) {
+  const mounted = useIsMounted();
+  const [remaining, setRemaining] = useState<Remaining>(() =>
+    computeRemaining(new Date(targetDate))
+  );
+
+  useEffect(() => {
+    const target = new Date(targetDate);
+    const interval = setInterval(() => setRemaining(computeRemaining(target)), 1000);
+    return () => clearInterval(interval);
+  }, [targetDate]);
+
+  const units: { value: string; label: string }[] = [
+    { value: String(remaining.days), label: "jours" },
+    { value: pad(remaining.hours), label: "heures" },
+    { value: pad(remaining.minutes), label: "minutes" },
+    ...(showSeconds ? [{ value: pad(remaining.seconds), label: "secondes" }] : []),
+  ];
+
+  return (
+    <div role="timer" aria-label={label} className="flex gap-4 md:gap-6">
+      {units.map((unit) => (
+        <div key={unit.label} className="flex min-w-14 flex-col md:min-w-16">
+          <span className="font-display text-3xl font-extrabold leading-none tracking-tight tabular-nums md:text-4xl">
+            {/* Before mount the digits would diverge from the ISR-cached HTML, so the slot is
+                reserved with a non-breaking space of the same line height instead. */}
+            {mounted ? unit.value : " "}
+          </span>
+          <span className="mt-1 text-xs text-muted-foreground">{unit.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/home/ElectionBanner.tsx
+++ b/src/components/home/ElectionBanner.tsx
@@ -1,65 +1,215 @@
 import Link from "next/link";
-import { Landmark, Building2, Map, Stars, Vote, ChevronRight } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import type { ElectionType } from "@/generated/prisma";
+import { ChevronRight, Info } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { BannerCountdown } from "@/components/home/BannerCountdown";
+import type { FeaturedElection } from "@/lib/data/elections";
+import { deriveElectionBannerState } from "@/lib/elections/banner-state";
+import { getBannerPresentation, type BannerAction } from "@/lib/elections/banner-presentation";
+import { getVoterRegistrationDeadline } from "@/config/election-guides";
+import { formatDate } from "@/lib/utils";
 
-interface FeaturedElection {
-  slug: string;
-  title: string;
-  shortTitle: string | null;
-  type: ElectionType;
-  round1Date: Date | null;
-  hasResults: boolean;
-  communesDepouillees: number;
-}
+/**
+ * Homepage election banner. Occupies its existing slot between HomeHero and HomeIntentGrid and does
+ * not leave it: the homepage stays an observatory's homepage, not an election page.
+ *
+ * The component knows neither the presidential race nor the municipal one. It renders a temporal
+ * state (banner-state.ts) crossed with a presentation strategy (banner-presentation.ts).
+ *
+ * `now` is injected rather than read here so the five states are testable without touching the
+ * render clock.
+ */
 
 interface ElectionBannerProps {
   election: FeaturedElection;
-  daysUntil: number | null;
+  now: Date;
 }
 
-const ELECTION_TYPE_LUCIDE: Record<ElectionType, LucideIcon> = {
-  PRESIDENTIELLE: Landmark,
-  LEGISLATIVES: Landmark,
-  SENATORIALES: Landmark,
-  MUNICIPALES: Building2,
-  DEPARTEMENTALES: Map,
-  REGIONALES: Map,
-  EUROPEENNES: Stars,
-  REFERENDUM: Vote,
-};
+/** French percentage: comma as decimal separator, one decimal, non-breaking space before %. */
+function formatPct(pct: number): string {
+  return `${pct.toFixed(1).replace(".", ",")} %`;
+}
 
-export function ElectionBanner({ election, daysUntil }: ElectionBannerProps) {
-  const Icon = ELECTION_TYPE_LUCIDE[election.type];
+function ActionLink({
+  action,
+  variant,
+}: {
+  action: BannerAction;
+  variant: "primary" | "secondary";
+}) {
+  const className =
+    variant === "primary"
+      ? "flex min-h-11 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      : "flex min-h-8 items-center justify-center gap-1 text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+  const content = (
+    <>
+      {action.label}
+      <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+    </>
+  );
+
+  if (action.external) {
+    return (
+      <a href={action.href} target="_blank" rel="noopener noreferrer" className={className}>
+        {content}
+      </a>
+    );
+  }
 
   return (
-    <Link
-      href={`/elections/${election.slug}`}
-      prefetch={false}
-      className="group flex items-center gap-3 rounded-xl border bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-    >
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-        <Icon className="h-5 w-5" aria-hidden="true" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-semibold leading-tight">
-          {election.shortTitle || election.title}
-        </div>
-        {(daysUntil !== null && daysUntil > 0) || election.hasResults ? (
-          <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
-            {daysUntil !== null && daysUntil > 0 && (
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 font-semibold text-primary">
-                J-{daysUntil}
-              </span>
-            )}
-            {election.hasResults && <span>Résultats disponibles</span>}
-          </div>
-        ) : null}
-      </div>
-      <ChevronRight
-        className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
-        aria-hidden="true"
-      />
+    <Link href={action.href} prefetch={false} className={className}>
+      {content}
     </Link>
+  );
+}
+
+export function ElectionBanner({ election, now }: ElectionBannerProps) {
+  const state = deriveElectionBannerState({
+    round1Date: election.round1Date,
+    round2Date: election.round2Date,
+    now,
+    round1Scores: election.round1Scores,
+    winner: election.winner,
+  });
+  // No dates means nothing to announce and nothing to count toward.
+  if (state === null) return null;
+
+  const presentation = getBannerPresentation(election.type);
+  const ctx = {
+    electionSlug: election.slug,
+    sourcedCandidacyCount: election.sourcedCandidacyCount,
+  };
+  const primary = presentation.primaryAction(state.kind, ctx);
+  const secondary = presentation.secondaryAction(state.kind, ctx);
+  const label = election.shortTitle || election.title;
+
+  // A 3px gradient rule, never a coloured background: a solid fill would read as campaign material
+  // and would crush the rest of the page.
+  const rule =
+    state.kind === "AFTER"
+      ? "bg-border"
+      : state.kind === "VOTING_DAY"
+        ? "bg-brand"
+        : "bg-gradient-to-r from-brand to-primary";
+
+  const registrationDeadline =
+    state.kind === "LAST_MONTH" ? getVoterRegistrationDeadline(election.slug, now) : null;
+
+  const roundSuffix =
+    state.kind === "VOTING_DAY"
+      ? state.round === 1
+        ? " · 1er tour"
+        : " · 2d tour"
+      : state.kind === "BETWEEN_ROUNDS"
+        ? " · 2d tour"
+        : state.kind === "AFTER"
+          ? " · terminée"
+          : "";
+
+  return (
+    // Plain div rather than <Card>: Card carries py-6, and the gradient rule has to sit flush
+    // against the top edge.
+    <section
+      aria-labelledby="election-banner-label"
+      className="overflow-hidden rounded-xl border bg-card"
+    >
+      <div className={`h-[3px] ${rule}`} aria-hidden="true" />
+      <div className="flex flex-col gap-4 p-4 md:grid md:grid-cols-[1fr_auto_auto] md:items-center md:gap-9 md:p-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              id="election-banner-label"
+              className={`text-xs font-bold uppercase tracking-widest ${
+                state.kind === "AFTER" ? "text-muted-foreground" : "text-brand"
+              }`}
+            >
+              {label}
+              {roundSuffix}
+            </span>
+            {!election.dateConfirmed && state.kind !== "AFTER" && (
+              <Badge variant="outline" className="text-[10px]">
+                Dates provisoires
+              </Badge>
+            )}
+          </div>
+
+          {state.kind === "VOTING_DAY" && (
+            <p className="font-display text-lg font-extrabold leading-tight">
+              Les bureaux ferment dans
+            </p>
+          )}
+
+          {state.kind === "AFTER" && presentation.showWinnerScore && election.winner && (
+            <p className="font-display text-lg font-extrabold leading-tight">
+              {election.winner.candidateName} élu·e avec {formatPct(election.winner.pct)} des voix
+            </p>
+          )}
+
+          {presentation.promise && state.kind !== "VOTING_DAY" && (
+            <p className="text-sm leading-snug md:text-base">{presentation.promise}</p>
+          )}
+
+          {election.round1Date && state.kind !== "AFTER" && (
+            <p className="text-xs text-muted-foreground">
+              1er tour le {formatDate(election.round1Date)}
+              {election.round2Date && <> · 2d tour le {formatDate(election.round2Date)}</>}
+            </p>
+          )}
+
+          {registrationDeadline && (
+            <p className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-xs leading-snug text-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+              <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>
+                Inscription sur les listes électorales : jusqu&apos;au{" "}
+                {formatDate(registrationDeadline)}.
+              </span>
+            </p>
+          )}
+
+          {state.kind === "BETWEEN_ROUNDS" &&
+            presentation.showRound1Scores &&
+            state.round1Scores.length > 0 && (
+              <div className="mt-1 flex flex-col gap-1 border-t border-border pt-3">
+                <span className="text-xs font-bold text-muted-foreground">
+                  Résultats du 1er tour
+                </span>
+                {state.round1Scores.map((score) => (
+                  <span
+                    key={score.candidateName}
+                    className="flex items-center justify-between gap-2 text-sm"
+                  >
+                    <span>
+                      {score.candidateName}
+                      {score.partyLabel && (
+                        <span className="text-muted-foreground"> ({score.partyLabel})</span>
+                      )}
+                    </span>
+                    <span className="font-bold tabular-nums">{formatPct(score.pct)}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+        </div>
+
+        {state.kind !== "AFTER" && (
+          <div className="md:border-l md:border-border md:pl-9">
+            <BannerCountdown
+              targetDate={state.targetDate.toISOString()}
+              showSeconds={state.showSeconds}
+              label={
+                state.kind === "VOTING_DAY"
+                  ? "Compte à rebours jusqu'à la fermeture des bureaux"
+                  : `Compte à rebours jusqu'au ${state.kind === "BETWEEN_ROUNDS" ? "second" : "premier"} tour`
+              }
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 md:min-w-52">
+          <ActionLink action={primary} variant="primary" />
+          {secondary && <ActionLink action={secondary} variant="secondary" />}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/home/ElectionBanner.tsx
+++ b/src/components/home/ElectionBanner.tsx
@@ -6,7 +6,7 @@ import type { FeaturedElection } from "@/lib/data/elections";
 import { deriveElectionBannerState } from "@/lib/elections/banner-state";
 import { getBannerPresentation, type BannerAction } from "@/lib/elections/banner-presentation";
 import { getVoterRegistrationDeadline } from "@/config/election-guides";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatPct } from "@/lib/utils";
 
 /**
  * Homepage election banner. Occupies its existing slot between HomeHero and HomeIntentGrid and does
@@ -22,11 +22,6 @@ import { formatDate } from "@/lib/utils";
 interface ElectionBannerProps {
   election: FeaturedElection;
   now: Date;
-}
-
-/** French percentage: comma as decimal separator, one decimal, non-breaking space before %. */
-function formatPct(pct: number): string {
-  return `${pct.toFixed(1).replace(".", ",")} %`;
 }
 
 function ActionLink({

--- a/src/components/home/HomeIntentGrid.tsx
+++ b/src/components/home/HomeIntentGrid.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
-import { UserSearch, Vote, Scale, MapPinned, ChevronRight } from "lucide-react";
+import { UserSearch, Vote, Scale, Landmark, ChevronRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 interface IntentCard {
@@ -8,6 +8,8 @@ interface IntentCard {
   description: string;
   href: string;
   icon: LucideIcon;
+  /** The one card that speaks of the coming deadline. Accented, and only ever one. */
+  accent?: boolean;
 }
 
 interface HomeIntentGridProps {
@@ -35,10 +37,14 @@ export function HomeIntentGrid({ enabledFlags }: HomeIntentGridProps) {
       icon: Scale,
     },
     {
-      title: "Je veux suivre les municipales",
-      description: "Candidats, listes et résultats dans votre commune.",
-      href: enabledFlags.has("MUNICIPALES_2026") ? "/elections/municipales-2026" : "/elections",
-      icon: MapPinned,
+      title: "Je veux comparer les candidats à 2027",
+      description: "Programmes, votes et bilans mis côte à côte, sujet par sujet.",
+      href: "/elections/presidentielle-2027",
+      icon: Landmark,
+      // Replaces "suivre les municipales", which pointed at a completed election. Aims at the
+      // task, not at the event. The municipales pages stay reachable from the navigation, which
+      // still gates them on the MUNICIPALES_2026 flag.
+      accent: true,
     },
   ];
 
@@ -50,9 +56,17 @@ export function HomeIntentGrid({ enabledFlags }: HomeIntentGridProps) {
           const Icon = card.icon;
           return (
             <Link key={card.href + card.title} href={card.href} prefetch={false}>
-              <Card className="group h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-md">
+              <Card
+                className={`group h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-md ${
+                  card.accent ? "ring-1 ring-brand/25" : ""
+                }`}
+              >
                 <CardContent className="flex items-start gap-3 p-4">
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <span
+                    className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+                      card.accent ? "bg-brand/12 text-brand" : "bg-primary/10 text-primary"
+                    }`}
+                  >
                     <Icon className="h-5 w-5" aria-hidden="true" />
                   </span>
                   <div className="min-w-0 flex-1">

--- a/src/components/home/__tests__/BannerCountdown.test.tsx
+++ b/src/components/home/__tests__/BannerCountdown.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BannerCountdown } from "@/components/home/BannerCountdown";
+
+describe("BannerCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rend trois unités quand les secondes ne sont pas demandées", () => {
+    render(
+      <BannerCountdown
+        targetDate="2027-04-11T06:00:00.000Z"
+        showSeconds={false}
+        label="Compte à rebours jusqu'au premier tour"
+      />
+    );
+
+    expect(screen.getByText("jours")).toBeInTheDocument();
+    expect(screen.getByText("heures")).toBeInTheDocument();
+    expect(screen.getByText("minutes")).toBeInTheDocument();
+    expect(screen.queryByText("secondes")).not.toBeInTheDocument();
+  });
+
+  it("rend les secondes quand elles sont demandées", () => {
+    render(
+      <BannerCountdown
+        targetDate="2026-08-07T18:00:00.000Z"
+        showSeconds
+        label="Fermeture des bureaux"
+      />
+    );
+
+    expect(screen.getByText("secondes")).toBeInTheDocument();
+  });
+
+  it("expose un role timer avec son libellé", () => {
+    render(
+      <BannerCountdown
+        targetDate="2027-04-11T06:00:00.000Z"
+        showSeconds={false}
+        label="Compte à rebours jusqu'au premier tour"
+      />
+    );
+
+    expect(
+      screen.getByRole("timer", { name: "Compte à rebours jusqu'au premier tour" })
+    ).toBeInTheDocument();
+  });
+
+  it("réserve la place avant montage au lieu de ne rien rendre", () => {
+    // The homepage is ISR-cached for 300 s, so hours and minutes cannot be rendered on the server
+    // without diverging at hydration. The skeleton keeps the layout stable instead of collapsing
+    // the tallest card on the page.
+    const { container } = render(
+      <BannerCountdown
+        targetDate="2027-04-11T06:00:00.000Z"
+        showSeconds={false}
+        label="Compte à rebours"
+      />
+    );
+
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("n'affiche jamais de valeur négative une fois la cible passée", () => {
+    render(
+      <BannerCountdown
+        targetDate="2026-01-01T00:00:00.000Z"
+        showSeconds={false}
+        label="Cible passée"
+      />
+    );
+
+    expect(screen.queryByText(/-/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/home/__tests__/ElectionBanner.test.tsx
+++ b/src/components/home/__tests__/ElectionBanner.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ElectionBanner } from "@/components/home/ElectionBanner";
+import type { FeaturedElection } from "@/lib/data/elections";
+
+const presidentielle: FeaturedElection = {
+  slug: "presidentielle-2027",
+  title: "Élection présidentielle de 2027",
+  shortTitle: "Présidentielle 2027",
+  type: "PRESIDENTIELLE",
+  round1Date: new Date("2027-04-11T00:00:00.000Z"),
+  round2Date: new Date("2027-04-25T00:00:00.000Z"),
+  dateConfirmed: false,
+  round1Scores: [],
+  winner: null,
+  sourcedCandidacyCount: 25,
+  hasResults: false,
+  communesDepouillees: 0,
+};
+
+describe("ElectionBanner", () => {
+  it("annonce l'élection et sa promesse loin du scrutin", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2026-08-07T10:00:00.000Z")} />);
+
+    expect(screen.getByText(/Présidentielle 2027/)).toBeInTheDocument();
+    expect(screen.getByText(/ce qu'elle a voté/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Ouvrir le dossier/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+  });
+
+  it("affiche « Dates provisoires » tant que le décret n'est pas paru", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2026-08-07T10:00:00.000Z")} />);
+
+    expect(screen.getByText("Dates provisoires")).toBeInTheDocument();
+  });
+
+  it("retire « Dates provisoires » quand dateConfirmed passe à vrai", () => {
+    render(
+      <ElectionBanner
+        election={{ ...presidentielle, dateConfirmed: true }}
+        now={new Date("2026-08-07T10:00:00.000Z")}
+      />
+    );
+
+    expect(screen.queryByText("Dates provisoires")).not.toBeInTheDocument();
+  });
+
+  it("compte les candidatures recensées et jamais « documentées »", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2026-08-07T10:00:00.000Z")} />);
+
+    expect(screen.getByRole("link", { name: /25 candidatures recensées/ })).toBeInTheDocument();
+    expect(screen.queryByText(/candidatures documentées/)).not.toBeInTheDocument();
+  });
+
+  it("ne rend pas de secondes hors du jour du vote", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2026-08-07T10:00:00.000Z")} />);
+
+    expect(screen.queryByText("secondes")).not.toBeInTheDocument();
+  });
+
+  it("rend les secondes et le bureau de vote le jour du scrutin", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2027-04-11T10:00:00.000Z")} />);
+
+    expect(screen.getByText("secondes")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /bureau de vote/ });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("ne rend aucun compte à rebours après le second tour", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2027-05-10T10:00:00.000Z")} />);
+
+    expect(screen.queryByRole("timer")).not.toBeInTheDocument();
+    expect(screen.queryByText("jours")).not.toBeInTheDocument();
+  });
+
+  it("omet le bloc de résultats entre les tours quand les scores manquent", () => {
+    render(<ElectionBanner election={presidentielle} now={new Date("2027-04-13T10:00:00.000Z")} />);
+
+    expect(screen.queryByText(/Résultats du 1/)).not.toBeInTheDocument();
+  });
+
+  it("rend le bloc de résultats entre les tours quand les scores existent", () => {
+    render(
+      <ElectionBanner
+        election={{
+          ...presidentielle,
+          round1Scores: [
+            {
+              candidateName: "Camille Rivière",
+              politicianSlug: "camille-riviere",
+              partyLabel: "UD",
+              pct: 27.4,
+            },
+          ],
+        }}
+        now={new Date("2027-04-13T10:00:00.000Z")}
+      />
+    );
+
+    expect(screen.getByText("Camille Rivière")).toBeInTheDocument();
+    expect(screen.getByText("27,4 %")).toBeInTheDocument();
+  });
+
+  it("n'accorde aucun bouton présidentiel à une municipale à la une", () => {
+    render(
+      <ElectionBanner
+        election={{
+          ...presidentielle,
+          slug: "municipales-2032",
+          shortTitle: "Municipales 2032",
+          type: "MUNICIPALES",
+        }}
+        now={new Date("2032-04-01T10:00:00.000Z")}
+      />
+    );
+
+    expect(screen.queryByText(/ce qu'elle a voté/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Ouvrir le dossier/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Voir l'élection/ })).toBeInTheDocument();
+  });
+
+  it("ne rend rien du tout quand l'élection n'a pas de date de premier tour", () => {
+    const { container } = render(
+      <ElectionBanner
+        election={{ ...presidentielle, round1Date: null, round2Date: null }}
+        now={new Date("2026-08-07T10:00:00.000Z")}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/home/__tests__/HomeIntentGrid.test.tsx
+++ b/src/components/home/__tests__/HomeIntentGrid.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HomeIntentGrid } from "@/components/home/HomeIntentGrid";
+
+describe("HomeIntentGrid", () => {
+  it("propose de comparer les candidats à 2027 en quatrième carte", () => {
+    render(<HomeIntentGrid enabledFlags={new Set<string>()} />);
+
+    const link = screen.getByRole("link", { name: /comparer les candidats à 2027/i });
+    expect(link).toHaveAttribute("href", "/elections/presidentielle-2027");
+  });
+
+  it("ne propose plus de suivre les municipales, qui sont passées", () => {
+    render(<HomeIntentGrid enabledFlags={new Set(["MUNICIPALES_2026"])} />);
+
+    expect(screen.queryByText(/suivre les municipales/i)).not.toBeInTheDocument();
+  });
+
+  it("garde les trois autres cartes et le comportement du drapeau de comparaison", () => {
+    render(<HomeIntentGrid enabledFlags={new Set(["COMPARISON_TOOL"])} />);
+
+    expect(screen.getByRole("link", { name: /vérifier un élu/i })).toHaveAttribute(
+      "href",
+      "/politiques"
+    );
+    expect(screen.getByRole("link", { name: /comprendre un vote/i })).toHaveAttribute(
+      "href",
+      "/parlement/votes"
+    );
+    expect(screen.getByRole("link", { name: /comparer les partis/i })).toHaveAttribute(
+      "href",
+      "/comparer"
+    );
+  });
+});

--- a/src/components/politicians/CandidacyNotice.tsx
+++ b/src/components/politicians/CandidacyNotice.tsx
@@ -1,0 +1,164 @@
+import Link from "next/link";
+import { ChevronRight, CircleX, ExternalLink, Landmark, TrendingUp } from "lucide-react";
+import { CANDIDACY_STATUS_LABELS, candidacyRoleLabel } from "@/config/labels";
+import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
+import { deriveCandidacyNoticeState } from "@/lib/politicians/candidacy-notice-state";
+import { formatDate } from "@/lib/utils";
+
+/**
+ * Candidacy notice on a politician's fiche. Full width, under the badges, above the tabs, at both
+ * widths.
+ *
+ * Two placement decisions are load-bearing and belong in the caller's tree, not here: no
+ * "candidat 2027" badge is added to the party/mandate badge row (there it would read as a
+ * qualification awarded by Poligraph), and the notice sits before the tabs because the tabs are
+ * where reading engages, so whatever changes the frame has to be read first.
+ *
+ * A merely rumoured candidacy is rendered deliberately weaker: no accent rule, no coloured pill, a
+ * conditional title. A press mention must not look like a declaration.
+ */
+
+interface CandidacyNoticeProps {
+  candidacy: PoliticianCandidacy;
+  /** Drives the gender of the notice title. */
+  civility: string | null;
+  now: Date;
+}
+
+/** French percentage: comma as decimal separator, one decimal, non-breaking space before %. */
+function formatPct(pct: number): string {
+  return `${pct.toFixed(1).replace(".", ",")} %`;
+}
+
+export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticeProps) {
+  const state = deriveCandidacyNoticeState(candidacy, now);
+  const hubHref = `/elections/${candidacy.electionSlug}`;
+  const accented = state.kind === "DECLARED_WITH_MEASURES" || state.kind === "DECLARED_EMPTY";
+
+  const Icon = state.kind === "WITHDRAWN" ? CircleX : state.kind === "PAST" ? TrendingUp : Landmark;
+
+  const title =
+    state.kind === "POSSIBLE"
+      ? "Cité parmi les candidatures possibles"
+      : state.kind === "WITHDRAWN"
+        ? `Candidature retirée${candidacy.withdrewAt ? ` le ${formatDate(candidacy.withdrewAt)}` : ""}`
+        : state.kind === "PAST"
+          ? `${candidacyRoleLabel(civility)} en 2027`
+          : candidacyRoleLabel(civility);
+
+  const explanation =
+    state.kind === "DECLARED_EMPTY"
+      ? "Aucune mesure publiée à ce jour. Nous publions une mesure quand elle est sourcée et relue, pas à l'annonce."
+      : state.kind === "POSSIBLE"
+        ? "Rien n'a été déclaré. La mention vient de la presse, elle est datée, et elle disparaît si elle n'est pas confirmée."
+        : state.kind === "WITHDRAWN" && candidacy.publishedMeasureCount > 0
+          ? `Les ${candidacy.publishedMeasureCount} mesures documentées restent consultables, datées de la période de campagne.`
+          : null;
+
+  const footer =
+    state.kind === "DECLARED_WITH_MEASURES"
+      ? {
+          // Until the candidate fiche route exists (PR C), the hub is the destination. The link
+          // announces the volume either way, so the reader knows what they will find.
+          href: hubHref,
+          label: "Son programme, sujet par sujet",
+          detail: `${candidacy.publishedMeasureCount} mesures sur ${candidacy.themesCoveredCount} sujets${
+            candidacy.lastReviewedAt ? ` · revue le ${formatDate(candidacy.lastReviewedAt)}` : ""
+          }`,
+        }
+      : state.kind === "DECLARED_EMPTY"
+        ? {
+            href: hubHref,
+            label: `Suivre le dossier ${candidacy.electionShortTitle}`,
+            detail: null,
+          }
+        : state.kind === "WITHDRAWN"
+          ? { href: hubHref, label: "Son programme, archivé", detail: null }
+          : state.kind === "PAST"
+            ? { href: hubHref, label: "Résultats et programme de 2027", detail: null }
+            : { href: hubHref, label: "Voir toutes les candidatures", detail: null };
+
+  return (
+    <section
+      className={`overflow-hidden rounded-xl border bg-card ${
+        accented ? "border-l-4 border-l-brand" : ""
+      }`}
+      aria-labelledby="candidacy-notice-title"
+    >
+      <div className="flex items-start gap-3 p-4 md:items-center md:gap-4 md:p-5">
+        <span
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+            accented ? "bg-brand/12 text-brand" : "bg-muted text-muted-foreground"
+          }`}
+        >
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p
+            className={`text-xs font-bold uppercase tracking-widest ${
+              accented ? "text-brand" : "text-muted-foreground"
+            }`}
+          >
+            {candidacy.electionShortTitle}
+          </p>
+          <p
+            id="candidacy-notice-title"
+            className="font-display text-base font-bold leading-tight md:text-lg"
+          >
+            {title}
+          </p>
+
+          {state.kind !== "PAST" && (
+            <p className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
+                {CANDIDACY_STATUS_LABELS[candidacy.status]}
+              </span>
+              <a
+                href={candidacy.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[11px] underline hover:no-underline"
+              >
+                {candidacy.sourceLabel}
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+              </a>
+            </p>
+          )}
+
+          {state.kind === "PAST" && state.results && (
+            <p className="text-xs leading-snug text-muted-foreground">
+              {state.results.round1Pct !== null && (
+                <>{formatPct(state.results.round1Pct)} au 1er tour</>
+              )}
+              {state.results.round1Pct !== null && state.results.round2Pct !== null && ", "}
+              {state.results.round2Pct !== null && (
+                <>{formatPct(state.results.round2Pct)} au second</>
+              )}
+              {candidacy.publishedMeasureCount > 0 && (
+                <>. Ses {candidacy.publishedMeasureCount} mesures restent liées à cette campagne.</>
+              )}
+            </p>
+          )}
+
+          {explanation && (
+            <p className="text-xs leading-snug text-muted-foreground">{explanation}</p>
+          )}
+        </div>
+      </div>
+
+      <Link
+        href={footer.href}
+        prefetch={false}
+        className="flex min-h-14 items-center gap-3 border-t border-border bg-muted px-4 py-3 transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-bold text-primary">{footer.label}</span>
+          {footer.detail && (
+            <span className="mt-0.5 block text-xs text-muted-foreground">{footer.detail}</span>
+          )}
+        </span>
+        <ChevronRight className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+      </Link>
+    </section>
+  );
+}

--- a/src/components/politicians/CandidacyNotice.tsx
+++ b/src/components/politicians/CandidacyNotice.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/config/labels";
 import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
 import { deriveCandidacyNoticeState } from "@/lib/politicians/candidacy-notice-state";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatPct } from "@/lib/utils";
 
 /**
  * Candidacy notice on a politician's fiche. Full width, under the badges, above the tabs, at both
@@ -35,11 +35,6 @@ interface CandidacyNoticeProps {
    * her programme when the fiche exists, and to a six-candidate page when it does not.
    */
   ficheHref: string | null;
-}
-
-/** French percentage: comma as decimal separator, one decimal, non-breaking space before %. */
-function formatPct(pct: number): string {
-  return `${pct.toFixed(1).replace(".", ",")} %`;
 }
 
 /**
@@ -77,6 +72,13 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
   const showStatusPill =
     state.kind !== "PAST" && CANDIDACY_STATUS_LABELS[candidacy.status] !== title;
 
+  // Agreement follows the count, not just the noun: "Les 1 mesure documentées" is bad French, and the
+  // gate opens at one measure.
+  const measuresPhrase = (suffix: string) =>
+    candidacy.publishedMeasureCount === 1
+      ? `La mesure documentée reste consultable${suffix}`
+      : `Les ${candidacy.publishedMeasureCount} mesures documentées restent consultables${suffix}`;
+
   const explanation =
     state.kind === "DECLARED_EMPTY"
       ? "Aucune mesure publiée à ce jour. Nous publions une mesure quand elle est sourcée et relue, pas à l'annonce."
@@ -86,9 +88,16 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
           ? // The date lives in the title, so the sentence can only point at it when it exists.
             // Without it, naming the gap beats implying a dating we do not hold.
             candidacy.withdrewAt
-            ? `Les ${plural(candidacy.publishedMeasureCount, "mesure")} documentées restent consultables, datées de la période de campagne.`
-            : `Les ${plural(candidacy.publishedMeasureCount, "mesure")} documentées restent consultables. Date du retrait non renseignée.`
-          : null;
+            ? measuresPhrase(", datées de la période de campagne.")
+            : measuresPhrase(". Date du retrait non renseignée.")
+          : // Deliberately OUTSIDE the results guard. Nesting it there emptied the card between the
+            // close of the second round and the import of the results: no pill, no source, no
+            // explanation, no counter, on the state that carries the strongest claim.
+            state.kind === "PAST" && candidacy.publishedMeasureCount > 0
+            ? candidacy.publishedMeasureCount === 1
+              ? "Sa mesure documentée reste liée à cette campagne."
+              : `Ses ${candidacy.publishedMeasureCount} mesures documentées restent liées à cette campagne.`
+            : null;
 
   const footer =
     state.kind === "DECLARED_WITH_MEASURES"
@@ -129,9 +138,12 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
           <Icon className="h-5 w-5" aria-hidden="true" />
         </span>
         <div className="min-w-0 flex-1 space-y-1.5">
+          {/* `brand-on-surface` and not `brand`: measured at 12px bold on --card in dark, the base
+              token gives 4.11:1 against the 4.5:1 AA needs. The readable variant gives 5.24:1 and
+              aliases the base in light mode. */}
           <p
             className={`text-xs font-bold uppercase tracking-widest ${
-              accented ? "text-brand" : "text-muted-foreground"
+              accented ? "text-brand-on-surface" : "text-muted-foreground"
             }`}
           >
             {candidacy.electionShortTitle}
@@ -143,27 +155,41 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
             {title}
           </p>
 
-          {state.kind !== "PAST" && (
-            <p className="flex flex-wrap items-center gap-2">
-              {showStatusPill && (
-                <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
-                  {CANDIDACY_STATUS_LABELS[candidacy.status]}
-                </span>
-              )}
-              <a
-                href={candidacy.sourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-[11px] underline hover:no-underline"
-              >
-                {candidacy.sourceLabel}
-                <ExternalLink className="h-3 w-3" aria-hidden="true" />
-              </a>
-            </p>
-          )}
+          {/* The source is shown in EVERY state, PAST included. The withdrawn state drops the pill
+              when it duplicates the title, and the past state drops the pill because the results
+              replace the status, but neither drops the attribution: the notice never says more than
+              its source, and PAST carries the strongest claim of the five. */}
+          <p className="flex flex-wrap items-center gap-2">
+            {showStatusPill && (
+              <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
+                {CANDIDACY_STATUS_LABELS[candidacy.status]}
+              </span>
+            )}
+            <a
+              href={candidacy.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[11px] underline hover:no-underline"
+            >
+              {candidacy.sourceLabel}
+              <ExternalLink className="h-3 w-3" aria-hidden="true" />
+            </a>
+          </p>
 
           {state.kind === "PAST" && state.results && (
             <p className="text-xs leading-snug text-muted-foreground">
+              {/* `isElected` was read from the database, carried through the type, and rendered
+                  nowhere: an elected president's fiche did not say they had won. Agreement follows
+                  civility, and drops to a formulation that genders nobody when it is unknown. */}
+              {state.results.isElected && (
+                <>
+                  {civility === "Mme"
+                    ? "Élue."
+                    : civility === "M."
+                      ? "Élu."
+                      : "Élection remportée."}{" "}
+                </>
+              )}
               {state.results.round1Pct !== null && (
                 <>{formatPct(state.results.round1Pct)} au 1er tour</>
               )}
@@ -171,9 +197,7 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
               {state.results.round2Pct !== null && (
                 <>{formatPct(state.results.round2Pct)} au second</>
               )}
-              {candidacy.publishedMeasureCount > 0 && (
-                <>. Ses {candidacy.publishedMeasureCount} mesures restent liées à cette campagne.</>
-              )}
+              .
             </p>
           )}
 
@@ -190,8 +214,12 @@ export function CandidacyNotice({ candidacy, civility, now, ficheHref }: Candida
       >
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-bold text-primary">{footer.label}</span>
+          {/* `muted-foreground-strong`: measured at 12px on --muted in dark, the base token gives
+              3.83:1 against the 4.5:1 AA needs. The readable variant gives 5.25:1. */}
           {footer.detail && (
-            <span className="mt-0.5 block text-xs text-muted-foreground">{footer.detail}</span>
+            <span className="mt-0.5 block text-xs text-muted-foreground-strong">
+              {footer.detail}
+            </span>
           )}
         </span>
         <ChevronRight className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />

--- a/src/components/politicians/CandidacyNotice.tsx
+++ b/src/components/politicians/CandidacyNotice.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { ChevronRight, CircleX, ExternalLink, Landmark, TrendingUp } from "lucide-react";
-import { CANDIDACY_STATUS_LABELS, candidacyRoleLabel } from "@/config/labels";
+import {
+  CANDIDACY_STATUS_LABELS,
+  candidacyPossibleLabel,
+  candidacyRoleLabel,
+} from "@/config/labels";
 import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
 import { deriveCandidacyNoticeState } from "@/lib/politicians/candidacy-notice-state";
 import { formatDate } from "@/lib/utils";
@@ -30,6 +34,16 @@ function formatPct(pct: number): string {
   return `${pct.toFixed(1).replace(".", ",")} %`;
 }
 
+/**
+ * Plural agreement on the counters.
+ *
+ * Not cosmetic: `isFicheCandidatPublishable` opens the state at ONE primary-sourced measure, so
+ * "1 mesures sur 1 sujets" is reachable the day a candidacy crosses the gate with a single measure.
+ */
+function plural(count: number, singular: string): string {
+  return `${count} ${singular}${count > 1 ? "s" : ""}`;
+}
+
 export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticeProps) {
   const state = deriveCandidacyNoticeState(candidacy, now);
   const hubHref = `/elections/${candidacy.electionSlug}`;
@@ -39,12 +53,21 @@ export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticePro
 
   const title =
     state.kind === "POSSIBLE"
-      ? "Cité parmi les candidatures possibles"
+      ? candidacyPossibleLabel(civility)
       : state.kind === "WITHDRAWN"
         ? `Candidature retirée${candidacy.withdrewAt ? ` le ${formatDate(candidacy.withdrewAt)}` : ""}`
         : state.kind === "PAST"
           ? `${candidacyRoleLabel(civility)} en 2027`
           : candidacyRoleLabel(civility);
+
+  // The status pill sits next to the source link, which is why it is not simply dropped when it
+  // repeats the title. Observed on the only withdrawn candidacy in production: with `withdrewAt`
+  // null, the title falls back to "Candidature retirée", which is verbatim
+  // CANDIDACY_STATUS_LABELS.RETIRE, and the page printed the same sentence twice in a row. Guarding
+  // on equality rather than on the state kills the whole class, including a future label edit that
+  // would make another state collide.
+  const showStatusPill =
+    state.kind !== "PAST" && CANDIDACY_STATUS_LABELS[candidacy.status] !== title;
 
   const explanation =
     state.kind === "DECLARED_EMPTY"
@@ -52,7 +75,11 @@ export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticePro
       : state.kind === "POSSIBLE"
         ? "Rien n'a été déclaré. La mention vient de la presse, elle est datée, et elle disparaît si elle n'est pas confirmée."
         : state.kind === "WITHDRAWN" && candidacy.publishedMeasureCount > 0
-          ? `Les ${candidacy.publishedMeasureCount} mesures documentées restent consultables, datées de la période de campagne.`
+          ? // The date lives in the title, so the sentence can only point at it when it exists.
+            // Without it, naming the gap beats implying a dating we do not hold.
+            candidacy.withdrewAt
+            ? `Les ${plural(candidacy.publishedMeasureCount, "mesure")} documentées restent consultables, datées de la période de campagne.`
+            : `Les ${plural(candidacy.publishedMeasureCount, "mesure")} documentées restent consultables. Date du retrait non renseignée.`
           : null;
 
   const footer =
@@ -62,7 +89,7 @@ export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticePro
           // announces the volume either way, so the reader knows what they will find.
           href: hubHref,
           label: "Son programme, sujet par sujet",
-          detail: `${candidacy.publishedMeasureCount} mesures sur ${candidacy.themesCoveredCount} sujets${
+          detail: `${plural(candidacy.publishedMeasureCount, "mesure")} sur ${plural(candidacy.themesCoveredCount, "sujet")}${
             candidacy.lastReviewedAt ? ` · revue le ${formatDate(candidacy.lastReviewedAt)}` : ""
           }`,
         }
@@ -110,9 +137,11 @@ export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticePro
 
           {state.kind !== "PAST" && (
             <p className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
-                {CANDIDACY_STATUS_LABELS[candidacy.status]}
-              </span>
+              {showStatusPill && (
+                <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
+                  {CANDIDACY_STATUS_LABELS[candidacy.status]}
+                </span>
+              )}
               <a
                 href={candidacy.sourceUrl}
                 target="_blank"

--- a/src/components/politicians/CandidacyNotice.tsx
+++ b/src/components/politicians/CandidacyNotice.tsx
@@ -27,6 +27,14 @@ interface CandidacyNoticeProps {
   /** Drives the gender of the notice title. */
   civility: string | null;
   now: Date;
+  /**
+   * Target of the state-A footer link. Null when the fiche is below its publication gate, in which
+   * case the footer falls back to the hub rather than to a page that redirects.
+   *
+   * The distinction matters for the wording as much as for the destination: "Son programme" leads to
+   * her programme when the fiche exists, and to a six-candidate page when it does not.
+   */
+  ficheHref: string | null;
 }
 
 /** French percentage: comma as decimal separator, one decimal, non-breaking space before %. */
@@ -44,7 +52,7 @@ function plural(count: number, singular: string): string {
   return `${count} ${singular}${count > 1 ? "s" : ""}`;
 }
 
-export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticeProps) {
+export function CandidacyNotice({ candidacy, civility, now, ficheHref }: CandidacyNoticeProps) {
   const state = deriveCandidacyNoticeState(candidacy, now);
   const hubHref = `/elections/${candidacy.electionSlug}`;
   const accented = state.kind === "DECLARED_WITH_MEASURES" || state.kind === "DECLARED_EMPTY";
@@ -85,10 +93,10 @@ export function CandidacyNotice({ candidacy, civility, now }: CandidacyNoticePro
   const footer =
     state.kind === "DECLARED_WITH_MEASURES"
       ? {
-          // Until the candidate fiche route exists (PR C), the hub is the destination. The link
-          // announces the volume either way, so the reader knows what they will find.
-          href: hubHref,
-          label: "Son programme, sujet par sujet",
+          href: ficheHref ?? hubHref,
+          // The possessive wording is only honest when the destination is the person's own fiche.
+          // Without it the link lands on a page listing every candidacy, so it says so.
+          label: ficheHref ? "Son programme, sujet par sujet" : "Le dossier, sujet par sujet",
           detail: `${plural(candidacy.publishedMeasureCount, "mesure")} sur ${plural(candidacy.themesCoveredCount, "sujet")}${
             candidacy.lastReviewedAt ? ` · revue le ${formatDate(candidacy.lastReviewedAt)}` : ""
           }`,

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -78,7 +78,7 @@ describe("CandidacyNotice", () => {
   });
 
   it("traite une candidature pressentie plus faiblement, au conditionnel", () => {
-    const { container } = renderNotice({ ...base, status: "PRESSENTI" });
+    const { container } = renderNotice({ ...base, status: "PRESSENTI" }, "M.");
     expect(screen.getByText("Cité parmi les candidatures possibles")).toBeInTheDocument();
     expect(screen.getByText(/Rien n'a été déclaré/)).toBeInTheDocument();
     // No accent rule: a press mention must not look like a declaration.
@@ -111,6 +111,69 @@ describe("CandidacyNotice", () => {
   it("n'affiche aucun score après l'élection quand la base n'en a pas", () => {
     renderNotice(base, "Mme", AFTER);
     expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+
+  it("ne répète pas le statut quand le titre le dit déjà mot pour mot", () => {
+    // Observed on the only withdrawn candidacy in production: withdrewAt is null, so the title
+    // falls back to "Candidature retirée", which is verbatim CANDIDACY_STATUS_LABELS.RETIRE, and
+    // the page printed the same sentence twice in a row.
+    renderNotice({ ...base, status: "RETIRE", withdrewAt: null });
+
+    expect(screen.getAllByText("Candidature retirée")).toHaveLength(1);
+  });
+
+  it("garde la pastille de statut dès que le titre en diffère", () => {
+    renderNotice({
+      ...base,
+      status: "RETIRE",
+      withdrewAt: new Date("2027-03-03T00:00:00.000Z"),
+    });
+
+    expect(screen.getByText(/Candidature retirée le/)).toBeInTheDocument();
+    expect(screen.getByText("Candidature retirée")).toBeInTheDocument();
+  });
+
+  it("nomme la date de retrait manquante au lieu de sous-entendre un datage", () => {
+    renderNotice({
+      ...base,
+      status: "RETIRE",
+      withdrewAt: null,
+      publishedMeasureCount: 18,
+      primarySourceMeasureCount: 15,
+    });
+
+    expect(screen.getByText(/Date du retrait non renseignée/)).toBeInTheDocument();
+    expect(screen.queryByText(/datées de la période de campagne/)).not.toBeInTheDocument();
+  });
+
+  it("accorde les compteurs au singulier : le seuil de publication s'ouvre à une mesure", () => {
+    renderNotice({
+      ...base,
+      publishedMeasureCount: 1,
+      themesCoveredCount: 1,
+      primarySourceMeasureCount: 1,
+    });
+
+    expect(screen.getByText(/1 mesure sur 1 sujet/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 mesures/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/1 sujets/)).not.toBeInTheDocument();
+  });
+
+  it("ne genre pas la personne quand la civilité est inconnue", () => {
+    // 5 of the 25 sourced presidential candidacies carry a null civility. Defaulting to the
+    // masculine would state a gender the database does not hold.
+    renderNotice(base, null);
+
+    expect(screen.getByText("Candidature à la présidentielle")).toBeInTheDocument();
+    expect(screen.queryByText("Candidat à la présidentielle")).not.toBeInTheDocument();
+  });
+
+  it("accorde le participe de l'état pressenti, et le retire quand la civilité manque", () => {
+    renderNotice({ ...base, status: "PRESSENTI" }, "Mme");
+    expect(screen.getByText("Citée parmi les candidatures possibles")).toBeInTheDocument();
+
+    renderNotice({ ...base, status: "PRESSENTI" }, null);
+    expect(screen.getByText("Parmi les candidatures possibles")).toBeInTheDocument();
   });
 
   it("garde le traitement du retrait après l'élection", () => {

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -211,6 +211,49 @@ describe("CandidacyNotice", () => {
     expect(screen.queryByText(/Son programme, sujet par sujet/)).not.toBeInTheDocument();
   });
 
+  it("cite sa source même après l'élection : c'est l'état qui affirme le plus", () => {
+    renderNotice({ ...base, round1Pct: 27.4, round2Pct: 47.2 }, "Mme", AFTER);
+
+    const link = screen.getByRole("link", { name: /Le Monde, 14 janvier 2026/ });
+    expect(link).toHaveAttribute("href", "https://example.org/source");
+  });
+
+  it("garde les mesures après l'élection même quand les scores ne sont pas importés", () => {
+    // The real state of the site between the close of the second round and the results import.
+    renderNotice({ ...base, publishedMeasureCount: 10 }, "Mme", AFTER);
+
+    expect(
+      screen.getByText(/10 mesures documentées restent liées à cette campagne/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+
+  it("dit que la personne a gagné, en accordant sur la civilité", () => {
+    const elected = { ...base, round1Pct: 27.4, round2Pct: 52.8, isElected: true };
+
+    renderNotice(elected, "Mme", AFTER);
+    expect(screen.getByText(/Élue\./)).toBeInTheDocument();
+  });
+
+  it("ne genre personne dans l'annonce de victoire quand la civilité manque", () => {
+    renderNotice({ ...base, round2Pct: 52.8, isElected: true }, null, AFTER);
+
+    expect(screen.getByText(/Élection remportée\./)).toBeInTheDocument();
+    expect(screen.queryByText(/Élu\./)).not.toBeInTheDocument();
+  });
+
+  it("accorde la phrase des mesures au singulier dans l'état retiré", () => {
+    renderNotice({
+      ...base,
+      status: "RETIRE",
+      withdrewAt: new Date("2027-03-03T00:00:00.000Z"),
+      publishedMeasureCount: 1,
+    });
+
+    expect(screen.getByText(/La mesure documentée reste consultable/)).toBeInTheDocument();
+    expect(screen.queryByText(/Les 1 mesure/)).not.toBeInTheDocument();
+  });
+
   it("garde le traitement du retrait après l'élection", () => {
     renderNotice(
       { ...base, status: "RETIRE", withdrewAt: new Date("2027-03-03T00:00:00.000Z") },

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CandidacyNotice } from "@/components/politicians/CandidacyNotice";
+import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
+
+const BEFORE = new Date("2026-08-07T10:00:00.000Z");
+const AFTER = new Date("2027-05-10T10:00:00.000Z");
+
+const base: PoliticianCandidacy = {
+  electionSlug: "presidentielle-2027",
+  electionShortTitle: "Présidentielle 2027",
+  round1Date: new Date("2027-04-11T00:00:00.000Z"),
+  round2Date: new Date("2027-04-25T00:00:00.000Z"),
+  status: "DECLARE",
+  sourceUrl: "https://example.org/source",
+  sourceLabel: "Le Monde, 14 janvier 2026",
+  declaredAt: new Date("2026-01-14T00:00:00.000Z"),
+  withdrewAt: null,
+  publishedMeasureCount: 0,
+  themesCoveredCount: 0,
+  primarySourceMeasureCount: 0,
+  lastReviewedAt: null,
+  round1Pct: null,
+  round2Pct: null,
+  isElected: false,
+};
+
+function renderNotice(
+  candidacy: PoliticianCandidacy = base,
+  civility: string | null = null,
+  now: Date = BEFORE
+) {
+  return render(<CandidacyNotice candidacy={candidacy} civility={civility} now={now} />);
+}
+
+describe("CandidacyNotice", () => {
+  it("féminise le titre selon la civilité", () => {
+    renderNotice(base, "Mme");
+    expect(screen.getByText("Candidate à la présidentielle")).toBeInTheDocument();
+  });
+
+  it("garde le masculin par défaut", () => {
+    renderNotice(base, "M.");
+    expect(screen.getByText("Candidat à la présidentielle")).toBeInTheDocument();
+  });
+
+  it("affiche le statut avec le libellé du dépôt", () => {
+    renderNotice();
+    expect(screen.getByText("Candidature déclarée")).toBeInTheDocument();
+  });
+
+  it("ouvre la source dans un nouvel onglet, sans fuite de référent", () => {
+    renderNotice();
+    const link = screen.getByRole("link", { name: /Le Monde, 14 janvier 2026/ });
+    expect(link).toHaveAttribute("href", "https://example.org/source");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("nomme l'absence de mesures au lieu de la masquer", () => {
+    renderNotice();
+    expect(screen.getByText(/Aucune mesure publiée à ce jour/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Suivre le dossier/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+  });
+
+  it("annonce le volume avant le clic quand la fiche est publiable", () => {
+    renderNotice({
+      ...base,
+      publishedMeasureCount: 27,
+      themesCoveredCount: 9,
+      primarySourceMeasureCount: 20,
+      lastReviewedAt: new Date("2026-08-02T00:00:00.000Z"),
+    });
+    expect(screen.getByText(/27 mesures sur 9 sujets/)).toBeInTheDocument();
+  });
+
+  it("traite une candidature pressentie plus faiblement, au conditionnel", () => {
+    const { container } = renderNotice({ ...base, status: "PRESSENTI" });
+    expect(screen.getByText("Cité parmi les candidatures possibles")).toBeInTheDocument();
+    expect(screen.getByText(/Rien n'a été déclaré/)).toBeInTheDocument();
+    // No accent rule: a press mention must not look like a declaration.
+    expect(container.querySelector(".border-l-brand")).toBeNull();
+  });
+
+  it("porte le liseré accent sur une candidature déclarée", () => {
+    const { container } = renderNotice();
+    expect(container.querySelector(".border-l-brand")).not.toBeNull();
+  });
+
+  it("dit à quelle date les mesures ont cessé d'être défendues", () => {
+    renderNotice({
+      ...base,
+      status: "RETIRE",
+      withdrewAt: new Date("2027-03-03T00:00:00.000Z"),
+      publishedMeasureCount: 18,
+      primarySourceMeasureCount: 15,
+    });
+    expect(screen.getByText(/Candidature retirée le/)).toBeInTheDocument();
+    expect(screen.getByText(/18 mesures documentées restent consultables/)).toBeInTheDocument();
+  });
+
+  it("passe au passé après l'élection, avec les scores", () => {
+    renderNotice({ ...base, round1Pct: 27.4, round2Pct: 47.2 }, "Mme", AFTER);
+    expect(screen.getByText(/27,4 %/)).toBeInTheDocument();
+    expect(screen.getByText(/47,2 %/)).toBeInTheDocument();
+  });
+
+  it("n'affiche aucun score après l'élection quand la base n'en a pas", () => {
+    renderNotice(base, "Mme", AFTER);
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+
+  it("garde le traitement du retrait après l'élection", () => {
+    renderNotice(
+      { ...base, status: "RETIRE", withdrewAt: new Date("2027-03-03T00:00:00.000Z") },
+      "Mme",
+      AFTER
+    );
+    expect(screen.getByText(/Candidature retirée le/)).toBeInTheDocument();
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -28,10 +28,20 @@ const base: PoliticianCandidacy = {
 function renderNotice(
   candidacy: PoliticianCandidacy = base,
   civility: string | null = null,
-  now: Date = BEFORE
+  now: Date = BEFORE,
+  ficheHref: string | null = null
 ) {
-  return render(<CandidacyNotice candidacy={candidacy} civility={civility} now={now} />);
+  return render(
+    <CandidacyNotice candidacy={candidacy} civility={civility} now={now} ficheHref={ficheHref} />
+  );
 }
+
+const publishable: PoliticianCandidacy = {
+  ...base,
+  publishedMeasureCount: 27,
+  themesCoveredCount: 9,
+  primarySourceMeasureCount: 20,
+};
 
 describe("CandidacyNotice", () => {
   it("féminise le titre selon la civilité", () => {
@@ -174,6 +184,31 @@ describe("CandidacyNotice", () => {
 
     renderNotice({ ...base, status: "PRESSENTI" }, null);
     expect(screen.getByText("Parmi les candidatures possibles")).toBeInTheDocument();
+  });
+
+  it("pointe vers la fiche candidat quand elle est publiable", () => {
+    renderNotice(
+      publishable,
+      "Mme",
+      BEFORE,
+      "/elections/presidentielle-2027/candidats/camille-riviere"
+    );
+
+    expect(screen.getByRole("link", { name: /Son programme, sujet par sujet/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/candidats/camille-riviere"
+    );
+  });
+
+  it("abandonne le possessif quand la destination est le hub et pas sa fiche", () => {
+    // The destination lists every candidacy, so promising "son programme" would not be honest.
+    renderNotice(publishable, "Mme", BEFORE, null);
+
+    expect(screen.getByRole("link", { name: /Le dossier, sujet par sujet/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+    expect(screen.queryByText(/Son programme, sujet par sujet/)).not.toBeInTheDocument();
   });
 
   it("garde le traitement du retrait après l'élection", () => {

--- a/src/config/election-guides.ts
+++ b/src/config/election-guides.ts
@@ -199,3 +199,20 @@ export const ELECTION_GUIDES: Partial<Record<ElectionType, ElectionGuideSection[
     },
   ],
 };
+
+/**
+ * Deadline to register on the electoral roll, per election, when a decree has actually set one.
+ *
+ * Absent by design for présidentielle 2027: the decree has not been published, and inventing a date
+ * would be worse than omitting the reminder. The banner renders the reminder only when a deadline
+ * exists AND has not passed.
+ */
+const VOTER_REGISTRATION_DEADLINES: Record<string, Date> = {
+  "municipales-2026": new Date("2026-02-07T00:00:00.000Z"),
+};
+
+export function getVoterRegistrationDeadline(electionSlug: string, now: Date): Date | null {
+  const deadline = VOTER_REGISTRATION_DEADLINES[electionSlug];
+  if (!deadline) return null;
+  return deadline.getTime() > now.getTime() ? deadline : null;
+}

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,15 +1,14 @@
 /**
- * Feature flags - static, typed, deployed via Vercel (~1 min redeploy).
+ * Feature flags: static, typed, deployed via Vercel (~1 min redeploy).
  *
  * To toggle a feature: change the value, push, done.
- * For anticipated elections: change FEATURED_ELECTION_SLUG.
+ *
+ * The featured election is NOT here. It is `Election.featured`, read by `getFeaturedElection()`.
+ * `ELECTION_BANNER` and `FEATURED_ELECTION_SLUG` used to live here, were read by nothing, and were
+ * removed on 2026-08-07 along with the corresponding paragraph of the hub spec (§6.3).
  */
 
 export const FEATURES = {
-  /** Show featured election banner on the homepage */
-  ELECTION_BANNER: true,
-  /** Slug of the election highlighted on the homepage */
-  FEATURED_ELECTION_SLUG: "municipales-2026",
   /** Show practical guide section on election detail pages */
   ELECTION_GUIDE_SECTION: true,
 } as const;

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1440,6 +1440,17 @@ export const CANDIDACY_STATUS_LABELS: Record<CandidacyStatus, string> = {
   RETIRE: "Candidature retirée",
 };
 
+/**
+ * The candidacy notice's title is a ROLE, so it agrees in gender with `civility`.
+ *
+ * Not routed through `feminizePartyRole`: that helper is a closed replacement table over four party
+ * role labels and "Candidat" is not one of them. Extending it would make it a general feminiser it
+ * was never designed to be.
+ */
+export function candidacyRoleLabel(civility: string | null | undefined): string {
+  return civility === "Mme" ? "Candidate à la présidentielle" : "Candidat à la présidentielle";
+}
+
 // ---------------------------------------------------------------------------
 // Mesures : le modèle éditorial versionné du hub présidentielle (lot 1 et 2).
 // ---------------------------------------------------------------------------

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1446,9 +1446,30 @@ export const CANDIDACY_STATUS_LABELS: Record<CandidacyStatus, string> = {
  * Not routed through `feminizePartyRole`: that helper is a closed replacement table over four party
  * role labels and "Candidat" is not one of them. Extending it would make it a general feminiser it
  * was never designed to be.
+ *
+ * The third branch is the one the mockup does not cover. `Politician.civility` is null on 5 of the
+ * 25 sourced presidential candidacies, and falling back to the masculine would state a gender the
+ * database does not hold, on a real person's fiche. The neutral form agrees with "candidature", a
+ * feminine noun, and says nothing about the person, which is what the notice already does in its
+ * withdrawn state.
  */
 export function candidacyRoleLabel(civility: string | null | undefined): string {
-  return civility === "Mme" ? "Candidate à la présidentielle" : "Candidat à la présidentielle";
+  if (civility === "Mme") return "Candidate à la présidentielle";
+  if (civility === "M.") return "Candidat à la présidentielle";
+  return "Candidature à la présidentielle";
+}
+
+/**
+ * Title of the notice for a candidacy the press mentions and nobody declared.
+ *
+ * Same three branches and the same reason: "Cité" is a past participle that agrees with the person,
+ * so the mockup's single wording would print "Cité" on a woman's fiche. The neutral branch drops the
+ * participle rather than guessing.
+ */
+export function candidacyPossibleLabel(civility: string | null | undefined): string {
+  if (civility === "Mme") return "Citée parmi les candidatures possibles";
+  if (civility === "M.") return "Cité parmi les candidatures possibles";
+  return "Parmi les candidatures possibles";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/data/__tests__/featured-election.integration.test.ts
+++ b/src/lib/data/__tests__/featured-election.integration.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value, which throws at load without DATABASE_URL.
+let db: typeof import("@/lib/db").db;
+let loadFeaturedElection: typeof import("../elections").loadFeaturedElection;
+
+const PREFIX = "featured-test";
+
+/**
+ * `Election.featured` is the single authority for the homepage banner (spec §4.1). Two things have
+ * to hold and neither is enforced by the schema: an election whose last round is long past must
+ * stop being featured, and two rows at `featured: true` must resolve deterministically rather than
+ * letting findFirst arbitrate.
+ */
+describeIfDisposableDb("loadFeaturedElection", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ loadFeaturedElection } = await import("../elections"));
+    // Order independence: the disposable DB is shared across test files, and this suite asserts on
+    // WHICH election is featured, including a case that expects none. Any leftover featured row
+    // from another fixture would make those assertions depend on file order.
+    await db.election.updateMany({ where: { featured: true }, data: { featured: false } });
+  });
+
+  afterEach(async () => {
+    await db.candidacy.deleteMany({ where: { election: { slug: { startsWith: PREFIX } } } });
+    await db.election.deleteMany({ where: { slug: { startsWith: PREFIX } } });
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  async function election(options: {
+    suffix: string;
+    round1: Date;
+    round2: Date | null;
+    featured: boolean;
+  }) {
+    return db.election.create({
+      data: {
+        slug: `${PREFIX}-${options.suffix}`,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: `Élection de test ${options.suffix}`,
+        round1Date: options.round1,
+        round2Date: options.round2,
+        featured: options.featured,
+      },
+    });
+  }
+
+  const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+  const daysAhead = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+
+  it("retourne une élection à venir", async () => {
+    await election({
+      suffix: "soon",
+      round1: daysAhead(100),
+      round2: daysAhead(114),
+      featured: true,
+    });
+    const found = await loadFeaturedElection();
+    expect(found?.slug).toBe(`${PREFIX}-soon`);
+  });
+
+  it("retourne encore une élection dont le second tour est passé de 10 jours", async () => {
+    await election({ suffix: "recent", round1: daysAgo(24), round2: daysAgo(10), featured: true });
+    const found = await loadFeaturedElection();
+    expect(found?.slug).toBe(`${PREFIX}-recent`);
+  });
+
+  it("ne retourne plus une élection dont le second tour est passé de 40 jours", async () => {
+    await election({ suffix: "old", round1: daysAgo(54), round2: daysAgo(40), featured: true });
+    expect(await loadFeaturedElection()).toBeNull();
+  });
+
+  it("mesure la fenêtre sur round1Date quand il n'y a pas de second tour", async () => {
+    await election({ suffix: "single", round1: daysAgo(40), round2: null, featured: true });
+    expect(await loadFeaturedElection()).toBeNull();
+  });
+
+  it("départage deux élections à la une sur l'échéance la plus proche", async () => {
+    await election({ suffix: "b-far", round1: daysAhead(300), round2: null, featured: true });
+    await election({ suffix: "a-near", round1: daysAhead(30), round2: null, featured: true });
+    const found = await loadFeaturedElection();
+    expect(found?.slug).toBe(`${PREFIX}-a-near`);
+  });
+
+  it("compte les candidatures sourcées, pas toutes les candidatures", async () => {
+    const e = await election({
+      suffix: "counts",
+      round1: daysAhead(100),
+      round2: daysAhead(114),
+      featured: true,
+    });
+    await db.candidacy.create({
+      data: {
+        electionId: e.id,
+        candidateName: "Sourcée",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/a",
+        sourceLabel: "Source A",
+      },
+    });
+    await db.candidacy.create({
+      data: { electionId: e.id, candidateName: "Sans statut ni source" },
+    });
+    await db.candidacy.create({
+      data: {
+        electionId: e.id,
+        candidateName: "Source incomplète",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/b",
+      },
+    });
+    const found = await loadFeaturedElection();
+    expect(found?.sourcedCandidacyCount).toBe(1);
+  });
+
+  it("expose round2Date et dateConfirmed, que le bandeau exigeait sans les recevoir", async () => {
+    await election({
+      suffix: "fields",
+      round1: daysAhead(100),
+      round2: daysAhead(114),
+      featured: true,
+    });
+    const found = await loadFeaturedElection();
+    expect(found?.round2Date).not.toBeNull();
+    expect(found?.dateConfirmed).toBe(false);
+  });
+
+  it("porte les scores du premier tour des qualifiés quand ils existent", async () => {
+    const e = await election({
+      suffix: "scores",
+      round1: daysAgo(5),
+      round2: daysAhead(9),
+      featured: true,
+    });
+    await db.candidacy.create({
+      data: {
+        electionId: e.id,
+        candidateName: "Qualifiée A",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/a",
+        sourceLabel: "Source A",
+        round1Pct: "27.40",
+        round1Qualified: true,
+      },
+    });
+    await db.candidacy.create({
+      data: {
+        electionId: e.id,
+        candidateName: "Éliminé B",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/b",
+        sourceLabel: "Source B",
+        round1Pct: "9.10",
+        round1Qualified: false,
+      },
+    });
+    const found = await loadFeaturedElection();
+    expect(found?.round1Scores.map((s) => s.candidateName)).toEqual(["Qualifiée A"]);
+    expect(found?.round1Scores[0]?.pct).toBeCloseTo(27.4, 2);
+  });
+});

--- a/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+let db: typeof import("@/lib/db").db;
+let getPublicMeasureStatsByCandidacy: typeof import("../measures").getPublicMeasureStatsByCandidacy;
+
+const SLUG = "stats-by-candidacy";
+
+/**
+ * These counters feed a PUBLICATION GATE (`isFicheCandidatPublishable`), so the two ways they could
+ * be wrong both open a public surface that nothing justifies:
+ *
+ * - counting a measure carried by a DRAFT-extension candidacy, which no public page renders;
+ * - counting a PRIMARY source that belongs to an unpublished draft revision rather than to the
+ *   revision the public actually sees.
+ */
+describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
+  let publishedCandidacyId: string;
+  let draftExtensionCandidacyId: string;
+  let secondarySourceCandidacyId: string;
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getPublicMeasureStatsByCandidacy } = await import("../measures"));
+    const { createMeasure, reviewMeasureRevision, publishMeasureRevision, draftMeasureRevision } =
+      await import("@/lib/measures/transitions");
+
+    const election = await db.election.create({
+      data: {
+        slug: SLUG,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Élection de test (compteurs)",
+      },
+    });
+    electionId = election.id;
+
+    async function candidacy(name: string, publicationStatus: "PUBLISHED" | "DRAFT") {
+      const pol = await db.politician.create({
+        data: {
+          slug: `${SLUG}-${name}`,
+          firstName: name,
+          lastName: "Fixture",
+          fullName: `${name} Fixture`,
+        },
+      });
+      const c = await db.candidacy.create({
+        data: {
+          electionId: election.id,
+          politicianId: pol.id,
+          candidateName: `${name} Fixture`,
+          status: "DECLARE",
+          sourceUrl: "https://example.org/source",
+          sourceLabel: "Source",
+        },
+      });
+      await db.candidacyPresidential.create({
+        data: { candidacyId: c.id, publicationStatus },
+      });
+      return { candidacyId: c.id, politicianId: pol.id };
+    }
+
+    async function publishOne(options: {
+      candidacyId: string;
+      politicianId: string;
+      theme: "LOGEMENT_URBANISME" | "SANTE";
+      tier: "PRIMARY" | "SECONDARY";
+      text: string;
+    }) {
+      const { measureId, revisionId } = await createMeasure({
+        politicianId: options.politicianId,
+        electionId: election.id,
+        candidacyId: options.candidacyId,
+        programEditionId: null,
+        attribution: "PERSONAL",
+        theme: options.theme,
+        precedingMeasureId: null,
+        revision: {
+          text: `Mesure de test ${options.text}`,
+          precision: null,
+          validFrom: new Date("2026-01-01T00:00:00.000Z"),
+          extractionMethod: "MANUAL",
+          extractionConfidence: null,
+          extractorVersion: null,
+        },
+        sources: [
+          {
+            sourceKind: "PROGRAMME_PARTI",
+            tier: options.tier,
+            url: `https://example.org/${options.text}`,
+            page: null,
+            publishedAt: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        ],
+      });
+      await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "test" });
+      await publishMeasureRevision({ measureId, revisionId });
+      return measureId;
+    }
+
+    const published = await candidacy("published", "PUBLISHED");
+    publishedCandidacyId = published.candidacyId;
+    await publishOne({ ...published, theme: "LOGEMENT_URBANISME", tier: "PRIMARY", text: "a" });
+    await publishOne({ ...published, theme: "SANTE", tier: "SECONDARY", text: "b" });
+
+    const draftExt = await candidacy("draft-ext", "DRAFT");
+    draftExtensionCandidacyId = draftExt.candidacyId;
+    await publishOne({ ...draftExt, theme: "LOGEMENT_URBANISME", tier: "PRIMARY", text: "c" });
+
+    // The revision trap: published revision carries a SECONDARY source, an unpublished draft
+    // carries a PRIMARY one.
+    const secondary = await candidacy("secondary", "PUBLISHED");
+    secondarySourceCandidacyId = secondary.candidacyId;
+    const measureId = await publishOne({
+      ...secondary,
+      theme: "LOGEMENT_URBANISME",
+      tier: "SECONDARY",
+      text: "d",
+    });
+    await draftMeasureRevision({
+      measureId,
+      revision: {
+        text: "Version brouillon avec une source primaire",
+        precision: null,
+        validFrom: new Date("2026-02-01T00:00:00.000Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "PROGRAMME_PARTI",
+          tier: "PRIMARY",
+          url: "https://example.org/draft-primary",
+          page: null,
+          publishedAt: new Date("2026-02-01T00:00:00.000Z"),
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await db.measure.deleteMany({ where: { electionId } });
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.$disconnect();
+  });
+
+  it("compte les mesures publiées et les sujets couverts", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+    expect(stats.measureCount).toBe(2);
+    expect(stats.themesCoveredCount).toBe(2);
+  });
+
+  it("compte une seule mesure à source primaire quand l'autre est secondaire", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+    expect(stats.primarySourceMeasureCount).toBe(1);
+  });
+
+  it("rend une date de dernière revue", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+    expect(stats.lastReviewedAt).toBeInstanceOf(Date);
+  });
+
+  it("ne compte rien pour une candidature à extension DRAFT", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(draftExtensionCandidacyId);
+    expect(stats.measureCount).toBe(0);
+    expect(stats.primarySourceMeasureCount).toBe(0);
+    expect(stats.lastReviewedAt).toBeNull();
+  });
+
+  it("ignore une source primaire portée par un brouillon non publié", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(secondarySourceCandidacyId);
+    expect(stats.measureCount).toBe(1);
+    expect(stats.primarySourceMeasureCount).toBe(0);
+  });
+});

--- a/src/lib/data/__tests__/politician-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/politician-candidacy.integration.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+let db: typeof import("@/lib/db").db;
+let loadPoliticianPresidentialCandidacy: typeof import("../politician-candidacy").loadPoliticianPresidentialCandidacy;
+
+const SLUG = "politician-candidacy";
+
+/**
+ * The reverse read of `getHubCandidacyField`. Its whole point is a split between two populations:
+ * identity and status are read WITHOUT the PUBLISHED-extension filter (otherwise the notice
+ * disappears from every fiche a candidacy exists for), measure counters are read WITH it (otherwise
+ * the notice announces measures no page renders).
+ *
+ * Exercises the plain loader, not the cached wrapper: a `"use cache"` boundary throws outside a Next
+ * request context, which is why the module is split this way.
+ */
+describeIfDisposableDb("loadPoliticianPresidentialCandidacy", () => {
+  const ids: Record<string, string> = {};
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ loadPoliticianPresidentialCandidacy } = await import("../politician-candidacy"));
+    const { PRESIDENTIELLE_2027_SLUG } = await import("@/lib/presidentielle/themes");
+
+    // The read under test hardcodes this slug, so the fixture cannot namespace it. The disposable DB
+    // is shared across test files, so a leftover row would break the unique constraint.
+    await db.candidacy.deleteMany({ where: { election: { slug: PRESIDENTIELLE_2027_SLUG } } });
+    await db.election.deleteMany({ where: { slug: PRESIDENTIELLE_2027_SLUG } });
+
+    const election = await db.election.create({
+      data: {
+        slug: PRESIDENTIELLE_2027_SLUG,
+        type: "PRESIDENTIELLE",
+        scope: "NATIONAL",
+        title: "Élection présidentielle de test",
+        shortTitle: "Présidentielle 2027",
+        round1Date: new Date("2027-04-11T00:00:00.000Z"),
+        round2Date: new Date("2027-04-25T00:00:00.000Z"),
+      },
+    });
+    electionId = election.id;
+
+    async function seed(
+      name: string,
+      data: {
+        status?: "DECLARE" | "PRESSENTI" | "ENVISAGE" | "RETIRE";
+        sourceUrl?: string;
+        sourceLabel?: string;
+      }
+    ) {
+      const pol = await db.politician.create({
+        data: {
+          slug: `${SLUG}-${name}`,
+          firstName: name,
+          lastName: "Fixture",
+          fullName: `${name} Fixture`,
+        },
+      });
+      ids[name] = pol.id;
+      await db.candidacy.create({
+        data: {
+          electionId: election.id,
+          politicianId: pol.id,
+          candidateName: `${name} Fixture`,
+          ...data,
+        },
+      });
+    }
+
+    await seed("declared", {
+      status: "DECLARE",
+      sourceUrl: "https://example.org/declared",
+      sourceLabel: "Le Monde, 14 janvier 2026",
+    });
+    await seed("nostatus", {
+      sourceUrl: "https://example.org/nostatus",
+      sourceLabel: "Source",
+    });
+    await seed("nosource", { status: "DECLARE", sourceLabel: "Source sans URL" });
+    await seed("withdrawn", {
+      status: "RETIRE",
+      sourceUrl: "https://example.org/withdrawn",
+      sourceLabel: "Communiqué",
+    });
+
+    const orphan = await db.politician.create({
+      data: {
+        slug: `${SLUG}-orphan`,
+        firstName: "Orphan",
+        lastName: "Fixture",
+        fullName: "Orphan Fixture",
+      },
+    });
+    ids.orphan = orphan.id;
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { id: electionId } });
+    await db.$disconnect();
+  });
+
+  it("retourne la candidature déclarée avec son statut et sa source", async () => {
+    const found = await loadPoliticianPresidentialCandidacy(ids.declared!);
+    expect(found).not.toBeNull();
+    expect(found?.status).toBe("DECLARE");
+    expect(found?.sourceLabel).toBe("Le Monde, 14 janvier 2026");
+    expect(found?.electionShortTitle).toBe("Présidentielle 2027");
+  });
+
+  it("retourne une candidature retirée : l'extension PUBLISHED n'est pas requise", async () => {
+    const found = await loadPoliticianPresidentialCandidacy(ids.withdrawn!);
+    expect(found?.status).toBe("RETIRE");
+  });
+
+  it("retourne null quand la candidature n'a pas de statut", async () => {
+    expect(await loadPoliticianPresidentialCandidacy(ids.nostatus!)).toBeNull();
+  });
+
+  it("retourne null quand la source est incomplète", async () => {
+    expect(await loadPoliticianPresidentialCandidacy(ids.nosource!)).toBeNull();
+  });
+
+  it("retourne null pour un politique sans candidature", async () => {
+    expect(await loadPoliticianPresidentialCandidacy(ids.orphan!)).toBeNull();
+  });
+
+  it("compte zéro mesure publiée tant qu'aucune extension n'est publiée", async () => {
+    const found = await loadPoliticianPresidentialCandidacy(ids.declared!);
+    expect(found?.publishedMeasureCount).toBe(0);
+    expect(found?.primarySourceMeasureCount).toBe(0);
+  });
+});

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -3,6 +3,7 @@ import { cacheTag, cacheLife } from "next/cache";
 import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import type { ElectionType } from "@/types";
+import type { ElectionRoundScore } from "@/lib/elections/banner-state";
 
 // ============================================
 // Types
@@ -510,39 +511,145 @@ export async function getUpcomingElections() {
 }
 
 // ============================================
-// 5b. getFeaturedElection — for homepage hero CTA
+// 5b. getFeaturedElection — for the homepage banner
 // ============================================
 
-export async function getFeaturedElection() {
-  "use cache";
-  cacheTag("elections", "homepage");
-  cacheLife("synced");
+/**
+ * Days after the last round during which the election stays featured, in its archive state.
+ *
+ * Without this window the banner would vanish the moment the election completes, which is what
+ * happened to municipales-2026: `status` is derived from the round dates, so the old
+ * `status != COMPLETED` filter silently emptied the homepage banner slot. The archive state is also
+ * the only state that carries no countdown, which is what stops the banner counting toward a date
+ * in the past.
+ */
+export const FEATURED_ELECTION_ARCHIVE_DAYS = 30;
+
+export type FeaturedElection = {
+  slug: string;
+  title: string;
+  shortTitle: string | null;
+  type: ElectionType;
+  round1Date: Date | null;
+  round2Date: Date | null;
+  dateConfirmed: boolean;
+  round1Scores: ElectionRoundScore[];
+  winner: ElectionRoundScore | null;
+  /** Candidacies with a status AND both source fields. The number the banner is allowed to show. */
+  sourcedCandidacyCount: number;
+  hasResults: boolean;
+  communesDepouillees: number;
+};
+
+/**
+ * Plain async, integration-testable. Pages call `getFeaturedElection`, which caches this.
+ */
+export async function loadFeaturedElection(): Promise<FeaturedElection | null> {
+  const cutoff = new Date(Date.now() - FEATURED_ELECTION_ARCHIVE_DAYS * 24 * 60 * 60 * 1000);
 
   const election = await db.election.findFirst({
-    where: { featured: true, status: { not: "COMPLETED" } },
+    where: {
+      featured: true,
+      // The archive window replaces the former `status != COMPLETED` filter. Measured on the last
+      // known round: round2Date when there is one, round1Date otherwise.
+      OR: [
+        { round2Date: { gte: cutoff } },
+        { round2Date: null, round1Date: { gte: cutoff } },
+        { round1Date: null },
+      ],
+    },
+    // Deterministic tie-break. Nothing in the schema forbids two featured rows, and without an
+    // explicit order findFirst would arbitrate: the nearest deadline wins, and it is documented
+    // here rather than discovered in production.
+    orderBy: [{ round1Date: { sort: "asc", nulls: "last" } }, { slug: "asc" }],
     select: {
+      id: true,
       slug: true,
       title: true,
       shortTitle: true,
       type: true,
       round1Date: true,
+      round2Date: true,
+      dateConfirmed: true,
     },
   });
   if (!election) return null;
 
-  // Check if results are available
-  const resultatsSnapshot = await db.statsSnapshot.findUnique({
-    where: { key: `${election.slug}-resultats` },
-  });
-  const resultats = resultatsSnapshot?.data as {
-    communesDepouillees?: number;
-  } | null;
+  const [sourcedCandidacyCount, qualified, elected, resultatsSnapshot] = await Promise.all([
+    db.candidacy.count({
+      where: {
+        electionId: election.id,
+        status: { not: null },
+        sourceUrl: { not: null },
+        sourceLabel: { not: null },
+      },
+    }),
+    db.candidacy.findMany({
+      where: { electionId: election.id, round1Qualified: true },
+      select: {
+        candidateName: true,
+        partyLabel: true,
+        round1Pct: true,
+        politician: { select: { slug: true } },
+      },
+      orderBy: { round1Pct: { sort: "desc", nulls: "last" } },
+      take: 2,
+    }),
+    db.candidacy.findFirst({
+      where: { electionId: election.id, isElected: true },
+      select: {
+        candidateName: true,
+        partyLabel: true,
+        round2Pct: true,
+        politician: { select: { slug: true } },
+      },
+    }),
+    db.statsSnapshot.findUnique({ where: { key: `${election.slug}-resultats` } }),
+  ]);
+
+  const resultats = resultatsSnapshot?.data as { communesDepouillees?: number } | null;
 
   return {
-    ...election,
+    slug: election.slug,
+    title: election.title,
+    shortTitle: election.shortTitle,
+    type: election.type,
+    round1Date: election.round1Date,
+    round2Date: election.round2Date,
+    dateConfirmed: election.dateConfirmed,
+    // A score is omitted rather than defaulted to zero: "0 %" would be a claim, absence is not.
+    round1Scores: qualified.flatMap((c) =>
+      c.round1Pct === null
+        ? []
+        : [
+            {
+              candidateName: c.candidateName,
+              politicianSlug: c.politician?.slug ?? null,
+              partyLabel: c.partyLabel,
+              pct: Number(c.round1Pct),
+            },
+          ]
+    ),
+    winner:
+      elected && elected.round2Pct !== null
+        ? {
+            candidateName: elected.candidateName,
+            politicianSlug: elected.politician?.slug ?? null,
+            partyLabel: elected.partyLabel,
+            pct: Number(elected.round2Pct),
+          }
+        : null,
+    sourcedCandidacyCount,
     hasResults: (resultats?.communesDepouillees ?? 0) > 0,
     communesDepouillees: resultats?.communesDepouillees ?? 0,
   };
+}
+
+export async function getFeaturedElection(): Promise<FeaturedElection | null> {
+  "use cache";
+  cacheTag("elections", "homepage");
+  cacheLife("synced");
+  return loadFeaturedElection();
 }
 
 // ============================================

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -234,6 +234,66 @@ export async function getLatestPresidentialReviewDate(
 }
 
 /**
+ * Counters for ONE candidacy, without loading a single measure.
+ *
+ * Lives here and not on the calling page because `PUBLIC_MEASURE_WHERE` is private to this file and
+ * this module's doctrine is that no page reads `db.measure.*`.
+ *
+ * Composed from the two existing predicates, like `getLatestPresidentialReviewDate` above and for
+ * the same reason: a third hand-rolled copy of the publishable population is how the hub's count
+ * and its review date drifted apart.
+ *
+ * The PRIMARY-source condition is expressed on `publishedRevision`, never as a join over the
+ * measure's revisions. A draft revision that nobody published must not make its measure count as
+ * primary-sourced: these numbers feed `isFicheCandidatPublishable()`, so a looser predicate would
+ * open a candidate fiche on the strength of unpublished work.
+ */
+export type PublicMeasureStats = {
+  measureCount: number;
+  themesCoveredCount: number;
+  primarySourceMeasureCount: number;
+  lastReviewedAt: Date | null;
+};
+
+export async function getPublicMeasureStatsByCandidacy(
+  candidacyId: string
+): Promise<PublicMeasureStats> {
+  const scope: Prisma.MeasureWhereInput = {
+    candidacyId,
+    // `is` and not a bare object, as in getLatestPresidentialReviewDate: it also rules out a
+    // candidacy row that has no presidential extension at all.
+    candidacy: { is: PUBLIC_CANDIDACY_WHERE },
+    withdrawnAt: null,
+    ...PUBLIC_MEASURE_WHERE,
+  };
+
+  const [byTheme, primarySourceMeasureCount, lastReviewed] = await Promise.all([
+    db.measure.groupBy({ by: ["theme"], where: scope, _count: { _all: true } }),
+    db.measure.count({
+      where: {
+        ...scope,
+        publishedRevision: {
+          ...PUBLIC_MEASURE_WHERE.publishedRevision,
+          sources: { some: { tier: "PRIMARY" } },
+        },
+      },
+    }),
+    db.measure.findFirst({
+      where: scope,
+      orderBy: { publishedRevision: { reviewedAt: "desc" } },
+      select: { publishedRevision: { select: { reviewedAt: true } } },
+    }),
+  ]);
+
+  return {
+    measureCount: byTheme.reduce((n, row) => n + row._count._all, 0),
+    themesCoveredCount: byTheme.length,
+    primarySourceMeasureCount,
+    lastReviewedAt: lastReviewed?.publishedRevision?.reviewedAt ?? null,
+  };
+}
+
+/**
  * The revision publicly in force on a given day. The condition on publishedAt is not
  * optional: without it the query can select a draft that was never published, and make the
  * site report a text it never displayed.

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -1,0 +1,139 @@
+import "server-only";
+import { cacheLife, cacheTag } from "next/cache";
+import type { CandidacyStatus } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { getPublicMeasureStatsByCandidacy } from "./measures";
+
+/**
+ * The reverse of `getHubCandidacyField`: "the presidential candidacy of THIS politician".
+ *
+ * One doctrine governs this file, and it is a split between two populations:
+ *
+ * - identity, status and source are read WITHOUT the PUBLISHED-extension filter. A candidacy can be
+ *   sourced and public knowledge months before anyone publishes its editorial extension, so
+ *   filtering here would make the notice disappear from every fiche it exists for;
+ * - measure counters are read WITH it, through `getPublicMeasureStatsByCandidacy`. Counting a
+ *   measure that no subject page renders would announce measures the reader cannot reach.
+ *
+ * The same split is documented in `hub.ts` for the hub page. It is restated here because the
+ * politician fiche is not the hub, and a reader of this file should not have to go looking.
+ *
+ * Scoped to the presidential election on purpose. No other election uses `CandidacyStatus` today,
+ * so a generic "candidacy for the current election" would be speculative generality.
+ */
+export type PoliticianCandidacy = {
+  electionSlug: string;
+  electionShortTitle: string;
+  round1Date: Date | null;
+  round2Date: Date | null;
+  /** Non-null: a candidacy without a sourced status is not returned at all. */
+  status: CandidacyStatus;
+  sourceUrl: string;
+  sourceLabel: string;
+  declaredAt: Date | null;
+  withdrewAt: Date | null;
+  publishedMeasureCount: number;
+  themesCoveredCount: number;
+  primarySourceMeasureCount: number;
+  lastReviewedAt: Date | null;
+  round1Pct: number | null;
+  round2Pct: number | null;
+  isElected: boolean;
+};
+
+/**
+ * Plain async, integration-testable. Pages call `getPoliticianPresidentialCandidacy`, which caches
+ * this: a `"use cache"` boundary throws outside a Next request context, the same reason
+ * `loadHubMeasureContext` and `loadSubjectPageData` are split this way.
+ */
+export async function loadPoliticianPresidentialCandidacy(
+  politicianId: string
+): Promise<PoliticianCandidacy | null> {
+  const row = await db.candidacy.findFirst({
+    where: {
+      politicianId,
+      election: { slug: PRESIDENTIELLE_2027_SLUG },
+      // The three conditions that make the notice sayable at all. Without them there is no state to
+      // render: the notice has no "I do not know" state, it simply does not appear.
+      status: { not: null },
+      sourceUrl: { not: null },
+      sourceLabel: { not: null },
+    },
+    select: {
+      id: true,
+      status: true,
+      sourceUrl: true,
+      sourceLabel: true,
+      round1Pct: true,
+      round2Pct: true,
+      isElected: true,
+      election: {
+        select: { slug: true, title: true, shortTitle: true, round1Date: true, round2Date: true },
+      },
+      presidentialData: { select: { declaredAt: true, withdrewAt: true } },
+    },
+  });
+
+  // Narrowing the three nullable columns the where clause already excluded. Defensive rather than
+  // redundant: this is the only place that turns them into non-nullable fields.
+  if (!row || row.status === null || row.sourceUrl === null || row.sourceLabel === null) {
+    return null;
+  }
+
+  const stats = await getPublicMeasureStatsByCandidacy(row.id);
+
+  return {
+    electionSlug: row.election.slug,
+    electionShortTitle: row.election.shortTitle ?? row.election.title,
+    round1Date: row.election.round1Date,
+    round2Date: row.election.round2Date,
+    status: row.status,
+    sourceUrl: row.sourceUrl,
+    sourceLabel: row.sourceLabel,
+    declaredAt: row.presidentialData?.declaredAt ?? null,
+    withdrewAt: row.presidentialData?.withdrewAt ?? null,
+    publishedMeasureCount: stats.measureCount,
+    themesCoveredCount: stats.themesCoveredCount,
+    primarySourceMeasureCount: stats.primarySourceMeasureCount,
+    lastReviewedAt: stats.lastReviewedAt,
+    round1Pct: row.round1Pct === null ? null : Number(row.round1Pct),
+    round2Pct: row.round2Pct === null ? null : Number(row.round2Pct),
+    isElected: row.isElected,
+  };
+}
+
+/**
+ * Cached read for the politician fiche, carrying BOTH tags of the presidential surfaces.
+ *
+ * `election-candidacies` because the notice's state depends on `CandidacyPresidential`
+ * publicationStatus through its measure counters, and `election-measures` because those counters
+ * move on a measure publication. Omitting either would recreate the exact debt #678 paid off: the
+ * four hub reads carried only the measures tag while the extension mutations purged `elections`, two
+ * sets that do not overlap, so a DRAFT to PUBLISHED transition busted nothing and the surfaces
+ * stayed closed for 24h with the data already in place.
+ *
+ * The election id is resolved first because both tags are keyed on it, and the slug alone cannot
+ * name them.
+ */
+export async function getPoliticianPresidentialCandidacy(
+  politicianId: string
+): Promise<PoliticianCandidacy | null> {
+  const election = await db.election.findUnique({
+    where: { slug: PRESIDENTIELLE_2027_SLUG },
+    select: { id: true },
+  });
+  if (election === null) return null;
+  return getPoliticianPresidentialCandidacyCached(politicianId, election.id);
+}
+
+async function getPoliticianPresidentialCandidacyCached(
+  politicianId: string,
+  electionId: string
+): Promise<PoliticianCandidacy | null> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheTag(`election-candidacies:${electionId}`);
+  cacheLife("synced");
+  return loadPoliticianPresidentialCandidacy(politicianId);
+}

--- a/src/lib/elections/__tests__/banner-presentation.test.ts
+++ b/src/lib/elections/__tests__/banner-presentation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { getBannerPresentation } from "@/lib/elections/banner-presentation";
+import type { ElectionType } from "@/generated/prisma";
+
+const ALL_TYPES: ElectionType[] = [
+  "PRESIDENTIELLE",
+  "LEGISLATIVES",
+  "SENATORIALES",
+  "MUNICIPALES",
+  "DEPARTEMENTALES",
+  "REGIONALES",
+  "EUROPEENNES",
+  "REFERENDUM",
+];
+
+const CTX = { electionSlug: "presidentielle-2027", sourcedCandidacyCount: 25 };
+
+describe("getBannerPresentation", () => {
+  it("couvre les huit types d'élection", () => {
+    for (const type of ALL_TYPES) {
+      expect(getBannerPresentation(type)).toBeDefined();
+    }
+  });
+
+  it("donne à la présidentielle une promesse éditoriale et les blocs de scores", () => {
+    const p = getBannerPresentation("PRESIDENTIELLE");
+    expect(p.promise).not.toBeNull();
+    expect(p.showRound1Scores).toBe(true);
+    expect(p.showWinnerScore).toBe(true);
+  });
+
+  it("ouvre le dossier depuis l'état FAR", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").primaryAction("FAR", CTX);
+    expect(action).toEqual({
+      label: "Ouvrir le dossier",
+      href: "/elections/presidentielle-2027",
+      external: false,
+    });
+  });
+
+  it("compte les candidatures « recensées » et non « documentées »", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").secondaryAction("FAR", CTX);
+    expect(action?.label).toBe("25 candidatures recensées");
+    expect(action?.label).not.toContain("documentées");
+  });
+
+  it("accorde le libellé au singulier sur une seule candidature", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").secondaryAction("FAR", {
+      ...CTX,
+      sourcedCandidacyCount: 1,
+    });
+    expect(action?.label).toBe("1 candidature recensée");
+  });
+
+  it("envoie vers un service externe le jour du vote", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").primaryAction("VOTING_DAY", CTX);
+    expect(action.external).toBe(true);
+    expect(action.href).toMatch(/^https:\/\//);
+  });
+
+  it("n'offre aucun lien secondaire le jour du vote", () => {
+    expect(getBannerPresentation("PRESIDENTIELLE").secondaryAction("VOTING_DAY", CTX)).toBeNull();
+  });
+
+  it("propose de comparer les deux programmes entre les tours", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").primaryAction("BETWEEN_ROUNDS", CTX);
+    expect(action.label).toBe("Comparer les deux programmes");
+  });
+
+  it("bascule vers le suivi des promesses après le second tour", () => {
+    const action = getBannerPresentation("PRESIDENTIELLE").primaryAction("AFTER", CTX);
+    expect(action.label).toBe("Suivre les promesses");
+    // /suivi does not exist yet: the hub is the honest fallback, never a dead link.
+    expect(action.href).toBe("/elections/presidentielle-2027");
+  });
+
+  it("omet « Résultats détaillés » pour la présidentielle, dont la page générique est le hub", () => {
+    expect(getBannerPresentation("PRESIDENTIELLE").secondaryAction("AFTER", CTX)).toBeNull();
+  });
+
+  it("n'accorde aucun bouton présidentiel aux autres types", () => {
+    for (const type of ALL_TYPES.filter((t) => t !== "PRESIDENTIELLE")) {
+      const p = getBannerPresentation(type);
+      const ctx = { electionSlug: "municipales-2032", sourcedCandidacyCount: 0 };
+      expect(p.primaryAction("BETWEEN_ROUNDS", ctx).label).not.toContain("programmes");
+      expect(p.primaryAction("AFTER", ctx).label).not.toContain("promesses");
+      expect(p.showRound1Scores).toBe(false);
+      expect(p.showWinnerScore).toBe(false);
+      expect(p.promise).toBeNull();
+    }
+  });
+
+  it("renvoie les autres types vers leur page d'élection générique", () => {
+    const ctx = { electionSlug: "municipales-2032", sourcedCandidacyCount: 0 };
+    expect(getBannerPresentation("MUNICIPALES").primaryAction("FAR", ctx).href).toBe(
+      "/elections/municipales-2032"
+    );
+    expect(getBannerPresentation("MUNICIPALES").secondaryAction("AFTER", ctx)?.label).toBe(
+      "Résultats détaillés"
+    );
+  });
+});

--- a/src/lib/elections/__tests__/banner-state.test.ts
+++ b/src/lib/elections/__tests__/banner-state.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { deriveElectionBannerState, type ElectionRoundScore } from "@/lib/elections/banner-state";
+
+// 2027 round dates as stored by the importer: midnight UTC on the polling day.
+const ROUND1 = new Date("2027-04-11T00:00:00.000Z");
+const ROUND2 = new Date("2027-04-25T00:00:00.000Z");
+
+const SCORES: ElectionRoundScore[] = [
+  {
+    candidateName: "Camille Rivière",
+    politicianSlug: "camille-riviere",
+    partyLabel: "UD",
+    pct: 27.4,
+  },
+  { candidateName: "Jean Vasseur", politicianSlug: "jean-vasseur", partyLabel: "AC", pct: 23.1 },
+];
+
+function derive(
+  now: string,
+  overrides: Partial<Parameters<typeof deriveElectionBannerState>[0]> = {}
+) {
+  return deriveElectionBannerState({
+    round1Date: ROUND1,
+    round2Date: ROUND2,
+    now: new Date(now),
+    round1Scores: [],
+    winner: null,
+    ...overrides,
+  });
+}
+
+describe("deriveElectionBannerState", () => {
+  it("rend null quand l'élection n'a pas de date de premier tour", () => {
+    expect(derive("2026-08-07T10:00:00.000Z", { round1Date: null })).toBeNull();
+  });
+
+  it("rend FAR à plus de 30 jours du premier tour", () => {
+    const state = derive("2027-03-01T10:00:00.000Z");
+    expect(state).toMatchObject({ kind: "FAR", showSeconds: false });
+  });
+
+  it("rend LAST_MONTH à 29 jours du premier tour", () => {
+    const state = derive("2027-03-14T10:00:00.000Z");
+    expect(state).toMatchObject({ kind: "LAST_MONTH", showSeconds: false });
+  });
+
+  it("bascule de FAR à LAST_MONTH sur la borne des 30 jours", () => {
+    // 2027-04-11 08:00 Paris is 2027-04-11T06:00Z. 30 days earlier: 2027-03-12T06:00Z.
+    expect(derive("2027-03-12T05:59:00.000Z")).toMatchObject({ kind: "FAR" });
+    expect(derive("2027-03-12T06:01:00.000Z")).toMatchObject({ kind: "LAST_MONTH" });
+  });
+
+  it("vise 08:00 Paris le jour du scrutin, pas minuit UTC", () => {
+    const state = derive("2027-03-01T10:00:00.000Z");
+    // April is CEST (UTC+2), so 08:00 Paris is 06:00Z.
+    if (state?.kind !== "FAR") throw new Error("état inattendu");
+    expect(state.targetDate.toISOString()).toBe("2027-04-11T06:00:00.000Z");
+  });
+
+  it("rend VOTING_DAY avec les secondes à 19:59 Paris le jour du premier tour", () => {
+    const state = derive("2027-04-11T17:59:00.000Z");
+    expect(state).toMatchObject({ kind: "VOTING_DAY", showSeconds: true, round: 1 });
+    if (state?.kind !== "VOTING_DAY") throw new Error("état inattendu");
+    expect(state.targetDate.toISOString()).toBe("2027-04-11T18:00:00.000Z");
+  });
+
+  it("bascule en BETWEEN_ROUNDS à 20:01 Paris le jour du premier tour", () => {
+    const state = derive("2027-04-11T18:01:00.000Z");
+    expect(state).toMatchObject({ kind: "BETWEEN_ROUNDS", showSeconds: false });
+    if (state?.kind !== "BETWEEN_ROUNDS") throw new Error("état inattendu");
+    expect(state.targetDate.toISOString()).toBe("2027-04-25T06:00:00.000Z");
+  });
+
+  it("laisse BETWEEN_ROUNDS sans scores quand ils ne sont pas encore importés", () => {
+    const state = derive("2027-04-11T18:01:00.000Z");
+    if (state?.kind !== "BETWEEN_ROUNDS") throw new Error("état inattendu");
+    expect(state.round1Scores).toEqual([]);
+  });
+
+  it("porte les scores du premier tour en BETWEEN_ROUNDS quand ils existent", () => {
+    const state = derive("2027-04-14T10:00:00.000Z", { round1Scores: SCORES });
+    if (state?.kind !== "BETWEEN_ROUNDS") throw new Error("état inattendu");
+    expect(state.round1Scores).toHaveLength(2);
+  });
+
+  it("rend VOTING_DAY le jour du second tour", () => {
+    const state = derive("2027-04-25T17:59:00.000Z");
+    expect(state).toMatchObject({ kind: "VOTING_DAY", showSeconds: true, round: 2 });
+  });
+
+  it("bascule en AFTER à 20:01 Paris le jour du second tour", () => {
+    expect(derive("2027-04-25T18:01:00.000Z")).toMatchObject({ kind: "AFTER" });
+  });
+
+  it("porte le vainqueur en AFTER quand il est connu", () => {
+    const winner: ElectionRoundScore = {
+      candidateName: "Camille Rivière",
+      politicianSlug: "camille-riviere",
+      partyLabel: "UD",
+      pct: 52.8,
+    };
+    const state = derive("2027-05-02T10:00:00.000Z", { winner });
+    if (state?.kind !== "AFTER") throw new Error("état inattendu");
+    expect(state.winner?.pct).toBe(52.8);
+  });
+
+  it("ne rend jamais de date cible en AFTER", () => {
+    const state = derive("2027-05-02T10:00:00.000Z");
+    if (state?.kind !== "AFTER") throw new Error("état inattendu");
+    expect(state).not.toHaveProperty("targetDate");
+  });
+
+  it("passe de VOTING_DAY à AFTER sans BETWEEN_ROUNDS quand il n'y a qu'un tour", () => {
+    expect(derive("2027-04-11T17:59:00.000Z", { round2Date: null })).toMatchObject({
+      kind: "VOTING_DAY",
+      round: 1,
+    });
+    expect(derive("2027-04-11T18:01:00.000Z", { round2Date: null })).toMatchObject({
+      kind: "AFTER",
+    });
+  });
+
+  it("lit le décalage horaire de la zone au lieu de le supposer (scrutin de mars, CET)", () => {
+    // A March round is CET (UTC+1), so 08:00 Paris is 07:00Z, not 06:00Z. A hardcoded +2 offset
+    // would make this assertion fail, which is the point of the test.
+    const march = new Date("2027-03-14T00:00:00.000Z");
+    const state = deriveElectionBannerState({
+      round1Date: march,
+      round2Date: null,
+      now: new Date("2027-02-01T10:00:00.000Z"),
+      round1Scores: [],
+      winner: null,
+    });
+    if (state?.kind !== "FAR") throw new Error("état inattendu");
+    expect(state.targetDate.toISOString()).toBe("2027-03-14T07:00:00.000Z");
+  });
+});

--- a/src/lib/elections/banner-presentation.ts
+++ b/src/lib/elections/banner-presentation.ts
@@ -1,0 +1,123 @@
+import type { ElectionType } from "@/generated/prisma";
+import type { ElectionBannerState } from "./banner-state";
+
+/**
+ * Presentation of the homepage banner, keyed by election TYPE.
+ *
+ * Separated from `banner-state.ts` on purpose. `Election.featured` is generic and any election can
+ * be featured, so a rendering that talks about "the two programmes" or "following the promises"
+ * must be selected by type, not baked into the component. Without this split, a municipal election
+ * featured in 2032 would inherit presidential calls to action and no test would fail.
+ *
+ * The registry is a non-partial Record: adding an ElectionType to the Prisma schema breaks the
+ * build here rather than silently falling back to the presidential strategy.
+ */
+
+export type BannerAction = {
+  label: string;
+  href: string;
+  /** True for a link leaving the site: rendered with target=_blank and rel=noopener noreferrer. */
+  external: boolean;
+};
+
+export type BannerActionContext = {
+  electionSlug: string;
+  /** Candidacies with a status AND both source fields. Never the count of published fiches. */
+  sourcedCandidacyCount: number;
+};
+
+export type BannerPresentation = {
+  /** One-line editorial promise, above the dates. Null for elections we make no promise about. */
+  promise: string | null;
+  showRound1Scores: boolean;
+  showWinnerScore: boolean;
+  primaryAction(state: ElectionBannerState["kind"], ctx: BannerActionContext): BannerAction;
+  secondaryAction(
+    state: ElectionBannerState["kind"],
+    ctx: BannerActionContext
+  ): BannerAction | null;
+};
+
+/**
+ * Official entry point for checking one's electoral registration, which is what tells a voter
+ * where they vote.
+ *
+ * What was actually checked, on 2026-08-07: this service-public.fr path answers with a redirect
+ * (not a 404) to https://situation.elections.interieur.gouv.fr/. That final host refuses
+ * non-browser clients with a 403, so its content could NOT be loaded from the build environment.
+ * The service-public.fr path is kept rather than the redirect target for two reasons: it is the
+ * documented entry point maintained by DILA, and it will follow if the underlying service moves.
+ */
+const VOTER_SITUATION_LOOKUP_URL =
+  "https://www.service-public.fr/particuliers/vosdroits/services-en-ligne-et-formulaires/ISE";
+
+const genericPresentation: BannerPresentation = {
+  promise: null,
+  showRound1Scores: false,
+  showWinnerScore: false,
+  primaryAction: (_state, ctx) => ({
+    label: "Voir l'élection",
+    href: `/elections/${ctx.electionSlug}`,
+    external: false,
+  }),
+  secondaryAction: (state, ctx) =>
+    state === "AFTER"
+      ? { label: "Résultats détaillés", href: `/elections/${ctx.electionSlug}`, external: false }
+      : null,
+};
+
+const presidentiellePresentation: BannerPresentation = {
+  promise:
+    "Ce que chaque candidature propose, ce qu'elle a voté, ce qu'elle a fait quand elle était au pouvoir.",
+  showRound1Scores: true,
+  showWinnerScore: true,
+  primaryAction: (state, ctx) => {
+    const hub = `/elections/${ctx.electionSlug}`;
+    switch (state) {
+      case "VOTING_DAY":
+        return {
+          label: "Trouver mon bureau de vote",
+          href: VOTER_SITUATION_LOOKUP_URL,
+          external: true,
+        };
+      case "BETWEEN_ROUNDS":
+        return { label: "Comparer les deux programmes", href: hub, external: false };
+      case "AFTER":
+        // `/elections/<slug>/suivi` belongs to lot 8 and does not exist. The hub is the honest
+        // destination until it does: a dead link would be worse than a less precise one.
+        return { label: "Suivre les promesses", href: hub, external: false };
+      default:
+        return { label: "Ouvrir le dossier", href: hub, external: false };
+    }
+  },
+  secondaryAction: (state, ctx) => {
+    if (state === "VOTING_DAY" || state === "BETWEEN_ROUNDS") return null;
+    // No "Résultats détaillés" here: the static segment src/app/elections/presidentielle-2027/
+    // takes precedence over [slug], so the generic election page and the hub are the same URL and
+    // the link would point at the page carrying it.
+    if (state === "AFTER") return null;
+    const plural = ctx.sourcedCandidacyCount > 1 ? "s" : "";
+    return {
+      // "recensées" and not "documentées": this counts sourced candidacies, not candidacies whose
+      // programme is published. "Documentée" would read as "we have their measures".
+      label: `${ctx.sourcedCandidacyCount} candidature${plural} recensée${plural}`,
+      href: `/elections/${ctx.electionSlug}#candidatures`,
+      external: false,
+    };
+  },
+};
+
+const BANNER_PRESENTATIONS: Record<ElectionType, BannerPresentation> = {
+  PRESIDENTIELLE: presidentiellePresentation,
+  LEGISLATIVES: genericPresentation,
+  SENATORIALES: genericPresentation,
+  MUNICIPALES: genericPresentation,
+  DEPARTEMENTALES: genericPresentation,
+  REGIONALES: genericPresentation,
+  EUROPEENNES: genericPresentation,
+  REFERENDUM: genericPresentation,
+};
+
+export function getBannerPresentation(type: ElectionType): BannerPresentation {
+  return BANNER_PRESENTATIONS[type];
+}

--- a/src/lib/elections/banner-state.ts
+++ b/src/lib/elections/banner-state.ts
@@ -1,0 +1,137 @@
+/**
+ * Temporal state of the homepage election banner.
+ *
+ * Deliberately agnostic of the election TYPE: the five states are properties of a one or two
+ * round ballot, not of the presidential race. Labels and link targets live in
+ * `banner-presentation.ts`, keyed by `ElectionType`.
+ *
+ * The state machine exists to make one bug unrepresentable: a banner counting down toward a date
+ * that has passed. `AFTER` carries no target date at all, so no rendering path can accidentally
+ * show a countdown once the last round is over.
+ */
+
+/** Paris wall-clock hour at which polling stations open on election day. */
+export const POLLS_OPEN_HOUR_PARIS = 8;
+/** Paris wall-clock hour at which polling stations close, and at which the banner switches state. */
+export const POLLS_CLOSE_HOUR_PARIS = 20;
+/** Above this many days before the first round, the banner stays in its low-key `FAR` state. */
+export const LAST_MONTH_THRESHOLD_DAYS = 30;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type ElectionRoundScore = {
+  candidateName: string;
+  politicianSlug: string | null;
+  partyLabel: string | null;
+  pct: number;
+};
+
+export type ElectionBannerState =
+  | { kind: "FAR"; targetDate: Date; showSeconds: false }
+  | { kind: "LAST_MONTH"; targetDate: Date; showSeconds: false }
+  | { kind: "VOTING_DAY"; targetDate: Date; showSeconds: true; round: 1 | 2 }
+  | {
+      kind: "BETWEEN_ROUNDS";
+      targetDate: Date;
+      showSeconds: false;
+      round1Scores: ElectionRoundScore[];
+    }
+  | { kind: "AFTER"; winner: ElectionRoundScore | null };
+
+export type DeriveElectionBannerStateInput = {
+  round1Date: Date | null;
+  round2Date: Date | null;
+  now: Date;
+  /** The qualified candidacies with their first-round share. Empty until results are imported. */
+  round1Scores: ElectionRoundScore[];
+  /** The elected candidacy with its second-round share. Null until there is one. */
+  winner: ElectionRoundScore | null;
+};
+
+/**
+ * Minutes to add to a UTC timestamp to read the Europe/Paris wall clock at that instant.
+ *
+ * Read from the zone rather than hardcoded: Paris is UTC+1 or UTC+2 depending on the season, and
+ * a March round falls on the other side of the switch from an April one.
+ */
+function parisOffsetMinutes(at: Date): number {
+  // "en-CA" yields ISO-ordered numeric parts, which recompose deterministically.
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(at);
+  const part = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? "0");
+  const asIfUtc = Date.UTC(
+    part("year"),
+    part("month") - 1,
+    part("day"),
+    part("hour"),
+    part("minute"),
+    part("second")
+  );
+  return (asIfUtc - at.getTime()) / 60_000;
+}
+
+/**
+ * The instant at which the Paris wall clock reads `hour`:00 on the calendar day of `day`.
+ *
+ * `day` is read in UTC because that is how round dates are stored (midnight UTC on the polling
+ * day). The two-step guess-then-correct is exact for the hours this module uses: DST switches
+ * happen at 02:00/03:00 local, never at 08:00 or 20:00, so the offset at the guessed instant
+ * equals the offset at the corrected one.
+ */
+function parisInstantOnDay(day: Date, hour: number): Date {
+  const guess = Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate(), hour);
+  return new Date(guess - parisOffsetMinutes(new Date(guess)) * 60_000);
+}
+
+export function deriveElectionBannerState(
+  input: DeriveElectionBannerStateInput
+): ElectionBannerState | null {
+  const { round1Date, round2Date, now, round1Scores, winner } = input;
+  if (round1Date === null) return null;
+
+  const round1Open = parisInstantOnDay(round1Date, POLLS_OPEN_HOUR_PARIS);
+  const round1Close = parisInstantOnDay(round1Date, POLLS_CLOSE_HOUR_PARIS);
+  const lastRound = round2Date ?? round1Date;
+  const lastRoundClose = parisInstantOnDay(lastRound, POLLS_CLOSE_HOUR_PARIS);
+
+  // Ordered from the latest situation to the earliest, so each branch only has to rule out what
+  // comes after it.
+  if (now.getTime() >= lastRoundClose.getTime()) {
+    return { kind: "AFTER", winner };
+  }
+
+  if (round2Date !== null && now.getTime() >= round1Close.getTime()) {
+    // Polls closed on round 1 and round 2 has not closed yet. Voting day of round 2 is the window
+    // between midnight and 20:00 on that day; before it, the reader is between rounds.
+    const round2DayStart = parisInstantOnDay(round2Date, 0);
+    const round2Close = parisInstantOnDay(round2Date, POLLS_CLOSE_HOUR_PARIS);
+    if (now.getTime() >= round2DayStart.getTime() && now.getTime() < round2Close.getTime()) {
+      return { kind: "VOTING_DAY", targetDate: round2Close, showSeconds: true, round: 2 };
+    }
+    return {
+      kind: "BETWEEN_ROUNDS",
+      targetDate: parisInstantOnDay(round2Date, POLLS_OPEN_HOUR_PARIS),
+      showSeconds: false,
+      round1Scores,
+    };
+  }
+
+  const round1DayStart = parisInstantOnDay(round1Date, 0);
+  if (now.getTime() >= round1DayStart.getTime()) {
+    return { kind: "VOTING_DAY", targetDate: round1Close, showSeconds: true, round: 1 };
+  }
+
+  const daysUntilOpen = (round1Open.getTime() - now.getTime()) / MS_PER_DAY;
+  if (daysUntilOpen >= LAST_MONTH_THRESHOLD_DAYS) {
+    return { kind: "FAR", targetDate: round1Open, showSeconds: false };
+  }
+  return { kind: "LAST_MONTH", targetDate: round1Open, showSeconds: false };
+}

--- a/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
+++ b/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { deriveCandidacyNoticeState } from "@/lib/politicians/candidacy-notice-state";
+import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
+
+const BEFORE = new Date("2026-08-07T10:00:00.000Z");
+const AFTER = new Date("2027-05-10T10:00:00.000Z");
+
+const base: PoliticianCandidacy = {
+  electionSlug: "presidentielle-2027",
+  electionShortTitle: "Présidentielle 2027",
+  round1Date: new Date("2027-04-11T00:00:00.000Z"),
+  round2Date: new Date("2027-04-25T00:00:00.000Z"),
+  status: "DECLARE",
+  sourceUrl: "https://example.org/source",
+  sourceLabel: "Le Monde, 14 janvier 2026",
+  declaredAt: new Date("2026-01-14T00:00:00.000Z"),
+  withdrewAt: null,
+  publishedMeasureCount: 0,
+  themesCoveredCount: 0,
+  primarySourceMeasureCount: 0,
+  lastReviewedAt: null,
+  round1Pct: null,
+  round2Pct: null,
+  isElected: false,
+};
+
+describe("deriveCandidacyNoticeState", () => {
+  it("rend DECLARED_EMPTY quand rien n'est publié : l'état du lancement", () => {
+    expect(deriveCandidacyNoticeState(base, BEFORE).kind).toBe("DECLARED_EMPTY");
+  });
+
+  it("rend DECLARED_WITH_MEASURES quand la fiche franchit son seuil", () => {
+    const state = deriveCandidacyNoticeState(
+      {
+        ...base,
+        publishedMeasureCount: 27,
+        themesCoveredCount: 9,
+        primarySourceMeasureCount: 20,
+        lastReviewedAt: new Date("2026-08-02T00:00:00.000Z"),
+      },
+      BEFORE
+    );
+    expect(state.kind).toBe("DECLARED_WITH_MEASURES");
+  });
+
+  it("reste DECLARED_EMPTY quand les mesures existent sans source primaire", () => {
+    const state = deriveCandidacyNoticeState(
+      { ...base, publishedMeasureCount: 12, themesCoveredCount: 4, primarySourceMeasureCount: 0 },
+      BEFORE
+    );
+    expect(state.kind).toBe("DECLARED_EMPTY");
+  });
+
+  it("rend POSSIBLE pour une candidature pressentie", () => {
+    expect(deriveCandidacyNoticeState({ ...base, status: "PRESSENTI" }, BEFORE).kind).toBe(
+      "POSSIBLE"
+    );
+  });
+
+  it("rend POSSIBLE pour une candidature évoquée", () => {
+    expect(deriveCandidacyNoticeState({ ...base, status: "ENVISAGE" }, BEFORE).kind).toBe(
+      "POSSIBLE"
+    );
+  });
+
+  it("rend WITHDRAWN pour une candidature retirée, même avec des mesures publiées", () => {
+    const state = deriveCandidacyNoticeState(
+      {
+        ...base,
+        status: "RETIRE",
+        withdrewAt: new Date("2027-03-03T00:00:00.000Z"),
+        publishedMeasureCount: 18,
+        primarySourceMeasureCount: 15,
+      },
+      BEFORE
+    );
+    expect(state.kind).toBe("WITHDRAWN");
+  });
+
+  it("garde WITHDRAWN après le scrutin : un retrait ne devient pas une participation", () => {
+    const state = deriveCandidacyNoticeState(
+      { ...base, status: "RETIRE", withdrewAt: new Date("2027-03-03T00:00:00.000Z") },
+      AFTER
+    );
+    expect(state.kind).toBe("WITHDRAWN");
+  });
+
+  it("garde POSSIBLE après le scrutin : une mention de presse ne devient pas une candidature", () => {
+    expect(deriveCandidacyNoticeState({ ...base, status: "PRESSENTI" }, AFTER).kind).toBe(
+      "POSSIBLE"
+    );
+  });
+
+  it("rend PAST avec ses résultats après le scrutin", () => {
+    const state = deriveCandidacyNoticeState({ ...base, round1Pct: 27.4, round2Pct: 47.2 }, AFTER);
+    expect(state.kind).toBe("PAST");
+    if (state.kind !== "PAST") throw new Error("état inattendu");
+    expect(state.results).toEqual({ round1Pct: 27.4, round2Pct: 47.2, isElected: false });
+  });
+
+  it("rend PAST sans bloc de résultats quand aucun score n'est enregistré", () => {
+    const state = deriveCandidacyNoticeState(base, AFTER);
+    expect(state.kind).toBe("PAST");
+    if (state.kind !== "PAST") throw new Error("état inattendu");
+    // No score in the database means either "never on the ballot" or "results not imported yet",
+    // and nothing distinguishes the two. Omitting the block asserts neither.
+    expect(state.results).toBeNull();
+  });
+
+  it("bascule en PAST à 20:00 Paris le jour du second tour, pas à minuit", () => {
+    expect(deriveCandidacyNoticeState(base, new Date("2027-04-25T17:59:00.000Z")).kind).toBe(
+      "DECLARED_EMPTY"
+    );
+    expect(deriveCandidacyNoticeState(base, new Date("2027-04-25T18:01:00.000Z")).kind).toBe(
+      "PAST"
+    );
+  });
+
+  it("mesure la fin du scrutin sur le premier tour quand il n'y a pas de second", () => {
+    const state = deriveCandidacyNoticeState(
+      { ...base, round2Date: null },
+      new Date("2027-04-11T18:01:00.000Z")
+    );
+    expect(state.kind).toBe("PAST");
+  });
+
+  it("ne devient jamais PAST quand l'élection n'a pas de date", () => {
+    const state = deriveCandidacyNoticeState(
+      { ...base, round1Date: null, round2Date: null },
+      AFTER
+    );
+    expect(state.kind).toBe("DECLARED_EMPTY");
+  });
+});

--- a/src/lib/politicians/candidacy-notice-state.ts
+++ b/src/lib/politicians/candidacy-notice-state.ts
@@ -1,0 +1,76 @@
+import { isFicheCandidatPublishable } from "@/config/publication-gates";
+import type { PoliticianCandidacy } from "@/lib/data/politician-candidacy";
+import { deriveElectionBannerState } from "@/lib/elections/banner-state";
+
+/**
+ * The five states of the candidacy notice on a politician's fiche.
+ *
+ * The rule that matters is the ORDER of evaluation: status first, date second. After the second
+ * round, "withdrawn", "merely rumoured" and "the ballot is over" are all true at once, and letting
+ * the date win would turn someone who dropped out in February into a former candidate with a results
+ * block. That would be wrong twice over: they did not run, and the results are not theirs.
+ *
+ * Unlike the homepage banner, this state has NO archive window. The 30 days of
+ * `FEATURED_ELECTION_ARCHIVE_DAYS` decide what is featured on the homepage; a person's candidacy
+ * stays a fact of their career, and the notice keeps it indefinitely.
+ */
+
+export type CandidacyResults = {
+  round1Pct: number | null;
+  round2Pct: number | null;
+  isElected: boolean;
+};
+
+export type CandidacyNoticeState =
+  | { kind: "DECLARED_WITH_MEASURES" }
+  | { kind: "DECLARED_EMPTY" }
+  | { kind: "POSSIBLE" }
+  | { kind: "WITHDRAWN" }
+  | { kind: "PAST"; results: CandidacyResults | null };
+
+export function deriveCandidacyNoticeState(
+  candidacy: PoliticianCandidacy,
+  now: Date
+): CandidacyNoticeState {
+  // Status before date. A withdrawal and a press mention are both facts about what the person did,
+  // and no amount of elapsed time turns either into a participation.
+  if (candidacy.status === "RETIRE") return { kind: "WITHDRAWN" };
+  if (candidacy.status === "PRESSENTI" || candidacy.status === "ENVISAGE") {
+    return { kind: "POSSIBLE" };
+  }
+
+  // Reusing the banner derivation rather than re-implementing "is the ballot over": the 20:00 Paris
+  // boundary and the no-second-round case are already settled there, and two answers to the same
+  // question would eventually disagree.
+  const ballot = deriveElectionBannerState({
+    round1Date: candidacy.round1Date,
+    round2Date: candidacy.round2Date,
+    now,
+    round1Scores: [],
+    winner: null,
+  });
+
+  if (ballot?.kind === "AFTER") {
+    const hasScore = candidacy.round1Pct !== null || candidacy.round2Pct !== null;
+    return {
+      kind: "PAST",
+      // Strictly conditional. A null score means either "never reached the ballot" or "results not
+      // imported yet", and the database has no field distinguishing them. Rendering nothing asserts
+      // neither.
+      results: hasScore
+        ? {
+            round1Pct: candidacy.round1Pct,
+            round2Pct: candidacy.round2Pct,
+            isElected: candidacy.isElected,
+          }
+        : null,
+    };
+  }
+
+  return isFicheCandidatPublishable({
+    statusSourced: true,
+    verifiedMeasuresWithPrimarySource: candidacy.primarySourceMeasureCount,
+  })
+    ? { kind: "DECLARED_WITH_MEASURES" }
+    : { kind: "DECLARED_EMPTY" };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,6 +55,18 @@ export function stripMarkdown(text: string): string {
     .replace(/_([^_]+)_/g, "$1");
 }
 
+/**
+ * French percentage: comma as the decimal separator and a NON-BREAKING space before the sign, so the
+ * "%" never wraps to its own line.
+ *
+ * The space is a literal U+00A0 and not an escape, because two copies of this function previously
+ * documented a non-breaking space while typing an ordinary one, and nothing caught it: the only state
+ * that rendered a percentage was never rendered in a test.
+ */
+export function formatPct(pct: number, decimals = 1): string {
+  return `${pct.toFixed(decimals).replace(".", ",")} %`;
+}
+
 export function formatDate(date: Date | string | null): string {
   if (!date) return "—";
   const d = typeof date === "string" ? new Date(date) : date;


### PR DESCRIPTION
Ouvre l'entrée dans la présidentielle depuis les deux surfaces les plus fréquentées : le bandeau de l'accueil et la fiche d'un politique, plus la route de fiche candidat vers laquelle l'encart mène.

## Pourquoi une seule PR et pas trois

Le plan prévoyait un découpage en trois (bandeau, encart, route). Deux raisons de ne pas le tenir.

Le dernier commit touche `ElectionBanner` et `CandidacyNotice` ensemble, plus `globals.css` et `lib/utils.ts` : découper demanderait de réécrire l'historique pour un gain de revue nul.

Surtout, l'encart ne doit pas partir sans la route. Sans elle, son pied promet « Son programme » et mène au hub, qui liste six candidats : le lecteur clique sur une promesse nominative et atterrit sur une liste.

## Ce que ça change

**Bandeau d'accueil.** Réécrit sur cinq états temporels dérivés des dates de tour, avec décompte sans saut de mise en page. L'élection reste à la une un mois après son dernier tour, au lieu de disparaître le lendemain. La carte d'intention de l'accueil pointe désormais vers la présidentielle 2027.

**Encart sur la fiche d'un politique.** Signale la candidature présidentielle, avec le liseré accent du parti, l'état dérivé du statut avant la date, et le nombre de mesures et de sujets documentés. Quatre défauts trouvés sur données réelles sont corrigés dans `c133eaac`, dont un « Candidature retirée » affiché deux fois quand la candidature n'a pas de date de retrait, et la civilité nulle qui produisait « Candidat » sur une fiche sans genre renseigné.

**Route de fiche candidat.** `/elections/presidentielle-2027/candidats/[slug]`, ouverte derrière son seuil de publication, `noindex` en dessous et exclue du sitemap.

## Périmètre

30 fichiers, +2977 −86, dont 14 fichiers de tests. La spec et le plan du lot sont recopiés dans `docs/superpowers/`, et la section 6.3 de `2026-08-04-presidentielle-hub-design.md` est amendée pour renvoyer vers le nouveau document.

## Validation

Suite complète verte, `tsc` sans erreur de source, `eslint` sans erreur. Les 338 tests des zones touchées passent.

## Deux réserves connues, non bloquantes

Le statut HTTP des redirections et des 404 n'est pas vérifié en build de production. En développement, `notFound()` et `redirect()` rendent tous deux 200, y compris sur `/politiques/[slug]`, `/affaires/[slug]` et `/dev` qui préexistent : c'est un comportement du projet entier, pas de cette route. La protection SEO n'en dépend pas, elle repose sur le `noindex` sous le seuil et l'exclusion du sitemap.

Le coût à froid des deux lectures ajoutées à la fiche d'un politique n'est pas mesuré : toutes les réponses observées étaient des `x-nextjs-cache HIT`.

## Ce qui rendra le travail visible

Rien n'apparaîtra tant que `presidentielle-2027` n'est pas l'élection à la une. Aujourd'hui `municipales-2026` l'est, mais son second tour a plus de trente jours, donc `getFeaturedElection()` retourne null et l'accueil ne porte aucun bandeau. La bascule se fait en une transaction unique, hors de cette PR.
