### PR TITLE
fix(ui): garde l'infobulle ouverte après une tape sur mobile

### DIFF
--- a/src/components/ui/info-tooltip.test.tsx
+++ b/src/components/ui/info-tooltip.test.tsx
@@ -1,10 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { InfoTooltip } from "./info-tooltip";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
+// jsdom doesn't ship ResizeObserver; Radix positions the tooltip content with it.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
 function renderWithTooltip(ui: React.ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+/** A tap: `pointerdown`/`pointerup` with `pointerType: "touch"`, then the mouse events
+ *  the browser emulates from it — including the focus that used to open the tooltip
+ *  just before the click closed it again. */
+function tap(user: ReturnType<typeof userEvent.setup>, target: HTMLElement) {
+  return user.pointer({ target, keys: "[TouchA]" });
 }
 
 describe("InfoTooltip", () => {
@@ -21,5 +38,49 @@ describe("InfoTooltip", () => {
   it("should render with glossary term", () => {
     renderWithTooltip(<InfoTooltip term="sursis" />);
     expect(screen.getByRole("button", { name: /aide : sursis/i })).toBeInTheDocument();
+  });
+
+  /**
+   * Mobile has no hover. The definition has to survive the tap that asked for it,
+   * where it used to flash and disappear within the same gesture.
+   */
+  it("garde la définition affichée après une tape au doigt", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<InfoTooltip text="Une définition" />);
+
+    await tap(user, screen.getByRole("button", { name: /aide/i }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Une définition");
+  });
+
+  it("referme la définition à la tape suivante", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<InfoTooltip text="Une définition" />);
+    const trigger = screen.getByRole("button", { name: /aide/i });
+
+    await tap(user, trigger);
+    await screen.findByRole("tooltip");
+    await tap(user, trigger);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("ouvre toujours la définition au survol de la souris", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<InfoTooltip text="Une définition" />);
+
+    await user.hover(screen.getByRole("button", { name: /aide/i }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Une définition");
+  });
+
+  it("ouvre toujours la définition au clavier", async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(<InfoTooltip text="Une définition" />);
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: /aide/i })).toHaveFocus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Une définition");
   });
 });

--- a/src/components/ui/info-tooltip.tsx
+++ b/src/components/ui/info-tooltip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { GLOSSARY, type GlossaryKey } from "@/config/glossary";
@@ -21,7 +22,8 @@ interface InfoTooltipProps {
 }
 
 /**
- * Small info icon (?) that shows an explanatory tooltip on hover/focus.
+ * Small info icon (?) that shows an explanatory tooltip on hover/focus,
+ * and on tap for readers who have no pointer to hover with.
  * Accessible: focusable, announces content to screen readers.
  *
  * Usage:
@@ -37,16 +39,62 @@ export function InfoTooltip({
   className,
   side = "top",
 }: InfoTooltipProps) {
+  /* A tap fires, in this order, `pointerdown`, `focus`, then `click`. Radix opens the
+     tooltip on focus and closes it on click, so on mobile the definition appeared and
+     vanished in the same gesture — the bug reported on the sénatoriales hub. Nothing in
+     the sequence is avoidable, so the open state is driven here instead: the focus-opening
+     is ignored on touch and the tap becomes a toggle. Hover and keyboard keep Radix's own
+     behaviour, which already works. */
+  const [open, setOpen] = React.useState(false);
+  /** Whether the last pointer on the trigger was a finger or a stylus rather than a mouse. */
+  const isTouchRef = React.useRef(false);
+  /** Whether the tooltip was open when that pointer went down. */
+  const wasOpenRef = React.useRef(false);
+
   const content = term ? GLOSSARY[term] : text;
   if (!content) return null;
 
   const iconSize = size === "sm" ? "w-3.5 h-3.5" : "w-4 h-4";
 
+  const rememberPointerType = (event: React.PointerEvent<HTMLButtonElement>) => {
+    isTouchRef.current = event.pointerType !== "mouse";
+  };
+
   return (
-    <Tooltip>
+    <Tooltip
+      open={open}
+      onOpenChange={(next) => {
+        // Drop the opening that the tap's focus asks for; every closing is honoured,
+        // including the one from tapping outside or pressing Échap.
+        if (next && isTouchRef.current) return;
+        setOpen(next);
+      }}
+    >
       <TooltipTrigger asChild>
         <button
           type="button"
+          onPointerMove={rememberPointerType}
+          onPointerDown={(event) => {
+            rememberPointerType(event);
+            /* Radix closes an open tooltip on `pointerdown`, and a tap outside the tooltip
+               dismisses it too, so by the time the click lands the state no longer says
+               whether the finger meant to open or to close. Read it here instead: these
+               handlers run before Radix's own, which `Slot` composes after the child's. */
+            wasOpenRef.current = open;
+          }}
+          onClick={(event) => {
+            if (!isTouchRef.current) return;
+            /* Stops Radix's click handler, which would close what the focus just opened:
+               `composeEventHandlers` skips it once the event is default-prevented. The
+               button submits nothing, so preventing the default costs nothing. */
+            event.preventDefault();
+            setOpen(!wasOpenRef.current);
+          }}
+          onBlur={() => {
+            /* Leaving the trigger clears the touch flag: on a laptop with a touchscreen,
+               a later hover or Tab must open the tooltip the ordinary way. */
+            isTouchRef.current = false;
+          }}
           className={cn(
             "inline-flex items-center justify-center rounded-full text-muted-foreground/60 hover:text-muted-foreground transition-colors",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",


### PR DESCRIPTION
Sur mobile, l'infobulle « série » de la page sénatoriales apparaissait puis
disparaissait aussitôt. Une tape déclenche pointerdown, focus, puis click :
Radix ouvre l'infobulle au focus et la referme au click, dans le même geste.

`InfoTooltip` pilote donc désormais son état d'ouverture. Sur pointeur tactile,
l'ouverture venue du focus est ignorée et la tape devient une bascule ; le
survol souris et le clavier conservent le comportement de Radix. Vérifié sous
Chromium en émulation Pixel 5 : ouverture, fermeture à la tape suivante,
réouverture, et fermeture en tapant ailleurs.

Le correctif est dans le composant partagé, donc il vaut pour toutes les
infobulles d'aide (votes, déclarations, affaires, municipales).