### PR TITLE
Intégrer la 3e passe du hub présidentielle (variante 3a)

### DIFF
--- a/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
@@ -29,8 +29,8 @@ import { CandidacyStatusBadge } from "./CandidacyStatusBadge";
  * ZERO flat fill in the list, which is what the third pass of the handoff turns on. A navy button
  * repeated twenty-eight times stops reading as an action and becomes the only pattern the eye
  * sees; the name of the candidate, which is what the reader came for, drops to second place. The
- * links are now found by their INVARIABLE POSITION — the "Consulter" column above lg, the footer
- * band below — and by their navy colour, not by their weight. The one coloured element left is the
+ * links are now found by their INVARIABLE POSITION (the "Consulter" column above lg, the footer
+ * band below) and by their navy colour, not by their weight. The one coloured element left is the
  * status badge, and that is information rather than an action.
  *
  * A client component, deliberately. Filtering through `searchParams` on the server would make the
@@ -133,14 +133,24 @@ function PartyMark({ candidacy }: { candidacy: HubCandidacy }) {
  */
 function ProgrammeLine({ candidacy }: { candidacy: HubCandidacy }) {
   if (candidacy.measureCount === 0) {
+    // Three branches, not a binary. `resolveProgrammeAbsence` never returns null at zero measures,
+    // so the third one is unreachable through `getHubCandidacyField` today; it exists because a
+    // two-branch fallback puts "Aucun programme publié" on a candidacy whose data we simply do not
+    // have, which is a false claim about a person made out of a missing field. The third sentence
+    // speaks only about us.
+    const absence =
+      candidacy.programmeAbsence === "aucun_programme"
+        ? "Aucun programme publié à ce jour"
+        : candidacy.programmeAbsence === "non_depouille"
+          ? "Programme publié, pas encore documenté"
+          : "Pas encore documenté par Poligraph";
+
     return (
       <span
         data-programme-absence={candidacy.programmeAbsence}
         className="block text-xs leading-snug text-muted-foreground-strong"
       >
-        {candidacy.programmeAbsence === "non_depouille"
-          ? "Programme publié, pas encore documenté"
-          : "Aucun programme publié à ce jour"}
+        {absence}
       </span>
     );
   }
@@ -167,7 +177,7 @@ function FichePlaceholder({ withDivider }: { withDivider: boolean }) {
   return (
     <span
       // `lg:pl-[23px]`: the two links start after a 15px icon and a 8px gap, and a note that
-      // begins 23px to their left turns the column into a ragged edge — which is the opposite of
+      // begins 23px to their left turns the column into a ragged edge, which is the opposite of
       // the invariable position the whole variant rests on.
       className={`${SLOT} flex-col gap-px leading-tight text-muted-foreground-strong lg:flex-col lg:items-start lg:pl-[23px] ${
         withDivider ? "border-r border-border/60 lg:border-r-0" : ""
@@ -176,7 +186,7 @@ function FichePlaceholder({ withDivider }: { withDivider: boolean }) {
       <span className="font-display text-[13px] font-bold">Fiche candidature à venir</span>
       {/* `lg:sr-only`, not `lg:hidden`: the second line is what the 44px half of the mobile band
           is for, and above lg it would push the Poligraph link 13px below the one on the row
-          next door — the exact zigzag the fixed slot height exists to prevent. Kept in the
+          next door, the exact zigzag the fixed slot height exists to prevent. Kept in the
           accessibility tree at every width rather than dropped from it. */}
       <span className="text-[11px] lg:sr-only">dès que nous l&apos;aurons documentée</span>
     </span>

--- a/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ExternalLink, Search } from "lucide-react";
-import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
+import { FileText, Search, UserRound } from "lucide-react";
 import { getAccessibleTextColor } from "@/lib/contrast";
 import type { HubCandidacy } from "@/lib/data/hub";
 import {
@@ -14,6 +13,7 @@ import {
   parseCandidacyFilter,
   type CandidacyFilter,
 } from "@/lib/presidentielle/candidacy-filters";
+import { CandidacyStatusBadge } from "./CandidacyStatusBadge";
 
 /**
  * The field as a list of rows rather than a grid of cards.
@@ -22,19 +22,50 @@ import {
  * each on repeating the same badge and the same "Fiche PoliGraph" button, and showed none of our
  * own work. Each row now carries what we have on that candidacy.
  *
- * The row is NOT itself a link any more, and that is the point of `RowLinks`: it led to a page that
- * silently redirects elsewhere for half the field, so one gesture had two destinations and named
- * neither.
+ * The row is NOT itself a link any more, and that is the point of `ConsultCell`: it led to a page
+ * that silently redirects elsewhere for half the field, so one gesture had two destinations and
+ * named neither.
+ *
+ * ZERO flat fill in the list, which is what the third pass of the handoff turns on. A navy button
+ * repeated twenty-eight times stops reading as an action and becomes the only pattern the eye
+ * sees; the name of the candidate, which is what the reader came for, drops to second place. The
+ * links are now found by their INVARIABLE POSITION — the "Consulter" column above lg, the footer
+ * band below — and by their navy colour, not by their weight. The one coloured element left is the
+ * status badge, and that is information rather than an action.
  *
  * A client component, deliberately. Filtering through `searchParams` on the server would make the
  * hub page dynamic and cost it its ISR; the whole field is twenty-five rows already in the payload,
  * so it filters here and writes the URL back for shareability. The rows are still server-rendered.
  *
- * NOT a `<table>`: every cell says its own unit ("12 mesures documentées", "8 sujets sur 13") so a
- * screen reader needs no column header to read it, and the visual header row is decorative.
+ * NOT a `<table>`: every cell says its own unit ("8 sujets documentés sur 13") so a screen reader
+ * needs no column header to read it, and the visual header row is decorative.
  */
 
 const TOTAL_THEMES = 13;
+
+/**
+ * Column widths, shared by the decorative header and every row so the grid actually lines up.
+ *
+ * Written out twice rather than composed, because Tailwind scans this file as TEXT: a class built
+ * at runtime (`` `lg:${COL}` ``) is never emitted and the column silently sizes to its content.
+ * The header lives inside an `lg:flex` container, so it needs no prefix; the row is a stack below
+ * lg and only becomes a grid above it.
+ */
+const COL_PROGRAMME = "w-[230px] shrink-0";
+const COL_PROGRAMME_ROW = "lg:w-[230px] lg:shrink-0";
+const COL_CONSULT = "w-[210px] shrink-0";
+const COL_CONSULT_ROW = "lg:w-[210px] lg:shrink-0";
+
+/**
+ * One slot of the "Consulter" column, whatever it holds.
+ *
+ * The height is fixed per breakpoint rather than per content, and that is the whole reason the
+ * placeholder exists: a row without a candidacy fiche has to leave the Poligraph link at the same
+ * y as its neighbours, otherwise the second link zigzags down the column. 44px on mobile is the
+ * touch target; 32px above lg fits both a single 13px line and the two-line placeholder.
+ */
+const SLOT =
+  "flex min-h-11 flex-1 items-center justify-center gap-2 px-2 text-center lg:min-h-[32px] lg:flex-none lg:justify-start lg:px-0 lg:text-left";
 
 /**
  * The party mark: a monogram, never a logo, on every row.
@@ -64,7 +95,7 @@ function PartyMark({ candidacy }: { candidacy: HubCandidacy }) {
     return (
       <span
         aria-hidden="true"
-        className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] bg-muted text-xs font-bold text-muted-foreground"
+        className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] bg-muted text-xs font-bold text-muted-foreground-strong"
       >
         {initials}
       </span>
@@ -86,23 +117,26 @@ function PartyMark({ candidacy }: { candidacy: HubCandidacy }) {
 }
 
 /**
- * What we have on this candidacy, and when we have nothing, why.
+ * The line under the badge: our coverage, and when there is none, why.
  *
  * The zero case is two different facts and gets two different sentences. "Aucun programme publié"
  * is about the candidacy; "Programme publié, pas encore documenté" is about our own backlog. Saying
  * the first when the second is true would blame a candidate for our delay.
  *
+ * The measure COUNT lives in the badge now, so this line carries what the badge cannot: the spread
+ * over the thirteen subjects. Repeating "12 mesures" two lines below "Déclarée · 12 mesures" would
+ * spend the row's quietest line on an echo.
+ *
  * "Documenté" rather than "dépouillé" throughout, and the reason is specific to this site: on a
  * page about an election, dépouillement is what happens to ballots. The word sent the reader to the
- * count, not to the reading of a programme. It was also the minority term — the fiche and the hub
- * cards already said "documentées" — so one screen contradicted the next.
+ * count, not to the reading of a programme.
  */
-function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
+function ProgrammeLine({ candidacy }: { candidacy: HubCandidacy }) {
   if (candidacy.measureCount === 0) {
     return (
       <span
         data-programme-absence={candidacy.programmeAbsence}
-        className="block text-xs leading-snug text-muted-foreground"
+        className="block text-xs leading-snug text-muted-foreground-strong"
       >
         {candidacy.programmeAbsence === "non_depouille"
           ? "Programme publié, pas encore documenté"
@@ -112,153 +146,138 @@ function MeasureCell({ candidacy }: { candidacy: HubCandidacy }) {
   }
 
   return (
-    <span className="block leading-tight">
-      <span className="font-display text-lg font-extrabold">{candidacy.measureCount}</span>{" "}
-      <span className="text-xs text-muted-foreground">
-        {candidacy.measureCount === 1 ? "mesure documentée" : "mesures documentées"}
-      </span>
-      <span className="mt-0.5 block text-xs text-muted-foreground">
-        {candidacy.themesCoveredCount} sur {TOTAL_THEMES} sujets
-      </span>
+    <span className="block text-xs leading-snug text-muted-foreground-strong">
+      {candidacy.themesCoveredCount === 1
+        ? `1 sujet documenté sur ${TOTAL_THEMES}`
+        : `${candidacy.themesCoveredCount} sujets documentés sur ${TOTAL_THEMES}`}
     </span>
   );
 }
 
 /**
- * The source, on one line and never more.
+ * Our page is what is missing, not the candidacy.
  *
- * `sourceLabel` holds whole quotations of up to ~115 characters, which on the old card were the
- * loudest thing on the row: a source has to be verifiable, not dominant. The full wording stays in
- * `title` and on the fiche.
+ * Poligraph does not declare candidacies, so "Candidature à venir" would state something about a
+ * person that we are in no position to state. The two lines say whose delay it is.
  *
- * `max-w-full` on the link and `min-w-0` on the span are both required: an `inline-flex` box sizes
- * to its content and happily overflows its parent, and a flex child refuses to shrink below its
- * content width without `min-w-0`, so `truncate` alone silently does nothing.
+ * Inert on purpose: `aria-hidden` would hide the only explanation a screen reader gets for the
+ * missing link, so it stays in the accessibility tree as plain text.
  */
-function SourceLink({ candidacy }: { candidacy: HubCandidacy }) {
-  if (candidacy.sourceUrl === null || candidacy.sourceLabel === null) return null;
-
+function FichePlaceholder({ withDivider }: { withDivider: boolean }) {
   return (
-    <a
-      href={candidacy.sourceUrl}
-      rel="nofollow noopener"
-      target="_blank"
-      title={candidacy.sourceLabel}
-      className="inline-flex min-h-11 max-w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground hover:underline"
+    <span
+      // `lg:pl-[23px]`: the two links start after a 15px icon and a 8px gap, and a note that
+      // begins 23px to their left turns the column into a ragged edge — which is the opposite of
+      // the invariable position the whole variant rests on.
+      className={`${SLOT} flex-col gap-px leading-tight text-muted-foreground-strong lg:flex-col lg:items-start lg:pl-[23px] ${
+        withDivider ? "border-r border-border/60 lg:border-r-0" : ""
+      }`}
     >
-      <ExternalLink aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
-      <span className="min-w-0 truncate">{candidacy.sourceLabel}</span>
-    </a>
+      <span className="font-display text-[13px] font-bold">Fiche candidature à venir</span>
+      {/* `lg:sr-only`, not `lg:hidden`: the second line is what the 44px half of the mobile band
+          is for, and above lg it would push the Poligraph link 13px below the one on the row
+          next door — the exact zigzag the fixed slot height exists to prevent. Kept in the
+          accessibility tree at every width rather than dropped from it. */}
+      <span className="text-[11px] lg:sr-only">dès que nous l&apos;aurons documentée</span>
+    </span>
   );
 }
 
 /**
- * The two destinations a row leads to, named rather than guessed.
+ * The two destinations a row leads to, named rather than guessed, at a constant position.
  *
- * There used to be one link on the name, pointing at the candidacy fiche. That page
- * redirects to the politician's fiche when it has no verified measure, so the same
- * gesture landed on two different pages depending on a rule the reader cannot see, and
- * said nothing about it. Naming both destinations costs one line and removes the
- * surprise entirely.
+ * There used to be one link on the name, pointing at the candidacy fiche. That page redirects to
+ * the politician's fiche when it has no verified measure, so the same gesture landed on two
+ * different pages depending on a rule the reader cannot see, and said nothing about it.
  *
- * The unavailable case is stated, not hidden: "fiche de candidature à venir" tells the
- * reader the page exists as an intention and is not ready, which is true, instead of
- * quietly dropping them somewhere else.
+ * Above lg the pair is a third column titled "Consulter", separated by a rule; below it, a footer
+ * band split into two halves of 44px. Never a filled button, never a full-width button: in a list,
+ * a button that repeats on every row is decoration.
  */
-function RowLinks({ candidacy }: { candidacy: HubCandidacy }) {
-  if (candidacy.politicianSlug === null) return null;
+function ConsultCell({ candidacy }: { candidacy: HubCandidacy }) {
+  const slug = candidacy.politicianSlug;
+
+  // No linked politician: neither destination exists, and the placeholder alone keeps the row
+  // aligned with its neighbours instead of collapsing the column.
+  if (slug === null) {
+    return <FichePlaceholder withDivider={false} />;
+  }
+
+  const linkClass = `${SLOT} font-display text-[13px] font-bold text-primary hover:bg-muted/60 lg:hover:bg-transparent lg:hover:underline`;
 
   return (
-    <span className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+    <>
       {candidacy.ficheAvailable ? (
         <Link
-          href={`/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`}
+          href={`/elections/presidentielle-2027/candidats/${slug}`}
           prefetch={false}
-          className="inline-flex min-h-[32px] items-center font-bold text-primary hover:underline"
+          className={`${linkClass} border-r border-border/60 lg:border-r-0`}
         >
+          <FileText aria-hidden="true" className="h-[15px] w-[15px] shrink-0" />
           Sa candidature
           <span className="sr-only"> pour la présidentielle 2027, {candidacy.candidateName}</span>
         </Link>
       ) : (
-        <span className="inline-flex min-h-[32px] items-center text-muted-foreground">
-          Fiche de candidature à venir
-        </span>
+        <FichePlaceholder withDivider />
       )}
-      <Link
-        href={`/politiques/${candidacy.politicianSlug}`}
-        prefetch={false}
-        className="inline-flex min-h-[32px] items-center text-muted-foreground hover:text-foreground hover:underline"
-      >
-        Sa fiche Poligraph
+      <Link href={`/politiques/${slug}`} prefetch={false} className={linkClass}>
+        <UserRound aria-hidden="true" className="h-[15px] w-[15px] shrink-0" />
+        Fiche Poligraph
         <span className="sr-only">, {candidacy.candidateName}</span>
       </Link>
-    </span>
+    </>
   );
 }
 
+/**
+ * One DOM for both layouts rather than two hidden copies.
+ *
+ * The previous row rendered the measure and the source twice, once per breakpoint, which doubled
+ * every assertion and every screen-reader pass. Here the same three blocks reflow: stacked card
+ * with a footer band below lg, three columns above it.
+ */
 function CandidacyRow({ candidacy }: { candidacy: HubCandidacy }) {
   const isRetiree = candidacy.status === "RETIRE";
-  const statusLabel = candidacy.status === null ? null : CANDIDACY_STATUS_LABELS[candidacy.status];
-
-  const identity = (
-    <span className="flex min-w-0 flex-1 items-center gap-3">
-      <PartyMark candidacy={candidacy} />
-      <span className="min-w-0">
-        <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <span
-            className={`font-display text-base font-bold tracking-tight ${
-              isRetiree ? "text-muted-foreground line-through" : ""
-            }`}
-          >
-            {candidacy.candidateName}
-          </span>
-          {/* The badge appears only when the status is NOT "déclarée". Twenty of twenty-five rows
-              carry the same status, so repeating it says nothing; the five exceptions are the
-              information. */}
-          {candidacy.status !== null && candidacy.status !== "DECLARE" && (
-            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-bold text-foreground">
-              {statusLabel}
-            </span>
-          )}
-        </span>
-        {candidacy.partyLabel !== null && (
-          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-            {candidacy.partyLabel}
-          </span>
-        )}
-      </span>
-    </span>
-  );
 
   return (
     <li className="border-b border-border/60 last:border-b-0">
-      <div className="flex items-start gap-3 px-4 pt-3 lg:items-center lg:gap-5 lg:py-3">
-        <span className="flex min-w-0 flex-1 flex-col gap-1">
-          {identity}
-          <span className="lg:hidden">
-            <RowLinks candidacy={candidacy} />
+      <div className="flex flex-col lg:flex-row lg:items-center lg:gap-5 lg:px-4 lg:py-3 lg:hover:bg-muted/40">
+        <div className="flex items-center gap-3 px-4 pt-3 lg:min-w-0 lg:flex-1 lg:px-0 lg:pt-0">
+          <PartyMark candidacy={candidacy} />
+          <span className="min-w-0">
+            <span
+              className={`block font-display text-base font-bold tracking-tight ${
+                isRetiree ? "text-muted-foreground-strong line-through" : ""
+              }`}
+            >
+              {candidacy.candidateName}
+            </span>
+            {candidacy.partyLabel !== null && (
+              <span className="mt-0.5 block truncate text-xs text-muted-foreground-strong">
+                {candidacy.partyLabel}
+              </span>
+            )}
           </span>
-        </span>
+        </div>
 
-        <span className="hidden w-[168px] shrink-0 lg:block">
-          <MeasureCell candidacy={candidacy} />
-        </span>
+        <div
+          className={`flex flex-col gap-1.5 px-4 pb-3 pt-2 ${COL_PROGRAMME_ROW} lg:px-0 lg:pb-0 lg:pt-0`}
+        >
+          <CandidacyStatusBadge
+            status={candidacy.status}
+            measureCount={candidacy.measureCount}
+            programmeAbsence={candidacy.programmeAbsence}
+            sourceUrl={candidacy.sourceUrl}
+            sourceLabel={candidacy.sourceLabel}
+          />
+          <ProgrammeLine candidacy={candidacy} />
+        </div>
 
-        <span className="hidden w-[220px] shrink-0 lg:block">
-          <SourceLink candidacy={candidacy} />
-        </span>
-
-        <span className="hidden w-[190px] shrink-0 lg:block">
-          <RowLinks candidacy={candidacy} />
-        </span>
-      </div>
-
-      {/* Below lg the two columns fold under the name rather than shrinking. The source folds with
-          them rather than disappearing: this site is read on a phone first, and a status the reader
-          cannot check is exactly what the section exists to avoid. */}
-      <div className="space-y-1 px-4 pb-3 lg:hidden">
-        <MeasureCell candidacy={candidacy} />
-        <SourceLink candidacy={candidacy} />
+        <div
+          className={`flex items-stretch border-t border-border/60 bg-muted/30 ${COL_CONSULT_ROW} lg:flex-col lg:items-start lg:gap-1 lg:border-l lg:border-t-0 lg:bg-transparent lg:pl-5`}
+        >
+          <ConsultCell candidacy={candidacy} />
+        </div>
       </div>
     </li>
   );
@@ -302,7 +321,7 @@ export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandida
     <div className="overflow-hidden rounded-xl border border-border bg-card">
       <div className="space-y-3 border-b border-border px-4 py-4">
         <label className="flex min-h-11 items-center gap-2 rounded-[10px] border border-border px-3 sm:max-w-xs">
-          <Search aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Search aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground-strong" />
           <span className="sr-only">Filtrer les candidatures par nom ou par parti</span>
           <input
             type="search"
@@ -337,7 +356,7 @@ export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandida
         {/* The gap, counted and stated. Leaving the reader to infer it from twenty-five rows would
             hide the one fact this section is least able to show. */}
         {sansProgramme > 0 && (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground-strong">
             {sansProgramme}{" "}
             {sansProgramme === 1
               ? "candidature n'a publié aucun programme à ce jour"
@@ -351,16 +370,15 @@ export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandida
           only. Announcing it would promise a table the markup deliberately is not. */}
       <div
         aria-hidden="true"
-        className="hidden items-center gap-5 border-b border-border bg-muted/50 px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider text-muted-foreground lg:flex"
+        className="hidden items-center gap-5 border-b border-border bg-muted/50 px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider text-muted-foreground-strong lg:flex"
       >
         <span className="min-w-0 flex-1">Candidature</span>
-        <span className="w-[168px] shrink-0">Ce que nous avons documenté</span>
-        <span className="w-[220px] shrink-0">Source de la candidature</span>
-        <span className="w-[190px] shrink-0">Où aller</span>
+        <span className={COL_PROGRAMME}>Programme documenté</span>
+        <span className={`${COL_CONSULT} border-l border-border/60 pl-5`}>Consulter</span>
       </div>
 
       {visible.length === 0 ? (
-        <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+        <p className="px-4 py-8 text-center text-sm text-muted-foreground-strong">
           Aucune candidature ne correspond à ce filtre.{" "}
           <button
             type="button"

--- a/src/app/elections/presidentielle-2027/_components/CandidacyStatusBadge.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyStatusBadge.tsx
@@ -8,7 +8,7 @@ import type { CandidacyStatus } from "@/generated/prisma";
  * Two pieces of information that were never read apart: "déclarée" without "combien de mesures
  * avons-nous" says nothing about what the reader will find here, and a measure count without a
  * status says nothing about whether the candidacy exists. Merged, they fit in one pastille and
- * free the rest of the row of every flat fill — which is the whole point of the third pass:
+ * free the rest of the row of every flat fill, which is the whole point of the third pass:
  * repeated twenty-eight times, a navy button becomes the only pattern the eye sees and the
  * candidate's name drops to second place.
  *
@@ -70,55 +70,72 @@ export function candidacyBadgeLabel(params: {
 }
 
 /**
- * `min-h` and padding, never a fixed `height`.
+ * `min-h` and padding on the pastille, never a fixed `height`.
  *
  * "Pressentie · aucun programme" is 26 characters and wraps to two lines in the 230px column of
  * the desktop list. With `height` the second line escapes the pastille; with `min-height` the
  * pastille grows. Same reason `leading-[1.35]` rather than a centred single line.
  */
+const PILL =
+  "inline-flex min-h-[26px] max-w-full items-center gap-1.5 rounded-full border px-2.5 py-[3px] font-display text-xs font-bold leading-[1.35]";
+
 export function CandidacyStatusBadge({
   status,
   measureCount,
   programmeAbsence,
   sourceUrl,
   sourceLabel,
-  className = "",
 }: {
   status: CandidacyStatus | null;
   measureCount: number;
   programmeAbsence: ProgrammeAbsence;
   sourceUrl?: string | null;
   sourceLabel?: string | null;
-  className?: string;
 }) {
   const label = candidacyBadgeLabel({ status, measureCount, programmeAbsence });
-  const shape = `inline-flex max-w-full items-center gap-1.5 self-start rounded-full border px-2.5 py-[3px] font-display text-xs font-bold leading-[1.35] ${VARIANT_CLASS[badgeVariant(status, measureCount)]} ${className}`;
+  const pill = `${PILL} ${VARIANT_CLASS[badgeVariant(status, measureCount)]}`;
 
   if (sourceUrl == null || sourceLabel == null) {
     return (
-      <span className={`min-h-[26px] ${shape}`}>
+      <span className={`${pill} self-start`}>
         <span className="min-w-0">{label}</span>
       </span>
     );
   }
 
+  /**
+   * The touch target grows, the pastille does not.
+   *
+   * Merging the status and the source made this pastille the row's external link, so it falls
+   * under the 44px rule; the source link it replaced already carried `min-h-11`, and losing that
+   * while merging two elements would be a tactile regression dressed up as a visual
+   * simplification. Painting the pastille itself 44px tall would instead break the geometry the
+   * handoff specifies (min-height, padding 3px 10px), and put a slab of navy back on every row,
+   * which is the one thing this pass exists to remove. So the anchor is a transparent 44px band
+   * and the coloured pastille sits centred inside it, back to 26px above lg where a pointer needs
+   * no such margin.
+   */
   return (
     <a
       href={sourceUrl}
-      rel="nofollow noopener"
+      // AGENTS.md: every external link carries `noopener noreferrer`. `nofollow` on top of it
+      // because the destination is an unvetted source, not a page we vouch for.
+      rel="nofollow noopener noreferrer"
       target="_blank"
       // `title` for the pointer, `aria-label` for everyone else: a title attribute is not reliably
       // announced, and a link named "Déclarée · 19 mesures" that opens an external site without
       // saying which one is exactly the surprise the row exists to remove. `aria-label` rather
       // than an `sr-only` sibling because the accessibility tree joins sibling nodes with a space,
-      // which announces "19 mesures , source" — the visible label stays a prefix of it, so the
-      // spoken name still starts with what a speech-input user sees (WCAG 2.5.3).
+      // announcing "19 mesures , source". The visible label stays a prefix of it, so the spoken
+      // name still starts with what a speech-input user sees (WCAG 2.5.3).
       title={sourceLabel}
       aria-label={`${label}, source de la candidature : ${sourceLabel}`}
-      className={`min-h-[26px] hover:brightness-95 ${shape}`}
+      className="inline-flex min-h-11 max-w-full items-center self-start hover:brightness-95 lg:min-h-[26px]"
     >
-      <span className="min-w-0">{label}</span>
-      <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70" />
+      <span className={pill}>
+        <span className="min-w-0">{label}</span>
+        <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70" />
+      </span>
     </a>
   );
 }

--- a/src/app/elections/presidentielle-2027/_components/CandidacyStatusBadge.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyStatusBadge.tsx
@@ -1,0 +1,124 @@
+import { ExternalLink } from "lucide-react";
+import { CANDIDACY_STATUS_SHORT_LABELS } from "@/config/labels";
+import type { CandidacyStatus } from "@/generated/prisma";
+
+/**
+ * Status and documented programme, merged into the single coloured element of a row.
+ *
+ * Two pieces of information that were never read apart: "déclarée" without "combien de mesures
+ * avons-nous" says nothing about what the reader will find here, and a measure count without a
+ * status says nothing about whether the candidacy exists. Merged, they fit in one pastille and
+ * free the rest of the row of every flat fill — which is the whole point of the third pass:
+ * repeated twenty-eight times, a navy button becomes the only pattern the eye sees and the
+ * candidate's name drops to second place.
+ *
+ * The badge is INFORMATION, not an action, even though it is a link: it opens the source of the
+ * declaration. That is why it keeps its colour while the two navigation links are plain navy text.
+ *
+ * No alert colour anywhere. `--brand` (red) stays reserved for judicial signals; a withdrawn
+ * candidacy is a fact about a schedule, not about a person's record.
+ */
+
+type ProgrammeAbsence = "aucun_programme" | "non_depouille" | null;
+
+type BadgeVariant = "documented" | "declared" | "pending" | "withdrawn";
+
+/**
+ * `border` on every variant, transparent where the mockup has none: without it the four states
+ * would not share a box height, and the pastilles of two consecutive rows would sit 2px apart.
+ */
+const VARIANT_CLASS: Record<BadgeVariant, string> = {
+  documented: "border-primary bg-primary text-primary-foreground",
+  declared: "border-primary bg-card text-primary",
+  pending: "border-transparent bg-muted text-foreground",
+  withdrawn: "border-dashed border-border bg-transparent text-muted-foreground-strong",
+};
+
+function badgeVariant(status: CandidacyStatus | null, measureCount: number): BadgeVariant {
+  if (status === "RETIRE") return "withdrawn";
+  if (measureCount > 0) return "documented";
+  if (status === "DECLARE") return "declared";
+  return "pending";
+}
+
+/**
+ * The zero case never says "aucun programme" unless the data says so.
+ *
+ * `aucun_programme` is a claim about the CANDIDACY, `non_depouille` a claim about OUR backlog.
+ * They are not interchangeable, and the fallback is the one about us: asserting a candidate has
+ * published nothing, because our own field is null, would be a false claim about a real person.
+ */
+function programmePart(measureCount: number, programmeAbsence: ProgrammeAbsence): string {
+  if (measureCount > 0) {
+    return `${measureCount} ${measureCount === 1 ? "mesure" : "mesures"}`;
+  }
+  return programmeAbsence === "aucun_programme" ? "aucun programme" : "non documenté";
+}
+
+export function candidacyBadgeLabel(params: {
+  status: CandidacyStatus | null;
+  measureCount: number;
+  programmeAbsence: ProgrammeAbsence;
+}): string {
+  // A withdrawal ends the candidacy: what we did or did not document of its programme is no
+  // longer the reader's question, so the badge says the one thing that still holds.
+  if (params.status === "RETIRE") return CANDIDACY_STATUS_SHORT_LABELS.RETIRE;
+
+  const programme = programmePart(params.measureCount, params.programmeAbsence);
+  if (params.status === null) return programme;
+  return `${CANDIDACY_STATUS_SHORT_LABELS[params.status]} · ${programme}`;
+}
+
+/**
+ * `min-h` and padding, never a fixed `height`.
+ *
+ * "Pressentie · aucun programme" is 26 characters and wraps to two lines in the 230px column of
+ * the desktop list. With `height` the second line escapes the pastille; with `min-height` the
+ * pastille grows. Same reason `leading-[1.35]` rather than a centred single line.
+ */
+export function CandidacyStatusBadge({
+  status,
+  measureCount,
+  programmeAbsence,
+  sourceUrl,
+  sourceLabel,
+  className = "",
+}: {
+  status: CandidacyStatus | null;
+  measureCount: number;
+  programmeAbsence: ProgrammeAbsence;
+  sourceUrl?: string | null;
+  sourceLabel?: string | null;
+  className?: string;
+}) {
+  const label = candidacyBadgeLabel({ status, measureCount, programmeAbsence });
+  const shape = `inline-flex max-w-full items-center gap-1.5 self-start rounded-full border px-2.5 py-[3px] font-display text-xs font-bold leading-[1.35] ${VARIANT_CLASS[badgeVariant(status, measureCount)]} ${className}`;
+
+  if (sourceUrl == null || sourceLabel == null) {
+    return (
+      <span className={`min-h-[26px] ${shape}`}>
+        <span className="min-w-0">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={sourceUrl}
+      rel="nofollow noopener"
+      target="_blank"
+      // `title` for the pointer, `aria-label` for everyone else: a title attribute is not reliably
+      // announced, and a link named "Déclarée · 19 mesures" that opens an external site without
+      // saying which one is exactly the surprise the row exists to remove. `aria-label` rather
+      // than an `sr-only` sibling because the accessibility tree joins sibling nodes with a space,
+      // which announces "19 mesures , source" — the visible label stays a prefix of it, so the
+      // spoken name still starts with what a speech-input user sees (WCAG 2.5.3).
+      title={sourceLabel}
+      aria-label={`${label}, source de la candidature : ${sourceLabel}`}
+      className={`min-h-[26px] hover:brightness-95 ${shape}`}
+    >
+      <span className="min-w-0">{label}</span>
+      <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70" />
+    </a>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/CandidacyStatusBadge.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/CandidacyStatusBadge.test.tsx
@@ -72,11 +72,40 @@ describe("CandidacyStatusBadge", () => {
     const lien = screen.getByRole("link", { name: /Le Monde, 4 juin 2026/ });
     expect(lien).toHaveAttribute("href", "https://example.org/declaration");
     expect(lien).toHaveAttribute("title", "Le Monde, 4 juin 2026");
+    // AGENTS.md §accessibilité : tout lien externe porte `noopener noreferrer`. `nofollow` s'y
+    // ajoute parce que la destination est une source non maîtrisée.
+    expect(lien).toHaveAttribute("rel", "nofollow noopener noreferrer");
+    expect(lien).toHaveAttribute("target", "_blank");
     // Le nom accessible porte les deux : ce que dit la pastille ET où elle mène. Un lien nommé
     // « Déclarée · 3 mesures » qui ouvre un site externe sans dire lequel est la surprise à retirer.
     expect(lien).toHaveAccessibleName(
       "Déclarée · 3 mesures, source de la candidature : Le Monde, 4 juin 2026"
     );
+  });
+
+  it("garde une cible tactile de 44 px sur mobile dès qu'elle devient cliquable", () => {
+    // La pastille est devenue le lien vers la source, donc elle tombe sous la règle des 44 px
+    // (AGENTS.md). L'ancien lien de source portait `min-h-11` ; la perdre en fusionnant les deux
+    // éléments serait une régression tactile déguisée en simplification visuelle.
+    render(
+      <CandidacyStatusBadge
+        status="DECLARE"
+        measureCount={3}
+        programmeAbsence={null}
+        sourceUrl="https://example.org/declaration"
+        sourceLabel="Le Monde"
+      />
+    );
+    const lien = screen.getByRole("link");
+    expect(lien.className).toContain("min-h-11");
+    expect(lien.className).toContain("lg:min-h-[26px]");
+
+    // La géométrie de la maquette tient quand même : l'aplat coloré reste une pastille de 26 px,
+    // c'est la zone de contact qui grandit autour d'elle.
+    const aplat = lien.querySelector("span");
+    expect(aplat?.className).toContain("min-h-[26px]");
+    expect(aplat?.className).toContain("rounded-full");
+    expect(lien.className).not.toContain("rounded-full");
   });
 
   it("reste un simple texte quand la source manque, jamais un lien mort", () => {

--- a/src/app/elections/presidentielle-2027/_components/__tests__/CandidacyStatusBadge.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/CandidacyStatusBadge.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CandidacyStatusBadge } from "../CandidacyStatusBadge";
+
+/**
+ * Le contrôle avant merge que ces assertions verrouillent : « aucun aplat de couleur ne se répète
+ * d'une ligne à l'autre de la liste ». Un seul des quatre états porte un fond plein, et c'est
+ * celui qui distingue une candidature documentée des vingt autres. Si un second état passait en
+ * `bg-primary`, le motif reviendrait et le nom du candidat repasserait au second plan.
+ */
+function pastille(over: Parameters<typeof CandidacyStatusBadge>[0]) {
+  const { container } = render(<CandidacyStatusBadge {...over} />);
+  return container.firstElementChild as HTMLElement;
+}
+
+describe("CandidacyStatusBadge", () => {
+  it("réserve l'aplat plein à la candidature documentée", () => {
+    const el = pastille({ status: "DECLARE", measureCount: 19, programmeAbsence: null });
+    expect(el).toHaveTextContent("Déclarée · 19 mesures");
+    expect(el.className).toContain("bg-primary");
+  });
+
+  it("laisse la déclarée non documentée en contour, jamais en aplat", () => {
+    const el = pastille({ status: "DECLARE", measureCount: 0, programmeAbsence: "non_depouille" });
+    expect(el).toHaveTextContent("Déclarée · non documenté");
+    expect(el.className).toContain("border-primary");
+    expect(el.className).not.toContain("bg-primary");
+  });
+
+  it("rend la pressentie en gris neutre, sans couleur d'alerte", () => {
+    const el = pastille({
+      status: "PRESSENTI",
+      measureCount: 0,
+      programmeAbsence: "aucun_programme",
+    });
+    expect(el).toHaveTextContent("Pressentie · aucun programme");
+    expect(el.className).toContain("bg-muted");
+    // `--brand` (rouge) reste réservé aux signaux judiciaires : un retard de programme n'en est pas un.
+    expect(el.className).not.toContain("brand");
+    expect(el.className).not.toContain("destructive");
+  });
+
+  it("rend la retirée en pointillés, sans fond", () => {
+    const el = pastille({ status: "RETIRE", measureCount: 0, programmeAbsence: "aucun_programme" });
+    expect(el).toHaveTextContent("Retirée");
+    expect(el.className).toContain("border-dashed");
+    expect(el.className).toContain("bg-transparent");
+  });
+
+  it("laisse le libellé respirer sur deux lignes plutôt que de le rogner", () => {
+    // « Pressentie · aucun programme » passe sur deux lignes dans la colonne de 230 px. Avec une
+    // `height` fixe, la seconde ligne sortirait de la pastille.
+    const el = pastille({
+      status: "PRESSENTI",
+      measureCount: 0,
+      programmeAbsence: "aucun_programme",
+    });
+    expect(el.className).toContain("min-h-[26px]");
+    expect(el.className).not.toMatch(/(^|\s)h-\[?\d/);
+  });
+
+  it("ouvre la source quand elle existe et la nomme pour un lecteur d'écran", () => {
+    render(
+      <CandidacyStatusBadge
+        status="DECLARE"
+        measureCount={3}
+        programmeAbsence={null}
+        sourceUrl="https://example.org/declaration"
+        sourceLabel="Le Monde, 4 juin 2026"
+      />
+    );
+    const lien = screen.getByRole("link", { name: /Le Monde, 4 juin 2026/ });
+    expect(lien).toHaveAttribute("href", "https://example.org/declaration");
+    expect(lien).toHaveAttribute("title", "Le Monde, 4 juin 2026");
+    // Le nom accessible porte les deux : ce que dit la pastille ET où elle mène. Un lien nommé
+    // « Déclarée · 3 mesures » qui ouvre un site externe sans dire lequel est la surprise à retirer.
+    expect(lien).toHaveAccessibleName(
+      "Déclarée · 3 mesures, source de la candidature : Le Monde, 4 juin 2026"
+    );
+  });
+
+  it("reste un simple texte quand la source manque, jamais un lien mort", () => {
+    render(<CandidacyStatusBadge status="DECLARE" measureCount={3} programmeAbsence={null} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Déclarée · 3 mesures")).toBeInTheDocument();
+  });
+});

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -133,13 +133,18 @@ describe("HubCandidacyField", () => {
   });
 
   it("ne suppose jamais « aucun programme » quand la raison du vide est inconnue", () => {
-    // `programmeAbsence` nul avec zéro mesure ne devrait pas arriver, mais le repli doit porter
-    // sur NOTRE retard : affirmer qu'un candidat n'a rien publié, faute de donnée, serait une
-    // affirmation fausse sur une personne réelle.
+    // `resolveProgrammeAbsence` ne rend jamais `null` à zéro mesure, donc ce cas ne sort pas de
+    // `getHubCandidacyField` aujourd'hui. Le garde reste nécessaire parce qu'il ne coûte rien et
+    // qu'il tient la doctrine : affirmer qu'un candidat n'a rien publié, faute de donnée de notre
+    // côté, serait une affirmation fausse sur une personne réelle. La troisième phrase ne parle
+    // que de nous.
     render(<HubCandidacyField candidacies={[candidacy({ programmeAbsence: null })]} />);
 
     expect(screen.getByText("Pressentie · non documenté")).toBeInTheDocument();
-    expect(screen.queryByText(/aucun programme/)).not.toBeInTheDocument();
+    expect(screen.getByText("Pas encore documenté par Poligraph")).toBeInTheDocument();
+    // `i` : sans lui la regex ne voit pas « Aucun programme publié à ce jour » et le test passe
+    // en ne vérifiant rien, ce qui était le cas dans la première version de cette PR.
+    expect(screen.queryByText(/aucun programme/i)).not.toBeInTheDocument();
   });
 
   it("compte les candidatures sans programme, et jamais celles que nous n'avons pas documentées", () => {

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { HubCandidacy } from "@/lib/data/hub";
 import { HubCandidacyField } from "../HubCandidacyField";
@@ -39,8 +39,8 @@ describe("HubCandidacyField", () => {
 
     expect(screen.getByText("Alix Dupont")).toBeInTheDocument();
     expect(screen.getByText("Bruno Martin")).toBeInTheDocument();
-    expect(screen.getByText("Candidature pressentie")).toBeInTheDocument();
-    expect(screen.getByText("Candidature évoquée")).toBeInTheDocument();
+    expect(screen.getByText("Pressentie · aucun programme")).toBeInTheDocument();
+    expect(screen.getByText("Évoquée · aucun programme")).toBeInTheDocument();
   });
 
   it("nomme les deux destinations quand la fiche de candidature existe", () => {
@@ -55,38 +55,60 @@ describe("HubCandidacyField", () => {
       />
     );
 
-    expect(screen.getAllByRole("link", { name: /Sa candidature/ })[0]).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Sa candidature/ })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats/alix-dupont"
     );
-    expect(screen.getAllByRole("link", { name: /Sa fiche Poligraph/ })[0]).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Fiche Poligraph/ })).toHaveAttribute(
       "href",
       "/politiques/alix-dupont"
     );
   });
 
-  it("annonce l'absence de fiche de candidature au lieu d'y mener quand même", () => {
+  it("annonce que c'est NOTRE page qui manque, jamais la candidature", () => {
+    // Poligraph ne déclare pas les candidatures : « Candidature à venir » affirmerait sur une
+    // personne quelque chose que nous ne sommes pas en position d'affirmer.
     render(
       <HubCandidacyField
         candidacies={[candidacy({ politicianSlug: "alix-dupont", ficheAvailable: false })]}
       />
     );
 
-    expect(screen.getAllByText("Fiche de candidature à venir").length).toBeGreaterThan(0);
+    expect(screen.getByText("Fiche candidature à venir")).toBeInTheDocument();
+    expect(screen.getByText("dès que nous l'aurons documentée")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /Sa candidature/ })).not.toBeInTheDocument();
     // La fiche Poligraph, elle, existe toujours : le lecteur n'est jamais laissé sans issue.
-    expect(screen.getAllByRole("link", { name: /Sa fiche Poligraph/ })[0]).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Fiche Poligraph/ })).toHaveAttribute(
       "href",
       "/politiques/alix-dupont"
     );
   });
 
-  it("n'affiche pas de badge sur une candidature déclarée", () => {
-    // Vingt lignes sur vingt-cinq portent le même statut : le répéter n'informe pas, ce sont les
-    // exceptions qui informent.
-    render(<HubCandidacyField candidacies={[candidacy({ status: "DECLARE" })]} />);
-    expect(screen.queryByText("Candidature déclarée")).not.toBeInTheDocument();
-    expect(screen.getByText("Alix Dupont")).toBeInTheDocument();
+  it("garde l'emplacement de la candidature occupé, jamais étiré ni effondré", () => {
+    // Le contrôle avant merge : une ligne sans fiche candidature garde le même alignement qu'une
+    // ligne complète. Le placeholder et le lien occupent le même emplacement, de même hauteur, et
+    // Poligraph ne s'étale jamais sur la largeur libérée.
+    const { container } = render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({ id: "c1", politicianSlug: "avec", ficheAvailable: true, measureCount: 2 }),
+          candidacy({ id: "c2", politicianSlug: "sans", ficheAvailable: false }),
+        ]}
+      />
+    );
+
+    const lignes = container.querySelectorAll("li");
+    expect(lignes).toHaveLength(2);
+
+    const avec = within(lignes[0] as HTMLElement).getByRole("link", { name: /Sa candidature/ });
+    const sans = within(lignes[1] as HTMLElement).getByText("Fiche candidature à venir")
+      .parentElement as HTMLElement;
+
+    for (const emplacement of [avec, sans]) {
+      expect(emplacement.className).toContain("min-h-11");
+      expect(emplacement.className).toContain("lg:min-h-[32px]");
+      expect(emplacement.className).toContain("flex-1");
+    }
   });
 
   it("distingue « aucun programme publié » de « pas encore documenté »", () => {
@@ -105,9 +127,19 @@ describe("HubCandidacyField", () => {
       />
     );
 
-    expect(screen.getAllByText("Aucun programme publié à ce jour").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Programme publié, pas encore documenté").length).toBeGreaterThan(0);
+    expect(screen.getByText("Aucun programme publié à ce jour")).toBeInTheDocument();
+    expect(screen.getByText("Programme publié, pas encore documenté")).toBeInTheDocument();
     expect(container.querySelector('[data-programme-absence="non_depouille"]')).not.toBeNull();
+  });
+
+  it("ne suppose jamais « aucun programme » quand la raison du vide est inconnue", () => {
+    // `programmeAbsence` nul avec zéro mesure ne devrait pas arriver, mais le repli doit porter
+    // sur NOTRE retard : affirmer qu'un candidat n'a rien publié, faute de donnée, serait une
+    // affirmation fausse sur une personne réelle.
+    render(<HubCandidacyField candidacies={[candidacy({ programmeAbsence: null })]} />);
+
+    expect(screen.getByText("Pressentie · non documenté")).toBeInTheDocument();
+    expect(screen.queryByText(/aucun programme/)).not.toBeInTheDocument();
   });
 
   it("compte les candidatures sans programme, et jamais celles que nous n'avons pas documentées", () => {
@@ -126,37 +158,87 @@ describe("HubCandidacyField", () => {
     ).toBeInTheDocument();
   });
 
-  it("rend le compte de mesures avec son unité accordée et sa couverture", () => {
+  it("fusionne statut et programme dans une seule pastille, avec son unité accordée", () => {
     render(
       <HubCandidacyField
         candidacies={[
-          candidacy({ id: "c1", measureCount: 1, themesCoveredCount: 1, programmeAbsence: null }),
-          candidacy({ id: "c2", measureCount: 12, themesCoveredCount: 8, programmeAbsence: null }),
+          candidacy({
+            id: "c1",
+            status: "DECLARE",
+            measureCount: 1,
+            themesCoveredCount: 1,
+            programmeAbsence: null,
+          }),
+          candidacy({
+            id: "c2",
+            status: "DECLARE",
+            measureCount: 12,
+            themesCoveredCount: 8,
+            programmeAbsence: null,
+          }),
         ]}
       />
     );
 
-    expect(screen.getAllByText("mesure documentée").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("mesures documentées").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("8 sur 13 sujets").length).toBeGreaterThan(0);
+    expect(screen.getByText("Déclarée · 1 mesure")).toBeInTheDocument();
+    expect(screen.getByText("Déclarée · 12 mesures")).toBeInTheDocument();
+    // Le compte vit dans la pastille : la ligne du dessous porte ce qu'elle ne peut pas dire.
+    expect(screen.getByText("1 sujet documenté sur 13")).toBeInTheDocument();
+    expect(screen.getByText("8 sujets documentés sur 13")).toBeInTheDocument();
   });
 
-  it("porte la citation de source en title, jamais en pleine ligne", () => {
-    // `sourceLabel` contient des phrases entières (jusqu'à ~115 caractères). Sur l'ancienne carte
-    // c'était l'élément le plus voyant de la ligne ; une source doit être vérifiable, pas dominante.
+  it("affiche une pastille sur une candidature déclarée aussi", () => {
+    // Changement assumé de la 3e passe : la pastille ne dit plus seulement le statut, elle dit ce
+    // que nous avons documenté. Sur une liste où vingt lignes sur vingt-huit sont « déclarée »,
+    // c'est la seconde moitié qui informe, et elle diffère d'une ligne à l'autre.
+    render(<HubCandidacyField candidacies={[candidacy({ status: "DECLARE" })]} />);
+    expect(screen.getByText("Déclarée · aucun programme")).toBeInTheDocument();
+  });
+
+  it("réduit une candidature retirée à son statut, et barre le nom", () => {
+    render(
+      <HubCandidacyField
+        candidacies={[
+          candidacy({
+            status: "RETIRE",
+            measureCount: 7,
+            themesCoveredCount: 3,
+            programmeAbsence: null,
+          }),
+        ]}
+      />
+    );
+
+    // Un retrait clôt la candidature : ce que nous avions documenté de son programme n'est plus
+    // la question posée.
+    expect(screen.getByText("Retirée")).toBeInTheDocument();
+    expect(screen.queryByText(/7 mesures/)).not.toBeInTheDocument();
+    expect(screen.getByText("Alix Dupont").className).toContain("line-through");
+  });
+
+  it("ouvre la source de la déclaration depuis la pastille, et la nomme", () => {
+    // `sourceLabel` contient des phrases entières (jusqu'à ~115 caractères). Sur l'ancienne ligne
+    // c'était l'élément le plus voyant ; une source doit être vérifiable, pas dominante. Le `title`
+    // sert le pointeur, la mention sr-only sert tout le monde : un lien nommé « Déclarée · 19
+    // mesures » qui ouvre un site externe sans dire lequel est exactement la surprise à retirer.
     const longue =
       "Lutte ouvrière : « nous avons voté que je serai candidate pour Lutte ouvrière », conférence de presse du 8 décembre 2025";
     render(<HubCandidacyField candidacies={[candidacy({ sourceLabel: longue })]} />);
 
-    // Deux rendus : la colonne au-dessus de lg, le repli en dessous. Les deux doivent porter la
-    // source, sinon un lecteur mobile ne peut plus vérifier le statut affiché.
-    const liens = screen.getAllByRole("link", { name: new RegExp(longue.slice(0, 20)) });
-    expect(liens).toHaveLength(2);
-    for (const lien of liens) {
-      expect(lien).toHaveAttribute("title", longue);
-      expect(lien).toHaveAttribute("href", "https://example.org/source");
-      expect(lien).toHaveAttribute("rel", expect.stringContaining("noopener"));
-    }
+    const pastille = screen.getByRole("link", { name: new RegExp(longue.slice(0, 20)) });
+    expect(pastille).toHaveAttribute("title", longue);
+    expect(pastille).toHaveAttribute("href", "https://example.org/source");
+    expect(pastille).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(pastille).toHaveAttribute("target", "_blank");
+    // La citation entière n'occupe aucune ligne de la grille.
+    expect(screen.queryByText(longue)).not.toBeInTheDocument();
+  });
+
+  it("garde la pastille inerte quand la source manque", () => {
+    render(<HubCandidacyField candidacies={[candidacy({ sourceUrl: null, sourceLabel: null })]} />);
+
+    expect(screen.getByText("Pressentie · aucun programme")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Pressentie/ })).not.toBeInTheDocument();
   });
 
   it("annonce le critère de tri réellement appliqué", () => {

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidacyBackBar.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidacyBackBar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CandidacyBackBar } from "../_components/CandidacyBackBar";
+
+describe("CandidacyBackBar", () => {
+  it("offre une sortie nommée vers le champ, collée sous l'en-tête du site", () => {
+    const { container } = render(<CandidacyBackBar electionSlug="presidentielle-2027" />);
+
+    const lien = screen.getByRole("link", { name: "Toutes les candidatures" });
+    expect(lien).toHaveAttribute("href", "/elections/presidentielle-2027");
+
+    // `top-16`, la hauteur exacte du `<header>` global : sans cet offset la barre se glisse
+    // sous l'en-tête au défilement au lieu de se poser dessous.
+    const barre = container.firstElementChild as HTMLElement;
+    expect(barre.className).toContain("sticky");
+    expect(barre.className).toContain("top-16");
+  });
+
+  it("ne redouble pas le logo de l'en-tête, et ne nomme la destination qu'une fois", () => {
+    // La maquette dessine un logo Poligraph dans cette barre : c'est l'en-tête du site, que le
+    // layout rend déjà en `sticky top-0`. Le reproduire empilerait deux barres et deux logos.
+    render(<CandidacyBackBar electionSlug="presidentielle-2027" />);
+
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("garde une cible tactile de 44 px sur mobile", () => {
+    render(<CandidacyBackBar electionSlug="presidentielle-2027" />);
+    const lien = screen.getByRole("link", { name: "Toutes les candidatures" });
+    expect(lien.className).toContain("min-h-11");
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidacyBackBar.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidacyBackBar.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+/**
+ * The way out of a candidate fiche, visible at every scroll position.
+ *
+ * The breadcrumb carries the hierarchy, which is not the same thing as an exit: a reader who has
+ * just finished the page had to travel back up to leave it, and on a phone that is the whole page.
+ *
+ * The handoff draws a Poligraph logo inside this bar, but that logo is the site header, which this
+ * layout already renders `sticky top-0` two pixels above. Reproducing it would stack two bars and
+ * two logos, so the bar carries the one control the header does not: the way back to the field.
+ * `top-16` is the header's own `h-16`, and the pattern (offset, z-index, blur) is the one
+ * `AffairStickyBar` already established for a sub-bar on a detail page.
+ *
+ * One control at both widths rather than the mockup's arrow + text pair, for the same reason: the
+ * pair only existed to flank the logo. Two links to the same page, side by side, name one
+ * destination twice.
+ */
+export function CandidacyBackBar({ electionSlug }: { electionSlug: string }) {
+  return (
+    <nav
+      aria-label="Retour à la liste des candidatures"
+      className="sticky top-16 z-30 border-b bg-background/80 backdrop-blur-md"
+    >
+      <div className="container mx-auto flex items-center px-4 py-2">
+        <Link
+          href={`/elections/${electionSlug}`}
+          prefetch={false}
+          className="inline-flex min-h-11 items-center gap-2 rounded-[11px] border border-border bg-card px-3 font-display text-sm font-bold text-primary hover:border-primary hover:bg-muted lg:min-h-[42px] lg:px-4"
+        >
+          <ArrowLeft aria-hidden="true" className="h-[19px] w-[19px] shrink-0" />
+          Toutes les candidatures
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, UserRound } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
-import { CANDIDACY_STATUS_LABELS, candidacyRoleLabel } from "@/config/labels";
+import { candidacyRoleLabel } from "@/config/labels";
 import { isFicheCandidatPublishable } from "@/config/publication-gates";
 // Reuses the established politician authority rather than adding a second, lighter read for three
 // fields. It loads more than this page needs, but it is already cached under `politician:<slug>`.
@@ -12,6 +12,8 @@ import {
   getCandidateFicheDetail,
   getPoliticianPresidentialCandidacy,
 } from "@/lib/data/politician-candidacy";
+import { CandidacyStatusBadge } from "../../_components/CandidacyStatusBadge";
+import { CandidacyBackBar } from "./_components/CandidacyBackBar";
 import {
   CandidateIntegrity,
   CandidateRecentVotes,
@@ -97,112 +99,121 @@ export default async function CandidateFichePage({ params }: PageProps) {
   const detail = await getCandidateFicheDetail(candidacy.candidacyId, politician.id);
 
   return (
-    <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
-      <Breadcrumb
-        items={[
-          { label: "Élections", href: "/elections" },
-          { label: "Présidentielle 2027", href: `/elections/${candidacy.electionSlug}` },
-          { label: politician.fullName },
-        ]}
-      />
+    <>
+      <CandidacyBackBar electionSlug={candidacy.electionSlug} />
+      <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
+        <Breadcrumb
+          items={[
+            { label: "Élections", href: "/elections" },
+            { label: "Présidentielle 2027", href: `/elections/${candidacy.electionSlug}` },
+            { label: politician.fullName },
+          ]}
+        />
 
-      <header className="space-y-3">
-        <p className="text-xs font-bold uppercase tracking-widest text-brand">
-          {candidacy.electionShortTitle}
-        </p>
-        <h1 className="font-display text-3xl font-extrabold leading-tight tracking-tight md:text-4xl">
-          {politician.fullName}
-        </h1>
-        <p className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="font-semibold">{candidacyRoleLabel(politician.civility)}</span>
-          <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-bold text-muted-foreground">
-            {CANDIDACY_STATUS_LABELS[candidacy.status]}
-          </span>
-          <a
-            href={candidacy.sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-xs underline hover:no-underline"
+        <header className="space-y-3">
+          <p className="text-xs font-bold uppercase tracking-widest text-brand">
+            {candidacy.electionShortTitle}
+          </p>
+          <h1 className="font-display text-3xl font-extrabold leading-tight tracking-tight md:text-4xl">
+            {politician.fullName}
+          </h1>
+          <p className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="font-semibold">{candidacyRoleLabel(politician.civility)}</span>
+            {/* The same badge language as the field, so a reader arriving from the list sees the
+                pastille they clicked, unchanged. Not a link here: the source is a full line just
+                below, and two controls to the same URL name one destination twice. */}
+            <CandidacyStatusBadge
+              status={candidacy.status}
+              measureCount={candidacy.publishedMeasureCount}
+              programmeAbsence={null}
+            />
+            <a
+              href={candidacy.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs underline hover:no-underline"
+            >
+              {candidacy.sourceLabel}
+              <ExternalLink className="h-3 w-3" aria-hidden="true" />
+            </a>
+          </p>
+        </header>
+
+        <CandidateSynthesis
+          synthesis={candidacy.synthesis}
+          generatedAt={candidacy.synthesisGeneratedAt}
+          measureCount={candidacy.publishedMeasureCount}
+        />
+
+        {/* Measures before the counters, everywhere and not only on mobile.
+            The three counters describe the COVERAGE of our own work; they are a caption on the
+            measures, not an introduction to them. Reading them first meant scrolling past a
+            description of the content to reach the content, which on a phone is the whole first
+            screen. One order for every width rather than two: a block that belongs after on a
+            phone does not belong before on a desktop, it was simply less costly there. */}
+        <CandidateThemes
+          themes={detail.themes}
+          electionSlug={candidacy.electionSlug}
+          lastReviewedAt={candidacy.lastReviewedAt}
+        />
+
+        <CandidateStats
+          measureCount={candidacy.publishedMeasureCount}
+          themesCoveredCount={candidacy.themesCoveredCount}
+          mandateCount={detail.mandateCount}
+        />
+
+        <CandidateThemeSpread themes={detail.themes} />
+
+        <CandidateRecentVotes votes={detail.recentVotes} politicianSlug={slug} />
+
+        <CandidateIntegrity
+          declarationCount={politician.declarations.length}
+          affairCount={politician.affairs.length}
+          politicianSlug={slug}
+        />
+
+        <section className="space-y-2 rounded-xl border bg-card p-4 text-sm text-muted-foreground md:p-6">
+          <h2 className="font-display text-base font-bold tracking-tight text-foreground">
+            D&apos;où viennent ces données
+          </h2>
+          <p>
+            Chaque mesure est extraite d&apos;un document daté, relue, et publiée avec sa source. Le
+            statut de la candidature vient de la source citée ci-dessus, à sa date. Aucun
+            classement, aucun score de proximité : l&apos;ordre des candidatures est alphabétique
+            partout sur le site.
+          </p>
+          {/* Named rather than hidden: a reader who sees the gap stated can tell "not built yet"
+              from "nothing to say". Neither block has a date, and promising one would be worse. */}
+          <p>
+            Deux volets manquent encore. Le rapprochement entre chaque mesure et les scrutins
+            portant sur le même objet, qui demande un rattachement que la base ne porte pas encore.
+            Et le bilan des fonctions exercées, objectifs annoncés face aux chiffres constatés, qui
+            demande un suivi post-électoral à construire.
+          </p>
+        </section>
+
+        {/* The one filled-weight control of the page, and it is an outline: the fiche is about the
+            candidacy, so what lies outside it gets a single named exit rather than a navy block
+            competing with the measures. The way back to the field is no longer repeated here, it
+            is in the bar that stays on screen throughout. */}
+        <section className="rounded-xl border bg-card p-4 md:p-6">
+          <h2 className="font-display text-[11px] font-bold uppercase tracking-[0.09em] text-muted-foreground-strong">
+            Aller plus loin
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground-strong">
+            Mandats, votes, patrimoine et procédures : hors périmètre de la candidature.
+          </p>
+          <Link
+            href={`/politiques/${slug}`}
+            prefetch={false}
+            className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-[10px] border border-border px-4 font-display text-sm font-bold text-primary hover:border-primary hover:bg-muted md:min-h-[40px]"
           >
-            {candidacy.sourceLabel}
-            <ExternalLink className="h-3 w-3" aria-hidden="true" />
-          </a>
-        </p>
-      </header>
-
-      <CandidateSynthesis
-        synthesis={candidacy.synthesis}
-        generatedAt={candidacy.synthesisGeneratedAt}
-        measureCount={candidacy.publishedMeasureCount}
-      />
-
-      {/* Measures before the counters, everywhere and not only on mobile.
-          The three counters describe the COVERAGE of our own work; they are a caption on the
-          measures, not an introduction to them. Reading them first meant scrolling past a
-          description of the content to reach the content, which on a phone is the whole first
-          screen. One order for every width rather than two: a block that belongs after on a
-          phone does not belong before on a desktop, it was simply less costly there. */}
-      <CandidateThemes
-        themes={detail.themes}
-        electionSlug={candidacy.electionSlug}
-        lastReviewedAt={candidacy.lastReviewedAt}
-      />
-
-      <CandidateStats
-        measureCount={candidacy.publishedMeasureCount}
-        themesCoveredCount={candidacy.themesCoveredCount}
-        mandateCount={detail.mandateCount}
-      />
-
-      <CandidateThemeSpread themes={detail.themes} />
-
-      <CandidateRecentVotes votes={detail.recentVotes} politicianSlug={slug} />
-
-      <CandidateIntegrity
-        declarationCount={politician.declarations.length}
-        affairCount={politician.affairs.length}
-        politicianSlug={slug}
-      />
-
-      <section className="space-y-2 rounded-xl border bg-card p-4 text-sm text-muted-foreground md:p-6">
-        <h2 className="font-display text-base font-bold tracking-tight text-foreground">
-          D&apos;où viennent ces données
-        </h2>
-        <p>
-          Chaque mesure est extraite d&apos;un document daté, relue, et publiée avec sa source. Le
-          statut de la candidature vient de la source citée ci-dessus, à sa date. Aucun classement,
-          aucun score de proximité : l&apos;ordre des candidatures est alphabétique partout sur le
-          site.
-        </p>
-        {/* Named rather than hidden: a reader who sees the gap stated can tell "not built yet" from
-            "nothing to say". Neither block has a date, and promising one would be worse. */}
-        <p>
-          Deux volets manquent encore. Le rapprochement entre chaque mesure et les scrutins portant
-          sur le même objet, qui demande un rattachement que la base ne porte pas encore. Et le
-          bilan des fonctions exercées, objectifs annoncés face aux chiffres constatés, qui demande
-          un suivi post-électoral à construire.
-        </p>
-      </section>
-
-      {/* The way back, at the end rather than only at the top. The breadcrumb carries the
-          hierarchy, which is not the same thing as an exit: a reader who has just finished the
-          page has to travel back up to leave it, and on a phone that is the whole page. */}
-      <nav aria-label="Suite de la navigation" className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
-        <Link
-          href={`/elections/${candidacy.electionSlug}`}
-          prefetch={false}
-          className="font-bold text-primary hover:underline"
-        >
-          ← Toutes les candidatures
-        </Link>
-        <Link
-          href={`/politiques/${slug}`}
-          prefetch={false}
-          className="text-muted-foreground hover:text-foreground hover:underline"
-        >
-          Sa fiche Poligraph, mandats, votes et déclarations
-        </Link>
-      </nav>
-    </div>
+            <UserRound aria-hidden="true" className="h-4 w-4 shrink-0" />
+            Sa fiche Poligraph
+          </Link>
+        </section>
+      </div>
+    </>
   );
 }

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1469,6 +1469,21 @@ export const CANDIDACY_STATUS_LABELS: Record<CandidacyStatus, string> = {
 };
 
 /**
+ * The same four levels, without the noun, for the merged status + programme badge.
+ *
+ * The badge reads "Déclarée · 19 mesures" in a 230px column: repeating "Candidature" in a list
+ * whose column is titled "Candidature" would cost a third of the width to say nothing. The
+ * adjectives agree with "candidature", so the short form states no gender for the person, which
+ * is the same reason `candidacyRoleLabel` has a neutral branch.
+ */
+export const CANDIDACY_STATUS_SHORT_LABELS: Record<CandidacyStatus, string> = {
+  DECLARE: "Déclarée",
+  PRESSENTI: "Pressentie",
+  ENVISAGE: "Évoquée",
+  RETIRE: "Retirée",
+};
+
+/**
  * The candidacy notice's title is a ROLE, so it agrees in gender with `civility`.
  *
  * Not routed through `feminizePartyRole`: that helper is a closed replacement table over four party

--- a/tests/visual/presidentielle-hub.spec.ts
+++ b/tests/visual/presidentielle-hub.spec.ts
@@ -29,6 +29,13 @@ const PAGES = [
     name: "page sujet sous seuil (numérique & tech)",
     path: "/elections/presidentielle-2027/sujets/numerique-tech",
   },
+  // La fiche candidature porte la barre de retour persistante : son bouton doit garder sa cible
+  // tactile et son contraste aux trois largeurs, et la barre ne doit pas provoquer de débordement.
+  // `presidentielle-hub-demo-c` est la première candidature publiée du seed.
+  {
+    name: "fiche candidature publiée",
+    path: "/elections/presidentielle-2027/candidats/presidentielle-hub-demo-c",
+  },
 ];
 
 for (const { name, path } of PAGES) {


### PR DESCRIPTION
Intègre la 3e passe du handoff « Hub Présidentielles mobile », variante **3a** (colonne de liens à position fixe). La variante 3b, où le nom porte le lien, a été écartée : la maquette ne la décline qu'en mobile, et quand la fiche candidature n'existe pas le nom mène ailleurs, ce qui réintroduit le geste à deux destinations que la liste avait justement supprimé.

## Le principe

Un aplat navy répété sur 28 lignes devient le seul motif que l'œil voit, et le nom du candidat passe au second plan. La liste perd donc tout aplat. Les deux liens se trouvent par leur position invariable (colonne « Consulter » au-dessus de `lg`, bandeau de pied en dessous) et par leur couleur navy. Le seul élément coloré qui reste est la pastille de statut, qui est de l'information et non une action.

## Liste des candidatures

| Avant                                                                      | Après                                                                                                 |
| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| 4 colonnes : Candidature / Ce que nous avons documenté / Source / Où aller | 3 colonnes : Candidature / Programme documenté (230 px) / Consulter (210 px, filet à gauche)          |
| Pastille de statut seulement sur les non-« déclarée »                      | Une pastille par ligne, `Déclarée · 12 mesures`, qui **est** le lien vers la source de la déclaration |
| Colonne portant la citation de source entière                              | Citation en `title` + `aria-label`, plus aucune ligne de grille                                       |
| Liens texte mêlés à la ligne, rendus deux fois (un DOM par breakpoint)     | Deux liens navy à position fixe, un seul DOM qui reflue                                               |
| « Fiche de candidature à venir »                                           | Placeholder inerte à deux lignes, qui occupe l'emplacement pour tenir l'alignement                    |

Quatre états de pastille, un seul aplat plein : navy (documentée), contour navy (déclarée, rien de documenté), gris neutre (pressentie, évoquée), pointillés avec nom barré (retirée). Aucune couleur d'alerte : `--brand` reste réservé aux signaux judiciaires.

Le compte de mesures a trois replis, pas deux : `aucun_programme` affirme quelque chose sur la candidature, `non_depouille` affirme quelque chose sur notre retard, et quand la donnée manque la phrase ne parle que de nous (« Pas encore documenté par Poligraph »).

## Fiche candidature

Barre de retour persistante (`sticky top-16`, sous l'en-tête du site) avec « Toutes les candidatures ». Bloc « Aller plus loin » à contour blanc pour la fiche Poligraph, à la place du duo de liens en pied de page. La même pastille sert d'en-tête.

## Écarts assumés par rapport à la maquette

1. **Pas de second logo dans la barre de retour.** Le logo dessiné dans la maquette est l'en-tête du site, que le layout rend déjà en `sticky top-0`. Le reproduire empilerait deux barres et deux logos. Le duo « flèche 44×44 + lien Candidatures » du mobile devient donc un seul bouton nommé : deux liens côte à côte vers la même page nomment une destination deux fois.
2. **Couleurs en tokens, pas en hexadécimal.** `#002654 → primary`, `#eceef1 → muted`, `#6b7280 → muted-foreground-strong`. Recopier les hex de la maquette cassait le thème sombre : `--muted-foreground` sur `--card` tombe à ~4,4:1 en sombre, la variante `-strong` remonte à ~5,6:1.
3. **La sous-ligne ne répète plus le compte.** La pastille dit « Déclarée · 12 mesures », la ligne du dessous dit « 8 sujets documentés sur 13 » au lieu de re-dire « 12 mesures » deux lignes plus bas.
4. **La zone de contact de la pastille est plus grande que la pastille.** Fusionner statut et source rend la pastille cliquable, donc soumise à la règle des 44 px. Peindre la pastille elle-même sur 44 px casserait la géométrie du handoff (min-height, padding 3px 10px) et remettrait un pavé de couleur sur chaque ligne. Le lien est donc une bande transparente de 44 px qui contient une pastille de 26 px, et redescend à 26 px au-dessus de `lg`.

Un point de détail : la seconde ligne du placeholder passe en `lg:sr-only` plutôt qu'en `lg:hidden`. Elle reste annoncée aux lecteurs d'écran à toutes les largeurs, et au-dessus de `lg` elle ne pousse plus « Fiche Poligraph » 13 px sous le lien de la ligne voisine.

## Test plan

- `npx vitest run` complet : 3882 passés, 379 skipped, 0 échec. Dont 101 sur `presidentielle-2027`, 21 nouveaux (4 états de pastille, cible tactile, contrat `rel`, alignement des emplacements, barre de retour, repli du vide inconnu).
- Playwright a11y sur base jetable (`docker-compose.test-search.yml` + `seed-presidentielle-hub-demo.ts`, jamais la production) : 12/12, 0 violation WCAG AA, 0 débordement horizontal à 375 / 768 / 1440. La fiche candidature est ajoutée au spec, elle n'y était pas.
- Boîtes mesurées au navigateur, pas seulement les classes : lien de source à 44 px de haut en 390 et 768 px, 26 px en 1440 px, pastille peinte à 26 px partout, `rel="nofollow noopener noreferrer"` sur les cinq lignes.
- Alignement mesuré au navigateur : hauteur d'emplacement 32 px et `poligraphTop` 48 px sur toutes les lignes, avec ou sans fiche candidature ; hauteur de ligne 93 px partout.
- Contrôle en mode sombre au navigateur : 0 violation de contraste dans la liste.
- `tsc --noEmit` : 0 erreur. `eslint` sur les fichiers touchés : propre.

## Contrôles avant merge du handoff

- [x] Aucun aplat de couleur ne se répète d'une ligne à l'autre.
- [x] Tous les gris de texte sur `muted-foreground-strong`, mesuré AA en clair et en sombre.
- [x] Cibles tactiles ≥ 44 px sur mobile, **mesurées au navigateur** : bandeau (44), bouton de retour (44), bouton Poligraph (44), lien de source (44).
- [x] Pastille à deux lignes : `min-height` et jamais `height`, verrouillé par un test.
- [x] Chaque pastille ouvre la source de la déclaration, et la nomme dans son nom accessible.
- [x] Une ligne sans fiche candidature garde la même hauteur et le même alignement.

## Suite à la revue (commit `3a227d9b`)

Quatre corrections, toutes précédées d'un test qui échouait :

- La pastille devenue lien restait à 26 px de haut sur mobile, sous la règle des 44 px d'`AGENTS.md`. Le contrôle correspondant était coché à tort dans cette description : c'est corrigé, et la mesure est faite dans le navigateur plutôt que sur les classes.
- Le nouveau lien externe portait `nofollow noopener` sans `noreferrer`, hérité de l'ancien `SourceLink` sans vérifier la règle. Le contrat est maintenant verrouillé par un test.
- Le repli de `ProgrammeLine` était binaire, donc `programmeAbsence: null` tombait sur « Aucun programme publié à ce jour », l'inverse exact de la doctrine annoncée. Le cas ne sort pas de `getHubCandidacyField` aujourd'hui (`resolveProgrammeAbsence` rend toujours l'une des deux raisons), mais le garde était faux et le test censé le verrouiller était un faux positif : `/aucun programme/` sans `i` ne voit pas `Aucun programme…`.
- Les tirets cadratins introduits dans les commentaires sont retirés.

## Hors périmètre

Deux défauts de contraste préexistants apparaissent en mode sombre, dans des fichiers que cette PR ne touche pas : le `<kbd>Ctrl+K</kbd>` de l'en-tête (3,83:1) et l'eyebrow « PRÉSIDENTIELLE 2027 » de la page hub (4,44:1, il faut 4,5). Le spec a11y du dépôt ne testait que le mode clair, c'est pourquoi ils passaient inaperçus.
