### PR TITLE
Fermer les mandats périmés et capturer la composition sortante du Sénat

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "visual": "tsx scripts/visual-test-runner.ts",
     "audit:affairs": "tsx scripts/audit-affairs.ts",
     "audit:senateurs-series": "tsx scripts/audit-senateurs-series.ts",
+    "senat:capture-composition": "tsx scripts/capture-senate-composition.ts",
     "audit:compliance": "tsx scripts/audit-affairs-compliance.ts",
     "remediate:unverified": "tsx scripts/remediate-unverified-published-affairs.ts",
     "purge:restricted-text": "tsx scripts/purge-restricted-source-text.ts",

--- a/scripts/capture-senate-composition.ts
+++ b/scripts/capture-senate-composition.ts
@@ -7,17 +7,24 @@
  * reconstructs who stood for re-election, which is what the post-ballot comparison
  * (re-elected, newcomers, share of women) is made of.
  *
- * Three refusals rather than one, because a wrong capture is worse than no capture:
+ * Everything runs inside a single REPEATABLE READ transaction: the existence check, the
+ * two counts, the read of the 178 seats, the group aggregation and the write. Spread
+ * across independent queries, a concurrent `sync:senat` could close a mandate between
+ * the count and the read, and the capture would freeze a composition that never existed
+ * at any single instant. The unique constraint on `StatsSnapshot.key` is the last line
+ * of defence against two captures racing each other.
+ *
+ * Three refusals, because a wrong capture is worse than no capture:
  *
  *  1. If the key already exists, stop. Never an upsert: a second run must not quietly
  *     replace the record with a post-ballot one. Deleting the row is a deliberate act.
  *  2. If the database does not hold exactly 348 sitting senators with 178 in the
- *     renewed series, stop. A capture taken mid-sync would freeze an incomplete state.
+ *     renewed series, stop.
  *  3. If the control invariants of #700 do not hold, stop, and write nothing.
  *
  * Usage:
- *   npx tsx --env-file=.env scripts/capture-senate-composition.ts --dry-run
- *   npx tsx --env-file=.env scripts/capture-senate-composition.ts
+ *   npm run senat:capture-composition -- --dry-run
+ *   npm run senat:capture-composition
  */
 
 import "dotenv/config";
