### PR TITLE
Ancrer le repli de recadrage en haut du cadre

### DIFF
--- a/src/lib/photos/__tests__/crop.test.ts
+++ b/src/lib/photos/__tests__/crop.test.ts
@@ -31,8 +31,16 @@ async function syntheticPortrait(
     .toBuffer();
 }
 
-/** A source with no skin tones at all, to exercise the fallback. */
-async function greyscaleScene(width: number, height: number): Promise<Buffer> {
+/**
+ * A source with no skin tones at all, to exercise the fallback. The lone bright
+ * patch is what sharp's attention strategy locks onto, so moving it moves the
+ * attention point.
+ */
+async function greyscaleScene(
+  width: number,
+  height: number,
+  patchAt: { left: number; top: number } = { left: 40, top: 40 }
+): Promise<Buffer> {
   const patch = await sharp({
     create: { width: 200, height: 200, channels: 3, background: { r: 150, g: 150, b: 150 } },
   })
@@ -41,7 +49,7 @@ async function greyscaleScene(width: number, height: number): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 60, g: 60, b: 60 } },
   })
-    .composite([{ input: patch, left: 40, top: 40 }])
+    .composite([{ input: patch, left: patchAt.left, top: patchAt.top }])
     .jpeg()
     .toBuffer();
 }
