### PR TITLE
Fondations données Sénatoriales 2026 : seed, série, PLM

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test:visual:grep": "playwright test --grep",
     "visual": "tsx scripts/visual-test-runner.ts",
     "audit:affairs": "tsx scripts/audit-affairs.ts",
+    "audit:senateurs-series": "tsx scripts/audit-senateurs-series.ts",
     "audit:compliance": "tsx scripts/audit-affairs-compliance.ts",
     "remediate:unverified": "tsx scripts/remediate-unverified-published-affairs.ts",
     "purge:restricted-text": "tsx scripts/purge-restricted-source-text.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -334,6 +334,10 @@ model Mandate {
   role           String? // Ex: "Président de l'Assemblée nationale", "Vice-président du Sénat"
   constituency   String? // Ex: "Rhône (3ème)"
   departmentCode String? // Code département (01-95, 2A, 2B, 971-976, 977, 978, 987, 988)
+  // Senate renewal series (1 or 2), filled by sync:senat from the Senate API.
+  // Null outside senatorial mandates. Neither the start date nor the department
+  // code can derive it: see src/config/senatoriales.ts.
+  senateSeries   Int?
 
   startDate DateTime
   endDate   DateTime?

--- a/scripts/__tests__/seed-elections-data.test.ts
+++ b/scripts/__tests__/seed-elections-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ELECTIONS } from "../seed-elections";
+import { ELECTIONS } from "../lib/elections-seed";
 
 /**
  * The seed is idempotent and its `update` rewrites `round1Date` and

--- a/scripts/__tests__/seed-elections-data.test.ts
+++ b/scripts/__tests__/seed-elections-data.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { ELECTIONS } from "../seed-elections";
+
+/**
+ * The seed is idempotent and its `update` rewrites `round1Date` and
+ * `dateConfirmed` unconditionally. A wrong value here is therefore not a
+ * first-run display glitch: it is a regression that re-arms on every run,
+ * including after a manual correction in the database.
+ */
+describe("seed élections : sénatoriales 2026", () => {
+  const senatoriales = ELECTIONS.find((e) => e.slug === "senatoriales-2026");
+
+  it("existe dans le seed", () => {
+    expect(senatoriales).toBeDefined();
+  });
+
+  it("porte la date du décret n° 2026-301, le 27 septembre et non le 28", () => {
+    expect(senatoriales?.round1Date?.toISOString().slice(0, 10)).toBe("2026-09-27");
+  });
+
+  it("ne présente pas la date comme provisoire alors que le décret est publié", () => {
+    expect(senatoriales?.dateConfirmed).toBe(true);
+  });
+
+  it("porte un tour unique", () => {
+    expect(senatoriales?.round2Date).toBeNull();
+  });
+
+  it("ouvre le dépôt des candidatures du 7 au 11 septembre", () => {
+    expect(senatoriales?.candidacyOpenDate?.toISOString().slice(0, 10)).toBe("2026-09-07");
+    expect(senatoriales?.candidacyDeadline?.toISOString().slice(0, 10)).toBe("2026-09-11");
+  });
+
+  it("renseigne les trois champs dont dépendent des sections de la page", () => {
+    expect(senatoriales?.description).toBeTruthy();
+    expect(senatoriales?.sourceUrl).toBeTruthy();
+    expect(senatoriales?.decreeUrl).toContain("legifrance.gouv.fr");
+  });
+
+  it("remet en jeu 178 sièges au suffrage indirect", () => {
+    expect(senatoriales?.totalSeats).toBe(178);
+    expect(senatoriales?.suffrage).toBe("INDIRECT");
+  });
+});
+
+describe("seed élections : invariants généraux", () => {
+  it("n'a pas de slug en double", () => {
+    const slugs = ELECTIONS.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("ne marque une date comme confirmée que si un premier tour est fixé", () => {
+    for (const e of ELECTIONS) {
+      if (e.dateConfirmed) expect(e.round1Date, `${e.slug}`).not.toBeNull();
+    }
+  });
+});

--- a/scripts/audit-senateurs-series.ts
+++ b/scripts/audit-senateurs-series.ts
@@ -77,12 +77,14 @@ async function main() {
       startDate: true,
       constituency: true,
       senateSeries: true,
+      source: true,
       politician: { select: { fullName: true } },
     },
     orderBy: { startDate: "asc" },
   });
 
   const stale: string[] = [];
+  let staleOutsideSyncReach = 0;
   const missingInDb = new Set(apiSeries.keys());
   const seriesNotStored: string[] = [];
   const implausible: AuditRow[] = [];
