### PR TITLE
Écrire la doctrine réseaux sociaux dans le dépôt

### DIFF
--- a/docs/editorial/reseaux-sociaux.md
+++ b/docs/editorial/reseaux-sociaux.md
@@ -1,0 +1,96 @@
+# Réseaux sociaux : règles opposables
+
+Ce que Poligraph publie sur ses comptes suit les mêmes exigences que le site, avec une contrainte de
+plus : une publication sortie de son contexte reste lisible et reste citée. Un visuel se repartage
+seul, sans la page qui le portait, et il ne se corrige plus une fois publié.
+
+Ce document fixe les règles. Il ne contient ni calendrier, ni contenu à venir, ni plan de saison :
+ces éléments sont datés et n'ont pas leur place dans un dépôt public.
+
+---
+
+## 1. Un compte est un média, pas un canal de distribution
+
+Une publication doit valoir pour qui ne cliquera jamais vers le site. Cela exclut le teasing, le
+renvoi sans contenu et le post de présentation. Le lien vers poligraph.fr est une suite possible,
+jamais la raison d'être de la publication.
+
+Conséquence pratique : si le contenu ne tient pas dans le format, on ajoute un visuel plutôt que de
+réduire l'information, et on renonce plutôt que de publier une version amputée.
+
+## 2. La portée d'un chiffre
+
+**Un chiffre ne se publie qu'avec ce qu'il mesure.** Deux familles ne se confondent pas :
+
+- les chiffres qui mesurent **le pays**, établis par une source publique (un texte, une institution) ;
+- les chiffres qui mesurent **la couverture de Poligraph**, c'est-à-dire l'état de notre collecte.
+
+Un décompte d'élus présents dans notre base ne dit pas combien il y en a en France : il dit combien
+nous en avons enregistrés. Publié sans cette précision, il transforme une limite de collecte en
+affirmation sur le réel. La règle vaut aussi pour les décomptes internes présentés comme des
+résultats, du type « N mesures vérifiées » : la mention de Poligraph est obligatoire.
+
+Corollaire : un chiffre issu d'un texte de loi se cite par le texte, jamais par notre décompte. Un
+décompte de mandats publie une vacance comme si elle était la règle, là où le texte donne le nombre
+statutaire.
+
+## 3. Le fait d'abord
+
+Aucun adjectif de jugement, aucun verbe d'intention prêté à quiconque. Une publication décrit ce qui
+est établi, avec sa date et sa source.
+
+**Ne jamais dramatiser la difficulté d'accès à l'information.** « Les données sont publiques mais
+difficiles à suivre » se vérifie ; « on vous cache tout » ne se vérifie pas.
+
+**Ne jamais plaider sa propre neutralité.** Sont interdits « nous ne classons pas », « sans parti
+pris », « nous n'inventons rien ». La provenance de la donnée et sa date font le travail : la
+neutralité se constate dans le contenu, elle ne s'annonce pas.
+
+**Aucun classement nominatif**, aucun score d'affrontement entre personnes ou entre partis.
+
+## 4. Sourcer
+
+Une ligne de source accompagne chaque publication qui porte des données : quelle autorité, à quelle
+date, sous quelle référence. Si le gabarit visuel n'a pas d'emplacement pour cette ligne, c'est le
+gabarit qu'il faut corriger, pas la règle.
+
+Nommer la source par ce qui l'établit. Une date de scrutin est indicative tant que le texte qui la
+fixe n'est pas publié ; une fois publié, c'est lui qu'on cite.
+
+## 5. Le judiciaire entre par la pédagogie
+
+Les affaires judiciaires ne font pas l'objet de publications nominatives. Ce qui se publie, c'est la
+grammaire : comment lire une mise en examen, ce que change un non-lieu, pourquoi relaxe et
+acquittement ne sont pas synonymes.
+
+La raison tient au format autant qu'au fond. Un visuel se repartage hors contexte : la mention de
+présomption d'innocence ne suit pas la capture d'écran de celui qui la précédait, et l'espace de
+commentaires se transforme en tribunal. Aucun décompte de condamnations n'est publié, et aucune
+comparaison entre personnes sur ce terrain.
+
+## 6. Fact-checks
+
+Le verdict publié est celui du média vérificateur, jamais celui de Poligraph, et il est attribué
+comme tel. Nous rapportons une vérification, nous n'en produisons pas.
+
+## 7. Revue de presse
+
+Titre, média, date, lien. Rien du corps de l'article, aucun résumé généré. Republier le contenu
+d'un éditeur n'entre pas dans ce que nous faisons, et un résumé produit automatiquement engage notre
+responsabilité sur un texte que nous n'avons pas écrit.
+
+## 8. Travail parlementaire
+
+Toute publication sur la participation rappelle qu'un scrutin public ne couvre pas l'ensemble du
+travail parlementaire : commissions, rapports et amendements n'y figurent pas. Un taux de présence
+en séance n'est pas une mesure d'activité.
+
+## 9. Une publication ne se corrige pas
+
+Sur la plupart des plateformes, la légende s'édite, le visuel non : corriger une image impose de
+supprimer et republier. Une publication est donc un instantané figé pendant que le site reste
+vivant.
+
+Cela pèse sur la formulation. Un chiffre susceptible d'être révisé se présente par ce qui le
+produit plutôt que par sa valeur seule, et une règle se formule par le texte qui la fixe plutôt que
+par son résultat du jour.


### PR DESCRIPTION
## Pourquoi

Les règles éditoriales des comptes sociaux ne vivaient que dans un document de travail sous `docs/superpowers/`, répertoire gitignoré. Elles n'existaient donc que sur une machine, et personne d'autre ne pouvait les lire ni les opposer.

`docs/editorial/` porte déjà deux doctrines versionnées (`candidatures-et-mesures.md`, `qualifications-mesures.md`). Ce document rejoint la même famille et suit la même forme : titre, cadrage, règles opposables, aucun front-matter.

## Ce qui entre, ce qui reste dehors

Entrent les règles qui survivent aux saisons : la portée d'un chiffre, le fait d'abord, l'interdiction de plaider sa propre neutralité, le traitement du judiciaire par la pédagogie, la revue de presse limitée à titre / média / date / lien, le rappel sur le travail parlementaire.

Restent hors du dépôt le calendrier de publication, le texte des publications à venir et le plan de saison. Le dépôt est public : y committer du contenu non publié reviendrait à le publier.

## Deux règles qui méritent d'être signalées

**La portée d'un chiffre.** Un décompte issu de notre base mesure notre collecte, pas le pays. Publié sans cette précision, il transforme une limite de collecte en affirmation sur le réel. Le document énonce la règle sans citer de chiffre de production, pour ne pas se périmer et ne rien exposer.

**Une publication ne se corrige pas.** La légende s'édite, le visuel non. Cela pèse sur la formulation : un chiffre révisable se présente par ce qui le produit plutôt que par sa valeur seule.

## Périmètre

Un seul fichier ajouté, aucun code touché. Le document est indépendant de la plateforme, il vaudra pour Bluesky et X.

`AGENTS.md` ne référence pas `docs/editorial/` et le dossier n'a pas d'index : rien à raccorder, mais c'est peut-être un manque à traiter séparément.