### PR TITLE
docs(audit): version audit baseline and remediation protocol

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/remediation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/remediation.md
@@ -9,10 +9,12 @@
 ## Regression or attack scenario
 
 <!-- Describe a safe, concrete scenario that violated the invariant before remediation. -->
+<!-- For an unresolved exploitable security finding, do not include exploit-enabling evidence in a public PR. Reference the private security advisory instead. -->
 
 ## Before-proof or reproduction
 
 <!-- Link the red test, measurement, or bounded manual reproduction. Exclude secrets and personal data. -->
+<!-- For an unresolved exploitable security finding, do not include exploit-enabling evidence in a public PR. Reference the private security advisory instead. -->
 
 ## Correction
 
@@ -29,6 +31,7 @@
 ## Adversary and independent verification
 
 <!-- Record the second context, bypass attempts, regressions considered, and unresolved blockers. -->
+<!-- For an unresolved exploitable security finding, do not include exploit-enabling evidence in a public PR. Reference the private security advisory instead. -->
 
 ## Out of scope
 

--- a/.github/PULL_REQUEST_TEMPLATE/remediation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/remediation.md
@@ -1,0 +1,51 @@
+## Finding
+
+<!-- SEC-*, CI-*, DB-*, UX-*, or AGENT-* identifier. -->
+
+## Root cause
+
+<!-- Describe the evidence-based cause, not only the observed symptom. -->
+
+## Regression or attack scenario
+
+<!-- Describe a safe, concrete scenario that violated the invariant before remediation. -->
+
+## Before-proof or reproduction
+
+<!-- Link the red test, measurement, or bounded manual reproduction. Exclude secrets and personal data. -->
+
+## Correction
+
+<!-- Explain the smallest correction and why it preserves product and editorial invariants. -->
+
+## After-tests
+
+<!-- List exact commands, measurements, and results. Include required GitHub CI before merge. -->
+
+## Affected invariants
+
+<!-- Link the finding register and name every security, business, editorial, UX, or performance invariant. -->
+
+## Adversary and independent verification
+
+<!-- Record the second context, bypass attempts, regressions considered, and unresolved blockers. -->
+
+## Out of scope
+
+<!-- List related work deliberately excluded from this PR. -->
+
+## Rollback
+
+<!-- Required for risky changes. For DB work, include the versioned rollback or forward-fix plan. -->
+
+## Domain-specific evidence
+
+<!-- DB: metric or EXPLAIN before and after. UI: relevant mobile, desktop, keyboard, and axe checks. -->
+
+## Checklist
+
+- [ ] The living findings register has current status, owner, evidence, PR, and last-updated values
+- [ ] The Implementer did not self-certify the change
+- [ ] The standard local verification suite passed before opening the PR
+- [ ] Required GitHub CI passes before merge
+- [ ] No sensitive data is included in code, logs, evidence, or this PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ scripts/            Ops scripts (sync, backfill, fix, audit)
 ```bash
 node -v                # Must be >= 22
 npm install
-# Set up .env with DATABASE_URL, ADMIN_TOKEN, ANTHROPIC_API_KEY
+# Set up .env with DATABASE_URL, ADMIN_PASSWORD, ANTHROPIC_API_KEY
 npm run db:generate    # Generate Prisma client
 npm run dev            # Dev server on localhost:3000
 ```
@@ -436,6 +436,12 @@ Beyond this file:
 - GitHub Issues — ongoing initiatives, roadmap.
 
 A personal `CLAUDE.local.md` may exist in the working directory with deploy-specific workflows (Vercel aliases, production debugging, local shortcuts). It is gitignored by design. Do not copy its content into this file.
+
+### Agentic remediation findings
+
+When a task carries a `SEC-*`, `CI-*`, `DB-*`, `UX-*`, or `AGENT-*` identifier, read
+`docs/audits/security-ux-baseline-2026-08.md` and
+`docs/engineering/agentic-remediation.md` before investigating or changing code.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm run dev
 | `GOOGLE_FACTCHECK_API_KEY` | Clé API Google Fact Check         | Pour `sync:factchecks` |
 | `VOYAGE_API_KEY`           | Clé Voyage AI (embeddings)        | Pour le chatbot        |
 | `MAILJET_API_KEY`          | Clé Mailjet                       | Pour la newsletter     |
-| `ADMIN_TOKEN`              | Token d'authentification admin    | Pour l'admin           |
+| `ADMIN_PASSWORD`           | Mot de passe admin                | Pour l'admin           |
 
 Voir `docs/DATASOURCES.md` pour la liste complète.
 

--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -1,170 +1,164 @@
-# Baseline sécurité, architecture, performance et UX, août 2026
+# Security, architecture, performance, and UX baseline, August 2026
 
-Ce document est le registre versionné des constats retenus pour la remédiation agentique de
-Poligraph. Il décrit des risques et des invariants cibles. Il ne vaut ni preuve d'exploitation en
-production, ni autorisation de modifier la production, ni correction des constats.
+This document is the versioned register of findings selected for Poligraph's agentic remediation
+program. It records risks and target invariants. It is not evidence of production exploitation,
+authorization to modify production, or a remediation of any finding.
 
-## Métadonnées du baseline
+## Baseline metadata
 
-| Champ                      | Valeur                                                                             |
-| -------------------------- | ---------------------------------------------------------------------------------- |
-| Lot                        | `AGENT-00`                                                                         |
-| Date de référence          | 8 août 2026                                                                        |
-| Révision du code inspectée | `a24fcc13`                                                                         |
-| Branche de référence       | `origin/main`                                                                      |
-| État initial des constats  | À instruire                                                                        |
-| Protocole obligatoire      | [`docs/engineering/agentic-remediation.md`](../engineering/agentic-remediation.md) |
+| Field                  | Value                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| Work package           | `AGENT-00`                                                                         |
+| Baseline date          | August 8, 2026                                                                     |
+| Inspected revision     | `a24fcc13`                                                                         |
+| Reference branch       | `origin/main`                                                                      |
+| Initial finding status | To investigate                                                                     |
+| Required protocol      | [`docs/engineering/agentic-remediation.md`](../engineering/agentic-remediation.md) |
 
-Les preuves ci-dessous sont des points de départ observés dans le dépôt. Le Scout de chaque lot
-doit les revérifier sur le code et, si nécessaire, sur un environnement de mesure autorisé. Une
-affirmation sur les données de production doit être confirmée par une mesure en lecture seule.
+The evidence below consists of starting points observed in the repository. The Scout for each work
+package must verify them against the current code and, when needed, an authorized measurement
+environment. Any claim about production data must be confirmed by a read-only measurement.
 
-## États du registre
+## Register statuses
 
-- `À instruire` : contexte initial versionné, reproduction et périmètre à confirmer.
-- `Confirmé` : reproduction sûre ou mesure disponible.
-- `En remédiation` : PR dédiée ouverte.
-- `Vérifié` : correction testée par un contexte distinct de celui qui l'a implémentée.
-- `Clos` : correction fusionnée et preuve après archivées.
-- `Accepté` : risque explicitement accepté, avec responsable, justification et date de revue.
+- `To investigate`: initial context is versioned, but reproduction and scope remain to be confirmed.
+- `Confirmed`: a safe reproduction or measurement is available.
+- `In remediation`: a dedicated pull request is open.
+- `Verified`: a context distinct from the Implementer has tested the remediation.
+- `Closed`: the remediation is merged and the after-evidence is archived.
+- `Accepted`: the risk is explicitly accepted with an owner, rationale, and review date.
 
-Un finding ne passe pas directement de `À instruire` à `Clos`. Les preuves avant et après restent
-liées à son identifiant dans la PR de remédiation.
+A finding must not move directly from `To investigate` to `Closed`. The remediation PR must retain
+links to the before and after evidence under the finding identifier.
 
-## Vue d'ensemble
+## Overview
 
-| Identifiant | Priorité               | Domaine              | État initial | Invariant principal                                          |
-| ----------- | ---------------------- | -------------------- | ------------ | ------------------------------------------------------------ |
-| `SEC-01`    | P0                     | Sécurité applicative | À instruire  | Aucun HTML ou attribut exécutable issu d'un texte non fiable |
-| `SEC-02`    | P0                     | Contrôle d'accès     | À instruire  | Aucune donnée non publiée par une voie alternative           |
-| `SEC-03`    | P1                     | Supabase             | À instruire  | Surface publique explicitement minimale                      |
-| `SEC-04`    | P1                     | Authentification     | À instruire  | Sessions admin séparées, révocables et fail-closed           |
-| `CI-01`     | P1                     | CI                   | À instruire  | Chaque guard critique est testé en positif et en négatif     |
-| `CI-02`     | P1                     | Qualité              | À instruire  | Les scripts sensibles passent une analyse statique adaptée   |
-| `SEC-05`    | P1                     | Chaîne logicielle    | À instruire  | Dépendances et actions font l'objet de contrôles versionnés  |
-| `DB-01`     | À prioriser par mesure | Performance DB       | À instruire  | Calculer seulement le travail nécessaire                     |
-| `DB-02`     | Continu                | Performance DB       | À instruire  | Prioriser fréquence, coût et impact utilisateur              |
-| `UX-01`     | P1                     | UX et qualité        | À instruire  | Les défauts récurrents deviennent des contrats sémantiques   |
-| `AGENT-01`  | P1                     | Gouvernance          | À instruire  | Les règles critiques sont dérivables, testables ou vérifiées |
+| Identifier | Priority           | Area                  | Initial status | Primary invariant                                           |
+| ---------- | ------------------ | --------------------- | -------------- | ----------------------------------------------------------- |
+| `SEC-01`   | P0                 | Application security  | To investigate | Untrusted text cannot produce executable HTML or attributes |
+| `SEC-02`   | P0                 | Access control        | To investigate | Unpublished data has no alternative public path             |
+| `SEC-03`   | P1                 | Supabase              | To investigate | The public surface is explicitly minimal                    |
+| `SEC-04`   | P1                 | Authentication        | To investigate | Admin sessions are separated, revocable, and fail closed    |
+| `CI-01`    | P1                 | CI                    | To investigate | Every critical guard has positive and negative tests        |
+| `CI-02`    | P1                 | Quality               | To investigate | Sensitive scripts receive suitable static analysis          |
+| `SEC-05`   | P1                 | Software supply chain | To investigate | Dependencies and actions have versioned controls            |
+| `DB-01`    | Measurement-driven | Database performance  | To investigate | Compute only the necessary work                             |
+| `DB-02`    | Continuous         | Database performance  | To investigate | Prioritize frequency, cost, and user impact                 |
+| `UX-01`    | P1                 | UX and quality        | To investigate | Recurring defects become semantic contracts                 |
+| `AGENT-01` | P1                 | Governance            | To investigate | Critical rules are derivable, testable, or verified         |
 