@@ -31,20 +38,55 @@ import {
 import {
   EXPECTED_SEATS_AT_STAKE,
   EXPECTED_TOTAL_SEATS,
+  summariseOutgoingMajority,
   verifyComposition,
 } from "../src/lib/senatoriales/outgoing-composition";
 
 const RENEWED_SERIES = 2;
 
-async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposition> {
+/** Raised inside the transaction so a refusal rolls back rather than half-writes. */
+class CaptureRefused extends Error {
+  constructor(
+    message: string,
+    readonly details: string[] = []
+  ) {
+    super(message);
+    this.name = "CaptureRefused";
+  }
+}
+
+/**
+ * Raised to roll back a successful dry run. A distinct type rather than a refusal with
+ * no details: inferring success from an empty detail list would exit 0 on a real
+ * refusal that happens to carry none.
+ */
+class DryRunComplete extends Error {
+  constructor(readonly composition: OutgoingSenateComposition) {
+    super("dry run");
+    this.name = "DryRunComplete";
+  }
+}
+
+/**
+ * The transaction client of an *extended* Prisma client, which is not
+ * `Prisma.TransactionClient`: the extension changes the model types, so the plain
+ * interface no longer matches. Derived from `db` by removing what a transaction
+ * forbids.
+ */
+type Tx = Omit<
+  typeof db,
+  "$transaction" | "$connect" | "$disconnect" | "$on" | "$use" | "$extends"
+>;
+
+async function readComposition(tx: Tx, capturedAt: Date): Promise<OutgoingSenateComposition> {
   const [totalSeats, seatsAtStake] = await Promise.all([
-    db.mandate.count({ where: { type: "SENATEUR", isCurrent: true } }),
-    db.mandate.count({
+    tx.mandate.count({ where: { type: "SENATEUR", isCurrent: true } }),
+    tx.mandate.count({
       where: { type: "SENATEUR", isCurrent: true, senateSeries: RENEWED_SERIES },
     }),
   ]);
 
-  const mandates = await db.mandate.findMany({
+  const mandates = await tx.mandate.findMany({
     where: { type: "SENATEUR", isCurrent: true, senateSeries: RENEWED_SERIES },
     select: {
       departmentCode: true,
@@ -52,16 +94,23 @@ async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposi
       senateSeries: true,
       politician: { select: { id: true, slug: true, fullName: true } },
       parliamentaryData: {
-        select: { parliamentaryGroup: { select: { name: true, shortName: true } } },
+        select: { parliamentaryGroup: { select: { code: true, name: true, shortName: true } } },
       },
     },
     orderBy: { politician: { lastName: "asc" } },
   });
 
-  const groups = await db.$queryRaw<
-    Array<{ groupName: string; shortName: string | null; held: number; atStake: number }>
+  const groups = await tx.$queryRaw<
+    Array<{
+      groupCode: string;
+      groupName: string;
+      shortName: string | null;
+      held: number;
+      atStake: number;
+    }>
   >(Prisma.sql`
-    SELECT g.name AS "groupName",
+    SELECT g.code AS "groupCode",
+           g.name AS "groupName",
            g."shortName",
            COUNT(*)::int AS held,
            COUNT(*) FILTER (WHERE m."senateSeries" = ${RENEWED_SERIES})::int AS "atStake"
@@ -71,7 +120,7 @@ async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposi
     WHERE m.type = 'SENATEUR'
       AND m."isCurrent" = true
       AND m."senateSeries" IS NOT NULL
-    GROUP BY 1, 2
+    GROUP BY 1, 2, 3
     ORDER BY held DESC
   `);
 
@@ -86,6 +135,7 @@ async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposi
       departmentCode: m.departmentCode,
       constituency: m.constituency,
       series: m.senateSeries ?? RENEWED_SERIES,
+      groupCode: m.parliamentaryData?.parliamentaryGroup.code ?? null,
       groupName: m.parliamentaryData?.parliamentaryGroup.name ?? null,
       groupShortName: m.parliamentaryData?.parliamentaryGroup.shortName ?? null,
     })),
@@ -93,88 +143,111 @@ async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposi
   };
 }
 
+function report(composition: OutgoingSenateComposition): void {
+  console.log(`Sénateurs en cours de mandat : ${composition.totalSeats}`);
+  console.log(`Sièges de la série renouvelée : ${composition.seatsAtStake}`);
+  console.log(`Sièges capturés individuellement : ${composition.seats.length}\n`);
+  console.log("Exposition par groupe :");
+  for (const group of composition.groups) {
+    console.log(
+      `  ${group.groupCode.padEnd(8)} ${String(group.atStake).padStart(3)} / ${String(group.held).padStart(3)}  ${group.groupName}`
+    );
+  }
+  const majority = summariseOutgoingMajority(composition);
+  console.log(`  majorité sortante : ${majority.atStake} sur ${majority.held}`);
+}
+
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
   console.log(`=== Capture de la composition sortante du Sénat ${dryRun ? "(à blanc)" : ""} ===\n`);
 
-  // 1. Write-once.
-  const existing = await db.statsSnapshot.findUnique({
-    where: { key: SENATE_OUTGOING_COMPOSITION_KEY },
-    select: { computedAt: true },
-  });
-  if (existing) {
-    console.log(
-      `La composition sortante est déjà capturée (${existing.computedAt.toISOString()}).\n` +
-        `Clé : ${SENATE_OUTGOING_COMPOSITION_KEY}\n\n` +
-        `Ce script n'écrase jamais une capture existante : elle est le seul témoignage d'un\n` +
-        `état qui n'existe plus. Pour refaire la photographie, supprimer la ligne\n` +
-        `délibérément, après avoir vérifié que le scrutin n'a pas encore eu lieu.`
-    );
-    await db.$disconnect();
-    process.exit(1);
-  }
-
   const capturedAt = new Date();
-  const composition = await buildComposition(capturedAt);
 
-  console.log(`Sénateurs en cours de mandat : ${composition.totalSeats}`);
-  console.log(`Sièges de la série renouvelée : ${composition.seatsAtStake}`);
-  console.log(`Sièges capturés individuellement : ${composition.seats.length}\n`);
+  try {
+    const composition = await db.$transaction(
+      async (tx) => {
+        // 1. Write-once, checked inside the transaction so a concurrent run cannot
+        //    slip between the check and the insert.
+        const existing = await tx.statsSnapshot.findUnique({
+          where: { key: SENATE_OUTGOING_COMPOSITION_KEY },
+          select: { computedAt: true },
+        });
+        if (existing) {
+          throw new CaptureRefused(
+            `La composition sortante est déjà capturée (${existing.computedAt.toISOString()}).\n` +
+              `Clé : ${SENATE_OUTGOING_COMPOSITION_KEY}\n\n` +
+              `Ce script n'écrase jamais une capture existante : elle est le seul témoignage\n` +
+              `d'un état qui n'existe plus. Pour refaire la photographie, supprimer la ligne\n` +
+              `délibérément, après avoir vérifié que le scrutin n'a pas encore eu lieu.`
+          );
+        }
 
-  // 2. The database must match the Senate before anything is frozen.
-  if (
-    composition.totalSeats !== EXPECTED_TOTAL_SEATS ||
-    composition.seatsAtStake !== EXPECTED_SEATS_AT_STAKE
-  ) {
-    console.error(
-      `Base non conforme : ${composition.totalSeats} mandats courants et ` +
-        `${composition.seatsAtStake} sièges de série renouvelée, attendu ` +
-        `${EXPECTED_TOTAL_SEATS} et ${EXPECTED_SEATS_AT_STAKE}.\n` +
-        `Lancer \`npm run audit:senateurs-series -- --verbose\` avant de recommencer.`
+        const candidate = await readComposition(tx, capturedAt);
+        report(candidate);
+
+        // 2. The database must match the Senate before anything is frozen.
+        if (
+          candidate.totalSeats !== EXPECTED_TOTAL_SEATS ||
+          candidate.seatsAtStake !== EXPECTED_SEATS_AT_STAKE
+        ) {
+          throw new CaptureRefused(
+            `Base non conforme : ${candidate.totalSeats} mandats courants et ` +
+              `${candidate.seatsAtStake} sièges de série renouvelée, attendu ` +
+              `${EXPECTED_TOTAL_SEATS} et ${EXPECTED_SEATS_AT_STAKE}.\n` +
+              `Lancer \`npm run audit:senateurs-series -- --verbose\` avant de recommencer.`
+          );
+        }
+
+        // 3. Control invariants, recomputed and never assumed.
+        const problems = verifyComposition(candidate);
+        if (problems.length > 0) {
+          throw new CaptureRefused(
+            `${problems.length} invariant(s) non tenu(s), rien n'est écrit :`,
+            problems
+          );
+        }
+        console.log("\nTous les invariants de contrôle sont tenus.");
+
+        // Parsed before the write, not only on read: a shape error must surface while
+        // the state it describes still exists.
+        const parsed = OutgoingSenateCompositionSchema.parse(candidate);
+
+        if (dryRun) throw new DryRunComplete(parsed);
+
+        await tx.statsSnapshot.create({
+          data: {
+            key: SENATE_OUTGOING_COMPOSITION_KEY,
+            data: parsed as unknown as Prisma.InputJsonValue,
+          },
+        });
+
+        return parsed;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead }
     );
-    await db.$disconnect();
-    process.exit(1);
-  }
 
-  // 3. Control invariants, recomputed and never assumed.
-  const problems = verifyComposition(composition);
-  console.log("Exposition par groupe :");
-  for (const group of composition.groups) {
     console.log(
-      `  ${(group.shortName ?? group.groupName).padEnd(14)} ${String(group.atStake).padStart(3)} / ${String(group.held).padStart(3)}`
+      `\nCapture écrite sous ${SENATE_OUTGOING_COMPOSITION_KEY} ` +
+        `(${composition.seats.length} sièges, ${composition.capturedAt}).`
     );
-  }
-
-  if (problems.length > 0) {
-    console.error(`\n${problems.length} invariant(s) non tenu(s), rien n'est écrit :`);
-    for (const problem of problems) console.error(`  - ${problem}`);
     await db.$disconnect();
-    process.exit(1);
+  } catch (error) {
+    if (error instanceof DryRunComplete) {
+      console.log(
+        `\nÀ blanc : ${error.composition.seats.length} sièges seraient capturés, ` +
+          "aucune écriture. Relancer sans --dry-run pour capturer."
+      );
+      await db.$disconnect();
+      return;
+    }
+    if (error instanceof CaptureRefused) {
+      console.error(`\n${error.message}`);
+      for (const detail of error.details) console.error(`  - ${detail}`);
+      await db.$disconnect();
+      process.exit(1);
+    }
+    throw error;
   }
-  console.log("\nTous les invariants de contrôle sont tenus.");
-
-  // The schema is parsed before the write, not only on read: a shape error must
-  // surface now, while the state it describes still exists.
-  const parsed = OutgoingSenateCompositionSchema.parse(composition);
-
-  if (dryRun) {
-    console.log("\nÀ blanc : aucune écriture. Relancer sans --dry-run pour capturer.");
-    await db.$disconnect();
-    return;
-  }
-
-  await db.statsSnapshot.create({
-    data: {
-      key: SENATE_OUTGOING_COMPOSITION_KEY,
-      data: parsed as unknown as Prisma.InputJsonValue,
-    },
-  });
-
-  console.log(
-    `\nCapture écrite sous ${SENATE_OUTGOING_COMPOSITION_KEY} ` +
-      `(${parsed.seats.length} sièges, ${capturedAt.toISOString()}).`
-  );
-  await db.$disconnect();
 }
 
 main().catch(async (error) => {

--- a/scripts/capture-senate-composition.ts
+++ b/scripts/capture-senate-composition.ts
@@ -1,0 +1,184 @@
+/**
+ * Capture the Senate's composition as it stands before the 27 September 2026 ballot.
+ *
+ * Write-once, and the only record of a state that stops existing. Every read of the
+ * Senate goes through `Mandate` with `isCurrent = true`, so the first `sync:senat`
+ * after the ballot swaps the 178 outgoing senators for the incoming ones. Nothing then
+ * reconstructs who stood for re-election, which is what the post-ballot comparison
+ * (re-elected, newcomers, share of women) is made of.
+ *
+ * Three refusals rather than one, because a wrong capture is worse than no capture:
+ *
+ *  1. If the key already exists, stop. Never an upsert: a second run must not quietly
+ *     replace the record with a post-ballot one. Deleting the row is a deliberate act.
+ *  2. If the database does not hold exactly 348 sitting senators with 178 in the
+ *     renewed series, stop. A capture taken mid-sync would freeze an incomplete state.
+ *  3. If the control invariants of #700 do not hold, stop, and write nothing.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/capture-senate-composition.ts --dry-run
+ *   npx tsx --env-file=.env scripts/capture-senate-composition.ts
+ */
+
+import "dotenv/config";
+import { db } from "../src/lib/db";
+import { Prisma } from "../src/generated/prisma";
+import {
+  SENATE_OUTGOING_COMPOSITION_KEY,
+  OutgoingSenateCompositionSchema,
+  type OutgoingSenateComposition,
+} from "../src/types/stats-snapshots";
+import {
+  EXPECTED_SEATS_AT_STAKE,
+  EXPECTED_TOTAL_SEATS,
+  verifyComposition,
+} from "../src/lib/senatoriales/outgoing-composition";
+
+const RENEWED_SERIES = 2;
+
+async function buildComposition(capturedAt: Date): Promise<OutgoingSenateComposition> {
+  const [totalSeats, seatsAtStake] = await Promise.all([
+    db.mandate.count({ where: { type: "SENATEUR", isCurrent: true } }),
+    db.mandate.count({
+      where: { type: "SENATEUR", isCurrent: true, senateSeries: RENEWED_SERIES },
+    }),
+  ]);
+
+  const mandates = await db.mandate.findMany({
+    where: { type: "SENATEUR", isCurrent: true, senateSeries: RENEWED_SERIES },
+    select: {
+      departmentCode: true,
+      constituency: true,
+      senateSeries: true,
+      politician: { select: { id: true, slug: true, fullName: true } },
+      parliamentaryData: {
+        select: { parliamentaryGroup: { select: { name: true, shortName: true } } },
+      },
+    },
+    orderBy: { politician: { lastName: "asc" } },
+  });
+
+  const groups = await db.$queryRaw<
+    Array<{ groupName: string; shortName: string | null; held: number; atStake: number }>
+  >(Prisma.sql`
+    SELECT g.name AS "groupName",
+           g."shortName",
+           COUNT(*)::int AS held,
+           COUNT(*) FILTER (WHERE m."senateSeries" = ${RENEWED_SERIES})::int AS "atStake"
+    FROM "Mandate" m
+    JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+    JOIN "ParliamentaryGroup" g ON g.id = mp."parliamentaryGroupId"
+    WHERE m.type = 'SENATEUR'
+      AND m."isCurrent" = true
+      AND m."senateSeries" IS NOT NULL
+    GROUP BY 1, 2
+    ORDER BY held DESC
+  `);
+
+  return {
+    capturedAt: capturedAt.toISOString(),
+    totalSeats,
+    seatsAtStake,
+    seats: mandates.map((m) => ({
+      politicianId: m.politician.id,
+      fullName: m.politician.fullName,
+      slug: m.politician.slug,
+      departmentCode: m.departmentCode,
+      constituency: m.constituency,
+      series: m.senateSeries ?? RENEWED_SERIES,
+      groupName: m.parliamentaryData?.parliamentaryGroup.name ?? null,
+      groupShortName: m.parliamentaryData?.parliamentaryGroup.shortName ?? null,
+    })),
+    groups,
+  };
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  console.log(`=== Capture de la composition sortante du Sénat ${dryRun ? "(à blanc)" : ""} ===\n`);
+
+  // 1. Write-once.
+  const existing = await db.statsSnapshot.findUnique({
+    where: { key: SENATE_OUTGOING_COMPOSITION_KEY },
+    select: { computedAt: true },
+  });
+  if (existing) {
+    console.log(
+      `La composition sortante est déjà capturée (${existing.computedAt.toISOString()}).\n` +
+        `Clé : ${SENATE_OUTGOING_COMPOSITION_KEY}\n\n` +
+        `Ce script n'écrase jamais une capture existante : elle est le seul témoignage d'un\n` +
+        `état qui n'existe plus. Pour refaire la photographie, supprimer la ligne\n` +
+        `délibérément, après avoir vérifié que le scrutin n'a pas encore eu lieu.`
+    );
+    await db.$disconnect();
+    process.exit(1);
+  }
+
+  const capturedAt = new Date();
+  const composition = await buildComposition(capturedAt);
+
+  console.log(`Sénateurs en cours de mandat : ${composition.totalSeats}`);
+  console.log(`Sièges de la série renouvelée : ${composition.seatsAtStake}`);
+  console.log(`Sièges capturés individuellement : ${composition.seats.length}\n`);
+
+  // 2. The database must match the Senate before anything is frozen.
+  if (
+    composition.totalSeats !== EXPECTED_TOTAL_SEATS ||
+    composition.seatsAtStake !== EXPECTED_SEATS_AT_STAKE
+  ) {
+    console.error(
+      `Base non conforme : ${composition.totalSeats} mandats courants et ` +
+        `${composition.seatsAtStake} sièges de série renouvelée, attendu ` +
+        `${EXPECTED_TOTAL_SEATS} et ${EXPECTED_SEATS_AT_STAKE}.\n` +
+        `Lancer \`npm run audit:senateurs-series -- --verbose\` avant de recommencer.`
+    );
+    await db.$disconnect();
+    process.exit(1);
+  }
+
+  // 3. Control invariants, recomputed and never assumed.
+  const problems = verifyComposition(composition);
+  console.log("Exposition par groupe :");
+  for (const group of composition.groups) {
+    console.log(
+      `  ${(group.shortName ?? group.groupName).padEnd(14)} ${String(group.atStake).padStart(3)} / ${String(group.held).padStart(3)}`
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error(`\n${problems.length} invariant(s) non tenu(s), rien n'est écrit :`);
+    for (const problem of problems) console.error(`  - ${problem}`);
+    await db.$disconnect();
+    process.exit(1);
+  }
+  console.log("\nTous les invariants de contrôle sont tenus.");
+
+  // The schema is parsed before the write, not only on read: a shape error must
+  // surface now, while the state it describes still exists.
+  const parsed = OutgoingSenateCompositionSchema.parse(composition);
+
+  if (dryRun) {
+    console.log("\nÀ blanc : aucune écriture. Relancer sans --dry-run pour capturer.");
+    await db.$disconnect();
+    return;
+  }
+
+  await db.statsSnapshot.create({
+    data: {
+      key: SENATE_OUTGOING_COMPOSITION_KEY,
+      data: parsed as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  console.log(
+    `\nCapture écrite sous ${SENATE_OUTGOING_COMPOSITION_KEY} ` +
+      `(${parsed.seats.length} sièges, ${capturedAt.toISOString()}).`
+  );
+  await db.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error("Erreur:", error);
+  await db.$disconnect();
+  process.exit(1);
+});

--- a/scripts/fix-stale-senator-mandates.ts
+++ b/scripts/fix-stale-senator-mandates.ts
@@ -1,0 +1,153 @@
+/**
+ * One-shot: close three senatorial mandates still marked current.
+ *
+ * Éric Bocquet, Philippe Bas and Maurice Perrion left the Senate between October 2024
+ * and March 2025, but their mandate row still carries `isCurrent = true` with no end
+ * date. They come from the Wikidata lineage (`source = WIKIDATA`) and their profiles
+ * hold no Senate external id, while the closing step of `syncSenateurs()` is scoped to
+ * `source: DataSource.SENAT` and keys on that id. No amount of syncing will ever reach
+ * them.
+ *
+ * They were left alone in #697 because stamping today's date as their departure would
+ * have replaced one wrong value with another. Each end date below is read from the
+ * senator's own page on senat.fr, with its stated reason.
+ *
+ * This blocks #700: a capture of the outgoing composition taken now would record three
+ * seats that do not exist.
+ *
+ * Deliberately narrow. It does not touch `startDate`, and it settles nothing about the
+ * provenance of the other 338 dates: that is #698.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/fix-stale-senator-mandates.ts --dry-run
+ *   npx tsx --env-file=.env scripts/fix-stale-senator-mandates.ts
+ */
+
+import "dotenv/config";
+import { db } from "../src/lib/db";
+
+interface Closure {
+  slug: string;
+  fullName: string;
+  /** End of term, as published by the Senate. */
+  endDate: string;
+  reason: string;
+  sourceUrl: string;
+}
+
+const CLOSURES: Closure[] = [
+  {
+    slug: "eric-bocquet",
+    fullName: "Eric Bocquet",
+    endDate: "2024-10-31",
+    reason: "démissionnaire",
+    sourceUrl: "https://www.senat.fr/senateur/bocquet_eric11040e.html",
+  },
+  {
+    slug: "philippe-bas",
+    fullName: "Philippe Bas",
+    endDate: "2025-03-01",
+    reason: "nommé membre du Conseil constitutionnel",
+    sourceUrl: "https://www.senat.fr/senateur/bas_philippe05008e.html",
+  },
+  {
+    slug: "maurice-perrion",
+    fullName: "Maurice Perrion",
+    endDate: "2025-01-23",
+    reason: "reprise de l'exercice du mandat par un ancien membre du Gouvernement",
+    sourceUrl: "https://www.senat.fr/senateur/perrion_maurice21420g.html",
+  },
+];
+
+/** What the database must look like once these three are closed. */
+const EXPECTED_CURRENT = 348;
+const EXPECTED_SERIES_1 = 170;
+const EXPECTED_SERIES_2 = 178;
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  console.log(`=== Fermeture des mandats sénatoriaux périmés ${dryRun ? "(à blanc)" : ""} ===\n`);
+
+  const before = await db.mandate.count({ where: { type: "SENATEUR", isCurrent: true } });
+  console.log(`Mandats sénatoriaux courants avant : ${before}\n`);
+
+  let closed = 0;
+
+  for (const closure of CLOSURES) {
+    const mandates = await db.mandate.findMany({
+      where: {
+        type: "SENATEUR",
+        isCurrent: true,
+        politician: { slug: closure.slug },
+      },
+      select: { id: true, startDate: true, source: true },
+    });
+
+    if (mandates.length === 0) {
+      console.log(`  ~ ${closure.fullName} : aucun mandat courant, déjà fermé`);
+      continue;
+    }
+    if (mandates.length > 1) {
+      throw new Error(
+        `${closure.fullName} porte ${mandates.length} mandats courants : cas non prévu, arrêt.`
+      );
+    }
+
+    const mandate = mandates[0]!;
+    const endDate = new Date(`${closure.endDate}T00:00:00Z`);
+    if (endDate < mandate.startDate) {
+      throw new Error(
+        `${closure.fullName} : date de fin ${closure.endDate} antérieure au début ` +
+          `${mandate.startDate.toISOString().slice(0, 10)}, arrêt.`
+      );
+    }
+
+    console.log(
+      `  + ${closure.fullName} : fin au ${closure.endDate} (${closure.reason}), source=${mandate.source}`
+    );
+    console.log(`      ${closure.sourceUrl}`);
+
+    if (!dryRun) {
+      await db.mandate.update({
+        where: { id: mandate.id },
+        data: { isCurrent: false, endDate },
+      });
+    }
+    closed++;
+  }
+
+  if (dryRun) {
+    console.log(`\nÀ blanc : ${closed} mandat(s) seraient fermés. Aucune écriture.`);
+    await db.$disconnect();
+    return;
+  }
+
+  // Control invariant: the database must now match the Senate exactly.
+  const [current, series1, series2] = await Promise.all([
+    db.mandate.count({ where: { type: "SENATEUR", isCurrent: true } }),
+    db.mandate.count({ where: { type: "SENATEUR", isCurrent: true, senateSeries: 1 } }),
+    db.mandate.count({ where: { type: "SENATEUR", isCurrent: true, senateSeries: 2 } }),
+  ]);
+
+  console.log(`\n${closed} mandat(s) fermés.`);
+  console.log(`Mandats sénatoriaux courants : ${current} (attendu ${EXPECTED_CURRENT})`);
+  console.log(`  série 1 : ${series1} (attendu ${EXPECTED_SERIES_1})`);
+  console.log(`  série 2 : ${series2} (attendu ${EXPECTED_SERIES_2})`);
+
+  const ok =
+    current === EXPECTED_CURRENT && series1 === EXPECTED_SERIES_1 && series2 === EXPECTED_SERIES_2;
+  console.log(
+    ok
+      ? "\nInvariant tenu : la base correspond à l'open data du Sénat."
+      : "\nInvariant NON tenu : relancer `npm run audit:senateurs-series -- --verbose`."
+  );
+
+  await db.$disconnect();
+  if (!ok) process.exit(1);
+}
+
+main().catch(async (error) => {
+  console.error("Erreur:", error);
+  await db.$disconnect();
+  process.exit(1);
+});

--- a/src/lib/senatoriales/__tests__/outgoing-composition.test.ts
+++ b/src/lib/senatoriales/__tests__/outgoing-composition.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { verifyComposition } from "../outgoing-composition";
+import type { OutgoingSenateComposition } from "@/types/stats-snapshots";
+
+/**
+ * The capture happens once and can never be redone, so these invariants run before the
+ * write, not after. A capture that passes them is trustworthy; one that fails must
+ * leave the database untouched.
+ */
+
+function seat(index: number, series = 2) {
+  return {
+    politicianId: `pol_${index}`,
+    fullName: `Sénateur ${index}`,
+    slug: `senateur-${index}`,
+    departmentCode: "33",
+    constituency: "Gironde",
+    series,
+    groupName: "Groupe A",
+    groupShortName: "GA",
+  };
+}
+
+/** A capture matching the published figures for this renewal. */
+function validComposition(): OutgoingSenateComposition {
+  return {
+    capturedAt: "2026-08-10T09:00:00.000Z",
+    totalSeats: 348,
+    seatsAtStake: 178,
+    seats: Array.from({ length: 178 }, (_, i) => seat(i)),
+    groups: [
+      { groupName: "Groupe A", shortName: "GA", held: 131, atStake: 77 },
+      { groupName: "Groupe B", shortName: "GB", held: 59, atStake: 30 },
+      { groupName: "Groupe C", shortName: null, held: 64, atStake: 30 },
+      { groupName: "Groupe D", shortName: null, held: 20, atStake: 9 },
+      { groupName: "Groupe E", shortName: null, held: 19, atStake: 11 },
+      { groupName: "Groupe F", shortName: null, held: 18, atStake: 4 },
+      { groupName: "Groupe G", shortName: null, held: 17, atStake: 9 },
+      { groupName: "Groupe H", shortName: null, held: 16, atStake: 7 },
+      { groupName: "Groupe I", shortName: null, held: 4, atStake: 1 },
+    ],
+  };
+}
+
+describe("verifyComposition : capture conforme", () => {
+  it("ne signale rien sur une capture qui tient les quatre invariants", () => {
+    expect(verifyComposition(validComposition())).toEqual([]);
+  });
+
+  it("retrouve 178 sur 348 en agrégeant les groupes", () => {
+    const c = validComposition();
+    expect(c.groups.reduce((s, g) => s + g.atStake, 0)).toBe(178);
+    expect(c.groups.reduce((s, g) => s + g.held, 0)).toBe(348);
+  });
+
+  /**
+   * Régression sur l'invariant lui-même. Une première version dérivait la majorité
+   * sortante comme « les deux groupes détenant le plus de sièges ». C'est faux : le
+   * deuxième groupe par sièges détenus (64) n'est pas celui de la majorité (59), donc
+   * la somme par rang donne 195 et non 190. Elle coïncidait sur les sièges remis en
+   * jeu parce que les deux groupes en ont 30, ce qui est exactement ainsi qu'un
+   * invariant faux passe une relecture. Un groupe s'identifie par son couple, jamais
+   * par son rang.
+   */
+  it("les 107 sur 190 viennent des couples attendus, pas du classement par taille", () => {
+    const c = validComposition();
+    const byHeld = [...c.groups].sort((a, b) => b.held - a.held).slice(0, 2);
+    expect(byHeld.reduce((s, g) => s + g.held, 0)).not.toBe(190);
+
+    const lr = c.groups.find((g) => g.held === 131 && g.atStake === 77)!;
+    const uc = c.groups.find((g) => g.held === 59 && g.atStake === 30)!;
+    expect(lr.held + uc.held).toBe(190);
+    expect(lr.atStake + uc.atStake).toBe(107);
+  });
+
+  it("exige un groupe distinct par couple attendu", () => {
+    const c = validComposition();
+    // Deux groupes au même couple 18/4 ne peuvent pas satisfaire deux attentes.
+    c.groups[1] = { ...c.groups[1]!, held: 18, atStake: 4 };
+    c.groups[2] = { ...c.groups[2]!, held: 105, atStake: 30 };
+    expect(verifyComposition(c).some((p) => p.includes("30 sièges remis en jeu sur 59"))).toBe(
+      true
+    );
+  });
+});
+
+describe("verifyComposition : refus", () => {
+  it("refuse un total de sièges inattendu", () => {
+    const c = { ...validComposition(), totalSeats: 351 };
+    expect(verifyComposition(c).some((p) => p.includes("total des sièges"))).toBe(true);
+  });
+
+  it("refuse un nombre de sièges remis en jeu inattendu", () => {
+    const c = { ...validComposition(), seatsAtStake: 176 };
+    expect(verifyComposition(c).some((p) => p.includes("sièges remis en jeu"))).toBe(true);
+  });
+
+  it("refuse une liste de sièges incomplète", () => {
+    const c = validComposition();
+    c.seats = c.seats.slice(0, 177);
+    expect(verifyComposition(c).some((p) => p.includes("sièges capturés"))).toBe(true);
+  });
+
+  // Capturer un siège de série 1 signifierait que la requête ne filtre pas ce qu'on croit.
+  it("refuse un siège hors de la série renouvelée", () => {
+    const c = validComposition();
+    c.seats[0] = seat(0, 1);
+    expect(verifyComposition(c).some((p) => p.includes("hors de la série renouvelée"))).toBe(true);
+  });
+
+  it("refuse un sénateur capturé deux fois", () => {
+    const c = validComposition();
+    c.seats[1] = { ...c.seats[0]! };
+    expect(verifyComposition(c).some((p) => p.includes("deux fois"))).toBe(true);
+  });
+
+  it("refuse un siège sans identifiant ou sans nom", () => {
+    const c = validComposition();
+    c.seats[5] = { ...c.seats[5]!, politicianId: "" };
+    expect(verifyComposition(c).some((p) => p.includes("sans identifiant"))).toBe(true);
+  });
+
+  // L'agrégat et les lignes individuelles doivent raconter la même histoire.
+  it("refuse une somme par groupe incohérente avec les totaux", () => {
+    const c = validComposition();
+    c.groups[0] = { ...c.groups[0]!, held: 130 };
+    const problems = verifyComposition(c);
+    expect(problems.some((p) => p.includes("somme des sièges par groupe"))).toBe(true);
+  });
+
+  it("refuse l'absence d'une exposition de groupe attendue", () => {
+    const c = validComposition();
+    c.groups[5] = { ...c.groups[5]!, atStake: 5, held: 17 };
+    expect(verifyComposition(c).some((p) => p.includes("4 sièges remis en jeu sur 18"))).toBe(true);
+  });
+
+  it("refuse un couple de majorité altéré, même à totaux constants", () => {
+    const c = validComposition();
+    // Un siège déplacé du groupe à 59 vers un autre : les totaux restent justes, mais
+    // le couple 59/30 disparaît et l'addition 131 + 59 = 190 ne tient plus.
+    c.groups[1] = { ...c.groups[1]!, held: 58 };
+    c.groups[3] = { ...c.groups[3]!, held: 21 };
+    expect(verifyComposition(c).some((p) => p.includes("30 sièges remis en jeu sur 59"))).toBe(
+      true
+    );
+  });
+
+  it("accumule tous les problèmes plutôt que de s'arrêter au premier", () => {
+    const c = { ...validComposition(), totalSeats: 300, seatsAtStake: 100 };
+    expect(verifyComposition(c).length).toBeGreaterThan(2);
+  });
+});

--- a/src/lib/senatoriales/__tests__/outgoing-composition.test.ts
+++ b/src/lib/senatoriales/__tests__/outgoing-composition.test.ts
@@ -1,90 +1,114 @@
 import { describe, it, expect } from "vitest";
-import { verifyComposition } from "../outgoing-composition";
-import type { OutgoingSenateComposition } from "@/types/stats-snapshots";
+import {
+  EXPECTED_SENATE_COMPOSITION,
+  EXPECTED_SEATS_AT_STAKE,
+  EXPECTED_TOTAL_SEATS,
+  summariseOutgoingMajority,
+  verifyComposition,
+} from "../outgoing-composition";
+import type { OutgoingSenateComposition, OutgoingSenateSeat } from "@/types/stats-snapshots";
 
 /**
  * The capture happens once and can never be redone, so these invariants run before the
  * write, not after. A capture that passes them is trustworthy; one that fails must
  * leave the database untouched.
+ *
+ * The fixture is built from `EXPECTED_SENATE_COMPOSITION` itself, so a test cannot
+ * drift from the reference data it checks: change a group's seats in one place and the
+ * fixture follows.
  */
 
-function seat(index: number, series = 2) {
-  return {
-    politicianId: `pol_${index}`,
-    fullName: `Sénateur ${index}`,
-    slug: `senateur-${index}`,
-    departmentCode: "33",
-    constituency: "Gironde",
-    series,
-    groupName: "Groupe A",
-    groupShortName: "GA",
-  };
-}
+const GROUP_NAMES: Record<string, string> = {
+  LR: "Les Républicains",
+  SER: "Socialiste, Écologiste et Républicain",
+  UC: "Union Centriste",
+  LIRT: "Les Indépendants - République et Territoires",
+  RDPI: "Rassemblement des démocrates, progressistes et indépendants",
+  "CRCE-K": "Communiste, Républicain, Citoyen et Écologiste - Kanaky",
+  RDSE: "Rassemblement Démocratique et Social Européen",
+  GEST: "Écologiste - Solidarité et Territoires",
+  NI: "Non-inscrits",
+};
 
-/** A capture matching the published figures for this renewal. */
 function validComposition(): OutgoingSenateComposition {
+  const seats: OutgoingSenateSeat[] = [];
+  let index = 0;
+  for (const [code, expected] of Object.entries(EXPECTED_SENATE_COMPOSITION)) {
+    for (let i = 0; i < expected.atStake; i++) {
+      seats.push({
+        politicianId: `pol_${index}`,
+        fullName: `Sénateur ${index}`,
+        slug: `senateur-${index}`,
+        departmentCode: "33",
+        constituency: "Gironde",
+        series: 2,
+        groupCode: code,
+        groupName: GROUP_NAMES[code] ?? code,
+        groupShortName: code,
+      });
+      index++;
+    }
+  }
+
   return {
-    capturedAt: "2026-08-10T09:00:00.000Z",
-    totalSeats: 348,
-    seatsAtStake: 178,
-    seats: Array.from({ length: 178 }, (_, i) => seat(i)),
-    groups: [
-      { groupName: "Groupe A", shortName: "GA", held: 131, atStake: 77 },
-      { groupName: "Groupe B", shortName: "GB", held: 59, atStake: 30 },
-      { groupName: "Groupe C", shortName: null, held: 64, atStake: 30 },
-      { groupName: "Groupe D", shortName: null, held: 20, atStake: 9 },
-      { groupName: "Groupe E", shortName: null, held: 19, atStake: 11 },
-      { groupName: "Groupe F", shortName: null, held: 18, atStake: 4 },
-      { groupName: "Groupe G", shortName: null, held: 17, atStake: 9 },
-      { groupName: "Groupe H", shortName: null, held: 16, atStake: 7 },
-      { groupName: "Groupe I", shortName: null, held: 4, atStake: 1 },
-    ],
+    capturedAt: "2026-08-10T09:47:26.080Z",
+    totalSeats: EXPECTED_TOTAL_SEATS,
+    seatsAtStake: EXPECTED_SEATS_AT_STAKE,
+    seats,
+    groups: Object.entries(EXPECTED_SENATE_COMPOSITION).map(([code, expected]) => ({
+      groupCode: code,
+      groupName: GROUP_NAMES[code] ?? code,
+      shortName: code,
+      held: expected.held,
+      atStake: expected.atStake,
+    })),
   };
 }
 
-describe("verifyComposition : capture conforme", () => {
-  it("ne signale rien sur une capture qui tient les quatre invariants", () => {
-    expect(verifyComposition(validComposition())).toEqual([]);
+describe("EXPECTED_SENATE_COMPOSITION", () => {
+  it("couvre les neuf groupes du Sénat", () => {
+    expect(Object.keys(EXPECTED_SENATE_COMPOSITION)).toHaveLength(9);
   });
 
-  it("retrouve 178 sur 348 en agrégeant les groupes", () => {
-    const c = validComposition();
-    expect(c.groups.reduce((s, g) => s + g.atStake, 0)).toBe(178);
-    expect(c.groups.reduce((s, g) => s + g.held, 0)).toBe(348);
+  it("somme exactement à 348 sièges détenus et 178 remis en jeu", () => {
+    const values = Object.values(EXPECTED_SENATE_COMPOSITION);
+    expect(values.reduce((s, g) => s + g.held, 0)).toBe(EXPECTED_TOTAL_SEATS);
+    expect(values.reduce((s, g) => s + g.atStake, 0)).toBe(EXPECTED_SEATS_AT_STAKE);
+  });
+
+  it("reproduit les chiffres publiés pour ce renouvellement", () => {
+    expect(EXPECTED_SENATE_COMPOSITION.LR).toEqual({ held: 131, atStake: 77 });
+    expect(EXPECTED_SENATE_COMPOSITION["CRCE-K"]).toEqual({ held: 18, atStake: 4 });
+    const majority = ["LR", "UC"].map((c) => EXPECTED_SENATE_COMPOSITION[c]!);
+    expect(majority.reduce((s, g) => s + g.held, 0)).toBe(190);
+    expect(majority.reduce((s, g) => s + g.atStake, 0)).toBe(107);
   });
 
   /**
-   * Régression sur l'invariant lui-même. Une première version dérivait la majorité
+   * Régression sur l'invariant lui-même. Une version antérieure dérivait la majorité
    * sortante comme « les deux groupes détenant le plus de sièges ». C'est faux : le
-   * deuxième groupe par sièges détenus (64) n'est pas celui de la majorité (59), donc
-   * la somme par rang donne 195 et non 190. Elle coïncidait sur les sièges remis en
-   * jeu parce que les deux groupes en ont 30, ce qui est exactement ainsi qu'un
-   * invariant faux passe une relecture. Un groupe s'identifie par son couple, jamais
-   * par son rang.
+   * deuxième par sièges détenus est SER avec 64, la majorité passe par UC avec 59, donc
+   * la somme par rang donne 195 et non 190. Elle coïncidait sur les sièges remis en jeu
+   * parce que SER et UC en ont 30 chacun, ce qui est exactement ainsi qu'un invariant
+   * faux passe une relecture.
    */
-  it("les 107 sur 190 viennent des couples attendus, pas du classement par taille", () => {
-    const c = validComposition();
-    const byHeld = [...c.groups].sort((a, b) => b.held - a.held).slice(0, 2);
-    expect(byHeld.reduce((s, g) => s + g.held, 0)).not.toBe(190);
-
-    const lr = c.groups.find((g) => g.held === 131 && g.atStake === 77)!;
-    const uc = c.groups.find((g) => g.held === 59 && g.atStake === 30)!;
-    expect(lr.held + uc.held).toBe(190);
-    expect(lr.atStake + uc.atStake).toBe(107);
-  });
-
-  it("exige un groupe distinct par couple attendu", () => {
-    const c = validComposition();
-    // Deux groupes au même couple 18/4 ne peuvent pas satisfaire deux attentes.
-    c.groups[1] = { ...c.groups[1]!, held: 18, atStake: 4 };
-    c.groups[2] = { ...c.groups[2]!, held: 105, atStake: 30 };
-    expect(verifyComposition(c).some((p) => p.includes("30 sièges remis en jeu sur 59"))).toBe(
-      true
-    );
+  it("ne se laisse pas dériver du classement par sièges détenus", () => {
+    const byHeld = Object.values(EXPECTED_SENATE_COMPOSITION).sort((a, b) => b.held - a.held);
+    const topTwo = byHeld.slice(0, 2);
+    expect(topTwo.reduce((s, g) => s + g.held, 0)).toBe(195);
+    expect(topTwo.reduce((s, g) => s + g.held, 0)).not.toBe(190);
+    // Et le piège : la somme des sièges remis en jeu coïncide malgré tout.
+    expect(topTwo.reduce((s, g) => s + g.atStake, 0)).toBe(107);
   });
 });
 
-describe("verifyComposition : refus", () => {
+describe("verifyComposition : capture conforme", () => {
+  it("ne signale rien sur une capture conforme", () => {
+    expect(verifyComposition(validComposition())).toEqual([]);
+  });
+});
+
+describe("verifyComposition : totaux et sièges", () => {
   it("refuse un total de sièges inattendu", () => {
     const c = { ...validComposition(), totalSeats: 351 };
     expect(verifyComposition(c).some((p) => p.includes("total des sièges"))).toBe(true);
@@ -92,7 +116,7 @@ describe("verifyComposition : refus", () => {
 
   it("refuse un nombre de sièges remis en jeu inattendu", () => {
     const c = { ...validComposition(), seatsAtStake: 176 };
-    expect(verifyComposition(c).some((p) => p.includes("sièges remis en jeu"))).toBe(true);
+    expect(verifyComposition(c).some((p) => p.includes("sièges remis en jeu : 176"))).toBe(true);
   });
 
   it("refuse une liste de sièges incomplète", () => {
@@ -104,7 +128,7 @@ describe("verifyComposition : refus", () => {
   // Capturer un siège de série 1 signifierait que la requête ne filtre pas ce qu'on croit.
   it("refuse un siège hors de la série renouvelée", () => {
     const c = validComposition();
-    c.seats[0] = seat(0, 1);
+    c.seats[0] = { ...c.seats[0]!, series: 1 };
     expect(verifyComposition(c).some((p) => p.includes("hors de la série renouvelée"))).toBe(true);
   });
 
@@ -120,33 +144,98 @@ describe("verifyComposition : refus", () => {
     expect(verifyComposition(c).some((p) => p.includes("sans identifiant"))).toBe(true);
   });
 
-  // L'agrégat et les lignes individuelles doivent raconter la même histoire.
-  it("refuse une somme par groupe incohérente avec les totaux", () => {
+  it("refuse un siège sans code de groupe", () => {
     const c = validComposition();
-    c.groups[0] = { ...c.groups[0]!, held: 130 };
+    c.seats[7] = { ...c.seats[7]!, groupCode: null };
+    expect(verifyComposition(c).some((p) => p.includes("sans code de groupe"))).toBe(true);
+  });
+});
+
+/**
+ * Validation exhaustive et symétrique : les neuf groupes sont vérifiés de la même
+ * manière, dans les deux sens. Aucun groupe attendu ne peut manquer, aucun groupe
+ * inattendu ne peut passer. Une empreinte anonyme laissait six groupes sans contrôle
+ * et survivait à une permutation d'identité entre deux groupes aux mêmes nombres.
+ */
+describe("verifyComposition : agrégat par code de groupe", () => {
+  it("refuse un groupe attendu absent", () => {
+    const c = validComposition();
+    c.groups = c.groups.filter((g) => g.groupCode !== "UC");
+    expect(verifyComposition(c).some((p) => p.includes("groupe UC absent"))).toBe(true);
+  });
+
+  it("refuse un groupe inattendu", () => {
+    const c = validComposition();
+    c.groups.push({
+      groupCode: "XXX",
+      groupName: "Groupe fantôme",
+      shortName: null,
+      held: 0,
+      atStake: 0,
+    });
+    expect(verifyComposition(c).some((p) => p.includes("groupe XXX inattendu"))).toBe(true);
+  });
+
+  it("refuse un groupe présent deux fois", () => {
+    const c = validComposition();
+    c.groups.push({ ...c.groups[0]! });
+    expect(verifyComposition(c).some((p) => p.includes("deux fois dans l'agrégat"))).toBe(true);
+  });
+
+  it("refuse des nombres qui ne correspondent pas au code", () => {
+    const c = validComposition();
+    c.groups = c.groups.map((g) => (g.groupCode === "LR" ? { ...g, atStake: 76 } : g));
+    expect(verifyComposition(c).some((p) => p.includes("groupe LR : 76 sur 131"))).toBe(true);
+  });
+
+  // Le piège que l'empreinte anonyme ne voyait pas : deux groupes aux mêmes nombres
+  // échangés. SER et UC ont tous deux 30 sièges remis en jeu.
+  it("refuse une permutation d'identité entre deux groupes aux mêmes sièges remis en jeu", () => {
+    const c = validComposition();
+    c.groups = c.groups.map((g) => {
+      if (g.groupCode === "SER") return { ...g, held: 59 };
+      if (g.groupCode === "UC") return { ...g, held: 64 };
+      return g;
+    });
     const problems = verifyComposition(c);
-    expect(problems.some((p) => p.includes("somme des sièges par groupe"))).toBe(true);
+    expect(problems.some((p) => p.includes("groupe SER"))).toBe(true);
+    expect(problems.some((p) => p.includes("groupe UC"))).toBe(true);
+  });
+});
+
+describe("verifyComposition : cohérence entre lignes et agrégat", () => {
+  it("refuse un agrégat qui annonce plus de sièges que ceux capturés", () => {
+    const c = validComposition();
+    // Un siège LR reversé à UC dans les lignes, agrégat inchangé.
+    c.seats[0] = { ...c.seats[0]!, groupCode: "UC", groupName: GROUP_NAMES.UC! };
+    const problems = verifyComposition(c);
+    expect(problems.some((p) => p.includes("groupe LR : 76 siège(s) capturé(s)"))).toBe(true);
+    expect(problems.some((p) => p.includes("groupe UC : 31 siège(s) capturé(s)"))).toBe(true);
   });
 
-  it("refuse l'absence d'une exposition de groupe attendue", () => {
+  it("refuse un groupe annonçant des sièges dont aucun n'est capturé", () => {
     const c = validComposition();
-    c.groups[5] = { ...c.groups[5]!, atStake: 5, held: 17 };
-    expect(verifyComposition(c).some((p) => p.includes("4 sièges remis en jeu sur 18"))).toBe(true);
-  });
-
-  it("refuse un couple de majorité altéré, même à totaux constants", () => {
-    const c = validComposition();
-    // Un siège déplacé du groupe à 59 vers un autre : les totaux restent justes, mais
-    // le couple 59/30 disparaît et l'addition 131 + 59 = 190 ne tient plus.
-    c.groups[1] = { ...c.groups[1]!, held: 58 };
-    c.groups[3] = { ...c.groups[3]!, held: 21 };
-    expect(verifyComposition(c).some((p) => p.includes("30 sièges remis en jeu sur 59"))).toBe(
-      true
-    );
+    c.seats = c.seats.filter((s) => s.groupCode !== "NI");
+    c.seats.push({ ...c.seats[0]!, politicianId: "pol_extra", slug: "extra" });
+    expect(verifyComposition(c).some((p) => p.includes("groupe NI annonce 1 siège(s)"))).toBe(true);
   });
 
   it("accumule tous les problèmes plutôt que de s'arrêter au premier", () => {
     const c = { ...validComposition(), totalSeats: 300, seatsAtStake: 100 };
-    expect(verifyComposition(c).length).toBeGreaterThan(2);
+    c.seats[0] = { ...c.seats[0]!, series: 1, politicianId: "" };
+    c.groups = c.groups.filter((g) => g.groupCode !== "NI");
+    const problems = verifyComposition(c);
+    // Total détenu, total remis en jeu, série, identifiant, groupe absent, sommes.
+    expect(problems.length).toBeGreaterThanOrEqual(6);
+    expect(problems.some((p) => p.includes("total des sièges"))).toBe(true);
+    expect(problems.some((p) => p.includes("hors de la série renouvelée"))).toBe(true);
+    expect(problems.some((p) => p.includes("sans identifiant"))).toBe(true);
+    expect(problems.some((p) => p.includes("groupe NI absent"))).toBe(true);
+  });
+});
+
+describe("summariseOutgoingMajority", () => {
+  it("additionne les sièges de la majorité sortante, 107 sur 190", () => {
+    expect(summariseOutgoingMajority(validComposition())).toEqual({ held: 190, atStake: 107 });
   });
 });

--- a/src/lib/senatoriales/outgoing-composition.ts
+++ b/src/lib/senatoriales/outgoing-composition.ts
@@ -1,14 +1,23 @@
 /**
  * Control invariants for the pre-ballot capture of the Senate's composition.
  *
- * The capture happens once and can never be redone, so it has to be checked before it
- * is trusted rather than after. These predicates are pure so they can be tested
- * without a database, and they are the same ones the capture script runs.
+ * The capture happens once and can never be redone, so it is checked before it is
+ * trusted rather than after. These predicates are pure, so they run in tests without a
+ * database, and the capture script runs exactly the same ones.
  *
- * They are stated as (held, atStake) pairs and never as group names. Two reasons: a
- * group can be renamed between now and the ballot, and naming parties in verification
- * code is the first step towards party-asymmetric logic, which AGENTS.md §2 forbids
- * outright. The pairs identify the groups without designating them.
+ * Validation is **exhaustive and symmetric**: every one of the nine Senate groups is
+ * declared by `ParliamentaryGroup.code`, and every one is checked the same way. Naming
+ * groups in reference data is not partisan logic; applying a different rule to one
+ * group would be, and none of that happens here.
+ *
+ * An earlier version listed only three anonymous `(held, atStake)` pairs, to avoid
+ * writing group names. That was weaker on two counts: a pair is an unlabelled
+ * fingerprint that survives an identity permutation between two groups with the same
+ * numbers, and six groups went unchecked entirely. It also produced an outright wrong
+ * invariant when the majority was derived by rank: the second largest group by seats
+ * held has 64, the majority partner has 59, so ranking sums to 195 rather than 190. It
+ * matched on seats at stake because both have 30, which is how a wrong invariant
+ * survives review.
  */
 
 import type { OutgoingSenateComposition } from "@/types/stats-snapshots";
@@ -16,25 +25,32 @@ import type { OutgoingSenateComposition } from "@/types/stats-snapshots";
 export const EXPECTED_TOTAL_SEATS = 348;
 export const EXPECTED_SEATS_AT_STAKE = 178;
 
+export interface GroupExposureExpectation {
+  held: number;
+  atStake: number;
+}
+
 /**
- * Group exposures that must be present, from the figures published for this renewal:
- * 77 of 131, 30 of 59, and 4 of 18.
+ * The full Senate as it stands before the 27 September 2026 renewal, by group code.
  *
- * The 107-of-190 figure for the outgoing senatorial majority is the sum of the first
- * two, so it is not checked separately: verifying both pairs already pins it, and
- * 131 + 59 = 190 needs no assertion.
- *
- * An earlier version derived the majority as "the two groups holding the most seats".
- * That is wrong: the second largest group by seats held (64) is not the one in the
- * majority (59), so the rank-based sum gives 195, not 190. It happened to match on
- * seats at stake because both groups have 30, which is exactly how a wrong invariant
- * survives review. Identify a group by its pair, never by its rank.
+ * Sums to 348 held and 178 at stake, and reproduces the published figures: 77 of 131
+ * for Les Républicains, 4 of 18 for the communist group, and 107 of 190 for the
+ * outgoing majority (LR plus Union Centriste, 77 + 30 of 131 + 59).
  */
-export const EXPECTED_GROUP_EXPOSURES: Array<{ held: number; atStake: number }> = [
-  { held: 131, atStake: 77 },
-  { held: 59, atStake: 30 },
-  { held: 18, atStake: 4 },
-];
+export const EXPECTED_SENATE_COMPOSITION: Record<string, GroupExposureExpectation> = {
+  LR: { held: 131, atStake: 77 }, // Les Républicains
+  SER: { held: 64, atStake: 30 }, // Socialiste, Écologiste et Républicain
+  UC: { held: 59, atStake: 30 }, // Union Centriste
+  LIRT: { held: 20, atStake: 9 }, // Les Indépendants - République et Territoires
+  RDPI: { held: 19, atStake: 11 }, // Rassemblement des démocrates, progressistes et indépendants
+  "CRCE-K": { held: 18, atStake: 4 }, // Communiste, Républicain, Citoyen et Écologiste - Kanaky
+  RDSE: { held: 17, atStake: 9 }, // Rassemblement Démocratique et Social Européen
+  GEST: { held: 16, atStake: 7 }, // Écologiste - Solidarité et Territoires
+  NI: { held: 4, atStake: 1 }, // Non-inscrits
+};
+
+/** Groups whose seats form the outgoing senatorial majority, for reporting only. */
+export const OUTGOING_MAJORITY_CODES = ["LR", "UC"] as const;
 
 /**
  * Everything wrong with a candidate capture. Empty means it is safe to write.
@@ -69,39 +85,99 @@ export function verifyComposition(composition: OutgoingSenateComposition): strin
     problems.push(`${duplicates} sénateur(s) capturé(s) deux fois`);
   }
 
-  const missingId = composition.seats.filter((s) => !s.politicianId || !s.fullName);
-  if (missingId.length > 0) {
-    problems.push(`${missingId.length} siège(s) sans identifiant ou sans nom`);
+  const incomplete = composition.seats.filter((s) => !s.politicianId || !s.fullName);
+  if (incomplete.length > 0) {
+    problems.push(`${incomplete.length} siège(s) sans identifiant ou sans nom`);
   }
 
-  // Group exposures must add up to the seat counts, otherwise the aggregate and the
-  // individual rows disagree and neither can be trusted.
-  const groupHeld = composition.groups.reduce((sum, g) => sum + g.held, 0);
-  const groupAtStake = composition.groups.reduce((sum, g) => sum + g.atStake, 0);
-  if (groupHeld !== composition.totalSeats) {
+  const seatsWithoutGroup = composition.seats.filter((s) => !s.groupCode);
+  if (seatsWithoutGroup.length > 0) {
     problems.push(
-      `somme des sièges par groupe : ${groupHeld}, incohérente avec le total ${composition.totalSeats}`
-    );
-  }
-  if (groupAtStake !== composition.seatsAtStake) {
-    problems.push(
-      `somme des sièges remis en jeu par groupe : ${groupAtStake}, incohérente avec ${composition.seatsAtStake}`
+      `${seatsWithoutGroup.length} siège(s) sans code de groupe, dont ${seatsWithoutGroup[0]!.fullName}`
     );
   }
 
-  // Each expected pair must be matched by a distinct group row, so one group cannot
-  // satisfy two expectations at once.
-  const unmatched = [...composition.groups];
-  for (const expected of EXPECTED_GROUP_EXPOSURES) {
-    const index = unmatched.findIndex(
-      (g) => g.held === expected.held && g.atStake === expected.atStake
-    );
-    if (index === -1) {
-      problems.push(`aucun groupe à ${expected.atStake} sièges remis en jeu sur ${expected.held}`);
+  // ─── Aggregate: every group, same check, both directions ───
+
+  const duplicateGroups =
+    composition.groups.length - new Set(composition.groups.map((g) => g.groupCode)).size;
+  if (duplicateGroups > 0) {
+    problems.push(`${duplicateGroups} groupe(s) présent(s) deux fois dans l'agrégat`);
+  }
+
+  const byCode = new Map(composition.groups.map((g) => [g.groupCode, g]));
+
+  for (const [code, expected] of Object.entries(EXPECTED_SENATE_COMPOSITION)) {
+    const actual = byCode.get(code);
+    if (!actual) {
+      problems.push(`groupe ${code} absent de l'agrégat`);
       continue;
     }
-    unmatched.splice(index, 1);
+    if (actual.held !== expected.held || actual.atStake !== expected.atStake) {
+      problems.push(
+        `groupe ${code} : ${actual.atStake} sur ${actual.held}, attendu ` +
+          `${expected.atStake} sur ${expected.held}`
+      );
+    }
+  }
+
+  for (const group of composition.groups) {
+    if (!(group.groupCode in EXPECTED_SENATE_COMPOSITION)) {
+      problems.push(`groupe ${group.groupCode} inattendu dans l'agrégat`);
+    }
+  }
+
+  const groupHeld = composition.groups.reduce((sum, g) => sum + g.held, 0);
+  const groupAtStake = composition.groups.reduce((sum, g) => sum + g.atStake, 0);
+  if (groupHeld !== EXPECTED_TOTAL_SEATS) {
+    problems.push(`somme des sièges par groupe : ${groupHeld}, attendu ${EXPECTED_TOTAL_SEATS}`);
+  }
+  if (groupAtStake !== EXPECTED_SEATS_AT_STAKE) {
+    problems.push(
+      `somme des sièges remis en jeu par groupe : ${groupAtStake}, attendu ${EXPECTED_SEATS_AT_STAKE}`
+    );
+  }
+
+  // ─── The 178 individual rows must agree with the aggregate ───
+
+  const seatsPerCode = new Map<string, number>();
+  for (const seat of composition.seats) {
+    if (!seat.groupCode) continue;
+    seatsPerCode.set(seat.groupCode, (seatsPerCode.get(seat.groupCode) ?? 0) + 1);
+  }
+  for (const [code, count] of seatsPerCode) {
+    const aggregate = byCode.get(code);
+    if (!aggregate) {
+      problems.push(`groupe ${code} présent sur des sièges capturés mais absent de l'agrégat`);
+      continue;
+    }
+    if (aggregate.atStake !== count) {
+      problems.push(
+        `groupe ${code} : ${count} siège(s) capturé(s) contre ${aggregate.atStake} annoncé(s) dans l'agrégat`
+      );
+    }
+  }
+  for (const group of composition.groups) {
+    if (group.atStake > 0 && !seatsPerCode.has(group.groupCode)) {
+      problems.push(
+        `groupe ${group.groupCode} annonce ${group.atStake} siège(s) remis en jeu mais aucun n'est capturé`
+      );
+    }
   }
 
   return problems;
+}
+
+/** Held and at-stake seats of the outgoing majority, for the operator's report. */
+export function summariseOutgoingMajority(composition: OutgoingSenateComposition): {
+  held: number;
+  atStake: number;
+} {
+  const codes = new Set<string>(OUTGOING_MAJORITY_CODES);
+  return composition.groups
+    .filter((g) => codes.has(g.groupCode))
+    .reduce((acc, g) => ({ held: acc.held + g.held, atStake: acc.atStake + g.atStake }), {
+      held: 0,
+      atStake: 0,
+    });
 }

--- a/src/lib/senatoriales/outgoing-composition.ts
+++ b/src/lib/senatoriales/outgoing-composition.ts
@@ -1,0 +1,107 @@
+/**
+ * Control invariants for the pre-ballot capture of the Senate's composition.
+ *
+ * The capture happens once and can never be redone, so it has to be checked before it
+ * is trusted rather than after. These predicates are pure so they can be tested
+ * without a database, and they are the same ones the capture script runs.
+ *
+ * They are stated as (held, atStake) pairs and never as group names. Two reasons: a
+ * group can be renamed between now and the ballot, and naming parties in verification
+ * code is the first step towards party-asymmetric logic, which AGENTS.md §2 forbids
+ * outright. The pairs identify the groups without designating them.
+ */
+
+import type { OutgoingSenateComposition } from "@/types/stats-snapshots";
+
+export const EXPECTED_TOTAL_SEATS = 348;
+export const EXPECTED_SEATS_AT_STAKE = 178;
+
+/**
+ * Group exposures that must be present, from the figures published for this renewal:
+ * 77 of 131, 30 of 59, and 4 of 18.
+ *
+ * The 107-of-190 figure for the outgoing senatorial majority is the sum of the first
+ * two, so it is not checked separately: verifying both pairs already pins it, and
+ * 131 + 59 = 190 needs no assertion.
+ *
+ * An earlier version derived the majority as "the two groups holding the most seats".
+ * That is wrong: the second largest group by seats held (64) is not the one in the
+ * majority (59), so the rank-based sum gives 195, not 190. It happened to match on
+ * seats at stake because both groups have 30, which is exactly how a wrong invariant
+ * survives review. Identify a group by its pair, never by its rank.
+ */
+export const EXPECTED_GROUP_EXPOSURES: Array<{ held: number; atStake: number }> = [
+  { held: 131, atStake: 77 },
+  { held: 59, atStake: 30 },
+  { held: 18, atStake: 4 },
+];
+
+/**
+ * Everything wrong with a candidate capture. Empty means it is safe to write.
+ */
+export function verifyComposition(composition: OutgoingSenateComposition): string[] {
+  const problems: string[] = [];
+
+  if (composition.totalSeats !== EXPECTED_TOTAL_SEATS) {
+    problems.push(`total des sièges : ${composition.totalSeats}, attendu ${EXPECTED_TOTAL_SEATS}`);
+  }
+  if (composition.seatsAtStake !== EXPECTED_SEATS_AT_STAKE) {
+    problems.push(
+      `sièges remis en jeu : ${composition.seatsAtStake}, attendu ${EXPECTED_SEATS_AT_STAKE}`
+    );
+  }
+  if (composition.seats.length !== EXPECTED_SEATS_AT_STAKE) {
+    problems.push(
+      `sièges capturés : ${composition.seats.length}, attendu ${EXPECTED_SEATS_AT_STAKE}`
+    );
+  }
+
+  const wrongSeries = composition.seats.filter((seat) => seat.series !== 2);
+  if (wrongSeries.length > 0) {
+    problems.push(
+      `${wrongSeries.length} siège(s) capturé(s) hors de la série renouvelée, dont ${wrongSeries[0]!.fullName}`
+    );
+  }
+
+  const duplicates =
+    composition.seats.length - new Set(composition.seats.map((s) => s.politicianId)).size;
+  if (duplicates > 0) {
+    problems.push(`${duplicates} sénateur(s) capturé(s) deux fois`);
+  }
+
+  const missingId = composition.seats.filter((s) => !s.politicianId || !s.fullName);
+  if (missingId.length > 0) {
+    problems.push(`${missingId.length} siège(s) sans identifiant ou sans nom`);
+  }
+
+  // Group exposures must add up to the seat counts, otherwise the aggregate and the
+  // individual rows disagree and neither can be trusted.
+  const groupHeld = composition.groups.reduce((sum, g) => sum + g.held, 0);
+  const groupAtStake = composition.groups.reduce((sum, g) => sum + g.atStake, 0);
+  if (groupHeld !== composition.totalSeats) {
+    problems.push(
+      `somme des sièges par groupe : ${groupHeld}, incohérente avec le total ${composition.totalSeats}`
+    );
+  }
+  if (groupAtStake !== composition.seatsAtStake) {
+    problems.push(
+      `somme des sièges remis en jeu par groupe : ${groupAtStake}, incohérente avec ${composition.seatsAtStake}`
+    );
+  }
+
+  // Each expected pair must be matched by a distinct group row, so one group cannot
+  // satisfy two expectations at once.
+  const unmatched = [...composition.groups];
+  for (const expected of EXPECTED_GROUP_EXPOSURES) {
+    const index = unmatched.findIndex(
+      (g) => g.held === expected.held && g.atStake === expected.atStake
+    );
+    if (index === -1) {
+      problems.push(`aucun groupe à ${expected.atStake} sièges remis en jeu sur ${expected.held}`);
+      continue;
+    }
+    unmatched.splice(index, 1);
+  }
+
+  return problems;
+}

--- a/src/types/stats-snapshots.ts
+++ b/src/types/stats-snapshots.ts
@@ -68,12 +68,15 @@ export const OutgoingSenateSeatSchema = z.object({
   departmentCode: z.string().nullable(),
   constituency: z.string().nullable(),
   series: z.number().int(),
+  /** `ParliamentaryGroup.code`, the stable identity a display name does not give. */
+  groupCode: z.string().nullable(),
   groupName: z.string().nullable(),
   groupShortName: z.string().nullable(),
 });
 export type OutgoingSenateSeat = z.infer<typeof OutgoingSenateSeatSchema>;
 
 export const OutgoingSenateGroupSchema = z.object({
+  groupCode: z.string(),
   groupName: z.string(),
   shortName: z.string().nullable(),
   held: z.number().int(),

--- a/src/types/stats-snapshots.ts
+++ b/src/types/stats-snapshots.ts
@@ -47,6 +47,51 @@ export type DeptPartyRow = z.infer<typeof DeptPartyRowSchema>;
 export const DeptPartyDataSchema = z.array(DeptPartyRowSchema);
 export type DeptPartyData = z.infer<typeof DeptPartyDataSchema>;
 
+// ─── senatoriales-2026-outgoing-composition ───────────────
+/**
+ * The Senate as it stood before the 27 September 2026 ballot.
+ *
+ * Unlike every other snapshot here, this one is not a cache: it is the only record of
+ * a state that stops existing. All reads of the Senate go through `Mandate` with
+ * `isCurrent = true`, so the first `sync:senat` after the ballot replaces the 178
+ * outgoing senators with the incoming ones, and nothing can reconstruct what was.
+ *
+ * It is therefore written once and never recomputed. Seats are stored individually
+ * rather than pre-aggregated: the post-ballot comparison (re-elected, newcomers,
+ * share of women) needs to join seat by seat, and aggregates cannot be un-summed.
+ */
+export const OutgoingSenateSeatSchema = z.object({
+  politicianId: z.string(),
+  /** Name as captured, so the record survives a later rename or merge. */
+  fullName: z.string(),
+  slug: z.string(),
+  departmentCode: z.string().nullable(),
+  constituency: z.string().nullable(),
+  series: z.number().int(),
+  groupName: z.string().nullable(),
+  groupShortName: z.string().nullable(),
+});
+export type OutgoingSenateSeat = z.infer<typeof OutgoingSenateSeatSchema>;
+
+export const OutgoingSenateGroupSchema = z.object({
+  groupName: z.string(),
+  shortName: z.string().nullable(),
+  held: z.number().int(),
+  atStake: z.number().int(),
+});
+export type OutgoingSenateGroup = z.infer<typeof OutgoingSenateGroupSchema>;
+
+export const OutgoingSenateCompositionSchema = z.object({
+  capturedAt: z.string(),
+  /** Total sitting senators at capture time, both series. */
+  totalSeats: z.number().int(),
+  /** Seats of the renewed series, which the ballot puts back in play. */
+  seatsAtStake: z.number().int(),
+  seats: z.array(OutgoingSenateSeatSchema),
+  groups: z.array(OutgoingSenateGroupSchema),
+});
+export type OutgoingSenateComposition = z.infer<typeof OutgoingSenateCompositionSchema>;
+
 // ─── Key registry ─────────────────────────────────────────
 export const MUNICIPALES_SNAPSHOT_KEYS = {
   parityOutliers: "municipales-2026-parite-outliers",
@@ -56,6 +101,12 @@ export const MUNICIPALES_SNAPSHOT_KEYS = {
 
 export type MunicipalesSnapshotKey =
   (typeof MUNICIPALES_SNAPSHOT_KEYS)[keyof typeof MUNICIPALES_SNAPSHOT_KEYS];
+
+/**
+ * Write-once key. `scripts/capture-senate-composition.ts` refuses to run if a row
+ * already carries it, so a second capture cannot overwrite the first.
+ */
+export const SENATE_OUTGOING_COMPOSITION_KEY = "senatoriales-2026-outgoing-composition";
 
 /**
  * Parse a `StatsSnapshot.data` JSON value with the right schema.


### PR DESCRIPTION
Ferme #700 et le volet bloquant de #698. **Les deux opérations ont déjà été exécutées en production**, avec leurs contrôles ; la PR apporte le code, ses garde-fous et ses tests.

## 1. Trois mandats périmés, fermés avec leur source

Éric Bocquet, Philippe Bas et Maurice Perrion restaient marqués `isCurrent` alors qu'ils ont quitté le Sénat. De source Wikidata et sans identifiant externe Sénat sur leur fiche, ils échappaient définitivement à l'étape de fermeture de `syncSenateurs()`, filtrée sur `source: DataSource.SENAT`.

Chaque date de fin est relevée sur la fiche du sénateur, avec son motif, et vérifiée avant écriture :

| Sénateur        | Fin de mandat   | Motif                                                  |
| --------------- | --------------- | ------------------------------------------------------ |
| Éric Bocquet    | 31 octobre 2024 | démissionnaire                                         |
| Maurice Perrion | 23 janvier 2025 | reprise du mandat par un ancien membre du Gouvernement |
| Philippe Bas    | 1er mars 2025   | nommé membre du Conseil constitutionnel                |

Le script est volontairement étroit : il ne touche pas aux `startDate` et ne règle rien de la provenance des 338 autres dates, qui reste #698. Il refuse d'agir si une personne porte plusieurs mandats courants, ou si la date de fin précède le début.

Résultat, vérifié par `npm run audit:senateurs-series` :

```
Base : 348 mandats sénatoriaux courants
  appariés à l'API : 348 (série 1 : 170, série 2 : 178)
--- Séries non stockées ou divergentes : 0 ---
--- Mandats courants absents de l'API : 0 ---
--- Sénateurs de l'API sans mandat courant en base : 0 ---
```

Tous les écarts structurels sont à zéro. Le cas Perrion confirme au passage que son `startDate` du 22 octobre 2024 était juste : il remplaçait Laurence Garnier, entrée au Gouvernement.

## 2. La composition sortante, capturée

`StatsSnapshot`, clé `senatoriales-2026-outgoing-composition`, schéma Zod dans `src/types/stats-snapshots.ts`. Les 178 sièges de la série renouvelée sont stockés **individuellement** (`politicianId`, nom capturé, circonscription, département, série, groupe), plus l'exposition par groupe et `capturedAt`. Un agrégat ne se dés-additionne pas, et la comparaison d'après scrutin joint siège par siège.

Trois refus, parce qu'une capture fausse est pire qu'une capture absente :

1. **Jamais d'upsert.** Si la clé existe, le script s'arrête et explique que la ligne est le seul témoignage d'un état disparu. Recapturer suppose de supprimer la ligne délibérément.
2. **Base conforme exigée** : 348 mandats courants et 178 sièges de série renouvelée, sinon arrêt. Une capture prise en cours de synchronisation figerait un état incomplet.
3. **Invariants recalculés** avant écriture, jamais supposés, et le schéma est parsé avant l'écriture et non seulement à la lecture.

Exécutée le 10 août : 178 sièges, invariants tenus, relecture Zod vérifiée (178 sièges, tous en série renouvelée, 178 identifiants distincts, aucun sans groupe). Une seconde exécution refuse bien d'écraser.

## Un invariant faux, attrapé par son propre test

La première version dérivait la majorité sénatoriale sortante comme « les deux groupes détenant le plus de sièges », pour éviter de nommer des partis dans du code de vérification.

C'est faux. Le deuxième groupe par sièges détenus en compte **64**, celui de la majorité en compte **59** : la somme par rang donne 195, pas 190. Elle coïncidait sur les sièges remis en jeu parce que les deux groupes en ont 30, ce qui est exactement la manière dont un invariant faux passe une relecture.

Un groupe s'identifie donc par son couple (sièges détenus, sièges remis en jeu), jamais par son rang. Les trois couples attendus doivent être satisfaits par des lignes **distinctes**, et le 107 sur 190 de la majorité découle de l'addition des deux premiers couples plutôt que d'une assertion séparée. Un test verrouille la leçon, en vérifiant explicitement que le classement par taille ne donne pas 190.

Aucun nom de parti n'apparaît dans le code de vérification, conformément à AGENTS.md §2.

## Ce que cela débloque

`getGroupExposure()` peut désormais afficher la composition sortante au passé après le scrutin, au lieu du retrait posé en garde dans #699. Et l'état 4 du hub devient reconstituable : réélus, nouveaux entrants et part de femmes se calculent en joignant cette capture aux mandats d'après scrutin.

## Suite

`scripts/fix-stale-senator-mandates.ts` est un one-shot : l'état qu'il répare a cessé d'exister au moment de son exécution. Il est versionné ici pour la traçabilité de l'écriture en production, et à supprimer dans une PR suivante, conformément à AGENTS.md §4.

Suite de #697 et #699. Ferme #700, débloque le reste de #698.
