### PR TITLE
Compacter la recherche du header entre lg et xl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Explicit, unlike the build job above: that one runs `npm run build`, which is
+      # `prisma generate && next build`. This job serves the app with `next dev`, which
+      # generates nothing, so without this step every import of `@/generated/prisma`
+      # fails to resolve and the dev server never comes up.
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
       - name: Create extensions and publicId sequences
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f docker/init-search.sql
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,81 @@ jobs:
       - name: Check the hosts the build reached
         if: always()
         run: npm run build:net-check
+
+  header-responsive:
+    name: Header responsive
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # The header is global, and #688 showed a 100px overflow at exactly 1024px surviving a
+    # full green pipeline: nothing here ran a browser. This job is the narrowest thing that
+    # makes that class of defect fail a check rather than reach production.
+    #
+    # Deliberately not the whole visual suite. The other specs need their own seeded
+    # fixtures; this one was written to hold on `/` with an empty database plus three flags.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: poligraph_test
+          POSTGRES_PASSWORD: poligraph_test
+          POSTGRES_DB: poligraph_test
+        ports:
+          - 5432:5432
+        # -h localhost forces TCP: the entrypoint runs a temporary server on the Unix
+        # socket while executing its init scripts, and a socket probe reports healthy
+        # against that one.
+        options: >-
+          --health-cmd "pg_isready -h localhost -U poligraph_test -d poligraph_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DIRECT_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DATABASE_SSL: "false"
+      NEXT_TELEMETRY_DISABLED: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create extensions and publicId sequences
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f docker/init-search.sql
+
+      - name: Apply the schema
+        run: npx prisma db push
+
+      # The header renders two of its five primary links behind flags, and the Boussole
+      # behind a third. Enabling them is what makes this run measure the widest header
+      # instead of whatever a bare database happens to produce.
+      - name: Enable the flags that widen the header
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/visual/fixtures/header-flags.sql
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Playwright starts `npm run dev` itself (see playwright.config.ts). Only `/` is
+      # visited, so only that route compiles.
+      - name: Run the header guard
+        run: npx playwright test tests/visual/header-responsive.spec.ts --project=chromium
+
+      - name: Upload the report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: header-responsive-report
+          path: |
+            tests/visual/playwright-report
+            tests/visual/test-results
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -82,6 +82,9 @@ export default defineConfig({
     command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // Locally 120s is plenty against a warm .next cache. On a CI runner the cache is
+    // cold and the first route still has to compile, so the old value made the job fail
+    // on its own start-up rather than on anything it was meant to measure.
+    timeout: (process.env.CI ? 300 : 120) * 1000,
   },
 });

--- a/src/components/layout/NavIconBar.tsx
+++ b/src/components/layout/NavIconBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Compass } from "lucide-react";
-import { CommandPaletteTrigger, CommandPaletteTriggerMobile } from "@/components/search";
+import { CommandPaletteTrigger, CommandPaletteTriggerCompact } from "@/components/search";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import type { NavItem } from "@/config/navigation";
 