-## Findings P0
+## P0 findings
 
 ### SEC-01: Eliminate Markdown stored-XSS path
 
-**Contexte observé.** `src/components/ui/markdown.tsx` construit une chaîne HTML puis la transmet
-à `dangerouslySetInnerHTML`. Le renderer échappe actuellement `&`, `<` et `>`, mais génère aussi
-des attributs `href` à partir du texte Markdown sans échapper les guillemets. Il est utilisé pour
-des contenus éditoriaux, externes ou produits par des pipelines IA. Toute sortie LLM est une donnée
-non fiable.
+**Observed context.** `src/components/ui/markdown.tsx` builds an HTML string and passes it to
+`dangerouslySetInnerHTML`. The renderer currently escapes `&`, `<`, and `>`, but also creates `href`
+attributes from Markdown text without escaping quotes. It renders editorial, external, and
+AI-pipeline content. Every LLM output is untrusted data.
 
-**Invariant cible.** Aucun texte éditorial, externe ou généré par IA ne doit pouvoir injecter du
-HTML ou des attributs exécutables dans l'application.
+**Target invariant.** No editorial, external, or AI-generated text can inject executable HTML or
+attributes into the application.
 
-**Preuve attendue avant correction.** Un test automatisé, avec des payloads inoffensifs, démontre
-qu'un texte non fiable ne peut créer ni élément HTML arbitraire, ni gestionnaire d'événement, ni URL
-exécutable, y compris dans le texte et la destination d'un lien.
+**Required before-evidence.** An automated test using harmless payloads demonstrates whether
+untrusted text can create arbitrary HTML, event handlers, or executable URLs, including through
+link text and destinations.
 
-**Critères de clôture.** Le renderer repose sur une construction sûre ou une sanitisation éprouvée,
-les cas de contournement sont couverts, les usages existants ont été inventoriés, et un Adversary
-distinct a testé des payloads alternatifs.
+**Closure criteria.** The renderer uses a safe construction method or proven sanitization, bypass
+cases are covered, existing consumers are inventoried, and a distinct Adversary has tested
+alternative payloads.
 
-**Mapping.** OWASP A05 Injection. OWASP A08 Software and Data Integrity Failures lorsque la donnée
-provient d'un pipeline IA.
+**Mapping.** OWASP A05 Injection. OWASP A08 Software and Data Integrity Failures when data comes
+from an AI pipeline.
 
 ### SEC-02: Close unintended Supabase Data API exposure
 
-**Contexte observé.** L'application utilise principalement PostgreSQL via Prisma et aucune
-utilisation applicative évidente de `supabase-js` n'a été trouvée. Les fichiers SQL versionnés
-activent RLS, mais `prisma/migrations/manual/rls-public-read-policies.sql` définit pour `FactCheck`
-une policy `SELECT TO anon USING (true)`. Le modèle `FactCheck` possède `publicationStatus` avec
-`DRAFT` par défaut. L'audit signale l'existence de fact-checks non publiés en production, point à
-confirmer par une requête en lecture seule avant toute remédiation.
+**Observed context.** The application primarily uses PostgreSQL through Prisma, and no obvious
+application use of `supabase-js` was found. The versioned SQL files enable RLS, but
+`prisma/migrations/manual/rls-public-read-policies.sql` defines a `SELECT TO anon USING (true)`
+policy for `FactCheck`. The `FactCheck` model has a `publicationStatus` field that defaults to
+`DRAFT`. The audit reports unpublished fact-checks in production. A read-only query must confirm
+that production claim before remediation.
 
-**Invariant cible.** Une donnée non publiée ne doit jamais devenir publiquement accessible par une
-voie alternative à l'application.
+**Target invariant.** Unpublished data must never become publicly accessible through a path that
+bypasses the application.
 
-**Preuve attendue avant correction.** Reproduire sur un environnement isolé les droits effectifs
-des rôles Data API et inventorier les tables, vues, colonnes, policies, grants et RPC exposés. Une
-mesure de production éventuelle reste strictement en lecture seule et ne contient aucune donnée
-sensible dans les artefacts de PR.
+**Required before-evidence.** Reproduce effective Data API permissions in an isolated environment
+and inventory exposed tables, views, columns, policies, grants, and RPC functions. Any production
+measurement remains read-only and excludes sensitive data from PR artifacts.
 
-**Critères de clôture.** Un test avec le rôle public refuse les fact-checks non publiés et autorise
-uniquement la surface publique décidée. Le schéma versionné, l'état déployé et la documentation sont
-alignés.
+**Closure criteria.** A test using the public role rejects unpublished fact-checks and allows only
+the approved public surface. The versioned schema, deployed state, and documentation are aligned.
 
 **Mapping.** OWASP A01 Broken Access Control. OWASP A02 Security Misconfiguration.
 
-## Findings P1
+## P1 findings
 
 ### SEC-03: Least-privilege Supabase public surface
 
-**But.** Décider explicitement si la Data API doit exister. Si elle est inutile, la désactiver. Si
-elle est nécessaire, n'exposer que les vues, tables et colonnes explicitement publiques, puis revoir
-les grants, les policies et les fonctions RPC avec le principe du moindre privilège.
+**Goal.** Explicitly decide whether the Data API should exist. Disable it if it is unnecessary. If
+it is required, expose only explicitly public views, tables, and columns, then review grants,
+policies, and RPC functions according to least privilege.
 
-**Investigation attendue.** Inventorier les clients réels, les clés publiques, les schémas exposés,
-les privilèges par rôle, les fonctions `SECURITY DEFINER` et les dépendances externes. Ne pas déduire
-l'état de production des seuls fichiers SQL manuels.
+**Required investigation.** Inventory actual clients, public keys, exposed schemas, privileges by
+role, `SECURITY DEFINER` functions, and external dependencies. Do not infer production state from
+manual SQL files alone.
 
-**Critères de clôture.** La décision d'architecture est documentée, la surface nécessaire est testée
-par rôle et tout accès non prévu échoue par défaut.
+**Closure criteria.** The architecture decision is documented, the required surface is tested by
+role, and every unintended access fails closed.
 
 ### SEC-04: Harden admin authentication
 
-**Contexte observé.** Le code actuel utilise `ADMIN_PASSWORD` pour vérifier le mot de passe et comme
-clé HMAC d'un cookie de session stateless valable sept jours. L'absence de variable échoue fermée.
-Le lot devra vérifier sans présumer de leur absence ou présence :
+**Observed context.** The current code uses `ADMIN_PASSWORD` both to verify the password and as the
+HMAC key for a stateless session cookie valid for seven days. A missing variable fails closed. The
+work package must verify, without assuming presence or absence:
 
-- la séparation du mot de passe et du secret de session ;
-- la durée des sessions ;
-- la révocation ;
-- une limitation distribuée des tentatives de connexion ;
-- le comportement fail-closed en production ;
-- une évolution future vers MFA sans réécriture complète.
+- separation between the password and the session secret;
+- session duration;
+- revocation;
+- distributed login-attempt rate limiting;
+- fail-closed production behavior;
+- a future MFA path that does not require rewriting the architecture.
 
-**Critères de clôture.** Le modèle de menace, les propriétés de session, la rotation et la révocation
-sont testés. La correction reste compatible avec l'ajout futur de MFA et ne réduit pas les contrôles
-d'accès existants.
+**Closure criteria.** The threat model, session properties, rotation, and revocation are tested. The
+remediation supports a future MFA addition and does not weaken existing access controls.
 
 ### CI-01: Make security guards trustworthy
 
-**Contexte observé.** `.github/workflows/code-quality.yml` contient plusieurs guards utiles. Le guard
-`No JSON.parse of user input without try-catch` utilise `grep | while ...`; l'affectation
-`FOUND=1` se produit dans un sous-shell Bash et peut être perdue avant `exit $FOUND`.
+**Observed context.** `.github/workflows/code-quality.yml` contains several useful guards. The
+`No JSON.parse of user input without try-catch` guard uses `grep | while ...`; its `FOUND=1`
+assignment occurs in a Bash subshell and can be lost before `exit $FOUND`.
 
-**Invariant cible.** Chaque guard critique doit disposer d'un cas volontairement invalide qui fait
-échouer le guard et d'un cas valide qui passe.
+**Target invariant.** Every critical guard must include a deliberately invalid case that fails the
+guard and a valid case that passes.
 
-**Critères de clôture.** Les guards critiques sont extraits ou structurés pour être testables, leurs
-tests positif et négatif s'exécutent en CI, et les modes d'échec du shell sont explicites.
+**Closure criteria.** Critical guards are extracted or structured for testing, their positive and
+negative tests run in CI, and shell failure modes are explicit.
 
 ### CI-02: Bring scripts under static analysis
 
-**Contexte observé.** `eslint.config.mjs` exclut `scripts/**`, alors que ce dossier contient des
-importeurs, synchronisations, migrations, purges, backfills et traitements IA. TypeScript inclut la
-majorité des fichiers `.ts`, sauf `scripts/tmp-*`, mais cela ne remplace pas les règles ESLint.
+**Observed context.** `eslint.config.mjs` excludes `scripts/**`, although the directory contains
+importers, synchronization jobs, migrations, purge jobs, backfills, and AI processing. TypeScript
+includes most `.ts` files except `scripts/tmp-*`, but this does not replace ESLint rules.
 
-**But.** Définir une analyse statique adaptée aux scripts, sans masquer les écarts par une exclusion
-globale. Les exceptions nécessaires doivent être étroites, justifiées et testées.
+**Goal.** Define suitable static analysis for scripts without hiding issues through a global
+exclusion. Necessary exceptions must be narrow, justified, and tested.
 
-**Critères de clôture.** Les scripts durables passent une configuration versionnée, les scripts
-temporaires suivent leur convention de sortie, et les règles de sécurité pertinentes couvrent les
-chemins opérationnels.
+**Closure criteria.** Durable scripts pass a versioned configuration, temporary scripts follow the
+repository exit convention, and relevant security rules cover operational paths.
 
 ### SEC-05: Software supply-chain baseline
 
