### PR TITLE
Sénatoriales 2026 : hub état 1 et collège électoral

### DIFF
--- a/scripts/audit-senateurs-series.ts
+++ b/scripts/audit-senateurs-series.ts
@@ -11,6 +11,12 @@
  * This script fixes nothing. It measures the gap between the API and the database
  * so we can decide what to correct, and from which source.
  *
+ * It deliberately does NOT flag "start date earlier than the series renewal" as
+ * wrong: a re-elected senator legitimately carries an older date (95 of the 170
+ * series-1 seats went to a re-elected senator in 2023). What it flags is a date
+ * sitting on one of the two exact values the fallback could write, which makes its
+ * provenance indistinguishable from the fallback.
+ *
  * Usage:
  *   npm run audit:senateurs-series
  *   npm run audit:senateurs-series -- --verbose   (list every suspect mandate)
@@ -31,8 +37,14 @@ interface AuditRow {
   constituency: string | null;
   series: SenateSeries;
   startDate: Date;
-  termStart: Date;
+  impossibleForSeries: boolean;
 }
+
+/** The two exact values the broken series fallback could ever write. */
+const FALLBACK_TIMESTAMPS = new Set<number>([
+  getSeriesTermStart(1).getTime(),
+  getSeriesTermStart(2).getTime(),
+]);
 
 function formatDate(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -87,7 +99,7 @@ async function main() {
   let staleOutsideSyncReach = 0;
   const missingInDb = new Set(apiSeries.keys());
   const seriesNotStored: string[] = [];
-  const implausible: AuditRow[] = [];
+  const onFallbackDate: AuditRow[] = [];
   const dbCounts = { 1: 0, 2: 0 };
 
   for (const mandate of mandates) {
@@ -115,14 +127,21 @@ async function main() {
       );
     }
 
-    const termStart = getSeriesTermStart(series);
-    if (mandate.startDate < termStart) {
-      implausible.push({
+    // The fallback wrote one of two exact timestamps. A date sitting precisely on
+    // one of them is indistinguishable from it, whatever its real provenance: that
+    // is what needs checking, not "earlier than the renewal". A re-elected senator
+    // legitimately carries a date older than their series' last renewal (95 of the
+    // 170 series-1 seats were held by a re-elected senator in 2023), so an earlier
+    // date proves nothing on its own.
+    if (FALLBACK_TIMESTAMPS.has(mandate.startDate.getTime())) {
+      onFallbackDate.push({
         fullName: mandate.politician.fullName,
         constituency: mandate.constituency,
         series,
         startDate: mandate.startDate,
-        termStart,
+        // A series-1 seat was never renewed on 1 October 2020, so that value cannot
+        // be an election-driven start for this series.
+        impossibleForSeries: mandate.startDate.getTime() !== getSeriesTermStart(series).getTime(),
       });
     }
   }
@@ -156,34 +175,50 @@ async function main() {
     for (const externalId of missingInDb) console.log(`  ${externalId}`);
   }
 
-  console.log(`\n--- Dates de début invraisemblables : ${implausible.length} ---`);
-  console.log("  Un sénateur ne peut pas occuper son siège avant que sa série ne l'ait pourvu.");
-  if (implausible.length > 0) {
+  console.log(
+    `\n--- Dates de début dont la provenance reste à vérifier : ${onFallbackDate.length} sur ${dbCounts[1] + dbCounts[2]} ---`
+  );
+  console.log(
+    "  Ces dates valent exactement une des deux valeurs que le repli de série écrivait.\n" +
+      "  Certaines sont donc peut-être justes : elles sont seulement indiscernables du repli.\n" +
+      "  Un sénateur réélu porte légitimement une date antérieure au dernier renouvellement\n" +
+      "  de sa série, donc « antérieure au renouvellement » ne prouve rien en soi."
+  );
+  if (onFallbackDate.length > 0) {
     const bySeries = { 1: 0, 2: 0 };
-    for (const row of implausible) bySeries[row.series]++;
-    console.log(`  série 1 : ${bySeries[1]} sur ${dbCounts[1]}`);
-    console.log(`  série 2 : ${bySeries[2]} sur ${dbCounts[2]}`);
+    const impossible = { 1: 0, 2: 0 };
+    for (const row of onFallbackDate) {
+      bySeries[row.series]++;
+      if (row.impossibleForSeries) impossible[row.series]++;
+    }
+    for (const series of [1, 2] as const) {
+      console.log(
+        `  série ${series} : ${bySeries[series]} sur ${dbCounts[series]}, dont ` +
+          `${impossible[series]} portant une date qui n'est pas une prise de fonction de cette série`
+      );
+    }
     console.log(
-      "  Ces dates viennent du repli de série, pas d'une source individuelle. Elles ne " +
-        "seront pas corrigées par un simple sync:senat, qui préserve toute date existante."
+      "  Une concentration sur un seul jour n'est pas une distribution de réélections :\n" +
+        "  c'est la signature du repli. Aucun sync:senat ne la corrigera, il préserve\n" +
+        "  toute date existante. Voir l'issue #698."
     );
-    const shown = verbose ? implausible : implausible.slice(0, 10);
+    const shown = verbose ? onFallbackDate : onFallbackDate.slice(0, 10);
     for (const row of shown) {
       console.log(
         `  ${row.fullName} (${row.constituency ?? "?"}) série ${row.series} : ` +
-          `${formatDate(row.startDate)} < ${formatDate(row.termStart)}`
+          `${formatDate(row.startDate)}${row.impossibleForSeries ? " (impossible pour cette série)" : ""}`
       );
     }
-    if (!verbose && implausible.length > shown.length) {
+    if (!verbose && onFallbackDate.length > shown.length) {
       console.log(
-        `  ... et ${implausible.length - shown.length} autres (--verbose pour tout voir)`
+        `  ... et ${onFallbackDate.length - shown.length} autres (--verbose pour tout voir)`
       );
     }
   }
 
   console.log(
-    "\nTant que ces dates ne sont pas corrigées, aucune surface publique ne doit rendre " +
-      "« sénateur depuis <startDate> » pour la série 1."
+    "\nAucune surface publique ne doit rendre « sénateur depuis <startDate> » tant que la\n" +
+      "provenance de ces dates n'est pas établie, séries 1 et 2 confondues."
   );
 
   await db.$disconnect();

--- a/scripts/seed-communes.ts
+++ b/scripts/seed-communes.ts
@@ -155,6 +155,32 @@ async function main() {
     }
   }
 
+  // Final report
+  const countAfter = await db.commune.count();
+  const newlyCreated = countAfter - countBefore;
+
+  console.log("\n=== Done ===");
+  console.log(`  API communes: ${communes.length}`);
+  console.log(`  Upserted: ${upserted}`);
+  console.log(`  New: ~${newlyCreated}`);
+  console.log(`  Updated: ~${upserted - newlyCreated}`);
+  if (errors > 0) {
+    console.log(`  Errors: ${errors}`);
+  }
+  console.log(`  Communes in DB: ${countAfter}`);
+
+  // A partial import must not be dated. A commune whose upsert failed keeps its
+  // previous population, and stamping lastSyncAt would present that stale figure as
+  // freshly imported: the provenance line would then vouch for a number it never
+  // fetched. Fail loudly and leave the previous date standing, rather than move it
+  // forward over data we did not refresh.
+  if (errors > 0) {
+    throw new Error(
+      `Import incomplet : ${errors} erreur(s) sur ${communes.length}. ` +
+        `Provenance non datée, ${COMMUNE_DATA_SYNC_KEY} laissé inchangé.`
+    );
+  }
+
   // Record when we asked geo.api.gouv.fr, since the API publishes no population
   // vintage. Surfaces that render a population date the import, not a vintage
   // they cannot verify. See src/config/communes.ts.
@@ -172,20 +198,6 @@ async function main() {
       extra: { source: COMMUNE_POPULATION_SOURCE.via, url: COMMUNE_POPULATION_SOURCE.url },
     },
   });
-
-  // Final report
-  const countAfter = await db.commune.count();
-  const newlyCreated = countAfter - countBefore;
-
-  console.log("\n=== Done ===");
-  console.log(`  API communes: ${communes.length}`);
-  console.log(`  Upserted: ${upserted}`);
-  console.log(`  New: ~${newlyCreated}`);
-  console.log(`  Updated: ~${upserted - newlyCreated}`);
-  if (errors > 0) {
-    console.log(`  Errors: ${errors}`);
-  }
-  console.log(`  Communes in DB: ${countAfter}`);
 }
 
 main()

--- a/src/app/api/elections/senatoriales-2026/commune/route.ts
+++ b/src/app/api/elections/senatoriales-2026/commune/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withPublicRoute } from "@/lib/api/with-public-route";
+import { withCache } from "@/lib/cache";
+import {
+  findCommunesByPostalCode,
+  getCommuneCollege,
+  getSittingSenators,
+} from "@/lib/data/senatoriales";
+import { inhabitantsPerDelegate } from "@/lib/senatoriales/college";
+
+/**
+ * Resolves a postal code, then a commune, for the Sénatoriales 2026 college lookup.
+ *
+ * Two modes rather than one, because a postal code is not a commune identifier. 4,204
+ * of them cover several communes and one covers 46, so `?cp=` answers with the list of
+ * candidates and lets the caller disambiguate, while `?insee=` answers with the full
+ * college for a settled commune. Silently keeping the largest commune would give a
+ * confident wrong answer, which is worse than a second click.
+ *
+ * Both parameters are bounded (a 5-digit code, an INSEE code), so the responses are
+ * cacheable, unlike a free-text commune search.
+ */
+
+const POSTAL_CODE = /^[0-9]{5}$/;
+// INSEE commune codes: 5 chars, second position may be a letter for Corsica (2A/2B).
+const INSEE_CODE = /^[0-9][0-9AB][0-9]{3}$/;
+
+export const GET = withPublicRoute(async (request: NextRequest) => {
+  const params = request.nextUrl.searchParams;
+  const cp = params.get("cp");
+  const insee = params.get("insee");
+
+  if (cp !== null) {
+    if (!POSTAL_CODE.test(cp)) {
+      return NextResponse.json({ error: "Code postal invalide" }, { status: 400 });
+    }
+    const communes = await findCommunesByPostalCode(cp);
+    return withCache(NextResponse.json({ postalCode: cp, communes }), "daily");
+  }
+
+  if (insee !== null) {
+    if (!INSEE_CODE.test(insee)) {
+      return NextResponse.json({ error: "Code INSEE invalide" }, { status: 400 });
+    }
+    const view = await getCommuneCollege(insee);
+    if (!view) {
+      return NextResponse.json({ error: "Commune inconnue" }, { status: 404 });
+    }
+    const senators = await getSittingSenators(view.departmentCode);
+    return withCache(
+      NextResponse.json({
+        commune: {
+          id: view.id,
+          name: view.name,
+          departmentCode: view.departmentCode,
+          departmentName: view.departmentName,
+        },
+        college: view.college,
+        inhabitantsPerDelegate: inhabitantsPerDelegate(view.college),
+        renewal: view.renewal,
+        seatsAtStake: view.seatsAtStake,
+        senators,
+      }),
+      "daily"
+    );
+  }
+
+  return NextResponse.json({ error: "Paramètre requis : cp ou insee" }, { status: 400 });
+});

--- a/src/app/elections/[slug]/page.tsx
+++ b/src/app/elections/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { db } from "@/lib/db";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { SENATORIALES_2026_SLUG } from "@/lib/data/senatoriales";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatDate } from "@/lib/utils";
@@ -33,7 +34,12 @@ export const revalidate = 3600; // ISR: revalidate every hour
 export async function generateStaticParams() {
   const elections = await db.election.findMany({
     select: { slug: true },
-    where: { type: { not: "MUNICIPALES" }, slug: { not: PRESIDENTIELLE_2027_SLUG } },
+    where: {
+      type: { not: "MUNICIPALES" },
+      // Elections with a dedicated portal: the static route wins at request time, so
+      // prerendering the generic template for them builds a page nobody can reach.
+      slug: { notIn: [PRESIDENTIELLE_2027_SLUG, SENATORIALES_2026_SLUG] },
+    },
     take: 50,
     orderBy: { round1Date: "desc" },
   });

--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -11,7 +11,7 @@ import { SourceLine } from "@/components/ui/SourceLine";
 import { getDepartmentLocative } from "@/config/department-prepositions";
 import type { CommuneCollege } from "@/lib/senatoriales/college";
 import type { DepartmentRenewal, SittingSenator } from "@/lib/data/senatoriales";
-import { SOURCE_ELECTORAL_CODE, SOURCE_SENAT } from "../_content";
+import { SOURCE_ELECTORAL_CODE, SOURCE_SENAT, type BallotPhase } from "../_content";
 
 interface CommuneStub {
   id: string;
@@ -43,6 +43,39 @@ function formatInt(value: number): string {
 }
 
 /**
+ * The block's tense follows the resolved phase, not a date compared here.
+ *
+ * Once the ballot is held it says the department took part, and stops there: no
+ * result is announced while nothing feeds one. A page that still reads "à pourvoir le
+ * 27 septembre" on 28 September is not merely stale, it asserts something false.
+ */
+function renewedHeadline(phase: BallotPhase, seats: number | null, where: string): string {
+  const count = seats !== null && seats > 0 ? seats : null;
+  const seatWord = count !== null && count > 1 ? "sièges" : "siège";
+  if (phase === "after") {
+    return `Ce département faisait partie du renouvellement du 27 septembre`;
+  }
+  if (phase === "polling-day") {
+    return count !== null
+      ? `${count} ${seatWord} sont à pourvoir ${where} aujourd'hui`
+      : `Des sièges sont à pourvoir ${where} aujourd'hui`;
+  }
+  return count !== null
+    ? `${count} ${seatWord} à pourvoir ${where} le 27 septembre`
+    : `Des sièges sont à pourvoir ${where} le 27 septembre`;
+}
+
+function renewedDetail(phase: BallotPhase, delegates: number, communeName: string): string {
+  if (phase === "after") {
+    return `Les ${formatInt(delegates)} grands électeurs de ${communeName} y ont pris part.`;
+  }
+  if (phase === "polling-day") {
+    return `Les ${formatInt(delegates)} grands électeurs de ${communeName} votent aujourd'hui.`;
+  }
+  return `Les ${formatInt(delegates)} grands électeurs de ${communeName} voteront ce jour-là.`;
+}
+
+/**
  * "Vos grands électeurs" : the only interactive block of the hub.
  *
  * Three things it must get right, each of which the obvious implementation gets wrong.
@@ -59,7 +92,7 @@ function formatInt(value: number): string {
  * are in that case, so the block shows their delegates and says they will vote at the
  * next renewal, rather than turning into a dead end.
  */
-export function CommuneLookup() {
+export function CommuneLookup({ phase }: { phase: BallotPhase }) {
   const inputId = useId();
   const errorId = useId();
   const [postalCode, setPostalCode] = useState("");
@@ -175,13 +208,13 @@ export function CommuneLookup() {
           </div>
         )}
 
-        {state.kind === "answer" && <CommuneAnswerPanel answer={state.answer} />}
+        {state.kind === "answer" && <CommuneAnswerPanel answer={state.answer} phase={phase} />}
       </div>
     </section>
   );
 }
 
-function CommuneAnswerPanel({ answer }: { answer: CommuneAnswer }) {
+function CommuneAnswerPanel({ answer, phase }: { answer: CommuneAnswer; phase: BallotPhase }) {
   const { commune, college, inhabitantsPerDelegate, renewal, seatsAtStake, senators } = answer;
   const locative = getDepartmentLocative(commune.departmentCode);
   const where = locative ?? `dans le département ${commune.departmentName}`;
@@ -232,15 +265,10 @@ function CommuneAnswerPanel({ answer }: { answer: CommuneAnswer }) {
         <div className="mt-3 rounded-lg border border-border p-3">
           {renewal === "renewed" && (
             <>
-              <p className="font-semibold">
-                {seatsAtStake !== null && seatsAtStake > 0
-                  ? `${seatsAtStake} ${seatsAtStake > 1 ? "sièges" : "siège"} à pourvoir ${where} le 27 septembre`
-                  : `Des sièges sont à pourvoir ${where} le 27 septembre`}
-              </p>
+              <p className="font-semibold">{renewedHeadline(phase, seatsAtStake, where)}</p>
               {college !== null && (
                 <p className="mt-0.5 text-sm text-muted-foreground">
-                  Les {formatInt(college.total)} grands électeurs de {commune.name} voteront ce
-                  jour-là.
+                  {renewedDetail(phase, college.total, commune.name)}
                 </p>
               )}
             </>
@@ -248,11 +276,16 @@ function CommuneAnswerPanel({ answer }: { answer: CommuneAnswer }) {
           {renewal === "not-renewed" && (
             <>
               <p className="font-semibold">Aucun siège à pourvoir {where} cette année</p>
+              {/* The 21 April decree convened only the councils of the renewed
+                  departments (plus Guyane and Polynésie française) on 5 June, so a
+                  série-1 commune designated nothing that day. The figure is therefore
+                  what the barème gives on today's population and council, not a count
+                  of people already appointed. */}
               <p className="mt-0.5 text-sm text-muted-foreground">
                 Ce département relève de la série renouvelée en 2029.
                 {college !== null
-                  ? ` Ses ${formatInt(college.total)} grands électeurs ont bien été désignés le 5 juin : ils voteront au prochain renouvellement.`
-                  : " Ses grands électeurs ont bien été désignés le 5 juin : ils voteront au prochain renouvellement."}
+                  ? ` Avec sa population et l'effectif actuel du conseil, le barème donne aujourd'hui ${formatInt(college.total)} grands électeurs pour ${commune.name} ; le collège appelé à voter en 2029 sera constitué pour ce renouvellement.`
+                  : " Son collège sera constitué pour ce renouvellement."}
               </p>
             </>
           )}

--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useId, useState } from "react";
+import Link from "next/link";
+import { Scale } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { MissingData } from "@/components/ui/MissingData";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { getDepartmentLocative } from "@/config/department-prepositions";
+import type { CommuneCollege } from "@/lib/senatoriales/college";
+import type { DepartmentRenewal, SittingSenator } from "@/lib/data/senatoriales";
+import { SOURCE_ELECTORAL_CODE, SOURCE_SENAT } from "../_content";
+
+interface CommuneStub {
+  id: string;
+  name: string;
+  departmentCode: string;
+  departmentName: string;
+}
+
+interface CommuneAnswer {
+  commune: CommuneStub;
+  college: CommuneCollege | null;
+  inhabitantsPerDelegate: number | null;
+  renewal: DepartmentRenewal;
+  seatsAtStake: number | null;
+  senators: SittingSenator[];
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "choose"; postalCode: string; communes: CommuneStub[] }
+  | { kind: "answer"; answer: CommuneAnswer };
+
+const API = "/api/elections/senatoriales-2026/commune";
+
+function formatInt(value: number): string {
+  return value.toLocaleString("fr-FR");
+}
+
+/**
+ * "Vos grands électeurs" : the only interactive block of the hub.
+ *
+ * Three things it must get right, each of which the obvious implementation gets wrong.
+ *
+ * A postal code is not a commune: 4,204 of them cover several communes and one covers
+ * 46, so an ambiguous code offers a choice instead of quietly keeping the largest.
+ * `33430` alone returns thirteen communes, including the design's own example.
+ *
+ * A code resolves to a commune, never to an arrondissement. `75011` gives Paris
+ * because `Commune.postalCodes` carries all 21 Parisian codes on the 75056 row: an
+ * arrondissement designates no senatorial delegate, the Conseil de Paris does.
+ *
+ * And a department outside the renewal still gets a real answer. Half of the visitors
+ * are in that case, so the block shows their delegates and says they will vote at the
+ * next renewal, rather than turning into a dead end.
+ */
+export function CommuneLookup() {
+  const inputId = useId();
+  const errorId = useId();
+  const [postalCode, setPostalCode] = useState("");
+  const [state, setState] = useState<State>({ kind: "idle" });
+
+  async function lookupPostalCode(code: string) {
+    setState({ kind: "loading" });
+    try {
+      const response = await fetch(`${API}?cp=${encodeURIComponent(code)}`);
+      if (!response.ok) {
+        setState({ kind: "error", message: "Code postal à cinq chiffres attendu." });
+        return;
+      }
+      const data = (await response.json()) as { communes: CommuneStub[] };
+      if (data.communes.length === 0) {
+        setState({ kind: "error", message: `Aucune commune trouvée pour le code ${code}.` });
+        return;
+      }
+      if (data.communes.length === 1) {
+        await lookupCommune(data.communes[0]!.id);
+        return;
+      }
+      setState({ kind: "choose", postalCode: code, communes: data.communes });
+    } catch {
+      setState({ kind: "error", message: "La recherche a échoué. Réessayez dans un instant." });
+    }
+  }
+
+  async function lookupCommune(inseeCode: string) {
+    setState({ kind: "loading" });
+    try {
+      const response = await fetch(`${API}?insee=${encodeURIComponent(inseeCode)}`);
+      if (!response.ok) {
+        setState({ kind: "error", message: "Cette commune n'a pas pu être chargée." });
+        return;
+      }
+      setState({ kind: "answer", answer: (await response.json()) as CommuneAnswer });
+    } catch {
+      setState({ kind: "error", message: "La recherche a échoué. Réessayez dans un instant." });
+    }
+  }
+
+  return (
+    <section aria-labelledby="commune-heading" className="space-y-4">
+      <div className="space-y-2">
+        <h2
+          id="commune-heading"
+          className="font-display text-xl font-bold tracking-tight md:text-2xl"
+        >
+          Votre commune, vos grands électeurs
+        </h2>
+        <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+          Combien de voix votre conseil municipal envoie-t-il au scrutin ?
+        </p>
+      </div>
+
+      <form
+        className="flex flex-wrap items-end gap-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void lookupPostalCode(postalCode.trim());
+        }}
+      >
+        <div className="min-w-0">
+          <label htmlFor={inputId} className="mb-1.5 block text-sm font-medium">
+            Code postal
+          </label>
+          <Input
+            id={inputId}
+            type="text"
+            inputMode="numeric"
+            autoComplete="postal-code"
+            maxLength={5}
+            placeholder="33000"
+            value={postalCode}
+            aria-describedby={state.kind === "error" ? errorId : undefined}
+            aria-invalid={state.kind === "error" || undefined}
+            onChange={(event) => setPostalCode(event.target.value.replace(/[^0-9]/g, ""))}
+            className="h-11 w-32 tabular-nums"
+          />
+        </div>
+        <Button type="submit" className="h-11 px-5" disabled={state.kind === "loading"}>
+          {state.kind === "loading" ? "Recherche…" : "Voir"}
+        </Button>
+      </form>
+
+      <div aria-live="polite" className="space-y-4">
+        {state.kind === "error" && (
+          <p id={errorId} className="text-sm text-destructive">
+            {state.message}
+          </p>
+        )}
+
+        {state.kind === "choose" && (
+          <div className="rounded-xl border border-border p-4">
+            <p className="text-sm font-medium">
+              Le code {state.postalCode} couvre {state.communes.length} communes. Laquelle est la
+              vôtre ?
+            </p>
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {state.communes.map((commune) => (
+                <li key={commune.id}>
+                  <button
+                    type="button"
+                    onClick={() => void lookupCommune(commune.id)}
+                    className="flex min-h-11 items-center rounded-lg border border-border px-3 text-sm transition-colors hover:bg-muted/60"
+                  >
+                    {commune.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {state.kind === "answer" && <CommuneAnswerPanel answer={state.answer} />}
+      </div>
+    </section>
+  );
+}
+
+function CommuneAnswerPanel({ answer }: { answer: CommuneAnswer }) {
+  const { commune, college, inhabitantsPerDelegate, renewal, seatsAtStake, senators } = answer;
+  const locative = getDepartmentLocative(commune.departmentCode);
+  const where = locative ?? `dans le département ${commune.departmentName}`;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {commune.departmentName} ({commune.departmentCode})
+        </p>
+        <p className="font-display text-2xl font-extrabold tracking-tight">{commune.name}</p>
+
+        {college === null ? (
+          <MissingData className="mt-3" title="Nombre de délégués inconnu">
+            Il manque la population municipale ou l{"'"}effectif du conseil pour appliquer le
+            barème. Nous ne l{"'"}estimons pas.
+          </MissingData>
+        ) : (
+          <>
+            <dl className="mt-3 grid grid-cols-2 gap-3">
+              {/* muted-foreground-strong, not muted-foreground: 12px text on the
+                  tinted bg-muted/50 measures 4.4:1 in dark with the base token. */}
+              <div className="rounded-lg bg-muted/50 p-3">
+                <dt className="text-xs text-muted-foreground-strong">conseillers municipaux</dt>
+                <dd className="font-display text-xl font-extrabold tabular-nums">
+                  {formatInt(college.councilSeats)}
+                </dd>
+              </div>
+              <div className="rounded-lg bg-muted/50 p-3">
+                <dt className="text-xs text-muted-foreground-strong">grands électeurs</dt>
+                <dd className="font-display text-xl font-extrabold tabular-nums">
+                  {formatInt(college.total)}
+                </dd>
+              </div>
+            </dl>
+
+            {inhabitantsPerDelegate !== null && (
+              <p className="mt-3 text-sm text-muted-foreground">
+                Poids par habitant :{" "}
+                <span className="font-medium text-foreground tabular-nums">
+                  1 grand électeur pour {formatInt(Math.round(inhabitantsPerDelegate))} habitants
+                </span>
+              </p>
+            )}
+          </>
+        )}
+
+        <div className="mt-3 rounded-lg border border-border p-3">
+          {renewal === "renewed" && (
+            <>
+              <p className="font-semibold">
+                {seatsAtStake !== null && seatsAtStake > 0
+                  ? `${seatsAtStake} ${seatsAtStake > 1 ? "sièges" : "siège"} à pourvoir ${where} le 27 septembre`
+                  : `Des sièges sont à pourvoir ${where} le 27 septembre`}
+              </p>
+              {college !== null && (
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  Les {formatInt(college.total)} grands électeurs de {commune.name} voteront ce
+                  jour-là.
+                </p>
+              )}
+            </>
+          )}
+          {renewal === "not-renewed" && (
+            <>
+              <p className="font-semibold">Aucun siège à pourvoir {where} cette année</p>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Ce département relève de la série renouvelée en 2029.
+                {college !== null
+                  ? ` Ses ${formatInt(college.total)} grands électeurs ont bien été désignés le 5 juin : ils voteront au prochain renouvellement.`
+                  : " Ses grands électeurs ont bien été désignés le 5 juin : ils voteront au prochain renouvellement."}
+              </p>
+            </>
+          )}
+          {renewal === "unknown" && (
+            <MissingData title="Série de renouvellement inconnue">
+              Nous ne savons pas si les sièges de ce département sont remis en jeu cette année. La
+              série est reprise de l{"'"}open data du Sénat.
+            </MissingData>
+          )}
+        </div>
+
+        <Link
+          href="/elections/senatoriales-2026/college-electoral"
+          className="mt-3 inline-flex min-h-11 items-center text-sm font-medium text-primary hover:underline"
+        >
+          Voir le calcul du barème
+        </Link>
+      </div>
+
+      <SenatorsList senators={senators} where={where} />
+
+      <SourceLine
+        sources={[SOURCE_SENAT, SOURCE_ELECTORAL_CODE]}
+        note="Barème appliqué à la population municipale et à l'effectif du conseil"
+      />
+    </div>
+  );
+}
+
+function SenatorsList({ senators, where }: { senators: SittingSenator[]; where: string }) {
+  if (senators.length === 0) {
+    return (
+      <MissingData title="Aucun sénateur rattaché à ce département">
+        Les mandats sénatoriaux en cours sont repris de l{"'"}open data du Sénat. Si vous constatez
+        une absence, signalez-la nous.
+      </MissingData>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="font-semibold">Vos sénateurs {where}</h3>
+      <ul className="space-y-2">
+        {senators.map((senator) => (
+          <li key={senator.slug} className="rounded-xl border border-border p-3">
+            <div className="flex flex-wrap items-center justify-between gap-x-3">
+              {/* min-h-11 rather than a bare text link: the name is the card's only
+                  target, and measured at 24px it fell short of the 44px rule. */}
+              <Link
+                href={`/politiques/${senator.slug}`}
+                className="inline-flex min-h-11 items-center font-medium text-primary hover:underline"
+              >
+                {senator.fullName}
+              </Link>
+              {senator.series !== null && (
+                <Badge variant="outline" className="text-xs">
+                  {senator.series === 2 ? "Siège en jeu" : "Jusqu'en 2029"}
+                </Badge>
+              )}
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {senator.groupName ?? "Groupe non renseigné"}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {senator.declarationYear !== null ? (
+                <>Déclaration de patrimoine {senator.declarationYear}</>
+              ) : (
+                <>Aucune déclaration publiée par la HATVP à ce jour</>
+              )}
+            </p>
+            {/* Discreet signal, never a filter, never a sort key, never an aggregate.
+                The presumption of innocence is stated at every occurrence. No link of
+                its own: the card already leads to the profile through the name, and a
+                second link to the same place would compete with it while adding a
+                target too small to hit. */}
+            {senator.ongoingProceedings > 0 && (
+              <p className="mt-1.5 flex items-start gap-1.5 text-xs text-muted-foreground">
+                <Scale className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span>
+                  {senator.ongoingProceedings === 1
+                    ? "1 procédure en cours"
+                    : `${senator.ongoingProceedings} procédures en cours`}
+                  , présomption d{"'"}innocence. Détail sur la fiche.
+                </span>
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+      {/* One discreet line for an absence that applies to the whole section, per the
+          MissingData pattern: senator vote participation is not shown because 323 of
+          339 sit at exactly 100 %, the Senate scrutin import recording no absences. */}
+      <p className="text-xs text-muted-foreground">
+        La participation aux scrutins n{"'"}est pas affichée pour les sénateurs : les données dont
+        nous disposons ne distinguent pas encore les absences.
+      </p>
+    </div>
+  );
+}

--- a/src/app/elections/senatoriales-2026/_components/MunicipalBridge.tsx
+++ b/src/app/elections/senatoriales-2026/_components/MunicipalBridge.tsx
@@ -1,0 +1,56 @@
+import { ArrowRight } from "lucide-react";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { BRIDGE_STEPS, SOURCE_DECREE, SOURCE_ELECTORAL_CODE, SOURCE_SENAT } from "../_content";
+
+/**
+ * The thesis of the page, and therefore its first block of content: the September
+ * ballot does not create its electorate, it inherits it from the councils elected in
+ * March.
+ *
+ * Rendered as an ordered list because the four steps are a sequence, not a set of
+ * statistics. The arrows are decorative on desktop and disappear on mobile, where the
+ * vertical stack already carries the ordering.
+ */
+export function MunicipalBridge() {
+  return (
+    <section aria-labelledby="pont-heading" className="space-y-4">
+      <div className="space-y-2">
+        <h2 id="pont-heading" className="font-display text-xl font-bold tracking-tight md:text-2xl">
+          De votre conseil municipal au Sénat
+        </h2>
+        <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+          Le scrutin de septembre ne crée pas son électorat, il l{"'"}hérite. Le corps qui élit les
+          sénateurs a été composé par les conseils municipaux installés après les municipales, puis
+          désigné le 5 juin.
+        </p>
+      </div>
+
+      <ol className="grid gap-3 md:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] md:items-stretch md:gap-2">
+        {BRIDGE_STEPS.map((step, index) => (
+          <li key={step.when} className="contents">
+            <div className="h-full rounded-xl border border-border p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-brand-on-surface">
+                {step.when}
+              </p>
+              <p className="mt-1.5 font-semibold leading-snug">{step.headline}</p>
+              <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">{step.detail}</p>
+            </div>
+            {index < BRIDGE_STEPS.length - 1 && (
+              <div
+                aria-hidden="true"
+                className="hidden items-center justify-center text-muted-foreground md:flex"
+              >
+                <ArrowRight className="h-4 w-4" />
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+
+      <SourceLine
+        sources={[SOURCE_SENAT, SOURCE_DECREE, SOURCE_ELECTORAL_CODE]}
+        note="Répartition du collège publiée par le Sénat"
+      />
+    </section>
+  );
+}

--- a/src/app/elections/senatoriales-2026/_components/ScrutinRules.tsx
+++ b/src/app/elections/senatoriales-2026/_components/ScrutinRules.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { SCRUTIN_RULES, SOURCE_ELECTORAL_CODE } from "../_content";
+
+/**
+ * How the ballot works, and the door to the college page.
+ *
+ * The threshold is the number of seats in the department, which is why a page about a
+ * national ballot keeps sending the reader back to a local figure.
+ */
+export function ScrutinRules() {
+  return (
+    <section aria-labelledby="scrutin-heading" className="space-y-4">
+      <h2
+        id="scrutin-heading"
+        className="font-display text-xl font-bold tracking-tight md:text-2xl"
+      >
+        Comment fonctionne ce scrutin
+      </h2>
+
+      <dl className="grid gap-3 sm:grid-cols-2">
+        {SCRUTIN_RULES.map((rule) => (
+          <div key={rule.seats} className="rounded-xl border border-border p-4">
+            <dt>
+              <span className="text-xs font-semibold uppercase tracking-wide text-brand-on-surface">
+                {rule.seats}
+              </span>
+              <span className="mt-1 block font-semibold">{rule.mode}</span>
+            </dt>
+            <dd className="mt-1.5 text-sm leading-relaxed text-muted-foreground">{rule.detail}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Full-width row so the touch target is comfortably above 44px on mobile. */}
+      <Link
+        href="/elections/senatoriales-2026/college-electoral"
+        className="flex items-center gap-3 rounded-xl border border-border p-4 transition-colors hover:bg-muted/50"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block font-semibold">Qui sont les grands électeurs ?</span>
+          <span className="mt-0.5 block text-sm text-muted-foreground">
+            Le barème appliqué à une commune réelle, et pourquoi un village pèse plus qu{"'"}une
+            métropole.
+          </span>
+        </span>
+        <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      </Link>
+
+      <SourceLine sources={[SOURCE_ELECTORAL_CODE]} reportHref={null} />
+    </section>
+  );
+}

--- a/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
+++ b/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
@@ -1,0 +1,76 @@
+import { SourceLine } from "@/components/ui/SourceLine";
+import { MissingData } from "@/components/ui/MissingData";
+import type { GroupExposure } from "@/lib/data/senatoriales";
+import { SENATE_SEATS_AT_STAKE, SENATE_SEATS_TOTAL, SOURCE_SENAT } from "../_content";
+
+/**
+ * How exposed each Senate group is to this renewal.
+ *
+ * Computed from `Mandate.senateSeries`, so the Sénat is the only source needed: the
+ * design quoted a press tally for the same figures, and this query reproduces them
+ * (107 of 190 for the outgoing majority, 77 of 131 for Les Républicains, 4 of 18 for
+ * the communists). A group's exposure follows the series its seats belong to, not its
+ * size, which is the point worth showing.
+ *
+ * No projection of any kind: the bars measure seats *at stake*, never seats expected.
+ */
+export function SeatsAtStake({ groups }: { groups: GroupExposure[] }) {
+  const ranked = groups.filter((g) => g.held > 0).sort((a, b) => b.atStake - a.atStake);
+
+  return (
+    <section aria-labelledby="enjeu-heading" className="space-y-4">
+      <div className="space-y-2">
+        <h2
+          id="enjeu-heading"
+          className="font-display text-xl font-bold tracking-tight md:text-2xl"
+        >
+          Ce qui est remis en jeu
+        </h2>
+        <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+          {SENATE_SEATS_AT_STAKE} sièges sur {SENATE_SEATS_TOTAL} sont renouvelés. L{"'"}exposition
+          d{"'"}un groupe dépend de la série à laquelle ses sièges appartiennent, pas de sa taille.
+        </p>
+      </div>
+
+      {ranked.length === 0 ? (
+        <MissingData title="Répartition par groupe indisponible">
+          La série de renouvellement n{"'"}est pas encore renseignée sur les mandats sénatoriaux.
+          Elle est reprise de l{"'"}open data du Sénat à chaque synchronisation.
+        </MissingData>
+      ) : (
+        <ul className="space-y-2.5">
+          {ranked.map((group) => {
+            const share = group.held > 0 ? (group.atStake / group.held) * 100 : 0;
+            return (
+              <li key={group.groupName} className="rounded-lg border border-border p-3">
+                <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                  <p className="text-sm font-medium">{group.groupName}</p>
+                  <p className="text-sm tabular-nums text-muted-foreground">
+                    <span className="font-semibold text-foreground">{group.atStake}</span>
+                    <span> sur {group.held} sièges</span>
+                  </p>
+                </div>
+                {/* Proportion of the group's own seats being renewed. Decorative:
+                    the figures above already state it for screen readers. */}
+                <div
+                  aria-hidden="true"
+                  className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted"
+                >
+                  <div
+                    className="h-full rounded-full bg-brand-on-surface"
+                    style={{ width: `${Math.round(share)}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <SourceLine
+        sources={[SOURCE_SENAT]}
+        note="Sièges comptés par série sur les mandats sénatoriaux en cours"
+      />
+    </section>
+  );
+}

--- a/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
+++ b/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
@@ -1,7 +1,12 @@
 import { SourceLine } from "@/components/ui/SourceLine";
 import { MissingData } from "@/components/ui/MissingData";
 import type { GroupExposure } from "@/lib/data/senatoriales";
-import { SENATE_SEATS_AT_STAKE, SENATE_SEATS_TOTAL, SOURCE_SENAT } from "../_content";
+import {
+  SENATE_SEATS_AT_STAKE,
+  SENATE_SEATS_TOTAL,
+  SOURCE_SENAT,
+  type BallotPhase,
+} from "../_content";
 
 /**
  * How exposed each Senate group is to this renewal.
@@ -14,8 +19,39 @@ import { SENATE_SEATS_AT_STAKE, SENATE_SEATS_TOTAL, SOURCE_SENAT } from "../_con
  *
  * No projection of any kind: the bars measure seats *at stake*, never seats expected.
  */
-export function SeatsAtStake({ groups }: { groups: GroupExposure[] }) {
+export function SeatsAtStake({ groups, phase }: { groups: GroupExposure[]; phase: BallotPhase }) {
   const ranked = groups.filter((g) => g.held > 0).sort((a, b) => b.atStake - a.atStake);
+
+  /**
+   * After the ballot this query stops describing what it claims to.
+   *
+   * `getGroupExposure()` counts `isCurrent` mandates, so the first `sync:senat` that
+   * follows 27 September replaces the outgoing senators with the incoming ones. The
+   * bars would then show the *new* composition under the heading "remis en jeu",
+   * turning a correct query into a false statement without anything failing.
+   *
+   * The block therefore withdraws instead of relabelling: nothing captured the
+   * pre-ballot composition, so there is nothing honest to show yet. A snapshot taken
+   * before 27 September is the real fix, and it has a deadline.
+   */
+  if (phase === "after") {
+    return (
+      <section aria-labelledby="enjeu-heading" className="space-y-4">
+        <h2
+          id="enjeu-heading"
+          className="font-display text-xl font-bold tracking-tight md:text-2xl"
+        >
+          Ce qui était remis en jeu
+        </h2>
+        <MissingData title="Composition sortante non conservée">
+          Le scrutin a eu lieu. La répartition par groupe que nous calculons décrit désormais le
+          Sénat renouvelé, pas celui qui se présentait devant les grands électeurs : nous préférons
+          ne rien afficher plutôt que de présenter l{"'"}une pour l{"'"}autre.
+        </MissingData>
+        <SourceLine sources={[SOURCE_SENAT]} reportHref={null} />
+      </section>
+    );
+  }
 
   return (
     <section aria-labelledby="enjeu-heading" className="space-y-4">

--- a/src/app/elections/senatoriales-2026/_components/SenateMilestones.tsx
+++ b/src/app/elections/senatoriales-2026/_components/SenateMilestones.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@/components/ui/badge";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { MILESTONES, SOURCE_DECREE, SOURCE_SENAT } from "../_content";
+
+/**
+ * The five dates of the renewal.
+ *
+ * A dedicated list rather than the shared `ElectionKeyDates`: that component renders
+ * the `Election` model's date columns, and two of these milestones have no column (the
+ * 5 June designation of delegates, the October election of the Senate president). It
+ * would drop them silently.
+ *
+ * Only the last one is not settled by a published act, and it says so instead of
+ * being dressed up as a fixed date.
+ */
+export function SenateMilestones() {
+  return (
+    <section aria-labelledby="dates-heading" className="space-y-4">
+      <h2 id="dates-heading" className="font-display text-xl font-bold tracking-tight md:text-2xl">
+        Dates clés
+      </h2>
+
+      <ol className="space-y-3">
+        {MILESTONES.map((milestone) => (
+          <li key={milestone.label} className="flex gap-3">
+            <span
+              aria-hidden="true"
+              className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-muted-foreground/40"
+            />
+            <div className="min-w-0">
+              <p className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span className="font-semibold">{milestone.label}</span>
+                <span className="text-sm text-muted-foreground">{milestone.when}</span>
+                {!milestone.confirmed && (
+                  <Badge variant="outline" className="text-xs">
+                    Date non fixée
+                  </Badge>
+                )}
+              </p>
+              <p className="mt-0.5 text-sm leading-relaxed text-muted-foreground">
+                {milestone.note}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <SourceLine sources={[SOURCE_DECREE, SOURCE_SENAT]} reportHref={null} />
+    </section>
+  );
+}

--- a/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
@@ -125,7 +125,7 @@ describe("CommuneLookup : désambiguïsation", () => {
         "insee=33036": BAZAS_ANSWER,
       })
     );
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     const user = await search("33430");
 
     await screen.findByText(/couvre 2 communes/);
@@ -145,7 +145,7 @@ describe("CommuneLookup : désambiguïsation", () => {
         "insee=33036": BAZAS_ANSWER,
       })
     );
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
 
     await screen.findByText("Bazas");
@@ -154,7 +154,7 @@ describe("CommuneLookup : désambiguïsation", () => {
 
   it("dit qu'aucune commune ne correspond plutôt que de rester muet", async () => {
     vi.stubGlobal("fetch", mockFetch({ "cp=99999": { postalCode: "99999", communes: [] } }));
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("99999");
 
     await screen.findByText(/Aucune commune trouvée/);
@@ -173,14 +173,14 @@ describe("CommuneLookup : département renouvelable", () => {
   });
 
   it("accorde la préposition du département au lieu d'un « en » figé", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     await screen.findByText(/6 sièges à pourvoir en Gironde le 27 septembre/);
     expect(screen.getByRole("heading", { name: "Vos sénateurs en Gironde" })).toBeInTheDocument();
   });
 
   it("montre le barème et le poids par habitant", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     await screen.findByText("27");
     expect(screen.getByText("15")).toBeInTheDocument();
@@ -188,13 +188,13 @@ describe("CommuneLookup : département renouvelable", () => {
   });
 
   it("marque chaque siège remis en jeu", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     await waitFor(() => expect(screen.getAllByText("Siège en jeu")).toHaveLength(2));
   });
 
   it("nomme l'autorité quand aucune déclaration n'est publiée", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     await screen.findByText(/Aucune déclaration publiée par la HATVP à ce jour/);
     expect(screen.getByText(/Déclaration de patrimoine 2026/)).toBeInTheDocument();
@@ -202,14 +202,14 @@ describe("CommuneLookup : département renouvelable", () => {
 
   // Signal discret, jamais un filtre, jamais un tri, jamais un compteur agrégé.
   it("mentionne la présomption d'innocence à chaque procédure signalée", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     const signal = await screen.findByText(/2 procédures en cours/);
     expect(signal.textContent).toMatch(/présomption d'innocence/);
   });
 
   it("n'affiche ni ancienneté ni participation, faute de provenance fiable", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
     await screen.findByText("Bazas");
     expect(screen.queryByText(/sénatrice depuis|sénateur depuis/i)).toBeNull();
@@ -233,27 +233,88 @@ describe("CommuneLookup : département non renouvelable", () => {
 
   // La moitié des visiteurs est dans ce cas : le bloc doit répondre, pas se fermer.
   it("montre quand même les grands électeurs et dit quand ils voteront", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("75011");
 
     await screen.findByText(/Aucun siège à pourvoir à Paris cette année/);
     expect(screen.getByText("2 755")).toBeInTheDocument();
     expect(screen.getByText(/série renouvelée en 2029/)).toBeInTheDocument();
-    expect(screen.getByText(/désignés le 5 juin/)).toBeInTheDocument();
+  });
+
+  /**
+   * Régression : le décret du 21 avril 2026 ne convoque le 5 juin que les conseils
+   * municipaux des départements renouvelés, plus la Guyane et la Polynésie française.
+   * Une commune de série 1 n'a désigné personne ce jour-là, et le chiffre affiché est
+   * ce que donne le barème aujourd'hui, pas un décompte de délégués déjà nommés.
+   */
+  it("n'attribue aucune désignation du 5 juin à un département non renouvelé", async () => {
+    render(<CommuneLookup phase="before" />);
+    await search("75011");
+
+    await screen.findByText(/Aucun siège à pourvoir à Paris cette année/);
+    expect(screen.queryByText(/5 juin/)).toBeNull();
+    expect(screen.queryByText(/ont bien été désignés/)).toBeNull();
+    expect(
+      screen.getByText(/le barème donne aujourd'hui 2 755 grands électeurs/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/sera constitué pour ce renouvellement/)).toBeInTheDocument();
   });
 
   it("emploie « à Paris », jamais « en Paris »", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("75011");
     await screen.findByText(/à Paris cette année/);
     expect(screen.queryByText(/en Paris/)).toBeNull();
   });
 
   it("applique l'effectif réel du Conseil de Paris, pas le barème générique", async () => {
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("75011");
     await screen.findByText("163");
     expect(screen.queryByText("69")).toBeNull();
+  });
+});
+
+/**
+ * La formulation suit la phase résolue, jamais une date comparée dans le composant.
+ * Après le scrutin, une page qui lit encore « à pourvoir le 27 septembre » n'est pas
+ * seulement périmée : elle affirme quelque chose de faux.
+ */
+describe("CommuneLookup : formulation selon la phase du scrutin", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS] },
+        "insee=33036": BAZAS_ANSWER,
+      })
+    );
+  });
+
+  it("avant le scrutin : au futur, avec la date", async () => {
+    render(<CommuneLookup phase="before" />);
+    await search("33430");
+    await screen.findByText(/6 sièges à pourvoir en Gironde le 27 septembre/);
+    expect(screen.getByText(/voteront ce jour-là/)).toBeInTheDocument();
+  });
+
+  it("le jour du scrutin : au présent, sans renvoyer à une date à venir", async () => {
+    render(<CommuneLookup phase="polling-day" />);
+    await search("33430");
+    await screen.findByText(/6 sièges sont à pourvoir en Gironde aujourd'hui/);
+    expect(screen.getByText(/votent aujourd'hui/)).toBeInTheDocument();
+    expect(screen.queryByText(/le 27 septembre/)).toBeNull();
+  });
+
+  it("après le scrutin : au passé, et aucun résultat annoncé", async () => {
+    render(<CommuneLookup phase="after" />);
+    await search("33430");
+    await screen.findByText(/faisait partie du renouvellement du 27 septembre/);
+    expect(screen.getByText(/y ont pris part/)).toBeInTheDocument();
+    expect(screen.queryByText(/à pourvoir/)).toBeNull();
+    expect(screen.queryByText(/voteront|votent aujourd'hui/)).toBeNull();
+    // Rien ne doit ressembler à une proclamation tant que l'état 4 n'existe pas.
+    expect(screen.queryByText(/élu|réélu|résultat/i)).toBeNull();
   });
 });
 
@@ -270,7 +331,7 @@ describe("CommuneLookup : absences", () => {
         },
       })
     );
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
 
     await screen.findByText(/Nombre de délégués inconnu/);
@@ -285,7 +346,7 @@ describe("CommuneLookup : absences", () => {
         "insee=33036": { ...BAZAS_ANSWER, renewal: "unknown", seatsAtStake: null },
       })
     );
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
 
     await screen.findByText(/Série de renouvellement inconnue/);
@@ -298,7 +359,7 @@ describe("CommuneLookup : absences", () => {
       "fetch",
       vi.fn(() => Promise.reject(new Error("offline")))
     );
-    render(<CommuneLookup />);
+    render(<CommuneLookup phase="before" />);
     await search("33430");
 
     await screen.findByText(/La recherche a échoué/);

--- a/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CommuneLookup } from "../CommuneLookup";
+
+/**
+ * The lookup carries three promises the obvious implementation breaks.
+ *
+ * A postal code is not a commune, so an ambiguous one must offer a choice instead of
+ * quietly keeping the largest match. A code resolves to a commune and never to an
+ * arrondissement. And a department outside this renewal still gets a real answer,
+ * because half the visitors are in that case.
+ */
+
+const BAZAS = {
+  id: "33036",
+  name: "Bazas",
+  departmentCode: "33",
+  departmentName: "Gironde",
+};
+const BERNOS = {
+  id: "33046",
+  name: "Bernos-Beaulac",
+  departmentCode: "33",
+  departmentName: "Gironde",
+};
+const PARIS = { id: "75056", name: "Paris", departmentCode: "75", departmentName: "Paris" };
+
+const BAZAS_ANSWER = {
+  commune: BAZAS,
+  college: {
+    councilSeats: 27,
+    population: 4854,
+    regime: "scale",
+    scaleDelegates: 15,
+    delegatesByRight: null,
+    supplementaryDelegates: 0,
+    supplementaryBrackets: 0,
+    total: 15,
+  },
+  inhabitantsPerDelegate: 323.6,
+  renewal: "renewed",
+  seatsAtStake: 6,
+  senators: [
+    {
+      slug: "florence-lassarade",
+      fullName: "Florence Lassarade",
+      civility: "Mme",
+      photoUrl: null,
+      constituency: "Gironde",
+      series: 2,
+      groupName: "Les Républicains",
+      groupShortName: "LR",
+      groupColor: null,
+      declarationYear: 2026,
+      ongoingProceedings: 0,
+    },
+    {
+      slug: "temoin-procedure",
+      fullName: "Sénateur Témoin",
+      civility: "M.",
+      photoUrl: null,
+      constituency: "Gironde",
+      series: 2,
+      groupName: "Groupe Témoin",
+      groupShortName: null,
+      groupColor: null,
+      declarationYear: null,
+      ongoingProceedings: 2,
+    },
+  ],
+};
+
+const PARIS_ANSWER = {
+  commune: PARIS,
+  college: {
+    councilSeats: 163,
+    population: 2103778,
+    regime: "by-right",
+    scaleDelegates: null,
+    delegatesByRight: 163,
+    supplementaryDelegates: 2592,
+    supplementaryBrackets: 2592,
+    total: 2755,
+  },
+  inhabitantsPerDelegate: 763.6,
+  renewal: "not-renewed",
+  seatsAtStake: null,
+  senators: [],
+};
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn((url: string) => {
+    for (const [fragment, payload] of Object.entries(routes)) {
+      if (url.includes(fragment)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) } as Response);
+      }
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch({}));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function search(code: string) {
+  const user = userEvent.setup();
+  await user.clear(screen.getByLabelText("Code postal"));
+  await user.type(screen.getByLabelText("Code postal"), code);
+  await user.click(screen.getByRole("button", { name: "Voir" }));
+  return user;
+}
+
+describe("CommuneLookup : désambiguïsation", () => {
+  it("propose un choix quand le code postal couvre plusieurs communes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS, BERNOS] },
+        "insee=33036": BAZAS_ANSWER,
+      })
+    );
+    render(<CommuneLookup />);
+    const user = await search("33430");
+
+    await screen.findByText(/couvre 2 communes/);
+    expect(screen.getByRole("button", { name: "Bazas" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Bernos-Beaulac" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Bazas" }));
+    await screen.findByText("Bazas");
+    expect(screen.getByText("15")).toBeInTheDocument();
+  });
+
+  it("résout directement quand le code ne désigne qu'une commune", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS] },
+        "insee=33036": BAZAS_ANSWER,
+      })
+    );
+    render(<CommuneLookup />);
+    await search("33430");
+
+    await screen.findByText("Bazas");
+    expect(screen.queryByText(/couvre/)).toBeNull();
+  });
+
+  it("dit qu'aucune commune ne correspond plutôt que de rester muet", async () => {
+    vi.stubGlobal("fetch", mockFetch({ "cp=99999": { postalCode: "99999", communes: [] } }));
+    render(<CommuneLookup />);
+    await search("99999");
+
+    await screen.findByText(/Aucune commune trouvée/);
+  });
+});
+
+describe("CommuneLookup : département renouvelable", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS] },
+        "insee=33036": BAZAS_ANSWER,
+      })
+    );
+  });
+
+  it("accorde la préposition du département au lieu d'un « en » figé", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    await screen.findByText(/6 sièges à pourvoir en Gironde le 27 septembre/);
+    expect(screen.getByRole("heading", { name: "Vos sénateurs en Gironde" })).toBeInTheDocument();
+  });
+
+  it("montre le barème et le poids par habitant", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    await screen.findByText("27");
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.getByText(/1 grand électeur pour 324 habitants/)).toBeInTheDocument();
+  });
+
+  it("marque chaque siège remis en jeu", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    await waitFor(() => expect(screen.getAllByText("Siège en jeu")).toHaveLength(2));
+  });
+
+  it("nomme l'autorité quand aucune déclaration n'est publiée", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    await screen.findByText(/Aucune déclaration publiée par la HATVP à ce jour/);
+    expect(screen.getByText(/Déclaration de patrimoine 2026/)).toBeInTheDocument();
+  });
+
+  // Signal discret, jamais un filtre, jamais un tri, jamais un compteur agrégé.
+  it("mentionne la présomption d'innocence à chaque procédure signalée", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    const signal = await screen.findByText(/2 procédures en cours/);
+    expect(signal.textContent).toMatch(/présomption d'innocence/);
+  });
+
+  it("n'affiche ni ancienneté ni participation, faute de provenance fiable", async () => {
+    render(<CommuneLookup />);
+    await search("33430");
+    await screen.findByText("Bazas");
+    expect(screen.queryByText(/sénatrice depuis|sénateur depuis/i)).toBeNull();
+    expect(screen.queryByText(/Participation\s*\d/)).toBeNull();
+    expect(
+      screen.getByText(/La participation aux scrutins n'est pas affichée/)
+    ).toBeInTheDocument();
+  });
+});
+
+describe("CommuneLookup : département non renouvelable", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=75011": { postalCode: "75011", communes: [PARIS] },
+        "insee=75056": PARIS_ANSWER,
+      })
+    );
+  });
+
+  // La moitié des visiteurs est dans ce cas : le bloc doit répondre, pas se fermer.
+  it("montre quand même les grands électeurs et dit quand ils voteront", async () => {
+    render(<CommuneLookup />);
+    await search("75011");
+
+    await screen.findByText(/Aucun siège à pourvoir à Paris cette année/);
+    expect(screen.getByText("2 755")).toBeInTheDocument();
+    expect(screen.getByText(/série renouvelée en 2029/)).toBeInTheDocument();
+    expect(screen.getByText(/désignés le 5 juin/)).toBeInTheDocument();
+  });
+
+  it("emploie « à Paris », jamais « en Paris »", async () => {
+    render(<CommuneLookup />);
+    await search("75011");
+    await screen.findByText(/à Paris cette année/);
+    expect(screen.queryByText(/en Paris/)).toBeNull();
+  });
+
+  it("applique l'effectif réel du Conseil de Paris, pas le barème générique", async () => {
+    render(<CommuneLookup />);
+    await search("75011");
+    await screen.findByText("163");
+    expect(screen.queryByText("69")).toBeNull();
+  });
+});
+
+describe("CommuneLookup : absences", () => {
+  it("dit que le nombre de délégués est inconnu au lieu d'afficher un zéro", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS] },
+        "insee=33036": {
+          ...BAZAS_ANSWER,
+          college: null,
+          inhabitantsPerDelegate: null,
+        },
+      })
+    );
+    render(<CommuneLookup />);
+    await search("33430");
+
+    await screen.findByText(/Nombre de délégués inconnu/);
+    expect(screen.queryByText(/^0$/)).toBeNull();
+  });
+
+  it("dit qu'elle ne connaît pas la série plutôt que de choisir un camp", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=33430": { postalCode: "33430", communes: [BAZAS] },
+        "insee=33036": { ...BAZAS_ANSWER, renewal: "unknown", seatsAtStake: null },
+      })
+    );
+    render(<CommuneLookup />);
+    await search("33430");
+
+    await screen.findByText(/Série de renouvellement inconnue/);
+    expect(screen.queryByText(/à pourvoir/)).toBeNull();
+    expect(screen.queryByText(/Aucun siège/)).toBeNull();
+  });
+
+  it("signale une panne réseau au lieu de rester sur un état vide", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline")))
+    );
+    render(<CommuneLookup />);
+    await search("33430");
+
+    await screen.findByText(/La recherche a échoué/);
+  });
+});

--- a/src/app/elections/senatoriales-2026/_components/__tests__/SeatsAtStake.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/SeatsAtStake.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SeatsAtStake } from "../SeatsAtStake";
+import { getBallotPhase } from "../../_content";
+
+const GROUPS = [
+  { groupName: "Les Républicains", shortName: "LR", color: null, held: 131, atStake: 77 },
+  { groupName: "Union Centriste", shortName: "UC", color: null, held: 59, atStake: 30 },
+  { groupName: "CRCE-K", shortName: null, color: null, held: 18, atStake: 4 },
+];
+
+describe("SeatsAtStake avant le scrutin", () => {
+  it("rend l'exposition de chaque groupe, calculée et non citée", () => {
+    render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    expect(screen.getByText("Ce qui est remis en jeu")).toBeInTheDocument();
+    expect(screen.getByText("77")).toBeInTheDocument();
+    expect(screen.getByText(/sur 131 sièges/)).toBeInTheDocument();
+    expect(screen.getByText(/sur 18 sièges/)).toBeInTheDocument();
+  });
+
+  it("classe par nombre de sièges remis en jeu, pas par taille de groupe", () => {
+    render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    const names = screen.getAllByRole("listitem").map((li) => li.textContent ?? "");
+    expect(names[0]).toContain("Les Républicains");
+    expect(names[2]).toContain("CRCE-K");
+  });
+
+  it("dit l'absence quand la série n'est pas encore renseignée", () => {
+    render(<SeatsAtStake groups={[]} phase="before" />);
+    expect(screen.getByText(/Répartition par groupe indisponible/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * Régression : `getGroupExposure()` compte les mandats `isCurrent`. Le premier
+ * `sync:senat` qui suit le 27 septembre remplace donc les sortants par les entrants, et
+ * les barres décriraient le Sénat renouvelé sous un titre annonçant les sièges remis en
+ * jeu. Rien n'échoue, la page se met simplement à mentir. Le bloc se retire.
+ */
+describe("SeatsAtStake après le scrutin", () => {
+  it("ne présente plus la composition courante comme la composition sortante", () => {
+    render(<SeatsAtStake groups={GROUPS} phase="after" />);
+    expect(screen.getByText(/Composition sortante non conservée/)).toBeInTheDocument();
+    expect(screen.queryByText("77")).toBeNull();
+    expect(screen.queryByText(/sur 131 sièges/)).toBeNull();
+    expect(screen.queryByText("Ce qui est remis en jeu")).toBeNull();
+  });
+
+  it("emploie le passé dans son titre", () => {
+    render(<SeatsAtStake groups={GROUPS} phase="after" />);
+    expect(screen.getByText("Ce qui était remis en jeu")).toBeInTheDocument();
+  });
+});
+
+describe("getBallotPhase", () => {
+  it("garde le futur avant le premier tour", () => {
+    for (const status of ["UPCOMING", "REGISTRATION", "CANDIDACIES", "CAMPAIGN"] as const) {
+      expect(getBallotPhase(status), status).toBe("before");
+    }
+  });
+
+  it("passe au présent le jour du scrutin", () => {
+    expect(getBallotPhase("ROUND_1")).toBe("polling-day");
+  });
+
+  it("passe au passé dès que le scrutin est derrière", () => {
+    expect(getBallotPhase("BETWEEN_ROUNDS")).toBe("after");
+    expect(getBallotPhase("COMPLETED")).toBe("after");
+  });
+});

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -1,0 +1,164 @@
+/**
+ * Editorial content for the Sénatoriales 2026 hub.
+ *
+ * Gathered in one module so the prose is reviewed as prose, once, instead of being
+ * scattered across components. Per AGENTS.md §7 none of it is model-generated: every
+ * figure below is either quoted from an identified source or computed from the
+ * database at render time, and anything that is neither has been left out.
+ *
+ * Two numbers from the design mockup are deliberately absent. The count of municipal
+ * councils elected in March 2026 (given as 34,875) is not in the sourced set and our
+ * own data counts 34,754 communes with recorded elected councillors, a gap that
+ * reflects import completeness rather than reality. And the 2020 to 2026 shift in
+ * municipal political blocs is not computable at the granularity the mockup claims,
+ * so it is not stated at all rather than stated loosely.
+ */
+
+export const SENATE_SEATS_TOTAL = 348;
+export const SENATE_SEATS_AT_STAKE = 178;
+
+/**
+ * 64 constituencies, not 63 departments: the Sénat counts the 63 renewable
+ * departments and collectivities plus the Français établis hors de France, who vote
+ * separately. Saying "63 préfectures" drops that last constituency.
+ */
+export const CONSTITUENCY_COUNT = 64;
+
+export const GRANDS_ELECTEURS_TOTAL = 93469;
+export const MUNICIPAL_DELEGATE_SHARE = "95,2 %";
+
+export const DECREE_LABEL = "Décret n° 2026-301 du 21 avril 2026";
+export const DECREE_URL = "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053925339";
+export const SENATE_OFFICIAL_URL = "https://senatoriales2026.senat.fr/";
+export const ELECTORAL_CODE_URL =
+  "https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006070239/LEGISCTA000006134760/";
+
+/** Source labels, so the same body is never named two ways on one page. */
+export const SOURCE_SENAT = { label: "Sénat", url: SENATE_OFFICIAL_URL };
+export const SOURCE_DECREE = { label: DECREE_LABEL, url: DECREE_URL };
+export const SOURCE_ELECTORAL_CODE = {
+  label: "Code électoral, art. L. 280 à L. 293",
+  url: ELECTORAL_CODE_URL,
+};
+
+// ─── The thesis ─────────────────────────────────────────────────────
+
+export const HUB_TITLE = "Le Sénat se joue dans les conseils municipaux";
+export const HUB_TITLE_PAST = "Le Sénat s'est joué dans les conseils municipaux";
+
+export const HUB_LEDE =
+  "Vous n'aurez pas de bulletin à mettre. 93 469 grands électeurs voteront à votre place, " +
+  "et 95,2 % d'entre eux ont été désignés par les conseils municipaux que vous avez élus.";
+export const HUB_LEDE_PAST =
+  "Le scrutin a eu lieu. 93 469 grands électeurs ont voté à votre place, et 95,2 % d'entre eux " +
+  "avaient été désignés par les conseils municipaux que vous avez élus.";
+
+// ─── From your council to the Senate ────────────────────────────────
+
+export interface BridgeStep {
+  when: string;
+  headline: string;
+  detail: string;
+}
+
+export const BRIDGE_STEPS: BridgeStep[] = [
+  {
+    when: "15 et 22 mars 2026",
+    headline: "Vous élisez votre conseil municipal",
+    detail:
+      "Toutes les communes votent au scrutin de liste paritaire, une première. C'est le seul " +
+      "moment de la chaîne où vous déposez un bulletin.",
+  },
+  {
+    when: "5 juin 2026",
+    headline: "Les conseils désignent leurs délégués",
+    detail:
+      "93 469 grands électeurs, dont 95,2 % de délégués des conseils municipaux. Le nombre de " +
+      "délégués d'une commune découle d'un barème, pas d'une négociation.",
+  },
+  {
+    when: "27 septembre 2026",
+    headline: "Les grands électeurs élisent les sénateurs",
+    detail:
+      "178 sièges sur 348, dans 64 circonscriptions : 63 départements et collectivités, plus " +
+      "les Français établis hors de France. Le vote y est obligatoire.",
+  },
+  {
+    when: "Jusqu'en 2032",
+    headline: "Les sénateurs siègent six ans",
+    detail:
+      "Le Sénat ne peut pas être dissous. Un conseil municipal élu en mars 2026 pèse donc sur " +
+      "la chambre haute jusqu'en 2032.",
+  },
+];
+
+// ─── Voting rules ───────────────────────────────────────────────────
+
+export interface ScrutinRule {
+  seats: string;
+  mode: string;
+  detail: string;
+}
+
+export const SCRUTIN_RULES: ScrutinRule[] = [
+  {
+    seats: "1 ou 2 sièges",
+    mode: "Scrutin majoritaire",
+    detail:
+      "Deux tours dans la journée : majorité absolue au premier, majorité relative au second.",
+  },
+  {
+    seats: "3 sièges et plus",
+    mode: "Proportionnelle de liste",
+    detail: "Un seul tour, listes paritaires, répartition à la plus forte moyenne.",
+  },
+];
+
+// ─── Milestones ─────────────────────────────────────────────────────
+
+export interface Milestone {
+  label: string;
+  when: string;
+  note: string;
+  /** Settled by a published act, as opposed to scheduled by usage. */
+  confirmed: boolean;
+}
+
+/**
+ * The generic `ElectionKeyDates` renders the `Election` model's date columns and maps
+ * each label to a phase. Two milestones that matter here have no column (the 5 June
+ * designation, the October election of the Senate president), so it would silently
+ * drop them. Hence a dedicated list.
+ */
+export const MILESTONES: Milestone[] = [
+  {
+    label: "Décret de convocation",
+    when: "21 avril 2026",
+    note: "Décret n° 2026-301, publié au Journal officiel.",
+    confirmed: true,
+  },
+  {
+    label: "Désignation des délégués",
+    when: "5 juin 2026",
+    note: "Les conseils municipaux élisent leurs délégués et leurs suppléants.",
+    confirmed: true,
+  },
+  {
+    label: "Dépôt des candidatures",
+    when: "7 au 11 septembre 2026",
+    note: "En préfecture, jusqu'à 18 h le vendredi.",
+    confirmed: true,
+  },
+  {
+    label: "Scrutin",
+    when: "dimanche 27 septembre 2026",
+    note: "Dans les 64 circonscriptions concernées. Le vote est obligatoire pour les grands électeurs.",
+    confirmed: true,
+  },
+  {
+    label: "Élection du président du Sénat",
+    when: "début octobre 2026",
+    note: "Le Sénat renouvelé élit son président, son bureau et ses présidences de commission.",
+    confirmed: false,
+  },
+];

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -14,6 +14,23 @@
  * so it is not stated at all rather than stated loosely.
  */
 
+import type { ElectionStatus } from "@/types";
+
+/**
+ * Where the ballot stands, reduced to what changes the wording.
+ *
+ * Derived from the phase the data layer resolves at read time, never from a date
+ * compared in a component: two surfaces comparing the same date independently drift
+ * apart the moment one of them is cached differently.
+ */
+export type BallotPhase = "before" | "polling-day" | "after";
+
+export function getBallotPhase(status: ElectionStatus): BallotPhase {
+  if (status === "ROUND_1" || status === "ROUND_2") return "polling-day";
+  if (status === "BETWEEN_ROUNDS" || status === "COMPLETED") return "after";
+  return "before";
+}
+
 export const SENATE_SEATS_TOTAL = 348;
 export const SENATE_SEATS_AT_STAKE = 178;
 
@@ -140,7 +157,12 @@ export const MILESTONES: Milestone[] = [
   {
     label: "Désignation des délégués",
     when: "5 juin 2026",
-    note: "Les conseils municipaux élisent leurs délégués et leurs suppléants.",
+    // The decree convened only the councils of the renewed departments, plus Guyane
+    // and Polynésie française. Saying "les conseils municipaux" flat would credit a
+    // designation to série-1 communes that never took part.
+    note:
+      "Les conseils municipaux des départements renouvelés élisent leurs délégués et leurs " +
+      "suppléants.",
     confirmed: true,
   },
   {

--- a/src/app/elections/senatoriales-2026/college-electoral/page.tsx
+++ b/src/app/elections/senatoriales-2026/college-electoral/page.tsx
@@ -1,0 +1,318 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Check } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { MissingData } from "@/components/ui/MissingData";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { getDepartmentLocative } from "@/config/department-prepositions";
+import {
+  DELEGATES_BY_RIGHT_THRESHOLD,
+  SUPPLEMENTARY_DELEGATE_FLOOR,
+  SUPPLEMENTARY_DELEGATE_STEP,
+} from "@/config/senatoriales";
+import { COMMUNE_POPULATION_SOURCE } from "@/config/communes";
+import { getCommuneCollege, getCommuneDataFetchedAt } from "@/lib/data/senatoriales";
+import { inhabitantsPerDelegate } from "@/lib/senatoriales/college";
+import { ELECTORAL_CODE_URL, GRANDS_ELECTEURS_TOTAL, SOURCE_ELECTORAL_CODE } from "../_content";
+
+export const revalidate = 300;
+
+/**
+ * A city and a village of the same department, voting for the same seats. Both are in
+ * série 2 (Gironde), so the comparison is not muddied by a difference of series.
+ */
+const CITY_INSEE = "33063"; // Bordeaux
+const VILLAGE_INSEE = "33036"; // Bazas
+
+export const metadata: Metadata = {
+  title: "Le collège électoral sénatorial : qui vote à votre place | Poligraph",
+  description:
+    "Le nombre de grands électeurs d'une commune découle d'un barème, articles L. 284 et " +
+    "L. 285 du code électoral. Le calcul posé sur une commune réelle, et la comparaison " +
+    "ville contre village.",
+  alternates: { canonical: "/elections/senatoriales-2026/college-electoral" },
+};
+
+function formatInt(value: number): string {
+  return value.toLocaleString("fr-FR");
+}
+
+export default async function CollegeElectoralPage() {
+  const [city, village, fetchedAt] = await Promise.all([
+    getCommuneCollege(CITY_INSEE),
+    getCommuneCollege(VILLAGE_INSEE),
+    getCommuneDataFetchedAt(),
+  ]);
+
+  const cityLocative = getDepartmentLocative(city?.departmentCode);
+  const populationSource = {
+    label: `${COMMUNE_POPULATION_SOURCE.label}, via ${COMMUNE_POPULATION_SOURCE.via}`,
+    url: COMMUNE_POPULATION_SOURCE.url,
+  };
+
+  return (
+    <main id="main-content" className="container mx-auto max-w-3xl px-4 pt-4 pb-12">
+      <Breadcrumb
+        items={[
+          { label: "Élections", href: "/elections" },
+          { label: "Sénatoriales 2026", href: "/elections/senatoriales-2026" },
+          { label: "Le collège électoral" },
+        ]}
+      />
+
+      <div className="space-y-10">
+        <header className="space-y-3">
+          <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
+            Le collège électoral sénatorial
+          </p>
+          <h1 className="font-display text-2xl font-extrabold leading-tight tracking-tight md:text-4xl">
+            Qui vote à votre place
+          </h1>
+          <p className="max-w-2xl text-sm text-muted-foreground md:text-lg">
+            Le nombre de grands électeurs d{"'"}une commune n{"'"}est ni négocié ni politique : c
+            {"'"}est une formule, fixée aux articles L. 284 et L. 285 du code électoral.
+            {city ? ` Appliquons-la à ${city.name}.` : ""}
+          </p>
+        </header>
+
+        {/* ─── The calculation, laid out ─── */}
+        {city === null || city.college === null ? (
+          <MissingData title="Calcul indisponible">
+            Il manque la population municipale ou l{"'"}effectif du conseil de la commune servant d
+            {"'"}exemple. Nous ne remplaçons pas ces valeurs par une estimation.
+          </MissingData>
+        ) : (
+          <section aria-labelledby="calcul-heading" className="space-y-4">
+            <h2 id="calcul-heading" className="sr-only">
+              Le calcul appliqué à {city.name}
+            </h2>
+
+            <div className="rounded-xl border border-border p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {city.departmentName}
+                {city.renewal === "renewed" ? " · série renouvelée le 27 septembre" : ""}
+              </p>
+              <p className="font-display text-2xl font-extrabold tracking-tight">{city.name}</p>
+              <dl className="mt-3 grid grid-cols-2 gap-3">
+                <div className="rounded-lg bg-muted/50 p-3">
+                  {/* muted-foreground-strong, not muted-foreground: 12px text on the
+                      tinted bg-muted/50 measures 4.4:1 in dark with the base token. */}
+                  <dt className="text-xs text-muted-foreground-strong">habitants</dt>
+                  <dd className="font-display text-xl font-extrabold tabular-nums">
+                    {formatInt(city.college.population)}
+                  </dd>
+                </div>
+                <div className="rounded-lg bg-muted/50 p-3">
+                  <dt className="text-xs text-muted-foreground-strong">conseillers municipaux</dt>
+                  <dd className="font-display text-xl font-extrabold tabular-nums">
+                    {formatInt(city.college.councilSeats)}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <ol className="space-y-3">
+              <li className="flex gap-3 rounded-xl border border-border p-4">
+                <span
+                  aria-hidden="true"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted font-semibold tabular-nums"
+                >
+                  1
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold">
+                    {city.name} compte {formatInt(DELEGATES_BY_RIGHT_THRESHOLD)} habitants ou plus
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Les {formatInt(city.college.councilSeats)} conseillers municipaux sont donc{" "}
+                    <strong className="font-semibold text-foreground">délégués de droit</strong>.
+                    Ils n{"'"}ont pas à être élus une seconde fois. (art. L. 285)
+                  </p>
+                </div>
+                <p className="shrink-0 font-display text-xl font-extrabold tabular-nums">
+                  {formatInt(city.college.councilSeats)}
+                </p>
+              </li>
+
+              <li className="flex gap-3 rounded-xl border border-border p-4">
+                <span
+                  aria-hidden="true"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted font-semibold tabular-nums"
+                >
+                  2
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold">
+                    {city.name} dépasse {formatInt(SUPPLEMENTARY_DELEGATE_FLOOR)} habitants
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Le conseil élit un délégué supplémentaire par tranche complète de{" "}
+                    {SUPPLEMENTARY_DELEGATE_STEP} habitants au-delà de{" "}
+                    {formatInt(SUPPLEMENTARY_DELEGATE_FLOOR)} : (
+                    {formatInt(city.college.population)} − {formatInt(SUPPLEMENTARY_DELEGATE_FLOOR)}
+                    ) ÷ {SUPPLEMENTARY_DELEGATE_STEP} ={" "}
+                    {formatInt(city.college.supplementaryBrackets)} tranches complètes. Ces
+                    délégués-là{" "}
+                    <strong className="font-semibold text-foreground">ne sont pas des élus</strong>{" "}
+                    : n{"'"}importe quel électeur de la commune peut l{"'"}être.
+                  </p>
+                </div>
+                <p className="shrink-0 font-display text-xl font-extrabold tabular-nums">
+                  + {formatInt(city.college.supplementaryDelegates)}
+                </p>
+              </li>
+
+              <li className="flex gap-3 rounded-xl border border-primary/30 bg-primary/5 p-4">
+                <span
+                  aria-hidden="true"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary"
+                >
+                  <Check className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold">
+                    {city.name} envoie {formatInt(city.college.total)} grands électeurs
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Sur les {formatInt(GRANDS_ELECTEURS_TOTAL)} qui votent le 27 septembre. Le vote
+                    est obligatoire : un grand électeur qui s{"'"}abstient sans excuse encourt une
+                    amende.
+                  </p>
+                </div>
+                <p className="shrink-0 font-display text-xl font-extrabold tabular-nums">
+                  {formatInt(city.college.total)}
+                </p>
+              </li>
+            </ol>
+
+            <SourceLine
+              sources={[SOURCE_ELECTORAL_CODE, populationSource]}
+              consultedAt={fetchedAt}
+              note={
+                fetchedAt
+                  ? undefined
+                  : "Date d'import du référentiel communal non enregistrée : geo.api.gouv.fr ne publie pas de millésime de population"
+              }
+            />
+          </section>
+        )}
+
+        {/* ─── City against village ─── */}
+        <section aria-labelledby="comparaison-heading" className="space-y-4">
+          <div className="space-y-2">
+            <h2
+              id="comparaison-heading"
+              className="font-display text-xl font-bold tracking-tight md:text-2xl"
+            >
+              La même formule, appliquée à un village
+            </h2>
+            {city && village && (
+              <p className="max-w-2xl text-sm text-muted-foreground md:text-base">
+                {village.name} est dans le même département que {city.name}
+                {cityLocative ? "" : ""}, et vote pour les mêmes sièges.
+              </p>
+            )}
+          </div>
+
+          {city?.college && village?.college ? (
+            <>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {[city, village].map((commune) => {
+                  const ratio = inhabitantsPerDelegate(commune.college);
+                  return (
+                    <div key={commune.id} className="rounded-xl border border-border p-4">
+                      <p className="font-display text-lg font-extrabold tracking-tight">
+                        {commune.name}
+                      </p>
+                      <dl className="mt-2 space-y-1 text-sm">
+                        <div className="flex justify-between gap-3">
+                          <dt className="text-muted-foreground">Habitants</dt>
+                          <dd className="tabular-nums">{formatInt(commune.college!.population)}</dd>
+                        </div>
+                        <div className="flex justify-between gap-3">
+                          <dt className="text-muted-foreground">Conseillers municipaux</dt>
+                          <dd className="tabular-nums">
+                            {formatInt(commune.college!.councilSeats)}
+                          </dd>
+                        </div>
+                        <div className="flex justify-between gap-3">
+                          <dt className="text-muted-foreground">Grands électeurs</dt>
+                          <dd className="tabular-nums">{formatInt(commune.college!.total)}</dd>
+                        </div>
+                      </dl>
+                      {ratio !== null && (
+                        <p className="mt-3 rounded-lg bg-muted/50 p-3">
+                          <span className="font-display text-lg font-extrabold tabular-nums">
+                            1 pour {formatInt(Math.round(ratio))}
+                          </span>
+                          <span className="block text-xs text-muted-foreground-strong">
+                            habitants
+                          </span>
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <p className="rounded-xl border border-border bg-muted/40 p-4 text-sm leading-relaxed">
+                Cet écart est dans la loi, pas dans son application : le barème de l{"'"}article L.
+                284 attribue des délégués par paliers de taille de conseil, et le supplément de l
+                {"'"}article L. 285 ne compense qu{"'"}au-delà de{" "}
+                {formatInt(SUPPLEMENTARY_DELEGATE_FLOOR)} habitants. C{"'"}est ce qui vaut au Sénat
+                sa réputation de chambre des territoires ruraux.
+              </p>
+            </>
+          ) : (
+            <MissingData title="Comparaison indisponible">
+              Il manque la population ou l{"'"}effectif du conseil de l{"'"}une des deux communes.
+            </MissingData>
+          )}
+        </section>
+
+        {/* ─── The remaining 5 % ─── */}
+        <section aria-labelledby="autres-heading" className="space-y-4">
+          <h2
+            id="autres-heading"
+            className="font-display text-xl font-bold tracking-tight md:text-2xl"
+          >
+            Et les grands électeurs qui ne sont pas des délégués municipaux
+          </h2>
+          <p className="max-w-2xl text-sm text-muted-foreground md:text-base">
+            Les délégués des conseils municipaux forment 95,2 % du collège. Le reste siège de droit.
+          </p>
+          <dl className="grid gap-3 sm:grid-cols-2">
+            {[
+              ["Les députés", "Membres de droit du collège de leur département."],
+              ["Les sénateurs", "Y compris ceux dont le siège n'est pas renouvelé cette année."],
+              [
+                "Les conseillers régionaux",
+                "Au titre de la section départementale de leur liste d'élection.",
+              ],
+              ["Les conseillers départementaux", "L'ensemble du conseil départemental."],
+            ].map(([term, detail]) => (
+              <div key={term} className="rounded-xl border border-border p-4">
+                <dt className="font-semibold">{term}</dt>
+                <dd className="mt-1 text-sm leading-relaxed text-muted-foreground">{detail}</dd>
+              </div>
+            ))}
+          </dl>
+          <SourceLine
+            sources={[
+              { label: "Code électoral, art. L. 280 à L. 293", url: ELECTORAL_CODE_URL },
+              { label: "Sénat", url: "https://senatoriales2026.senat.fr/" },
+            ]}
+          />
+        </section>
+
+        <Link
+          href="/elections/senatoriales-2026"
+          className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Retour aux sénatoriales 2026
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/elections/senatoriales-2026/page.tsx
+++ b/src/app/elections/senatoriales-2026/page.tsx
@@ -1,0 +1,176 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Landmark } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { Card, CardContent } from "@/components/ui/card";
+import { SourceLine } from "@/components/ui/SourceLine";
+import { EventJsonLd } from "@/components/seo/JsonLd";
+import { formatDate } from "@/lib/utils";
+import { SITE_URL } from "@/config/site";
+import {
+  getGroupExposure,
+  getSenatorialesElection,
+  SENATORIALES_2026_SLUG,
+} from "@/lib/data/senatoriales";
+import { CommuneLookup } from "./_components/CommuneLookup";
+import { MunicipalBridge } from "./_components/MunicipalBridge";
+import { ScrutinRules } from "./_components/ScrutinRules";
+import { SeatsAtStake } from "./_components/SeatsAtStake";
+import { SenateMilestones } from "./_components/SenateMilestones";
+import {
+  CONSTITUENCY_COUNT,
+  HUB_LEDE,
+  HUB_LEDE_PAST,
+  HUB_TITLE,
+  HUB_TITLE_PAST,
+  SENATE_SEATS_AT_STAKE,
+  SENATE_SEATS_TOTAL,
+  SOURCE_DECREE,
+  SOURCE_SENAT,
+} from "./_content";
+
+/**
+ * ISR at five minutes, flat.
+ *
+ * A shorter window only matters around 27 September, but `revalidate` must be
+ * statically analysable, so a conditional value is not an option. Five minutes
+ * everywhere costs little on a page this stable and removes the need to remember an
+ * operation on the eve of the ballot: the phase change propagates on its own.
+ */
+export const revalidate = 300;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const election = await getSenatorialesElection();
+  if (!election) {
+    return { title: "Sénatoriales 2026", robots: { index: false, follow: true } };
+  }
+  return {
+    title: "Sénatoriales 2026 : le Sénat se joue dans les conseils municipaux | Poligraph",
+    description:
+      "Le 27 septembre 2026, 178 sièges du Sénat sont renouvelés par 93 469 grands électeurs. " +
+      "Vos délégués, le barème du collège et les sénateurs sortants de votre département.",
+    alternates: { canonical: `/elections/${SENATORIALES_2026_SLUG}` },
+  };
+}
+
+export default async function SenatorialesHubPage() {
+  const [election, groups] = await Promise.all([getSenatorialesElection(), getGroupExposure()]);
+  if (!election) notFound();
+
+  // Phase resolved at read time by the data layer: the stored column never
+  // transitions on its own, so a page trusting it would still say "à venir" on
+  // 28 September.
+  const isOver = election.status === "COMPLETED";
+  const now = new Date();
+  const daysUntil =
+    election.round1Date && !isOver
+      ? Math.ceil((election.round1Date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+      : null;
+
+  return (
+    <>
+      {election.round1Date && (
+        <EventJsonLd
+          name={election.title}
+          description={election.description || undefined}
+          startDate={election.round1Date.toISOString()}
+          location="France"
+          url={`${SITE_URL}/elections/${SENATORIALES_2026_SLUG}`}
+        />
+      )}
+
+      <main id="main-content" className="container mx-auto max-w-5xl px-4 pt-4 pb-12">
+        <Breadcrumb
+          items={[{ label: "Élections", href: "/elections" }, { label: "Sénatoriales 2026" }]}
+        />
+
+        <div className="space-y-10">
+          <header className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
+                Élections sénatoriales
+                {election.round1Date ? ` · ${formatDate(election.round1Date)}` : ""}
+              </p>
+              <h1 className="font-display text-2xl font-extrabold leading-tight tracking-tight md:text-4xl">
+                {isOver ? HUB_TITLE_PAST : HUB_TITLE}
+              </h1>
+              <p className="max-w-2xl text-sm text-muted-foreground md:text-lg">
+                {isOver ? HUB_LEDE_PAST : HUB_LEDE}
+              </p>
+            </div>
+
+            <Card>
+              <CardContent className="space-y-4">
+                <div className="flex items-center gap-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Landmark className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold leading-tight">
+                      Renouvellement de la série 2
+                    </p>
+                    <p className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      {daysUntil !== null && daysUntil > 0 && (
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 font-semibold text-primary">
+                          J-{daysUntil}
+                        </span>
+                      )}
+                      {election.round1Date && (
+                        <span>
+                          {isOver ? "Tenu le" : "Scrutin le"} {formatDate(election.round1Date)}
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                </div>
+
+                {/* "0 bulletin pour vous" is the thesis in figure form, so it sits with
+                    the other two rather than in the prose. */}
+                <dl className="grid grid-cols-3 gap-3 border-t border-border pt-4">
+                  <div>
+                    <dd className="font-display text-2xl font-extrabold tabular-nums text-primary">
+                      {SENATE_SEATS_AT_STAKE}
+                    </dd>
+                    <dt className="text-xs text-muted-foreground">
+                      sièges sur {SENATE_SEATS_TOTAL}
+                    </dt>
+                  </div>
+                  <div>
+                    <dd className="font-display text-2xl font-extrabold tabular-nums text-primary">
+                      {CONSTITUENCY_COUNT}
+                    </dd>
+                    <dt className="text-xs text-muted-foreground">circonscriptions</dt>
+                  </div>
+                  <div>
+                    <dd className="font-display text-2xl font-extrabold tabular-nums text-primary">
+                      0
+                    </dd>
+                    <dt className="text-xs text-muted-foreground">bulletin pour vous</dt>
+                  </div>
+                </dl>
+
+                <SourceLine
+                  sources={[SOURCE_DECREE, SOURCE_SENAT]}
+                  note="63 départements et collectivités, plus les Français établis hors de France"
+                  reportHref={null}
+                />
+              </CardContent>
+            </Card>
+          </header>
+
+          {/* The bridge is the first block of content, before the college, before the
+              seats: it is the answer to "why does this concern me". */}
+          <MunicipalBridge />
+
+          <CommuneLookup />
+
+          <SeatsAtStake groups={groups} />
+
+          <ScrutinRules />
+
+          <SenateMilestones />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/elections/senatoriales-2026/page.tsx
+++ b/src/app/elections/senatoriales-2026/page.tsx
@@ -27,6 +27,7 @@ import {
   SENATE_SEATS_TOTAL,
   SOURCE_DECREE,
   SOURCE_SENAT,
+  getBallotPhase,
 } from "./_content";
 
 /**
@@ -60,7 +61,8 @@ export default async function SenatorialesHubPage() {
   // Phase resolved at read time by the data layer: the stored column never
   // transitions on its own, so a page trusting it would still say "à venir" on
   // 28 September.
-  const isOver = election.status === "COMPLETED";
+  const phase = getBallotPhase(election.status);
+  const isOver = phase === "after";
   const now = new Date();
   const daysUntil =
     election.round1Date && !isOver
@@ -162,9 +164,9 @@ export default async function SenatorialesHubPage() {
               seats: it is the answer to "why does this concern me". */}
           <MunicipalBridge />
 
-          <CommuneLookup />
+          <CommuneLookup phase={phase} />
 
-          <SeatsAtStake groups={groups} />
+          <SeatsAtStake groups={groups} phase={phase} />
 
           <ScrutinRules />
 

--- a/src/components/ui/MissingData.stories.tsx
+++ b/src/components/ui/MissingData.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MissingData } from "./MissingData";
+
+const meta: Meta<typeof MissingData> = {
+  title: "UI/MissingData",
+  component: MissingData,
+};
+
+export default meta;
+type Story = StoryObj<typeof MissingData>;
+
+/**
+ * Cas « non publiée » : l'autorité n'a pas rendu la donnée publique. L'état vide la
+ * nomme, et le ton reste factuel : « aucune déclaration publiée », pas « n'a pas
+ * déclaré ».
+ */
+export const NotPublished: Story = {
+  args: {
+    title: "Aucune déclaration publiée",
+    children: "La HATVP n'a pas publié de déclaration de patrimoine pour ce mandat.",
+  },
+};
+
+/**
+ * Cas « inconnue » : la donnée existe mais nous ne l'avons pas. On dit ce qui manque,
+ * pourquoi, et où chercher.
+ */
+export const Unknown: Story = {
+  args: {
+    title: "Les candidatures ne sont pas publiées en open data",
+    children:
+      "Aucun jeu de données national ne recense les candidats au Sénat : les listes sont arrêtées par chaque préfecture. Nous les saisissons département par département.",
+  },
+};
+
+// Sans titre, quand le corps porte tout le message.
+export const BodyOnly: Story = {
+  args: {
+    children:
+      "Il manque la population municipale ou l'effectif du conseil pour appliquer le barème. Nous ne l'estimons pas.",
+  },
+};
+
+// Un symbole Unicode discret est admis. Jamais d'emoji, jamais d'illustration.
+export const WithGlyph: Story = {
+  args: {
+    glyph: "◦",
+    title: "Série de renouvellement inconnue",
+    children:
+      "Nous ne savons pas si les sièges de ce département sont remis en jeu cette année. La série est reprise de l'open data du Sénat.",
+  },
+};
+
+/**
+ * Le piège que ce composant existe pour éviter : à gauche une absence dite, à droite
+ * un zéro qui se lit comme un fait. « 0 délégué » est une information ; « inconnu »
+ * est une lacune, et les deux ne doivent jamais se rendre pareil.
+ */
+export const AgainstAFalseZero: Story = {
+  render: () => (
+    <div className="grid max-w-3xl gap-4 sm:grid-cols-2">
+      <MissingData title="Nombre de délégués inconnu">
+        Il manque la population municipale pour appliquer le barème.
+      </MissingData>
+      <div className="rounded-md border border-border p-4">
+        <p className="text-xs text-muted-foreground">grands électeurs</p>
+        <p className="font-display text-xl font-extrabold tabular-nums">0</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          À ne pas faire pour une valeur absente.
+        </p>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/MissingData.tsx
+++ b/src/components/ui/MissingData.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+/**
+ * MissingData: dire une absence sans la déguiser en information.
+ *
+ * Implements docs/design/patterns/MissingData.md. On a public-data platform an
+ * absence is itself information: it is stated, never filled in and never hidden to
+ * make a page look complete.
+ *
+ * Three rules this primitive enforces by construction:
+ *
+ * - It is not a `Skeleton`. A skeleton says "this is loading"; this says "this does
+ *   not exist yet, and here is why". Rendering one for the other misleads.
+ * - No `0`, no dash, no "N/A". Zero is a fact, unknown is a gap, and the two must not
+ *   look alike (invariant I8).
+ * - The tone is never evaluative. "Aucune déclaration publiée", not "n'a pas déclaré".
+ *
+ * The dashed border comes from `--muted-foreground` rather than `--border` because
+ * `--border` drops to `oklch(1 0 0 / 10%)` in dark mode, where a dashed rule at that
+ * opacity reads as a broken box rather than an empty one.
+ */
+
+interface MissingDataProps {
+  /** What is missing. Optional: omit when the body carries it. */
+  title?: ReactNode;
+  /**
+   * Why it is missing and, when possible, where to look instead. One message per
+   * absence: two sentences that contradict each other are worth less than nothing.
+   */
+  children: ReactNode;
+  /** Discreet leading glyph. Unicode only, never an emoji, never an illustration. */
+  glyph?: string;
+  className?: string;
+}
+
+export function MissingData({ title, children, glyph, className }: MissingDataProps) {
+  return (
+    <div
+      className={`rounded-md border border-dashed border-muted-foreground/30 px-4 py-3 ${className ?? ""}`.trim()}
+    >
+      {title && (
+        <p className="flex items-baseline gap-2 text-sm font-medium">
+          {glyph && (
+            <span aria-hidden="true" className="text-muted-foreground">
+              {glyph}
+            </span>
+          )}
+          <span>{title}</span>
+        </p>
+      )}
+      <div
+        className={`text-sm leading-relaxed text-muted-foreground ${title ? "mt-1" : ""}`.trim()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/SourceLine.stories.tsx
+++ b/src/components/ui/SourceLine.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SourceLine } from "./SourceLine";
+
+const meta: Meta<typeof SourceLine> = {
+  title: "UI/SourceLine",
+  component: SourceLine,
+};
+
+export default meta;
+type Story = StoryObj<typeof SourceLine>;
+
+export const OneSource: Story = {
+  args: {
+    sources: [{ label: "Sénat", url: "https://senatoriales2026.senat.fr/" }],
+    consultedAt: new Date("2026-08-10"),
+  },
+};
+
+export const SeveralSources: Story = {
+  args: {
+    sources: [
+      { label: "Décret n° 2026-301 du 21 avril 2026", url: "https://www.legifrance.gouv.fr/" },
+      { label: "Sénat", url: "https://senatoriales2026.senat.fr/" },
+      { label: "Code électoral, art. L. 280 à L. 293", url: "https://www.legifrance.gouv.fr/" },
+    ],
+    note: "Répartition du collège publiée par le Sénat",
+    consultedAt: new Date("2026-08-10"),
+  },
+};
+
+// A source with no stable public URL renders as text, not as a dead link.
+export const WithoutLink: Story = {
+  args: {
+    sources: [{ label: "Arrêté préfectoral" }, { label: "Sénat", url: "https://www.senat.fr/" }],
+    consultedAt: new Date("2026-08-10"),
+  },
+};
+
+/**
+ * No consultation date available. The mention disappears entirely rather than
+ * rendering an empty value: `formatDate(null)` would print a dash, and "Vérifié"
+ * without a date is an unverifiable claim on a verification platform.
+ */
+export const Undated: Story = {
+  args: {
+    sources: [
+      {
+        label: "Population municipale (INSEE), via geo.api.gouv.fr",
+        url: "https://geo.api.gouv.fr/decoupage-administratif/communes",
+      },
+    ],
+    note: "Date d'import du référentiel communal non enregistrée",
+    consultedAt: null,
+  },
+};
+
+// Inside a block, at the size and colour it ships at.
+export const InContext: Story = {
+  render: () => (
+    <div className="max-w-2xl space-y-3 rounded-xl border border-border p-4">
+      <p className="font-semibold">178 sièges sur 348 sont renouvelés</p>
+      <p className="text-sm text-muted-foreground">
+        Dans 64 circonscriptions : 63 départements et collectivités, plus les Français établis hors
+        de France.
+      </p>
+      <SourceLine
+        sources={[
+          { label: "Décret n° 2026-301 du 21 avril 2026", url: "https://www.legifrance.gouv.fr/" },
+          { label: "Sénat", url: "https://senatoriales2026.senat.fr/" },
+        ]}
+        consultedAt={new Date("2026-08-10")}
+      />
+    </div>
+  ),
+};

--- a/src/components/ui/SourceLine.tsx
+++ b/src/components/ui/SourceLine.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import { formatDate } from "@/lib/utils";
+
+/**
+ * SourceLine: attribution de source, sous le bloc qu'elle justifie.
+ *
+ * Implements docs/design/patterns/SourceAttribution.md. A factual claim without a
+ * source is a content bug (invariant I6), so this is the primitive that makes the
+ * claim checkable: which body the figure comes from, when we consulted it, and a way
+ * to report an error.
+ *
+ * Two deliberate choices from the pattern doc. The consultation date stays discreet
+ * but the body name does not fade to `--muted-foreground` in dark mode, otherwise the
+ * only part that carries accountability becomes the least legible. And the line is
+ * always visible: never behind a hover, never inside a collapsed "Sources (3)".
+ */
+
+export interface SourceRef {
+  /** Name the body, not the pipeline: "Sénat", not "import senat v2". */
+  label: string;
+  /** Outbound link. Omitted when the source has no stable public URL. */
+  url?: string;
+}
+
+interface SourceLineProps {
+  sources: SourceRef[];
+  /** When we read the source. Rendered as "Consulté le ...". */
+  consultedAt?: Date | string | null;
+  /** Short methodological note, when the figure needs one to be read correctly. */
+  note?: ReactNode;
+  /** Where to report an error. Defaults to the contact page. */
+  reportHref?: string | null;
+  className?: string;
+}
+
+function SourceItem({ source }: { source: SourceRef }) {
+  if (!source.url) {
+    return <span>{source.label}</span>;
+  }
+  const isExternal = /^https?:\/\//.test(source.url);
+  if (!isExternal) {
+    return (
+      <a href={source.url} className="underline hover:text-primary">
+        {source.label}
+      </a>
+    );
+  }
+  return (
+    <a
+      href={source.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline hover:text-primary"
+      aria-label={`${source.label} (nouvel onglet)`}
+    >
+      {source.label}
+    </a>
+  );
+}
+
+export function SourceLine({
+  sources,
+  consultedAt,
+  note,
+  reportHref = "/contact",
+  className,
+}: SourceLineProps) {
+  const named = sources.filter((s) => s.label.trim().length > 0);
+
+  return (
+    <p className={`text-xs leading-relaxed text-muted-foreground ${className ?? ""}`.trim()}>
+      {named.length > 0 && (
+        <>
+          <span className="font-medium text-muted-foreground-strong">
+            {named.length > 1 ? "Sources" : "Source"} :{" "}
+          </span>
+          {named.map((source, index) => (
+            <span key={`${source.label}-${index}`}>
+              {index > 0 && <span aria-hidden="true"> · </span>}
+              <SourceItem source={source} />
+            </span>
+          ))}
+        </>
+      )}
+      {note && (
+        <>
+          {named.length > 0 && <span aria-hidden="true"> · </span>}
+          <span>{note}</span>
+        </>
+      )}
+      {consultedAt && (
+        <>
+          <span aria-hidden="true"> · </span>
+          <span>Consulté le {formatDate(consultedAt)}</span>
+        </>
+      )}
+      {reportHref && (
+        <>
+          <span aria-hidden="true"> · </span>
+          <a href={reportHref} className="underline hover:text-primary">
+            Signaler une erreur
+          </a>
+        </>
+      )}
+    </p>
+  );
+}

--- a/src/components/ui/__tests__/MissingData.test.tsx
+++ b/src/components/ui/__tests__/MissingData.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MissingData } from "../MissingData";
+
+describe("MissingData", () => {
+  it("énonce l'absence et sa raison", () => {
+    render(
+      <MissingData title="Aucune déclaration publiée">
+        La HATVP n{"'"}a pas publié de déclaration pour ce mandat.
+      </MissingData>
+    );
+    expect(screen.getByText("Aucune déclaration publiée")).toBeInTheDocument();
+    expect(screen.getByText(/La HATVP/)).toBeInTheDocument();
+  });
+
+  it("fonctionne sans titre, quand le corps porte le message", () => {
+    render(<MissingData>Les candidatures ne sont pas publiées en open data.</MissingData>);
+    expect(screen.getByText(/open data/)).toBeInTheDocument();
+  });
+
+  // Le squelette dit « ça arrive », pas « ça n'existe pas » : il ne doit pas servir ici.
+  it("n'est pas un squelette de chargement", () => {
+    const { container } = render(<MissingData>Donnée inconnue.</MissingData>);
+    expect(container.querySelector("[class*='animate-pulse']")).toBeNull();
+  });
+
+  it("borde en pointillé depuis un jeton, sans couleur codée en dur", () => {
+    const { container } = render(<MissingData>Donnée inconnue.</MissingData>);
+    const box = container.firstElementChild!;
+    expect(box.className).toContain("border-dashed");
+    expect(box.className).toContain("border-muted-foreground/30");
+  });
+
+  it("masque le glyphe aux lecteurs d'écran", () => {
+    render(
+      <MissingData title="Collecte en cours" glyph="◦">
+        Rien à afficher pour le moment.
+      </MissingData>
+    );
+    const glyph = screen.getByText("◦");
+    expect(glyph).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("n'introduit ni tiret ni zéro de remplissage", () => {
+    const { container } = render(<MissingData>Nombre de délégués inconnu.</MissingData>);
+    expect(container.textContent).not.toMatch(/—|N\/A/);
+  });
+});

--- a/src/components/ui/__tests__/SourceLine.test.tsx
+++ b/src/components/ui/__tests__/SourceLine.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SourceLine } from "../SourceLine";
+
+describe("SourceLine", () => {
+  it("accorde le libellé au nombre de sources", () => {
+    const { unmount } = render(<SourceLine sources={[{ label: "Sénat" }]} />);
+    expect(screen.getByText(/^Source :/)).toBeInTheDocument();
+    unmount();
+
+    render(<SourceLine sources={[{ label: "Sénat" }, { label: "HATVP" }]} />);
+    expect(screen.getByText(/^Sources :/)).toBeInTheDocument();
+  });
+
+  it("ouvre un lien externe dans un nouvel onglet, en le disant", () => {
+    render(<SourceLine sources={[{ label: "Sénat", url: "https://www.senat.fr/" }]} />);
+    const link = screen.getByRole("link", { name: /Sénat/ });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+    expect(link.getAttribute("aria-label")).toMatch(/nouvel onglet/);
+  });
+
+  it("laisse un lien interne en navigation normale", () => {
+    render(<SourceLine sources={[{ label: "Méthodologie", url: "/methodologie" }]} />);
+    const link = screen.getByRole("link", { name: "Méthodologie" });
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("rend une source sans URL en texte, pas en lien mort", () => {
+    render(<SourceLine sources={[{ label: "Arrêté préfectoral" }]} reportHref={null} />);
+    expect(screen.getByText("Arrêté préfectoral")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("date la consultation en français", () => {
+    render(<SourceLine sources={[{ label: "Sénat" }]} consultedAt={new Date("2026-08-10")} />);
+    expect(screen.getByText(/Consulté le 10 août 2026/)).toBeInTheDocument();
+  });
+
+  // formatDate(null) renvoie un tiret cadratin, banni de l'interface : sans date de
+  // consultation la mention doit disparaître, pas s'afficher vide.
+  it("n'affiche aucune mention de consultation sans date", () => {
+    render(<SourceLine sources={[{ label: "Sénat" }]} consultedAt={null} />);
+    expect(screen.queryByText(/Consulté le/)).toBeNull();
+    expect(screen.queryByText(/—/)).toBeNull();
+  });
+
+  it("propose toujours de signaler une erreur, sauf demande explicite", () => {
+    const { unmount } = render(<SourceLine sources={[{ label: "Sénat" }]} />);
+    expect(screen.getByRole("link", { name: "Signaler une erreur" })).toBeInTheDocument();
+    unmount();
+
+    render(<SourceLine sources={[{ label: "Sénat" }]} reportHref={null} />);
+    expect(screen.queryByRole("link", { name: "Signaler une erreur" })).toBeNull();
+  });
+
+  it("ignore une source au libellé vide plutôt que d'afficher un séparateur orphelin", () => {
+    render(<SourceLine sources={[{ label: "  " }, { label: "Sénat" }]} reportHref={null} />);
+    expect(screen.getByText(/^Source :/)).toBeInTheDocument();
+  });
+
+  it("porte la note méthodologique quand elle est fournie", () => {
+    render(
+      <SourceLine
+        sources={[{ label: "Ministère de l'Intérieur" }]}
+        note="Nuances regroupées en blocs"
+      />
+    );
+    expect(screen.getByText("Nuances regroupées en blocs")).toBeInTheDocument();
+  });
+});

--- a/src/config/__tests__/department-prepositions.test.ts
+++ b/src/config/__tests__/department-prepositions.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { DEPARTMENT_LOCATIVE, getDepartmentLocative } from "../department-prepositions";
+import { DEPARTMENTS } from "../departments";
+
+describe("DEPARTMENT_LOCATIVE", () => {
+  it("couvre exactement les départements de DEPARTMENTS", () => {
+    expect(Object.keys(DEPARTMENT_LOCATIVE).sort()).toEqual(Object.keys(DEPARTMENTS).sort());
+  });
+
+  it("contient le nom du département dans sa forme locative", () => {
+    for (const [code, { name }] of Object.entries(DEPARTMENTS)) {
+      expect(DEPARTMENT_LOCATIVE[code], `${code} (${name})`).toContain(name);
+    }
+  });
+
+  it("commence toujours par une préposition connue", () => {
+    for (const [code, locative] of Object.entries(DEPARTMENT_LOCATIVE)) {
+      expect(locative, code).toMatch(/^(en |à |dans le |dans la |dans les |dans l')/);
+    }
+  });
+
+  // Les quatre pièges que « en » + libellé produirait : « en Nord », « en Paris »,
+  // « en Yvelines », « en Ain ».
+  it("emploie la bonne préposition sur les cas qui cassent une règle naïve", () => {
+    expect(DEPARTMENT_LOCATIVE["75"]).toBe("à Paris");
+    expect(DEPARTMENT_LOCATIVE["59"]).toBe("dans le Nord");
+    expect(DEPARTMENT_LOCATIVE["78"]).toBe("dans les Yvelines");
+    expect(DEPARTMENT_LOCATIVE["01"]).toBe("dans l'Ain");
+    expect(DEPARTMENT_LOCATIVE["33"]).toBe("en Gironde");
+    expect(DEPARTMENT_LOCATIVE["974"]).toBe("à La Réunion");
+  });
+
+  it("élide devant une voyelle", () => {
+    for (const code of [
+      "01",
+      "02",
+      "03",
+      "10",
+      "11",
+      "12",
+      "27",
+      "34",
+      "36",
+      "60",
+      "61",
+      "89",
+      "91",
+    ]) {
+      expect(DEPARTMENT_LOCATIVE[code], code).toMatch(/^dans l'/);
+    }
+  });
+});
+
+describe("getDepartmentLocative", () => {
+  it("renvoie la forme locative d'un code connu", () => {
+    expect(getDepartmentLocative("33")).toBe("en Gironde");
+  });
+
+  // Un repli « en » + libellé produirait « en Nord » : mieux vaut rendre la main
+  // à l'appelant pour qu'il reformule la phrase entière.
+  it("renvoie null sur un code inconnu plutôt qu'une forme fabriquée", () => {
+    expect(getDepartmentLocative("999")).toBeNull();
+    expect(getDepartmentLocative(null)).toBeNull();
+    expect(getDepartmentLocative(undefined)).toBeNull();
+    expect(getDepartmentLocative("")).toBeNull();
+  });
+});

--- a/src/config/department-prepositions.ts
+++ b/src/config/department-prepositions.ts
@@ -1,0 +1,133 @@
+/**
+ * Locative form of every department and collectivity, by INSEE code.
+ *
+ * French has no rule that derives this from the name: it depends on gender, number
+ * and initial sound. "en Gironde" but "dans le Nord", "dans les Yvelines", "dans
+ * l'Ain", "à Paris". Concatenating a fixed "en " in front of a label produces "en
+ * Nord" and "en Paris", which is the kind of mistake a reader notices immediately and
+ * an author never sees, because the sentence is assembled from a variable.
+ *
+ * So the locative is stored, not computed. Keys mirror `DEPARTMENTS` in
+ * `./departments.ts`; a guard test keeps the two in step.
+ */
+
+export const DEPARTMENT_LOCATIVE: Record<string, string> = {
+  "01": "dans l'Ain",
+  "02": "dans l'Aisne",
+  "03": "dans l'Allier",
+  "04": "dans les Alpes-de-Haute-Provence",
+  "05": "dans les Hautes-Alpes",
+  "06": "dans les Alpes-Maritimes",
+  "07": "en Ardèche",
+  "08": "dans les Ardennes",
+  "09": "en Ariège",
+  "10": "dans l'Aube",
+  "11": "dans l'Aude",
+  "12": "dans l'Aveyron",
+  "13": "dans les Bouches-du-Rhône",
+  "14": "dans le Calvados",
+  "15": "dans le Cantal",
+  "16": "en Charente",
+  "17": "en Charente-Maritime",
+  "18": "dans le Cher",
+  "19": "en Corrèze",
+  "2A": "en Corse-du-Sud",
+  "2B": "en Haute-Corse",
+  "21": "en Côte-d'Or",
+  "22": "dans les Côtes-d'Armor",
+  "23": "en Creuse",
+  "24": "en Dordogne",
+  "25": "dans le Doubs",
+  "26": "dans la Drôme",
+  "27": "dans l'Eure",
+  "28": "en Eure-et-Loir",
+  "29": "dans le Finistère",
+  "30": "dans le Gard",
+  "31": "en Haute-Garonne",
+  "32": "dans le Gers",
+  "33": "en Gironde",
+  "34": "dans l'Hérault",
+  "35": "en Ille-et-Vilaine",
+  "36": "dans l'Indre",
+  "37": "en Indre-et-Loire",
+  "38": "en Isère",
+  "39": "dans le Jura",
+  "40": "dans les Landes",
+  "41": "en Loir-et-Cher",
+  "42": "dans la Loire",
+  "43": "en Haute-Loire",
+  "44": "en Loire-Atlantique",
+  "45": "dans le Loiret",
+  "46": "dans le Lot",
+  "47": "en Lot-et-Garonne",
+  "48": "en Lozère",
+  "49": "en Maine-et-Loire",
+  "50": "dans la Manche",
+  "51": "dans la Marne",
+  "52": "en Haute-Marne",
+  "53": "en Mayenne",
+  "54": "en Meurthe-et-Moselle",
+  "55": "dans la Meuse",
+  "56": "dans le Morbihan",
+  "57": "en Moselle",
+  "58": "dans la Nièvre",
+  "59": "dans le Nord",
+  "60": "dans l'Oise",
+  "61": "dans l'Orne",
+  "62": "dans le Pas-de-Calais",
+  "63": "dans le Puy-de-Dôme",
+  "64": "dans les Pyrénées-Atlantiques",
+  "65": "dans les Hautes-Pyrénées",
+  "66": "dans les Pyrénées-Orientales",
+  "67": "dans le Bas-Rhin",
+  "68": "dans le Haut-Rhin",
+  "69": "dans le Rhône",
+  "70": "en Haute-Saône",
+  "71": "en Saône-et-Loire",
+  "72": "dans la Sarthe",
+  "73": "en Savoie",
+  "74": "en Haute-Savoie",
+  "75": "à Paris",
+  "76": "en Seine-Maritime",
+  "77": "en Seine-et-Marne",
+  "78": "dans les Yvelines",
+  "79": "dans les Deux-Sèvres",
+  "80": "dans la Somme",
+  "81": "dans le Tarn",
+  "82": "en Tarn-et-Garonne",
+  "83": "dans le Var",
+  "84": "dans le Vaucluse",
+  "85": "en Vendée",
+  "86": "dans la Vienne",
+  "87": "en Haute-Vienne",
+  "88": "dans les Vosges",
+  "89": "dans l'Yonne",
+  "90": "dans le Territoire de Belfort",
+  "91": "dans l'Essonne",
+  "92": "dans les Hauts-de-Seine",
+  "93": "en Seine-Saint-Denis",
+  "94": "dans le Val-de-Marne",
+  "95": "dans le Val-d'Oise",
+  "971": "en Guadeloupe",
+  "972": "en Martinique",
+  "973": "en Guyane",
+  "974": "à La Réunion",
+  "975": "à Saint-Pierre-et-Miquelon",
+  "976": "à Mayotte",
+  "977": "à Saint-Barthélemy",
+  "978": "à Saint-Martin",
+  "986": "à Wallis-et-Futuna",
+  "987": "en Polynésie française",
+  "988": "en Nouvelle-Calédonie",
+};
+
+/**
+ * Locative form for a department code, or null when we have none.
+ *
+ * Returning null lets the caller rephrase the whole sentence rather than emit a
+ * grammatically broken one. Never fall back to `"en " + name`.
+ */
+export function getDepartmentLocative(departmentCode: string | null | undefined): string | null {
+  if (!departmentCode) return null;
+  return DEPARTMENT_LOCATIVE[departmentCode] ?? null;
+}

--- a/src/config/senatoriales.ts
+++ b/src/config/senatoriales.ts
@@ -79,3 +79,36 @@ export const PLM_COUNCIL_SEATS: Record<string, number> = {
 export function getCouncilSeats(communeId: string, totalSeats: number | null): number | null {
   return PLM_COUNCIL_SEATS[communeId] ?? totalSeats;
 }
+
+/**
+ * Article L. 284: below 9,000 inhabitants the council elects delegates from among
+ * its members, on a scale keyed on the council size, not on the population.
+ *
+ * Text in force since 23 March 2014: one delegate for councils of seven and eleven
+ * members, three for fifteen, five for nineteen, seven for twenty-three, fifteen for
+ * twenty-seven and twenty-nine. The sizes match the L. 2121-2 CGCT scale that
+ * `scripts/seed-communes.ts` applies, so every commune under 9,000 lands on one of
+ * these keys.
+ *
+ * @see https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027433875
+ */
+export const SENATE_DELEGATE_SCALE: Record<number, number> = {
+  7: 1,
+  11: 1,
+  15: 3,
+  19: 5,
+  23: 7,
+  27: 15,
+  29: 15,
+};
+
+/**
+ * Article L. 285 thresholds: at or above this population every councillor is a
+ * delegate by right, and above `SUPPLEMENTARY_DELEGATE_FLOOR` the council elects one
+ * extra delegate per complete `SUPPLEMENTARY_DELEGATE_STEP` inhabitants beyond it.
+ *
+ * @see https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027804508
+ */
+export const DELEGATES_BY_RIGHT_THRESHOLD = 9000;
+export const SUPPLEMENTARY_DELEGATE_FLOOR = 30000;
+export const SUPPLEMENTARY_DELEGATE_STEP = 800;

--- a/src/lib/data/senatoriales.ts
+++ b/src/lib/data/senatoriales.ts
@@ -1,0 +1,332 @@
+/**
+ * Data access for the Sénatoriales 2026 section.
+ *
+ * Two constraints shape everything here.
+ *
+ * The reader does not vote at this ballot, so the useful unit is not "your
+ * candidate" but "your commune's weight in the college". Queries are therefore keyed
+ * on communes and departments, not on candidacies (of which there are none: senate
+ * candidacies have no national open data).
+ *
+ * And two fields are deliberately not exposed even though they exist in the database:
+ * senatorial start dates (see issue #698) and senator vote participation (323 of 339
+ * sit at exactly 100 %, because the Senate scrutin import records no absences). Both
+ * would render a data defect as a public claim.
+ */
+
+import { cache } from "react";
+import { db } from "@/lib/db";
+import { Prisma } from "@/generated/prisma";
+import { resolveElectionStatus } from "@/lib/elections/status";
+import { getMisEnCauseWhere } from "@/lib/affairs/public-filters";
+import { COMMUNE_DATA_SYNC_KEY } from "@/config/communes";
+import { computeCommuneCollege, type CommuneCollege } from "@/lib/senatoriales/college";
+import type { ElectionStatus } from "@/types";
+
+export const SENATORIALES_2026_SLUG = "senatoriales-2026";
+
+/** Series renewed on 27 September 2026. */
+const RENEWED_SERIES = 2;
+
+// ─── Election ───────────────────────────────────────────────────────
+
+export interface SenatorialesElection {
+  id: string;
+  title: string;
+  shortTitle: string | null;
+  description: string | null;
+  round1Date: Date | null;
+  dateConfirmed: boolean;
+  candidacyOpenDate: Date | null;
+  candidacyDeadline: Date | null;
+  totalSeats: number | null;
+  decreeUrl: string | null;
+  sourceUrl: string | null;
+  /** Phase derived at read time: the stored column never transitions on its own. */
+  status: ElectionStatus;
+}
+
+export const getSenatorialesElection = cache(
+  async function getSenatorialesElection(): Promise<SenatorialesElection | null> {
+    const election = await db.election.findUnique({
+      where: { slug: SENATORIALES_2026_SLUG },
+      select: {
+        id: true,
+        title: true,
+        shortTitle: true,
+        description: true,
+        round1Date: true,
+        round2Date: true,
+        dateConfirmed: true,
+        candidacyOpenDate: true,
+        candidacyDeadline: true,
+        totalSeats: true,
+        decreeUrl: true,
+        sourceUrl: true,
+        status: true,
+      },
+    });
+    if (!election) return null;
+
+    const { round2Date, ...rest } = election;
+    return { ...rest, status: resolveElectionStatus({ ...election, round2Date }) };
+  }
+);
+
+// ─── Seats at stake, per parliamentary group ────────────────────────
+
+export interface GroupExposure {
+  groupName: string;
+  shortName: string | null;
+  color: string | null;
+  /** Seats the group holds today, across both series. */
+  held: number;
+  /** Of those, the ones renewed on 27 September. */
+  atStake: number;
+}
+
+/**
+ * How exposed each group is to this renewal.
+ *
+ * Computed from `Mandate.senateSeries` rather than quoted from a press tally, which
+ * makes the Senate the only source needed. The three figures the design cited
+ * (107/190 for the outgoing majority, 77/131 for Les Républicains, 4/18 for the
+ * communists) fall out of this query exactly.
+ */
+export const getGroupExposure = cache(async function getGroupExposure(): Promise<GroupExposure[]> {
+  const rows = await db.$queryRaw<
+    Array<{
+      groupName: string;
+      shortName: string | null;
+      color: string | null;
+      held: number;
+      atStake: number;
+    }>
+  >(Prisma.sql`
+    SELECT g.name AS "groupName",
+           g."shortName",
+           g.color,
+           COUNT(*)::int AS held,
+           COUNT(*) FILTER (WHERE m."senateSeries" = ${RENEWED_SERIES})::int AS "atStake"
+    FROM "Mandate" m
+    JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+    JOIN "ParliamentaryGroup" g ON g.id = mp."parliamentaryGroupId"
+    WHERE m.type = 'SENATEUR'
+      AND m."isCurrent" = true
+      AND m."senateSeries" IS NOT NULL
+    GROUP BY 1, 2, 3
+    ORDER BY held DESC
+  `);
+  return rows;
+});
+
+// ─── Department series ──────────────────────────────────────────────
+
+export type DepartmentRenewal = "renewed" | "not-renewed" | "unknown";
+
+/**
+ * Whether a department's seats are up on 27 September.
+ *
+ * A department belongs entirely to one series, so the series of its sitting senators
+ * settles it. When a department carries both values, the data is inconsistent and we
+ * return "unknown" rather than picking a side: the page then says it does not know.
+ */
+export const getDepartmentRenewal = cache(async function getDepartmentRenewal(
+  departmentCode: string
+): Promise<DepartmentRenewal> {
+  const rows = await db.mandate.findMany({
+    where: {
+      type: "SENATEUR",
+      isCurrent: true,
+      departmentCode,
+      senateSeries: { not: null },
+    },
+    select: { senateSeries: true },
+    distinct: ["senateSeries"],
+  });
+  if (rows.length !== 1) return "unknown";
+  return rows[0]!.senateSeries === RENEWED_SERIES ? "renewed" : "not-renewed";
+});
+
+// ─── Sitting senators of a department ───────────────────────────────
+
+export interface SittingSenator {
+  slug: string;
+  fullName: string;
+  civility: string | null;
+  photoUrl: string | null;
+  constituency: string | null;
+  /** 1 or 2, null when the sync has not filled it. */
+  series: number | null;
+  groupName: string | null;
+  groupShortName: string | null;
+  groupColor: string | null;
+  /** Latest published HATVP declaration year, null when none is published. */
+  declarationYear: number | null;
+  /**
+   * Ongoing published proceedings where the person is mis en cause. A discreet signal
+   * on the card, never a filter, never a sort key, never an aggregate.
+   */
+  ongoingProceedings: number;
+}
+
+export const getSittingSenators = cache(async function getSittingSenators(
+  departmentCode: string
+): Promise<SittingSenator[]> {
+  const mandates = await db.mandate.findMany({
+    where: { type: "SENATEUR", isCurrent: true, departmentCode },
+    select: {
+      constituency: true,
+      senateSeries: true,
+      politician: {
+        select: {
+          id: true,
+          slug: true,
+          fullName: true,
+          civility: true,
+          photoUrl: true,
+          declarations: {
+            select: { year: true },
+            orderBy: { year: "desc" },
+            take: 1,
+          },
+        },
+      },
+      parliamentaryData: {
+        select: {
+          parliamentaryGroup: { select: { name: true, shortName: true, color: true } },
+        },
+      },
+    },
+    orderBy: { politician: { lastName: "asc" } },
+  });
+
+  if (mandates.length === 0) return [];
+
+  // One grouped count instead of one query per senator. The where-builder is the
+  // centralised one: no hand-rolled publicationStatus filter on a public surface.
+  const politicianIds = mandates.map((m) => m.politician.id);
+  const proceedings = await db.affair.groupBy({
+    by: ["politicianId"],
+    where: { politicianId: { in: politicianIds }, ...getMisEnCauseWhere() },
+    _count: { _all: true },
+  });
+  const byPolitician = new Map(proceedings.map((p) => [p.politicianId, p._count._all]));
+
+  return mandates.map((m) => ({
+    slug: m.politician.slug,
+    fullName: m.politician.fullName,
+    civility: m.politician.civility,
+    photoUrl: m.politician.photoUrl,
+    constituency: m.constituency,
+    series: m.senateSeries,
+    groupName: m.parliamentaryData?.parliamentaryGroup.name ?? null,
+    groupShortName: m.parliamentaryData?.parliamentaryGroup.shortName ?? null,
+    groupColor: m.parliamentaryData?.parliamentaryGroup.color ?? null,
+    declarationYear: m.politician.declarations[0]?.year ?? null,
+    ongoingProceedings: byPolitician.get(m.politician.id) ?? 0,
+  }));
+});
+
+// ─── Commune lookup ────────────────────────────────────────────────
+
+export interface CommuneCollegeView {
+  id: string;
+  name: string;
+  departmentCode: string;
+  departmentName: string;
+  college: CommuneCollege | null;
+  renewal: DepartmentRenewal;
+  /** Seats up in this department on 27 September, null when not renewed or unknown. */
+  seatsAtStake: number | null;
+}
+
+/**
+ * Communes matching an exact 5-digit postal code.
+ *
+ * A postal code is not a commune identifier: 4,204 of them cover several communes,
+ * one of them covers 46. The caller must disambiguate, so this returns every match
+ * rather than silently keeping the largest.
+ *
+ * Arrondissements need no special handling: `Commune.postalCodes` carries all 21
+ * Parisian codes on the single 75056 row, so `75011` resolves to Paris. An
+ * arrondissement designates no senatorial delegate, the Conseil de Paris does.
+ */
+export async function findCommunesByPostalCode(
+  postalCode: string
+): Promise<Array<{ id: string; name: string; departmentCode: string; departmentName: string }>> {
+  if (!/^[0-9]{5}$/.test(postalCode)) return [];
+  return db.commune.findMany({
+    where: { postalCodes: { has: postalCode } },
+    select: { id: true, name: true, departmentCode: true, departmentName: true },
+    orderBy: [{ population: "desc" }, { name: "asc" }],
+    take: 50,
+  });
+}
+
+/** Seats up for renewal in a department, counted from the sitting senators. */
+async function countSeatsAtStake(departmentCode: string): Promise<number> {
+  return db.mandate.count({
+    where: {
+      type: "SENATEUR",
+      isCurrent: true,
+      departmentCode,
+      senateSeries: RENEWED_SERIES,
+    },
+  });
+}
+
+export const getCommuneCollege = cache(async function getCommuneCollege(
+  communeId: string
+): Promise<CommuneCollegeView | null> {
+  const commune = await db.commune.findUnique({
+    where: { id: communeId },
+    select: {
+      id: true,
+      name: true,
+      departmentCode: true,
+      departmentName: true,
+      population: true,
+      totalSeats: true,
+    },
+  });
+  if (!commune) return null;
+
+  const [renewal, seats] = await Promise.all([
+    getDepartmentRenewal(commune.departmentCode),
+    countSeatsAtStake(commune.departmentCode),
+  ]);
+
+  return {
+    id: commune.id,
+    name: commune.name,
+    departmentCode: commune.departmentCode,
+    departmentName: commune.departmentName,
+    college: computeCommuneCollege({
+      communeId: commune.id,
+      population: commune.population,
+      totalSeats: commune.totalSeats,
+    }),
+    renewal,
+    seatsAtStake: renewal === "renewed" ? seats : null,
+  };
+});
+
+// ─── Provenance ────────────────────────────────────────────────────
+
+/**
+ * When we last read the commune reference from geo.api.gouv.fr.
+ *
+ * The API publishes no population vintage, so surfaces date the import instead of
+ * claiming a year. Null when the seed has not recorded a run yet, in which case the
+ * page says the provenance is undated rather than inventing one.
+ */
+export const getCommuneDataFetchedAt = cache(
+  async function getCommuneDataFetchedAt(): Promise<Date | null> {
+    const row = await db.syncMetadata.findUnique({
+      where: { sourceKey: COMMUNE_DATA_SYNC_KEY },
+      select: { lastSyncAt: true },
+    });
+    return row?.lastSyncAt ?? null;
+  }
+);

--- a/src/lib/senatoriales/__tests__/college.test.ts
+++ b/src/lib/senatoriales/__tests__/college.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { computeCommuneCollege, inhabitantsPerDelegate } from "../college";
+
+// Real production rows, so the arithmetic stays anchored to what the page will read.
+const BORDEAUX = { communeId: "33063", population: 267991, totalSeats: 65 };
+const BAZAS = { communeId: "33036", population: 4854, totalSeats: 27 };
+const PARIS = { communeId: "75056", population: 2103778, totalSeats: 69 };
+const LYON = { communeId: "69123", population: 519127, totalSeats: 69 };
+const MARSEILLE = { communeId: "13055", population: 886040, totalSeats: 69 };
+
+describe("computeCommuneCollege : régime de l'article L. 285", () => {
+  it("Bordeaux : 65 délégués de droit plus 297 tranches de 800 au-delà de 30 000", () => {
+    const college = computeCommuneCollege(BORDEAUX);
+    expect(college).not.toBeNull();
+    expect(college!.regime).toBe("by-right");
+    expect(college!.delegatesByRight).toBe(65);
+    // (267 991 − 30 000) / 800 = 297,49 donc 297 tranches complètes
+    expect(college!.supplementaryBrackets).toBe(297);
+    expect(college!.total).toBe(362);
+    expect(college!.scaleDelegates).toBeNull();
+  });
+
+  it("ne compte aucun délégué supplémentaire entre 9 000 et 30 000 habitants", () => {
+    const college = computeCommuneCollege({
+      communeId: "00001",
+      population: 25000,
+      totalSeats: 33,
+    });
+    expect(college!.regime).toBe("by-right");
+    expect(college!.delegatesByRight).toBe(33);
+    expect(college!.supplementaryDelegates).toBe(0);
+    expect(college!.total).toBe(33);
+  });
+
+  it("bascule sous le régime des délégués de droit dès 9 000 habitants pile", () => {
+    const college = computeCommuneCollege({ communeId: "00002", population: 9000, totalSeats: 29 });
+    expect(college!.regime).toBe("by-right");
+    expect(college!.total).toBe(29);
+  });
+
+  it("ne compte que les tranches complètes, jamais la tranche entamée", () => {
+    // 30 799 : une tranche entamée mais incomplète
+    expect(
+      computeCommuneCollege({ communeId: "x", population: 30799, totalSeats: 35 })!.total
+    ).toBe(35);
+    // 30 800 : première tranche complète
+    expect(
+      computeCommuneCollege({ communeId: "x", population: 30800, totalSeats: 35 })!.total
+    ).toBe(36);
+  });
+});
+
+describe("computeCommuneCollege : barème de l'article L. 284", () => {
+  it("Bazas : un conseil de 27 membres désigne 15 délégués", () => {
+    const college = computeCommuneCollege(BAZAS);
+    expect(college!.regime).toBe("scale");
+    expect(college!.scaleDelegates).toBe(15);
+    expect(college!.total).toBe(15);
+    expect(college!.delegatesByRight).toBeNull();
+  });
+
+  it("applique le barème sur la taille du conseil, pas sur la population", () => {
+    const cas: Array<[number, number]> = [
+      [7, 1],
+      [11, 1],
+      [15, 3],
+      [19, 5],
+      [23, 7],
+      [27, 15],
+      [29, 15],
+    ];
+    for (const [seats, delegates] of cas) {
+      const college = computeCommuneCollege({ communeId: "x", population: 800, totalSeats: seats });
+      expect(college!.total, `conseil de ${seats}`).toBe(delegates);
+    }
+  });
+});
+
+describe("computeCommuneCollege : dérogation PLM", () => {
+  it("Paris compte 163 conseillers, pas les 69 du barème générique", () => {
+    const college = computeCommuneCollege(PARIS);
+    expect(college!.councilSeats).toBe(163);
+    // 163 + ⌊(2 103 778 − 30 000) / 800⌋ = 163 + 2592
+    expect(college!.total).toBe(2755);
+  });
+
+  it("Lyon compte 73 conseillers", () => {
+    const college = computeCommuneCollege(LYON);
+    expect(college!.councilSeats).toBe(73);
+    expect(college!.total).toBe(73 + Math.floor((519127 - 30000) / 800));
+  });
+
+  it("Marseille compte 111 conseillers depuis le renouvellement de 2026", () => {
+    const college = computeCommuneCollege(MARSEILLE);
+    expect(college!.councilSeats).toBe(111);
+    expect(college!.total).toBe(111 + Math.floor((886040 - 30000) / 800));
+  });
+
+  it("la dérogation change bien le résultat par rapport au barème brut", () => {
+    const avec = computeCommuneCollege(PARIS)!.total;
+    const sans = computeCommuneCollege({ ...PARIS, communeId: "99999" })!.total;
+    expect(avec).toBeGreaterThan(sans);
+    expect(avec - sans).toBe(163 - 69);
+  });
+});
+
+describe("computeCommuneCollege : absences", () => {
+  it("ne calcule rien sans population", () => {
+    expect(computeCommuneCollege({ communeId: "x", population: null, totalSeats: 27 })).toBeNull();
+  });
+
+  it("ne calcule rien sans taille de conseil", () => {
+    expect(
+      computeCommuneCollege({ communeId: "x", population: 4854, totalSeats: null })
+    ).toBeNull();
+  });
+
+  it("refuse une taille de conseil hors barème plutôt que d'inventer un nombre", () => {
+    // 33 sièges sous 9 000 habitants n'existe pas au barème CGCT : défaut de donnée.
+    expect(computeCommuneCollege({ communeId: "x", population: 4000, totalSeats: 33 })).toBeNull();
+  });
+
+  it("refuse des valeurs négatives ou nulles", () => {
+    expect(computeCommuneCollege({ communeId: "x", population: -1, totalSeats: 27 })).toBeNull();
+    expect(computeCommuneCollege({ communeId: "x", population: 4000, totalSeats: 0 })).toBeNull();
+  });
+});
+
+describe("inhabitantsPerDelegate", () => {
+  it("montre l'écart de poids entre Bordeaux et Bazas", () => {
+    const bordeaux = inhabitantsPerDelegate(computeCommuneCollege(BORDEAUX))!;
+    const bazas = inhabitantsPerDelegate(computeCommuneCollege(BAZAS))!;
+    expect(Math.round(bordeaux)).toBe(740);
+    expect(Math.round(bazas)).toBe(324);
+    expect(bordeaux / bazas).toBeGreaterThan(2);
+  });
+
+  it("propage l'absence", () => {
+    expect(inhabitantsPerDelegate(null)).toBeNull();
+  });
+});

--- a/src/lib/senatoriales/college.ts
+++ b/src/lib/senatoriales/college.ts
@@ -1,0 +1,100 @@
+/**
+ * How many senatorial delegates a commune sends, from the code électoral.
+ *
+ * The point of showing this calculation rather than summarising it is that the
+ * number is not negotiated: it falls out of two articles applied to a population
+ * and a council size. Both inputs come from the database, so the arithmetic must be
+ * reproducible from what the page displays.
+ *
+ * Returns null whenever an input is missing or off-scale. An absent delegate count
+ * is said, never guessed: see docs/design/patterns/MissingData.md.
+ */
+
+import {
+  DELEGATES_BY_RIGHT_THRESHOLD,
+  SENATE_DELEGATE_SCALE,
+  SUPPLEMENTARY_DELEGATE_FLOOR,
+  SUPPLEMENTARY_DELEGATE_STEP,
+  getCouncilSeats,
+} from "@/config/senatoriales";
+
+export interface CommuneCollegeInput {
+  communeId: string;
+  population: number | null;
+  totalSeats: number | null;
+}
+
+export type CollegeRegime = "scale" | "by-right";
+
+export interface CommuneCollege {
+  /** Council size actually used, PLM derogation applied. */
+  councilSeats: number;
+  population: number;
+  regime: CollegeRegime;
+  /** Delegates elected on the L. 284 scale. Null under the L. 285 regime. */
+  scaleDelegates: number | null;
+  /** Councillors who are delegates by right (L. 285). Null under the L. 284 regime. */
+  delegatesByRight: number | null;
+  /** Extra delegates for the population above 30,000 (L. 285). Zero below it. */
+  supplementaryDelegates: number;
+  /** Complete 800-inhabitant brackets above 30,000, kept so the page can show the division. */
+  supplementaryBrackets: number;
+  total: number;
+}
+
+/**
+ * Delegates for one commune, or null when we cannot say.
+ *
+ * Null happens on a missing population, a missing council size, or a council size
+ * that is not on the L. 284 scale. That last case is a data defect rather than a
+ * legal edge case, and it must surface as an absence instead of a plausible number.
+ */
+export function computeCommuneCollege(input: CommuneCollegeInput): CommuneCollege | null {
+  const councilSeats = getCouncilSeats(input.communeId, input.totalSeats);
+  const { population } = input;
+
+  if (population == null || population < 0) return null;
+  if (councilSeats == null || councilSeats <= 0) return null;
+
+  if (population >= DELEGATES_BY_RIGHT_THRESHOLD) {
+    const supplementaryBrackets =
+      population > SUPPLEMENTARY_DELEGATE_FLOOR
+        ? Math.floor((population - SUPPLEMENTARY_DELEGATE_FLOOR) / SUPPLEMENTARY_DELEGATE_STEP)
+        : 0;
+
+    return {
+      councilSeats,
+      population,
+      regime: "by-right",
+      scaleDelegates: null,
+      delegatesByRight: councilSeats,
+      supplementaryDelegates: supplementaryBrackets,
+      supplementaryBrackets,
+      total: councilSeats + supplementaryBrackets,
+    };
+  }
+
+  const scaleDelegates = SENATE_DELEGATE_SCALE[councilSeats];
+  if (scaleDelegates === undefined) return null;
+
+  return {
+    councilSeats,
+    population,
+    regime: "scale",
+    scaleDelegates,
+    delegatesByRight: null,
+    supplementaryDelegates: 0,
+    supplementaryBrackets: 0,
+    total: scaleDelegates,
+  };
+}
+
+/**
+ * Inhabitants per delegate, the figure that makes the rural weighting visible.
+ * Null when the college is unknown, so the comparison block disappears rather than
+ * showing a ratio built on a guess.
+ */
+export function inhabitantsPerDelegate(college: CommuneCollege | null): number | null {
+  if (!college || college.total <= 0) return null;
+  return college.population / college.total;
+}


### PR DESCRIPTION
Section Sénatoriales 2026 : hub état 1 et sous-page du collège électoral. Les états 2 à 4 et le graphique municipal viennent après, pour que les calculs, la provenance, le mobile et l'accessibilité soient relisibles ici.

Suite de #697. Deux corrections préalables ouvrent la PR.

## Corrections préalables

**La sémantique de l'audit des dates était fausse.** Le prédicat `startDate < prise de fonction de la série` ne démontre rien : le renouvellement de 2023 comptait 95 réélus sur 170, et un réélu conserve légitimement une date antérieure. Gérard Larcher est sénateur depuis le 1er octobre 2007 selon le Sénat.

L'audit cherche maintenant la vraie signature du repli, une date valant **exactement** une de ses deux valeurs, et distingue les cas où cette valeur ne peut pas être une prise de fonction de la série concernée.

| Série | Sur une date de repli | dont date impossible pour la série |
| ----- | --------------------- | ---------------------------------- |
| 1     | 166 sur 170           | **156**                            |
| 2     | 172 sur 178           | 0                                  |

Les 156 de série 1 sont tous au `2020-10-01`, jour de prise de fonction de la série 2. Une concentration sur un seul jour n'est pas une distribution de réélections. Les 172 de série 2 sont plausibles mais indiscernables du repli. #698 est corrigée en conséquence, et pose la question qui conditionne tout backfill : le champ doit-il porter le mandat en cours ou l'entrée au Sénat ?

**`seed-communes.ts` datait un import partiel.** Il écrivait `lastSyncAt` même avec des erreurs, si bien qu'une commune dont l'upsert avait échoué gardait son ancienne population tout en étant présentée comme fraîchement importée. Le script échoue maintenant avant d'écrire la provenance, et laisse la date précédente en place.

## Le hub

`/elections/senatoriales-2026`, RSC, `revalidate = 300` en dur. Statut résolu par `resolveElectionStatus()` au read time : `[slug]` lisant `election.status` brut afficherait encore « à venir » le 28 septembre.

Le pont municipales est le premier bloc de contenu, avant la date et avant les sièges. Pas de projection de sièges, pas de « votre voix », pas d'ajout au calendrier.

**Le bloc « ce qui est remis en jeu » est calculé, plus cité.** Maintenant que `senateSeries` est en base, `Mandate.senateSeries` croisé aux groupes parlementaires reproduit exactement les trois chiffres que le design tenait de calculs de presse : 107 sur 190 pour la majorité sortante, 77 sur 131 pour Les Républicains, 4 sur 18 pour les communistes. Le Sénat devient la seule source nécessaire.

**Le champ code postal désambiguïse réellement.** 4 204 codes couvrent plusieurs communes, jusqu'à 46. `33430`, l'exemple du design lui-même, en renvoie **13** : le champ propose un choix au lieu de garder la plus grande. `75011` résout vers Paris, sans traitement particulier : `Commune.postalCodes` porte les 21 codes parisiens sur la ligne 75056 et aucun arrondissement n'existe comme commune.

Le repli non renouvelable répond vraiment : Paris affiche ses 2 755 grands électeurs, dit qu'ils ont été désignés le 5 juin et qu'ils voteront en 2029.

## L'écran du collège

`/elections/senatoriales-2026/college-electoral`, sous-page et non modale. Le calcul est posé, pas résumé : 65 délégués de droit, plus 297 tranches complètes de 800 habitants au-delà de 30 000, soit 362 grands électeurs pour Bordeaux. Puis Bazas dans le même département : 1 pour 324 contre 1 pour 740.

Barème L. 284 vérifié à la source (version en vigueur depuis le 23 mars 2014) : 7 ou 11 membres donnent 1 délégué, 15 en donnent 3, 19 en donnent 5, 23 en donnent 7, 27 et 29 en donnent 15. Bazas, 27 conseillers, 15 délégués, ce qui recoupe la maquette.

**362 et non 354.** Le README fige le calcul sur 261 804 habitants ; notre `Commune` porte 267 991. On calcule depuis la base et on affiche la provenance, plutôt que de transposer un nombre.

## Écarts assumés par rapport au design

- **La participation des sénateurs n'est pas affichée.** 323 sur 339 sont à exactement 100,0 %, et 338 ont `eligibleScrutins` égal au nombre total de scrutins Sénat en base : l'import n'enregistre pas les absences. Une ligne discrète le dit en fin de section, plutôt que de publier un taux faux. À traiter séparément.
- **Aucune ancienneté sénatoriale**, ni affichée ni dérivée de `senateSeries` : la série qualifie le siège, pas son occupation.
- **Le « 34 875 conseils municipaux élus » de la maquette est écarté.** Il n'est pas dans la liste des données sourcées et notre base compte 34 754 communes avec des élus enregistrés, écart qui reflète l'import et non la réalité. La première étape du pont porte la date et le fait, sans compteur fabriqué.
- **« 64 circonscriptions », pas « 63 préfectures »** : 63 départements et collectivités plus les Français établis hors de France.
- **Une liste de dates dédiée** au lieu de `ElectionKeyDates`, qui rend les colonnes du modèle et laisserait tomber la désignation du 5 juin et l'élection du président du Sénat.
- **Pas de feature flag dédié** : le modèle du hub présidentielle suffira quand un gating éditorial sera nécessaire.

## Vérifications

Suite complète : 3 955 tests, dont 53 nouveaux. Build de production vert, `revalidate` à 300 s confirmé sur les deux routes dans le manifeste de prérendu, et `senatoriales-2026` bien retiré du prérendu de `[slug]`.

Mesuré au navigateur en 375 px et 1 280 px, thèmes clair et sombre, y compris l'état interactif après recherche :

- **0 débordement horizontal** (`scrollWidth` égal à la largeur de vue partout).
- **0 violation axe** WCAG 2.1 AA, hors un `<kbd>` de l'en-tête partagé à 3,83:1 qui préexiste sur tout le site.
- **0 cible tactile sous 44 px** dans les blocs de cette PR, après deux correctifs trouvés à la mesure et non à la lecture : quatre libellés à 12 px sur `bg-muted/50` mesuraient 4,4:1 en sombre et passent sur `--muted-foreground-strong` (5,25:1), et les liens de nom des sénateurs faisaient 24 px de haut.

Les 9 autres cibles sous 44 px relevées appartiennent à l'en-tête et au pied partagés : hors périmètre.
