### PR TITLE
Publier chaque portrait recadré sur une URL neuve

### DIFF
--- a/scripts/repair-portraits.ts
+++ b/scripts/repair-portraits.ts
@@ -37,7 +37,7 @@ import {
 import { cropToPortrait, readDimensions } from "../src/lib/photos/crop";
 import { screenFilename, screenGeometry } from "../src/lib/photos/portrait-guard";
 import { fetchP18Filenames, filenameFromThumbnailUrl } from "../src/lib/photos/wikidata-image";
-import { uploadCroppedPortrait } from "../src/lib/photos/blob";
+import { uploadCroppedPortrait, deleteCroppedPortrait } from "../src/lib/photos/blob";
 
 const client = new HTTPClient({ rateLimitMs: 150 });
 
@@ -219,6 +219,7 @@ async function runDiscover(options: Options): Promise<DiscoverEntry[]> {
     select: {
       id: true,
       fullName: true,
+      blobPhotoUrl: true,
       externalIds: { where: { source: "WIKIDATA" }, select: { externalId: true } },
     },
     orderBy: { prominenceScore: "desc" },
@@ -311,6 +312,9 @@ async function runDiscover(options: Options): Promise<DiscoverEntry[]> {
           photoCheckedAt: new Date(),
         },
       });
+      // Only after the row points at the new blob: an orphan is cheap, a dangling
+      // reference is a broken portrait.
+      await deleteCroppedPortrait(row.blobPhotoUrl);
       entry.blobUrl = blobUrl;
     }
 
@@ -349,7 +353,7 @@ async function runCrop(options: Options): Promise<CropEntry[]> {
   const total = await db.politician.count({ where });
   const rows = await db.politician.findMany({
     where,
-    select: { id: true, fullName: true, photoUrl: true },
+    select: { id: true, fullName: true, photoUrl: true, blobPhotoUrl: true },
     orderBy: { prominenceScore: "desc" },
     take: limit,
   });
@@ -417,6 +421,9 @@ async function runCrop(options: Options): Promise<CropEntry[]> {
         where: { id: row.id },
         data: { blobPhotoUrl: blobUrl },
       });
+      // Same order as in the discover phase, and the reason the re-crop is
+      // visible at all: the old blob is only dropped once nothing points at it.
+      await deleteCroppedPortrait(row.blobPhotoUrl);
       entry.blobUrl = blobUrl;
     }
 