-**Contexte observé.** Les workflows référencent notamment `actions/checkout@v4`,
-`actions/setup-node@v4` et `actions/github-script@v7`, sans pinning par SHA. Aucun fichier de
-configuration CodeQL, Dependency Review ou Dependabot n'a été trouvé dans `.github/` lors de cette
-révision. Le lockfile npm est versionné et les jobs CI utilisent `npm ci`.
+**Observed context.** Workflows reference `actions/checkout@v4`, `actions/setup-node@v4`, and
+`actions/github-script@v7`, among others, without SHA pinning. No CodeQL, Dependency Review, or
+Dependabot configuration file was found under `.github/` at this revision. The npm lockfile is
+versioned and CI jobs use `npm ci`.
 
-**Évaluation attendue.** Évaluer CodeQL, Dependency Review, Dependabot ou équivalent, l'audit des
-dépendances et le pinning SHA des GitHub Actions lorsque pertinent. Documenter la cadence, les
-responsables, les seuils bloquants, la gestion des faux positifs et la procédure de mise à jour des
-SHA.
+**Required evaluation.** Evaluate CodeQL, Dependency Review, Dependabot or an equivalent, dependency
+auditing, and GitHub Action SHA pinning where appropriate. Document cadence, ownership, blocking
+thresholds, false-positive handling, and the SHA update process.
 
-**Critères de clôture.** Le dépôt possède un baseline reproductible, les alertes ont une voie de
-triage, et les choix de non-adoption éventuels sont motivés et datés.
+**Closure criteria.** The repository has a reproducible baseline, alerts have a triage path, and any
+decision not to adopt a control is justified and dated.
 
 **Mapping.** OWASP A03 Software Supply Chain Failures.
 
@@ -172,78 +166,77 @@ triage, et les choix de non-adoption éventuels sont motivés et datés.
 
 ### DB-01: Incremental group-position computation
 
-**Contexte de mesure.** L'audit a observé une requête liée au calcul des positions de groupes autour
-de 11 à 12 secondes. Cette mesure n'a pas été reproduite dans `AGENT-00`. La requête utilise déjà des
-indexes, donc un index supplémentaire n'est pas une conclusion par défaut.
+**Measurement context.** The audit observed a query related to group-position computation at around
+11 to 12 seconds. `AGENT-00` did not reproduce this measurement. The query already uses indexes, so
+an additional index is not the default conclusion.
 
-**But.** Réduire la quantité de travail exécutée, notamment par calcul incrémental, projection ou
-matérialisation si les mesures le justifient.
+**Goal.** Reduce the amount of executed work, potentially through incremental computation,
+projection, or materialization when measurements justify it.
 
-**Critères de clôture.** Le lot conserve la requête et le jeu de données de référence, mesure avant
-et après, vérifie la fraîcheur des résultats et démontre l'absence de régression fonctionnelle.
+**Closure criteria.** The work package preserves the reference query and dataset, measures before
+and after, verifies result freshness, and demonstrates no functional regression.
 
 ### DB-02: Top SQL workload remediation
 
-**Principe.** Prioriser avec `pg_stat_statements` selon fréquence multipliée par coût, puis impact
-utilisateur. Une requête lente mais rare ne passe pas automatiquement devant une requête moins lente
-qui domine le temps total ou bloque une surface citoyenne importante.
+**Principle.** Prioritize with `pg_stat_statements` using frequency multiplied by cost, then user
+impact. A slow but rare query does not automatically rank above a faster query that dominates total
+time or blocks an important citizen-facing surface.
 
-Toute optimisation documente :
+Every optimization documents:
 
-1. la mesure avant ;
-2. l'hypothèse ;
-3. la modification ;
-4. la mesure après ;
-5. l'absence de régression.
+1. the before measurement;
+2. the hypothesis;
+3. the change;
+4. the after measurement;
+5. the absence of regression.
 
-Les mesures de production sont en lecture seule. Les expérimentations et écritures utilisent un
-environnement isolé, de préférence PostgreSQL 17 sous Docker.
+Production measurements are read-only. Experiments and writes use an isolated environment,
+preferably PostgreSQL 17 under Docker.
 
-## UX et qualité
+## UX and quality
 
 ### UX-01: Convert recurring UX defects into semantic contracts
 
-Les défauts récurrents doivent devenir des invariants testables ou des revues explicites :
+Recurring defects must become testable invariants or explicit review checks:
 
-- `unknown !== false` : une valeur inconnue ne doit pas être rendue comme fausse ;
-- un état passé ou futur dérivé de dates ne doit pas être codé en dur ;
-- le compteur affiché et la collection rendue partagent le même prédicat ;
-- le libellé d'un lien décrit sa destination réelle ;
-- un contenu généré par IA n'est pas un contenu vérifié ;
-- une information publique importante conserve sa source ;
-- un état n'est jamais communiqué uniquement par la couleur ;
-- aucun overflow horizontal ne survient à partir de 320 px ;
-- aucune nouvelle violation axe sérieuse n'est introduite.
+- `unknown !== false`;
+- a past or future state derived from dates must not be hard-coded;
+- the displayed count and rendered collection must share the same predicate;
+- a link label must describe its actual destination;
+- AI-generated content is not verified content;
+- important public information must retain its source;
+- state must never be communicated through color alone;
+- no horizontal overflow from 320 px upward;
+- no new serious axe violation.
 
-**Critères de clôture.** Chaque invariant possède un emplacement de référence, un moyen de
-vérification adapté et au moins un exemple de régression. Les contrats éditoriaux restent
-prioritaires sur la compacité ou l'engagement.
+**Closure criteria.** Every invariant has a reference location, a suitable verification method, and
+at least one regression example. Editorial contracts remain more important than compactness or
+engagement.
 
-## Gouvernance
+## Governance
 
 ### AGENT-01: Make AGENTS.md executable/verifiable
 
-**Objectif.** Pour chaque règle critique d'`AGENTS.md`, déterminer progressivement si elle peut être
-dérivée automatiquement du code, testée, ou vérifiée en CI. Les règles non automatisables gardent
-un responsable et une checklist de revue explicite.
+**Goal.** For every critical `AGENTS.md` rule, progressively determine whether it can be derived
+automatically from code, tested, or verified in CI. Rules that cannot be automated retain an owner
+and an explicit review checklist.
 
-**Risque de dérive.** Une règle documentaire peut décrire une variable, une architecture ou un guard
-qui n'existe plus. À l'inverse, le code peut ajouter une nouvelle voie publique ou opérationnelle
-sans mise à jour du document. Toute automatisation qui recherche seulement du texte peut aussi
-rester verte à cause d'un commentaire alors que l'invariant a disparu du code.
+**Drift risk.** A documentation rule can describe a variable, architecture, or guard that no longer
+exists. Conversely, code can add a new public or operational path without updating the document.
+Text-only automation can also remain green because a comment names a signal that has disappeared
+from executable code.
 
-**Critères de clôture.** Un inventaire relie chaque règle critique à sa source de vérité, son test ou
-sa revue. La CI détecte les divergences mécanisables et les exceptions sont étroites et justifiées.
+**Closure criteria.** An inventory links every critical rule to its source of truth, test, or review.
+CI detects automatable divergence, and exceptions are narrow and justified.
 
-## Limites de ce baseline
+## Baseline limitations
 
-`AGENT-00` ne corrige aucun finding. Il ne modifie ni comportement produit, ni route, ni modèle
-Prisma, ni migration, ni configuration Supabase, ni règle métier. Chaque remédiation reçoit une PR
-dédiée et suit le protocole agentique lié ci-dessus.
+`AGENT-00` remediates no finding. It changes no product behavior, route, Prisma model, migration,
+Supabase configuration, or business rule. Every remediation receives a dedicated PR and follows the
+agentic protocol linked above.
 
-## Dérive documentaire corrigée dans AGENT-00
+## Documentation drift corrected in AGENT-00
 
-`AGENTS.md` et `README.md` citaient encore `ADMIN_TOKEN`. Le code, `.env.example`, les tests visuels
-et le script de setup utilisent `ADMIN_PASSWORD`. Ces deux références documentaires ont été
-alignées sur le nom réel. Aucun code d'authentification, secret ou comportement de session n'a été
-modifié.
+`AGENTS.md` and `README.md` still referred to `ADMIN_TOKEN`. The code, `.env.example`, visual tests,
+and setup script use `ADMIN_PASSWORD`. These two documentation references were aligned with the
+actual name. No authentication code, secret, or session behavior was changed.

--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -41,61 +41,48 @@ change marks it `Closed`. Accepted risks retain their rationale and next review 
 
 ## Overview
 