@@ -93,9 +95,14 @@ async function main() {
 
     if (!series) {
       // Marked current in the database but absent from the API: seat since vacated.
+      // The source matters: the sync's closing step is scoped to source = SENAT, so
+      // a mandate from any other lineage stays current forever, no matter how many
+      // times sync:senat runs.
       stale.push(
-        `${mandate.politician.fullName} (${mandate.constituency ?? "circonscription inconnue"})`
+        `${mandate.politician.fullName} (${mandate.constituency ?? "circonscription inconnue"}) ` +
+          `source=${mandate.source ?? "inconnue"}`
       );
+      if (mandate.source !== "SENAT") staleOutsideSyncReach++;
       continue;
     }
 
@@ -135,6 +142,13 @@ async function main() {
   if (stale.length > 0) {
     console.log("  Sièges probablement libérés : isCurrent à revoir.");
     for (const line of stale) console.log(`  ${line}`);
+    if (staleOutsideSyncReach > 0) {
+      console.log(
+        `  Dont ${staleOutsideSyncReach} hors source SENAT : l'étape de fermeture du sync ` +
+          "étant filtrée sur cette source, elle ne les verra jamais. Les rejouer ne suffit pas, " +
+          "et leur attribuer une date de fin aujourd'hui inventerait la date de départ."
+      );
+    }
   }
 
   console.log(`\n--- Sénateurs de l'API sans mandat courant en base : ${missingInDb.size} ---`);

--- a/scripts/audit-senateurs-series.ts
+++ b/scripts/audit-senateurs-series.ts
@@ -1,0 +1,184 @@
+/**
+ * Read-only audit of senatorial mandates: renewal series and start-date plausibility.
+ *
+ * Why. `SenateurAPI.serie` was typed `number` while the Senate API returns a
+ * string, so the sync's `serie === 1` was never true. The series was not
+ * persisted, and the date fallback gave everyone the series-2 term start
+ * (1 October 2020), including series-1 senators elected in September 2023. The
+ * sync also preserves an existing date when NosSénateurs supplies none, so
+ * replaying sync:senat does not erase the dates already written.
+ *
+ * This script fixes nothing. It measures the gap between the API and the database
+ * so we can decide what to correct, and from which source.
+ *
+ * Usage:
+ *   npm run audit:senateurs-series
+ *   npm run audit:senateurs-series -- --verbose   (list every suspect mandate)
+ */
+
+import "dotenv/config";
+import { db } from "../src/lib/db";
+import { SENAT_API_URL } from "../src/services/sync/senateurs";
+import {
+  parseSenateSeries,
+  getSeriesTermStart,
+  type SenateSeries,
+} from "../src/config/senatoriales";
+import type { SenateurAPI } from "../src/services/sync/types";
+
+interface AuditRow {
+  fullName: string;
+  constituency: string | null;
+  series: SenateSeries;
+  startDate: Date;
+  termStart: Date;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+async function main() {
+  const verbose = process.argv.includes("--verbose");
+
+  console.log("=== Audit séries et dates de début des sénateurs ===\n");
+
+  const response = await fetch(SENAT_API_URL);
+  if (!response.ok) {
+    throw new Error(`API Sénat indisponible : ${response.status} ${response.statusText}`);
+  }
+  const senators: SenateurAPI[] = await response.json();
+
+  const apiSeries = new Map<string, SenateSeries>();
+  let unparsableSeries = 0;
+  for (const sen of senators) {
+    const series = parseSenateSeries(sen.serie);
+    if (series === null) {
+      unparsableSeries++;
+      continue;
+    }
+    apiSeries.set(`senat-${sen.matricule}`, series);
+  }
+
+  const apiCounts = { 1: 0, 2: 0 };
+  for (const series of apiSeries.values()) apiCounts[series]++;
+
+  console.log(`API Sénat : ${senators.length} sénateurs`);
+  console.log(`  série 1 : ${apiCounts[1]}`);
+  console.log(`  série 2 : ${apiCounts[2]}`);
+  if (unparsableSeries > 0) {
+    console.log(`  série illisible : ${unparsableSeries}`);
+  }
+
+  const mandates = await db.mandate.findMany({
+    where: { type: "SENATEUR", isCurrent: true },
+    select: {
+      externalId: true,
+      startDate: true,
+      constituency: true,
+      senateSeries: true,
+      politician: { select: { fullName: true } },
+    },
+    orderBy: { startDate: "asc" },
+  });
+
+  const stale: string[] = [];
+  const missingInDb = new Set(apiSeries.keys());
+  const seriesNotStored: string[] = [];
+  const implausible: AuditRow[] = [];
+  const dbCounts = { 1: 0, 2: 0 };
+
+  for (const mandate of mandates) {
+    const series = mandate.externalId ? apiSeries.get(mandate.externalId) : undefined;
+
+    if (!series) {
+      // Marked current in the database but absent from the API: seat since vacated.
+      stale.push(
+        `${mandate.politician.fullName} (${mandate.constituency ?? "circonscription inconnue"})`
+      );
+      continue;
+    }
+
+    missingInDb.delete(mandate.externalId!);
+    dbCounts[series]++;
+
+    if (mandate.senateSeries !== series) {
+      seriesNotStored.push(
+        `${mandate.politician.fullName} : base=${mandate.senateSeries ?? "absente"}, API=${series}`
+      );
+    }
+
+    const termStart = getSeriesTermStart(series);
+    if (mandate.startDate < termStart) {
+      implausible.push({
+        fullName: mandate.politician.fullName,
+        constituency: mandate.constituency,
+        series,
+        startDate: mandate.startDate,
+        termStart,
+      });
+    }
+  }
+
+  console.log(`\nBase : ${mandates.length} mandats sénatoriaux courants`);
+  console.log(
+    `  appariés à l'API : ${dbCounts[1] + dbCounts[2]} (série 1 : ${dbCounts[1]}, série 2 : ${dbCounts[2]})`
+  );
+
+  console.log(`\n--- Séries non stockées ou divergentes : ${seriesNotStored.length} ---`);
+  if (seriesNotStored.length > 0) {
+    console.log("  Rejouer `npm run sync:senat` pour les renseigner.");
+    if (verbose) for (const line of seriesNotStored) console.log(`  ${line}`);
+  }
+
+  console.log(`\n--- Mandats courants absents de l'API : ${stale.length} ---`);
+  if (stale.length > 0) {
+    console.log("  Sièges probablement libérés : isCurrent à revoir.");
+    for (const line of stale) console.log(`  ${line}`);
+  }
+
+  console.log(`\n--- Sénateurs de l'API sans mandat courant en base : ${missingInDb.size} ---`);
+  if (missingInDb.size > 0) {
+    for (const externalId of missingInDb) console.log(`  ${externalId}`);
+  }
+
+  console.log(`\n--- Dates de début invraisemblables : ${implausible.length} ---`);
+  console.log("  Un sénateur ne peut pas occuper son siège avant que sa série ne l'ait pourvu.");
+  if (implausible.length > 0) {
+    const bySeries = { 1: 0, 2: 0 };
+    for (const row of implausible) bySeries[row.series]++;
+    console.log(`  série 1 : ${bySeries[1]} sur ${dbCounts[1]}`);
+    console.log(`  série 2 : ${bySeries[2]} sur ${dbCounts[2]}`);
+    console.log(
+      "  Ces dates viennent du repli de série, pas d'une source individuelle. Elles ne " +
+        "seront pas corrigées par un simple sync:senat, qui préserve toute date existante."
+    );
+    const shown = verbose ? implausible : implausible.slice(0, 10);
+    for (const row of shown) {
+      console.log(
+        `  ${row.fullName} (${row.constituency ?? "?"}) série ${row.series} : ` +
+          `${formatDate(row.startDate)} < ${formatDate(row.termStart)}`
+      );
+    }
+    if (!verbose && implausible.length > shown.length) {
+      console.log(
+        `  ... et ${implausible.length - shown.length} autres (--verbose pour tout voir)`
+      );
+    }
+  }
+
+  console.log(
+    "\nTant que ces dates ne sont pas corrigées, aucune surface publique ne doit rendre " +
+      "« sénateur depuis <startDate> » pour la série 1."
+  );
+
+  await db.$disconnect();
+}
+
+if (require.main === module) {
+  main().catch(async (error) => {
+    console.error("Erreur:", error);
+    await db.$disconnect();
+    process.exit(1);
+  });
+}

--- a/scripts/lib/elections-seed.ts
+++ b/scripts/lib/elections-seed.ts
@@ -1,0 +1,139 @@
+/**
+ * Canonical seed data for upcoming French elections.
+ *
+ * Kept apart from `scripts/seed-elections.ts` so the regression test can import it
+ * without pulling in the Prisma singleton, which throws when DATABASE_URL is absent
+ * (as it is in CI). Type-only imports below keep this module free of runtime deps.
+ */
+
+import type { ElectionType, ElectionScope, SuffrageType } from "../../src/generated/prisma";
+
+export interface ElectionSeed {
+  slug: string;
+  type: ElectionType;
+  title: string;
+  shortTitle: string;
+  description?: string;
+  scope: ElectionScope;
+  round1Date: Date | null;
+  round2Date: Date | null;
+  dateConfirmed: boolean;
+  totalSeats: number | null;
+  suffrage: SuffrageType;
+  registrationDeadline?: Date;
+  candidacyOpenDate?: Date;
+  candidacyDeadline?: Date;
+  campaignStartDate?: Date;
+  sourceUrl?: string;
+  decreeUrl?: string;
+}
+
+export const ELECTIONS: ElectionSeed[] = [
+  {
+    slug: "municipales-2026",
+    type: "MUNICIPALES",
+    title: "Élections municipales de 2026",
+    shortTitle: "Municipales 2026",
+    description:
+      "Les élections municipales de 2026 permettront de renouveler l'ensemble des " +
+      "conseils municipaux et intercommunaux en France. Avec la réforme de 2025, toutes les " +
+      "communes passeront au scrutin de liste paritaire, une première historique. " +
+      "Environ 460 000 conseillers municipaux seront élus les 15 et 22 mars 2026.",
+    scope: "MUNICIPAL",
+    round1Date: new Date("2026-03-15"),
+    round2Date: new Date("2026-03-22"),
+    dateConfirmed: true,
+    totalSeats: 460000,
+    suffrage: "DIRECT",
+    registrationDeadline: new Date("2026-02-07"),
+    candidacyDeadline: new Date("2026-02-26"),
+    campaignStartDate: new Date("2026-03-02"),
+    sourceUrl: "https://www.service-public.fr/particuliers/vosdroits/N47",
+  },
+  {
+    slug: "senatoriales-2026",
+    type: "SENATORIALES",
+    title: "Élections sénatoriales de 2026",
+    shortTitle: "Sénatoriales 2026",
+    description:
+      "Le 27 septembre 2026, la série 2 du Sénat est renouvelée : 178 sièges sur 348, " +
+      "répartis sur 64 circonscriptions. Les sénateurs y sont désignés par 93 469 grands " +
+      "électeurs, dont 88 937 délégués des conseils municipaux, soit 95,2 % du collège. " +
+      "Les conseils municipaux ont désigné leurs délégués le 5 juin 2026. Les candidatures " +
+      "se déposent du 7 au 11 septembre 2026.",
+    scope: "NATIONAL",
+    // Date set by décret n° 2026-301 of 21 April 2026. The seed carried 28
+    // September with dateConfirmed false: since `update` rewrites both fields
+    // unconditionally, every run reinstated a wrong "provisional dates" badge on
+    // top of a wrong date.
+    round1Date: new Date("2026-09-27"),
+    round2Date: null,
+    dateConfirmed: true,
+    totalSeats: 178,
+    suffrage: "INDIRECT",
+    candidacyOpenDate: new Date("2026-09-07"),
+    candidacyDeadline: new Date("2026-09-11"),
+    sourceUrl: "https://senatoriales2026.senat.fr/",
+    decreeUrl: "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053925339",
+  },
+  {
+    slug: "presidentielle-2027",
+    type: "PRESIDENTIELLE",
+    title: "Élection présidentielle de 2027",
+    shortTitle: "Présidentielle 2027",
+    scope: "NATIONAL",
+    round1Date: new Date("2027-04-11"),
+    round2Date: new Date("2027-04-25"),
+    dateConfirmed: false,
+    totalSeats: 1,
+    suffrage: "DIRECT",
+  },
+  {
+    slug: "legislatives-2029",
+    type: "LEGISLATIVES",
+    title: "Élections législatives de 2029",
+    shortTitle: "Législatives 2029",
+    scope: "NATIONAL",
+    round1Date: null,
+    round2Date: null,
+    dateConfirmed: false,
+    totalSeats: 577,
+    suffrage: "DIRECT",
+  },
+  {
+    slug: "departementales-2028",
+    type: "DEPARTEMENTALES",
+    title: "Élections départementales de 2028",
+    shortTitle: "Départementales 2028",
+    scope: "DEPARTMENTAL",
+    round1Date: null,
+    round2Date: null,
+    dateConfirmed: false,
+    totalSeats: 4056,
+    suffrage: "DIRECT",
+  },
+  {
+    slug: "regionales-2028",
+    type: "REGIONALES",
+    title: "Élections régionales de 2028",
+    shortTitle: "Régionales 2028",
+    scope: "REGIONAL",
+    round1Date: null,
+    round2Date: null,
+    dateConfirmed: false,
+    totalSeats: 1757,
+    suffrage: "DIRECT",
+  },
+  {
+    slug: "europeennes-2029",
+    type: "EUROPEENNES",
+    title: "Élections européennes de 2029",
+    shortTitle: "Européennes 2029",
+    scope: "EUROPEAN",
+    round1Date: null,
+    round2Date: null,
+    dateConfirmed: false,
+    totalSeats: 81,
+    suffrage: "DIRECT",
+  },
+];

--- a/scripts/seed-communes.ts
+++ b/scripts/seed-communes.ts
@@ -14,6 +14,7 @@
 import { PrismaClient } from "@/generated/prisma";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
+import { COMMUNE_DATA_SYNC_KEY, COMMUNE_POPULATION_SOURCE } from "@/config/communes";
 
 // --- Dedicated pool for bulk operations (more generous than serverless default) ---
 
@@ -153,6 +154,24 @@ async function main() {
       );
     }
   }
+
+  // Record when we asked geo.api.gouv.fr, since the API publishes no population
+  // vintage. Surfaces that render a population date the import, not a vintage
+  // they cannot verify. See src/config/communes.ts.
+  await db.syncMetadata.upsert({
+    where: { sourceKey: COMMUNE_DATA_SYNC_KEY },
+    create: {
+      sourceKey: COMMUNE_DATA_SYNC_KEY,
+      lastSyncAt: new Date(),
+      itemCount: upserted,
+      extra: { source: COMMUNE_POPULATION_SOURCE.via, url: COMMUNE_POPULATION_SOURCE.url },
+    },
+    update: {
+      lastSyncAt: new Date(),
+      itemCount: upserted,
+      extra: { source: COMMUNE_POPULATION_SOURCE.via, url: COMMUNE_POPULATION_SOURCE.url },
+    },
+  });
 
   // Final report
   const countAfter = await db.commune.count();

--- a/scripts/seed-elections.ts
+++ b/scripts/seed-elections.ts
@@ -9,137 +9,7 @@
 
 import "dotenv/config";
 import { db } from "../src/lib/db";
-import type { ElectionType, ElectionScope, SuffrageType } from "../src/generated/prisma";
-
-interface ElectionSeed {
-  slug: string;
-  type: ElectionType;
-  title: string;
-  shortTitle: string;
-  description?: string;
-  scope: ElectionScope;
-  round1Date: Date | null;
-  round2Date: Date | null;
-  dateConfirmed: boolean;
-  totalSeats: number | null;
-  suffrage: SuffrageType;
-  registrationDeadline?: Date;
-  candidacyOpenDate?: Date;
-  candidacyDeadline?: Date;
-  campaignStartDate?: Date;
-  sourceUrl?: string;
-  decreeUrl?: string;
-}
-
-export const ELECTIONS: ElectionSeed[] = [
-  {
-    slug: "municipales-2026",
-    type: "MUNICIPALES",
-    title: "Élections municipales de 2026",
-    shortTitle: "Municipales 2026",
-    description:
-      "Les élections municipales de 2026 permettront de renouveler l'ensemble des " +
-      "conseils municipaux et intercommunaux en France. Avec la réforme de 2025, toutes les " +
-      "communes passeront au scrutin de liste paritaire, une première historique. " +
-      "Environ 460 000 conseillers municipaux seront élus les 15 et 22 mars 2026.",
-    scope: "MUNICIPAL",
-    round1Date: new Date("2026-03-15"),
-    round2Date: new Date("2026-03-22"),
-    dateConfirmed: true,
-    totalSeats: 460000,
-    suffrage: "DIRECT",
-    registrationDeadline: new Date("2026-02-07"),
-    candidacyDeadline: new Date("2026-02-26"),
-    campaignStartDate: new Date("2026-03-02"),
-    sourceUrl: "https://www.service-public.fr/particuliers/vosdroits/N47",
-  },
-  {
-    slug: "senatoriales-2026",
-    type: "SENATORIALES",
-    title: "Élections sénatoriales de 2026",
-    shortTitle: "Sénatoriales 2026",
-    description:
-      "Le 27 septembre 2026, la série 2 du Sénat est renouvelée : 178 sièges sur 348, " +
-      "répartis sur 64 circonscriptions. Les sénateurs y sont désignés par 93 469 grands " +
-      "électeurs, dont 88 937 délégués des conseils municipaux, soit 95,2 % du collège. " +
-      "Les conseils municipaux ont désigné leurs délégués le 5 juin 2026. Les candidatures " +
-      "se déposent du 7 au 11 septembre 2026.",
-    scope: "NATIONAL",
-    // Date set by décret n° 2026-301 of 21 April 2026. The seed carried 28
-    // September with dateConfirmed false: since `update` rewrites both fields
-    // unconditionally, every run reinstated a wrong "provisional dates" badge on
-    // top of a wrong date.
-    round1Date: new Date("2026-09-27"),
-    round2Date: null,
-    dateConfirmed: true,
-    totalSeats: 178,
-    suffrage: "INDIRECT",
-    candidacyOpenDate: new Date("2026-09-07"),
-    candidacyDeadline: new Date("2026-09-11"),
-    sourceUrl: "https://senatoriales2026.senat.fr/",
-    decreeUrl: "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053925339",
-  },
-  {
-    slug: "presidentielle-2027",
-    type: "PRESIDENTIELLE",
-    title: "Élection présidentielle de 2027",
-    shortTitle: "Présidentielle 2027",
-    scope: "NATIONAL",
-    round1Date: new Date("2027-04-11"),
-    round2Date: new Date("2027-04-25"),
-    dateConfirmed: false,
-    totalSeats: 1,
-    suffrage: "DIRECT",
-  },
-  {
-    slug: "legislatives-2029",
-    type: "LEGISLATIVES",
-    title: "Élections législatives de 2029",
-    shortTitle: "Législatives 2029",
-    scope: "NATIONAL",
-    round1Date: null,
-    round2Date: null,
-    dateConfirmed: false,
-    totalSeats: 577,
-    suffrage: "DIRECT",
-  },
-  {
-    slug: "departementales-2028",
-    type: "DEPARTEMENTALES",
-    title: "Élections départementales de 2028",
-    shortTitle: "Départementales 2028",
-    scope: "DEPARTMENTAL",
-    round1Date: null,
-    round2Date: null,
-    dateConfirmed: false,
-    totalSeats: 4056,
-    suffrage: "DIRECT",
-  },
-  {
-    slug: "regionales-2028",
-    type: "REGIONALES",
-    title: "Élections régionales de 2028",
-    shortTitle: "Régionales 2028",
-    scope: "REGIONAL",
-    round1Date: null,
-    round2Date: null,
-    dateConfirmed: false,
-    totalSeats: 1757,
-    suffrage: "DIRECT",
-  },
-  {
-    slug: "europeennes-2029",
-    type: "EUROPEENNES",
-    title: "Élections européennes de 2029",
-    shortTitle: "Européennes 2029",
-    scope: "EUROPEAN",
-    round1Date: null,
-    round2Date: null,
-    dateConfirmed: false,
-    totalSeats: 81,
-    suffrage: "DIRECT",
-  },
-];
+import { ELECTIONS } from "./lib/elections-seed";
 
 async function main() {
   console.log("=== Seed élections ===\n");
@@ -187,15 +57,11 @@ async function main() {
   console.log(`\nTerminé : ${created} créées, ${updated} mises à jour`);
 }
 
-// Guarded so importing this module (for the seed-data regression test) never
-// touches the database: main() only runs when this file is the process entry point.
-if (require.main === module) {
-  main()
-    .catch((error) => {
-      console.error("Erreur:", error);
-      process.exit(1);
-    })
-    .finally(async () => {
-      await db.$disconnect();
-    });
-}
+main()
+  .catch((error) => {
+    console.error("Erreur:", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/scripts/seed-elections.ts
+++ b/scripts/seed-elections.ts
@@ -24,12 +24,14 @@ interface ElectionSeed {
   totalSeats: number | null;
   suffrage: SuffrageType;
   registrationDeadline?: Date;
+  candidacyOpenDate?: Date;
   candidacyDeadline?: Date;
   campaignStartDate?: Date;
   sourceUrl?: string;
+  decreeUrl?: string;
 }
 
-const ELECTIONS: ElectionSeed[] = [
+export const ELECTIONS: ElectionSeed[] = [
   {
     slug: "municipales-2026",
     type: "MUNICIPALES",
@@ -56,12 +58,26 @@ const ELECTIONS: ElectionSeed[] = [
     type: "SENATORIALES",
     title: "Élections sénatoriales de 2026",
     shortTitle: "Sénatoriales 2026",
+    description:
+      "Le 27 septembre 2026, la série 2 du Sénat est renouvelée : 178 sièges sur 348, " +
+      "répartis sur 64 circonscriptions. Les sénateurs y sont désignés par 93 469 grands " +
+      "électeurs, dont 88 937 délégués des conseils municipaux, soit 95,2 % du collège. " +
+      "Les conseils municipaux ont désigné leurs délégués le 5 juin 2026. Les candidatures " +
+      "se déposent du 7 au 11 septembre 2026.",
     scope: "NATIONAL",
-    round1Date: new Date("2026-09-28"),
+    // Date set by décret n° 2026-301 of 21 April 2026. The seed carried 28
+    // September with dateConfirmed false: since `update` rewrites both fields
+    // unconditionally, every run reinstated a wrong "provisional dates" badge on
+    // top of a wrong date.
+    round1Date: new Date("2026-09-27"),
     round2Date: null,
-    dateConfirmed: false,
+    dateConfirmed: true,
     totalSeats: 178,
     suffrage: "INDIRECT",
+    candidacyOpenDate: new Date("2026-09-07"),
+    candidacyDeadline: new Date("2026-09-11"),
+    sourceUrl: "https://senatoriales2026.senat.fr/",
+    decreeUrl: "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053925339",
   },
   {
     slug: "presidentielle-2027",
@@ -144,9 +160,11 @@ async function main() {
       totalSeats: election.totalSeats,
       suffrage: election.suffrage,
       ...(election.registrationDeadline && { registrationDeadline: election.registrationDeadline }),
+      ...(election.candidacyOpenDate && { candidacyOpenDate: election.candidacyOpenDate }),
       ...(election.candidacyDeadline && { candidacyDeadline: election.candidacyDeadline }),
       ...(election.campaignStartDate && { campaignStartDate: election.campaignStartDate }),
       ...(election.sourceUrl && { sourceUrl: election.sourceUrl }),
+      ...(election.decreeUrl && { decreeUrl: election.decreeUrl }),
     };
 
     const result = await db.election.upsert({
@@ -169,11 +187,15 @@ async function main() {
   console.log(`\nTerminé : ${created} créées, ${updated} mises à jour`);
 }
 
-main()
-  .catch((error) => {
-    console.error("Erreur:", error);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await db.$disconnect();
-  });
+// Guarded so importing this module (for the seed-data regression test) never
+// touches the database: main() only runs when this file is the process entry point.
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error("Erreur:", error);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await db.$disconnect();
+    });
+}

--- a/src/components/politicians/timeline/__tests__/factories.ts
+++ b/src/components/politicians/timeline/__tests__/factories.ts
@@ -11,6 +11,7 @@ export function mandate(over: Partial<TimelineMandate> & { type: MandateType }):
     role: null,
     constituency: null,
     departmentCode: null,
+    senateSeries: null,
     startDate: new Date("2022-06-22"),
     endDate: null,
     isCurrent: true,

--- a/src/config/__tests__/senatoriales.test.ts
+++ b/src/config/__tests__/senatoriales.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSenateSeries,
+  getCouncilSeats,
+  getSeriesTermStart,
+  PLM_COUNCIL_SEATS,
+} from "../senatoriales";
+
+describe("parseSenateSeries", () => {
+  // Regression: the Senate API returns "1"/"2" as strings, and the sync compared
+  // `sen.serie === 1` on a field typed `number`. The branch was dead, the series
+  // was never persisted, and 156 series-1 senators inherited the 2020 fallback.
+  it("accepte la forme réellement renvoyée par l'API (chaîne)", () => {
+    expect(parseSenateSeries("1")).toBe(1);
+    expect(parseSenateSeries("2")).toBe(2);
+  });
+
+  it("accepte aussi la forme numérique", () => {
+    expect(parseSenateSeries(1)).toBe(1);
+    expect(parseSenateSeries(2)).toBe(2);
+  });
+
+  it("tolère les espaces autour de la valeur", () => {
+    expect(parseSenateSeries(" 2 ")).toBe(2);
+  });
+
+  it("rejette toute valeur hors du domaine plutôt que de la convertir", () => {
+    for (const raw of [0, 3, "3", "", "  ", "serie 1", null, undefined, {}, [], NaN, true]) {
+      expect(parseSenateSeries(raw)).toBeNull();
+    }
+  });
+});
+
+describe("getSeriesTermStart", () => {
+  it("place la prise de fonction de chaque série au 1er octobre suivant son scrutin", () => {
+    expect(getSeriesTermStart(1).toISOString()).toBe("2023-10-01T00:00:00.000Z");
+    expect(getSeriesTermStart(2).toISOString()).toBe("2020-10-01T00:00:00.000Z");
+  });
+
+  // The value is written to the database by the sync: two calls must not share
+  // the same Date object.
+  it("renvoie une copie à chaque appel", () => {
+    expect(getSeriesTermStart(2)).not.toBe(getSeriesTermStart(2));
+    expect(getSeriesTermStart(2)).toEqual(getSeriesTermStart(2));
+  });
+});
+
+describe("getCouncilSeats", () => {
+  // The generic scale of article L. 2121-2, applied by seed-communes.ts, caps at
+  // 69 seats. All three PLM cities exceed it.
+  it("substitue l'effectif légal pour Paris, Lyon et Marseille", () => {
+    expect(getCouncilSeats("75056", 69)).toBe(163);
+    expect(getCouncilSeats("69123", 69)).toBe(73);
+    expect(getCouncilSeats("13055", 69)).toBe(111);
+  });
+
+  it("laisse Commune.totalSeats faire autorité partout ailleurs", () => {
+    expect(getCouncilSeats("33063", 65)).toBe(65); // Bordeaux
+    expect(getCouncilSeats("33036", 27)).toBe(27); // Bazas
+  });
+
+  it("propage l'absence sans la combler", () => {
+    expect(getCouncilSeats("33036", null)).toBeNull();
+  });
+
+  it("garde la dérogation PLM même quand totalSeats est absent", () => {
+    expect(getCouncilSeats("75056", null)).toBe(163);
+  });
+
+  it("ne couvre que les trois communes à régime particulier", () => {
+    expect(Object.keys(PLM_COUNCIL_SEATS).sort()).toEqual(["13055", "69123", "75056"]);
+  });
+});

--- a/src/config/communes.ts
+++ b/src/config/communes.ts
@@ -1,0 +1,28 @@
+/**
+ * Provenance of the commune data imported by `scripts/seed-communes.ts`.
+ *
+ * `Commune.population` carries the INSEE population municipale, but it reaches us
+ * through geo.api.gouv.fr, whose API definition (https://geo.api.gouv.fr/definition.yml)
+ * describes the field without publishing its vintage. We therefore do not know
+ * which year the figure is from, and printing "Population INSEE 2026" under a
+ * number would be an unverifiable claim on a verification platform.
+ *
+ * What we do know and can prove: the source, and the date we queried it. That pair
+ * is what surfaces. The seed records the import date in `SyncMetadata` under
+ * `COMMUNE_DATA_SYNC_KEY`; any surface rendering a population reads that date
+ * instead of announcing a vintage.
+ *
+ * A single import fills all ~35,000 communes in one pass, so only one vintage
+ * exists at a time: provenance is global, not per row. Should several vintages
+ * ever coexist, this would need a `populationYear` column instead.
+ */
+
+export const COMMUNE_DATA_SYNC_KEY = "communes-geo-api";
+
+export const COMMUNE_POPULATION_SOURCE = {
+  /** What the figure measures, as the API defines it. */
+  label: "Population municipale (INSEE)",
+  /** How it reaches us. Name the body, not the pipeline. */
+  via: "geo.api.gouv.fr",
+  url: "https://geo.api.gouv.fr/decoupage-administratif/communes",
+} as const;

--- a/src/config/senatoriales.ts
+++ b/src/config/senatoriales.ts
@@ -1,0 +1,81 @@
+/**
+ * Sénatoriales: renewal series and the three special municipal regimes.
+ *
+ * The Senate renews half its seats every three years. A department belongs
+ * entirely to one series; only the Français établis hors de France are split
+ * across both (6 seats each). The series can therefore not be derived from a
+ * department code alone, and even less from a mandate start date: a senator
+ * replacing a resigning one takes the seat mid-cycle without changing series.
+ *
+ * Source of truth: the `serie` field of https://www.senat.fr/api-senat/senateurs.json
+ */
+
+export type SenateSeries = 1 | 2;
+
+/**
+ * Normalise the series returned by the Senate API.
+ *
+ * The API returns a string ("1" / "2") while `SenateurAPI.serie` was typed
+ * `number`, so the sync's strict `serie === 1` was always false and the series
+ * was never used. Accept both shapes and reject everything else rather than
+ * coercing blindly: an unexpected value must surface as absent, not as an
+ * arbitrary series.
+ */
+export function parseSenateSeries(raw: unknown): SenateSeries | null {
+  const value = typeof raw === "string" ? Number(raw.trim()) : raw;
+  if (value === 1 || value === 2) return value;
+  return null;
+}
+
+/**
+ * When each series last took office. The ballots were held on 24 September 2023
+ * (series 1) and 27 September 2020 (series 2); the terms run from the 1 October
+ * that follows.
+ *
+ * Used as a fallback when no individual date is available, and as the
+ * plausibility bound of `npm run audit:senateurs-series`: a senator cannot hold
+ * a seat before their series filled it.
+ */
+const SERIES_TERM_START_ISO: Record<SenateSeries, string> = {
+  1: "2023-10-01T00:00:00Z",
+  2: "2020-10-01T00:00:00Z",
+};
+
+/** Returns a fresh Date: the value is written to the database, never shared. */
+export function getSeriesTermStart(series: SenateSeries): Date {
+  return new Date(SERIES_TERM_START_ISO[series]);
+}
+
+/**
+ * Statutory council size for Paris, Lyon and Marseille, by INSEE code.
+ *
+ * These three cities have their own regime (CGCT, chapters II and III of title I
+ * of book V of part two) and escape the generic scale of article L. 2121-2 that
+ * `scripts/seed-communes.ts` applies to derive `Commune.totalSeats`. That scale
+ * caps at 69 seats, so all three carry 69 in the database instead of their real
+ * size. Senatorial delegates are counted from the council size, so reading
+ * `totalSeats` raw would understate their college by several hundred votes.
+ *
+ * Corrected here by explicit derogation rather than by patching the scale: these
+ * are distinct legal regimes, not exceptions to a shared rule.
+ *
+ * Marseille moves from 101 to 111 members as of the March 2026 renewal (2025
+ * reform of the PLM voting system).
+ *
+ * @see https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006070633/LEGISCTA000006164590/ (Paris)
+ * @see https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006164591 (Lyon and Marseille)
+ */
+export const PLM_COUNCIL_SEATS: Record<string, number> = {
+  "75056": 163, // Conseil de Paris
+  "69123": 73, // Conseil municipal de Lyon
+  "13055": 111, // Conseil municipal de Marseille, from the 2026 renewal
+};
+
+/**
+ * Council size to use for a commune.
+ *
+ * `Commune.totalSeats` is authoritative everywhere except Paris, Lyon, Marseille.
+ */
+export function getCouncilSeats(communeId: string, totalSeats: number | null): number | null {
+  return PLM_COUNCIL_SEATS[communeId] ?? totalSeats;
+}

--- a/src/services/sync/senateurs.ts
+++ b/src/services/sync/senateurs.ts
@@ -5,6 +5,7 @@ import { SenateurAPI, NosSenateursAPI, SenatSyncResult } from "./types";
 import { politicianService } from "@/services/politician";
 import { SENATE_GROUPS, type ParliamentaryGroupConfig } from "@/config/parliamentaryGroups";
 import { findDepartmentCode } from "@/config/departments";
+import { parseSenateSeries, getSeriesTermStart } from "@/config/senatoriales";
 import { HTTPClient } from "@/lib/api/http-client";
 import { SENAT_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { upsertPoliticianExternalId } from "@/lib/prisma-helpers";
@@ -12,7 +13,7 @@ import { shouldUpdatePhoto } from "@/config/photos";
 
 const client = new HTTPClient({ rateLimitMs: SENAT_RATE_LIMIT_MS });
 
-const SENAT_API_URL = "https://www.senat.fr/api-senat/senateurs.json";
+export const SENAT_API_URL = "https://www.senat.fr/api-senat/senateurs.json";
 const NOSSENATEURS_API_URL = "https://archive.nossenateurs.fr/senateurs/json";
 
 /**
@@ -178,6 +179,10 @@ async function syncSenator(
       birthPlace = extraData.lieu_naissance;
     }
 
+    // Renewal series, straight from the Senate API. Authoritative: neither the
+    // start date nor the department can stand in for it.
+    const senateSeries = parseSenateSeries(sen.serie);
+
     // Parse mandate start date
     let mandateStart: Date | null = null;
     const hasApiDate = Boolean(extraData?.mandat_debut);
@@ -185,11 +190,11 @@ async function syncSenator(
       mandateStart = new Date(extraData.mandat_debut);
       if (isNaN(mandateStart.getTime())) mandateStart = null;
     }
-    // Fallback: derive from senate renewal series (only for new senators;
-    // for existing senators without API date, we preserve their existing startDate)
-    // Serie 1 → elected Sept 24, 2023 | Serie 2 → elected Sept 27, 2020
-    if (!mandateStart && sen.serie) {
-      mandateStart = sen.serie === 1 ? new Date("2023-10-01") : new Date("2020-10-01");
+    // Fallback for a senator we have no individual date for: the day their series
+    // last took office. Approximate by construction, and wrong for anyone who took
+    // over mid-cycle, which is why `audit:senateurs-series` reports on it.
+    if (!mandateStart && senateSeries) {
+      mandateStart = getSeriesTermStart(senateSeries);
     }
 
     // Photo URL from senat.fr (urlAvatar is a relative path like /senimg/xxx.jpg)
@@ -249,6 +254,7 @@ async function syncSenator(
       departmentCode: sen.circonscription?.libelle
         ? findDepartmentCode(sen.circonscription.libelle)
         : null,
+      senateSeries,
       startDate: mandateStart || new Date(),
       isCurrent: true,
       source: DataSource.SENAT,

--- a/src/services/sync/types.ts
+++ b/src/services/sync/types.ts
@@ -85,7 +85,9 @@ export interface SenateurAPI {
   civilite: string; // "M." or "Mme"
   feminise: boolean;
   tri: string;
-  serie: number; // 1 or 2
+  // The API returns the series as a string ("1" / "2"). It was typed `number`,
+  // which made `serie === 1` always false. Normalise with `parseSenateSeries()`.
+  serie: string | number;
   siege: number;
   url: string;
   urlAvatar: string;


### PR DESCRIPTION
Fondations de données pour la section Sénatoriales 2026, avant tout travail d'interface. Trois défauts qui portent le récit de la future page, corrigés séparément pour que la PR du hub n'ait plus à s'en occuper.

## 1. Le seed des sénatoriales réarmait une date fausse

`scripts/seed-elections.ts` portait le 28 septembre 2026 avec `dateConfirmed: false`. La base de production est correcte depuis le 7 août, mais l'objet `update` de l'upsert réécrit `round1Date` et `dateConfirmed` sans condition : la prochaine exécution du seed reposait le 28 septembre et le badge « Dates provisoires » par-dessus la correction manuelle.

Le décret n° 2026-301 du 21 avril 2026 fixe le scrutin au **27 septembre**. L'entrée décrit maintenant l'état canonique attendu, y compris `description`, `sourceUrl`, `decreeUrl` et la fenêtre de dépôt des candidatures du 7 au 11 septembre.

La donnée passe dans `scripts/lib/elections-seed.ts`, module pur sans import runtime. Le test la couvre sans tirer le singleton Prisma, qui lève quand `DATABASE_URL` est absent : le premier jet était vert en local grâce au `dotenv/config` du script, et rouge en CI.

## 2. La série de renouvellement n'était jamais stockée

`SenateurAPI.serie` était typé `number` alors que l'API Sénat renvoie une chaîne. Le test `sen.serie === 1` du sync était donc toujours faux : branche morte, série jetée, et le repli de date attribuait à tout le monde la prise de fonction de la série 2.

Conséquences mesurées en production par le nouvel audit :

| Constat                                                            | Volume          |
| ------------------------------------------------------------------ | --------------- |
| Dates de début invraisemblables (série 1 antérieure au 01/10/2023) | **156 sur 170** |
| Mandats `isCurrent` absents de l'API                               | 3               |
| Sénateurs de l'API sans mandat courant en base                     | 2               |

L'API expose la série exactement telle qu'attendue : 348 sénateurs, 170 en série 1, 178 en série 2. `parseSenateSeries()` normalise les deux formes et rejette tout le reste plutôt que de convertir en aveugle. La valeur est persistée sur `Mandate.senateSeries`.

`npm run audit:senateurs-series` est en lecture seule et ne corrige rien. Les dates contaminées ne partiront pas d'elles-mêmes : le sync préserve toute date existante quand NosSénateurs n'en fournit pas. Il faut une source individuelle, donc un lot dédié.

**En attendant, aucune surface publique ne doit rendre « sénateur depuis <startDate> » pour la série 1.**

## 3. Paris, Lyon et Marseille portent un conseil municipal faux

`Commune.totalSeats` est dérivé du barème générique de l'article L. 2121-2, qui plafonne à 69 sièges. Les trois villes à régime PLM le dépassent toutes et portent donc 69 en base, contre 163, 73 et 111 en réalité. Le nombre de délégués sénatoriaux se calculant à partir de l'effectif du conseil, une lecture brute sous-estimerait le collège parisien de plusieurs centaines de voix, et Paris est justement le cas de repli central de la future page (département de série 1, la moitié des visiteurs).

Dérogation explicite et sourcée dans `src/config/senatoriales.ts` plutôt que retouche du barème : ce sont des régimes juridiques distincts. Marseille est à 111 depuis le renouvellement de 2026, pas à l'ancien 101.

## 4. La population communale n'a pas de millésime identifiable

`Commune.population` vient de geo.api.gouv.fr, dont la définition d'API décrit le champ sans publier son millésime. Écrire « Population INSEE 2026 » sous un nombre serait invérifiable.

Le seed enregistre désormais la date d'interrogation dans `SyncMetadata`. Un seul import alimente les ~35 000 communes en une passe, donc la provenance est globale et ne justifie pas de colonne `populationYear`.

## Schéma

`Mandate.senateSeries Int?`, additif et nullable. `prisma migrate diff` ne produisait que cette instruction, sans dérive résiduelle. Déjà appliqué en base.

## Ce que cette PR ne fait pas

- Ne corrige pas les 156 dates de début : l'audit les nomme, la correction demande une source individuelle.
- Ne ferme pas les 3 mandats périmés ni ne crée les 2 manquants.
- Ne rejoue pas `sync:senat` : le cron quotidien renseignera `senateSeries`. L'audit affichera alors 0 série divergente.
- Ne relance pas `seed-elections.ts` en production, qui est déjà à jour.
