### PR TITLE
Ajouter une image Open Graph au hub présidentielle

### DIFF
--- a/src/app/elections/presidentielle-2027/opengraph-image.tsx
+++ b/src/app/elections/presidentielle-2027/opengraph-image.tsx
@@ -1,0 +1,79 @@
+import { ImageResponse } from "next/og";
+import { OgLayout, OG_SIZE } from "@/lib/og-utils";
+
+/**
+ * Shared preview card for the whole presidential hub.
+ *
+ * Next inherits a route's `opengraph-image` down every descendant segment that does
+ * not define its own, so this one file covers the hub, the 13 subject pages, the 25
+ * candidate pages and /priorites. That inheritance is the point rather than a side
+ * effect: one image URL for the section instead of forty. Search Console attributed
+ * the large majority of the site's "crawled, currently not indexed" bucket to
+ * `opengraph-image` routes, so every one we do not create is crawl budget we keep.
+ * The route is covered without further work by OG_IMAGE_ROBOTS_SOURCE (X-Robots-Tag)
+ * and OG_IMAGE_DISALLOW_PATHS (robots.txt), both matching any path ending in
+ * `/opengraph-image`.
+ *
+ * For the same reason there is no `twitter-image` beside it. That filename is a
+ * different route family, and neither the header rule nor the robots.txt rule would
+ * match it. Twitter falls back to og:image and crops it to 2:1, which is why nothing
+ * that has to stay readable sits in the top or bottom 20 pixels.
+ *
+ * Nothing here is read from the database. A figure baked into an OG image is cached
+ * by every platform that ever rendered it, so "25 candidatures" would still be shown
+ * long after it stopped being true, with no way to correct it. It also spares a full
+ * render plus a query on each crawl.
+ */
+
+export const alt =
+  "Poligraph, présidentielle 2027 : pour chaque sujet, les propositions des candidats, leurs votes et leurs bilans.";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    <OgLayout>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "center",
+          gap: 28,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 26,
+            fontWeight: 700,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            color: "#7dd3fc",
+          }}
+        >
+          Présidentielle 2027
+        </span>
+
+        {/* The hub's own H1. Sized for a 500px-wide card in a feed, which is the
+              only place this image is ever seen. */}
+        <span
+          style={{
+            fontSize: 92,
+            fontWeight: 800,
+            lineHeight: 1.02,
+            letterSpacing: -2,
+            color: "white",
+            maxWidth: 1000,
+          }}
+        >
+          Qu&apos;est-ce qui changerait pour vous&nbsp;?
+        </span>
+
+        <span style={{ fontSize: 32, lineHeight: 1.3, color: "#cbd5e1", maxWidth: 900 }}>
+          Pour chaque sujet : les propositions, les votes, les bilans.
+        </span>
+      </div>
+    </OgLayout>,
+    { ...OG_SIZE }
+  );
+}

--- a/src/lib/seo/__tests__/og-image-robots.test.ts
+++ b/src/lib/seo/__tests__/og-image-robots.test.ts
@@ -33,6 +33,7 @@ describe("opengraph-image noindex header", () => {
     "/parlement/dossiers/reforme-des-retraites/opengraph-image",
     "/partis/renaissance/programme/opengraph-image",
     "/politiques/jean-dupont/opengraph-image",
+    "/elections/presidentielle-2027/opengraph-image",
   ])("noindexes OG image path %s", (path) => {
     expect(source.test(path)).toBe(true);
   });


### PR DESCRIPTION
Le hub présidentielle partageait l'image d'accueil du site. Il a maintenant la sienne.

## Direction retenue

La 1A du handoff : fond de marque, la question centrale de la page, une ligne de contenu. C'est celle que le document recommande « si une seule image doit servir toute la section », et c'est exactement le cas ici.

Le titre est le H1 réel de la page, pas une accroche inventée pour l'occasion. L'image dit donc la même chose que la page vers laquelle elle mène.

Les deux autres directions ont été écartées pour des raisons de fond, pas de goût. La 1B porte une ligne de statistiques, or une image Open Graph est mise en cache par chaque plateforme qui l'a rendue une fois : le chiffre y survit à sa péremption sans qu'on puisse le corriger. Il était de surcroît faux en l'état, « 25 candidatures déclarées » alors que 20 sont déclarées et 4 pressenties. La 1C est un aperçu du comparateur, une page qui n'existe pas encore.

## Une seule route, et c'est le sujet SEO

Next fait hériter un `opengraph-image` par tous les segments descendants qui n'en définissent pas. Ce fichier unique couvre donc le hub, les 13 pages de sujet, les 25 fiches de candidat et `/priorites`. Une image par candidat aurait créé 25 URLs de plus.

Ça compte ici précisément : la 3e vague anti-index-bloat avait attribué la large majorité du seau « explorée, non indexée » de la Search Console aux routes `opengraph-image`. Chaque route qu'on ne crée pas est du budget d'exploration conservé.

La protection est structurelle et couvre cette route sans rien ajouter : `OG_IMAGE_ROBOTS_SOURCE` (`/:path*/opengraph-image`) pose le `X-Robots-Tag: noindex`, `OG_IMAGE_DISALLOW_PATHS` bloque l'exploration dans le robots.txt, et `SOCIAL_PREVIEW_USER_AGENTS` garde son groupe séparé pour que les aperçus continuent de fonctionner. Le chemin est ajouté au test qui compile le vrai matcher de Next.

**Pas de `twitter-image` à côté.** C'est une famille de routes différente, que ni la règle d'en-tête ni celle du robots.txt ne matcheraient : on rouvrirait le trou qu'on vient de fermer. Twitter retombe sur `og:image` et la recadre en 2:1, ce qui est prévu, rien d'essentiel ne se trouve dans les 20 pixels du haut ni du bas.

## Rien n'est lu en base

Pas de requête, pas de chiffre, pas de date. Outre la péremption, ça évite un rendu complet et une requête à chaque exploration, sur une route qui en reçoit beaucoup.

## Vérifié

L'image a été rendue localement, pas seulement écrite : 1200 × 630, le titre tient en deux lignes.

Les deux contraintes du handoff sont mesurées sur le rendu réel. À 500 px de large, la largeur basse d'une carte dans un fil, le titre et la ligne de contenu restent lisibles. Au recadrage 2:1 de Twitter, seul le bandeau tricolore décoratif disparaît, le pied `poligraph.fr` survit.

`og:image:alt` décrit le contenu factuel de l'image et non son style, comme le demandait le handoff.

Suite `src/lib/seo` verte, 182 tests. `tsc` sans erreur dans `src/`, eslint et Prettier propres.