--- a/src/lib/photos/__tests__/blob.test.ts
+++ b/src/lib/photos/__tests__/blob.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const del = vi.fn();
+const put = vi.fn();
+
+vi.mock("@vercel/blob", () => ({
+  del: (...args: unknown[]) => del(...args),
+  put: (...args: unknown[]) => put(...args),
+}));
+
+const { uploadCroppedPortrait, deleteCroppedPortrait } = await import("../blob");
+
+const BLOB_HOST = "https://example.public.blob.vercel-storage.com";
+
+beforeEach(() => {
+  del.mockReset();
+  put.mockReset();
+  put.mockResolvedValue({ url: `${BLOB_HOST}/politicians/abc-portrait-Xy7.jpg` });
+});
+
+describe("uploadCroppedPortrait", () => {
+  it("uploads to a fresh pathname rather than overwriting", async () => {
+    // Blob serves portraits with a thirty-day max-age and the URL is the only cache
+    // key. Overwriting a fixed pathname shipped a corrected framing that nobody saw.
+    await uploadCroppedPortrait("abc", Buffer.from("jpeg"));
+
+    expect(put).toHaveBeenCalledTimes(1);
+    const options = put.mock.calls[0]![2] as Record<string, unknown>;
+    expect(options.addRandomSuffix).toBe(true);
+    expect(options.allowOverwrite).toBeUndefined();
+  });
+
+  it("keeps the -portrait marker, which is what identifies a derived image", async () => {
+    await uploadCroppedPortrait("abc", Buffer.from("jpeg"));
+    expect(put.mock.calls[0]![0]).toBe("politicians/abc-portrait");
+  });
+});
+
+describe("deleteCroppedPortrait", () => {
+  it("deletes a portrait we uploaded", async () => {
+    await expect(
+      deleteCroppedPortrait(`${BLOB_HOST}/politicians/abc-portrait-Xy7.jpg`)
+    ).resolves.toBe(true);
+    expect(del).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    // The raw cached copy the image proxy writes, still served by other code.
+    `${BLOB_HOST}/politicians/abc`,
+    // An upstream URL that is not ours at all.
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/a/b/Foo.jpg/500px-Foo.jpg",
+    "",
+  ])("refuses to delete %s", async (url) => {
+    await expect(deleteCroppedPortrait(url)).resolves.toBe(false);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it("refuses a null or undefined url", async () => {
+    await expect(deleteCroppedPortrait(null)).resolves.toBe(false);
+    await expect(deleteCroppedPortrait(undefined)).resolves.toBe(false);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it("swallows a deletion failure: an orphan must not abort a run", async () => {
+    del.mockRejectedValueOnce(new Error("blob store unreachable"));
+    await expect(
+      deleteCroppedPortrait(`${BLOB_HOST}/politicians/abc-portrait-Xy7.jpg`)
+    ).resolves.toBe(false);
+  });
+});

--- a/src/lib/photos/blob.ts
+++ b/src/lib/photos/blob.ts
@@ -1,18 +1,49 @@
-import { put } from "@vercel/blob";
+import { put, del } from "@vercel/blob";
 
 /**
- * Store a cropped portrait on Vercel Blob.
+ * Store a cropped portrait on Vercel Blob, at a URL that has never been served
+ * before.
  *
- * The `-portrait` suffix keeps these apart from the raw copies that
+ * The `-portrait` marker keeps these apart from the raw copies that
  * `/api/images/[id]` writes under `politicians/{id}`, so a cropped portrait is
  * identifiable from its URL alone and no extra column is needed to record that
  * the image is derived.
+ *
+ * `addRandomSuffix` is what makes a re-crop visible. Blob serves these files
+ * with `cache-control: public, max-age=2592000`, so overwriting a fixed key left
+ * the old bytes in the CDN and in browsers for up to thirty days: the URL was
+ * unchanged, and nothing told anyone to fetch it again. A corrected framing would
+ * have shipped and simply not appeared. A fresh pathname each time sidesteps the
+ * question entirely — there is no cache entry to invalidate.
+ *
+ * The caller owns the swap order: upload, write the new URL to the database, then
+ * drop the old blob. Failing on the last step leaves an orphan, which costs a few
+ * kilobytes; failing on any other order would leave a politician pointing at bytes
+ * that no longer exist.
  */
 export async function uploadCroppedPortrait(politicianId: string, buffer: Buffer): Promise<string> {
   const { url } = await put(`politicians/${politicianId}-portrait`, buffer, {
     access: "public",
     contentType: "image/jpeg",
-    allowOverwrite: true,
+    addRandomSuffix: true,
   });
   return url;
+}
+
+/**
+ * Delete a portrait we previously uploaded, once nothing points at it any more.
+ *
+ * Guarded on the `-portrait` marker: `blobPhotoUrl` may also hold a raw cached
+ * copy written by the image proxy, which other code still serves, and an external
+ * URL entirely. Deleting either would break a live image. Failure is swallowed on
+ * purpose — an orphaned blob is not worth aborting a run over.
+ */
+export async function deleteCroppedPortrait(url: string | null | undefined): Promise<boolean> {
+  if (!url || !url.includes("-portrait")) return false;
+  try {
+    await del(url);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Suite directe de #682. Le correctif de cadrage était juste, mais il n'aurait rien changé à l'écran.

## Le problème

`uploadCroppedPortrait` écrivait sur un chemin fixe, `politicians/{id}-portrait`, avec `allowOverwrite`. L'URL ne changeait donc jamais.

Or Blob sert ces fichiers ainsi, mesuré sur le portrait de Jean-Luc Mélenchon en production :

```
cache-control: public, max-age=2592000
x-vercel-cache: HIT
```

Trente jours, et l'URL est la seule clé de cache. On aurait republié 57 portraits corrigés, mis à jour la base, et le CDN comme les navigateurs auraient continué à servir les anciens octets pendant un mois, sans rien pour leur dire d'aller rechercher le fichier. Le recadrage aurait été livré et invisible.

## Le correctif

`addRandomSuffix: true`. Chaque upload produit un chemin qui n'a jamais été servi, donc il n'y a aucune entrée de cache à invalider. Le marqueur `-portrait` reste dans le nom, puisque c'est lui qui identifie une image dérivée sans colonne dédiée.

L'ancien blob est ensuite supprimé, **et seulement après** que la base pointe sur le nouveau. Un orphelin coûte quelques kilo-octets, une référence morte est un portrait cassé.

## La suppression est gardée

`blobPhotoUrl` ne contient pas toujours un recadrage. Il peut porter la copie brute écrite par le proxy d'images sous `politicians/{id}`, que d'autres pages servent encore, ou une URL externe. Supprimer l'un ou l'autre casserait une image en ligne, donc `deleteCroppedPortrait` exige le marqueur `-portrait` et échoue en silence sur tout le reste.

Prouvé par ablation : en retirant la garde, les deux cas dangereux passent à la suppression et les tests tombent.

Un échec de suppression est avalé volontairement. Perdre une campagne de 328 portraits parce qu'un `del` a échoué serait absurde.

## Vérifications

Suite `src/lib/photos` verte, 80 tests. `tsc` sans erreur sur les fichiers touchés, Prettier propre.

Mesuré sur un dry-run complet des 554 candidats, avec le correctif de #682 : **57 portraits changent de cadrage**, 271 restent identiques au pixel près, 0 nouveau. Les 243 issus de la détection de visage ne bougent pas, la branche qui les produit n'ayant pas changé. Les 57 passent tous à un carré ancré en haut, dont Christiane Taubira (480 → 0), Jean-Luc Mélenchon (419 → 0) et Sabrina Agresti-Roubache (321 → 0).