-| Identifier | Priority           | Area                  | Current status | Owner      | Evidence                                                               | Remediation PR | Last updated |
-| ---------- | ------------------ | --------------------- | -------------- | ---------- | ---------------------------------------------------------------------- | -------------- | ------------ |
-| `SEC-01`   | P0                 | Application security  | To investigate | Unassigned | [Context](#sec-01-eliminate-markdown-stored-xss-path)                  | None           | 2026-08-08   |
-| `SEC-02`   | P0                 | Access control        | To investigate | Unassigned | [Context](#sec-02-close-unintended-supabase-data-api-exposure)         | None           | 2026-08-08   |
-| `SEC-03`   | P1                 | Supabase              | To investigate | Unassigned | [Context](#sec-03-least-privilege-supabase-public-surface)             | None           | 2026-08-08   |
-| `SEC-04`   | P1                 | Authentication        | To investigate | Unassigned | [Context](#sec-04-harden-admin-authentication)                         | None           | 2026-08-08   |
-| `CI-01`    | P1                 | CI                    | To investigate | Unassigned | [Context](#ci-01-make-security-guards-trustworthy)                     | None           | 2026-08-08   |
-| `CI-02`    | P1                 | Quality               | To investigate | Unassigned | [Context](#ci-02-bring-scripts-under-static-analysis)                  | None           | 2026-08-08   |
-| `SEC-05`   | P1                 | Software supply chain | To investigate | Unassigned | [Context](#sec-05-software-supply-chain-baseline)                      | None           | 2026-08-08   |
-| `DB-01`    | Measurement-driven | Database performance  | To investigate | Unassigned | [Context](#db-01-incremental-group-position-computation)               | None           | 2026-08-08   |
-| `DB-02`    | Continuous         | Database performance  | To investigate | Unassigned | [Context](#db-02-top-sql-workload-remediation)                         | None           | 2026-08-08   |
-| `UX-01`    | P1                 | UX and quality        | To investigate | Unassigned | [Context](#ux-01-convert-recurring-ux-defects-into-semantic-contracts) | None           | 2026-08-08   |
-| `AGENT-01` | P1                 | Governance            | To investigate | Unassigned | [Context](#agent-01-make-agentsmd-executableverifiable)                | None           | 2026-08-08   |
+| Identifier | Priority           | Area                  | Current status | Owner      | Evidence                                                                    | Remediation PR | Last updated |
+| ---------- | ------------------ | --------------------- | -------------- | ---------- | --------------------------------------------------------------------------- | -------------- | ------------ |
+| `SEC-01`   | P0                 | Application security  | To investigate | Unassigned | Tracked privately until remediation                                         | None           | 2026-08-08   |
+| `SEC-02`   | P0                 | Access control        | To investigate | Unassigned | Tracked privately until remediation                                         | None           | 2026-08-08   |
+| `SEC-03`   | P1                 | Supabase              | To investigate | Unassigned | [Context](#sec-03-least-privilege-supabase-public-surface)                  | None           | 2026-08-08   |
+| `SEC-04`   | P1                 | Authentication        | To investigate | Unassigned | [Context](#sec-04-harden-admin-authentication)                              | None           | 2026-08-08   |
+| `SEC-06`   | P1                 | Database security     | To investigate | Unassigned | [Context](#sec-06-database-function-privilege-hardening)                    | None           | 2026-08-08   |
+| `SEC-07`   | P2                 | Application security  | To investigate | Unassigned | [Context](#sec-07-csp-hardening-without-sacrificing-rendering-architecture) | None           | 2026-08-08   |
+| `CI-01`    | P1                 | CI                    | To investigate | Unassigned | [Context](#ci-01-make-security-guards-trustworthy)                          | None           | 2026-08-08   |
+| `CI-02`    | P1                 | Quality               | To investigate | Unassigned | [Context](#ci-02-bring-scripts-under-static-analysis)                       | None           | 2026-08-08   |
+| `SEC-05`   | P1                 | Software supply chain | To investigate | Unassigned | [Context](#sec-05-software-supply-chain-baseline)                           | None           | 2026-08-08   |
+| `DB-01`    | Measurement-driven | Database performance  | To investigate | Unassigned | [Context](#db-01-incremental-group-position-computation)                    | None           | 2026-08-08   |
+| `DB-02`    | Continuous         | Database performance  | To investigate | Unassigned | [Context](#db-02-top-sql-workload-remediation)                              | None           | 2026-08-08   |
+| `DB-03`    | Measurement-driven | Database performance  | To investigate | Unassigned | [Context](#db-03-evaluate-foreign-key-indexing-from-measured-workloads)     | None           | 2026-08-08   |
+| `UX-01`    | P1                 | UX and quality        | To investigate | Unassigned | [Context](#ux-01-convert-recurring-ux-defects-into-semantic-contracts)      | None           | 2026-08-08   |
+| `AGENT-01` | P1                 | Governance            | To investigate | Unassigned | [Context](#agent-01-make-agentsmd-executableverifiable)                     | None           | 2026-08-08   |
 
 ## P0 findings
 
-### SEC-01: Eliminate Markdown stored-XSS path
+### SEC-01: Prevent active content injection from rich text
 
-**Observed context.** `src/components/ui/markdown.tsx` builds an HTML string and passes it to
-`dangerouslySetInnerHTML`. The renderer currently escapes `&`, `<`, and `>`, but also creates `href`
-attributes from Markdown text without escaping quotes. It renders editorial, external, and
-AI-pipeline content. Every LLM output is untrusted data.
+**Target invariant.** Untrusted editorial, external, or AI-generated rich text must never create
+executable active content in the application.
 
-**Target invariant.** No editorial, external, or AI-generated text can inject executable HTML or
-attributes into the application.
+Exploit-enabling evidence is tracked privately until remediation.
 
-**Required before-evidence.** An automated test using harmless payloads demonstrates whether
-untrusted text can create arbitrary HTML, event handlers, or executable URLs, including through
-link text and destinations.
-
-**Closure criteria.** The renderer uses a safe construction method or proven sanitization, bypass
-cases are covered, existing consumers are inventoried, and a distinct Adversary has tested
-alternative payloads.
+**Closure criteria.** Untrusted rich text is rendered through a safe construction method, regression
+tests enforce the invariant, and a distinct Adversary has completed private bypass testing.
 
 **Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A05:2025 Injection. A08:2025 Software or
 Data Integrity Failures when data comes from an AI pipeline.
 
-### SEC-02: Close unintended Supabase Data API exposure
+### SEC-02: Prevent alternate-path disclosure of unpublished data
 
-**Observed context.** The application primarily uses PostgreSQL through Prisma, and no obvious
-application use of `supabase-js` was found. The versioned SQL files enable RLS, but
-`prisma/migrations/manual/rls-public-read-policies.sql` defines a `SELECT TO anon USING (true)`
-policy for `FactCheck`. The `FactCheck` model has a `publicationStatus` field that defaults to
-`DRAFT`. The audit reports unpublished fact-checks in production. A read-only query must confirm
-that production claim before remediation.
+**Target invariant.** Unpublished data must never become publicly accessible through an alternate
+data-access path.
 
-**Target invariant.** Unpublished data must never become publicly accessible through a path that
-bypasses the application.
+Exploit-enabling evidence and access details are tracked privately until remediation.
 
-**Required before-evidence.** Reproduce effective Data API permissions in an isolated environment
-and inventory exposed tables, views, columns, policies, grants, and RPC functions. Any production
-measurement remains read-only and excludes sensitive data from PR artifacts.
-
-**Closure criteria.** A test using the public role rejects unpublished fact-checks and allows only
-the approved public surface. The versioned schema, deployed state, and documentation are aligned.
+**Closure criteria.** Role-based tests reject unpublished data through every public path, allow only
+the intentional public surface, and confirm that versioned controls, deployed state, and
+documentation are aligned.
 
 **Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A01:2025 Broken Access Control. A02:2025
 Security Misconfiguration.
@@ -171,6 +158,29 @@ decision not to adopt a control is justified and dated.
 
 **Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A03:2025 Software Supply Chain Failures.
 
+### SEC-06: Database function privilege hardening
+
+**Target invariant.** Database functions must execute with explicit, least-privilege semantics and
+must not unintentionally expose privileged operations to public roles.
+
+Exploit-enabling evidence and privilege details are tracked privately until remediation.
+
+**Closure criteria.** Function behavior and effective privileges are inventoried, object resolution
+is explicit where required, unnecessary execution rights are removed, intentional public API
+behavior is preserved, and tests verify access by role.
+
+### SEC-07: CSP hardening without sacrificing rendering architecture
+
+**Target invariant.** Browser security policy should reduce the impact of injection vulnerabilities
+without introducing unjustified regressions to static rendering, ISR, caching, or performance.
+
+**Required investigation.** Evaluate the current policy and relevant sinks, nonce-based policy,
+hash and SRI options, App Router rendering and cache compatibility, performance cost, and
+architectural impact.
+
+**Closure criteria.** A measured decision is documented and covered by CSP tests. CSP remains
+defense in depth and is not treated as a substitute for correcting injection sinks.
+
 ## Performance
 
 ### DB-01: Incremental group-position computation
@@ -201,6 +211,17 @@ Every optimization documents:
 
 Production measurements are read-only. Experiments and writes use an isolated environment,
 preferably PostgreSQL 17 under Docker.
+
+### DB-03: Evaluate foreign-key indexing from measured workloads
+
+**Target invariant.** Indexes must be justified by observed workload, cardinality, write cost, and
+measured query behavior rather than advisor output alone.
+
+**Required investigation.** For every candidate, evaluate cardinality, real joins, delete and update
+patterns, frequency, write cost, and whether an existing index already covers the need.
+
+**Closure criteria.** Every adopted index has before and after measurements. Every rejected index
+has a documented rationale.
 
 ## UX and quality
 

--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -1,0 +1,249 @@
+# Baseline sécurité, architecture, performance et UX, août 2026
+
+Ce document est le registre versionné des constats retenus pour la remédiation agentique de
+Poligraph. Il décrit des risques et des invariants cibles. Il ne vaut ni preuve d'exploitation en
+production, ni autorisation de modifier la production, ni correction des constats.
+
+## Métadonnées du baseline
+
+| Champ                      | Valeur                                                                             |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| Lot                        | `AGENT-00`                                                                         |
+| Date de référence          | 8 août 2026                                                                        |
+| Révision du code inspectée | `a24fcc13`                                                                         |
+| Branche de référence       | `origin/main`                                                                      |
+| État initial des constats  | À instruire                                                                        |
+| Protocole obligatoire      | [`docs/engineering/agentic-remediation.md`](../engineering/agentic-remediation.md) |
+
+Les preuves ci-dessous sont des points de départ observés dans le dépôt. Le Scout de chaque lot
+doit les revérifier sur le code et, si nécessaire, sur un environnement de mesure autorisé. Une
+affirmation sur les données de production doit être confirmée par une mesure en lecture seule.
+
+## États du registre
+
+- `À instruire` : contexte initial versionné, reproduction et périmètre à confirmer.
+- `Confirmé` : reproduction sûre ou mesure disponible.
+- `En remédiation` : PR dédiée ouverte.
+- `Vérifié` : correction testée par un contexte distinct de celui qui l'a implémentée.
+- `Clos` : correction fusionnée et preuve après archivées.
+- `Accepté` : risque explicitement accepté, avec responsable, justification et date de revue.
+
+Un finding ne passe pas directement de `À instruire` à `Clos`. Les preuves avant et après restent
+liées à son identifiant dans la PR de remédiation.
+
+## Vue d'ensemble
+
+| Identifiant | Priorité               | Domaine              | État initial | Invariant principal                                          |
+| ----------- | ---------------------- | -------------------- | ------------ | ------------------------------------------------------------ |
+| `SEC-01`    | P0                     | Sécurité applicative | À instruire  | Aucun HTML ou attribut exécutable issu d'un texte non fiable |
+| `SEC-02`    | P0                     | Contrôle d'accès     | À instruire  | Aucune donnée non publiée par une voie alternative           |
+| `SEC-03`    | P1                     | Supabase             | À instruire  | Surface publique explicitement minimale                      |
+| `SEC-04`    | P1                     | Authentification     | À instruire  | Sessions admin séparées, révocables et fail-closed           |
+| `CI-01`     | P1                     | CI                   | À instruire  | Chaque guard critique est testé en positif et en négatif     |
+| `CI-02`     | P1                     | Qualité              | À instruire  | Les scripts sensibles passent une analyse statique adaptée   |
+| `SEC-05`    | P1                     | Chaîne logicielle    | À instruire  | Dépendances et actions font l'objet de contrôles versionnés  |
+| `DB-01`     | À prioriser par mesure | Performance DB       | À instruire  | Calculer seulement le travail nécessaire                     |
+| `DB-02`     | Continu                | Performance DB       | À instruire  | Prioriser fréquence, coût et impact utilisateur              |
+| `UX-01`     | P1                     | UX et qualité        | À instruire  | Les défauts récurrents deviennent des contrats sémantiques   |
+| `AGENT-01`  | P1                     | Gouvernance          | À instruire  | Les règles critiques sont dérivables, testables ou vérifiées |
+
+## Findings P0
+
+### SEC-01: Eliminate Markdown stored-XSS path
+
+**Contexte observé.** `src/components/ui/markdown.tsx` construit une chaîne HTML puis la transmet
+à `dangerouslySetInnerHTML`. Le renderer échappe actuellement `&`, `<` et `>`, mais génère aussi
+des attributs `href` à partir du texte Markdown sans échapper les guillemets. Il est utilisé pour
+des contenus éditoriaux, externes ou produits par des pipelines IA. Toute sortie LLM est une donnée
+non fiable.
+
+**Invariant cible.** Aucun texte éditorial, externe ou généré par IA ne doit pouvoir injecter du
+HTML ou des attributs exécutables dans l'application.
+
+**Preuve attendue avant correction.** Un test automatisé, avec des payloads inoffensifs, démontre
+qu'un texte non fiable ne peut créer ni élément HTML arbitraire, ni gestionnaire d'événement, ni URL
+exécutable, y compris dans le texte et la destination d'un lien.
+
+**Critères de clôture.** Le renderer repose sur une construction sûre ou une sanitisation éprouvée,
+les cas de contournement sont couverts, les usages existants ont été inventoriés, et un Adversary
+distinct a testé des payloads alternatifs.
+
+**Mapping.** OWASP A05 Injection. OWASP A08 Software and Data Integrity Failures lorsque la donnée
+provient d'un pipeline IA.
+
+### SEC-02: Close unintended Supabase Data API exposure
+
+**Contexte observé.** L'application utilise principalement PostgreSQL via Prisma et aucune
+utilisation applicative évidente de `supabase-js` n'a été trouvée. Les fichiers SQL versionnés
+activent RLS, mais `prisma/migrations/manual/rls-public-read-policies.sql` définit pour `FactCheck`
+une policy `SELECT TO anon USING (true)`. Le modèle `FactCheck` possède `publicationStatus` avec
+`DRAFT` par défaut. L'audit signale l'existence de fact-checks non publiés en production, point à
+confirmer par une requête en lecture seule avant toute remédiation.
+
+**Invariant cible.** Une donnée non publiée ne doit jamais devenir publiquement accessible par une
+voie alternative à l'application.
+
+**Preuve attendue avant correction.** Reproduire sur un environnement isolé les droits effectifs
+des rôles Data API et inventorier les tables, vues, colonnes, policies, grants et RPC exposés. Une
+mesure de production éventuelle reste strictement en lecture seule et ne contient aucune donnée
+sensible dans les artefacts de PR.
+
+**Critères de clôture.** Un test avec le rôle public refuse les fact-checks non publiés et autorise
+uniquement la surface publique décidée. Le schéma versionné, l'état déployé et la documentation sont
+alignés.
+
+**Mapping.** OWASP A01 Broken Access Control. OWASP A02 Security Misconfiguration.
+
+## Findings P1
+
+### SEC-03: Least-privilege Supabase public surface
+
+**But.** Décider explicitement si la Data API doit exister. Si elle est inutile, la désactiver. Si
+elle est nécessaire, n'exposer que les vues, tables et colonnes explicitement publiques, puis revoir
+les grants, les policies et les fonctions RPC avec le principe du moindre privilège.
+
+**Investigation attendue.** Inventorier les clients réels, les clés publiques, les schémas exposés,
+les privilèges par rôle, les fonctions `SECURITY DEFINER` et les dépendances externes. Ne pas déduire
+l'état de production des seuls fichiers SQL manuels.
+
+**Critères de clôture.** La décision d'architecture est documentée, la surface nécessaire est testée
+par rôle et tout accès non prévu échoue par défaut.
+
+### SEC-04: Harden admin authentication
+
+**Contexte observé.** Le code actuel utilise `ADMIN_PASSWORD` pour vérifier le mot de passe et comme
+clé HMAC d'un cookie de session stateless valable sept jours. L'absence de variable échoue fermée.
+Le lot devra vérifier sans présumer de leur absence ou présence :
+
+- la séparation du mot de passe et du secret de session ;
+- la durée des sessions ;
+- la révocation ;
+- une limitation distribuée des tentatives de connexion ;
+- le comportement fail-closed en production ;
+- une évolution future vers MFA sans réécriture complète.
+
+**Critères de clôture.** Le modèle de menace, les propriétés de session, la rotation et la révocation
+sont testés. La correction reste compatible avec l'ajout futur de MFA et ne réduit pas les contrôles
+d'accès existants.
+
+### CI-01: Make security guards trustworthy
+
+**Contexte observé.** `.github/workflows/code-quality.yml` contient plusieurs guards utiles. Le guard
+`No JSON.parse of user input without try-catch` utilise `grep | while ...`; l'affectation
+`FOUND=1` se produit dans un sous-shell Bash et peut être perdue avant `exit $FOUND`.
+
+**Invariant cible.** Chaque guard critique doit disposer d'un cas volontairement invalide qui fait
+échouer le guard et d'un cas valide qui passe.
+
+**Critères de clôture.** Les guards critiques sont extraits ou structurés pour être testables, leurs
+tests positif et négatif s'exécutent en CI, et les modes d'échec du shell sont explicites.
+
+### CI-02: Bring scripts under static analysis
+
+**Contexte observé.** `eslint.config.mjs` exclut `scripts/**`, alors que ce dossier contient des
+importeurs, synchronisations, migrations, purges, backfills et traitements IA. TypeScript inclut la
+majorité des fichiers `.ts`, sauf `scripts/tmp-*`, mais cela ne remplace pas les règles ESLint.
+
+**But.** Définir une analyse statique adaptée aux scripts, sans masquer les écarts par une exclusion
+globale. Les exceptions nécessaires doivent être étroites, justifiées et testées.
+
+**Critères de clôture.** Les scripts durables passent une configuration versionnée, les scripts
+temporaires suivent leur convention de sortie, et les règles de sécurité pertinentes couvrent les
+chemins opérationnels.
+
+### SEC-05: Software supply-chain baseline
+
+**Contexte observé.** Les workflows référencent notamment `actions/checkout@v4`,
+`actions/setup-node@v4` et `actions/github-script@v7`, sans pinning par SHA. Aucun fichier de
+configuration CodeQL, Dependency Review ou Dependabot n'a été trouvé dans `.github/` lors de cette
+révision. Le lockfile npm est versionné et les jobs CI utilisent `npm ci`.
+
+**Évaluation attendue.** Évaluer CodeQL, Dependency Review, Dependabot ou équivalent, l'audit des
+dépendances et le pinning SHA des GitHub Actions lorsque pertinent. Documenter la cadence, les
+responsables, les seuils bloquants, la gestion des faux positifs et la procédure de mise à jour des
+SHA.
+
+**Critères de clôture.** Le dépôt possède un baseline reproductible, les alertes ont une voie de
+triage, et les choix de non-adoption éventuels sont motivés et datés.
+
+**Mapping.** OWASP A03 Software Supply Chain Failures.
+
+## Performance
+
+### DB-01: Incremental group-position computation
+
+**Contexte de mesure.** L'audit a observé une requête liée au calcul des positions de groupes autour
+de 11 à 12 secondes. Cette mesure n'a pas été reproduite dans `AGENT-00`. La requête utilise déjà des
+indexes, donc un index supplémentaire n'est pas une conclusion par défaut.
+
+**But.** Réduire la quantité de travail exécutée, notamment par calcul incrémental, projection ou
+matérialisation si les mesures le justifient.
+
+**Critères de clôture.** Le lot conserve la requête et le jeu de données de référence, mesure avant
+et après, vérifie la fraîcheur des résultats et démontre l'absence de régression fonctionnelle.
+
+### DB-02: Top SQL workload remediation
+
+**Principe.** Prioriser avec `pg_stat_statements` selon fréquence multipliée par coût, puis impact
+utilisateur. Une requête lente mais rare ne passe pas automatiquement devant une requête moins lente
+qui domine le temps total ou bloque une surface citoyenne importante.
+
+Toute optimisation documente :
+
+1. la mesure avant ;
+2. l'hypothèse ;
+3. la modification ;
+4. la mesure après ;
+5. l'absence de régression.
+
+Les mesures de production sont en lecture seule. Les expérimentations et écritures utilisent un
+environnement isolé, de préférence PostgreSQL 17 sous Docker.
+
+## UX et qualité
+
+### UX-01: Convert recurring UX defects into semantic contracts
+
+Les défauts récurrents doivent devenir des invariants testables ou des revues explicites :
+
+- `unknown !== false` : une valeur inconnue ne doit pas être rendue comme fausse ;
+- un état passé ou futur dérivé de dates ne doit pas être codé en dur ;
+- le compteur affiché et la collection rendue partagent le même prédicat ;
+- le libellé d'un lien décrit sa destination réelle ;
+- un contenu généré par IA n'est pas un contenu vérifié ;
+- une information publique importante conserve sa source ;
+- un état n'est jamais communiqué uniquement par la couleur ;
+- aucun overflow horizontal ne survient à partir de 320 px ;
+- aucune nouvelle violation axe sérieuse n'est introduite.
+
+**Critères de clôture.** Chaque invariant possède un emplacement de référence, un moyen de
+vérification adapté et au moins un exemple de régression. Les contrats éditoriaux restent
+prioritaires sur la compacité ou l'engagement.
+
+## Gouvernance
+
+### AGENT-01: Make AGENTS.md executable/verifiable
+
+**Objectif.** Pour chaque règle critique d'`AGENTS.md`, déterminer progressivement si elle peut être
+dérivée automatiquement du code, testée, ou vérifiée en CI. Les règles non automatisables gardent
+un responsable et une checklist de revue explicite.
+
+**Risque de dérive.** Une règle documentaire peut décrire une variable, une architecture ou un guard
+qui n'existe plus. À l'inverse, le code peut ajouter une nouvelle voie publique ou opérationnelle
+sans mise à jour du document. Toute automatisation qui recherche seulement du texte peut aussi
+rester verte à cause d'un commentaire alors que l'invariant a disparu du code.
+
+**Critères de clôture.** Un inventaire relie chaque règle critique à sa source de vérité, son test ou
+sa revue. La CI détecte les divergences mécanisables et les exceptions sont étroites et justifiées.
+
+## Limites de ce baseline
+
+`AGENT-00` ne corrige aucun finding. Il ne modifie ni comportement produit, ni route, ni modèle
+Prisma, ni migration, ni configuration Supabase, ni règle métier. Chaque remédiation reçoit une PR
+dédiée et suit le protocole agentique lié ci-dessus.
+
+## Dérive documentaire corrigée dans AGENT-00
+
+`AGENTS.md` et `README.md` citaient encore `ADMIN_TOKEN`. Le code, `.env.example`, les tests visuels
+et le script de setup utilisent `ADMIN_PASSWORD`. Ces deux références documentaires ont été
+alignées sur le nom réel. Aucun code d'authentification, secret ou comportement de session n'a été
+modifié.

--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -1,19 +1,21 @@
 # Security, architecture, performance, and UX baseline, August 2026
 
-This document is the versioned register of findings selected for Poligraph's agentic remediation
-program. It records risks and target invariants. It is not evidence of production exploitation,
-authorization to modify production, or a remediation of any finding.
+This document is the versioned, living register of findings selected for Poligraph's agentic
+remediation program. It records risks, target invariants, and current remediation state. Git history
+preserves the original audit snapshot and every subsequent status change. This document is not
+evidence of production exploitation, authorization to modify production, or a remediation of any
+finding.
 
 ## Baseline metadata
 
-| Field                  | Value                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------- |
-| Work package           | `AGENT-00`                                                                         |
-| Baseline date          | August 8, 2026                                                                     |
-| Inspected revision     | `a24fcc13`                                                                         |
-| Reference branch       | `origin/main`                                                                      |
-| Initial finding status | To investigate                                                                     |
-| Required protocol      | [`docs/engineering/agentic-remediation.md`](../engineering/agentic-remediation.md) |
+| Field                 | Value                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| Work package          | `AGENT-00`                                                                         |
+| Baseline date         | August 8, 2026                                                                     |
+| Inspected revision    | `a24fcc13`                                                                         |
+| Reference branch      | `origin/main`                                                                      |
+| Registry last updated | August 8, 2026                                                                     |
+| Required protocol     | [`docs/engineering/agentic-remediation.md`](../engineering/agentic-remediation.md) |
 
 The evidence below consists of starting points observed in the repository. The Scout for each work
 package must verify them against the current code and, when needed, an authorized measurement
@@ -31,21 +33,27 @@ environment. Any claim about production data must be confirmed by a read-only me
 A finding must not move directly from `To investigate` to `Closed`. The remediation PR must retain
 links to the before and after evidence under the finding identifier.
 
+Every remediation PR updates its finding row. It sets the status to `In remediation`, assigns an
+owner, links the evidence and PR, and refreshes `Last updated`. Before merge, it may advance the
+status to `Verified` only after independent verification. After merge, a follow-up documentation
+change marks it `Closed`. Accepted risks retain their rationale and next review date in `Evidence`.
+`Unassigned` and `None` are explicit values, not fields to leave blank.
+
 ## Overview
 
-| Identifier | Priority           | Area                  | Initial status | Primary invariant                                           |
-| ---------- | ------------------ | --------------------- | -------------- | ----------------------------------------------------------- |
-| `SEC-01`   | P0                 | Application security  | To investigate | Untrusted text cannot produce executable HTML or attributes |
-| `SEC-02`   | P0                 | Access control        | To investigate | Unpublished data has no alternative public path             |
-| `SEC-03`   | P1                 | Supabase              | To investigate | The public surface is explicitly minimal                    |
-| `SEC-04`   | P1                 | Authentication        | To investigate | Admin sessions are separated, revocable, and fail closed    |
-| `CI-01`    | P1                 | CI                    | To investigate | Every critical guard has positive and negative tests        |
-| `CI-02`    | P1                 | Quality               | To investigate | Sensitive scripts receive suitable static analysis          |
-| `SEC-05`   | P1                 | Software supply chain | To investigate | Dependencies and actions have versioned controls            |
-| `DB-01`    | Measurement-driven | Database performance  | To investigate | Compute only the necessary work                             |
-| `DB-02`    | Continuous         | Database performance  | To investigate | Prioritize frequency, cost, and user impact                 |
-| `UX-01`    | P1                 | UX and quality        | To investigate | Recurring defects become semantic contracts                 |
-| `AGENT-01` | P1                 | Governance            | To investigate | Critical rules are derivable, testable, or verified         |
+| Identifier | Priority           | Area                  | Current status | Owner      | Evidence                                                               | Remediation PR | Last updated |
+| ---------- | ------------------ | --------------------- | -------------- | ---------- | ---------------------------------------------------------------------- | -------------- | ------------ |
+| `SEC-01`   | P0                 | Application security  | To investigate | Unassigned | [Context](#sec-01-eliminate-markdown-stored-xss-path)                  | None           | 2026-08-08   |
+| `SEC-02`   | P0                 | Access control        | To investigate | Unassigned | [Context](#sec-02-close-unintended-supabase-data-api-exposure)         | None           | 2026-08-08   |
+| `SEC-03`   | P1                 | Supabase              | To investigate | Unassigned | [Context](#sec-03-least-privilege-supabase-public-surface)             | None           | 2026-08-08   |
+| `SEC-04`   | P1                 | Authentication        | To investigate | Unassigned | [Context](#sec-04-harden-admin-authentication)                         | None           | 2026-08-08   |
+| `CI-01`    | P1                 | CI                    | To investigate | Unassigned | [Context](#ci-01-make-security-guards-trustworthy)                     | None           | 2026-08-08   |
+| `CI-02`    | P1                 | Quality               | To investigate | Unassigned | [Context](#ci-02-bring-scripts-under-static-analysis)                  | None           | 2026-08-08   |
+| `SEC-05`   | P1                 | Software supply chain | To investigate | Unassigned | [Context](#sec-05-software-supply-chain-baseline)                      | None           | 2026-08-08   |
+| `DB-01`    | Measurement-driven | Database performance  | To investigate | Unassigned | [Context](#db-01-incremental-group-position-computation)               | None           | 2026-08-08   |
+| `DB-02`    | Continuous         | Database performance  | To investigate | Unassigned | [Context](#db-02-top-sql-workload-remediation)                         | None           | 2026-08-08   |
+| `UX-01`    | P1                 | UX and quality        | To investigate | Unassigned | [Context](#ux-01-convert-recurring-ux-defects-into-semantic-contracts) | None           | 2026-08-08   |
+| `AGENT-01` | P1                 | Governance            | To investigate | Unassigned | [Context](#agent-01-make-agentsmd-executableverifiable)                | None           | 2026-08-08   |
 
 ## P0 findings
 
@@ -67,8 +75,8 @@ link text and destinations.
 cases are covered, existing consumers are inventoried, and a distinct Adversary has tested
 alternative payloads.
 
-**Mapping.** OWASP A05 Injection. OWASP A08 Software and Data Integrity Failures when data comes
-from an AI pipeline.
+**Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A05:2025 Injection. A08:2025 Software or
+Data Integrity Failures when data comes from an AI pipeline.
 
 ### SEC-02: Close unintended Supabase Data API exposure
 
@@ -89,7 +97,8 @@ measurement remains read-only and excludes sensitive data from PR artifacts.
 **Closure criteria.** A test using the public role rejects unpublished fact-checks and allows only
 the approved public surface. The versioned schema, deployed state, and documentation are aligned.
 
-**Mapping.** OWASP A01 Broken Access Control. OWASP A02 Security Misconfiguration.
+**Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A01:2025 Broken Access Control. A02:2025
+Security Misconfiguration.
 
 ## P1 findings
 
@@ -160,7 +169,7 @@ thresholds, false-positive handling, and the SHA update process.
 **Closure criteria.** The repository has a reproducible baseline, alerts have a triage path, and any
 decision not to adopt a control is justified and dated.
 
-**Mapping.** OWASP A03 Software Supply Chain Failures.
+**Mapping.** [OWASP Top 10:2025](https://owasp.org/Top10/) A03:2025 Software Supply Chain Failures.
 
 ## Performance
 

--- a/docs/engineering/agentic-remediation.md
+++ b/docs/engineering/agentic-remediation.md
@@ -1,0 +1,137 @@
+# Protocole de remédiation agentique
+
+Ce protocole est obligatoire pour tout lot identifié par `SEC-*`, `CI-*`, `DB-*`, `UX-*` ou
+`AGENT-*`. Le registre de référence se trouve dans
+[`docs/audits/security-ux-baseline-2026-08.md`](../audits/security-ux-baseline-2026-08.md).
+
+Une même personne peut piloter le lot, mais un agent ou contexte ne peut pas auto-certifier sa
+propre modification. Les rôles Scout, Implementer et Verifier décrivent des responsabilités. Le rôle
+Adversary et la vérification finale doivent utiliser un second contexte suffisamment indépendant
+pour contester les hypothèses de l'implémentation.
+
+## 1. Scout
+
+Le Scout :
+
+- lit le code et les règles du dépôt ;
+- reproduit le problème sans action dangereuse ;
+- recherche les appels, consommateurs, dépendances et voies alternatives ;
+- mesure si nécessaire ;
+- produit une analyse de root cause fondée sur des preuves ;
+- délimite les invariants et le hors-périmètre ;
+- ne modifie pas le code.
+
+Le rapport du Scout cite les fichiers et lignes pertinents, les commandes reproductibles, les
+hypothèses non confirmées et les données qui ne doivent pas être copiées dans la PR.
+
+## 2. Reproduction
+
+Avant la correction, produire si possible un test qui échoue avec le comportement actuel. Le test
+doit démontrer l'invariant violé, pas seulement refléter la forme actuelle de l'implémentation.
+
+Pour une vulnérabilité :
+
+- reproduire uniquement dans un environnement de test ou isolé ;
+- n'effectuer aucune action dangereuse contre un service externe ou la production ;
+- utiliser des payloads inoffensifs et minimaux ;
+- encoder la reproduction dans un test automatisé ;
+- conserver la preuve avant sans secret ni donnée personnelle.
+
+Si un test automatisé est impossible, la PR explique pourquoi et fournit une procédure manuelle
+reproductible, bornée et sûre.
+
+## 3. Implementer
+
+L'Implementer :
+
+- corrige uniquement le finding concerné ;
+- choisit la correction minimale qui préserve les invariants ;
+- conserve ou améliore la traçabilité des sources ;
+- ne transforme pas le lot en refactoring sans rapport ;
+- documente les compromis et les éléments laissés hors périmètre.
+
+Une modification découverte mais indépendante reçoit un finding ou une PR séparée. Les sorties LLM
+sont toujours traitées comme des données non fiables.
+
+## 4. Adversary
+
+Un second contexte ou agent examine la correction sans se limiter à relire la justification de
+l'Implementer. Il cherche activement :
+
+- un bypass ou un payload alternatif ;
+- une régression métier ;
+- une régression éditoriale ;
+- une mauvaise hypothèse sur les données ou les appels ;
+- une régression responsive ou d'accessibilité si le lot touche l'UI ;
+- une régression de performance si le lot touche la base de données.
+
+L'Adversary produit des scénarios concrets, distingue les blocages des suggestions et référence les
+invariants concernés. L'Implementer traite les blocages, puis le Verifier rejoue les preuves.
+
+## 5. Verifier
+
+Le Verifier choisit les contrôles proportionnés au lot parmi :
+
+- TypeScript ;
+- ESLint ;
+- Prettier ;
+- tests unitaires ;
+- tests de sécurité ;
+- build ;
+- tests DB ;
+- Playwright ;
+- axe ;
+- mesures SQL.
+
+Seuls les contrôles pertinents sont lancés pendant l'itération. La suite CI standard est exécutée
+avant la PR. Le Verifier consigne les commandes exactes, leur résultat et les contrôles non lancés
+avec leur justification. Il confirme aussi que le diff reste dans le périmètre annoncé.
+
+## 6. PR
+
+Chaque PR de remédiation documente :
+
+- Finding ;
+- Root cause ;
+- Scénario de régression ou attaque ;
+- Preuve ou reproduction avant ;
+- Correction ;
+- Tests après ;
+- Invariants concernés ;
+- Éléments hors périmètre ;
+- rollback si le changement est risqué.
+
+Une PR DB ajoute la métrique ou l'`EXPLAIN` avant et après. Une PR UI ajoute une vérification mobile
+et desktop pertinente. Les résultats du second contexte sont visibles dans la description ou dans
+la revue.
+
+## Règles de travail
+
+- Un agent ne doit pas auto-certifier sa propre modification.
+- Aucune modification directe de la production ne sert à faire correspondre la production au code.
+- Les changements DB permanents sont versionnés.
+- Supabase production peut être interrogé en lecture pour mesurer lorsque les outils disponibles le
+  permettent. Les résultats sensibles restent hors du dépôt et de la PR.
+- Les expérimentations utilisent un environnement isolé.
+- PostgreSQL 17 sous Docker est privilégié pour les tests DB locaux.
+- Une recommandation Supabase Advisor ne devient jamais un changement automatique sans analyse.
+- Une requête n'est pas optimisée uniquement parce qu'un index semble manquer.
+- Toutes les sorties LLM sont considérées comme non fiables.
+- Les règles éditoriales de Poligraph restent prioritaires sur les optimisations techniques.
+- Les critères sont appliqués de façon identique à tous les partis et toutes les personnes.
+- Aucun changement de donnée judiciaire ne contourne les guards de publication, de matching ou de
+  présomption d'innocence.
+
+## Séquence et preuves minimales
+
+| Phase        | Entrée             | Sortie obligatoire                      | Écrit du code  |
+| ------------ | ------------------ | --------------------------------------- | -------------- |
+| Scout        | Finding versionné  | Root cause, périmètre, appels, mesure   | Non            |
+| Reproduction | Root cause         | Test rouge ou procédure sûre justifiée  | Test seulement |
+| Implementer  | Preuve avant       | Correction minimale et tests ciblés     | Oui            |
+| Adversary    | Diff et invariant  | Tentatives de bypass et régressions     | Non par défaut |
+| Verifier     | Diff révisé        | Résultats indépendants et CI standard   | Non par défaut |
+| PR           | Toutes les preuves | Description complète et rollback adapté | Non            |
+
+Le finding ne peut être déclaré `Vérifié` que lorsque la preuve avant échoue sur le comportement
+vulnérable, passe après correction, et que le second contexte n'a plus de blocage ouvert.

--- a/docs/engineering/agentic-remediation.md
+++ b/docs/engineering/agentic-remediation.md
@@ -83,9 +83,10 @@ The Verifier selects controls proportionate to the work package from:
 - axe;
 - SQL measurements.
 
-Only relevant controls run during iteration. The standard CI suite runs before the PR. The Verifier
-records exact commands, results, and any skipped control with its rationale. The Verifier also
-confirms that the diff remains within the declared scope.
+Only relevant controls run during iteration. The standard local verification suite runs before
+opening the PR. Required GitHub CI must pass before merge. The Verifier records exact commands,
+results, and any skipped control with its rationale. The Verifier also confirms that the diff
+remains within the declared scope.
 
 ## 6. PR
 
@@ -100,6 +101,9 @@ Every remediation PR documents:
 - Affected invariants;
 - Out-of-scope elements;
 - Rollback when the change is risky.
+
+Start from `.github/PULL_REQUEST_TEMPLATE/remediation.md` so these fields remain visible and
+consistent. The PR also updates the corresponding row in the living findings register.
 
 A database PR includes the metric or `EXPLAIN` before and after. A UI PR includes relevant mobile
 and desktop verification. Results from the second context are visible in the description or review.
@@ -122,14 +126,15 @@ and desktop verification. Results from the second context are visible in the des
 
 ## Sequence and minimum evidence
 
-| Phase        | Input              | Required output                            | Writes code   |
-| ------------ | ------------------ | ------------------------------------------ | ------------- |
-| Scout        | Versioned finding  | Root cause, scope, callers, measurement    | No            |
-| Reproduction | Root cause         | Red test or justified safe procedure       | Test only     |
-| Implementer  | Before-evidence    | Minimal correction and targeted tests      | Yes           |
-| Adversary    | Diff and invariant | Bypass attempts and regression scenarios   | No by default |
-| Verifier     | Revised diff       | Independent results and standard CI        | No by default |
-| PR           | All evidence       | Complete description and suitable rollback | No            |
+| Phase        | Input              | Required output                              | Writes code   |
+| ------------ | ------------------ | -------------------------------------------- | ------------- |
+| Scout        | Versioned finding  | Root cause, scope, callers, measurement      | No            |
+| Reproduction | Root cause         | Red test or justified safe procedure         | Test only     |
+| Implementer  | Before-evidence    | Minimal correction and targeted tests        | Yes           |
+| Adversary    | Diff and invariant | Bypass attempts and regression scenarios     | No by default |
+| Verifier     | Revised diff       | Independent results, local checks, GitHub CI | No by default |
+| PR           | All evidence       | Complete description and suitable rollback   | No            |
 
-A finding can be marked `Verified` only when the before-evidence fails against the vulnerable
-behavior, passes after remediation, and the second context has no unresolved blocker.
+A finding can be marked `Verified` only when the before-evidence demonstrates behavior or a metric
+that violates the invariant, the after-evidence satisfies the invariant, and the second context has
+no unresolved blocker.

--- a/docs/engineering/agentic-remediation.md
+++ b/docs/engineering/agentic-remediation.md
@@ -40,6 +40,22 @@ For a vulnerability:
 If an automated test is impossible, the PR explains why and provides a bounded, safe, reproducible
 manual procedure.
 
+### Public vs private security evidence
+
+For a security finding that remains exploitable:
+
+- keep the public register minimal;
+- store detailed reproduction evidence in an authorized private channel, preferably a GitHub
+  Repository Security Advisory;
+- do not include payloads, procedures, or evidence that facilitate exploitation in a public PR;
+- let `Before-proof`, `Regression or attack scenario`, and `Adversary` reference the private
+  advisory;
+- prove publicly that regression tests exist without exposing dangerous test data or procedures;
+- document details publicly after remediation when coordinated disclosure is appropriate.
+
+Security through obscurity is not the control. The objective is coordinated disclosure while a
+known vulnerability remains exploitable.
+
 ## 3. Implementer
 
 The Implementer:
@@ -103,7 +119,9 @@ Every remediation PR documents:
 - Rollback when the change is risky.
 
 Start from `.github/PULL_REQUEST_TEMPLATE/remediation.md` so these fields remain visible and
-consistent. The PR also updates the corresponding row in the living findings register.
+consistent. When creating a PR through CLI or API, explicitly read and populate that file. Do not
+assume GitHub applies it automatically. The PR also updates the corresponding row in the living
+findings register.
 
 A database PR includes the metric or `EXPLAIN` before and after. A UI PR includes relevant mobile
 and desktop verification. Results from the second context are visible in the description or review.

--- a/docs/engineering/agentic-remediation.md
+++ b/docs/engineering/agentic-remediation.md
@@ -1,137 +1,135 @@
-# Protocole de remédiation agentique
+# Agentic remediation protocol
 
-Ce protocole est obligatoire pour tout lot identifié par `SEC-*`, `CI-*`, `DB-*`, `UX-*` ou
-`AGENT-*`. Le registre de référence se trouve dans
+This protocol is mandatory for every work package identified by `SEC-*`, `CI-*`, `DB-*`, `UX-*`, or
+`AGENT-*`. The reference register is
 [`docs/audits/security-ux-baseline-2026-08.md`](../audits/security-ux-baseline-2026-08.md).
 
-Une même personne peut piloter le lot, mais un agent ou contexte ne peut pas auto-certifier sa
-propre modification. Les rôles Scout, Implementer et Verifier décrivent des responsabilités. Le rôle
-Adversary et la vérification finale doivent utiliser un second contexte suffisamment indépendant
-pour contester les hypothèses de l'implémentation.
+One person may coordinate the work package, but an agent or context must not self-certify its own
+change. Scout, Implementer, and Verifier describe responsibilities. The Adversary role and final
+verification must use a sufficiently independent second context that challenges the implementation
+assumptions.
 
 ## 1. Scout
 
-Le Scout :
+The Scout:
 
-- lit le code et les règles du dépôt ;
-- reproduit le problème sans action dangereuse ;
-- recherche les appels, consommateurs, dépendances et voies alternatives ;
-- mesure si nécessaire ;
-- produit une analyse de root cause fondée sur des preuves ;
-- délimite les invariants et le hors-périmètre ;
-- ne modifie pas le code.
+- reads the code and repository rules;
+- reproduces the issue without dangerous actions;
+- traces callers, consumers, dependencies, and alternative paths;
+- measures when necessary;
+- produces an evidence-based root cause analysis;
+- defines the invariants and out-of-scope elements;
+- does not modify code.
 
-Le rapport du Scout cite les fichiers et lignes pertinents, les commandes reproductibles, les
-hypothèses non confirmées et les données qui ne doivent pas être copiées dans la PR.
+The Scout report cites relevant files and lines, reproducible commands, unconfirmed assumptions,
+and any data that must not be copied into the PR.
 
 ## 2. Reproduction
 
-Avant la correction, produire si possible un test qui échoue avec le comportement actuel. Le test
-doit démontrer l'invariant violé, pas seulement refléter la forme actuelle de l'implémentation.
+Before remediation, produce a test that fails with the current behavior whenever possible. The test
+must demonstrate the violated invariant, not merely mirror the current implementation shape.
 
-Pour une vulnérabilité :
+For a vulnerability:
 
-- reproduire uniquement dans un environnement de test ou isolé ;
-- n'effectuer aucune action dangereuse contre un service externe ou la production ;
-- utiliser des payloads inoffensifs et minimaux ;
-- encoder la reproduction dans un test automatisé ;
-- conserver la preuve avant sans secret ni donnée personnelle.
+- reproduce only in a test or isolated environment;
+- perform no dangerous action against production or an external service;
+- use harmless, minimal payloads;
+- encode the reproduction in an automated test;
+- retain before-evidence without secrets or personal data.
 
-Si un test automatisé est impossible, la PR explique pourquoi et fournit une procédure manuelle
-reproductible, bornée et sûre.
+If an automated test is impossible, the PR explains why and provides a bounded, safe, reproducible
+manual procedure.
 
 ## 3. Implementer
 
-L'Implementer :
+The Implementer:
 
-- corrige uniquement le finding concerné ;
-- choisit la correction minimale qui préserve les invariants ;
-- conserve ou améliore la traçabilité des sources ;
-- ne transforme pas le lot en refactoring sans rapport ;
-- documente les compromis et les éléments laissés hors périmètre.
+- fixes only the finding in scope;
+- chooses the smallest correction that preserves the invariants;
+- preserves or improves source traceability;
+- does not turn the work package into an unrelated refactor;
+- documents tradeoffs and out-of-scope elements.
 
-Une modification découverte mais indépendante reçoit un finding ou une PR séparée. Les sorties LLM
-sont toujours traitées comme des données non fiables.
+An independent issue discovered during implementation receives a separate finding or PR. All LLM
+outputs are treated as untrusted data.
 
 ## 4. Adversary
 
-Un second contexte ou agent examine la correction sans se limiter à relire la justification de
-l'Implementer. Il cherche activement :
+A second context or agent examines the correction without simply rereading the Implementer's
+rationale. It actively looks for:
 
-- un bypass ou un payload alternatif ;
-- une régression métier ;
-- une régression éditoriale ;
-- une mauvaise hypothèse sur les données ou les appels ;
-- une régression responsive ou d'accessibilité si le lot touche l'UI ;
-- une régression de performance si le lot touche la base de données.
+- a bypass or alternative payload;
+- a business regression;
+- an editorial regression;
+- an incorrect assumption about data or callers;
+- a responsive or accessibility regression for UI work;
+- a performance regression for database work.
 
-L'Adversary produit des scénarios concrets, distingue les blocages des suggestions et référence les
-invariants concernés. L'Implementer traite les blocages, puis le Verifier rejoue les preuves.
+The Adversary provides concrete scenarios, separates blockers from suggestions, and references the
+affected invariants. The Implementer addresses blockers, then the Verifier reruns the evidence.
 
 ## 5. Verifier
 
-Le Verifier choisit les contrôles proportionnés au lot parmi :
+The Verifier selects controls proportionate to the work package from:
 
-- TypeScript ;
-- ESLint ;
-- Prettier ;
-- tests unitaires ;
-- tests de sécurité ;
-- build ;
-- tests DB ;
-- Playwright ;
-- axe ;
-- mesures SQL.
+- TypeScript;
+- ESLint;
+- Prettier;
+- unit tests;
+- security tests;
+- build;
+- database tests;
+- Playwright;
+- axe;
+- SQL measurements.
 
-Seuls les contrôles pertinents sont lancés pendant l'itération. La suite CI standard est exécutée
-avant la PR. Le Verifier consigne les commandes exactes, leur résultat et les contrôles non lancés
-avec leur justification. Il confirme aussi que le diff reste dans le périmètre annoncé.
+Only relevant controls run during iteration. The standard CI suite runs before the PR. The Verifier
+records exact commands, results, and any skipped control with its rationale. The Verifier also
+confirms that the diff remains within the declared scope.
 
 ## 6. PR
 
-Chaque PR de remédiation documente :
+Every remediation PR documents:
 
-- Finding ;
-- Root cause ;
-- Scénario de régression ou attaque ;
-- Preuve ou reproduction avant ;
-- Correction ;
-- Tests après ;
-- Invariants concernés ;
-- Éléments hors périmètre ;
-- rollback si le changement est risqué.
+- Finding;
+- Root cause;
+- Regression or attack scenario;
+- Before-proof or reproduction;
+- Correction;
+- After-tests;
+- Affected invariants;
+- Out-of-scope elements;
+- Rollback when the change is risky.
 
-Une PR DB ajoute la métrique ou l'`EXPLAIN` avant et après. Une PR UI ajoute une vérification mobile
-et desktop pertinente. Les résultats du second contexte sont visibles dans la description ou dans
-la revue.
+A database PR includes the metric or `EXPLAIN` before and after. A UI PR includes relevant mobile
+and desktop verification. Results from the second context are visible in the description or review.
 
-## Règles de travail
+## Working rules
 
-- Un agent ne doit pas auto-certifier sa propre modification.
-- Aucune modification directe de la production ne sert à faire correspondre la production au code.
-- Les changements DB permanents sont versionnés.
-- Supabase production peut être interrogé en lecture pour mesurer lorsque les outils disponibles le
-  permettent. Les résultats sensibles restent hors du dépôt et de la PR.
-- Les expérimentations utilisent un environnement isolé.
-- PostgreSQL 17 sous Docker est privilégié pour les tests DB locaux.
-- Une recommandation Supabase Advisor ne devient jamais un changement automatique sans analyse.
-- Une requête n'est pas optimisée uniquement parce qu'un index semble manquer.
-- Toutes les sorties LLM sont considérées comme non fiables.
-- Les règles éditoriales de Poligraph restent prioritaires sur les optimisations techniques.
-- Les critères sont appliqués de façon identique à tous les partis et toutes les personnes.
-- Aucun changement de donnée judiciaire ne contourne les guards de publication, de matching ou de
-  présomption d'innocence.
+- An agent must not self-certify its own change.
+- Do not modify production directly to make production match the code.
+- Permanent database changes must be versioned.
+- Supabase production may be queried read-only for measurement when available tools permit it.
+  Sensitive results remain outside the repository and PR.
+- Experiments must use an isolated environment.
+- Prefer PostgreSQL 17 under Docker for local database tests.
+- Never turn a Supabase Advisor recommendation into an automatic change without analysis.
+- Do not optimize a query solely because an index appears to be missing.
+- Treat every LLM output as untrusted data.
+- Poligraph's editorial rules take priority over technical optimizations.
+- Apply criteria identically to all parties and people.
+- No judicial-data change may bypass publication, matching, or presumption-of-innocence guards.
 
-## Séquence et preuves minimales
+## Sequence and minimum evidence
 
-| Phase        | Entrée             | Sortie obligatoire                      | Écrit du code  |
-| ------------ | ------------------ | --------------------------------------- | -------------- |
-| Scout        | Finding versionné  | Root cause, périmètre, appels, mesure   | Non            |
-| Reproduction | Root cause         | Test rouge ou procédure sûre justifiée  | Test seulement |
-| Implementer  | Preuve avant       | Correction minimale et tests ciblés     | Oui            |
-| Adversary    | Diff et invariant  | Tentatives de bypass et régressions     | Non par défaut |
-| Verifier     | Diff révisé        | Résultats indépendants et CI standard   | Non par défaut |
-| PR           | Toutes les preuves | Description complète et rollback adapté | Non            |
+| Phase        | Input              | Required output                            | Writes code   |
+| ------------ | ------------------ | ------------------------------------------ | ------------- |
+| Scout        | Versioned finding  | Root cause, scope, callers, measurement    | No            |
+| Reproduction | Root cause         | Red test or justified safe procedure       | Test only     |
+| Implementer  | Before-evidence    | Minimal correction and targeted tests      | Yes           |
+| Adversary    | Diff and invariant | Bypass attempts and regression scenarios   | No by default |
+| Verifier     | Revised diff       | Independent results and standard CI        | No by default |
+| PR           | All evidence       | Complete description and suitable rollback | No            |
 
-Le finding ne peut être déclaré `Vérifié` que lorsque la preuve avant échoue sur le comportement
-vulnérable, passe après correction, et que le second contexte n'a plus de blocage ouvert.
+A finding can be marked `Verified` only when the before-evidence fails against the vulnerable
+behavior, passes after remediation, and the second context has no unresolved blocker.


### PR DESCRIPTION
## What changed

- adds a versioned living AGENT-00 findings register with current status, owner, evidence, remediation PR, and last-updated fields
- separates public findings metadata from private exploit-enabling evidence
- defines the mandatory Scout, Reproduction, Implementer, Adversary, Verifier, and PR workflow
- adds a dedicated remediation PR template with coordinated-disclosure guidance
- links finding identifiers from AGENTS.md to both documents
- aligns the documented admin environment variable with the implementation
- versions security mappings as OWASP Top 10:2025
- adds generic database-function, CSP, and workload-driven indexing findings

## Why

The security, architecture, performance, and UX audit findings need a stable source of truth and a repeatable remediation protocol before any SEC, CI, DB, UX, or AGENT finding is implemented. Because Poligraph is public, active exploit-enabling evidence must remain in an authorized private channel until coordinated disclosure is appropriate.

## Review changes

- converted the overview into an operational living register
- clarified local verification before PR and required GitHub CI before merge
- materialized the remediation workflow in a dedicated PR template
- qualified OWASP mappings as Top 10:2025
- generalized verification criteria to every invariant
- redacted active security findings to public invariants and closure criteria
- documented private advisory references for public remediation PRs
- added the omitted findings in non-exploitable form

## Scope

Documentation and agent infrastructure only. No product behavior, route, Prisma model, migration, Supabase configuration, production data, or business rule changed. No finding is remediated in this PR.

## Verification

- targeted Prettier check for all modified files
- git diff --check
- complete diff inspection
- scope inspection confirming no runtime, database, or product file changed

Required GitHub CI must pass on the current commit before merge.

## Rollback

Revert the documentation commits. No runtime or database rollback is required.