@@ -14,7 +14,7 @@ export function NavIconBar({ tools: _tools, boussoleEnabled = false }: NavIconBa
   return (
     <div className="flex items-center gap-1">
       <CommandPaletteTrigger />
-      <CommandPaletteTriggerMobile />
+      <CommandPaletteTriggerCompact />
       <ThemeToggle />
       {boussoleEnabled && (
         <a

--- a/src/components/search/CommandPaletteTrigger.tsx
+++ b/src/components/search/CommandPaletteTrigger.tsx
@@ -11,7 +11,7 @@ export function CommandPaletteTrigger() {
     <button
       type="button"
       onClick={open}
-      className="hidden lg:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-input bg-background text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors min-w-[200px]"
+      className="hidden xl:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-input bg-background text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors min-w-[200px]"
       aria-label="Rechercher (Cmd+K)"
     >
       <Search className="h-4 w-4 shrink-0" />
@@ -23,14 +23,24 @@ export function CommandPaletteTrigger() {
   );
 }
 
-export function CommandPaletteTriggerMobile() {
+/**
+ * The search button for the narrow desktop window only, between `lg` and `xl`.
+ *
+ * At `lg` the whole desktop navigation appears at once, and the full trigger above carries a
+ * `min-w-[200px]` that pushes the header past the viewport. This one takes over until `xl`,
+ * where the space for the labelled trigger is back.
+ *
+ * Not a mobile button despite what its previous name said: below `lg` the header renders its own
+ * search button in `MobileMenu`, and this component is inside a `hidden lg:flex` nav.
+ */
+export function CommandPaletteTriggerCompact() {
   const { open } = useCommandPalette();
 
   return (
     <button
       type="button"
       onClick={open}
-      className="flex lg:hidden items-center justify-center h-9 w-9 rounded-lg text-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
+      className="hidden lg:flex xl:hidden items-center justify-center h-9 w-9 rounded-lg text-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
       aria-label="Rechercher"
     >
       <Search className="h-[18px] w-[18px]" />

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,3 +1,3 @@
 export { CommandPaletteProvider, useCommandPalette } from "./CommandPaletteProvider";
 export { CommandPalette } from "./CommandPalette";
-export { CommandPaletteTrigger, CommandPaletteTriggerMobile } from "./CommandPaletteTrigger";
+export { CommandPaletteTrigger, CommandPaletteTriggerCompact } from "./CommandPaletteTrigger";

--- a/tests/visual/fixtures/header-flags.sql
+++ b/tests/visual/fixtures/header-flags.sql
@@ -1,0 +1,21 @@
+-- Enables the three flags that widen the global header, so the responsive guard always
+-- measures its worst case: `STATISTIQUES_SECTION` and `PROGRAMMES_ENABLED` each add a
+-- labelled primary link, `BOUSSOLE_ENABLED` adds an icon to the tool rail.
+--
+-- Without this the guard reads whatever the database behind the dev server happens to
+-- hold, and a narrower header would pass while proving nothing.
+--
+-- Meant for a disposable database. Used by the `header-responsive` CI job, and by anyone
+-- reproducing it locally:
+--
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/visual/fixtures/header-flags.sql
+--
+-- `id` and `updatedAt` are supplied explicitly: Prisma generates the first with `cuid()`
+-- and maintains the second with `@updatedAt`, both client-side, so neither has a database
+-- default an INSERT could fall back on.
+INSERT INTO "FeatureFlag" ("id", "name", "label", "enabled", "updatedAt")
+VALUES
+  ('seed-statistiques-section', 'STATISTIQUES_SECTION', 'Section Statistiques', true, NOW()),
+  ('seed-programmes-enabled', 'PROGRAMMES_ENABLED', 'Section Programmes', true, NOW()),
+  ('seed-boussole-enabled', 'BOUSSOLE_ENABLED', 'Boussole politique', true, NOW())
+ON CONFLICT ("name") DO UPDATE SET "enabled" = true, "updatedAt" = NOW();

--- a/tests/visual/header-responsive.spec.ts
+++ b/tests/visual/header-responsive.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type Page } from "@playwright/test";
+import { horizontalScroll } from "./helpers/viewport";
+
+/**
+ * Guards the global header across the two breakpoints where its layout changes regime.
+ *
+ * The defect this spec was written for: at exactly 1024px the whole desktop navigation appeared at
+ * once next to a search trigger carrying `min-w-[200px]`, and the document overflowed by 100px. The
+ * existing guards sampled 375 / 768 / 1440 and stepped straight over it.
+ *
+ * The header is global, so `/` is only a witness page: any page would show the same defect. It is
+ * public and read-only, so no session is forged and no fixture is needed — a dev server serving the
+ * homepage is enough:
+ *
+ *   npm run dev
+ *   npx playwright test header-responsive --project=chromium
+ *
+ * Precondition: the three flags that widen the header (`STATISTIQUES_SECTION`, `PROGRAMMES_ENABLED`,
+ * `BOUSSOLE_ENABLED`) must be enabled on the database behind that server. They add two labelled links
+ * and one icon, so they produce the widest header — the only configuration where this guard means
+ * anything. The destinations assertion below fails loudly rather than passing on a narrower header.
+ */
+
+/** Tailwind `lg` is 1024 and `xl` is 1280. Each is tested one pixel below and at the boundary. */
+const BREAKPOINT_WIDTHS = [1023, 1024, 1279, 1280] as const;
+
+const THEMES = ["light", "dark"] as const;
+
+const PRIMARY_DESTINATIONS = [
+  { href: "/statistiques", label: "Statistiques" },
+  { href: "/politiques", label: "Politiques" },
+  { href: "/affaires", label: "Affaires" },
+  { href: "/programmes", label: "Programmes" },
+  { href: "/parlement", label: "Parlement" },
+];
+
+const MOBILE_MENU = '[role="dialog"][aria-label="Menu de navigation"]';
+
+type Regime = "mobile" | "desktop-compact" | "desktop-full";
+
+function regimeFor(width: number): Regime {
+  if (width < 1024) return "mobile";
+  return width < 1280 ? "desktop-compact" : "desktop-full";
+}
+
+/**
+ * Every header descendant whose box crosses a viewport edge.
+ *
+ * Complements the scroll measurement rather than repeating it: a sticky, clipped or
+ * `overflow: hidden` ancestor can swallow the page scroll while children still sit outside the
+ * viewport, which is a visual defect the scroll number alone reports as clean.
+ */
+async function headerElementsOutsideViewport(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const header = document.querySelector('header[role="banner"]');
+    if (!header) throw new Error('header[role="banner"] est introuvable');
+
+    const viewport = document.documentElement.clientWidth;
+    const escaped: string[] = [];
+
+    for (const element of header.querySelectorAll("*")) {
+      const box = element.getBoundingClientRect();
+
+      // Collapsed box: the element is not rendered at this width.
+      if (box.width === 0 && box.height === 0) continue;
+
+      // Screen-reader-only text is a 1px absolutely positioned box by design, and it is allowed to
+      // sit off-screen. It is never a visual overflow.
+      const style = getComputedStyle(element);
+      if (style.position === "absolute" && box.width <= 1 && box.height <= 1) continue;
+
+      // Half a pixel of tolerance: subpixel layout rounds boxes past an integer edge.
+      if (box.right > viewport + 0.5 || box.left < -0.5) {
+        // `getAttribute`, not `className`: on an SVG element the latter is an SVGAnimatedString
+        // and stringifies to "[object SVGAnimatedString]", which tells the reader nothing.
+        const classes = (element.getAttribute("class") ?? "")
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean)
+          .slice(0, 3)
+          .join(".");
+        escaped.push(
+          `<${element.tagName.toLowerCase()}${classes ? "." + classes : ""}> ` +
+            `left=${Math.round(box.left)} right=${Math.round(box.right)} (viewport ${viewport})`
+        );
+      }
+    }
+
+    return escaped;
+  });
+}
+
+for (const theme of THEMES) {
+  for (const width of BREAKPOINT_WIDTHS) {
+    const regime = regimeFor(width);
+
+    test.describe(`en-tête à ${width}px, thème ${theme === "dark" ? "sombre" : "clair"}`, () => {
+      test.beforeEach(async ({ page }) => {
+        await page.emulateMedia({ colorScheme: theme });
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto("/");
+        await expect(page.locator('header[role="banner"]')).toBeVisible();
+
+        // The theme is applied by next-themes from `prefers-color-scheme`, asynchronously after
+        // hydration. Asserting the class is what makes "verified in dark theme" a fact rather than
+        // a claim: without it, both runs could silently exercise the light theme.
+        await expect
+          .poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
+          .toBe(theme === "dark");
+      });
+
+      test("ne laisse aucun défilement horizontal", async ({ page }) => {
+        expect(await horizontalScroll(page)).toBe(0);
+      });
+
+      test("ne laisse aucun élément hors du viewport", async ({ page }) => {
+        expect(await headerElementsOutsideViewport(page)).toEqual([]);
+      });
+
+      test("garde les cinq destinations principales atteignables, libellés compris", async ({
+        page,
+      }) => {
+        if (regime === "mobile") {
+          await page.getByRole("button", { name: "Ouvrir le menu" }).click();
+          await expect(page.locator(MOBILE_MENU)).toBeVisible();
+        }
+
+        // The mobile menu is portalled out of the header, so the scope follows the regime.
+        const scope = regime === "mobile" ? page.locator(MOBILE_MENU) : page.locator("header");
+
+        for (const { href, label } of PRIMARY_DESTINATIONS) {
+          const link = scope.locator(`a[href="${href}"]`).first();
+          await expect(link, `destination ${href} absente à ${width}px`).toBeVisible();
+          await expect(link, `destination ${href} sans libellé à ${width}px`).toContainText(label);
+        }
+      });
+
+      test("garde recherche, thème et Boussole atteignables", async ({ page }) => {
+        if (regime === "mobile") {
+          // Search sits in the header bar; theme and Boussole live inside the menu.
+          //
+          // `:visible` is required, not cosmetic: two buttons carry the accessible name
+          // "Rechercher" in the header, and here one of them is hidden by an ancestor rather than
+          // by itself. Without it Playwright reports a strict mode violation at this width.
+          await expect(
+            page.locator('header button[aria-label="Rechercher"]:visible')
+          ).toBeVisible();
+          await page.getByRole("button", { name: "Ouvrir le menu" }).click();
+          await expect(page.locator(MOBILE_MENU)).toBeVisible();
+        }
+
+        const scope = regime === "mobile" ? page.locator(MOBILE_MENU) : page.locator("header");
+
+        await expect(
+          scope.getByRole("button", { name: /Changer le thème|Passer en mode/ })
+        ).toBeVisible();
+        await expect(scope.getByRole("link", { name: /^Boussole politique/ })).toBeVisible();
+      });
+
+      test("n'expose qu'un seul contrôle de recherche", async ({ page }) => {
+        // The regression this encodes: the compact trigger used to carry `lg:hidden` inside a
+        // `hidden lg:flex` nav, so it was visible at no width at all. A count of exactly one
+        // catches both that disappearance and the duplicate the fix could have introduced.
+        const searchControls = page.locator('header button[aria-label^="Rechercher"]:visible');
+        await expect(searchControls).toHaveCount(1);
+
+        const fullTrigger = page.locator('header button[aria-label="Rechercher (Cmd+K)"]');
+        if (regime === "desktop-full") {
+          await expect(fullTrigger).toBeVisible();
+        } else {
+          await expect(fullTrigger).toBeHidden();
+        }
+      });
+    });
+  }
+}

--- a/tests/visual/header-responsive.spec.ts
+++ b/tests/visual/header-responsive.spec.ts
@@ -19,6 +19,9 @@ import { horizontalScroll } from "./helpers/viewport";
  * `BOUSSOLE_ENABLED`) must be enabled on the database behind that server. They add two labelled links
  * and one icon, so they produce the widest header — the only configuration where this guard means
  * anything. The destinations assertion below fails loudly rather than passing on a narrower header.
+ *
+ * On a disposable database, `tests/visual/fixtures/header-flags.sql` sets them. That is what the
+ * `header-responsive` CI job runs, so a local reproduction and the pipeline read the same header.
  */
 
 /** Tailwind `lg` is 1024 and `xl` is 1280. Each is tested one pixel below and at the boundary. */

--- a/tests/visual/helpers/viewport.ts
+++ b/tests/visual/helpers/viewport.ts
@@ -1,0 +1,18 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * How far the page can actually be scrolled sideways.
+ *
+ * Not `documentElement.scrollWidth - clientWidth`: that value also counts content clipped by
+ * `overflow: hidden` and content inside a legitimate horizontal scroller, so it reports an
+ * overflow the visitor never experiences. Asking the browser to scroll and reading back where
+ * it landed measures what a visitor gets.
+ */
+export async function horizontalScroll(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    window.scrollTo(2000, 0);
+    const x = window.scrollX;
+    window.scrollTo(0, 0);
+    return x;
+  });
+}

