### PR TITLE
Refondre la page sujet en tableau de comparaison

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -89,7 +89,8 @@ export default async function CandidateFichePage({ params }: PageProps) {
     <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
       <Breadcrumb
         items={[
-          { label: "Présidentielle", href: `/elections/${candidacy.electionSlug}` },
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: `/elections/${candidacy.electionSlug}` },
           { label: politician.fullName },
         ]}
       />

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -83,7 +83,9 @@ export default async function PresidentialHubPage() {
         />
       )}
       <div className="container mx-auto px-4 pt-4 pb-8 space-y-8">
-        <Breadcrumb items={[{ label: "Présidentielle" }]} />
+        <Breadcrumb
+          items={[{ label: "Élections", href: "/elections" }, { label: "Présidentielle 2027" }]}
+        />
 
         <header className="space-y-6">
           {/* Mobile: compact election banner, distinct from the desktop hero card (no stats,

--- a/src/app/elections/presidentielle-2027/priorites/page.tsx
+++ b/src/app/elections/presidentielle-2027/priorites/page.tsx
@@ -40,7 +40,8 @@ export default async function PrioritesPage() {
     <div className="container mx-auto space-y-8 px-4 pt-4 pb-8">
       <Breadcrumb
         items={[
-          { label: "Présidentielle", href: "/elections/presidentielle-2027" },
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: "/elections/presidentielle-2027" },
           { label: "Priorités" },
         ]}
       />

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 import {
   CHAMBER_SHORT_LABELS,
-  MEASURE_PRECISION_LABELS,
   MEASURE_SOURCE_KIND_LABELS,
   SOURCE_TIER_LABELS,
   THEME_ACCENT_BAR,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
+import { MeasurePrecisionBadge } from "@/components/measures/MeasurePrecisionBadge";
 import { QualifiedEmptyCell } from "@/components/measures/QualifiedEmptyCell";
 import { VoteRelationBadge } from "@/components/measures/VoteRelationBadge";
 import type { ThemeCategory } from "@/generated/prisma";
@@ -133,9 +133,25 @@ function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: T
   );
 }
 
+/**
+ * Both cells describe THE MEASURE, so with no measure they have no subject to describe.
+ *
+ * The absence they state has to stay about this cell. An earlier version answered "N'a jamais
+ * siégé", which is a claim about a career derived from the emptiness of one theme: false for
+ * everyone who has sat, and not deducible from anything this page reads.
+ */
 function VoteCell({ entry }: { entry: SubjectCandidateEntry }) {
   const first = entry.measures[0];
-  if (first === undefined) return <QualifiedEmptyCell absence={{ kind: "never_sat" }} />;
+  if (first === undefined) {
+    return (
+      <QualifiedEmptyCell
+        absence={{
+          kind: "not_applicable",
+          reason: "Pas de mesure publiée à rapprocher d'un scrutin",
+        }}
+      />
+    );
+  }
   return (
     <VoteRelationBadge
       relation={first.voteRelation}
@@ -146,27 +162,32 @@ function VoteCell({ entry }: { entry: SubjectCandidateEntry }) {
   );
 }
 
+/**
+ * Nothing at all when there is no measure: the proposal cell on the same row already says no measure
+ * is published, and repeating it in a second column adds a line without adding a fact.
+ *
+ * A null precision is NOT "pas encore relu". Publication requires `reviewedAt` to be set
+ * (`PUBLIC_MEASURE_WHERE`), so a visible measure has been reviewed by construction and that label
+ * would contradict the very predicate that let the row appear.
+ */
 function PrecisionCell({ entry }: { entry: SubjectCandidateEntry }) {
   const first = entry.measures[0];
-  if (first === undefined || first.measure.precision === null) {
-    return <QualifiedEmptyCell absence={{ kind: "not_reviewed" }} />;
+  if (first === undefined) return null;
+  if (first.measure.precision === null) {
+    return (
+      <QualifiedEmptyCell
+        absence={{ kind: "not_applicable", reason: "Précision non renseignée" }}
+      />
+    );
   }
-  const precise = first.measure.precision === "CHIFFREE";
-  return (
-    <span
-      className={`inline-flex rounded-full px-2.5 py-1 text-xs font-bold ${
-        precise
-          ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200"
-          : "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200"
-      }`}
-    >
-      {MEASURE_PRECISION_LABELS[first.measure.precision]}
-    </span>
-  );
+  return <MeasurePrecisionBadge precision={first.measure.precision} />;
 }
 
 function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
   const { candidate, measures } = entry;
+  // Currently defended, not "ever published". `measures` includes withdrawals so the proposal cell
+  // can show them with their withdrawal line; this count says what the candidacy still stands on.
+  const defended = measures.filter((m) => m.measure.withdrawal === null).length;
   return (
     <span className="flex items-start gap-2.5">
       <span
@@ -188,9 +209,9 @@ function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
         )}
         <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
           {candidate.partyLabel !== null && <>{candidate.partyLabel} · </>}
-          {measures.length === 0
+          {defended === 0
             ? "aucune mesure sur ce sujet"
-            : `${measures.length} ${measures.length === 1 ? "mesure" : "mesures"} sur ce sujet`}
+            : `${defended} ${defended === 1 ? "mesure" : "mesures"} sur ce sujet`}
         </span>
       </span>
     </span>
@@ -210,18 +231,26 @@ function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
  * is linked to a measure.
  */
 const COLUMNS = [
-  { title: "Candidat·e", hint: "Ordre alphabétique" },
-  { title: "Ce qu'il ou elle propose", hint: "Phrase citée du programme" },
+  { title: "Candidat·e", hint: "Par nom de famille" },
+  // Not "du programme": a measure with no `programEditionId` was taken from a speech, an interview
+  // or an article, and the source line under each quote names which.
+  { title: "Ce qu'il ou elle propose", hint: "Phrase citée, avec sa source" },
   {
     title: "Déjà soumis au vote ?",
     hint: "Seulement si un texte proche a été voté et que la personne siégeait",
   },
-  { title: "Précision de la mesure", hint: "Chiffrée, datée, financée" },
+  // The enum holds two values, "Chiffrée" and "Objectif sans chiffre". There is no dated or funded
+  // criterion anywhere in the model, so naming them here promised a qualification we never make.
+  { title: "Précision de la mesure", hint: "Chiffrée ou objectif sans chiffre" },
 ];
 
 export function SubjectComparison({ data }: { data: SubjectPageData }) {
   const themeLabel = THEME_CATEGORY_LABELS[data.theme];
-  const documented = data.candidates.filter((c) => c.measures.length > 0).length;
+  // From the authority, not recomputed here. `entry.measures` carries withdrawn measures on purpose
+  // (`includeWithdrawn: true`), so counting rows with `measures.length > 0` would say a candidacy
+  // "porte une mesure" when every one of them has been withdrawn. The data layer already made that
+  // distinction on `withdrawal === null`, and it is the same distinction `totalMeasuresOnTheme` uses.
+  const documented = data.candidaciesWithVerifiedMeasure;
   const withoutMeasure = data.candidates.length - documented;
 
   return (
@@ -338,7 +367,7 @@ function ComparisonTable({ data }: { data: SubjectPageData }) {
         <table className="w-full min-w-[860px] table-fixed border-collapse text-left">
           <caption className="sr-only">
             Ce que chaque candidature propose sur {THEME_CATEGORY_LABELS[data.theme]}, avec sa
-            source, sa relation aux votes, la fonction exercée et la précision de la mesure.
+            source, sa relation aux votes et la précision de la mesure.
           </caption>
           <colgroup>
             <col className="w-[200px]" />
@@ -393,10 +422,15 @@ function ComparisonTable({ data }: { data: SubjectPageData }) {
             <div className="mt-3">
               <ProposalCell entry={entry} theme={data.theme} />
             </div>
+            {/* The precision pair drops out entirely when there is no measure. On the table an
+                empty cell sits under a header that explains it; here the term would stand alone
+                facing nothing, which reads as a value we failed to load. */}
             <dl className="mt-4 space-y-2 border-t border-border pt-3 text-sm">
               {[
                 { term: COLUMNS[2]!.title, cell: <VoteCell entry={entry} /> },
-                { term: COLUMNS[3]!.title, cell: <PrecisionCell entry={entry} /> },
+                ...(entry.measures.length > 0
+                  ? [{ term: COLUMNS[3]!.title, cell: <PrecisionCell entry={entry} /> }]
+                  : []),
               ].map(({ term, cell }) => (
                 <div key={term} className="flex flex-wrap items-start justify-between gap-2">
                   <dt className="text-xs uppercase tracking-wide text-muted-foreground">{term}</dt>
@@ -441,11 +475,15 @@ function FooterCard({
 function MethodCard() {
   return (
     <section className="flex flex-col gap-4 rounded-xl border border-border bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+      {/* The two states quoted here are the ones the badge actually renders today
+          (VOTE_RELATION_BASIS_LABELS). An earlier version quoted "aucun vote sur cet objet", a
+          string that exists nowhere: a reader would have looked for a wording they never meet. */}
       <p className="max-w-3xl text-sm text-muted-foreground">
-        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote&nbsp;:
-        une case «&nbsp;aucun vote sur cet objet&nbsp;» est le cas le plus fréquent et ne dit rien
-        de la mesure. La colonne vote ne se remplit que pour une candidature qui siégeait au moment
-        où un texte proche a été soumis.
+        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote. Cette
+        colonne dit donc surtout où nous en sommes&nbsp;: «&nbsp;périmètre non examiné&nbsp;» tant
+        que nous n&apos;avons pas cherché de scrutin proche, «&nbsp;périmètre examiné sans
+        résultat&nbsp;» quand nous avons cherché sans rien trouver. Une position ne s&apos;affiche
+        que pour une candidature qui siégeait au moment où un texte proche a été soumis.
       </p>
       <Link
         href="/methodologie"

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -1,8 +1,10 @@
+import Link from "next/link";
 import {
-  CANDIDACY_STATUS_LABELS,
   CHAMBER_SHORT_LABELS,
+  MEASURE_PRECISION_LABELS,
   MEASURE_SOURCE_KIND_LABELS,
   SOURCE_TIER_LABELS,
+  THEME_ACCENT_BAR,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
 import { QualifiedEmptyCell } from "@/components/measures/QualifiedEmptyCell";
@@ -13,13 +15,18 @@ import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
 import { formatDate } from "@/lib/utils";
 import { SubjectGate } from "./SubjectGate";
+import { SubjectSidebar } from "./SubjectSidebar";
 
 /**
- * A public subject page: for one theme, the candidates and their measures, side by side.
+ * A public subject page: for one theme, every publicly visible candidacy on one row, with what it
+ * proposes, whether a close text was ever voted, and how precise the measure is.
  *
- * Candidates come in the alphabetical order the authority returns. A candidate with no published measure
- * on the theme gets a qualified absence. Below the publication gate the page renders an explicit closed
- * state.
+ * One measure per candidacy is quoted, the rest fold into a disclosure. Six rows each carrying a
+ * dozen measures is a wall, and the comparison this page exists for happens between candidacies,
+ * not inside one.
+ *
+ * Candidates come in the alphabetical order the authority returns. Below the publication gate the
+ * page renders an explicit closed state.
  */
 
 function composeVoteBasis(reference: PublicVoteReference): string {
@@ -38,25 +45,27 @@ function composeVoteBasis(reference: PublicVoteReference): string {
 }
 
 /**
- * The evidence behind a measure: its sources, primary first (the doctrine's reference source), each with
- * its nature, its primary/secondary tier and its publication date, and a clickable link. A measure text
- * without its sources on screen would ask the reader to trust it; the whole point is that they don't have to.
+ * Every source of a measure, primary first, on one compact line each.
+ *
+ * All of them and not just the first: a measure text without its evidence on screen asks the reader
+ * to trust it, and the whole point is that they do not have to. The tier is named because the
+ * 60 % primary-source threshold of the priorities page is computed from it, so a reader comparing
+ * two candidacies needs to see which side of that line each source falls on.
  */
 function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
   if (sources.length === 0) return null;
   const ordered = [...sources].sort(
     (a, b) => (a.tier === "PRIMARY" ? 0 : 1) - (b.tier === "PRIMARY" ? 0 : 1)
   );
+
   return (
-    <ul aria-label="Sources de la mesure" className="space-y-1 text-xs text-muted-foreground">
+    <ul aria-label="Sources de la mesure" className="space-y-0.5 text-xs text-muted-foreground">
       {ordered.map((source) => (
         <li key={source.id}>
-          <a href={source.url} className="underline" rel="nofollow noopener">
+          <a href={source.url} className="font-semibold underline" rel="nofollow noopener">
             {MEASURE_SOURCE_KIND_LABELS[source.sourceKind]}
           </a>
-          {" · "}
-          {SOURCE_TIER_LABELS[source.tier]}
-          {" · "}
+          {source.page !== null && `, ${source.page}`} · {SOURCE_TIER_LABELS[source.tier]} ·{" "}
           {formatDate(source.publishedAt)}
         </li>
       ))}
@@ -64,87 +73,386 @@ function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
   );
 }
 
-function CandidateColumn({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
-  const { candidate, measures } = entry;
-  const statusLabel = candidate.status === null ? null : CANDIDACY_STATUS_LABELS[candidate.status];
-
+function WithdrawalLine({ withdrawal }: { withdrawal: NonNullable<PublicMeasure["withdrawal"]> }) {
   return (
-    <article className="rounded-lg border border-border p-4">
-      <h2 className="font-display text-lg font-semibold tracking-tight">
-        {candidate.candidateName}
-      </h2>
-      {statusLabel !== null && (
-        <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{statusLabel}</p>
-      )}
-      {candidate.sourceUrl !== null && candidate.sourceLabel !== null && (
-        <p className="mt-1 text-xs text-muted-foreground">
-          Candidature :{" "}
-          <a href={candidate.sourceUrl} className="underline" rel="nofollow noopener">
-            {candidate.sourceLabel}
+    <p className="text-xs text-muted-foreground">
+      Mesure retirée le {formatDate(withdrawal.withdrawnAt)}
+      {withdrawal.sourceUrl !== null && withdrawal.sourceLabel !== null && (
+        <>
+          {" · "}
+          <a href={withdrawal.sourceUrl} className="underline" rel="nofollow noopener">
+            {withdrawal.sourceLabel}
           </a>
-        </p>
+        </>
       )}
-
-      <div className="mt-3 space-y-4">
-        {measures.length === 0 ? (
-          <QualifiedEmptyCell absence={{ kind: "no_measure_published", theme }} />
-        ) : (
-          measures.map(({ measure, voteRelation, voteReference }) => (
-            <div key={measure.id} className="space-y-2">
-              <p className="text-sm">{measure.text}</p>
-              <MeasureSources sources={measure.sources} />
-              {measure.withdrawal !== null && (
-                <p className="text-xs text-muted-foreground">
-                  Mesure retirée le {formatDate(measure.withdrawal.withdrawnAt)}
-                  {measure.withdrawal.sourceUrl !== null &&
-                    measure.withdrawal.sourceLabel !== null && (
-                      <>
-                        {" · "}
-                        <a
-                          href={measure.withdrawal.sourceUrl}
-                          className="underline"
-                          rel="nofollow noopener"
-                        >
-                          {measure.withdrawal.sourceLabel}
-                        </a>
-                      </>
-                    )}
-                </p>
-              )}
-              <VoteRelationBadge
-                relation={voteRelation}
-                basisDetails={voteReference !== null ? composeVoteBasis(voteReference) : undefined}
-              />
-            </div>
-          ))
-        )}
-      </div>
-    </article>
+    </p>
   );
 }
 
-export function SubjectComparison({ data }: { data: SubjectPageData }) {
-  const themeLabel = THEME_CATEGORY_LABELS[data.theme];
-
+/** One quoted measure: its text, its source, and its withdrawal when there is one. */
+function QuotedMeasure({ entry }: { entry: SubjectCandidateEntry["measures"][number] }) {
   return (
-    <div className="space-y-6">
-      <header className="space-y-2">
-        <p className="text-sm text-muted-foreground">Présidentielle 2027</p>
-        <h1 className="font-display text-2xl font-bold tracking-tight">{themeLabel}</h1>
-        <p className="text-sm text-muted-foreground">
-          Les candidatures sont présentées par ordre alphabétique.
-        </p>
-      </header>
-
-      {!data.publishable ? (
-        <SubjectGate data={data} />
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {data.candidates.map((entry) => (
-            <CandidateColumn key={entry.candidate.id} entry={entry} theme={data.theme} />
-          ))}
-        </div>
+    <div className="space-y-1.5">
+      <p className="text-sm leading-relaxed">&laquo;&nbsp;{entry.measure.text}&nbsp;&raquo;</p>
+      <MeasureSources sources={entry.measure.sources} />
+      {entry.measure.withdrawal !== null && (
+        <WithdrawalLine withdrawal={entry.measure.withdrawal} />
       )}
     </div>
+  );
+}
+
+/**
+ * The proposal cell: the first measure quoted, the others behind a disclosure.
+ *
+ * `<details>` rather than a state hook: the page is a server component, and the browser's own
+ * disclosure is keyboard-operable and announced correctly without a line of JavaScript.
+ */
+function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
+  const [first, ...rest] = entry.measures;
+  if (first === undefined) {
+    return <QualifiedEmptyCell absence={{ kind: "no_measure_published", theme }} />;
+  }
+
+  return (
+    <div className="space-y-2">
+      <QuotedMeasure entry={first} />
+      {rest.length > 0 && (
+        <details className="group">
+          <summary className="inline-flex min-h-11 cursor-pointer items-center text-xs font-semibold text-primary underline decoration-dotted underline-offset-2 hover:decoration-solid">
+            + {rest.length} {rest.length === 1 ? "autre mesure" : "autres mesures"} sur ce sujet
+          </summary>
+          <div className="mt-2 space-y-3 border-l-2 border-border pl-3">
+            {rest.map((other) => (
+              <QuotedMeasure key={other.measure.id} entry={other} />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function VoteCell({ entry }: { entry: SubjectCandidateEntry }) {
+  const first = entry.measures[0];
+  if (first === undefined) return <QualifiedEmptyCell absence={{ kind: "never_sat" }} />;
+  return (
+    <VoteRelationBadge
+      relation={first.voteRelation}
+      basisDetails={
+        first.voteReference !== null ? composeVoteBasis(first.voteReference) : undefined
+      }
+    />
+  );
+}
+
+function PrecisionCell({ entry }: { entry: SubjectCandidateEntry }) {
+  const first = entry.measures[0];
+  if (first === undefined || first.measure.precision === null) {
+    return <QualifiedEmptyCell absence={{ kind: "not_reviewed" }} />;
+  }
+  const precise = first.measure.precision === "CHIFFREE";
+  return (
+    <span
+      className={`inline-flex rounded-full px-2.5 py-1 text-xs font-bold ${
+        precise
+          ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200"
+          : "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+      }`}
+    >
+      {MEASURE_PRECISION_LABELS[first.measure.precision]}
+    </span>
+  );
+}
+
+function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
+  const { candidate, measures } = entry;
+  return (
+    <span className="flex items-start gap-2.5">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 h-7 w-2 shrink-0 rounded-sm bg-border"
+        style={candidate.accentColor !== null ? { backgroundColor: candidate.accentColor } : {}}
+      />
+      <span className="min-w-0">
+        {candidate.politicianSlug !== null ? (
+          <Link
+            href={`/politiques/${candidate.politicianSlug}`}
+            prefetch={false}
+            className="text-sm font-bold hover:underline"
+          >
+            {candidate.candidateName}
+          </Link>
+        ) : (
+          <span className="text-sm font-bold">{candidate.candidateName}</span>
+        )}
+        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+          {candidate.partyLabel !== null && <>{candidate.partyLabel} · </>}
+          {measures.length === 0
+            ? "aucune mesure sur ce sujet"
+            : `${measures.length} ${measures.length === 1 ? "mesure" : "mesures"} sur ce sujet`}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Four columns, and the office one is deliberately not among them.
+ *
+ * "A exercé sur ce sujet" is gone: linking a mandate to a subject needs a mapping the model does not
+ * carry, so the cell held the same sentence on every row. It distinguished nothing and took 190px
+ * from the only column with content, which at anything under a very wide viewport squeezed the
+ * quoted measure down to one word per line. It comes back the day the mapping exists.
+ *
+ * "Déjà soumis au vote ?" stays although it is empty today, and the difference is not arbitrary:
+ * its nine states and their badge already exist, so the column starts varying the moment a scrutin
+ * is linked to a measure.
+ */
+const COLUMNS = [
+  { title: "Candidat·e", hint: "Ordre alphabétique" },
+  { title: "Ce qu'il ou elle propose", hint: "Phrase citée du programme" },
+  {
+    title: "Déjà soumis au vote ?",
+    hint: "Seulement si un texte proche a été voté et que la personne siégeait",
+  },
+  { title: "Précision de la mesure", hint: "Chiffrée, datée, financée" },
+];
+
+export function SubjectComparison({ data }: { data: SubjectPageData }) {
+  const themeLabel = THEME_CATEGORY_LABELS[data.theme];
+  const documented = data.candidates.filter((c) => c.measures.length > 0).length;
+  const withoutMeasure = data.candidates.length - documented;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[248px_1fr] lg:gap-8">
+      <SubjectSidebar themes={data.siblingThemes} current={data.theme} />
+
+      <div className="min-w-0 space-y-6">
+        <header className="space-y-3">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-xs font-bold`}
+          >
+            <span
+              aria-hidden="true"
+              className={`h-2 w-2 rounded-full ${THEME_ACCENT_BAR[data.theme]}`}
+            />
+            {themeLabel}
+          </span>
+          <h1 className="font-display text-3xl font-extrabold leading-tight tracking-tight md:text-4xl">
+            Quelles solutions proposent-ils&nbsp;?
+          </h1>
+          <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+            {data.totalMeasuresOnTheme}{" "}
+            {data.totalMeasuresOnTheme === 1 ? "mesure documentée" : "mesures documentées"} sur ce
+            sujet, réparties entre {documented} {documented === 1 ? "candidature" : "candidatures"}.
+            Classées par nom de famille.
+          </p>
+          {/* The candidacy's own declaration source used to sit in the first column, where six
+              labels of a hundred characters each became the tallest thing on the page and buried
+              the comparison. Here the evidence that matters is the measure's, which has its own
+              cell; the declaration belongs to the field, which lists it candidacy by candidacy. */}
+          <p className="text-xs text-muted-foreground">
+            Chaque candidature affichée a un statut sourcé.{" "}
+            <Link
+              href="/elections/presidentielle-2027#candidatures"
+              className="underline hover:text-foreground"
+            >
+              Voir les sources de candidature
+            </Link>
+          </p>
+        </header>
+
+        {!data.publishable ? (
+          <SubjectGate data={data} />
+        ) : (
+          <>
+            <ComparisonTable data={data} />
+            <FooterCard
+              documented={documented}
+              withoutMeasure={withoutMeasure}
+              total={data.totalMeasuresOnTheme}
+            />
+            <MethodCard />
+            <PlannedSections />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What this page will hold and does not yet.
+ *
+ * Announced rather than hidden, because both are planned and a reader who sees the gap named can
+ * tell "not built" from "nothing to say". The wording states the content, not the schedule: neither
+ * has a date, and promising one would be worse than promising nothing.
+ */
+function PlannedSections() {
+  const planned = [
+    {
+      title: "Les leviers d'un président sur ce sujet",
+      body: "Ce qu'un président décide réellement ici, et ce qui relève du Parlement, des collectivités ou de l'Union européenne. À écrire sujet par sujet.",
+    },
+    {
+      title: "Les votes au Parlement sur ce sujet",
+      body: "Les scrutins de l'Assemblée nationale et du Sénat portant sur ce sujet, avec leur issue et leur date. Le rattachement des scrutins aux sujets reste à construire.",
+    },
+    {
+      title: "Les fonctions exercées sur ce sujet",
+      body: "Le ministère ou la commission qu'une candidature a occupé en rapport avec ce sujet. Demande de relier les mandats aux sujets, ce que la base ne fait pas encore.",
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="a-venir"
+      className="rounded-xl border border-dashed border-border p-5"
+    >
+      <h2 id="a-venir" className="font-display text-base font-bold">
+        Ce que cette page ne montre pas encore
+      </h2>
+      <dl className="mt-3 grid gap-4 sm:grid-cols-3">
+        {planned.map((p) => (
+          <div key={p.title}>
+            <dt className="text-sm font-semibold">{p.title}</dt>
+            <dd className="mt-1 text-sm text-muted-foreground">{p.body}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function ComparisonTable({ data }: { data: SubjectPageData }) {
+  return (
+    <>
+      {/* lg and up: the full table. `table-fixed` with explicit widths, so a long quote
+          widens its own cell's line count instead of stretching the table past the viewport. */}
+      {/* `min-w-[860px]` is the fix for a table that crushed itself. With `table-fixed`, the three
+          side columns keep their pixel widths whatever happens, so on a container narrower than
+          their sum the flexible column collapsed towards zero and wrapped the quote one word per
+          line, headers overlapping. A minimum width makes the wrapper scroll instead. */}
+      <div className="hidden overflow-x-auto rounded-xl border border-border bg-card lg:block">
+        <table className="w-full min-w-[860px] table-fixed border-collapse text-left">
+          <caption className="sr-only">
+            Ce que chaque candidature propose sur {THEME_CATEGORY_LABELS[data.theme]}, avec sa
+            source, sa relation aux votes, la fonction exercée et la précision de la mesure.
+          </caption>
+          <colgroup>
+            <col className="w-[200px]" />
+            <col />
+            <col className="w-[180px]" />
+            <col className="w-[150px]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-border bg-muted/50 align-top">
+              {COLUMNS.map((c) => (
+                <th key={c.title} scope="col" className="px-4 py-3.5">
+                  <span className="block text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                    {c.title}
+                  </span>
+                  <span className="mt-1 block text-[11px] font-normal leading-snug text-muted-foreground">
+                    {c.hint}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.candidates.map((entry) => (
+              <tr
+                key={entry.candidate.id}
+                className="border-b border-border/60 align-top last:border-b-0"
+              >
+                <th scope="row" className="px-4 py-4 text-left font-normal">
+                  <CandidateIdentity entry={entry} />
+                </th>
+                <td className="px-4 py-4">
+                  <ProposalCell entry={entry} theme={data.theme} />
+                </td>
+                <td className="px-4 py-4">
+                  <VoteCell entry={entry} />
+                </td>
+                <td className="px-4 py-4">
+                  <PrecisionCell entry={entry} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Below lg: one card per candidacy. Five columns cannot be read at 390px, and shrinking the
+          type to fit would make the quote unreadable, so the layout changes rather than the content. */}
+      <ul className="space-y-3 lg:hidden">
+        {data.candidates.map((entry) => (
+          <li key={entry.candidate.id} className="rounded-xl border border-border bg-card p-4">
+            <CandidateIdentity entry={entry} />
+            <div className="mt-3">
+              <ProposalCell entry={entry} theme={data.theme} />
+            </div>
+            <dl className="mt-4 space-y-2 border-t border-border pt-3 text-sm">
+              {[
+                { term: COLUMNS[2]!.title, cell: <VoteCell entry={entry} /> },
+                { term: COLUMNS[3]!.title, cell: <PrecisionCell entry={entry} /> },
+              ].map(({ term, cell }) => (
+                <div key={term} className="flex flex-wrap items-start justify-between gap-2">
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">{term}</dt>
+                  <dd className="min-w-0 text-right">{cell}</dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function FooterCard({
+  documented,
+  withoutMeasure,
+  total,
+}: {
+  documented: number;
+  withoutMeasure: number;
+  total: number;
+}) {
+  return (
+    <p className="rounded-xl border border-border bg-card px-5 py-3.5 text-sm text-muted-foreground">
+      {documented} {documented === 1 ? "candidature porte" : "candidatures portent"} une mesure sur
+      ce sujet, pour {total} au total. Une seule est citée par candidature&nbsp;; les autres se
+      déplient.
+      {withoutMeasure > 0 && (
+        <>
+          {" "}
+          {withoutMeasure} {withoutMeasure === 1 ? "candidature" : "candidatures"} n&apos;en{" "}
+          {withoutMeasure === 1 ? "porte" : "portent"} aucune, et{" "}
+          {withoutMeasure === 1 ? "elle" : "elles"} {withoutMeasure === 1 ? "figure" : "figurent"}{" "}
+          quand même dans le tableau.
+        </>
+      )}
+    </p>
+  );
+}
+
+function MethodCard() {
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-border bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+      <p className="max-w-3xl text-sm text-muted-foreground">
+        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote&nbsp;:
+        une case «&nbsp;aucun vote sur cet objet&nbsp;» est le cas le plus fréquent et ne dit rien
+        de la mesure. La colonne vote ne se remplit que pour une candidature qui siégeait au moment
+        où un texte proche a été soumis.
+      </p>
+      <Link
+        href="/methodologie"
+        className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-lg bg-primary px-5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Voir la méthode
+      </Link>
+    </section>
   );
 }

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectSidebar.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectSidebar.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { THEME_ACCENT_BAR } from "@/config/labels";
+import type { SubjectPageData } from "@/lib/data/subject-page";
+
+/**
+ * The thirteen subjects, alongside the one being read.
+ *
+ * A sticky rail at `lg` and above. Below it the same list folds into a disclosure, closed by
+ * default: a rail would eat the width the comparison needs, and a horizontally scrolling chip row
+ * makes the whole page drift sideways.
+ *
+ * The count is the currently-defended measures of each subject, so a reader can see where the
+ * documentation actually is before clicking. A subject with none still appears: its emptiness is
+ * information, and hiding it would make the corpus look more complete than it is.
+ */
+
+function ThemeLinks({
+  themes,
+  current,
+}: {
+  themes: SubjectPageData["siblingThemes"];
+  current: SubjectPageData["theme"];
+}) {
+  return (
+    <ul className="space-y-0.5">
+      {themes.map((t) => {
+        const isCurrent = t.theme === current;
+        return (
+          <li key={t.theme}>
+            <Link
+              href={`/elections/presidentielle-2027/sujets/${t.slug}`}
+              aria-current={isCurrent ? "page" : undefined}
+              prefetch={false}
+              className={`flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 transition-colors ${
+                isCurrent ? "bg-muted font-bold" : "hover:bg-muted/60"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className={`h-6 w-1.5 shrink-0 rounded-full ${THEME_ACCENT_BAR[t.theme]}`}
+              />
+              <span className="min-w-0 flex-1 text-sm">{t.label}</span>
+              {/* The number is meaningless without its unit for a screen reader, and repeating
+                  "mesures" thirteen times on screen would be noise: the unit is spoken, not shown. */}
+              <span className="shrink-0 text-xs text-muted-foreground">
+                <span aria-hidden="true">{t.measureCount}</span>
+                <span className="sr-only">
+                  {t.measureCount} {t.measureCount === 1 ? "mesure" : "mesures"}
+                </span>
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function SubjectSidebar({
+  themes,
+  current,
+}: {
+  themes: SubjectPageData["siblingThemes"];
+  current: SubjectPageData["theme"];
+}) {
+  const currentLabel = themes.find((t) => t.theme === current)?.label ?? "";
+
+  return (
+    <div className="min-w-0">
+      {/* Below lg: a disclosure. `<details>` rather than a state hook, so it stays a server
+          component and the browser gives keyboard operation and announcement for free. */}
+      <details className="rounded-xl border border-border bg-card lg:hidden">
+        <summary className="flex min-h-11 cursor-pointer items-center justify-between gap-2 px-4 text-sm font-semibold">
+          <span>
+            Les sujets{" "}
+            <span className="font-normal text-muted-foreground">
+              ({themes.length}) &middot; {currentLabel}
+            </span>
+          </span>
+        </summary>
+        <div className="border-t border-border p-2">
+          <ThemeLinks themes={themes} current={current} />
+        </div>
+      </details>
+
+      <nav aria-label="Les sujets" className="hidden lg:sticky lg:top-20 lg:block">
+        <p className="mb-2 px-3 text-xs font-bold uppercase tracking-widest text-muted-foreground">
+          Les sujets
+        </p>
+        <ThemeLinks themes={themes} current={current} />
+      </nav>
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -52,6 +52,8 @@ function candidate(
     sourceLabel: null,
     slogan: null,
     accentColor: null,
+    partyLabel: "Parti Fixture",
+    partyShortName: "PF",
     declaredAt: null,
     ...over,
   };
@@ -84,14 +86,25 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
     pendingReviewRevisionCount: 0,
     lastReviewedAt: null,
     fallbackPublishableTheme: null,
+    siblingThemes: [
+      {
+        theme: "LOGEMENT_URBANISME",
+        label: "Logement & Urbanisme",
+        slug: "logement-urbanisme",
+        measureCount: 4,
+        publishable: true,
+      },
+      { theme: "SANTE", label: "Santé", slug: "sante", measureCount: 0, publishable: false },
+    ],
+    totalMeasuresOnTheme: 4,
     ...over,
   };
 }
 
 describe("SubjectComparison", () => {
-  it("annonce l'ordre alphabétique d'affichage", () => {
+  it("annonce le critère de tri réellement appliqué", () => {
     render(<SubjectComparison data={data()} />);
-    expect(screen.getByText(/présentées par ordre alphabétique/i)).toBeInTheDocument();
+    expect(screen.getByText(/Classées par nom de famille/)).toBeInTheDocument();
   });
 
   it("rend une absence qualifiée, jamais une cellule vide, pour un candidat sans mesure", () => {
@@ -132,8 +145,10 @@ describe("SubjectComparison", () => {
         })}
       />
     );
-    expect(screen.getByText(/Mesure retirée le/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Communiqué de retrait" })).toBeInTheDocument();
+    // Deux rendus : le tableau au-dessus de lg, les cartes en dessous. Les deux doivent porter
+    // le retrait, sinon un lecteur mobile verrait une mesure abandonnée comme encore défendue.
+    expect(screen.getAllByText(/Mesure retirée le/)).toHaveLength(2);
+    expect(screen.getAllByRole("link", { name: "Communiqué de retrait" })).toHaveLength(2);
   });
 
   it("n'affiche pas de lien de source de retrait quand le libellé manque", () => {
@@ -158,8 +173,12 @@ describe("SubjectComparison", () => {
         })}
       />
     );
-    expect(screen.getByText(/Mesure retirée le/)).toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Mesure retirée le/)).toHaveLength(2);
+    // Le lien de retrait n'apparaît pas. Les autres liens de la page (sources, sujets, méthode)
+    // ne sont pas concernés, d'où la portée sur le paragraphe de retrait lui-même.
+    for (const ligne of screen.getAllByText(/Mesure retirée le/)) {
+      expect(ligne.querySelector("a")).toBeNull();
+    }
   });
 
   it("rend un état explicite sous le seuil, sans comparaison à un seul candidat", () => {
@@ -188,9 +207,10 @@ describe("SubjectComparison", () => {
         })}
       />
     );
-    const alix = screen.getByRole("heading", { level: 2, name: "Alix" }).closest("article");
+    // La fixture n'a pas de slug de politicien, donc le nom est un texte et non un lien.
+    const ligne = screen.getAllByText("Alix")[0]!.closest("tr");
     expect(
-      within(alix as HTMLElement).getByText(/périmètre examiné sans résultat/)
+      within(ligne as HTMLElement).getByText(/périmètre examiné sans résultat/)
     ).toBeInTheDocument();
   });
 
@@ -206,11 +226,15 @@ describe("SubjectComparison", () => {
         })}
       />
     );
-    const link = screen.getByRole("link", { name: "Programme de parti" });
-    expect(link).toHaveAttribute("href", "https://example.org/programme.pdf");
-    const li = link.closest("li");
-    expect(li).toHaveTextContent("Source primaire");
-    expect(li).toHaveTextContent(/janvier 2027/);
+    // Deux rendus, tableau et cartes : la preuve doit tenir dans les deux.
+    const liens = screen.getAllByRole("link", { name: "Programme de parti" });
+    expect(liens).toHaveLength(2);
+    for (const lien of liens) {
+      expect(lien).toHaveAttribute("href", "https://example.org/programme.pdf");
+      const li = lien.closest("li");
+      expect(li).toHaveTextContent("Source primaire");
+      expect(li).toHaveTextContent(/janvier 2027/);
+    }
   });
 
   it("rend la source de déclaration de la candidature depuis sa colonne", () => {
@@ -226,9 +250,13 @@ describe("SubjectComparison", () => {
         })}
       />
     );
-    expect(screen.getByRole("link", { name: "Discours du 1er mars" })).toHaveAttribute(
+    // La source de déclaration n'est plus répétée par ligne : six libellés de cent caractères
+    // écrasaient la première colonne. La page dit que le statut est sourcé et renvoie au champ,
+    // qui porte la source de chaque candidature.
+    expect(screen.queryByRole("link", { name: "Discours du 1er mars" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Voir les sources de candidature/ })).toHaveAttribute(
       "href",
-      "https://example.org/annonce"
+      "/elections/presidentielle-2027#candidatures"
     );
   });
 });

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -259,4 +259,71 @@ describe("SubjectComparison", () => {
       "/elections/presidentielle-2027#candidatures"
     );
   });
+
+  it("n'affirme rien sur la carrière d'un candidat sans mesure sur le sujet", () => {
+    // Régression : la cellule vote rendait « N'a jamais siégé » dès que le thème était vide, une
+    // affirmation sur un parcours déduite de l'absence de mesure sur UN sujet. Faux pour tous ceux
+    // qui ont siégé, et indéductible de ce que cette page lit.
+    const { container } = render(
+      <SubjectComparison data={data({ candidates: [entry("Chloe", [])] })} />
+    );
+
+    expect(container.querySelector('[data-absence-kind="never_sat"]')).toBeNull();
+    expect(screen.queryByText(/jamais siégé/i)).not.toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-absence-kind="not_applicable"]').length
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Pas de mesure publiée à rapprocher d'un scrutin/).length).toBe(2);
+  });
+
+  it("ne dit jamais d'une mesure publiée qu'elle n'est pas relue", () => {
+    // Une mesure n'est publique que si `reviewedAt` est renseigné : « Pas encore relu » y
+    // contredirait le prédicat qui l'a rendue visible. Une précision nulle se dit pour ce qu'elle
+    // est, une qualification manquante.
+    const { container } = render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ precision: null }), "SEARCH_NOT_DONE")]),
+          ],
+        })}
+      />
+    );
+
+    expect(container.querySelector('[data-absence-kind="not_reviewed"]')).toBeNull();
+    expect(screen.queryByText(/Pas encore relu/)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Précision non renseignée").length).toBe(2);
+  });
+
+  it("ne compte pas une mesure retirée comme une mesure portée", () => {
+    // `entry.measures` inclut volontairement les retraits. Une candidature dont tout est retiré ne
+    // « porte » plus rien, et le compteur de l'autorité (candidaciesWithVerifiedMeasure) est seul
+    // à faire cette distinction.
+    const retiree = measure({
+      id: "m-out",
+      withdrawal: {
+        withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+        sourceUrl: null,
+        sourceLabel: null,
+      },
+    });
+    render(
+      <SubjectComparison
+        data={data({
+          candidaciesWithVerifiedMeasure: 1,
+          totalMeasuresOnTheme: 1,
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ id: "m-in" }), "SEARCH_NOT_DONE")]),
+            entry("Chloe", [subjectMeasure(retiree, "SEARCH_NOT_DONE")]),
+          ],
+        })}
+      />
+    );
+
+    // Une seule candidature porte encore une mesure, pas deux.
+    expect(screen.getByText(/1 candidature porte une mesure sur ce sujet/)).toBeInTheDocument();
+    expect(screen.getByText(/réparties entre 1 candidature/)).toBeInTheDocument();
+    // Et sous le nom de celle dont la mesure est retirée, le compte tombe à zéro.
+    expect(screen.getAllByText(/aucune mesure sur ce sujet/).length).toBe(2);
+  });
 });

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectGate.test.tsx
@@ -15,6 +15,17 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
     pendingReviewRevisionCount: 3,
     lastReviewedAt: new Date("2027-02-10T00:00:00Z"),
     fallbackPublishableTheme: null,
+    siblingThemes: [
+      {
+        theme: "LOGEMENT_URBANISME",
+        label: "Logement & Urbanisme",
+        slug: "logement-urbanisme",
+        measureCount: 4,
+        publishable: true,
+      },
+      { theme: "SANTE", label: "Santé", slug: "sante", measureCount: 0, publishable: false },
+    ],
+    totalMeasuresOnTheme: 4,
     ...over,
   };
 }

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectSidebar.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectSidebar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SubjectPageData } from "@/lib/data/subject-page";
+import { SubjectSidebar } from "../SubjectSidebar";
+
+const THEMES: SubjectPageData["siblingThemes"] = [
+  {
+    theme: "LOGEMENT_URBANISME",
+    label: "Logement & Urbanisme",
+    slug: "logement-urbanisme",
+    measureCount: 10,
+    publishable: true,
+  },
+  { theme: "SANTE", label: "Santé", slug: "sante", measureCount: 1, publishable: false },
+  {
+    theme: "INSTITUTIONS",
+    label: "Institutions",
+    slug: "institutions",
+    measureCount: 0,
+    publishable: false,
+  },
+];
+
+/**
+ * The list renders twice: a disclosure below `lg`, the rail at `lg` and above. jsdom applies no
+ * breakpoint, so both are in the DOM and every assertion counts occurrences — which also catches a
+ * layout that quietly stops rendering one of the two.
+ */
+describe("SubjectSidebar", () => {
+  it("rend les deux mises en page, repli et rail", () => {
+    const { container } = render(<SubjectSidebar themes={THEMES} current="LOGEMENT_URBANISME" />);
+    expect(container.querySelector("details")).not.toBeNull();
+    expect(screen.getByRole("navigation", { name: "Les sujets" })).toBeInTheDocument();
+  });
+
+  it("marque le sujet courant pour les lecteurs d'écran, pas seulement par la couleur", () => {
+    render(<SubjectSidebar themes={THEMES} current="SANTE" />);
+    const courants = screen.getAllByRole("link", { current: "page" });
+    expect(courants).toHaveLength(2);
+    for (const lien of courants) expect(lien).toHaveTextContent("Santé");
+  });
+
+  it("garde un sujet sans aucune mesure dans la liste", () => {
+    // Le vide est une information : masquer le sujet ferait paraître le corpus plus complet.
+    render(<SubjectSidebar themes={THEMES} current="LOGEMENT_URBANISME" />);
+    expect(screen.getAllByRole("link", { name: /Institutions/ })).toHaveLength(2);
+  });
+
+  it("donne l'unité du compteur à la voix, sans la répéter à l'écran", () => {
+    render(<SubjectSidebar themes={THEMES} current="LOGEMENT_URBANISME" />);
+    const lien = screen.getAllByRole("link", { name: /Logement & Urbanisme/ })[0]!;
+    // Le nombre nu est masqué aux lecteurs d'écran, la forme accordée leur est réservée.
+    expect(within(lien).getByText("10")).toHaveAttribute("aria-hidden", "true");
+    expect(lien).toHaveAccessibleName(expect.stringContaining("10 mesures"));
+  });
+
+  it("accorde le compteur au singulier", () => {
+    render(<SubjectSidebar themes={THEMES} current="LOGEMENT_URBANISME" />);
+    const lien = screen.getAllByRole("link", { name: /Santé/ })[0]!;
+    expect(lien).toHaveAccessibleName(expect.stringContaining("1 mesure"));
+    expect(lien).not.toHaveAccessibleName(expect.stringContaining("1 mesures"));
+  });
+
+  it("pointe chaque sujet vers sa page", () => {
+    render(<SubjectSidebar themes={THEMES} current="LOGEMENT_URBANISME" />);
+    expect(screen.getAllByRole("link", { name: /Santé/ })[0]).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/sujets/sante"
+    );
+  });
+});

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/page.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
 import { getSubjectPageData } from "@/lib/data/subject-page";
 import { parseThemeSlug, PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
@@ -44,7 +45,15 @@ export default async function SubjectPage({ params }: PageProps) {
   if (data === null) notFound();
 
   return (
-    <div className="container mx-auto px-4 pt-4 pb-8">
+    <div className="container mx-auto space-y-4 px-4 pt-4 pb-8">
+      <Breadcrumb
+        items={[
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: "/elections/presidentielle-2027" },
+          { label: "Sujets", href: "/elections/presidentielle-2027/sujets" },
+          { label: THEME_CATEGORY_LABELS[theme] },
+        ]}
+      />
       <SubjectComparison data={data} />
     </div>
   );

--- a/src/app/elections/presidentielle-2027/sujets/page.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/page.tsx
@@ -31,7 +31,8 @@ export default async function ThemesIndexPage() {
     <div className="container mx-auto px-4 pt-4 pb-8">
       <Breadcrumb
         items={[
-          { label: "Présidentielle", href: "/elections/presidentielle-2027" },
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: "/elections/presidentielle-2027" },
           { label: "Sujets" },
         ]}
       />

--- a/src/components/measures/MeasurePrecisionBadge.tsx
+++ b/src/components/measures/MeasurePrecisionBadge.tsx
@@ -1,0 +1,26 @@
+import type { MeasurePrecision } from "@/generated/prisma";
+import { MEASURE_PRECISION_LABELS, MEASURE_PRECISION_PILL_CLASS } from "@/config/labels";
+
+/**
+ * The two precision states of a published measure, on the same pill idiom as `VoteRelationBadge`.
+ *
+ * `precision` is nullable on the revision, and a null is NOT a state this badge renders: the caller
+ * decides what an unqualified measure looks like, because "we have not qualified it" is a statement
+ * about our own work and belongs to `QualifiedEmptyCell`, not to a pill that would read as a third
+ * precision level.
+ */
+export function MeasurePrecisionBadge({
+  precision,
+  className,
+}: {
+  precision: MeasurePrecision;
+  className?: string;
+}) {
+  const base = `inline-flex w-fit items-center rounded-full px-2.5 py-1 text-xs font-medium ${MEASURE_PRECISION_PILL_CLASS[precision]}`;
+
+  return (
+    <span data-measure-precision={precision} className={className ? `${base} ${className}` : base}>
+      {MEASURE_PRECISION_LABELS[precision]}
+    </span>
+  );
+}

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1514,6 +1514,15 @@ export const MEASURE_PRECISION_LABELS: Record<MeasurePrecision, string> = {
   OBJECTIF_SANS_CHIFFRE: "Objectif sans chiffre",
 };
 
+// Deliberately NOT a green/amber pair. A traffic light reads as a verdict, and a measure carrying a
+// figure is not a better measure than one stating an objective: it is a different kind of statement,
+// and grading it would be the ranking this site does not do. Same neutral slate as the vote
+// relations that state no position, distinguished by weight rather than by hue.
+export const MEASURE_PRECISION_PILL_CLASS: Record<MeasurePrecision, string> = {
+  CHIFFREE: "bg-[#6b7078] text-white",
+  OBJECTIF_SANS_CHIFFRE: "border border-border text-muted-foreground",
+};
+
 export const MEASURE_EXTRACTION_METHOD_LABELS: Record<MeasureExtractionMethod, string> = {
   MANUAL: "Saisie manuelle",
   AI_ASSISTED: "Assistée par IA",

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -956,6 +956,34 @@ export const THEME_CATEGORY_COLORS: Record<ThemeCategory, string> = {
     "bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-900/40 dark:text-teal-300 dark:border-teal-700",
 };
 
+/**
+ * The same thirteen hues as THEME_CATEGORY_COLORS, solid rather than tinted, for the accent bar the
+ * subject page puts before a theme in its navigation and before a candidate in its table.
+ *
+ * A separate map and not a derivation: the badge palette pairs a 100-level background with an
+ * 800-level text, and there is no rule that turns that pair into the single 500/600 fill an accent
+ * bar needs. Deriving it by string surgery on Tailwind class names would break silently the day a
+ * badge shade moves.
+ *
+ * Purely decorative wherever it is used: the theme is always named in text beside it, so the bar
+ * carries no information of its own and is `aria-hidden`.
+ */
+export const THEME_ACCENT_BAR: Record<ThemeCategory, string> = {
+  LOGEMENT_URBANISME: "bg-amber-500",
+  SANTE: "bg-rose-600",
+  SOCIAL_TRAVAIL: "bg-violet-600",
+  ECONOMIE_BUDGET: "bg-emerald-600",
+  ENVIRONNEMENT_ENERGIE: "bg-green-600",
+  SECURITE_JUSTICE: "bg-red-600",
+  EDUCATION_CULTURE: "bg-indigo-600",
+  IMMIGRATION: "bg-orange-600",
+  TRANSPORTS: "bg-teal-600",
+  AGRICULTURE_ALIMENTATION: "bg-lime-600",
+  NUMERIQUE_TECH: "bg-sky-600",
+  AFFAIRES_ETRANGERES_DEFENSE: "bg-cyan-600",
+  INSTITUTIONS: "bg-purple-600",
+};
+
 export const THEME_CATEGORY_ICONS: Record<ThemeCategory, string> = {
   ECONOMIE_BUDGET: "💰",
   SOCIAL_TRAVAIL: "👥",

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -3,6 +3,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
+import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import { loadThemesIndex } from "./themes-index";
 import { getLatestPresidentialReviewDate } from "./measures";
 
@@ -84,19 +85,7 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
     },
   });
 
