### PR TITLE
Mettre en avant les élections dans le menu mobile et le footer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -33,8 +33,10 @@ export async function Footer() {
             <nav key={section.title} aria-labelledby={`footer-nav-${section.title}`}>
               <h3
                 id={`footer-nav-${section.title}`}
+                // `brand-on-surface`, not `brand`: measured on the footer surface in dark, the base
+                // token gives 4.21:1 at 14px, below AA. See globals.css.
                 className={`font-display font-semibold text-sm mb-3 ${
-                  section.highlight ? "text-brand" : ""
+                  section.highlight ? "text-brand-on-surface" : ""
                 }`}
               >
                 {section.title}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -18,7 +18,7 @@ export async function Footer() {
       <HexPattern className="absolute inset-0 text-primary opacity-[0.02] dark:opacity-[0.04] pointer-events-none" />
       <div className="relative z-10 container mx-auto px-4 py-8 md:py-10">
         {/* Main footer content */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-8 mb-8">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-8 mb-8">
           {/* About */}
           <div className="col-span-2 sm:col-span-3 lg:col-span-1">
             <h3 className="font-display font-semibold text-sm mb-3">À propos</h3>
@@ -28,12 +28,14 @@ export async function Footer() {
             </p>
           </div>
 
-          {/* Navigation sections (4 columns) */}
+          {/* Navigation sections (5 columns) */}
           {filteredSections.map((section) => (
             <nav key={section.title} aria-labelledby={`footer-nav-${section.title}`}>
               <h3
                 id={`footer-nav-${section.title}`}
-                className="font-display font-semibold text-sm mb-3"
+                className={`font-display font-semibold text-sm mb-3 ${
+                  section.highlight ? "text-brand" : ""
+                }`}
               >
                 {section.title}
               </h3>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { NavIconBar } from "./NavIconBar";
 import { NAV_PRIMARY, NAV_TOOLS } from "@/config/navigation";
 import { BarChart3, Users, Scale, Vote, Landmark, BookOpen, Compass } from "lucide-react";
 import { getEnabledFlags } from "@/lib/feature-flags";
+import { getPastElectionSlugs } from "@/lib/data/elections";
 import type { LucideIcon } from "lucide-react";
 
 const PRIMARY_ICONS: Record<string, LucideIcon> = {
@@ -18,7 +19,10 @@ const PRIMARY_ICONS: Record<string, LucideIcon> = {
 };
 
 export async function Header() {
-  const enabledFlags = await getEnabledFlags();
+  const [enabledFlags, pastElectionSlugs] = await Promise.all([
+    getEnabledFlags(),
+    getPastElectionSlugs(),
+  ]);
 
   const filteredPrimary = NAV_PRIMARY.filter(
     (item) => !item.featureFlag || enabledFlags.has(item.featureFlag)
@@ -80,7 +84,7 @@ export async function Header() {
           </nav>
 
           {/* Mobile navigation */}
-          <MobileMenu enabledFlags={[...enabledFlags]} />
+          <MobileMenu enabledFlags={[...enabledFlags]} pastElectionSlugs={pastElectionSlugs} />
         </div>
       </div>
     </header>

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCommandPalette } from "@/components/search";
 import { MobileThemeToggle } from "@/components/theme/MobileThemeToggle";
-import { NAV_PRIMARY, NAV_SECONDARY } from "@/config/navigation";
+import { NAV_ELECTIONS, NAV_PRIMARY, NAV_SECONDARY } from "@/config/navigation";
 import {
   BarChart3,
   Users,
@@ -67,6 +67,9 @@ export function MobileMenu({ enabledFlags }: MobileMenuProps) {
     (item) => !item.featureFlag || flagSet.has(item.featureFlag)
   );
   const filteredSecondary = NAV_SECONDARY.filter(
+    (item) => !item.featureFlag || flagSet.has(item.featureFlag)
+  );
+  const filteredElections = NAV_ELECTIONS.filter(
     (item) => !item.featureFlag || flagSet.has(item.featureFlag)
   );
 
@@ -192,6 +195,56 @@ export function MobileMenu({ enabledFlags }: MobileMenuProps) {
 
             {/* Primary links */}
             <nav className="flex-1 overflow-y-auto px-4 py-6" aria-label="Navigation principale">
+              {/* Elections surfaced above the rest: upcoming first, past last */}
+              {filteredElections.length > 0 && (
+                <section aria-labelledby="mobile-menu-elections" className="mb-6">
+                  <h2
+                    id="mobile-menu-elections"
+                    className="px-4 mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    Élections
+                  </h2>
+                  <ul className="space-y-1">
+                    {filteredElections.map((item) => {
+                      const Icon = item.icon ? ICON_MAP[item.icon] : null;
+                      const isActive =
+                        pathname === item.href || pathname.startsWith(item.href + "/");
+                      return (
+                        <li key={item.href}>
+                          <Link
+                            href={item.href}
+                            onClick={close}
+                            aria-current={isActive ? "page" : undefined}
+                            className={`flex items-center justify-between px-4 py-3.5 rounded-xl text-lg font-display font-semibold transition-colors ${
+                              item.past
+                                ? "text-foreground/60 hover:bg-muted hover:text-foreground"
+                                : "border border-primary/40 text-primary hover:bg-primary/5"
+                            }`}
+                          >
+                            <span className="flex items-center gap-3">
+                              {Icon && <Icon className="h-5 w-5" />}
+                              {item.label}
+                              {/* `muted-foreground-strong`: at 12px on --muted in dark, the base
+                                  token measures 3.83:1, below AA. See globals.css. */}
+                              <span
+                                className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                                  item.past
+                                    ? "bg-muted text-muted-foreground-strong"
+                                    : "bg-primary/15 text-primary"
+                                }`}
+                              >
+                                {item.past ? "Passée" : "À venir"}
+                              </span>
+                            </span>
+                            <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              )}
+
               <ul className="space-y-1">
                 {filteredPrimary.map((item) => {
                   const Icon = item.icon ? ICON_MAP[item.icon] : null;

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -53,9 +53,11 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
 
 interface MobileMenuProps {
   enabledFlags: string[];
+  /** Slugs of the NAV_ELECTIONS whose ballot has been held, resolved server-side */
+  pastElectionSlugs: string[];
 }
 
-export function MobileMenu({ enabledFlags }: MobileMenuProps) {
+export function MobileMenu({ enabledFlags, pastElectionSlugs }: MobileMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
@@ -69,9 +71,11 @@ export function MobileMenu({ enabledFlags }: MobileMenuProps) {
   const filteredSecondary = NAV_SECONDARY.filter(
     (item) => !item.featureFlag || flagSet.has(item.featureFlag)
   );
+  // Upcoming first, held ones after, each group keeping its NAV_ELECTIONS order
+  const pastSlugs = new Set(pastElectionSlugs);
   const filteredElections = NAV_ELECTIONS.filter(
     (item) => !item.featureFlag || flagSet.has(item.featureFlag)
-  );
+  ).sort((a, b) => Number(pastSlugs.has(a.slug)) - Number(pastSlugs.has(b.slug)));
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -209,34 +213,35 @@ export function MobileMenu({ enabledFlags }: MobileMenuProps) {
                       const Icon = item.icon ? ICON_MAP[item.icon] : null;
                       const isActive =
                         pathname === item.href || pathname.startsWith(item.href + "/");
+                      const isPast = pastSlugs.has(item.slug);
                       return (
                         <li key={item.href}>
                           <Link
                             href={item.href}
                             onClick={close}
                             aria-current={isActive ? "page" : undefined}
-                            className={`flex items-center justify-between px-4 py-3.5 rounded-xl text-lg font-display font-semibold transition-colors ${
-                              item.past
+                            className={`flex items-center justify-between gap-2 px-4 py-3.5 rounded-xl text-lg font-display font-semibold transition-colors ${
+                              isPast
                                 ? "text-foreground/60 hover:bg-muted hover:text-foreground"
                                 : "border border-primary/40 text-primary hover:bg-primary/5"
                             }`}
                           >
-                            <span className="flex items-center gap-3">
-                              {Icon && <Icon className="h-5 w-5" />}
+                            <span className="flex items-center gap-3 min-w-0">
+                              {Icon && <Icon className="h-5 w-5 shrink-0" />}
                               {item.label}
                               {/* `muted-foreground-strong`: at 12px on --muted in dark, the base
                                   token measures 3.83:1, below AA. See globals.css. */}
                               <span
-                                className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                                  item.past
+                                className={`shrink-0 whitespace-nowrap text-xs font-medium px-2 py-0.5 rounded-full ${
+                                  isPast
                                     ? "bg-muted text-muted-foreground-strong"
                                     : "bg-primary/15 text-primary"
                                 }`}
                               >
-                                {item.past ? "Passée" : "À venir"}
+                                {isPast ? "Passée" : "À venir"}
                               </span>
                             </span>
-                            <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                            <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
                           </Link>
                         </li>
                       );

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -341,10 +341,12 @@ export function MobileMenu({ enabledFlags, pastElectionSlugs }: MobileMenuProps)
               )}
             </nav>
 
-            {/* Bottom section: theme toggle + boussole + CTA */}
+            {/* Bottom section: theme toggle + boussole + CTA.
+                Wraps: the three pills measure 405px side by side, which overflows every viewport
+                narrower than that, 320px included (WCAG 1.4.10). */}
             <div className="px-4 py-6 border-t border-border">
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <MobileThemeToggle />
                   {enabledFlags.includes("BOUSSOLE_ENABLED") && (
                     <a

--- a/src/config/__tests__/navigation-presidentielle.test.ts
+++ b/src/config/__tests__/navigation-presidentielle.test.ts
@@ -1,10 +1,44 @@
 import { describe, it, expect } from "vitest";
-import { NAV_SECONDARY } from "@/config/navigation";
+import { FOOTER_SECTIONS, NAV_ELECTIONS, NAV_SECONDARY } from "@/config/navigation";
 
-describe("nav hub présidentielle", () => {
-  it("points at the hub", () => {
-    const e = NAV_SECONDARY.find((i) => i.href === "/elections/presidentielle-2027");
+const HUB = "/elections/presidentielle-2027";
+const SENATORIALES = "/elections/senatoriales-2026";
+const MUNICIPALES = "/elections/municipales-2026";
+
+const footerHrefs = FOOTER_SECTIONS.flatMap((s) => s.links.map((l) => l.href));
+
+describe("nav élections", () => {
+  it("points at the presidential hub", () => {
+    const e = NAV_ELECTIONS.find((i) => i.href === HUB);
     expect(e).toBeDefined();
     expect(e?.label).toBe("Présidentielle 2027");
+  });
+
+  it("points at the 2026 senatorial election", () => {
+    const e = NAV_ELECTIONS.find((i) => i.href === SENATORIALES);
+    expect(e).toBeDefined();
+    expect(e?.label).toBe("Sénatoriales 2026");
+  });
+
+  it("lists upcoming elections before past ones", () => {
+    const firstPast = NAV_ELECTIONS.findIndex((i) => i.past);
+    const lastUpcoming = NAV_ELECTIONS.map((i) => Boolean(i.past)).lastIndexOf(false);
+    expect(firstPast).toBeGreaterThan(lastUpcoming);
+  });
+
+  it("marks the 2026 municipal election as past", () => {
+    expect(NAV_ELECTIONS.find((i) => i.href === MUNICIPALES)?.past).toBe(true);
+  });
+
+  it("surfaces every election in the footer", () => {
+    for (const item of NAV_ELECTIONS) {
+      expect(footerHrefs).toContain(item.href);
+    }
+  });
+
+  it("does not duplicate elections in the secondary pills", () => {
+    const electionHrefs = new Set(NAV_ELECTIONS.map((i) => i.href));
+    const duplicated = NAV_SECONDARY.filter((i) => electionHrefs.has(i.href));
+    expect(duplicated).toEqual([]);
   });
 });

--- a/src/config/__tests__/navigation-presidentielle.test.ts
+++ b/src/config/__tests__/navigation-presidentielle.test.ts
@@ -3,7 +3,6 @@ import { FOOTER_SECTIONS, NAV_ELECTIONS, NAV_SECONDARY } from "@/config/navigati
 
 const HUB = "/elections/presidentielle-2027";
 const SENATORIALES = "/elections/senatoriales-2026";
-const MUNICIPALES = "/elections/municipales-2026";
 
 const footerHrefs = FOOTER_SECTIONS.flatMap((s) => s.links.map((l) => l.href));
 
@@ -20,14 +19,22 @@ describe("nav élections", () => {
     expect(e?.label).toBe("Sénatoriales 2026");
   });
 
-  it("lists upcoming elections before past ones", () => {
-    const firstPast = NAV_ELECTIONS.findIndex((i) => i.past);
-    const lastUpcoming = NAV_ELECTIONS.map((i) => Boolean(i.past)).lastIndexOf(false);
-    expect(firstPast).toBeGreaterThan(lastUpcoming);
+  /**
+   * `getPastElectionSlugs` queries Election.slug with these values. A slug that does not match its
+   * own href matches no row, so the entry would silently stay "À venir" forever: the exact failure
+   * the database lookup exists to prevent.
+   */
+  it("keeps each slug in step with its href", () => {
+    for (const item of NAV_ELECTIONS) {
+      expect(item.href).toBe(`/elections/${item.slug}`);
+    }
   });
 
-  it("marks the 2026 municipal election as past", () => {
-    expect(NAV_ELECTIONS.find((i) => i.href === MUNICIPALES)?.past).toBe(true);
+  it("carries no hardcoded temporal state", () => {
+    for (const item of NAV_ELECTIONS) {
+      expect(item).not.toHaveProperty("past");
+      expect(item).not.toHaveProperty("when");
+    }
   });
 
   it("surfaces every election in the footer", () => {

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -98,13 +98,6 @@ export const NAV_SECONDARY: NavItem[] = [
     description: "Catalogue documenté des procédures-bâillons (SLAPP) en France",
   },
   {
-    href: "/elections/municipales-2026",
-    label: "Municipales 2026",
-    icon: "vote",
-    description: "Candidats, listes et résultats dans votre commune",
-    featureFlag: "MUNICIPALES_2026",
-  },
-  {
     href: "https://boussole.poligraph.fr",
     label: "Boussole",
     icon: "compass",
@@ -112,11 +105,36 @@ export const NAV_SECONDARY: NavItem[] = [
     external: true,
     featureFlag: "BOUSSOLE_ENABLED",
   },
+];
+
+export interface ElectionNavItem extends NavItem {
+  /** Election already held: listed after the upcoming ones, in a muted style */
+  past?: boolean;
+}
+
+// Elections surfaced ahead of the rest of the navigation, in the mobile menu
+// and in the footer. Upcoming first, past last. No date is rendered: the
+// presidential dates are not confirmed yet (Election.dateConfirmed).
+export const NAV_ELECTIONS: ElectionNavItem[] = [
+  {
+    href: "/elections/senatoriales-2026",
+    label: "Sénatoriales 2026",
+    icon: "landmark",
+    description: "178 sièges renouvelés au suffrage indirect",
+  },
   {
     href: "/elections/presidentielle-2027",
     label: "Présidentielle 2027",
     icon: "vote",
-    description: "Candidats et positions pour l'élection présidentielle",
+    description: "Candidatures, mesures et votes",
+  },
+  {
+    href: "/elections/municipales-2026",
+    label: "Municipales 2026",
+    icon: "mapPin",
+    description: "Résultats commune par commune",
+    past: true,
+    featureFlag: "MUNICIPALES_2026",
   },
 ];
 
@@ -165,9 +183,11 @@ export const CTA_MON_DEPUTE: NavItem = {
 export const CHAT_LINK = CTA_ASSISTANT;
 export const CTA_LINK = CTA_MON_DEPUTE;
 
-// Footer navigation (4 columns)
+// Footer navigation (5 columns)
 export interface FooterSection {
   title: string;
+  /** If true, the section heading is rendered in the accent colour */
+  highlight?: boolean;
   links: Array<{
     href: string;
     label: string;
@@ -178,17 +198,19 @@ export interface FooterSection {
 
 export const FOOTER_SECTIONS: FooterSection[] = [
   {
+    title: "Élections",
+    highlight: true,
+    links: [
+      ...NAV_ELECTIONS.map(({ href, label, featureFlag }) => ({ href, label, featureFlag })),
+      { href: "/elections", label: "Toutes les élections" },
+    ],
+  },
+  {
     title: "Représentants",
     links: [
       { href: "/politiques", label: "Tous les représentants" },
       { href: "/partis", label: "Partis politiques" },
       { href: "/affaires", label: "Affaires judiciaires" },
-      { href: "/elections", label: "Élections" },
-      {
-        href: "/elections/municipales-2026",
-        label: "Municipales 2026",
-        featureFlag: "MUNICIPALES_2026",
-      },
       { href: "/mon-depute", label: "Mon député", featureFlag: "MON_DEPUTE_SECTION" },
       { href: "/comparer", label: "Comparer", featureFlag: "COMPARISON_TOOL" },
       { href: "/factchecks", label: "Fact-checks" },

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -108,32 +108,39 @@ export const NAV_SECONDARY: NavItem[] = [
 ];
 
 export interface ElectionNavItem extends NavItem {
-  /** Election already held: listed after the upcoming ones, in a muted style */
-  past?: boolean;
+  /** Election.slug, so the renderer can ask the database whether the ballot has been held */
+  slug: string;
 }
 
-// Elections surfaced ahead of the rest of the navigation, in the mobile menu
-// and in the footer. Upcoming first, past last. No date is rendered: the
-// presidential dates are not confirmed yet (Election.dateConfirmed).
+// Elections surfaced ahead of the rest of the navigation, in the mobile menu and in the footer.
+//
+// Whether an election is over is NOT written here. A boolean in this file would still read
+// "À venir" the morning after the vote, until someone deploys. The renderer resolves it from
+// Election.round1Date / round2Date through `isElectionOver`, which is the same read-time
+// derivation the homepage banner uses. See src/lib/elections/status.ts.
+//
+// No date is rendered either: the presidential dates carry dateConfirmed = false.
 export const NAV_ELECTIONS: ElectionNavItem[] = [
   {
     href: "/elections/senatoriales-2026",
+    slug: "senatoriales-2026",
     label: "Sénatoriales 2026",
     icon: "landmark",
     description: "178 sièges renouvelés au suffrage indirect",
   },
   {
     href: "/elections/presidentielle-2027",
+    slug: "presidentielle-2027",
     label: "Présidentielle 2027",
     icon: "vote",
     description: "Candidatures, mesures et votes",
   },
   {
     href: "/elections/municipales-2026",
+    slug: "municipales-2026",
     label: "Municipales 2026",
     icon: "mapPin",
     description: "Résultats commune par commune",
-    past: true,
     featureFlag: "MUNICIPALES_2026",
   },
 ];

--- a/src/lib/data/__tests__/past-election-slugs-cache.test.ts
+++ b/src/lib/data/__tests__/past-election-slugs-cache.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * `getPastElectionSlugs` answers a question the clock can change on its own: an election flips from
+ * "À venir" to "Passée" on polling day, with no database write behind it. Nothing purges the
+ * "elections" tag that day either, since the daily sync revalidates "votes" alone.
+ *
+ * So its cache profile is load-bearing. Under `synced` (revalidate 86 400 s) the mobile menu would
+ * keep announcing a ballot that has already been held, for up to a day. `hours` (revalidate 3 600 s)
+ * is what `src/lib/cache.ts` designates as ELECTION_PROFILE, and what
+ * `revalidateTag("elections", …)` already passes on the purge side.
+ *
+ * Read from source rather than executed: `cacheLife` is a Next compiler directive with no runtime
+ * value to assert. The regex is deliberately narrow, matching this one function's body.
+ */
+describe("getPastElectionSlugs cache policy", () => {
+  const source = readFileSync(resolve(__dirname, "../../../lib/data/elections.ts"), "utf-8");
+
+  const body = source.slice(
+    source.indexOf("export async function getPastElectionSlugs"),
+    source.indexOf("export async function loadFeaturedElection")
+  );
+
+  it("finds the function it is guarding", () => {
+    expect(body).not.toBe("");
+    expect(body).toContain("isElectionOver");
+  });
+
+  it("caches on the election profile, not the daily one", () => {
+    expect(body).toMatch(/cacheLife\(\s*"hours"\s*\)/);
+    expect(body).not.toMatch(/cacheLife\(\s*"synced"\s*\)/);
+  });
+
+  it("stays purgeable through the elections tag", () => {
+    expect(body).toMatch(/cacheTag\(\s*"elections"/);
+  });
+});

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -523,11 +523,16 @@ export async function getUpcomingElections() {
  * reading "À venir" the morning after the vote until someone deploys. Same read-time derivation as
  * the homepage banner: the stored `status` is only advanced by the candidacy sync, so the round
  * dates are what actually prove the ballot happened.
+ *
+ * `hours`, not `synced`: this answer flips on the clock, not only on a database write. Nothing
+ * purges the "elections" tag on polling day (the daily sync revalidates "votes" alone), so with
+ * `synced` the menu would keep saying "À venir" for up to 24 h after the ballot. `hours` is also
+ * the profile `revalidateTag("elections", ELECTION_PROFILE)` already passes on the purge side.
  */
 export async function getPastElectionSlugs(): Promise<string[]> {
   "use cache";
   cacheTag("elections");
-  cacheLife("synced");
+  cacheLife("hours");
 
   const rows = await db.election.findMany({
     where: { slug: { in: NAV_ELECTIONS.map((item) => item.slug) } },

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -4,6 +4,8 @@ import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import type { ElectionType } from "@/types";
 import type { ElectionRoundScore } from "@/lib/elections/banner-state";
+import { isElectionOver } from "@/lib/elections/status";
+import { NAV_ELECTIONS } from "@/config/navigation";
 
 // ============================================
 // Types
@@ -508,6 +510,31 @@ export async function getUpcomingElections() {
     orderBy: { round1Date: "asc" },
     take: 4,
   });
+}
+
+// ============================================
+// 5a. getPastElectionSlugs — for the navigation
+// ============================================
+
+/**
+ * Slugs, among the elections surfaced in the navigation, whose ballot has been held.
+ *
+ * Resolved here rather than written in `NAV_ELECTIONS` because a boolean in the config would keep
+ * reading "À venir" the morning after the vote until someone deploys. Same read-time derivation as
+ * the homepage banner: the stored `status` is only advanced by the candidacy sync, so the round
+ * dates are what actually prove the ballot happened.
+ */
+export async function getPastElectionSlugs(): Promise<string[]> {
+  "use cache";
+  cacheTag("elections");
+  cacheLife("synced");
+
+  const rows = await db.election.findMany({
+    where: { slug: { in: NAV_ELECTIONS.map((item) => item.slug) } },
+    select: { slug: true, status: true, round1Date: true, round2Date: true },
+  });
+
+  return rows.filter((election) => isElectionOver(election)).map((election) => election.slug);
 }
 
 // ============================================


### PR DESCRIPTION
## Pourquoi

Les sénatoriales du 27 septembre 2026 n'étaient référencées **nulle part** dans la navigation : ni `NAV_PRIMARY`, ni `NAV_SECONDARY`, ni `FOOTER_SECTIONS`. La page `/elections/senatoriales-2026` était en ligne mais atteignable seulement en passant par `/elections`.

Le hub présidentielle, lui, n'était qu'une pastille parmi neuf dans le menu mobile, et absent du footer.

## Ce que fait la PR

**Une constante, `NAV_ELECTIONS`**, qui porte le libellé, l'icône et le `slug` de chaque scrutin mis en avant. Elle ne porte **aucune information temporelle** : ni date, ni booléen « passée ».

**L'état « À venir » / « Passée » est dérivé côté serveur.** `getPastElectionSlugs()` lit les lignes `Election` correspondantes et appelle `isElectionOver()`, la dérivation que le projet utilise déjà pour le bandeau d'accueil. `Header` la résout et passe les slugs au menu. Un booléen écrit en config aurait continué d'afficher « À venir » le lendemain du scrutin, jusqu'au déploiement suivant.

Le profil de cache est `hours`, pas `synced`. Cette réponse bascule avec l'horloge et pas seulement sur une écriture en base, or rien ne purge le tag `elections` le jour du vote : `sync-daily.ts:233` ne revalide que `votes`. Sous `synced` (revalidation 86 400 s) le menu aurait pu annoncer pendant 24 h un scrutin déjà tenu. `hours` (3 600 s) est aussi le profil que `revalidateTag("elections", ELECTION_PROFILE)` passe déjà côté purge : les deux côtés se parlent enfin.

**Menu mobile** : bloc « Élections » avant les liens primaires. Les scrutins à venir sont encadrés en `primary` avec une puce « À venir », les scrutins tenus passent dessous, en retrait, avec « Passée ». Le tri suit la dérivation, sans intervention.

**Footer** : colonne « Élections » en première position, intitulé en `brand-on-surface`. `/elections` et les municipales sortent de « Représentants », où elles étaient mal rangées.

**Bas du menu mobile** : les trois pastilles (thème, Boussole, Nous soutenir) mesuraient 405 px côte à côte, sans `flex-wrap`. « Nous soutenir » sortait donc de l'écran dès 390 px, et de 85 px à 320 px. Défaut antérieur à cette PR, trouvé par le contrôle 320 px demandé en revue, corrigé ici.

## Vérifications

Mesuré au navigateur, pas estimé.

### Débordement horizontal

Le menu est `fixed inset-0`, donc `document.documentElement.scrollWidth` ne dit rien de son contenu : c'est le conteneur qu'il faut mesurer. `#mobile-menu`, `scrollWidth` / `clientWidth`, clair et sombre :

| Viewport | Avant | Après | Descendants hors cadre | « Nous soutenir » entier |
|---|---|---|---|---|
| 320 px | 405 / 320 | 320 / 320 | 0 | oui |
| 390 px | 405 / 390 | 390 / 390 | 0 | oui |
| 430 px | 405 / 430 | 430 / 430 | 0 | oui |

### Contrastes, clair puis sombre

Bloc « Élections » du menu :

| | clair | sombre |
|---|---|---|
| Lignes à venir | 14,67:1 | 6,02:1 |
| Ligne passée | 5,04:1 | 6,41:1 |
| Puce « À venir » | 10,86:1 | 5,04:1 |
| Puce « Passée » | 7,08:1 | 5,25:1 |

Deux jetons ont été corrigés après mesure, tous deux documentés dans `globals.css` pour ce cas précis :

- la puce « Passée » mesurait **3,83:1** en sombre avec `muted-foreground` ; `muted-foreground-strong` la remonte à 5,25:1 ;
- le titre « Élections » du footer mesurait **4,21:1** en sombre avec `brand` ; `brand-on-surface` le remonte à 5,38:1 (4,98:1 en clair, inchangé).

### Footer

| Viewport | Colonnes | Largeur de colonne | Liens coupés sur 2 lignes | Hors cadre |
|---|---|---|---|---|
| 1024 px | 4 | 224 px | 0 / 28 | 0 |
| 1440 px | 7 | 151 px | 2 / 28 | 0 |

Une première version passait à 7 colonnes dès `lg` : 14 liens sur 28 se coupaient à 1024 px. D'où `lg:grid-cols-4 xl:grid-cols-7`.

### Tests

`npx tsc --noEmit` propre, `npm run format:check` propre, `eslint src` sans erreur, `npx vitest run` : **3816 tests passent**.

Le test de garde `navigation-presidentielle` passe de l'implémentation (« est dans `NAV_SECONDARY` ») à l'invariant : présence des deux scrutins, `slug` en phase avec son `href`, absence de toute propriété temporelle en dur, présence dans le footer, absence de doublon dans les pastilles.

Un second garde couvre la politique de cache de `getPastElectionSlugs`. Il a été vérifié en cassant volontairement l'invariant : il échoue bien, et repasse une fois la source restaurée.

## Hors périmètre, signalé

**Le document déborde de 100 px à 1024 px**, dans les deux thèmes : `scrollWidth` 1124 pour un `clientWidth` de 1024. Le coupable est l'en-tête desktop (`nav.hidden lg:flex` et le rail d'icônes), pas le footer, qui ne présente aucun descendant hors cadre. Antérieur à cette PR : le diff de `Header.tsx` ici se limite à un import, un `Promise.all` et le passage d'un prop, la nav desktop n'est pas touchée. À traiter séparément.

**`getUpcomingElections` est en `cacheLife("synced")`** alors qu'il porte `cacheTag("elections")`, purgé avec le profil `hours`. Même désaccord que celui corrigé ici, sur une fonction que cette PR ne touche pas.

## Coordination

Développé dans un worktree isolé, une session voisine travaillant en parallèle sur le hub présidentielle. Branche à jour avec `main` par merge, sans conflit : les 13 fichiers apportés par #687 sont identiques à `origin/main` dans cette branche.