@@ -95,13 +103,19 @@ describe("cropToPortrait", () => {
   });
 
   it("follows the head down a tall photo instead of centring", async () => {
+    // Both heads sit above MAX_HEAD_CENTRE_SHARE, so both are framed by the face
+    // strategy. Asserting that is the point: only the face strategy is allowed to
+    // move the square down the frame, and a head placed lower than this is not a
+    // head at all — it is the hand the guard exists to reject.
     const headHigh = await syntheticPortrait(600, 1800, { left: 200, top: 120, size: 200 });
-    const headLow = await syntheticPortrait(600, 1800, { left: 200, top: 1400, size: 200 });
+    const headLow = await syntheticPortrait(600, 1800, { left: 200, top: 800, size: 200 });
 
     const high = await cropToPortrait(headHigh);
     const low = await cropToPortrait(headLow);
 
-    expect(low.region.top).toBeGreaterThan(high.region.top + 800);
+    expect(high.strategy).toBe("face");
+    expect(low.strategy).toBe("face");
+    expect(low.region.top).toBeGreaterThan(high.region.top + 500);
   });
 
   it("always returns a region inside the source bounds", async () => {
@@ -138,6 +152,18 @@ describe("cropToPortrait", () => {
     expect(strategy).toBe("attention");
     // The fallback never zooms: the square is as large as the image allows.
     expect(region.size).toBe(900);
+  });
+
+  it("anchors the fallback to the top even when attention is drawn low", async () => {
+    // The failure this locks out. No face found, and the only thing in frame for
+    // sharp to lock onto sits near the bottom. Letting it choose the vertical
+    // offset published squares that started below the subject's chin, so a
+    // portrait that was correct at the source came out decapitated.
+    const scene = await greyscaleScene(900, 1600, { left: 350, top: 1350 });
+    const { strategy, region } = await cropToPortrait(scene);
+
+    expect(strategy).toBe("attention");
+    expect(region.top).toBe(0);
   });
 
   it("applies EXIF orientation before cropping", async () => {

--- a/src/lib/photos/crop.ts
+++ b/src/lib/photos/crop.ts
@@ -161,12 +161,33 @@ function chooseRegion(
     };
   }
 
-  // Largest square, centred on the attention point when we have one.
+  // Largest square, anchored to the top of the frame, centred horizontally on
+  // the attention point when we have one.
+  //
+  // The vertical axis is not sharp's to choose. Reaching this branch means no
+  // face was found, so the attention point is the only signal left, and it is
+  // routinely drawn to a lectern, a tie or a raised hand: on Jean-Luc
+  // Mélenchon's file it put the square's top edge below his chin, on Christiane
+  // Taubira's it cut the face at the nose. In a portrait the head is at the top,
+  // so anchoring there cannot decapitate the subject.
+  //
+  // That also bounds the fallback by what doing nothing would give — the same
+  // square a CSS `object-position: top` would show — which is the property the
+  // old code lacked: it could, and did, publish a framing worse than the
+  // untouched source.
+  //
+  // Horizontally the attention point still earns its keep: it is what picks the
+  // subject out of two people standing side by side.
+  //
+  // What this does not fix, and cannot: a source that is itself a tight vertical
+  // close-up, where the head fills the frame and no square holds all of it —
+  // Roselyne Bachelot's file loses the chin whatever the offset. That is a choice
+  // of photograph, not a choice of geometry, and telling the two apart needs the
+  // face detection that failed us to get here.
   const centreX = attention?.x ?? source.width / 2;
-  const centreY = attention?.y ?? source.height / 2;
   return {
     left: clamp(Math.round(centreX - maxSize / 2), 0, source.width - maxSize),
-    top: clamp(Math.round(centreY - maxSize / 2), 0, source.height - maxSize),
+    top: 0,
     size: maxSize,
   };
 }


### PR DESCRIPTION
Le recadrage automatique publiait des portraits pires que la photo d'origine.

## Ce qui se passait

Quand le scan de peau ne trouve pas de visage, le code se rabat sur le point d'attention de `sharp` et lui laisse choisir **les deux axes**. Sur l'axe vertical, ce point est régulièrement attiré par un pupitre, une cravate ou une main levée. Le carré partait alors sous le menton du sujet.

Mesuré sur la campagne d'août : 340 portraits recadrés, dont 252 par la détection de visage et **88 par ce repli**. Sur ces 88, **59 ont le carré décalé vers le bas**, jusqu'à la moitié de la hauteur disponible.

| Fichier                  | Ce que publiait le repli                               |
| ------------------------ | ------------------------------------------------------ |
| Jean-Luc Mélenchon       | carré à y=419 sur 960, visage coupé au niveau des yeux |
| Christiane Taubira       | visage coupé au nez, surtout du cou et de la veste     |
| Sabrina Agresti-Roubache | un manteau et une écharpe, pas de tête                 |

Les trois photos Commons d'origine sont correctement cadrées. Le pipeline les a dégradées.

## Le correctif

Le repli ancre désormais le carré **en haut du cadre**. L'axe horizontal continue de suivre le point d'attention, qui reste utile pour isoler un sujet parmi deux personnes côte à côte.

Le principe est celui qui manquait : le repli est borné par ce que donnerait l'inaction, soit le carré qu'un `object-position: top` afficherait. Il ne peut plus produire un cadrage pire que la source intacte. La branche « visage », elle, est inchangée.

Vérifié sur les fichiers réels, avec le nouveau code : Mélenchon, Taubira et Agresti-Roubache passent tous à `top: 0` et rendent un visage entier.

## Ce que ça ne corrige pas

Une source qui est elle-même un gros plan vertical très serré, où la tête remplit le cadre et où aucun carré ne la contient. Le fichier de Roselyne Bachelot perd le menton quel que soit le décalage. C'est un choix de photographie, pas de géométrie, et les distinguer demanderait la détection de visage qui a justement échoué. C'est écrit dans le code, à côté du correctif.

## Un test existant a dû bouger

`follows the head down a tall photo instead of centring` plaçait sa tête « basse » à 78 % de la hauteur, au-delà de `MAX_HEAD_CENTRE_SHARE`. Le code refusait donc de la traiter comme une tête et retombait sur le repli : le test verrouillait en réalité le comportement du repli, alors que son nom annonce celui de la stratégie visage, et il contredisait la garde documentée quinze lignes plus haut.

La tête basse revient à 44 % de la hauteur, dans la zone où elle est acceptée, et le test affirme maintenant explicitement `strategy === "face"` sur les deux cas. Il teste enfin ce qu'il annonce.

## Vérifications

Suite `src/lib/photos` verte, 72 tests. `tsc` sans erreur dans `src/`, eslint et Prettier propres.

Le nouveau test de garde a été prouvé par ablation : en rétablissant l'ancien repli, il échoue avec `expected 700 to be +0`.

## Après le merge

Relancer `repair-portraits --crop --apply` pour republier les 88 portraits concernés. Les 252 issus de la détection de visage seront recalculés à l'identique, la branche qui les produit n'ayant pas changé.