--- a/tests/visual/mesures-moderation.spec.ts
+++ b/tests/visual/mesures-moderation.spec.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+import { horizontalScroll } from "./helpers/viewport";
 
 /**
  * Accessibility and responsive checks for the measure moderation screens.
@@ -43,23 +44,6 @@ async function signIn(context: BrowserContext, password: string): Promise<void> 
       path: "/",
     },
   ]);
-}
-
-/**
- * How far the PAGE can actually be scrolled sideways.
- *
- * Not `documentElement.scrollWidth - clientWidth`: that value also counts content clipped by
- * `overflow: hidden` and content inside a legitimate horizontal scroller, so it reports an
- * overflow the visitor never experiences. Asking the browser to scroll and reading back where
- * it landed measures what a visitor gets.
- */
-async function horizontalScroll(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    window.scrollTo(2000, 0);
-    const x = window.scrollX;
-    window.scrollTo(0, 0);
-    return x;
-  });
 }
 
 /**

--- a/tests/visual/presidentielle-hub.spec.ts
+++ b/tests/visual/presidentielle-hub.spec.ts
@@ -1,5 +1,6 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { horizontalScroll } from "./helpers/viewport";
 
 /**
  * Accessibility and responsive checks for the public presidential hub, its themes index, and one
@@ -29,20 +30,6 @@ const PAGES = [
     path: "/elections/presidentielle-2027/sujets/numerique-tech",
   },
 ];
-
-/**
- * How far the PAGE can actually be scrolled sideways, not `scrollWidth - clientWidth` (which also counts
- * content clipped by overflow:hidden and legitimate inner scrollers). Asking the browser to scroll and
- * reading back where it landed measures what a visitor experiences.
- */
-async function horizontalScroll(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    window.scrollTo(2000, 0);
-    const x = window.scrollX;
-    window.scrollTo(0, 0);
-    return x;
-  });
-}
 
 for (const { name, path } of PAGES) {
   test.describe(`${name} (présidentielle 2027)`, () => {

--- a/tests/visual/presidentielle-sujet.spec.ts
+++ b/tests/visual/presidentielle-sujet.spec.ts
@@ -1,5 +1,6 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { horizontalScroll } from "./helpers/viewport";
 
 /**
  * Accessibility and responsive checks for the public presidential subject page.
@@ -20,20 +21,6 @@ import { expect, test, type Page } from "@playwright/test";
 const WCAG = ["wcag2a", "wcag2aa", "wcag21aa"];
 const SUBJECT_PATH = "/elections/presidentielle-2027/sujets/logement-urbanisme";
 const WIDTHS = [375, 768, 1440];
-
-/**
- * How far the PAGE can actually be scrolled sideways, not `scrollWidth - clientWidth` (which also counts
- * content clipped by overflow:hidden and legitimate inner scrollers). Asking the browser to scroll and
- * reading back where it landed measures what a visitor experiences.
- */
-async function horizontalScroll(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    window.scrollTo(2000, 0);
-    const x = window.scrollX;
-    window.scrollTo(0, 0);
-    return x;
-  });
-}
 
 test.describe("page sujet publique de la présidentielle 2027", () => {
   test("rend la comparaison seedée avec preuves et absence qualifiée", async ({ page }) => {


### PR DESCRIPTION
## Constat

À 1024 px, le document mesurait 1124 px de large. Barre de défilement horizontale de 100 px, sur toutes les pages puisque le défaut est dans le layout global.

## Cause

`lg` fait apparaître d'un coup les cinq liens libellés, le séparateur et le rail d'icônes. Dans ce rail, le déclencheur de recherche porte un `min-w-[200px]` incompressible. Rien n'est autorisé à se réduire ni à se replier, donc l'en-tête sort du cadre.

## Correction

La recherche devient une loupe entre `lg` et `xl`, puis reprend sa forme complète à partir de `xl`. Aucun breakpoint structurant ne bouge : le `<nav>` reste `hidden lg:flex`, le menu mobile reste `lg:hidden`. Les libellés de navigation restent lisibles à toutes les largeurs.

Le bouton compact existait déjà mais n'était visible à aucune largeur : il portait `lg:hidden` alors que son unique parent est `hidden lg:flex`. Il récupère ici la fenêtre pour laquelle il semblait avoir été écrit. Son nom devenait faux, d'où le renommage en `CommandPaletteTriggerCompact`.

| Largeur     | En-tête                                                  |
| ----------- | -------------------------------------------------------- |
| `< lg`      | loupe + hamburger (inchangé)                             |
| `lg` → `xl` | 5 liens libellés + loupe + thème + Boussole              |
| `>= xl`     | 5 liens libellés + recherche complète + thème + Boussole |

## Non-régression

Les gardes existantes échantillonnaient 375, 768 et 1440. Elles sautaient donc exactement la largeur qui introduisait le défaut, ce qui explique qu'il ait vécu sans être vu.

`tests/visual/header-responsive.spec.ts` couvre 1023, 1024, 1279 et 1280, en thème clair et sombre. Le helper `horizontalScroll`, jusque-là dupliqué à l'identique dans trois specs, est extrait dans `tests/visual/helpers/viewport.ts`. Les `WIDTHS` des specs présidentielle sont inchangées.

## La garde tourne en CI

Une spec disponible via `npm run test:visual` n'aurait rien empêché : aucun job du pipeline ne lançait de navigateur, et c'est exactement ce qui a permis à ce défaut de vivre à travers une CI verte.

Le job `header-responsive` de `ci.yml` reprend le montage déjà utilisé par le job `build` : PostgreSQL 17 vide, `docker/init-search.sql`, `prisma db push`. Il ajoute le seed des trois drapeaux (`tests/visual/fixtures/header-flags.sql`), Chromium seul, et la seule spec de l'en-tête.

Deux liens primaires sur cinq et la Boussole sont conditionnés par des drapeaux lus en base. Sans ce seed, la garde mesurerait un en-tête plus étroit que le pire cas et passerait au vert sans rien prouver. Le reste de la suite visuelle n'est pas lancé : les autres specs demandent leurs propres fixtures métier, celle-ci a été écrite pour tenir sur `/` avec une base vide.

## Test plan

Cycle rouge puis vert, en remettant l'en-tête dans son état d'avant correction :

- sans le correctif : 8 échecs ciblés, `horizontalScroll` à 100 et 10 éléments hors viewport à 1024 ;
- avec le correctif : 40 tests au vert, défilement à 0 sur les 8 combinaisons largeur x thème.

Par ailleurs : `tsc --noEmit` sans erreur, `eslint` sans erreur, suite vitest complète à 3816 tests passés.

Vérifié avec les trois drapeaux qui élargissent l'en-tête activés (`STATISTIQUES_SECTION`, `PROGRAMMES_ENABLED`, `BOUSSOLE_ENABLED`), c'est-à-dire dans sa configuration la plus large.

Le job a tourné sur cette PR : `INSERT 0 3` pour les drapeaux, puis `Running 40 tests`, `40 passed`. La page d'accueil se rend donc bien sur une base vide, ce qui n'allait pas de soi.

## Limites connues

Les trois specs recâblées n'ont pas été rejouées : elles demandent la base jetable seedée avec leurs fixtures. La fonction extraite est identique au caractère près aux copies supprimées, `tsc` valide l'import et Playwright collecte toujours leurs tests.

Le job sert l'application avec `next dev`, parce que c'est ce que lance le `webServer` de Playwright. Tailwind génère ses classes à la demande en dev et les purge en production : une classe présente en dev mais purgée en prod passerait au vert ici. Nos classes sont des littéraux statiques que le scanner voit, donc le risque est faible, mais la garde ne couvre pas ce cas.

Enfin, la garde vérifie que les cinq destinations actuelles sont présentes, ce qui la rend rouge si un drapeau s'éteint. Elle ne saurait pas qu'un futur sixième lien primaire, derrière un nouveau drapeau, manque au seed.

Issue: #688
