### PR TITLE
Nommer les destinations et montrer toutes les mesures

### DIFF
--- a/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronRight, ExternalLink, Search } from "lucide-react";
+import { ExternalLink, Search } from "lucide-react";
 import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
 import { getAccessibleTextColor } from "@/lib/contrast";
 import type { HubCandidacy } from "@/lib/data/hub";
@@ -20,15 +20,18 @@ import {
  *
  * Twenty-five homogeneous entries are a table, not a stack of cards: the old cards spent ~190px
  * each on repeating the same badge and the same "Fiche PoliGraph" button, and showed none of our
- * own work. Each row now carries what we have on that candidacy, and the row itself is the link.
+ * own work. Each row now carries what we have on that candidacy.
+ *
+ * The row is NOT itself a link any more, and that is the point of `RowLinks`: it led to a page that
+ * silently redirects elsewhere for half the field, so one gesture had two destinations and named
+ * neither.
  *
  * A client component, deliberately. Filtering through `searchParams` on the server would make the
  * hub page dynamic and cost it its ISR; the whole field is twenty-five rows already in the payload,
  * so it filters here and writes the URL back for shareability. The rows are still server-rendered.
  *
- * NOT a `<table>`: the row is one link, and a link cannot wrap a `<tr>`. Every cell therefore says
- * its own unit ("12 mesures dépouillées", "8 sujets sur 13") so a screen reader needs no column
- * header to read it, and the visual header row is decorative.
+ * NOT a `<table>`: every cell says its own unit ("12 mesures documentées", "8 sujets sur 13") so a
+ * screen reader needs no column header to read it, and the visual header row is decorative.
  */
 
 const TOTAL_THEMES = 13;
@@ -86,8 +89,13 @@ function PartyMark({ candidacy }: { candidacy: HubCandidacy }) {
  * What we have on this candidacy, and when we have nothing, why.
  *
  * The zero case is two different facts and gets two different sentences. "Aucun programme publié"
- * is about the candidacy; "Programme publié, pas encore dépouillé" is about our own backlog. Saying
+ * is about the candidacy; "Programme publié, pas encore documenté" is about our own backlog. Saying
  * the first when the second is true would blame a candidate for our delay.
+ *
+ * "Documenté" rather than "dépouillé" throughout, and the reason is specific to this site: on a
+ * page about an election, dépouillement is what happens to ballots. The word sent the reader to the
+ * count, not to the reading of a programme. It was also the minority term — the fiche and the hub
+ * cards already said "documentées" — so one screen contradicted the next.
  */
 function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
   if (candidacy.measureCount === 0) {
@@ -97,7 +105,7 @@ function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
         className="block text-xs leading-snug text-muted-foreground"
       >
         {candidacy.programmeAbsence === "non_depouille"
-          ? "Programme publié, pas encore dépouillé"
+          ? "Programme publié, pas encore documenté"
           : "Aucun programme publié à ce jour"}
       </span>
     );
@@ -107,7 +115,7 @@ function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
     <span className="block leading-tight">
       <span className="font-display text-lg font-extrabold">{candidacy.measureCount}</span>{" "}
       <span className="text-xs text-muted-foreground">
-        {candidacy.measureCount === 1 ? "mesure dépouillée" : "mesures dépouillées"}
+        {candidacy.measureCount === 1 ? "mesure documentée" : "mesures documentées"}
       </span>
       <span className="mt-0.5 block text-xs text-muted-foreground">
         {candidacy.themesCoveredCount} sur {TOTAL_THEMES} sujets
@@ -144,13 +152,53 @@ function SourceLink({ candidacy }: { candidacy: HubCandidacy }) {
   );
 }
 
+/**
+ * The two destinations a row leads to, named rather than guessed.
+ *
+ * There used to be one link on the name, pointing at the candidacy fiche. That page
+ * redirects to the politician's fiche when it has no verified measure, so the same
+ * gesture landed on two different pages depending on a rule the reader cannot see, and
+ * said nothing about it. Naming both destinations costs one line and removes the
+ * surprise entirely.
+ *
+ * The unavailable case is stated, not hidden: "fiche de candidature à venir" tells the
+ * reader the page exists as an intention and is not ready, which is true, instead of
+ * quietly dropping them somewhere else.
+ */
+function RowLinks({ candidacy }: { candidacy: HubCandidacy }) {
+  if (candidacy.politicianSlug === null) return null;
+
+  return (
+    <span className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+      {candidacy.ficheAvailable ? (
+        <Link
+          href={`/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`}
+          prefetch={false}
+          className="inline-flex min-h-[32px] items-center font-bold text-primary hover:underline"
+        >
+          Sa candidature
+          <span className="sr-only"> pour la présidentielle 2027, {candidacy.candidateName}</span>
+        </Link>
+      ) : (
+        <span className="inline-flex min-h-[32px] items-center text-muted-foreground">
+          Fiche de candidature à venir
+        </span>
+      )}
+      <Link
+        href={`/politiques/${candidacy.politicianSlug}`}
+        prefetch={false}
+        className="inline-flex min-h-[32px] items-center text-muted-foreground hover:text-foreground hover:underline"
+      >
+        Sa fiche Poligraph
+        <span className="sr-only">, {candidacy.candidateName}</span>
+      </Link>
+    </span>
+  );
+}
+
 function CandidacyRow({ candidacy }: { candidacy: HubCandidacy }) {
   const isRetiree = candidacy.status === "RETIRE";
   const statusLabel = candidacy.status === null ? null : CANDIDACY_STATUS_LABELS[candidacy.status];
-  const href =
-    candidacy.politicianSlug !== null
-      ? `/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`
-      : null;
 
   const identity = (
     <span className="flex min-w-0 flex-1 items-center gap-3">
@@ -184,15 +232,13 @@ function CandidacyRow({ candidacy }: { candidacy: HubCandidacy }) {
 
   return (
     <li className="border-b border-border/60 last:border-b-0">
-      <div className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40 lg:gap-5">
-        {href !== null ? (
-          <Link href={href} prefetch={false} className="flex min-w-0 flex-1 items-center gap-3">
-            {identity}
-            <span className="sr-only">, voir la fiche</span>
-          </Link>
-        ) : (
-          identity
-        )}
+      <div className="flex items-start gap-3 px-4 pt-3 lg:items-center lg:gap-5 lg:py-3">
+        <span className="flex min-w-0 flex-1 flex-col gap-1">
+          {identity}
+          <span className="lg:hidden">
+            <RowLinks candidacy={candidacy} />
+          </span>
+        </span>
 
         <span className="hidden w-[168px] shrink-0 lg:block">
           <MeasureCell candidacy={candidacy} />
@@ -202,12 +248,9 @@ function CandidacyRow({ candidacy }: { candidacy: HubCandidacy }) {
           <SourceLink candidacy={candidacy} />
         </span>
 
-        {href !== null && (
-          <ChevronRight
-            aria-hidden="true"
-            className="hidden h-4 w-4 shrink-0 text-muted-foreground lg:block"
-          />
-        )}
+        <span className="hidden w-[190px] shrink-0 lg:block">
+          <RowLinks candidacy={candidacy} />
+        </span>
       </div>
 
       {/* Below lg the two columns fold under the name rather than shrinking. The source folds with
@@ -311,9 +354,9 @@ export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandida
         className="hidden items-center gap-5 border-b border-border bg-muted/50 px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider text-muted-foreground lg:flex"
       >
         <span className="min-w-0 flex-1">Candidature</span>
-        <span className="w-[168px] shrink-0">Ce que nous avons dépouillé</span>
+        <span className="w-[168px] shrink-0">Ce que nous avons documenté</span>
         <span className="w-[220px] shrink-0">Source de la candidature</span>
-        <span className="w-4 shrink-0" />
+        <span className="w-[190px] shrink-0">Où aller</span>
       </div>
 
       {visible.length === 0 ? (

--- a/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubEntryCards.tsx
@@ -36,7 +36,7 @@ export function HubEntryCards() {
           <Card className="min-h-[72px] flex-row items-center gap-3 border-l-4 border-l-brand p-4 transition-colors hover:bg-muted/40">
             <div className="min-w-0 flex-1">
               <p className="font-display text-base font-bold leading-tight">
-                Chercher une personne
+                Partir d&apos;une candidature
               </p>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 Les candidatures sourcées, avec leur statut et leur origine.
@@ -77,7 +77,7 @@ export function HubEntryCards() {
           <Card className="h-full min-h-[200px] cursor-pointer border-t-4 border-t-brand transition-all hover:-translate-y-0.5 hover:shadow-md">
             <CardContent className="flex h-full flex-col gap-3">
               <h3 className="font-display text-xl font-bold tracking-tight">
-                Chercher une personne
+                Partir d&apos;une candidature
               </h3>
               <p className="flex-1 text-sm text-muted-foreground">
                 Les candidatures sourcées, avec leur statut et leur origine.

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -18,12 +18,13 @@ function candidacy(over: Partial<HubCandidacy> = {}): HubCandidacy {
     measureCount: 0,
     themesCoveredCount: 0,
     programmeAbsence: "aucun_programme",
+    ficheAvailable: false,
     ...over,
   };
 }
 
 describe("HubCandidacyField", () => {
-  it("rend une ligne par candidature, avec son statut honnête et le lien vers sa fiche", () => {
+  it("rend une ligne par candidature, avec son statut honnête", () => {
     const candidacies: HubCandidacy[] = [
       candidacy({ id: "c1", candidateName: "Alix Dupont", politicianSlug: "alix-dupont" }),
       candidacy({
@@ -40,12 +41,43 @@ describe("HubCandidacyField", () => {
     expect(screen.getByText("Bruno Martin")).toBeInTheDocument();
     expect(screen.getByText("Candidature pressentie")).toBeInTheDocument();
     expect(screen.getByText("Candidature évoquée")).toBeInTheDocument();
+  });
 
-    // La route candidat existe depuis #679 et redirige vers /politiques/[slug] sous le seuil de
-    // publication, donc un seul href suffit pour les 25 lignes sans fabriquer de lien mort.
-    expect(screen.getByRole("link", { name: /Alix Dupont/ })).toHaveAttribute(
+  it("nomme les deux destinations quand la fiche de candidature existe", () => {
+    // La régression que ça verrouille : un lien unique sur le nom, vers une page qui redirige
+    // silencieusement vers /politiques/[slug] sous le seuil de publication. Le même geste menait
+    // à deux pages différentes selon une règle invisible, sans jamais dire laquelle.
+    render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({ politicianSlug: "alix-dupont", ficheAvailable: true, measureCount: 4 }),
+        ]}
+      />
+    );
+
+    expect(screen.getAllByRole("link", { name: /Sa candidature/ })[0]).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats/alix-dupont"
+    );
+    expect(screen.getAllByRole("link", { name: /Sa fiche Poligraph/ })[0]).toHaveAttribute(
+      "href",
+      "/politiques/alix-dupont"
+    );
+  });
+
+  it("annonce l'absence de fiche de candidature au lieu d'y mener quand même", () => {
+    render(
+      <HubCandidacyField
+        candidacies={[candidacy({ politicianSlug: "alix-dupont", ficheAvailable: false })]}
+      />
+    );
+
+    expect(screen.getAllByText("Fiche de candidature à venir").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: /Sa candidature/ })).not.toBeInTheDocument();
+    // La fiche Poligraph, elle, existe toujours : le lecteur n'est jamais laissé sans issue.
+    expect(screen.getAllByRole("link", { name: /Sa fiche Poligraph/ })[0]).toHaveAttribute(
+      "href",
+      "/politiques/alix-dupont"
     );
   });
 
@@ -57,7 +89,7 @@ describe("HubCandidacyField", () => {
     expect(screen.getByText("Alix Dupont")).toBeInTheDocument();
   });
 
-  it("distingue « aucun programme publié » de « pas encore dépouillé »", () => {
+  it("distingue « aucun programme publié » de « pas encore documenté »", () => {
     // La régression que ça verrouille : afficher le même vide dans les deux cas imputerait notre
     // propre retard au candidat.
     const { container } = render(
@@ -66,7 +98,7 @@ describe("HubCandidacyField", () => {
           candidacy({ id: "c1", candidateName: "Sans programme" }),
           candidacy({
             id: "c2",
-            candidateName: "Non dépouillé",
+            candidateName: "Non documenté",
             programmeAbsence: "non_depouille",
           }),
         ]}
@@ -74,11 +106,11 @@ describe("HubCandidacyField", () => {
     );
 
     expect(screen.getAllByText("Aucun programme publié à ce jour").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Programme publié, pas encore dépouillé").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Programme publié, pas encore documenté").length).toBeGreaterThan(0);
     expect(container.querySelector('[data-programme-absence="non_depouille"]')).not.toBeNull();
   });
 
-  it("compte les candidatures sans programme, et jamais celles que nous n'avons pas dépouillées", () => {
+  it("compte les candidatures sans programme, et jamais celles que nous n'avons pas documentées", () => {
     render(
       <HubCandidacyField
         candidacies={[
@@ -104,8 +136,8 @@ describe("HubCandidacyField", () => {
       />
     );
 
-    expect(screen.getAllByText("mesure dépouillée").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("mesures dépouillées").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("mesure documentée").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("mesures documentées").length).toBeGreaterThan(0);
     expect(screen.getAllByText("8 sur 13 sujets").length).toBeGreaterThan(0);
   });
 

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CandidateFicheDetail } from "@/lib/data/politician-candidacy";
+import { CandidateThemes } from "../_components/CandidateFicheBlocks";
+
+type Theme = CandidateFicheDetail["themes"][number];
+
+function theme(over: Partial<Theme> = {}): Theme {
+  return {
+    theme: "SANTE",
+    slug: "sante",
+    measureCount: 1,
+    measures: [{ id: "m1", text: "Rouvrir des maternités de proximité.", sourceUrl: null }],
+    ...over,
+  };
+}
+
+describe("CandidateThemes", () => {
+  it("rend TOUTES les mesures d'un sujet, jamais un échantillon", () => {
+    // La régression que ça verrouille : la fiche citait la première mesure de chaque sujet et
+    // comptait le reste, si bien qu'une candidature à dix-neuf mesures en montrait treize au plus.
+    // Un `list[0]` réintroduit dans le loader repasserait ici en silence sans ce test.
+    render(
+      <CandidateThemes
+        themes={[
+          theme({
+            measureCount: 3,
+            measures: [
+              { id: "m1", text: "Première mesure santé.", sourceUrl: null },
+              { id: "m2", text: "Deuxième mesure santé.", sourceUrl: null },
+              { id: "m3", text: "Troisième mesure santé.", sourceUrl: null },
+            ],
+          }),
+        ]}
+        electionSlug="presidentielle-2027"
+        lastReviewedAt={null}
+      />
+    );
+
+    expect(screen.getByText("Première mesure santé.")).toBeInTheDocument();
+    expect(screen.getByText("Deuxième mesure santé.")).toBeInTheDocument();
+    expect(screen.getByText("Troisième mesure santé.")).toBeInTheDocument();
+  });
+
+  it("ne perd aucune mesure au regroupement, sur plusieurs sujets", () => {
+    render(
+      <CandidateThemes
+        themes={[
+          theme({
+            theme: "SANTE",
+            slug: "sante",
+            measureCount: 2,
+            measures: [
+              { id: "s1", text: "Santé un.", sourceUrl: null },
+              { id: "s2", text: "Santé deux.", sourceUrl: null },
+            ],
+          }),
+          theme({
+            theme: "TRANSPORTS",
+            slug: "transports",
+            measureCount: 1,
+            measures: [{ id: "t1", text: "Transports un.", sourceUrl: null }],
+          }),
+        ]}
+        electionSlug="presidentielle-2027"
+        lastReviewedAt={null}
+      />
+    );
+
+    const section = screen.getByRole("region", { name: /mesures/i });
+    // Trois textes de mesure rendus, pas deux têtes de liste.
+    expect(within(section).getByText("Santé un.")).toBeInTheDocument();
+    expect(within(section).getByText("Santé deux.")).toBeInTheDocument();
+    expect(within(section).getByText("Transports un.")).toBeInTheDocument();
+  });
+
+  it("porte un lien de source par mesure qui en a une, et rien pour les autres", () => {
+    render(
+      <CandidateThemes
+        themes={[
+          theme({
+            measureCount: 2,
+            measures: [
+              { id: "m1", text: "Avec source.", sourceUrl: "https://example.org/programme.pdf" },
+              { id: "m2", text: "Sans source.", sourceUrl: null },
+            ],
+          }),
+        ]}
+        electionSlug="presidentielle-2027"
+        lastReviewedAt={null}
+      />
+    );
+
+    const liens = screen.getAllByRole("link", { name: /source/i });
+    expect(liens).toHaveLength(1);
+    expect(liens[0]).toHaveAttribute("href", "https://example.org/programme.pdf");
+    expect(liens[0]).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("ne promet pas une comparaison là où le lien mène à l'index des sujets", () => {
+    // `/sujets` liste les treize sujets ; la comparaison se fait un cran plus bas, par sujet.
+    render(
+      <CandidateThemes
+        themes={[theme()]}
+        electionSlug="presidentielle-2027"
+        lastReviewedAt={null}
+      />
+    );
+
+    const lien = screen.getByRole("link", { name: /Explorer les mesures par sujet/ });
+    expect(lien).toHaveAttribute("href", "/elections/presidentielle-2027/sujets");
+    expect(screen.queryByText(/Comparer ces mesures/)).not.toBeInTheDocument();
+  });
+
+  it("n'affiche rien quand aucun sujet n'est couvert", () => {
+    const { container } = render(
+      <CandidateThemes themes={[]} electionSlug="presidentielle-2027" lastReviewedAt={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -86,24 +86,46 @@ export function CandidateStats({
   );
 }
 
-/** One line per theme: how many measures, and the first of them quoted. */
+/**
+ * Every documented measure, grouped under its subject.
+ *
+ * All of them, expanded, and that is a decision rather than an oversight. A collapsed
+ * subject is a subject most readers never open, and these measures are what the page is
+ * for. Nineteen of them is a long section; it is also the entire substance of a
+ * candidacy fiche, so length here is the content doing its job.
+ *
+ * The comparison link closes this section instead of floating between two others. It
+ * acts on what was just read, so it belongs to it: on its own, between blocks, it read
+ * as an orphan the layout had nowhere else to put.
+ */
 export function CandidateThemes({
   themes,
   electionSlug,
+  lastReviewedAt,
 }: {
   themes: CandidateFicheDetail["themes"];
   electionSlug: string;
+  lastReviewedAt: Date | null;
 }) {
   if (themes.length === 0) return null;
 
+  const total = themes.reduce((sum, t) => sum + t.measureCount, 0);
+
   return (
-    <section aria-labelledby="mesures" className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
-      <h2 id="mesures" className="font-display text-xl font-bold tracking-tight">
-        Ses mesures, sujet par sujet
-      </h2>
+    <section aria-labelledby="mesures" className="space-y-4 rounded-xl border bg-card p-4 md:p-6">
+      <div>
+        <h2 id="mesures" className="font-display text-xl font-bold tracking-tight">
+          Ses mesures, sujet par sujet
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {total} {total === 1 ? "mesure documentée" : "mesures documentées"} sur {themes.length}{" "}
+          {themes.length === 1 ? "sujet" : "sujets"}, chacune avec sa source.
+        </p>
+      </div>
+
       <ul className="divide-y divide-border">
         {themes.map((t) => (
-          <li key={t.theme} className="py-3 first:pt-0 last:pb-0">
+          <li key={t.theme} className="py-4 first:pt-0 last:pb-0">
             <div className="flex items-center gap-2.5">
               <span
                 aria-hidden="true"
@@ -120,28 +142,47 @@ export function CandidateThemes({
                 {t.measureCount} {t.measureCount === 1 ? "mesure" : "mesures"}
               </span>
             </div>
-            {t.quote !== null && (
-              <p className="mt-1.5 pl-4 text-sm leading-relaxed text-muted-foreground">
-                &laquo;&nbsp;{t.quote.text}&nbsp;&raquo;
-                {t.quote.sourceUrl !== null && (
-                  <>
-                    {" "}
-                    <a
-                      href={t.quote.sourceUrl}
-                      target="_blank"
-                      rel="nofollow noopener"
-                      className="inline-flex items-center gap-1 text-xs underline hover:no-underline"
-                    >
-                      source
-                      <ExternalLink aria-hidden="true" className="h-3 w-3" />
-                    </a>
-                  </>
-                )}
-              </p>
-            )}
+
+            <ul className="mt-2 space-y-2 pl-4">
+              {t.measures.map((measure) => (
+                <li key={measure.id} className="text-sm leading-relaxed">
+                  <span className="text-foreground">{measure.text}</span>
+                  {measure.sourceUrl !== null && (
+                    <>
+                      {" "}
+                      <a
+                        href={measure.sourceUrl}
+                        target="_blank"
+                        rel="nofollow noopener"
+                        className="inline-flex items-center gap-1 whitespace-nowrap text-xs text-muted-foreground underline hover:text-foreground hover:no-underline"
+                      >
+                        source
+                        <ExternalLink aria-hidden="true" className="h-3 w-3" />
+                      </a>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
           </li>
         ))}
       </ul>
+
+      <p className="border-t border-border pt-4 text-sm">
+        <Link
+          href={`/elections/${electionSlug}/sujets`}
+          prefetch={false}
+          className="font-bold text-primary hover:underline"
+        >
+          Comparer ces mesures à celles des autres candidatures
+        </Link>
+        {lastReviewedAt !== null && (
+          <span className="text-muted-foreground">
+            {" "}
+            · dernière revue le {formatDate(lastReviewedAt)}
+          </span>
+        )}
+      </p>
     </section>
   );
 }
@@ -180,7 +221,7 @@ export function CandidateThemeSpread({ themes }: { themes: CandidateFicheDetail[
         ))}
       </ul>
       <p className="text-xs text-muted-foreground">
-        Compte le nombre de mesures que nous avons dépouillées par sujet. Mesure ce dont la
+        Compte le nombre de mesures que nous avons documentées par sujet. Mesure ce dont la
         candidature parle, pas ce qui a été réalisé.
       </p>
     </section>

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -120,8 +120,12 @@ export function CandidateThemes({
         {/* No total here. The counters block a few centimetres below already states it, from
             another read: two counts of the same thing on one screen invite the reader to spot a
             disagreement, and eventually to find one. */}
+        {/* "Sa source" and not "le document dont elle est tirée": a measure may come from a
+            speech, a debate, an interview or an article, which is why `programEditionId` is
+            nullable. Naming a document would be the same over-promise as the filter that
+            announced a documented programme on a bare measure count. */}
         <p className="mt-1 text-xs text-muted-foreground">
-          Chaque mesure est citée avec le document dont elle est tirée.
+          Chaque mesure est citée avec sa source.
         </p>
       </div>
 

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -94,9 +94,11 @@ export function CandidateStats({
  * for. Nineteen of them is a long section; it is also the entire substance of a
  * candidacy fiche, so length here is the content doing its job.
  *
- * The comparison link closes this section instead of floating between two others. It
- * acts on what was just read, so it belongs to it: on its own, between blocks, it read
- * as an orphan the layout had nowhere else to put.
+ * The closing link acts on what was just read, so it belongs to this section rather than
+ * floating between two others. Its wording names where it goes: `/sujets` is the index of
+ * the thirteen subjects, and the comparison happens one level down, per subject. Promising
+ * "comparer ces mesures à celles des autres candidatures" and landing on a list of subjects
+ * is a promise the click does not keep.
  */
 export function CandidateThemes({
   themes,
@@ -109,17 +111,17 @@ export function CandidateThemes({
 }) {
   if (themes.length === 0) return null;
 
-  const total = themes.reduce((sum, t) => sum + t.measureCount, 0);
-
   return (
     <section aria-labelledby="mesures" className="space-y-4 rounded-xl border bg-card p-4 md:p-6">
       <div>
         <h2 id="mesures" className="font-display text-xl font-bold tracking-tight">
           Ses mesures, sujet par sujet
         </h2>
+        {/* No total here. The counters block a few centimetres below already states it, from
+            another read: two counts of the same thing on one screen invite the reader to spot a
+            disagreement, and eventually to find one. */}
         <p className="mt-1 text-xs text-muted-foreground">
-          {total} {total === 1 ? "mesure documentée" : "mesures documentées"} sur {themes.length}{" "}
-          {themes.length === 1 ? "sujet" : "sujets"}, chacune avec sa source.
+          Chaque mesure est citée avec le document dont elle est tirée.
         </p>
       </div>
 
@@ -174,7 +176,7 @@ export function CandidateThemes({
           prefetch={false}
           className="font-bold text-primary hover:underline"
         >
-          Comparer ces mesures à celles des autres candidatures
+          Explorer les mesures par sujet
         </Link>
         {lastReviewedAt !== null && (
           <span className="text-muted-foreground">

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -12,7 +12,6 @@ import {
   getCandidateFicheDetail,
   getPoliticianPresidentialCandidacy,
 } from "@/lib/data/politician-candidacy";
-import { formatDate } from "@/lib/utils";
 import {
   CandidateIntegrity,
   CandidateRecentVotes,
@@ -87,6 +86,10 @@ export default async function CandidateFichePage({ params }: PageProps) {
       verifiedMeasuresWithPrimarySource: candidacy.primarySourceMeasureCount,
     });
 
+  // A safety net now, not a routing rule. The field used to link every row here and let this
+  // redirect sort them out, so one link had two destinations and named neither; the row now
+  // reads the same gate and offers the destination it can name. What is left is the hand-typed
+  // URL and the stale bookmark, for which landing on the politician's fiche beats a 404.
   if (!candidacy || !publishable) {
     redirect(`/politiques/${slug}`);
   }
@@ -133,29 +136,23 @@ export default async function CandidateFichePage({ params }: PageProps) {
         measureCount={candidacy.publishedMeasureCount}
       />
 
+      {/* Measures before the counters, everywhere and not only on mobile.
+          The three counters describe the COVERAGE of our own work; they are a caption on the
+          measures, not an introduction to them. Reading them first meant scrolling past a
+          description of the content to reach the content, which on a phone is the whole first
+          screen. One order for every width rather than two: a block that belongs after on a
+          phone does not belong before on a desktop, it was simply less costly there. */}
+      <CandidateThemes
+        themes={detail.themes}
+        electionSlug={candidacy.electionSlug}
+        lastReviewedAt={candidacy.lastReviewedAt}
+      />
+
       <CandidateStats
         measureCount={candidacy.publishedMeasureCount}
         themesCoveredCount={candidacy.themesCoveredCount}
         mandateCount={detail.mandateCount}
       />
-
-      <CandidateThemes themes={detail.themes} electionSlug={candidacy.electionSlug} />
-
-      <p className="text-sm">
-        <Link
-          href={`/elections/${candidacy.electionSlug}/sujets`}
-          prefetch={false}
-          className="font-bold text-primary hover:underline"
-        >
-          Comparer ses mesures à celles des autres candidatures
-        </Link>
-        {candidacy.lastReviewedAt !== null && (
-          <span className="text-muted-foreground">
-            {" "}
-            · dernière revue le {formatDate(candidacy.lastReviewedAt)}
-          </span>
-        )}
-      </p>
 
       <CandidateThemeSpread themes={detail.themes} />
 
@@ -186,6 +183,26 @@ export default async function CandidateFichePage({ params }: PageProps) {
           un suivi post-électoral à construire.
         </p>
       </section>
+
+      {/* The way back, at the end rather than only at the top. The breadcrumb carries the
+          hierarchy, which is not the same thing as an exit: a reader who has just finished the
+          page has to travel back up to leave it, and on a phone that is the whole page. */}
+      <nav aria-label="Suite de la navigation" className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+        <Link
+          href={`/elections/${candidacy.electionSlug}`}
+          prefetch={false}
+          className="font-bold text-primary hover:underline"
+        >
+          ← Toutes les candidatures
+        </Link>
+        <Link
+          href={`/politiques/${slug}`}
+          prefetch={false}
+          className="text-muted-foreground hover:text-foreground hover:underline"
+        >
+          Sa fiche Poligraph, mandats, votes et déclarations
+        </Link>
+      </nav>
     </div>
   );
 }

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
-import { isHubPublishable } from "@/config/publication-gates";
+import { isFicheCandidatPublishable, isHubPublishable } from "@/config/publication-gates";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import {
   resolveProgrammeAbsence,
@@ -63,6 +63,15 @@ export type HubCandidacy = {
    * Null when `measureCount > 0`, since there is then no absence to qualify.
    */
   programmeAbsence: "aucun_programme" | "non_depouille" | null;
+  /**
+   * Whether `/candidats/[slug]` will actually render a fiche for this candidacy.
+   *
+   * The row needs this because that page redirects to `/politiques/[slug]` when the gate
+   * is not cleared. A single link therefore led to two different destinations depending
+   * on a rule no reader can see, which is the one thing a link must never do. With this,
+   * the row offers the destination it can name.
+   */
+  ficheAvailable: boolean;
 };
 
 export type HubMeasureContext = {
@@ -129,7 +138,11 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
   ]);
 
   const byCandidacy = rollupMeasuresByCandidacy(
-    measures,
+    measures.map((m) => ({
+      candidacyId: m.candidacyId,
+      theme: m.theme,
+      hasPrimarySource: m.sources.some((s) => s.tier === "PRIMARY"),
+    })),
     new Set(publicCandidates.map((c) => c.id))
   );
 
@@ -160,6 +173,15 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
       measureCount,
       themesCoveredCount: rollup?.themesCoveredCount ?? 0,
       programmeAbsence: resolveProgrammeAbsence(measureCount, hasProgramme),
+      // Evaluated with the gate the fiche itself uses, not re-derived from `measureCount`.
+      // The row is what decides which link to offer, so a disagreement between the two
+      // would send the reader to a page that redirects them somewhere else without a word.
+      ficheAvailable:
+        c.politician?.slug != null &&
+        isFicheCandidatPublishable({
+          statusSourced: true,
+          verifiedMeasuresWithPrimarySource: rollup?.primarySourceMeasureCount ?? 0,
+        }),
     };
   });
 }

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus, ThemeCategory, VotePosition } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { pickMeasureSourceUrl } from "@/lib/presidentielle/measure-source";
 import { PRESIDENTIELLE_2027_SLUG, themeToSlug } from "@/lib/presidentielle/themes";
 import {
   getPublicMeasureStatsByCandidacy,
@@ -204,13 +205,7 @@ export async function loadCandidateFicheDetail(
       measures: list.map((measure) => ({
         id: measure.id,
         text: measure.text,
-        // A primary source first, the oldest one only as a fallback. Sources come back ordered
-        // by `publishedAt asc`, so `sources[0]` is the EARLIEST, which is the wrong one as soon
-        // as a measure carries two: a proposal announced in an interview and later written into
-        // the programme would be cited from the interview. No measure has two sources today, so
-        // this fixes nothing visible and prevents the first one that will.
-        sourceUrl:
-          (measure.sources.find((s) => s.tier === "PRIMARY") ?? measure.sources[0])?.url ?? null,
+        sourceUrl: pickMeasureSourceUrl(measure.sources),
       })),
     }))
     // Most documented first: this block answers "where does this candidacy put the accent", and

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -204,7 +204,13 @@ export async function loadCandidateFicheDetail(
       measures: list.map((measure) => ({
         id: measure.id,
         text: measure.text,
-        sourceUrl: measure.sources[0]?.url ?? null,
+        // A primary source first, the oldest one only as a fallback. Sources come back ordered
+        // by `publishedAt asc`, so `sources[0]` is the EARLIEST, which is the wrong one as soon
+        // as a measure carries two: a proposal announced in an interview and later written into
+        // the programme would be cited from the interview. No measure has two sources today, so
+        // this fixes nothing visible and prevents the first one that will.
+        sourceUrl:
+          (measure.sources.find((s) => s.tier === "PRIMARY") ?? measure.sources[0])?.url ?? null,
       })),
     }))
     // Most documented first: this block answers "where does this candidacy put the accent", and

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -122,12 +122,25 @@ export async function loadPoliticianPresidentialCandidacy(
   };
 }
 
+export type CandidateThemeMeasure = {
+  id: string;
+  text: string;
+  sourceUrl: string | null;
+};
+
 export type CandidateThemeBreakdown = {
   theme: ThemeCategory;
   slug: string;
   measureCount: number;
-  /** The first measure of the theme, quoted on the fiche. Null only if the theme has none. */
-  quote: { text: string; sourceUrl: string | null } | null;
+  /**
+   * Every measure of the theme, not a sample.
+   *
+   * The fiche used to quote the first one and show a count for the rest, so a candidacy with
+   * nineteen documented measures displayed thirteen of them at most, one per subject, and the
+   * others existed only as a number. The measures ARE the fiche's subject; hiding them behind
+   * their own count made the page describe work instead of showing it.
+   */
+  measures: CandidateThemeMeasure[];
 };
 
 export type CandidateRecentVote = {
@@ -184,18 +197,16 @@ export async function loadCandidateFicheDetail(
   }
 
   const themes: CandidateThemeBreakdown[] = [...byTheme.entries()]
-    .map(([theme, list]) => {
-      const first = list[0];
-      return {
-        theme,
-        slug: themeToSlug(theme),
-        measureCount: list.length,
-        quote:
-          first === undefined
-            ? null
-            : { text: first.text, sourceUrl: first.sources[0]?.url ?? null },
-      };
-    })
+    .map(([theme, list]) => ({
+      theme,
+      slug: themeToSlug(theme),
+      measureCount: list.length,
+      measures: list.map((measure) => ({
+        id: measure.id,
+        text: measure.text,
+        sourceUrl: measure.sources[0]?.url ?? null,
+      })),
+    }))
     // Most documented first: this block answers "where does this candidacy put the accent", and
     // alphabetical order would bury the answer. It is a count of OUR extraction, not a ranking of
     // candidacies against each other, which is why it is allowed here and not on the field.

--- a/src/lib/presidentielle/__tests__/candidacy-rollup.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-rollup.test.ts
@@ -1,39 +1,81 @@
 import { describe, expect, it } from "vitest";
-import { resolveProgrammeAbsence, rollupMeasuresByCandidacy } from "../candidacy-rollup";
+import {
+  resolveProgrammeAbsence,
+  rollupMeasuresByCandidacy,
+  type RollupMeasure,
+} from "../candidacy-rollup";
+
+/** A measure with a primary source, the ordinary case. */
+function measure(
+  candidacyId: string | null,
+  theme: string,
+  hasPrimarySource = true
+): RollupMeasure {
+  return { candidacyId, theme, hasPrimarySource };
+}
 
 describe("rollupMeasuresByCandidacy", () => {
   it("ne compte pas une mesure portée par une candidature que rien ne rend publiquement", () => {
     // Invariant I7, déjà tenu par `loadThemesIndex` : une mesure rattachée à une candidature dont
     // l'extension est encore DRAFT n'apparaît sur aucune page sujet et sur aucune fiche. La compter
-    // ici annoncerait « 2 mesures dépouillées » sur une ligne qui ne mène à rien.
+    // ici annoncerait « 2 mesures documentées » sur une ligne qui ne mène à rien.
     const rollup = rollupMeasuresByCandidacy(
       [
-        { candidacyId: "publique", theme: "SANTE" },
-        { candidacyId: "brouillon", theme: "SANTE" },
-        { candidacyId: "brouillon", theme: "LOGEMENT_URBANISME" },
+        measure("publique", "SANTE"),
+        measure("brouillon", "SANTE"),
+        measure("brouillon", "LOGEMENT_URBANISME"),
       ],
       new Set(["publique"])
     );
 
-    expect(rollup.get("publique")).toEqual({ measureCount: 1, themesCoveredCount: 1 });
+    expect(rollup.get("publique")).toEqual({
+      measureCount: 1,
+      themesCoveredCount: 1,
+      primarySourceMeasureCount: 1,
+    });
     expect(rollup.has("brouillon")).toBe(false);
   });
 
   it("compte les sujets distincts, pas les mesures", () => {
     const rollup = rollupMeasuresByCandidacy(
+      [measure("c1", "SANTE"), measure("c1", "SANTE"), measure("c1", "LOGEMENT_URBANISME")],
+      new Set(["c1"])
+    );
+
+    expect(rollup.get("c1")).toEqual({
+      measureCount: 3,
+      themesCoveredCount: 2,
+      primarySourceMeasureCount: 3,
+    });
+  });
+
+  it("compte à part les mesures adossées à une source primaire", () => {
+    // C'est ce nombre, et non `measureCount`, que lit le seuil de la fiche candidat. Les deux
+    // coïncident aujourd'hui, donc les confondre paraîtrait correct jusqu'à la première mesure
+    // tirée d'un article seul : la ligne offrirait alors un lien vers une fiche qui redirige.
+    const rollup = rollupMeasuresByCandidacy(
       [
-        { candidacyId: "c1", theme: "SANTE" },
-        { candidacyId: "c1", theme: "SANTE" },
-        { candidacyId: "c1", theme: "LOGEMENT_URBANISME" },
+        measure("c1", "SANTE", false),
+        measure("c1", "LOGEMENT_URBANISME", false),
+        measure("c1", "TRANSPORTS", true),
       ],
       new Set(["c1"])
     );
 
-    expect(rollup.get("c1")).toEqual({ measureCount: 3, themesCoveredCount: 2 });
+    expect(rollup.get("c1")).toEqual({
+      measureCount: 3,
+      themesCoveredCount: 3,
+      primarySourceMeasureCount: 1,
+    });
+  });
+
+  it("rapporte zéro source primaire quand aucune mesure n'en porte", () => {
+    const rollup = rollupMeasuresByCandidacy([measure("c1", "SANTE", false)], new Set(["c1"]));
+    expect(rollup.get("c1")?.primarySourceMeasureCount).toBe(0);
   });
 
   it("ignore une mesure sans candidature", () => {
-    const rollup = rollupMeasuresByCandidacy([{ candidacyId: null, theme: "SANTE" }], new Set());
+    const rollup = rollupMeasuresByCandidacy([measure(null, "SANTE")], new Set());
     expect(rollup.size).toBe(0);
   });
 });

--- a/src/lib/presidentielle/__tests__/measure-source.test.ts
+++ b/src/lib/presidentielle/__tests__/measure-source.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { pickMeasureSourceUrl } from "../measure-source";
+
+const INTERVIEW = { url: "https://presse.example/interview", tier: "SECONDARY" };
+const PROGRAMME = { url: "https://parti.example/programme.pdf", tier: "PRIMARY" };
+
+describe("pickMeasureSourceUrl", () => {
+  it("préfère la source primaire, même arrivée après une secondaire", () => {
+    // La régression que ça verrouille : les sources sont triées par `publishedAt asc`, donc
+    // `sources[0]` est la PLUS ANCIENNE. Sur une mesure annoncée en interview puis inscrite au
+    // programme, citer la première revient à citer l'interview à côté d'une mesure que le
+    // programme porte.
+    expect(pickMeasureSourceUrl([INTERVIEW, PROGRAMME])).toBe(PROGRAMME.url);
+  });
+
+  it("prend la primaire quand elle est déjà la première", () => {
+    expect(pickMeasureSourceUrl([PROGRAMME, INTERVIEW])).toBe(PROGRAMME.url);
+  });
+
+  it("retombe sur la source disponible quand aucune n'est primaire", () => {
+    // `PUBLIC_MEASURE_WHERE` exige UNE source, pas une source primaire : une mesure adossée à un
+    // seul article est publiable et doit montrer d'où elle vient. Renvoyer null masquerait une
+    // source réelle pour faire respecter une préférence.
+    expect(pickMeasureSourceUrl([INTERVIEW])).toBe(INTERVIEW.url);
+  });
+
+  it("prend la plus ancienne des secondaires, l'ordre du chargement faisant foi", () => {
+    const seconde = { url: "https://presse.example/plus-tard", tier: "SECONDARY" };
+    expect(pickMeasureSourceUrl([INTERVIEW, seconde])).toBe(INTERVIEW.url);
+  });
+
+  it("renvoie null sans aucune source", () => {
+    expect(pickMeasureSourceUrl([])).toBeNull();
+  });
+});

--- a/src/lib/presidentielle/candidacy-filters.ts
+++ b/src/lib/presidentielle/candidacy-filters.ts
@@ -21,10 +21,15 @@ export const CANDIDACY_FILTER_LABELS: Record<CandidacyFilter, string> = {
   toutes: "Toutes",
   declarees: "Déclarées",
   pressenties: "Pressenties",
-  // The key stays `depouillees` because it is in shared URLs; only the label changes.
-  // "Dépouillé" reads as ballot-counting on an elections page, and the rest of the site
-  // already says "documenté".
-  depouillees: "Programme documenté",
+  // "Mesures documentées" and not "Programme documenté", because the predicate below is
+  // `measureCount > 0` and a measure does not imply a programme: `Measure.programEditionId`
+  // is nullable precisely so a proposal made in a speech, an interview or an article can be
+  // recorded. Labelling that as a documented programme would promise a published document
+  // this filter never checks.
+  //
+  // The key stays `depouillees`: it travels in shared URLs. Only the label changes, and
+  // "dépouillé" had to go anyway — on an elections page that word means counting ballots.
+  depouillees: "Mesures documentées",
 };
 
 /** The fields a filter reads, so a caller can pass its own row type unchanged. */

--- a/src/lib/presidentielle/candidacy-filters.ts
+++ b/src/lib/presidentielle/candidacy-filters.ts
@@ -21,7 +21,10 @@ export const CANDIDACY_FILTER_LABELS: Record<CandidacyFilter, string> = {
   toutes: "Toutes",
   declarees: "Déclarées",
   pressenties: "Pressenties",
-  depouillees: "Programme dépouillé",
+  // The key stays `depouillees` because it is in shared URLs; only the label changes.
+  // "Dépouillé" reads as ballot-counting on an elections page, and the rest of the site
+  // already says "documenté".
+  depouillees: "Programme documenté",
 };
 
 /** The fields a filter reads, so a caller can pass its own row type unchanged. */

--- a/src/lib/presidentielle/candidacy-rollup.ts
+++ b/src/lib/presidentielle/candidacy-rollup.ts
@@ -5,9 +5,25 @@
  * database: it is the kind of rule that reads as obviously correct and is silently wrong.
  */
 
-export type RollupMeasure = { candidacyId: string | null; theme: string };
+export type RollupMeasure = {
+  candidacyId: string | null;
+  theme: string;
+  /** Whether the measure carries at least one primary source. */
+  hasPrimarySource: boolean;
+};
 
-export type CandidacyRollup = { measureCount: number; themesCoveredCount: number };
+export type CandidacyRollup = {
+  measureCount: number;
+  themesCoveredCount: number;
+  /**
+   * Measures backed by a primary source, which is what the fiche gate reads.
+   *
+   * Tracked separately from `measureCount` rather than assumed equal to it: today every
+   * measure happens to carry a primary source, so the two numbers coincide and a single
+   * count would look correct until the first measure sourced from an article alone.
+   */
+  primarySourceMeasureCount: number;
+};
 
 /**
  * Counts a candidacy's measures, but ONLY for candidacies the public surfaces can actually show.
@@ -28,11 +44,15 @@ export function rollupMeasuresByCandidacy(
 ): Map<string, CandidacyRollup> {
   const themesByCandidacy = new Map<string, Set<string>>();
   const counts = new Map<string, number>();
+  const primaryCounts = new Map<string, number>();
 
   for (const measure of measures) {
     const id = measure.candidacyId;
     if (id === null || !publicCandidacyIds.has(id)) continue;
     counts.set(id, (counts.get(id) ?? 0) + 1);
+    if (measure.hasPrimarySource) {
+      primaryCounts.set(id, (primaryCounts.get(id) ?? 0) + 1);
+    }
     const themes = themesByCandidacy.get(id) ?? new Set<string>();
     themes.add(measure.theme);
     themesByCandidacy.set(id, themes);
@@ -41,7 +61,11 @@ export function rollupMeasuresByCandidacy(
   return new Map(
     [...counts].map(([id, measureCount]) => [
       id,
-      { measureCount, themesCoveredCount: themesByCandidacy.get(id)?.size ?? 0 },
+      {
+        measureCount,
+        themesCoveredCount: themesByCandidacy.get(id)?.size ?? 0,
+        primarySourceMeasureCount: primaryCounts.get(id) ?? 0,
+      },
     ])
   );
 }

--- a/src/lib/presidentielle/measure-source.ts
+++ b/src/lib/presidentielle/measure-source.ts
@@ -1,0 +1,22 @@
+/**
+ * Which source a surface cites for a measure, as a pure function.
+ *
+ * Pure and here rather than inline in the loader for the same reason as
+ * `candidacy-rollup`: it is a one-line rule that reads as obviously correct, and the
+ * obviously-correct version is the wrong one.
+ *
+ * Sources come back ordered by `publishedAt asc`, so `sources[0]` is the EARLIEST. On a
+ * measure announced in an interview and later written into the programme, that picks the
+ * interview and cites a secondary source next to a measure the programme carries.
+ *
+ * The fallback is not defensive padding either: `PUBLIC_MEASURE_WHERE` requires a source,
+ * not a primary one, so a measure backed only by an article is publishable and must still
+ * show where it comes from. Returning null there would hide a real source to enforce a
+ * preference.
+ */
+
+export type CitableSource = { url: string; tier: string };
+
+export function pickMeasureSourceUrl(sources: readonly CitableSource[]): string | null {
+  return (sources.find((source) => source.tier === "PRIMARY") ?? sources[0])?.url ?? null;
+}


### PR DESCRIPTION
Sept retours de lecture sur le hub et la fiche candidat. Deux étaient des défauts fonctionnels, deux des questions de vocabulaire, trois des problèmes de hiérarchie.

## Un lien qui menait à deux endroits

Le plus grave. Chaque ligne du champ pointait sur `/candidats/[slug]`, et cette page fait un `redirect()` vers `/politiques/[slug]` quand la candidature n'a aucune mesure vérifiée. Le même geste menait donc à deux pages différentes selon une règle invisible, et n'en nommait aucune.

La ligne porte maintenant **deux liens nommés** : « Sa candidature » quand la fiche existe, « Sa fiche Poligraph » toujours. Quand la fiche de candidature n'existe pas, la ligne le dit — « Fiche de candidature à venir » — au lieu d'y mener quand même.

Pour cela, la ligne évalue le **même seuil** que la fiche, jamais une approximation : `rollupMeasuresByCandidacy` compte désormais à part les mesures adossées à une source primaire, et `HubCandidacy.ficheAvailable` passe ce compte à `isFicheCandidatPublishable`. Les deux nombres coïncident aujourd'hui, mais les confondre aurait paru correct jusqu'à la première mesure tirée d'un article seul.

Le `redirect()` reste comme filet pour une URL tapée à la main ou un signet périmé, et c'est écrit à côté.

## Dix-neuf mesures, dix-neuf mesures affichées

La fiche citait la première mesure de chaque sujet et comptait le reste. Une candidature avec dix-neuf mesures documentées en montrait treize au plus, une par sujet, et les autres n'existaient que comme un nombre. Les mesures sont le sujet de la page ; les cacher derrière leur propre compte faisait décrire le travail au lieu de le montrer.

Tout est déplié, groupé par sujet, chaque mesure avec sa source. Vérifié au navigateur : **13 sujets et 19 mesures rendus** sur la fiche de Jean-Luc Mélenchon.

## Trois symptômes, une cause

Les KPI avant le contenu, le lien de comparaison flottant entre deux blocs, et l'absence de sortie en bas de page venaient tous de la même chose : une pile de blocs sans hiérarchie de lecture.

- Les trois compteurs décrivent la **couverture de notre travail**. Ils sont une légende des mesures, pas une introduction. Ils passent après, à toutes les largeurs et pas seulement sur mobile : un bloc qui a sa place après sur un téléphone ne l'a pas avant sur un écran large, il y coûtait juste moins cher.
- Le lien de comparaison agit sur ce qu'on vient de lire, donc il **ferme la section des mesures** au lieu de flotter entre deux autres.
- Une sortie explicite en fin de page, « ← Toutes les candidatures » et la fiche Poligraph. Le fil d'Ariane porte la hiérarchie, ce qui n'est pas la même chose qu'une sortie.

## Deux mots corrigés

**« Chercher une personne » ne cherchait rien** : c'est une ancre vers la liste plus bas. Le verbe était aussi faux que le nom. La carte jumelle dit « Partir d'un sujet », donc celle-ci dit **« Partir d'une candidature »**.

**« Dépouillé » devient « documenté »**, pour deux raisons. Sur une page d'élection, le dépouillement est ce qui arrive aux bulletins : le mot renvoyait au comptage des voix, pas à la lecture d'un programme. Et c'était le terme minoritaire, la fiche et les cartes du hub disant déjà « documentées », donc un écran contredisait le suivant. La clé d'URL `depouillees` du filtre ne bouge pas, elle circule dans des liens partagés.

Les « communes dépouillées » des municipales restent : là, c'est le vrai dépouillement.

## Vérifications

Suite complète verte, **3798 tests, code de sortie 0 relevé sans pipe**. `tsc` sans erreur dans `src/`, eslint et Prettier propres.

Mesuré au navigateur sur les deux pages, à 390 et 1440 px : **0 px de dérive latérale** et **0 violation axe** sur les balises WCAG 2.1 AA aux quatre combinaisons.

Trois tests verrouillaient l'ancien comportement et ont été réécrits, dont celui qui affirmait qu'« un seul href suffit pour les 25 lignes ». Deux nouveaux tiennent la règle inverse : les deux destinations sont nommées quand la fiche existe, et l'absence est annoncée sinon.