-  // Sorted by SURNAME, which is what the page announces. `candidateName` is "Prénom Nom", so ordering
-  // on it in SQL sorts by first name: "Édouard Philippe" would land under E, not P. The surname comes
-  // from the linked politician, which is where the database actually separates the two; a candidacy
-  // without a politician falls back to its full name rather than being dropped.
-  // localeCompare with "fr" so accents sort where a French reader expects (É with E, not after Z).
-  const collator = new Intl.Collator("fr", { sensitivity: "base" });
-  const sortKey = (c: (typeof rows)[number]) => c.politician?.lastName ?? c.candidateName;
-  rows.sort(
-    (a, b) =>
-      collator.compare(sortKey(a), sortKey(b)) || collator.compare(a.candidateName, b.candidateName)
-  );
-
-  return rows.map((c) => ({
+  return sortPresidentialCandidatesBySurname(rows).map((c) => ({
     id: c.id,
     candidateName: c.candidateName,
     politicianSlug: c.politician?.slug ?? null,

--- a/src/lib/data/presidential-candidates-public.ts
+++ b/src/lib/data/presidential-candidates-public.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { db } from "@/lib/db";
+import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import type { CandidacyStatus, Prisma } from "@/generated/prisma";
 
 /**
@@ -43,14 +44,15 @@ export async function getPublicPresidentialCandidates(
     where: { election: { slug: electionSlug }, ...PUBLIC_CANDIDACY_WHERE },
     include: {
       presidentialData: true,
-      politician: { select: { slug: true } },
+      politician: { select: { slug: true, lastName: true } },
       party: { select: { shortName: true } },
     },
-    // Alphabetical by candidate name. No ranking, no proximity score.
-    orderBy: { candidateName: "asc" },
+    // No `orderBy`: the order is a presidential policy, not a column. Sorting here on
+    // `candidateName` would file "Édouard Philippe" under E, and would disagree with the hub field,
+    // which lists the same people by surname. No ranking, no proximity score.
   });
 
-  return rows.map((row) => ({
+  return sortPresidentialCandidatesBySurname(rows).map((row) => ({
     id: row.id,
     candidateName: row.candidateName,
     politicianSlug: row.politician?.slug ?? null,

--- a/src/lib/data/presidential-candidates-public.ts
+++ b/src/lib/data/presidential-candidates-public.ts
@@ -30,6 +30,9 @@ export type PublicPresidentialCandidate = {
   sourceLabel: string | null;
   slogan: string | null;
   accentColor: string | null;
+  /** Wording of the source for the party, and the linked entity's sigle when there is one. */
+  partyLabel: string | null;
+  partyShortName: string | null;
   declaredAt: Date | null;
 };
 
@@ -41,6 +44,7 @@ export async function getPublicPresidentialCandidates(
     include: {
       presidentialData: true,
       politician: { select: { slug: true } },
+      party: { select: { shortName: true } },
     },
     // Alphabetical by candidate name. No ranking, no proximity score.
     orderBy: { candidateName: "asc" },
@@ -55,6 +59,8 @@ export async function getPublicPresidentialCandidates(
     sourceLabel: row.sourceLabel,
     slogan: row.presidentialData?.slogan ?? null,
     accentColor: row.presidentialData?.accentColor ?? null,
+    partyLabel: row.partyLabel,
+    partyShortName: row.party?.shortName ?? null,
     declaredAt: row.presidentialData?.declaredAt ?? null,
   }));
 }

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -67,6 +67,20 @@ export type SubjectPageData = {
   lastReviewedAt: Date | null;
   /** Another theme that already clears the gate, to redirect to when this one does not. */
   fallbackPublishableTheme: { slug: string; label: string } | null;
+  /**
+   * The thirteen subjects with their currently-defended measure count, in editorial order, for the
+   * navigation the page carries alongside its own content. Read from the themes index
+   * already loaded here, so the sidebar costs no extra query.
+   */
+  siblingThemes: {
+    theme: ThemeCategory;
+    label: string;
+    slug: string;
+    measureCount: number;
+    publishable: boolean;
+  }[];
+  /** Currently-defended measures on this theme, across the whole published population. */
+  totalMeasuresOnTheme: number;
 };
 
 /**
@@ -171,6 +185,15 @@ export async function loadSubjectPageData(
     pendingReviewRevisionCount,
     lastReviewedAt,
     fallbackPublishableTheme,
+    siblingThemes: themesIndex.themes.map((t) => ({
+      theme: t.theme,
+      label: t.label,
+      slug: t.slug,
+      measureCount: t.currentlyDefendedMeasureCount,
+      publishable: t.publishable,
+    })),
+    totalMeasuresOnTheme:
+      themesIndex.themes.find((t) => t.theme === theme)?.currentlyDefendedMeasureCount ?? 0,
   };
 }
 

--- a/src/lib/presidentielle/__tests__/candidate-order.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-order.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  presidentialCandidateSortKey,
+  sortPresidentialCandidatesBySurname,
+  type SurnameOrdered,
+} from "../candidate-order";
+
+function candidacy(candidateName: string, lastName: string | null = null): SurnameOrdered {
+  return { candidateName, politician: lastName === null ? null : { lastName } };
+}
+
+const names = (rows: SurnameOrdered[]) => rows.map((r) => r.candidateName);
+
+describe("sortPresidentialCandidatesBySurname", () => {
+  it("orders on the surname, not on the first name", () => {
+    // The regression this locks: an SQL `orderBy: { candidateName: "asc" }` files "Édouard
+    // Philippe" under E and "Gabriel Attal" under G, so Philippe would come first.
+    const sorted = sortPresidentialCandidatesBySurname([
+      candidacy("Édouard Philippe", "Philippe"),
+      candidacy("Gabriel Attal", "Attal"),
+    ]);
+
+    expect(names(sorted)).toEqual(["Gabriel Attal", "Édouard Philippe"]);
+  });
+
+  it("files an accented surname with its unaccented letter, not after Z", () => {
+    const sorted = sortPresidentialCandidatesBySurname([
+      candidacy("Marine Zavatta", "Zavatta"),
+      candidacy("Clara Égger", "Égger"),
+      candidacy("Nathalie Faure", "Faure"),
+    ]);
+
+    expect(names(sorted)).toEqual(["Clara Égger", "Nathalie Faure", "Marine Zavatta"]);
+  });
+
+  it("falls back to the full name when the candidacy has no linked politician", () => {
+    // Dropping such a candidacy would silently shorten the field, so it sorts on what it has.
+    const sorted = sortPresidentialCandidatesBySurname([
+      candidacy("Bruno Retailleau", "Retailleau"),
+      candidacy("Comité de soutien"),
+      candidacy("Anasse Kazib", "Kazib"),
+    ]);
+
+    expect(names(sorted)).toEqual(["Comité de soutien", "Anasse Kazib", "Bruno Retailleau"]);
+  });
+
+  it("breaks a tie between homonyms on the full name", () => {
+    const sorted = sortPresidentialCandidatesBySurname([
+      candidacy("Olivier Faure", "Faure"),
+      candidacy("Alice Faure", "Faure"),
+    ]);
+
+    expect(names(sorted)).toEqual(["Alice Faure", "Olivier Faure"]);
+  });
+
+  it("returns a new array and leaves the caller's own order alone", () => {
+    const rows = [candidacy("Édouard Philippe", "Philippe"), candidacy("Gabriel Attal", "Attal")];
+    const sorted = sortPresidentialCandidatesBySurname(rows);
+
+    expect(sorted).not.toBe(rows);
+    expect(names(rows)).toEqual(["Édouard Philippe", "Gabriel Attal"]);
+  });
+
+  it("exposes the key it sorts on", () => {
+    expect(presidentialCandidateSortKey(candidacy("Édouard Philippe", "Philippe"))).toBe(
+      "Philippe"
+    );
+    expect(presidentialCandidateSortKey(candidacy("Comité de soutien"))).toBe("Comité de soutien");
+  });
+});

--- a/src/lib/presidentielle/candidate-order.ts
+++ b/src/lib/presidentielle/candidate-order.ts
@@ -1,0 +1,40 @@
+/**
+ * The one alphabetical order of the presidential hub.
+ *
+ * Every surface that lists candidacies (hub field, subject pages, themes index) shows the same
+ * people, so it has to show them in the same order: two orders for the same twenty-five names reads
+ * as a bug whichever one the reader meets second.
+ *
+ * The order is by SURNAME, which is what the pages announce. `candidateName` is "Prénom Nom", so
+ * ordering on it (in SQL or otherwise) sorts by first name and files "Édouard Philippe" under E.
+ * The surname comes from the linked politician, the only place the database separates the two; a
+ * candidacy with no politician falls back to its full name rather than being dropped from the list.
+ *
+ * `Intl.Collator("fr")` so accents sort where a French reader expects them, É next to E rather than
+ * after Z, and `sensitivity: "base"` so case and accents never decide the order on their own.
+ */
+
+const collator = new Intl.Collator("fr", { sensitivity: "base" });
+
+/** The shape the order needs, so both authorities can pass their own row type unchanged. */
+export type SurnameOrdered = {
+  candidateName: string;
+  politician: { lastName: string } | null;
+};
+
+export function presidentialCandidateSortKey(row: SurnameOrdered): string {
+  return row.politician?.lastName ?? row.candidateName;
+}
+
+/**
+ * Returns a new array rather than sorting in place, so a caller can order rows it does not own.
+ * The tie-break on the full name keeps homonyms in a stable order instead of leaving them to
+ * whatever order the query returned.
+ */
+export function sortPresidentialCandidatesBySurname<T extends SurnameOrdered>(rows: T[]): T[] {
+  return [...rows].sort(
+    (a, b) =>
+      collator.compare(presidentialCandidateSortKey(a), presidentialCandidateSortKey(b)) ||
+      collator.compare(a.candidateName, b.candidateName)
+  );
+}


### PR DESCRIPTION
Refond la page sujet en tableau de comparaison, avec la navigation des treize sujets à côté. Corrige au passage les fils d'Ariane du hub, qui sautaient un niveau et taisaient l'année.

## Ce qui change

La page rendait une grille de cartes, une par candidature, chacune déroulant toutes ses mesures. Elle rend maintenant un tableau : une ligne par candidature, une mesure citée, les autres derrière un dépliant. La comparaison que cette page existe pour permettre se fait entre candidatures, pas à l'intérieur d'une seule.

Une barre latérale liste les treize sujets avec leur nombre de mesures défendues, pour qu'un lecteur voie où se trouve la documentation avant de cliquer. Un sujet à zéro y figure quand même : le vide est une information.

## Quatre colonnes et non cinq

La colonne « A exercé sur ce sujet » n'est pas reprise. Relier un mandat à un sujet demande un rattachement que le modèle ne porte pas, donc la cellule affichait la même phrase sur chaque ligne : elle ne distinguait rien et prenait 190 px à la seule colonne qui a du contenu. Avec `table-fixed`, la somme des colonnes latérales dépassait la largeur disponible, la colonne souple s'effondrait et les en-têtes se chevauchaient. Une largeur minimale fait désormais défiler le tableau au lieu de l'écraser.

La colonne « Déjà soumis au vote ? » reste, bien qu'elle soit vide aujourd'hui, et la différence n'est pas arbitraire : ses neuf états et leur pastille existent déjà, elle variera dès qu'un scrutin sera rattaché à une mesure.

## Ce que la page ne montre pas encore

Un bloc en pied nomme les trois manques et dit ce que chacun contiendra : les leviers d'un président sur le sujet, les scrutins du Parlement s'y rapportant, les fonctions exercées. Il annonce le contenu et jamais une date, parce qu'aucun n'en a.

## Responsive et accessibilité

Le tableau au-dessus de `lg`, des cartes empilées en dessous : cinq colonnes ne se lisent pas à 390 px, et réduire le corps pour les faire tenir rendrait la citation illisible.

Une première version faisait défiler la page entière de 2 180 px sur mobile. La rangée de puces défilante était un enfant de grille sans `min-width: 0`, donc elle se dimensionnait sur son contenu. La liste est devenue un dépliant fermé par défaut, ce qui supprime la classe de problème.

Mesuré à 1440, 900 et 390 : aucun débordement horizontal, défilement latéral réel à zéro, **0 violation axe** sur les balises WCAG 2.1 AA. Le tableau est un vrai `<table>` avec `<caption>` et `<th scope>`, le sujet courant porte `aria-current`, les barres de couleur sont décoratives et l'unité des compteurs est réservée à la voix.

## Fils d'Ariane

Ils manquaient entièrement sur la page sujet, et sur les autres pages du hub ils affichaient « Présidentielle » sans l'année, en sautant le niveau `/elections` qui est pourtant une page. La chaîne complète est maintenant Accueil › Élections › Présidentielle 2027 › Sujets › Thème, sur les cinq pages.

## Validation

Suite complète : 400 fichiers, 3732 tests, aucun échec. `tsc` sans erreur de source, `eslint` sans erreur, `next build` sorti à 0 avec la collecte des pages.

## Note de données, hors périmètre

`Candidacy.sourceLabel` contient des phrases entières là où le champ attend un libellé court : 114 caractères sur une candidature. Sur la première colonne du tableau, six libellés de cette longueur devenaient l'élément le plus haut de la page et enterraient la comparaison. La source de déclaration a donc quitté le tableau : la page dit que chaque statut est sourcé et renvoie au champ des candidatures, qui porte la source de chacune. La donnée elle-même appartient à une passe de modération.
