### PR TITLE
Refondre la liste des candidatures et étoffer la fiche candidat

### DIFF
--- a/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronRight, ExternalLink, Search } from "lucide-react";
+import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
+import { getAccessibleTextColor } from "@/lib/contrast";
+import type { HubCandidacy } from "@/lib/data/hub";
+import {
+  CANDIDACY_FILTERS,
+  CANDIDACY_FILTER_LABELS,
+  matchesCandidacyFilter,
+  matchesCandidacyQuery,
+  parseCandidacyFilter,
+  type CandidacyFilter,
+} from "@/lib/presidentielle/candidacy-filters";
+
+/**
+ * The field as a list of rows rather than a grid of cards.
+ *
+ * Twenty-five homogeneous entries are a table, not a stack of cards: the old cards spent ~190px
+ * each on repeating the same badge and the same "Fiche PoliGraph" button, and showed none of our
+ * own work. Each row now carries what we have on that candidacy, and the row itself is the link.
+ *
+ * A client component, deliberately. Filtering through `searchParams` on the server would make the
+ * hub page dynamic and cost it its ISR; the whole field is twenty-five rows already in the payload,
+ * so it filters here and writes the URL back for shareability. The rows are still server-rendered.
+ *
+ * NOT a `<table>`: the row is one link, and a link cannot wrap a `<tr>`. Every cell therefore says
+ * its own unit ("12 mesures dépouillées", "8 sujets sur 13") so a screen reader needs no column
+ * header to read it, and the visual header row is decorative.
+ */
+
+const TOTAL_THEMES = 13;
+
+/**
+ * The party mark: a monogram, never a logo, on every row.
+ *
+ * Measured rather than assumed. At 38px the real logos of this field split into two populations:
+ * roundels stay legible, wordmarks (Lutte ouvrière, UPR, PS, Horizons, Nouvelle Énergie) collapse
+ * into an unreadable smear. Three optical scales on three consecutive rows is exactly what the
+ * handoff set out to remove, so the mark is consistent by construction and the party name is
+ * written in full beside it anyway.
+ *
+ * Decorative (`aria-hidden`): announcing initials that the next line already spells out adds noise
+ * for a screen reader. Initials are NOT hardcoded white, because two party colours of this palette
+ * are pale yellows on which white text falls near 1.1:1; `getAccessibleTextColor` picks whichever
+ * of black or white actually contrasts.
+ */
+function PartyMark({ candidacy }: { candidacy: HubCandidacy }) {
+  const initials =
+    candidacy.partyShortName?.slice(0, 3) ??
+    candidacy.candidateName
+      .split(/\s+/)
+      .map((part) => part[0] ?? "")
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+
+  if (candidacy.partyColor === null) {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] bg-muted text-xs font-bold text-muted-foreground"
+      >
+        {initials}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] text-xs font-bold"
+      style={{
+        backgroundColor: candidacy.partyColor,
+        color: getAccessibleTextColor(candidacy.partyColor),
+      }}
+    >
+      {initials}
+    </span>
+  );
+}
+
+/**
+ * What we have on this candidacy, and when we have nothing, why.
+ *
+ * The zero case is two different facts and gets two different sentences. "Aucun programme publié"
+ * is about the candidacy; "Programme publié, pas encore dépouillé" is about our own backlog. Saying
+ * the first when the second is true would blame a candidate for our delay.
+ */
+function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
+  if (candidacy.measureCount === 0) {
+    return (
+      <span
+        data-programme-absence={candidacy.programmeAbsence}
+        className="block text-xs leading-snug text-muted-foreground"
+      >
+        {candidacy.programmeAbsence === "non_depouille"
+          ? "Programme publié, pas encore dépouillé"
+          : "Aucun programme publié à ce jour"}
+      </span>
+    );
+  }
+
+  return (
+    <span className="block leading-tight">
+      <span className="font-display text-lg font-extrabold">{candidacy.measureCount}</span>{" "}
+      <span className="text-xs text-muted-foreground">
+        {candidacy.measureCount === 1 ? "mesure dépouillée" : "mesures dépouillées"}
+      </span>
+      <span className="mt-0.5 block text-xs text-muted-foreground">
+        {candidacy.themesCoveredCount} sur {TOTAL_THEMES} sujets
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The source, on one line and never more.
+ *
+ * `sourceLabel` holds whole quotations of up to ~115 characters, which on the old card were the
+ * loudest thing on the row: a source has to be verifiable, not dominant. The full wording stays in
+ * `title` and on the fiche.
+ *
+ * `max-w-full` on the link and `min-w-0` on the span are both required: an `inline-flex` box sizes
+ * to its content and happily overflows its parent, and a flex child refuses to shrink below its
+ * content width without `min-w-0`, so `truncate` alone silently does nothing.
+ */
+function SourceLink({ candidacy }: { candidacy: HubCandidacy }) {
+  if (candidacy.sourceUrl === null || candidacy.sourceLabel === null) return null;
+
+  return (
+    <a
+      href={candidacy.sourceUrl}
+      rel="nofollow noopener"
+      target="_blank"
+      title={candidacy.sourceLabel}
+      className="inline-flex min-h-11 max-w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground hover:underline"
+    >
+      <ExternalLink aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 truncate">{candidacy.sourceLabel}</span>
+    </a>
+  );
+}
+
+function CandidacyRow({ candidacy }: { candidacy: HubCandidacy }) {
+  const isRetiree = candidacy.status === "RETIRE";
+  const statusLabel = candidacy.status === null ? null : CANDIDACY_STATUS_LABELS[candidacy.status];
+  const href =
+    candidacy.politicianSlug !== null
+      ? `/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`
+      : null;
+
+  const identity = (
+    <span className="flex min-w-0 flex-1 items-center gap-3">
+      <PartyMark candidacy={candidacy} />
+      <span className="min-w-0">
+        <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span
+            className={`font-display text-base font-bold tracking-tight ${
+              isRetiree ? "text-muted-foreground line-through" : ""
+            }`}
+          >
+            {candidacy.candidateName}
+          </span>
+          {/* The badge appears only when the status is NOT "déclarée". Twenty of twenty-five rows
+              carry the same status, so repeating it says nothing; the five exceptions are the
+              information. */}
+          {candidacy.status !== null && candidacy.status !== "DECLARE" && (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-bold text-foreground">
+              {statusLabel}
+            </span>
+          )}
+        </span>
+        {candidacy.partyLabel !== null && (
+          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+            {candidacy.partyLabel}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+
+  return (
+    <li className="border-b border-border/60 last:border-b-0">
+      <div className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40 lg:gap-5">
+        {href !== null ? (
+          <Link href={href} prefetch={false} className="flex min-w-0 flex-1 items-center gap-3">
+            {identity}
+            <span className="sr-only">, voir la fiche</span>
+          </Link>
+        ) : (
+          identity
+        )}
+
+        <span className="hidden w-[168px] shrink-0 lg:block">
+          <MeasureCell candidacy={candidacy} />
+        </span>
+
+        <span className="hidden w-[220px] shrink-0 lg:block">
+          <SourceLink candidacy={candidacy} />
+        </span>
+
+        {href !== null && (
+          <ChevronRight
+            aria-hidden="true"
+            className="hidden h-4 w-4 shrink-0 text-muted-foreground lg:block"
+          />
+        )}
+      </div>
+
+      {/* Below lg the two columns fold under the name rather than shrinking. The source folds with
+          them rather than disappearing: this site is read on a phone first, and a status the reader
+          cannot check is exactly what the section exists to avoid. */}
+      <div className="space-y-1 px-4 pb-3 lg:hidden">
+        <MeasureCell candidacy={candidacy} />
+        <SourceLink candidacy={candidacy} />
+      </div>
+    </li>
+  );
+}
+
+export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandidacy[] }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const filtre = parseCandidacyFilter(searchParams.get("statut"));
+  const query = searchParams.get("q") ?? "";
+
+  const counts = Object.fromEntries(
+    CANDIDACY_FILTERS.map((key) => [
+      key,
+      candidacies.filter((c) => matchesCandidacyFilter(c, key)).length,
+    ])
+  ) as Record<CandidacyFilter, number>;
+
+  const sansProgramme = candidacies.filter((c) => c.programmeAbsence === "aucun_programme").length;
+
+  const visible = candidacies.filter(
+    (c) => matchesCandidacyFilter(c, filtre) && matchesCandidacyQuery(c, query)
+  );
+
+  function update(next: { statut?: CandidacyFilter; q?: string }): void {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.statut !== undefined) {
+      if (next.statut === "toutes") params.delete("statut");
+      else params.set("statut", next.statut);
+    }
+    if (next.q !== undefined) {
+      if (next.q === "") params.delete("q");
+      else params.set("q", next.q);
+    }
+    const qs = params.toString();
+    router.replace(qs === "" ? "?" : `?${qs}`, { scroll: false });
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="space-y-3 border-b border-border px-4 py-4">
+        <label className="flex min-h-11 items-center gap-2 rounded-[10px] border border-border px-3 sm:max-w-xs">
+          <Search aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="sr-only">Filtrer les candidatures par nom ou par parti</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => update({ q: e.target.value })}
+            placeholder="Un nom, un parti"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {CANDIDACY_FILTERS.map((key) => {
+            const active = key === filtre;
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={active}
+                onClick={() => update({ statut: key })}
+                className={`inline-flex min-h-11 items-center rounded-full px-4 text-[13px] transition-colors ${
+                  active
+                    ? "bg-foreground font-bold text-background"
+                    : "border border-border hover:bg-muted"
+                }`}
+              >
+                {CANDIDACY_FILTER_LABELS[key]} · {counts[key]}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* The gap, counted and stated. Leaving the reader to infer it from twenty-five rows would
+            hide the one fact this section is least able to show. */}
+        {sansProgramme > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {sansProgramme}{" "}
+            {sansProgramme === 1
+              ? "candidature n'a publié aucun programme à ce jour"
+              : "candidatures n'ont publié aucun programme à ce jour"}
+            .
+          </p>
+        )}
+      </div>
+
+      {/* Decorative: every cell below states its own unit, so this row adds sighted alignment
+          only. Announcing it would promise a table the markup deliberately is not. */}
+      <div
+        aria-hidden="true"
+        className="hidden items-center gap-5 border-b border-border bg-muted/50 px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider text-muted-foreground lg:flex"
+      >
+        <span className="min-w-0 flex-1">Candidature</span>
+        <span className="w-[168px] shrink-0">Ce que nous avons dépouillé</span>
+        <span className="w-[220px] shrink-0">Source de la candidature</span>
+        <span className="w-4 shrink-0" />
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+          Aucune candidature ne correspond à ce filtre.{" "}
+          <button
+            type="button"
+            onClick={() => update({ statut: "toutes", q: "" })}
+            className="min-h-11 underline hover:text-foreground"
+          >
+            Tout afficher
+          </button>
+        </p>
+      ) : (
+        <ul>
+          {visible.map((candidacy) => (
+            <CandidacyRow key={candidacy.id} candidacy={candidacy} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
@@ -1,46 +1,22 @@
-import { CandidacyCard, type CandidacyCardData } from "@/components/elections/CandidacyCard";
+import { Suspense } from "react";
 import type { HubCandidacy } from "@/lib/data/hub";
+import { CandidacyFieldBrowser } from "./CandidacyFieldBrowser";
 
 /**
- * The whole field, not the published fiches: every sourced candidacy, pressenti/envisagé
- * included. `constituencyName`/`isElected`/`round1Pct`/`round2Pct` have no meaning before a
- * first round exists, so they map to their neutral values rather than to a guess.
+ * The whole field, not the published fiches: every sourced candidacy, pressenti/envisagé included.
+ *
+ * `<Suspense>` because the browser reads `useSearchParams`, which without a boundary opts the whole
+ * route into client-side rendering and would cost the hub its ISR.
  */
-function toCandidacyCardData(candidacy: HubCandidacy): CandidacyCardData {
-  return {
-    id: candidacy.id,
-    candidateName: candidacy.candidateName,
-    partyLabel: candidacy.partyLabel,
-    constituencyName: null,
-    isElected: false,
-    round1Pct: null,
-    round2Pct: null,
-    status: candidacy.status,
-    sourceUrl: candidacy.sourceUrl,
-    sourceLabel: candidacy.sourceLabel,
-    politician: candidacy.politicianSlug !== null ? { slug: candidacy.politicianSlug } : null,
-    // Null when the candidacy is not linked to a party entity: the card then renders no mark at
-    // all rather than a grey placeholder that would look like a party we failed to identify.
-    party:
-      candidacy.partyColor !== null || candidacy.partyLogoUrl !== null
-        ? {
-            color: candidacy.partyColor,
-            shortName: candidacy.partyShortName,
-            logoUrl: candidacy.partyLogoUrl,
-          }
-        : null,
-  };
-}
-
 export function HubCandidacyField({ candidacies }: { candidacies: HubCandidacy[] }) {
   return (
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground">Candidatures classées par nom de famille.</p>
-      <div className="space-y-2">
-        {candidacies.map((candidacy) => (
-          <CandidacyCard key={candidacy.id} candidacy={toCandidacyCardData(candidacy)} />
-        ))}
-      </div>
+      <Suspense
+        fallback={<div className="h-96 rounded-xl border border-border bg-card" aria-hidden />}
+      >
+        <CandidacyFieldBrowser candidacies={candidacies} />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -15,19 +15,17 @@ function candidacy(over: Partial<HubCandidacy> = {}): HubCandidacy {
     partyColor: "#ff0000",
     partyShortName: "PT",
     partyLogoUrl: null,
+    measureCount: 0,
+    themesCoveredCount: 0,
+    programmeAbsence: "aucun_programme",
     ...over,
   };
 }
 
 describe("HubCandidacyField", () => {
-  it("rend une carte par candidature avec son statut honnête et le lien vers la fiche", () => {
+  it("rend une ligne par candidature, avec son statut honnête et le lien vers sa fiche", () => {
     const candidacies: HubCandidacy[] = [
-      candidacy({
-        id: "c1",
-        candidateName: "Alix Dupont",
-        status: "PRESSENTI",
-        politicianSlug: "alix-dupont",
-      }),
+      candidacy({ id: "c1", candidateName: "Alix Dupont", politicianSlug: "alix-dupont" }),
       candidacy({
         id: "c2",
         candidateName: "Bruno Martin",
@@ -43,13 +41,94 @@ describe("HubCandidacyField", () => {
     expect(screen.getByText("Candidature pressentie")).toBeInTheDocument();
     expect(screen.getByText("Candidature évoquée")).toBeInTheDocument();
 
-    const link = screen.getByRole("link", { name: "Alix Dupont" });
-    expect(link).toHaveAttribute("href", "/politiques/alix-dupont");
+    // La route candidat existe depuis #679 et redirige vers /politiques/[slug] sous le seuil de
+    // publication, donc un seul href suffit pour les 25 lignes sans fabriquer de lien mort.
+    expect(screen.getByRole("link", { name: /Alix Dupont/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/candidats/alix-dupont"
+    );
+  });
+
+  it("n'affiche pas de badge sur une candidature déclarée", () => {
+    // Vingt lignes sur vingt-cinq portent le même statut : le répéter n'informe pas, ce sont les
+    // exceptions qui informent.
+    render(<HubCandidacyField candidacies={[candidacy({ status: "DECLARE" })]} />);
+    expect(screen.queryByText("Candidature déclarée")).not.toBeInTheDocument();
+    expect(screen.getByText("Alix Dupont")).toBeInTheDocument();
+  });
+
+  it("distingue « aucun programme publié » de « pas encore dépouillé »", () => {
+    // La régression que ça verrouille : afficher le même vide dans les deux cas imputerait notre
+    // propre retard au candidat.
+    const { container } = render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({ id: "c1", candidateName: "Sans programme" }),
+          candidacy({
+            id: "c2",
+            candidateName: "Non dépouillé",
+            programmeAbsence: "non_depouille",
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getAllByText("Aucun programme publié à ce jour").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Programme publié, pas encore dépouillé").length).toBeGreaterThan(0);
+    expect(container.querySelector('[data-programme-absence="non_depouille"]')).not.toBeNull();
+  });
+
+  it("compte les candidatures sans programme, et jamais celles que nous n'avons pas dépouillées", () => {
+    render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({ id: "c1", programmeAbsence: "aucun_programme" }),
+          candidacy({ id: "c2", programmeAbsence: "non_depouille" }),
+          candidacy({ id: "c3", measureCount: 4, themesCoveredCount: 2, programmeAbsence: null }),
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByText(/1 candidature n'a publié aucun programme à ce jour/)
+    ).toBeInTheDocument();
+  });
+
+  it("rend le compte de mesures avec son unité accordée et sa couverture", () => {
+    render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({ id: "c1", measureCount: 1, themesCoveredCount: 1, programmeAbsence: null }),
+          candidacy({ id: "c2", measureCount: 12, themesCoveredCount: 8, programmeAbsence: null }),
+        ]}
+      />
+    );
+
+    expect(screen.getAllByText("mesure dépouillée").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("mesures dépouillées").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("8 sur 13 sujets").length).toBeGreaterThan(0);
+  });
+
+  it("porte la citation de source en title, jamais en pleine ligne", () => {
+    // `sourceLabel` contient des phrases entières (jusqu'à ~115 caractères). Sur l'ancienne carte
+    // c'était l'élément le plus voyant de la ligne ; une source doit être vérifiable, pas dominante.
+    const longue =
+      "Lutte ouvrière : « nous avons voté que je serai candidate pour Lutte ouvrière », conférence de presse du 8 décembre 2025";
+    render(<HubCandidacyField candidacies={[candidacy({ sourceLabel: longue })]} />);
+
+    // Deux rendus : la colonne au-dessus de lg, le repli en dessous. Les deux doivent porter la
+    // source, sinon un lecteur mobile ne peut plus vérifier le statut affiché.
+    const liens = screen.getAllByRole("link", { name: new RegExp(longue.slice(0, 20)) });
+    expect(liens).toHaveLength(2);
+    for (const lien of liens) {
+      expect(lien).toHaveAttribute("title", longue);
+      expect(lien).toHaveAttribute("href", "https://example.org/source");
+      expect(lien).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    }
   });
 
   it("annonce le critère de tri réellement appliqué", () => {
     // Le tri se fait sur `politician.lastName`, pas sur `candidateName` qui est « Prénom Nom ».
-    // La phrase doit dire le nom de famille, sinon elle décrit un tri que le code ne fait pas.
     render(<HubCandidacyField candidacies={[candidacy()]} />);
     expect(screen.getByText("Candidatures classées par nom de famille.")).toBeInTheDocument();
   });

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
@@ -13,8 +13,11 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockGetCandidacy = vi.fn();
+const mockGetDetail = vi.fn();
 vi.mock("@/lib/data/politician-candidacy", () => ({
   getPoliticianPresidentialCandidacy: (id: string) => mockGetCandidacy(id),
+  getCandidateFicheDetail: (candidacyId: string, politicianId: string) =>
+    mockGetDetail(candidacyId, politicianId),
 }));
 
 const mockGetPolitician = vi.fn();
@@ -23,6 +26,7 @@ vi.mock("@/lib/data/politicians", () => ({
 }));
 
 const candidacy = (overrides: Record<string, unknown> = {}) => ({
+  candidacyId: "cand-1",
   electionSlug: "presidentielle-2027",
   electionShortTitle: "Présidentielle 2027",
   round1Date: new Date("2027-04-11T00:00:00.000Z"),
@@ -50,7 +54,10 @@ describe("page fiche candidat", () => {
       slug: "camille-riviere",
       fullName: "Camille Rivière",
       civility: "Mme",
+      declarations: [],
+      affairs: [],
     });
+    mockGetDetail.mockResolvedValue({ themes: [], recentVotes: [], mandateCount: 0 });
   });
 
   it("renvoie vers la fiche du politique quand la candidature est sous le seuil", async () => {

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -1,0 +1,244 @@
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { THEME_ACCENT_BAR, THEME_CATEGORY_LABELS, VOTE_POSITION_LABELS } from "@/config/labels";
+import type { CandidateFicheDetail } from "@/lib/data/politician-candidacy";
+import { formatDate } from "@/lib/utils";
+
+/**
+ * The blocks of the candidate fiche, below its header.
+ *
+ * Two blocks of the handoff's D3 screen are deliberately absent, and their absence is stated on the
+ * page rather than faked: "programme et votes face à face" needs a scrutin attached to a measure
+ * (`MeasureVoteLink` carries none yet), and "ce qu'il a fait au pouvoir" needs the post-election
+ * tracking models, which are a later lot and hold no rows. Rendering either from what exists today
+ * would mean inventing a link the data does not carry.
+ */
+
+export function CandidateStats({
+  measureCount,
+  themesCoveredCount,
+  mandateCount,
+}: {
+  measureCount: number;
+  themesCoveredCount: number;
+  mandateCount: number;
+}) {
+  const stats = [
+    {
+      value: measureCount,
+      label: measureCount === 1 ? "mesure documentée" : "mesures documentées",
+    },
+    { value: themesCoveredCount, label: "sujets couverts sur 13" },
+    { value: mandateCount, label: mandateCount === 1 ? "mandat exercé" : "mandats exercés" },
+  ];
+
+  return (
+    <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {stats.map((stat) => (
+        <div key={stat.label} className="rounded-xl border border-border bg-card px-4 py-3">
+          <dt className="text-xs text-muted-foreground">{stat.label}</dt>
+          <dd className="font-display text-2xl font-extrabold">{stat.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/** One line per theme: how many measures, and the first of them quoted. */
+export function CandidateThemes({
+  themes,
+  electionSlug,
+}: {
+  themes: CandidateFicheDetail["themes"];
+  electionSlug: string;
+}) {
+  if (themes.length === 0) return null;
+
+  return (
+    <section aria-labelledby="mesures" className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
+      <h2 id="mesures" className="font-display text-xl font-bold tracking-tight">
+        Ses mesures, sujet par sujet
+      </h2>
+      <ul className="divide-y divide-border">
+        {themes.map((t) => (
+          <li key={t.theme} className="py-3 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-2.5">
+              <span
+                aria-hidden="true"
+                className={`h-5 w-1.5 shrink-0 rounded-full ${THEME_ACCENT_BAR[t.theme]}`}
+              />
+              <Link
+                href={`/elections/${electionSlug}/sujets/${t.slug}`}
+                prefetch={false}
+                className="text-sm font-bold hover:underline"
+              >
+                {THEME_CATEGORY_LABELS[t.theme]}
+              </Link>
+              <span className="text-xs text-muted-foreground">
+                {t.measureCount} {t.measureCount === 1 ? "mesure" : "mesures"}
+              </span>
+            </div>
+            {t.quote !== null && (
+              <p className="mt-1.5 pl-4 text-sm leading-relaxed text-muted-foreground">
+                &laquo;&nbsp;{t.quote.text}&nbsp;&raquo;
+                {t.quote.sourceUrl !== null && (
+                  <>
+                    {" "}
+                    <a
+                      href={t.quote.sourceUrl}
+                      target="_blank"
+                      rel="nofollow noopener"
+                      className="inline-flex items-center gap-1 text-xs underline hover:no-underline"
+                    >
+                      source
+                      <ExternalLink aria-hidden="true" className="h-3 w-3" />
+                    </a>
+                  </>
+                )}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Where the programme puts its accent, as a share of what we extracted.
+ *
+ * The caption says what the bars measure and what they do not: a long bar means the candidacy
+ * talks about a subject often, not that it did anything about it.
+ */
+export function CandidateThemeSpread({ themes }: { themes: CandidateFicheDetail["themes"] }) {
+  if (themes.length === 0) return null;
+  const top = themes.slice(0, 5);
+  const max = Math.max(...top.map((t) => t.measureCount));
+
+  return (
+    <section
+      aria-labelledby="repartition"
+      className="space-y-3 rounded-xl border bg-card p-4 md:p-6"
+    >
+      <h2 id="repartition" className="font-display text-xl font-bold tracking-tight">
+        Les sujets les plus présents dans son programme
+      </h2>
+      <ul className="space-y-2">
+        {top.map((t) => (
+          <li key={t.theme} className="flex items-center gap-3">
+            <span className="w-44 shrink-0 truncate text-sm">{THEME_CATEGORY_LABELS[t.theme]}</span>
+            <span aria-hidden="true" className="h-2 flex-1 rounded-full bg-muted">
+              <span
+                className={`block h-2 rounded-full ${THEME_ACCENT_BAR[t.theme]}`}
+                style={{ width: `${Math.round((t.measureCount / max) * 100)}%` }}
+              />
+            </span>
+            <span className="w-6 shrink-0 text-right text-sm font-bold">{t.measureCount}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="text-xs text-muted-foreground">
+        Compte le nombre de mesures que nous avons dépouillées par sujet. Mesure ce dont la
+        candidature parle, pas ce qui a été réalisé.
+      </p>
+    </section>
+  );
+}
+
+export function CandidateRecentVotes({
+  votes,
+  politicianSlug,
+}: {
+  votes: CandidateFicheDetail["recentVotes"];
+  politicianSlug: string;
+}) {
+  if (votes.length === 0) return null;
+
+  return (
+    <section aria-labelledby="votes" className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
+      <h2 id="votes" className="font-display text-xl font-bold tracking-tight">
+        Ses derniers votes
+      </h2>
+      <ul className="divide-y divide-border">
+        {votes.map((v) => (
+          <li key={v.id} className="flex items-start gap-3 py-2.5 first:pt-0 last:pb-0">
+            <span className="w-20 shrink-0 text-xs font-bold uppercase tracking-wide text-muted-foreground">
+              {VOTE_POSITION_LABELS[v.position]}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm">{v.scrutinTitle}</span>
+              <span className="text-xs text-muted-foreground">{formatDate(v.votingDate)}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+      {/* The caveat is not decoration: a public scrutin covers a fraction of parliamentary work,
+          and a reader who takes this list for the whole record misreads it. */}
+      <p className="text-xs text-muted-foreground">
+        Un scrutin public ne couvre pas tout le travail parlementaire : commissions, rapports et
+        amendements n&apos;y figurent pas. Ces votes ne sont pas rattachés aux mesures ci-dessus, ce
+        rapprochement reste à construire.
+      </p>
+      <Link
+        href={`/politiques/${politicianSlug}`}
+        prefetch={false}
+        className="inline-block text-sm font-bold text-primary hover:underline"
+      >
+        Voir tous ses votes
+      </Link>
+    </section>
+  );
+}
+
+/**
+ * Integrity, stated in counts and never in adjectives.
+ *
+ * The caveat is required, not editorial politeness: an ongoing procedure is not a conviction, and
+ * a bare number next to a candidate's name invites exactly that reading.
+ */
+export function CandidateIntegrity({
+  declarationCount,
+  affairCount,
+  politicianSlug,
+}: {
+  declarationCount: number;
+  affairCount: number;
+  politicianSlug: string;
+}) {
+  return (
+    <section aria-labelledby="integrite" className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
+      <h2 id="integrite" className="font-display text-xl font-bold tracking-tight">
+        Intégrité
+      </h2>
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="rounded-lg border border-border px-4 py-3">
+          <dt className="text-xs text-muted-foreground">Déclarations HATVP</dt>
+          <dd className="text-sm font-bold">
+            {declarationCount === 0
+              ? "Aucune déclaration publiée"
+              : `${declarationCount} ${declarationCount === 1 ? "déclaration publiée" : "déclarations publiées"}`}
+          </dd>
+        </div>
+        <div className="rounded-lg border border-border px-4 py-3">
+          <dt className="text-xs text-muted-foreground">Procédures judiciaires</dt>
+          <dd className="text-sm font-bold">
+            {affairCount === 0
+              ? "Aucune procédure documentée"
+              : `${affairCount} ${affairCount === 1 ? "procédure documentée" : "procédures documentées"}`}
+          </dd>
+        </div>
+      </dl>
+      <p className="text-xs text-muted-foreground">
+        Quand une procédure existe, son statut exact figure sur sa fiche. Une mise en cause ne vaut
+        pas condamnation.
+      </p>
+      <Link
+        href={`/politiques/${politicianSlug}`}
+        prefetch={false}
+        className="inline-block text-sm font-bold text-primary hover:underline"
+      >
+        Voir le détail sur sa fiche
+      </Link>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -8,8 +8,18 @@ import { isFicheCandidatPublishable } from "@/config/publication-gates";
 // Reuses the established politician authority rather than adding a second, lighter read for three
 // fields. It loads more than this page needs, but it is already cached under `politician:<slug>`.
 import { getPolitician } from "@/lib/data/politicians";
-import { getPoliticianPresidentialCandidacy } from "@/lib/data/politician-candidacy";
+import {
+  getCandidateFicheDetail,
+  getPoliticianPresidentialCandidacy,
+} from "@/lib/data/politician-candidacy";
 import { formatDate } from "@/lib/utils";
+import {
+  CandidateIntegrity,
+  CandidateRecentVotes,
+  CandidateStats,
+  CandidateThemeSpread,
+  CandidateThemes,
+} from "./_components/CandidateFicheBlocks";
 
 /**
  * Candidate fiche for the presidential hub. `[slug]` is the POLITICIAN slug, consistent with
@@ -38,11 +48,6 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
 
 interface PageProps {
   params: Promise<{ slug: string }>;
-}
-
-/** Plural agreement: the gate opens at one measure, so "1 mesures" is reachable. */
-function plural(count: number, singular: string): string {
-  return `${count} ${singular}${count > 1 ? "s" : ""}`;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -85,6 +90,8 @@ export default async function CandidateFichePage({ params }: PageProps) {
     redirect(`/politiques/${slug}`);
   }
 
+  const detail = await getCandidateFicheDetail(candidacy.candidacyId, politician.id);
+
   return (
     <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
       <Breadcrumb
@@ -119,27 +126,39 @@ export default async function CandidateFichePage({ params }: PageProps) {
         </p>
       </header>
 
-      <section className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
-        <h2 className="font-display text-xl font-bold tracking-tight">Son programme par sujet</h2>
-        <p className="text-sm text-muted-foreground">
-          {plural(candidacy.publishedMeasureCount, "mesure")} publiée
-          {candidacy.publishedMeasureCount > 1 ? "s" : ""} sur{" "}
-          {plural(candidacy.themesCoveredCount, "sujet")}
-          {candidacy.lastReviewedAt && (
-            <> · dernière revue le {formatDate(candidacy.lastReviewedAt)}</>
-          )}
-          .
-        </p>
-        <p className="text-sm">
-          <Link
-            href={`/elections/${candidacy.electionSlug}/sujets`}
-            prefetch={false}
-            className="font-bold text-primary hover:underline"
-          >
-            Parcourir les sujets
-          </Link>
-        </p>
-      </section>
+      <CandidateStats
+        measureCount={candidacy.publishedMeasureCount}
+        themesCoveredCount={candidacy.themesCoveredCount}
+        mandateCount={detail.mandateCount}
+      />
+
+      <CandidateThemes themes={detail.themes} electionSlug={candidacy.electionSlug} />
+
+      <p className="text-sm">
+        <Link
+          href={`/elections/${candidacy.electionSlug}/sujets`}
+          prefetch={false}
+          className="font-bold text-primary hover:underline"
+        >
+          Comparer ses mesures à celles des autres candidatures
+        </Link>
+        {candidacy.lastReviewedAt !== null && (
+          <span className="text-muted-foreground">
+            {" "}
+            · dernière revue le {formatDate(candidacy.lastReviewedAt)}
+          </span>
+        )}
+      </p>
+
+      <CandidateThemeSpread themes={detail.themes} />
+
+      <CandidateRecentVotes votes={detail.recentVotes} politicianSlug={slug} />
+
+      <CandidateIntegrity
+        declarationCount={politician.declarations.length}
+        affairCount={politician.affairs.length}
+        politicianSlug={slug}
+      />
 
       <section className="space-y-2 rounded-xl border bg-card p-4 text-sm text-muted-foreground md:p-6">
         <h2 className="font-display text-base font-bold tracking-tight text-foreground">
@@ -150,6 +169,14 @@ export default async function CandidateFichePage({ params }: PageProps) {
           statut de la candidature vient de la source citée ci-dessus, à sa date. Aucun classement,
           aucun score de proximité : l&apos;ordre des candidatures est alphabétique partout sur le
           site.
+        </p>
+        {/* Named rather than hidden: a reader who sees the gap stated can tell "not built yet" from
+            "nothing to say". Neither block has a date, and promising one would be worse. */}
+        <p>
+          Deux volets manquent encore. Le rapprochement entre chaque mesure et les scrutins portant
+          sur le même objet, qui demande un rattachement que la base ne porte pas encore. Et le
+          bilan des fonctions exercées, objectifs annoncés face aux chiffres constatés, qui demande
+          un suivi post-électoral à construire.
         </p>
       </section>
     </div>

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -7,6 +7,7 @@ const BEFORE = new Date("2026-08-07T10:00:00.000Z");
 const AFTER = new Date("2027-05-10T10:00:00.000Z");
 
 const base: PoliticianCandidacy = {
+  candidacyId: "cand-1",
   electionSlug: "presidentielle-2027",
   electionShortTitle: "Présidentielle 2027",
   round1Date: new Date("2027-04-11T00:00:00.000Z"),

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import { loadThemesIndex } from "./themes-index";
-import { getLatestPresidentialReviewDate } from "./measures";
+import { getLatestPresidentialReviewDate, getPublicMeasuresByElection } from "./measures";
 
 /**
  * The two read authorities for the presidential hub page.
@@ -43,6 +43,21 @@ export type HubCandidacy = {
   partyColor: string | null;
   partyShortName: string | null;
   partyLogoUrl: string | null;
+  /** Currently defended public measures, withdrawals excluded. */
+  measureCount: number;
+  /** Distinct themes those measures cover, out of the thirteen. */
+  themesCoveredCount: number;
+  /**
+   * Why the measure count is zero, and never a bare zero.
+   *
+   * `aucun_programme` documents the CANDIDACY: nothing has been published for this election.
+   * `non_depouille` documents US: a programme exists and we have not extracted it yet. Presenting
+   * our own backlog as a candidate's silence would be a false claim about a person, so the two are
+   * distinct values and the display renders different sentences for them.
+   *
+   * Null when `measureCount > 0`, since there is then no absence to qualify.
+   */
+  programmeAbsence: "aucun_programme" | "non_depouille" | null;
 };
 
 export type HubMeasureContext = {
@@ -64,39 +79,89 @@ export type HubMeasureContext = {
  * that calls it is only as fresh as its ISR backstop.
  */
 export async function getHubCandidacyField(electionSlug: string): Promise<HubCandidacy[]> {
-  const rows = await db.candidacy.findMany({
-    // The field is the race, not the published fiches: sourced candidacies (status + both
-    // source fields non-null), no extension required. Alphabetical order.
-    where: {
-      election: { slug: electionSlug },
-      status: { not: null },
-      sourceUrl: { not: null },
-      sourceLabel: { not: null },
-    },
-    select: {
-      id: true,
-      candidateName: true,
-      status: true,
-      sourceUrl: true,
-      sourceLabel: true,
-      partyLabel: true,
-      politician: { select: { slug: true, lastName: true } },
-      party: { select: { color: true, shortName: true, logoUrl: true } },
-    },
+  const election = await db.election.findFirst({
+    where: { slug: electionSlug },
+    select: { id: true },
   });
+  if (election === null) return [];
 
-  return sortPresidentialCandidatesBySurname(rows).map((c) => ({
-    id: c.id,
-    candidateName: c.candidateName,
-    politicianSlug: c.politician?.slug ?? null,
-    status: c.status,
-    sourceUrl: c.sourceUrl,
-    sourceLabel: c.sourceLabel,
-    partyLabel: c.partyLabel,
-    partyColor: c.party?.color ?? null,
-    partyShortName: c.party?.shortName ?? null,
-    partyLogoUrl: c.party?.logoUrl ?? null,
-  }));
+  const [rows, measures, editions] = await Promise.all([
+    db.candidacy.findMany({
+      // The field is the race, not the published fiches: sourced candidacies (status + both
+      // source fields non-null), no extension required. Alphabetical order.
+      where: {
+        electionId: election.id,
+        status: { not: null },
+        sourceUrl: { not: null },
+        sourceLabel: { not: null },
+      },
+      select: {
+        id: true,
+        candidateName: true,
+        status: true,
+        sourceUrl: true,
+        sourceLabel: true,
+        partyLabel: true,
+        partyId: true,
+        politician: { select: { slug: true, lastName: true } },
+        party: { select: { color: true, shortName: true, logoUrl: true } },
+      },
+    }),
+    // Defended measures only: `getPublicMeasuresByElection` drops withdrawals unless asked, and a
+    // proposal a candidate has dropped is not one they still carry.
+    getPublicMeasuresByElection(election.id),
+    // A programme edition owned by the candidacy OR by its party. The party case is not a
+    // convenience: three socialist candidacies point at one Projet socialiste, and reading only
+    // `candidacyId` would report all three as having published nothing.
+    db.programEdition.findMany({
+      where: { electionId: election.id, publicationStatus: "PUBLISHED" },
+      select: { candidacyId: true, partyId: true },
+    }),
+  ]);
+
+  const byCandidacy = new Map<string, { count: number; themes: Set<string> }>();
+  for (const measure of measures) {
+    if (measure.candidacyId === null) continue;
+    const bucket = byCandidacy.get(measure.candidacyId) ?? { count: 0, themes: new Set<string>() };
+    bucket.count += 1;
+    bucket.themes.add(measure.theme);
+    byCandidacy.set(measure.candidacyId, bucket);
+  }
+
+  const editionCandidacyIds = new Set(
+    editions.map((e) => e.candidacyId).filter((id): id is string => id !== null)
+  );
+  const editionPartyIds = new Set(
+    editions.map((e) => e.partyId).filter((id): id is string => id !== null)
+  );
+
+  return sortPresidentialCandidatesBySurname(rows).map((c) => {
+    const bucket = byCandidacy.get(c.id);
+    const measureCount = bucket?.count ?? 0;
+    const hasProgramme =
+      editionCandidacyIds.has(c.id) || (c.partyId !== null && editionPartyIds.has(c.partyId));
+
+    return {
+      id: c.id,
+      candidateName: c.candidateName,
+      politicianSlug: c.politician?.slug ?? null,
+      status: c.status,
+      sourceUrl: c.sourceUrl,
+      sourceLabel: c.sourceLabel,
+      partyLabel: c.partyLabel,
+      partyColor: c.party?.color ?? null,
+      partyShortName: c.party?.shortName ?? null,
+      partyLogoUrl: c.party?.logoUrl ?? null,
+      measureCount,
+      themesCoveredCount: bucket?.themes.size ?? 0,
+      programmeAbsence:
+        measureCount > 0
+          ? null
+          : hasProgramme
+            ? ("non_depouille" as const)
+            : ("aucun_programme" as const),
+    };
+  });
 }
 
 /**

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -4,6 +4,11 @@ import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
+import {
+  resolveProgrammeAbsence,
+  rollupMeasuresByCandidacy,
+} from "@/lib/presidentielle/candidacy-rollup";
+import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
 import { loadThemesIndex } from "./themes-index";
 import { getLatestPresidentialReviewDate, getPublicMeasuresByElection } from "./measures";
 
@@ -85,7 +90,7 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
   });
   if (election === null) return [];
 
-  const [rows, measures, editions] = await Promise.all([
+  const [rows, measures, publicCandidates, editions] = await Promise.all([
     db.candidacy.findMany({
       // The field is the race, not the published fiches: sourced candidacies (status + both
       // source fields non-null), no extension required. Alphabetical order.
@@ -110,6 +115,10 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
     // Defended measures only: `getPublicMeasuresByElection` drops withdrawals unless asked, and a
     // proposal a candidate has dropped is not one they still carry.
     getPublicMeasuresByElection(election.id),
+    // The subject-page population, used to intersect those measures. Same read and same reason as
+    // `loadThemesIndex`: a measure on a DRAFT-extension candidacy is rendered nowhere, so counting
+    // it on this row would advertise work the reader cannot reach (invariant I7).
+    getPublicPresidentialCandidates(electionSlug),
     // A programme edition owned by the candidacy OR by its party. The party case is not a
     // convenience: three socialist candidacies point at one Projet socialiste, and reading only
     // `candidacyId` would report all three as having published nothing.
@@ -119,14 +128,10 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
     }),
   ]);
 
-  const byCandidacy = new Map<string, { count: number; themes: Set<string> }>();
-  for (const measure of measures) {
-    if (measure.candidacyId === null) continue;
-    const bucket = byCandidacy.get(measure.candidacyId) ?? { count: 0, themes: new Set<string>() };
-    bucket.count += 1;
-    bucket.themes.add(measure.theme);
-    byCandidacy.set(measure.candidacyId, bucket);
-  }
+  const byCandidacy = rollupMeasuresByCandidacy(
+    measures,
+    new Set(publicCandidates.map((c) => c.id))
+  );
 
   const editionCandidacyIds = new Set(
     editions.map((e) => e.candidacyId).filter((id): id is string => id !== null)
@@ -136,8 +141,8 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
   );
 
   return sortPresidentialCandidatesBySurname(rows).map((c) => {
-    const bucket = byCandidacy.get(c.id);
-    const measureCount = bucket?.count ?? 0;
+    const rollup = byCandidacy.get(c.id);
+    const measureCount = rollup?.measureCount ?? 0;
     const hasProgramme =
       editionCandidacyIds.has(c.id) || (c.partyId !== null && editionPartyIds.has(c.partyId));
 
@@ -153,13 +158,8 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
       partyShortName: c.party?.shortName ?? null,
       partyLogoUrl: c.party?.logoUrl ?? null,
       measureCount,
-      themesCoveredCount: bucket?.themes.size ?? 0,
-      programmeAbsence:
-        measureCount > 0
-          ? null
-          : hasProgramme
-            ? ("non_depouille" as const)
-            : ("aucun_programme" as const),
+      themesCoveredCount: rollup?.themesCoveredCount ?? 0,
+      programmeAbsence: resolveProgrammeAbsence(measureCount, hasProgramme),
     };
   });
 }

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -160,6 +160,25 @@ export async function getPublicMeasuresByTheme(
 }
 
 /**
+ * Every publicly visible measure of one candidacy, for its fiche.
+ *
+ * Same visibility rule as the two reads above, scoped to a candidacy instead of an election or a
+ * theme. Withdrawals are excluded by default here as everywhere: a fiche stating what a candidacy
+ * proposes should not count a proposal it has dropped.
+ */
+export async function getPublicMeasuresByCandidacy(
+  candidacyId: string,
+  options?: MeasureListOptions
+): Promise<PublicMeasure[]> {
+  const rows = await db.measure.findMany({
+    where: { candidacyId, ...PUBLIC_MEASURE_WHERE, ...withdrawalFilter(options) },
+    include: PUBLIC_MEASURE_INCLUDE,
+    orderBy: { createdAt: "asc" },
+  });
+  return rows.map(toPublicMeasure).filter((m): m is PublicMeasure => m !== null);
+}
+
+/**
  * Moderation read. Applies NO filter, on purpose: the admin has to see drafts, discarded
  * revisions and depublished measures, which is the whole reason the public and moderation
  * reads are two different functions in the same file.

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -1,9 +1,13 @@
 import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
-import type { CandidacyStatus } from "@/generated/prisma";
+import type { CandidacyStatus, ThemeCategory, VotePosition } from "@/generated/prisma";
 import { db } from "@/lib/db";
-import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
-import { getPublicMeasureStatsByCandidacy } from "./measures";
+import { PRESIDENTIELLE_2027_SLUG, themeToSlug } from "@/lib/presidentielle/themes";
+import {
+  getPublicMeasureStatsByCandidacy,
+  getPublicMeasuresByCandidacy,
+  type PublicMeasure,
+} from "./measures";
 
 /**
  * The reverse of `getHubCandidacyField`: "the presidential candidacy of THIS politician".
@@ -23,6 +27,8 @@ import { getPublicMeasureStatsByCandidacy } from "./measures";
  * so a generic "candidacy for the current election" would be speculative generality.
  */
 export type PoliticianCandidacy = {
+  /** The candidacy row, so the fiche can read its measures without resolving it a second time. */
+  candidacyId: string;
   electionSlug: string;
   electionShortTitle: string;
   round1Date: Date | null;
@@ -84,6 +90,7 @@ export async function loadPoliticianPresidentialCandidacy(
   const stats = await getPublicMeasureStatsByCandidacy(row.id);
 
   return {
+    candidacyId: row.id,
     electionSlug: row.election.slug,
     electionShortTitle: row.election.shortTitle ?? row.election.title,
     round1Date: row.election.round1Date,
@@ -100,6 +107,98 @@ export async function loadPoliticianPresidentialCandidacy(
     round1Pct: row.round1Pct === null ? null : Number(row.round1Pct),
     round2Pct: row.round2Pct === null ? null : Number(row.round2Pct),
     isElected: row.isElected,
+  };
+}
+
+export type CandidateThemeBreakdown = {
+  theme: ThemeCategory;
+  slug: string;
+  measureCount: number;
+  /** The first measure of the theme, quoted on the fiche. Null only if the theme has none. */
+  quote: { text: string; sourceUrl: string | null } | null;
+};
+
+export type CandidateRecentVote = {
+  id: string;
+  position: VotePosition;
+  votingDate: Date;
+  scrutinTitle: string;
+  scrutinId: string;
+};
+
+export type CandidateFicheDetail = {
+  /** Themes carrying at least one measure, most documented first. */
+  themes: CandidateThemeBreakdown[];
+  recentVotes: CandidateRecentVote[];
+  /** Every mandate ever held, for the header count. */
+  mandateCount: number;
+};
+
+/**
+ * What the fiche shows beyond the header counters, in one read.
+ *
+ * The vote list is NOT joined to the measures: no scrutin is attached to any measure yet
+ * (`MeasureVoteLink` is empty), so a "programme face aux votes" block would be an empty promise.
+ * The last votes are shown as what they are, recent parliamentary activity, and the page says so
+ * rather than implying a link the data does not carry.
+ */
+export async function loadCandidateFicheDetail(
+  candidacyId: string,
+  politicianId: string
+): Promise<CandidateFicheDetail> {
+  const [measures, votes, mandateCount] = await Promise.all([
+    getPublicMeasuresByCandidacy(candidacyId),
+    // Cheap and index-backed: `votingDate` is denormalized onto Vote precisely so a
+    // "votes for politician" sort needs no join.
+    db.vote.findMany({
+      where: { politicianId },
+      orderBy: { votingDate: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        position: true,
+        votingDate: true,
+        scrutin: { select: { id: true, title: true } },
+      },
+    }),
+    db.mandate.count({ where: { politicianId } }),
+  ]);
+
+  const byTheme = new Map<ThemeCategory, PublicMeasure[]>();
+  for (const measure of measures) {
+    const bucket = byTheme.get(measure.theme) ?? [];
+    bucket.push(measure);
+    byTheme.set(measure.theme, bucket);
+  }
+
+  const themes: CandidateThemeBreakdown[] = [...byTheme.entries()]
+    .map(([theme, list]) => {
+      const first = list[0];
+      return {
+        theme,
+        slug: themeToSlug(theme),
+        measureCount: list.length,
+        quote:
+          first === undefined
+            ? null
+            : { text: first.text, sourceUrl: first.sources[0]?.url ?? null },
+      };
+    })
+    // Most documented first: this block answers "where does this candidacy put the accent", and
+    // alphabetical order would bury the answer. It is a count of OUR extraction, not a ranking of
+    // candidacies against each other, which is why it is allowed here and not on the field.
+    .sort((a, b) => b.measureCount - a.measureCount);
+
+  return {
+    themes,
+    recentVotes: votes.map((v) => ({
+      id: v.id,
+      position: v.position,
+      votingDate: v.votingDate,
+      scrutinTitle: v.scrutin.title,
+      scrutinId: v.scrutin.id,
+    })),
+    mandateCount,
   };
 }
 
@@ -136,4 +235,34 @@ async function getPoliticianPresidentialCandidacyCached(
   cacheTag(`election-candidacies:${electionId}`);
   cacheLife("synced");
   return loadPoliticianPresidentialCandidacy(politicianId);
+}
+
+/**
+ * Cached companion of the read above, same tags for the same reason: the themes and their quotes
+ * move on a measure publication, and the candidacy's visibility on an extension transition. The
+ * `votes` tag as well, since the last-votes block is invalidated by a scrutin import.
+ */
+export async function getCandidateFicheDetail(
+  candidacyId: string,
+  politicianId: string
+): Promise<CandidateFicheDetail> {
+  const election = await db.election.findUnique({
+    where: { slug: PRESIDENTIELLE_2027_SLUG },
+    select: { id: true },
+  });
+  if (election === null) return { themes: [], recentVotes: [], mandateCount: 0 };
+  return getCandidateFicheDetailCached(candidacyId, politicianId, election.id);
+}
+
+async function getCandidateFicheDetailCached(
+  candidacyId: string,
+  politicianId: string,
+  electionId: string
+): Promise<CandidateFicheDetail> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheTag(`election-candidacies:${electionId}`);
+  cacheTag("votes");
+  cacheLife("synced");
+  return loadCandidateFicheDetail(candidacyId, politicianId);
 }

--- a/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
+++ b/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
@@ -6,6 +6,7 @@ const BEFORE = new Date("2026-08-07T10:00:00.000Z");
 const AFTER = new Date("2027-05-10T10:00:00.000Z");
 
 const base: PoliticianCandidacy = {
+  candidacyId: "cand-1",
   electionSlug: "presidentielle-2027",
   electionShortTitle: "Présidentielle 2027",
   round1Date: new Date("2027-04-11T00:00:00.000Z"),

--- a/src/lib/presidentielle/__tests__/candidacy-filters.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-filters.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchesCandidacyFilter,
+  matchesCandidacyQuery,
+  parseCandidacyFilter,
+  type FilterableCandidacy,
+} from "../candidacy-filters";
+
+function candidacy(over: Partial<FilterableCandidacy> = {}): FilterableCandidacy {
+  return {
+    candidateName: "Alix Dupont",
+    status: "DECLARE",
+    partyLabel: "Parti Test",
+    partyShortName: "PT",
+    measureCount: 0,
+    ...over,
+  };
+}
+
+describe("parseCandidacyFilter", () => {
+  it("retombe sur « toutes » pour une valeur d'URL inconnue ou absente", () => {
+    // L'URL est publique et modifiable à la main : une valeur inventée ne doit pas vider la liste.
+    expect(parseCandidacyFilter("depouillees")).toBe("depouillees");
+    expect(parseCandidacyFilter("n-importe-quoi")).toBe("toutes");
+    expect(parseCandidacyFilter(null)).toBe("toutes");
+  });
+});
+
+describe("matchesCandidacyFilter", () => {
+  it("range « évoquée » avec les pressenties", () => {
+    // La nuance entre pressentie et évoquée porte sur le degré de sourçage, pas sur la nature :
+    // qui filtre sur « pressenties » veut tous ceux qui ne sont pas encore déclarés.
+    expect(matchesCandidacyFilter(candidacy({ status: "ENVISAGE" }), "pressenties")).toBe(true);
+    expect(matchesCandidacyFilter(candidacy({ status: "PRESSENTI" }), "pressenties")).toBe(true);
+    expect(matchesCandidacyFilter(candidacy({ status: "DECLARE" }), "pressenties")).toBe(false);
+  });
+
+  it("exclut une retirée des déclarées", () => {
+    expect(matchesCandidacyFilter(candidacy({ status: "RETIRE" }), "declarees")).toBe(false);
+    expect(matchesCandidacyFilter(candidacy({ status: "RETIRE" }), "toutes")).toBe(true);
+  });
+
+  it("filtre « dépouillé » sur nos mesures, pas sur l'existence d'un programme", () => {
+    expect(matchesCandidacyFilter(candidacy({ measureCount: 3 }), "depouillees")).toBe(true);
+    expect(matchesCandidacyFilter(candidacy({ measureCount: 0 }), "depouillees")).toBe(false);
+  });
+});
+
+describe("matchesCandidacyQuery", () => {
+  it("ignore les accents et la casse", () => {
+    const melenchon = candidacy({ candidateName: "Jean-Luc Mélenchon" });
+    expect(matchesCandidacyQuery(melenchon, "melenchon")).toBe(true);
+    expect(matchesCandidacyQuery(melenchon, "MÉLENCHON")).toBe(true);
+    expect(matchesCandidacyQuery(melenchon, "Melanchon")).toBe(false);
+  });
+
+  it("cherche aussi dans le parti et son sigle", () => {
+    const row = candidacy({
+      candidateName: "Alix Dupont",
+      partyLabel: "Lutte ouvrière",
+      partyShortName: "LO",
+    });
+    expect(matchesCandidacyQuery(row, "ouvriere")).toBe(true);
+    expect(matchesCandidacyQuery(row, "lo")).toBe(true);
+  });
+
+  it("laisse tout passer sur une requête vide ou blanche", () => {
+    expect(matchesCandidacyQuery(candidacy(), "")).toBe(true);
+    expect(matchesCandidacyQuery(candidacy(), "   ")).toBe(true);
+  });
+
+  it("ne plante pas sur une candidature sans parti", () => {
+    const row = candidacy({ partyLabel: null, partyShortName: null });
+    expect(matchesCandidacyQuery(row, "parti")).toBe(false);
+    expect(matchesCandidacyQuery(row, "alix")).toBe(true);
+  });
+});

--- a/src/lib/presidentielle/__tests__/candidacy-rollup.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-rollup.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveProgrammeAbsence, rollupMeasuresByCandidacy } from "../candidacy-rollup";
+
+describe("rollupMeasuresByCandidacy", () => {
+  it("ne compte pas une mesure portée par une candidature que rien ne rend publiquement", () => {
+    // Invariant I7, déjà tenu par `loadThemesIndex` : une mesure rattachée à une candidature dont
+    // l'extension est encore DRAFT n'apparaît sur aucune page sujet et sur aucune fiche. La compter
+    // ici annoncerait « 2 mesures dépouillées » sur une ligne qui ne mène à rien.
+    const rollup = rollupMeasuresByCandidacy(
+      [
+        { candidacyId: "publique", theme: "SANTE" },
+        { candidacyId: "brouillon", theme: "SANTE" },
+        { candidacyId: "brouillon", theme: "LOGEMENT_URBANISME" },
+      ],
+      new Set(["publique"])
+    );
+
+    expect(rollup.get("publique")).toEqual({ measureCount: 1, themesCoveredCount: 1 });
+    expect(rollup.has("brouillon")).toBe(false);
+  });
+
+  it("compte les sujets distincts, pas les mesures", () => {
+    const rollup = rollupMeasuresByCandidacy(
+      [
+        { candidacyId: "c1", theme: "SANTE" },
+        { candidacyId: "c1", theme: "SANTE" },
+        { candidacyId: "c1", theme: "LOGEMENT_URBANISME" },
+      ],
+      new Set(["c1"])
+    );
+
+    expect(rollup.get("c1")).toEqual({ measureCount: 3, themesCoveredCount: 2 });
+  });
+
+  it("ignore une mesure sans candidature", () => {
+    const rollup = rollupMeasuresByCandidacy([{ candidacyId: null, theme: "SANTE" }], new Set());
+    expect(rollup.size).toBe(0);
+  });
+});
+
+describe("resolveProgrammeAbsence", () => {
+  it("n'impute jamais notre retard au candidat", () => {
+    expect(resolveProgrammeAbsence(0, true)).toBe("non_depouille");
+    expect(resolveProgrammeAbsence(0, false)).toBe("aucun_programme");
+  });
+
+  it("ne qualifie aucune absence dès qu'une mesure existe", () => {
+    expect(resolveProgrammeAbsence(1, false)).toBeNull();
+    expect(resolveProgrammeAbsence(12, true)).toBeNull();
+  });
+});

--- a/src/lib/presidentielle/candidacy-filters.ts
+++ b/src/lib/presidentielle/candidacy-filters.ts
@@ -1,0 +1,83 @@
+import type { CandidacyStatus } from "@/generated/prisma";
+
+/**
+ * What the field's filter chips mean, as a policy rather than as inline predicates.
+ *
+ * Here rather than in the component because these are editorial definitions, not presentation:
+ * "pressenties" covering both PRESSENTI and ENVISAGE is a decision about what the reader is being
+ * shown, and it deserves a test that does not have to render a list to make its point.
+ *
+ * There is deliberately no sort control. The only defensible order is the one the section
+ * announces, by surname, and a menu offering one option is furniture. A "par mesures" order would
+ * rank candidacies by the volume of OUR extraction, which reads as a leaderboard of programme
+ * quality and is exactly the ranking this site does not publish.
+ */
+
+export const CANDIDACY_FILTERS = ["toutes", "declarees", "pressenties", "depouillees"] as const;
+
+export type CandidacyFilter = (typeof CANDIDACY_FILTERS)[number];
+
+export const CANDIDACY_FILTER_LABELS: Record<CandidacyFilter, string> = {
+  toutes: "Toutes",
+  declarees: "Déclarées",
+  pressenties: "Pressenties",
+  depouillees: "Programme dépouillé",
+};
+
+/** The fields a filter reads, so a caller can pass its own row type unchanged. */
+export type FilterableCandidacy = {
+  candidateName: string;
+  status: CandidacyStatus | null;
+  partyLabel: string | null;
+  partyShortName: string | null;
+  measureCount: number;
+};
+
+export function parseCandidacyFilter(raw: string | null): CandidacyFilter {
+  return (CANDIDACY_FILTERS as readonly string[]).includes(raw ?? "")
+    ? (raw as CandidacyFilter)
+    : "toutes";
+}
+
+export function matchesCandidacyFilter(
+  candidacy: FilterableCandidacy,
+  filter: CandidacyFilter
+): boolean {
+  switch (filter) {
+    case "toutes":
+      return true;
+    case "declarees":
+      return candidacy.status === "DECLARE";
+    // Both, because the difference between "pressentie" and "évoquée" is a degree of sourcing and
+    // not a different thing: a reader filtering on "pressenties" wants everyone not yet declared.
+    case "pressenties":
+      return candidacy.status === "PRESSENTI" || candidacy.status === "ENVISAGE";
+    // Our own extraction, not a claim about the candidacy. A row with no measure can still have
+    // published a programme.
+    case "depouillees":
+      return candidacy.measureCount > 0;
+    default: {
+      const exhaustive: never = filter;
+      return exhaustive;
+    }
+  }
+}
+
+/** Accent and case insensitive, so "melenchon" finds "Mélenchon" and "lo" finds "Lutte ouvrière". */
+function fold(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+export function matchesCandidacyQuery(candidacy: FilterableCandidacy, query: string): boolean {
+  const needle = fold(query);
+  if (needle === "") return true;
+  return (
+    fold(candidacy.candidateName).includes(needle) ||
+    fold(candidacy.partyLabel ?? "").includes(needle) ||
+    fold(candidacy.partyShortName ?? "").includes(needle)
+  );
+}

--- a/src/lib/presidentielle/candidacy-rollup.ts
+++ b/src/lib/presidentielle/candidacy-rollup.ts
@@ -1,0 +1,63 @@
+/**
+ * What the field says about each candidacy's measures, as a pure function.
+ *
+ * Pure and here rather than inline in `hub.ts` so the invariant below can be tested without a
+ * database: it is the kind of rule that reads as obviously correct and is silently wrong.
+ */
+
+export type RollupMeasure = { candidacyId: string | null; theme: string };
+
+export type CandidacyRollup = { measureCount: number; themesCoveredCount: number };
+
+/**
+ * Counts a candidacy's measures, but ONLY for candidacies the public surfaces can actually show.
+ *
+ * The intersection with `publicCandidacyIds` is the whole point, and it is the same invariant
+ * `loadThemesIndex` enforces: a measure attached to a candidacy whose `CandidacyPresidential`
+ * extension is still DRAFT is rendered by no subject page and reachable on no fiche. Counting it
+ * here would announce "3 mesures dépouillées" on a row that leads the reader to nothing, and would
+ * do it in the one column added to show what we have actually done.
+ *
+ * This is not hypothetical: measures are written and published BEFORE the editorial extension is,
+ * so the un-intersected count is wrong during the normal editorial flow rather than in some edge
+ * case.
+ */
+export function rollupMeasuresByCandidacy(
+  measures: readonly RollupMeasure[],
+  publicCandidacyIds: ReadonlySet<string>
+): Map<string, CandidacyRollup> {
+  const themesByCandidacy = new Map<string, Set<string>>();
+  const counts = new Map<string, number>();
+
+  for (const measure of measures) {
+    const id = measure.candidacyId;
+    if (id === null || !publicCandidacyIds.has(id)) continue;
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+    const themes = themesByCandidacy.get(id) ?? new Set<string>();
+    themes.add(measure.theme);
+    themesByCandidacy.set(id, themes);
+  }
+
+  return new Map(
+    [...counts].map(([id, measureCount]) => [
+      id,
+      { measureCount, themesCoveredCount: themesByCandidacy.get(id)?.size ?? 0 },
+    ])
+  );
+}
+
+/**
+ * Why a candidacy shows no measure, and never a bare zero.
+ *
+ * `aucun_programme` documents the CANDIDACY: nothing published for this election. `non_depouille`
+ * documents US: a programme exists and we have not extracted it. Presenting our own backlog as a
+ * candidate's silence is a false claim about a person, which is why these are two values and not a
+ * boolean.
+ */
+export function resolveProgrammeAbsence(
+  measureCount: number,
+  hasPublishedProgramme: boolean
+): "aucun_programme" | "non_depouille" | null {
+  if (measureCount > 0) return null;
+  return hasPublishedProgramme ? "non_depouille" : "aucun_programme";
+}


### PR DESCRIPTION
Refond la section « Les candidatures » du hub et étoffe la fiche candidat.

## La liste

25 cartes de ~190 px deviennent 25 lignes. Chaque ligne porte enfin ce que nous avons dépouillé, ce qu'aucune carte ne montrait, et la citation de source cesse d'être l'élément le plus voyant : elle passe en `title`, tronquée sur une ligne. Le badge de statut n'apparaît que lorsqu'il n'est pas « déclarée », parce que 20 lignes sur 25 portaient le même.

Recherche et filtres vivent dans l'URL, mais dans un composant client et non en `searchParams` de page : mettre `searchParams` sur le hub le ferait basculer en rendu dynamique et lui coûterait son ISR. Le build confirme que la route reste `○ (Static)`, revalidation 1 jour.

Le tri est absent volontairement. Le seul ordre défendable est celui que la section annonce, par nom de famille, et un tri « par mesures » classerait les candidatures au volume de **notre** dépouillement, ce qui se lit comme un palmarès.

## Le vide, en deux phrases et non une

C'est le cœur du lot. Une cellule à zéro disait la même chose dans deux situations opposées.

- « Aucun programme publié à ce jour » documente la candidature.
- « Programme publié, pas encore dépouillé » documente **notre** retard.

La résolution lit `ProgramEdition` par `candidacyId` **ou** par le `partyId` de la candidature. Le second cas n'est pas un confort : trois candidatures socialistes pointent sur un seul Projet socialiste, et ne lire que `candidacyId` les déclarerait toutes les trois sans programme.

Sur les 25 candidatures : 6 dépouillées, 11 avec un programme non dépouillé, 8 sans aucun programme. Avant ce lot, les 19 dernières se lisaient identiquement.

## Les marques de parti

Monogramme partout, plus de logo. Mesuré et non supposé : à 38 px les logos se scindent en deux populations, les pastilles restent lisibles, les logos en forme de mot (Lutte ouvrière, UPR, PS, Horizons, Nouvelle Énergie) se réduisent à une tache. Trois échelles optiques sur trois lignes consécutives est précisément ce que la refonte devait supprimer. Le parti reste écrit en toutes lettres à côté.

## La fiche candidat

Elle ne portait que deux sections. Elle en porte six : trois compteurs d'en-tête, les mesures sujet par sujet avec une citation sourcée, la répartition des sujets, les derniers votes, l'intégrité, et la provenance.

Deux volets de la maquette restent absents **et sont nommés sur la page** : le rapprochement mesure/scrutin, qui demande un rattachement que `MeasureVoteLink` ne porte pas encore, et le bilan des fonctions exercées, qui relève du suivi post-électoral. Les rendre depuis ce qui existe reviendrait à inventer un lien que la donnée ne porte pas.

**Point à relire** : le bloc « Intégrité » affiche un décompte de procédures judiciaires sur la fiche d'un candidat. Il ne divulgue rien de nouveau, il compte les affaires déjà `PUBLISHED` et visibles sur la fiche politicien, et il porte la mention qu'une mise en cause ne vaut pas condamnation. C'est néanmoins une décision éditoriale et non une décision de mise en page.

## Vérifications

Suite complète au vert. `tsc` sans erreur de source, `eslint` et Prettier propres, `next build` sorti à 0 avec la collecte des pages.

Mesuré au navigateur sur les deux pages, à 1440 et 390 px : aucune dérive latérale et **0 violation axe** sur les balises WCAG 2.1 AA.

Les compteurs sont vérifiés contre la base de production : 25 lignes, `Toutes · 25 / Déclarées · 20 / Pressenties · 4 / Programme dépouillé · 6`, et « 8 candidatures n'ont publié aucun programme à ce jour ».
