### PR TITLE
Corriger le hub sénatoriales pour les deux séries

### DIFF
--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -145,7 +145,7 @@ export function CommuneLookup({ phase }: { phase: BallotPhase }) {
           Votre commune, vos grands électeurs
         </h2>
         <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
-          Combien de voix votre conseil municipal envoie-t-il au scrutin ?
+          Combien de grands électeurs le barème attribue-t-il à votre commune ?
         </p>
       </div>
 

--- a/src/app/elections/senatoriales-2026/_components/MunicipalBridge.tsx
+++ b/src/app/elections/senatoriales-2026/_components/MunicipalBridge.tsx
@@ -4,8 +4,8 @@ import { BRIDGE_STEPS, SOURCE_DECREE, SOURCE_ELECTORAL_CODE, SOURCE_SENAT } from
 
 /**
  * The thesis of the page, and therefore its first block of content: the September
- * ballot does not create its electorate, it inherits it from the councils elected in
- * March.
+ * ballot does not create its electorate, it inherits it from municipal councils. Which
+ * renewal a council participates in depends on its department's series.
  *
  * Rendered as an ordered list because the four steps are a sequence, not a set of
  * statistics. The arrows are decorative on desktop and disappear on mobile, where the
@@ -16,12 +16,11 @@ export function MunicipalBridge() {
     <section aria-labelledby="pont-heading" className="space-y-4">
       <div className="space-y-2">
         <h2 id="pont-heading" className="font-display text-xl font-bold tracking-tight md:text-2xl">
-          De votre conseil municipal au Sénat
+          Des conseils municipaux au Sénat
         </h2>
         <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
-          Le scrutin de septembre ne crée pas son électorat, il l{"'"}hérite. Le corps qui élit les
-          sénateurs a été composé par les conseils municipaux installés après les municipales, puis
-          désigné le 5 juin.
+          Les municipales déterminent les conseils municipaux. Selon la série de leur département,
+          ces conseils participent ensuite au renouvellement du Sénat en 2026 ou en 2029.
         </p>
       </div>
 

--- a/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { HUB_LEDE, HUB_LEDE_PAST, HUB_TITLE, HUB_TITLE_PAST } from "../../_content";
+import { BRIDGE_STEPS, HUB_LEDE, HUB_LEDE_PAST, HUB_TITLE, HUB_TITLE_PAST } from "../../_content";
 import { MunicipalBridge } from "../MunicipalBridge";
 
 const NATIONAL_HERO_VARIANTS = [HUB_TITLE, HUB_TITLE_PAST, HUB_LEDE, HUB_LEDE_PAST];
@@ -15,8 +15,10 @@ describe("MunicipalBridge", () => {
   it("garde les ledes avant et après scrutin sur le même périmètre de série 2", () => {
     for (const lede of [HUB_LEDE, HUB_LEDE_PAST]) {
       expect(lede).toMatch(/178 sièges de la série 2/i);
-      expect(lede).toMatch(/conseils municipaux concernés/i);
+      expect(lede).toMatch(/88 937, soit 95,2 %/i);
+      expect(lede).toMatch(/délégués des conseils municipaux/i);
       expect(lede).not.toMatch(/départements concernés/i);
+      expect(lede).not.toMatch(/désignés par les conseils municipaux/i);
     }
   });
 
@@ -28,11 +30,19 @@ describe("MunicipalBridge", () => {
     expect(HUB_LEDE_PAST).toMatch(/renouvellement[^.]*concernait 93 469/i);
   });
 
+  it("n'attribue pas la désignation de tous les délégués aux conseils municipaux", () => {
+    const bridgeCopy = BRIDGE_STEPS.flatMap(({ headline, detail }) => [headline, detail]).join(
+      ". "
+    );
+
+    expect(bridgeCopy).not.toMatch(/conseils?[^.]{0,80}désign/i);
+  });
+
   it("explique le calendrier propre à chaque série", () => {
     render(<MunicipalBridge />);
 
-    expect(screen.getByText(/série 2 les ont désignés le 5 juin 2026/i)).toBeInTheDocument();
-    expect(screen.getByText(/série 1, cette étape aura lieu.*2029/i)).toBeInTheDocument();
+    expect(screen.getByText(/série 2, cette étape a eu lieu le 5 juin 2026/i)).toBeInTheDocument();
+    expect(screen.getByText(/série 1, elle aura lieu.*2029/i)).toBeInTheDocument();
     expect(screen.getByText(/série 2 élus en 2026 siègent jusqu'en 2032/i)).toBeInTheDocument();
     expect(screen.getByText(/série 1 élus en 2029 siègent jusqu'en 2035/i)).toBeInTheDocument();
   });

--- a/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
@@ -20,11 +20,12 @@ describe("MunicipalBridge", () => {
     }
   });
 
-  it("décrit 93 469 comme l'effectif du collège, jamais comme une participation", () => {
+  it("décrit 93 469 comme un effectif agrégé, jamais comme une participation", () => {
     for (const lede of [HUB_LEDE, HUB_LEDE_PAST]) {
       expect(lede).not.toMatch(/93 469[^.]{0,120}(?:particip|vot)/i);
     }
-    expect(HUB_LEDE_PAST).toMatch(/collège électoral[^.]*comptait 93 469/i);
+    expect(HUB_LEDE_PAST).not.toMatch(/le collège électoral/i);
+    expect(HUB_LEDE_PAST).toMatch(/renouvellement[^.]*concernait 93 469/i);
   });
 
   it("explique le calendrier propre à chaque série", () => {

--- a/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
@@ -15,8 +15,16 @@ describe("MunicipalBridge", () => {
   it("garde les ledes avant et après scrutin sur le même périmètre de série 2", () => {
     for (const lede of [HUB_LEDE, HUB_LEDE_PAST]) {
       expect(lede).toMatch(/178 sièges de la série 2/i);
-      expect(lede).toMatch(/conseils municipaux des départements concernés/i);
+      expect(lede).toMatch(/conseils municipaux concernés/i);
+      expect(lede).not.toMatch(/départements concernés/i);
     }
+  });
+
+  it("décrit 93 469 comme l'effectif du collège, jamais comme une participation", () => {
+    for (const lede of [HUB_LEDE, HUB_LEDE_PAST]) {
+      expect(lede).not.toMatch(/93 469[^.]{0,120}(?:particip|vot)/i);
+    }
+    expect(HUB_LEDE_PAST).toMatch(/collège électoral[^.]*comptait 93 469/i);
   });
 
   it("explique le calendrier propre à chaque série", () => {

--- a/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/MunicipalBridge.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HUB_LEDE, HUB_LEDE_PAST, HUB_TITLE, HUB_TITLE_PAST } from "../../_content";
+import { MunicipalBridge } from "../MunicipalBridge";
+
+const NATIONAL_HERO_VARIANTS = [HUB_TITLE, HUB_TITLE_PAST, HUB_LEDE, HUB_LEDE_PAST];
+
+describe("MunicipalBridge", () => {
+  it("ne rattache aucun collège national de 2026 au conseil personnel du lecteur", () => {
+    for (const copy of NATIONAL_HERO_VARIANTS) {
+      expect(copy).not.toMatch(/votre (?:conseil|vote|délégué)/i);
+    }
+  });
+
+  it("garde les ledes avant et après scrutin sur le même périmètre de série 2", () => {
+    for (const lede of [HUB_LEDE, HUB_LEDE_PAST]) {
+      expect(lede).toMatch(/178 sièges de la série 2/i);
+      expect(lede).toMatch(/conseils municipaux des départements concernés/i);
+    }
+  });
+
+  it("explique le calendrier propre à chaque série", () => {
+    render(<MunicipalBridge />);
+
+    expect(screen.getByText(/série 2 les ont désignés le 5 juin 2026/i)).toBeInTheDocument();
+    expect(screen.getByText(/série 1, cette étape aura lieu.*2029/i)).toBeInTheDocument();
+    expect(screen.getByText(/série 2 élus en 2026 siègent jusqu'en 2032/i)).toBeInTheDocument();
+    expect(screen.getByText(/série 1 élus en 2029 siègent jusqu'en 2035/i)).toBeInTheDocument();
+  });
+
+  it("ne présente pas 2032 comme l'horizon de tout conseil élu en 2026", () => {
+    render(<MunicipalBridge />);
+
+    const bridge = screen.getByRole("region", { name: /des conseils municipaux au sénat/i });
+    expect(bridge).not.toHaveTextContent(/un conseil municipal.*jusqu'en 2032/i);
+    expect(bridge).toHaveTextContent(/2032.*série 1.*2035/i);
+  });
+});

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -137,12 +137,12 @@ export const HUB_TITLE_PAST = "La composition du Sénat s'est jouée dans les co
 
 export const HUB_LEDE =
   "Vous ne voterez pas directement aux élections sénatoriales. Le 27 septembre 2026, " +
-  "93 469 grands électeurs participeront au renouvellement des 178 sièges de la série 2. " +
-  "Parmi eux, 95,2 % ont été désignés par les conseils municipaux des départements concernés.";
+  "93 469 grands électeurs sont appelés à renouveler les 178 sièges de la série 2. Parmi eux, " +
+  "95,2 % ont été désignés par les conseils municipaux concernés.";
 export const HUB_LEDE_PAST =
-  "Le 27 septembre 2026, 93 469 grands électeurs ont participé au renouvellement des 178 " +
-  "sièges de la série 2. Parmi eux, 95,2 % avaient été désignés par les conseils municipaux " +
-  "des départements concernés.";
+  "Le collège électoral convoqué pour renouveler les 178 sièges de la série 2 comptait " +
+  "93 469 grands électeurs. Parmi eux, 95,2 % avaient été désignés par les conseils " +
+  "municipaux concernés.";
 
 // ─── From your council to the Senate ────────────────────────────────
 

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -132,15 +132,17 @@ export const SOURCE_FEHF_POLL = {
 
 // ─── The thesis ─────────────────────────────────────────────────────
 
-export const HUB_TITLE = "Les sénatoriales commencent dans votre conseil municipal";
+export const HUB_TITLE = "Des municipales au renouvellement du Sénat";
 export const HUB_TITLE_PAST = "La composition du Sénat s'est jouée dans les conseils municipaux";
 
 export const HUB_LEDE =
-  "Vous ne voterez pas directement aux élections sénatoriales. Ce sont 93 469 grands électeurs qui éliront les sénateurs, " +
-  "et 95,2 % d'entre eux ont été désignés par les conseils municipaux issus des élections municipales.";
+  "Vous ne voterez pas directement aux élections sénatoriales. Le 27 septembre 2026, " +
+  "93 469 grands électeurs participeront au renouvellement des 178 sièges de la série 2. " +
+  "Parmi eux, 95,2 % ont été désignés par les conseils municipaux des départements concernés.";
 export const HUB_LEDE_PAST =
-  "Le scrutin a eu lieu. 93 469 grands électeurs ont élu les sénateurs. " +
-  "Parmi eux, 95,2 % avaient été désignés par les conseils municipaux issus de votre vote.";
+  "Le 27 septembre 2026, 93 469 grands électeurs ont participé au renouvellement des 178 " +
+  "sièges de la série 2. Parmi eux, 95,2 % avaient été désignés par les conseils municipaux " +
+  "des départements concernés.";
 
 // ─── From your council to the Senate ────────────────────────────────
 
@@ -159,25 +161,25 @@ export const BRIDGE_STEPS: BridgeStep[] = [
       "moment de la chaîne où vous déposez un bulletin.",
   },
   {
-    when: "5 juin 2026",
-    headline: "Les conseils désignent leurs délégués",
+    when: "Selon la série",
+    headline: "Les conseils concernés désignent leurs délégués",
     detail:
-      "93 469 grands électeurs, dont 95,2 % de délégués des conseils municipaux. Le nombre de " +
-      "délégués d'une commune découle d'un barème, pas d'une négociation.",
+      "Ceux de la série 2 les ont désignés le 5 juin 2026. Pour la série 1, cette étape " +
+      "aura lieu lors du renouvellement de 2029.",
   },
   {
-    when: "27 septembre 2026",
+    when: "2026 ou 2029",
     headline: "Les grands électeurs élisent les sénateurs",
     detail:
-      "178 sièges sur 348, dans 64 circonscriptions : 63 départements et collectivités, plus " +
-      "les Français établis hors de France. Le vote y est obligatoire.",
+      "Le 27 septembre 2026, 178 sièges de la série 2 sont renouvelés. Les départements de " +
+      "série 1 seront concernés en 2029.",
   },
   {
-    when: "Jusqu'en 2032",
+    when: "Mandat de six ans",
     headline: "Les sénateurs siègent six ans",
     detail:
-      "Le Sénat ne peut pas être dissous. Un conseil municipal élu en mars 2026 pèse donc sur " +
-      "la chambre haute jusqu'en 2032.",
+      "Les sénateurs de série 2 élus en 2026 siègent jusqu'en 2032. Ceux de série 1 élus en " +
+      "2029 siègent jusqu'en 2035.",
   },
 ];
 

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -138,10 +138,10 @@ export const HUB_TITLE_PAST = "La composition du Sénat s'est jouée dans les co
 export const HUB_LEDE =
   "Vous ne voterez pas directement aux élections sénatoriales. Le 27 septembre 2026, " +
   "93 469 grands électeurs sont appelés à renouveler les 178 sièges de la série 2. Parmi eux, " +
-  "95,2 % ont été désignés par les conseils municipaux concernés.";
+  "88 937, soit 95,2 %, sont des délégués des conseils municipaux.";
 export const HUB_LEDE_PAST =
   "Le renouvellement des 178 sièges de la série 2 concernait 93 469 grands électeurs. " +
-  "Parmi eux, 95,2 % avaient été désignés par les conseils municipaux concernés.";
+  "Parmi eux, 88 937, soit 95,2 %, étaient des délégués des conseils municipaux.";
 
 // ─── From your council to the Senate ────────────────────────────────
 
@@ -161,10 +161,10 @@ export const BRIDGE_STEPS: BridgeStep[] = [
   },
   {
     when: "Selon la série",
-    headline: "Les conseils concernés désignent leurs délégués",
+    headline: "Les délégués municipaux sont désignés",
     detail:
-      "Ceux de la série 2 les ont désignés le 5 juin 2026. Pour la série 1, cette étape " +
-      "aura lieu lors du renouvellement de 2029.",
+      "Pour la série 2, cette étape a eu lieu le 5 juin 2026. Pour la série 1, elle aura lieu " +
+      "lors du renouvellement de 2029.",
   },
   {
     when: "2026 ou 2029",

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -140,9 +140,8 @@ export const HUB_LEDE =
   "93 469 grands électeurs sont appelés à renouveler les 178 sièges de la série 2. Parmi eux, " +
   "95,2 % ont été désignés par les conseils municipaux concernés.";
 export const HUB_LEDE_PAST =
-  "Le collège électoral convoqué pour renouveler les 178 sièges de la série 2 comptait " +
-  "93 469 grands électeurs. Parmi eux, 95,2 % avaient été désignés par les conseils " +
-  "municipaux concernés.";
+  "Le renouvellement des 178 sièges de la série 2 concernait 93 469 grands électeurs. " +
+  "Parmi eux, 95,2 % avaient été désignés par les conseils municipaux concernés.";
 
 // ─── From your council to the Senate ────────────────────────────────
 

--- a/src/app/elections/senatoriales-2026/page.tsx
+++ b/src/app/elections/senatoriales-2026/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata(): Promise<Metadata> {
       "Sénatoriales 2026 : la composition du Sénat se joue dans les conseils municipaux | Poligraph",
     description:
       "Le 27 septembre 2026, 178 sièges du Sénat sont renouvelés par 93 469 grands électeurs. " +
-      "Vos délégués, le barème du collège et les sénateurs sortants de votre département.",
+      "Le calendrier par série, le barème du collège et les sénateurs sortants par département.",
     alternates: { canonical: `/elections/${SENATORIALES_2026_SLUG}` },
   };
 }


### PR DESCRIPTION
## Contexte

Le hub national associait encore le renouvellement sénatorial de 2026 au conseil municipal personnel du lecteur et présentait 2032 comme un horizon universel. Ces formulations étaient fausses dans les départements de série 1, renouvelés en 2029.

Closes #705

## Modifications

- rend le héros national vrai pour les séries 1 et 2, avant comme après le scrutin
- distingue la désignation et le renouvellement de 2026 pour la série 2 de ceux de 2029 pour la série 1
- rattache explicitement les horizons 2032 et 2035 à leur série
- clarifie la metadata et l'invite de recherche locale
- ajoute des tests éditoriaux sur les invariants, sans figer toute la rédaction

## Vérifications

- `npm run typecheck`
- `npm run test:run` (4 088 tests réussis, 379 ignorés)
- `npm run build`
- ESLint et Prettier sur les cinq fichiers via le hook pré-commit
- navigateur desktop : Bordeaux, série 2, avant et après recherche
- navigateur mobile : Nantes, série 1, avant et après recherche

Le `npm run lint` global rencontre sur `main` une erreur de configuration ESLint : la règle `react-hooks/set-state-in-effect` référence un plugin non enregistré. Le lint ciblé du commit passe.
