### PR TITLE
fix(senatoriales): séparer les sièges statutaires des mandats

### DIFF
--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -13,6 +13,7 @@ import type { CommuneCollege } from "@/lib/senatoriales/college";
 import type { DepartmentRenewal, SittingSenator } from "@/lib/data/senatoriales";
 import {
   SOURCE_ELECTORAL_CODE,
+  SOURCE_MAYOTTE_SEATS,
   SOURCE_SENAT,
   SOURCE_TABLEAU_5,
   SOURCE_TABLEAU_6,
@@ -224,6 +225,10 @@ function CommuneAnswerPanel({ answer, phase }: { answer: CommuneAnswer; phase: B
   const { commune, college, inhabitantsPerDelegate, renewal, seatsAtStake, senators } = answer;
   const locative = getDepartmentLocative(commune.departmentCode);
   const where = locative ?? `dans le département ${commune.departmentName}`;
+  const statutorySources =
+    commune.departmentCode === "976"
+      ? [SOURCE_TABLEAU_5, SOURCE_MAYOTTE_SEATS]
+      : [SOURCE_TABLEAU_5, SOURCE_TABLEAU_6];
 
   return (
     <div className="space-y-4">
@@ -314,8 +319,12 @@ function CommuneAnswerPanel({ answer, phase }: { answer: CommuneAnswer; phase: B
       <SenatorsList senators={senators} where={where} />
 
       <SourceLine
-        sources={[SOURCE_TABLEAU_5, SOURCE_TABLEAU_6, SOURCE_SENAT, SOURCE_ELECTORAL_CODE]}
-        note="Série et sièges issus des tableaux légaux ; titulaires issus du Sénat ; barème appliqué à la population municipale et à l'effectif du conseil"
+        sources={[...statutorySources, SOURCE_SENAT, SOURCE_ELECTORAL_CODE]}
+        note={
+          commune.departmentCode === "976"
+            ? "Mayotte : 2 sièges selon LO473, renouvelés avec la série 1 selon L474 ; titulaires issus du Sénat ; barème appliqué à la population municipale et à l'effectif du conseil"
+            : "Série et sièges issus des tableaux légaux ; titulaires issus du Sénat ; barème appliqué à la population municipale et à l'effectif du conseil"
+        }
       />
     </div>
   );

--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -11,7 +11,13 @@ import { SourceLine } from "@/components/ui/SourceLine";
 import { getDepartmentLocative } from "@/config/department-prepositions";
 import type { CommuneCollege } from "@/lib/senatoriales/college";
 import type { DepartmentRenewal, SittingSenator } from "@/lib/data/senatoriales";
-import { SOURCE_ELECTORAL_CODE, SOURCE_SENAT, type BallotPhase } from "../_content";
+import {
+  SOURCE_ELECTORAL_CODE,
+  SOURCE_SENAT,
+  SOURCE_TABLEAU_5,
+  SOURCE_TABLEAU_6,
+  type BallotPhase,
+} from "../_content";
 
 interface CommuneStub {
   id: string;
@@ -291,8 +297,8 @@ function CommuneAnswerPanel({ answer, phase }: { answer: CommuneAnswer; phase: B
           )}
           {renewal === "unknown" && (
             <MissingData title="Série de renouvellement inconnue">
-              Nous ne savons pas si les sièges de ce département sont remis en jeu cette année. La
-              série est reprise de l{"'"}open data du Sénat.
+              Le code de cette circonscription est absent de notre référentiel légal. Nous ne lui
+              attribuons ni série ni nombre de sièges par approximation.
             </MissingData>
           )}
         </div>
@@ -308,8 +314,8 @@ function CommuneAnswerPanel({ answer, phase }: { answer: CommuneAnswer; phase: B
       <SenatorsList senators={senators} where={where} />
 
       <SourceLine
-        sources={[SOURCE_SENAT, SOURCE_ELECTORAL_CODE]}
-        note="Barème appliqué à la population municipale et à l'effectif du conseil"
+        sources={[SOURCE_TABLEAU_5, SOURCE_TABLEAU_6, SOURCE_SENAT, SOURCE_ELECTORAL_CODE]}
+        note="Série et sièges issus des tableaux légaux ; titulaires issus du Sénat ; barème appliqué à la population municipale et à l'effectif du conseil"
       />
     </div>
   );

--- a/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
+++ b/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
@@ -1,6 +1,6 @@
 import { SourceLine } from "@/components/ui/SourceLine";
 import { MissingData } from "@/components/ui/MissingData";
-import type { GroupExposure } from "@/lib/data/senatoriales";
+import type { GroupExposureSummary } from "@/lib/data/senatoriales";
 import {
   SENATE_SEATS_AT_STAKE,
   SENATE_SEATS_TOTAL,
@@ -12,15 +12,19 @@ import {
 /**
  * How exposed each Senate group is to this renewal.
  *
- * Computed from `Mandate.senateSeries`, so the Sénat is the only source needed: the
- * design quoted a press tally for the same figures, and this query reproduces them
- * (107 of 190 for the outgoing majority, 77 of 131 for Les Républicains, 4 of 18 for
- * the communists). A group's exposure follows the series its seats belong to, not its
- * size, which is the point worth showing.
+ * Group attribution is computed from current mandates. The statutory total remains
+ * separate: any gap is displayed without assigning a vacant or incomplete seat to a group.
  *
  * No projection of any kind: the bars measure seats *at stake*, never seats expected.
  */
-export function SeatsAtStake({ groups, phase }: { groups: GroupExposure[]; phase: BallotPhase }) {
+export function SeatsAtStake({
+  exposure,
+  phase,
+}: {
+  exposure: GroupExposureSummary;
+  phase: BallotPhase;
+}) {
+  const { groups, unattributedAtStake, isConsistent } = exposure;
   const ranked = groups.filter((g) => g.held > 0).sort((a, b) => b.atStake - a.atStake);
 
   /**
@@ -79,7 +83,12 @@ export function SeatsAtStake({ groups, phase }: { groups: GroupExposure[]; phase
         </p>
       </div>
 
-      {ranked.length === 0 ? (
+      {!isConsistent ? (
+        <MissingData title="Répartition par groupe incohérente">
+          Nos mandats attribuent plus de sièges aux groupes que le total légal de la série 2. La
+          ventilation est retirée tant que les données ne sont pas corrigées.
+        </MissingData>
+      ) : ranked.length === 0 ? (
         <MissingData title="Répartition par groupe indisponible">
           La série de renouvellement n{"'"}est pas encore renseignée sur les mandats sénatoriaux.
           Elle est reprise de l{"'"}open data du Sénat à chaque synchronisation.
@@ -121,6 +130,21 @@ export function SeatsAtStake({ groups, phase }: { groups: GroupExposure[]; phase
               </li>
             );
           })}
+          {unattributedAtStake > 0 && (
+            <li className="rounded-lg border border-dashed border-border p-3">
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                <p className="text-sm font-medium">Non attribué à un groupe dans nos données</p>
+                <p className="text-sm tabular-nums text-muted-foreground">
+                  <span className="font-semibold text-foreground">{unattributedAtStake}</span>
+                  <span> siège{unattributedAtStake > 1 ? "s" : ""} de la série 2</span>
+                </p>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Siège vacant ou mandat sans série ou groupe renseigné. Aucun groupe n{"'"}est
+                déduit.
+              </p>
+            </li>
+          )}
         </ul>
       )}
 
@@ -128,7 +152,7 @@ export function SeatsAtStake({ groups, phase }: { groups: GroupExposure[]; phase
           from tableau n° 5, the per-group breakdown from our own count of sitting mandates. */}
       <SourceLine
         sources={[SOURCE_TABLEAU_5, SOURCE_SENAT]}
-        note="Tableau n° 5 pour les 178 sièges de la série 2, répartition par groupe comptée sur les mandats sénatoriaux en cours"
+        note="Tableau n° 5 pour les 178 sièges de la série 2, attribution aux groupes comptée sur les mandats sénatoriaux en cours ; tout écart reste non attribué"
       />
     </section>
   );

--- a/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
+++ b/src/app/elections/senatoriales-2026/_components/SeatsAtStake.tsx
@@ -13,7 +13,7 @@ import {
  * How exposed each Senate group is to this renewal.
  *
  * Group attribution is computed from current mandates. The statutory total remains
- * separate: any gap is displayed without assigning a vacant or incomplete seat to a group.
+ * separate: each gap is displayed without assigning a vacant or incomplete seat to a group.
  *
  * No projection of any kind: the bars measure seats *at stake*, never seats expected.
  */

--- a/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
@@ -25,6 +25,12 @@ const BERNOS = {
   departmentName: "Gironde",
 };
 const PARIS = { id: "75056", name: "Paris", departmentCode: "75", departmentName: "Paris" };
+const MAMOUDZOU = {
+  id: "97611",
+  name: "Mamoudzou",
+  departmentCode: "976",
+  departmentName: "Mayotte",
+};
 
 const BAZAS_ANSWER = {
   commune: BAZAS,
@@ -84,6 +90,15 @@ const PARIS_ANSWER = {
     total: 2755,
   },
   inhabitantsPerDelegate: 763.6,
+  renewal: "not-renewed",
+  seatsAtStake: null,
+  senators: [],
+};
+
+const MAMOUDZOU_ANSWER = {
+  commune: MAMOUDZOU,
+  college: null,
+  inhabitantsPerDelegate: null,
   renewal: "not-renewed",
   seatsAtStake: null,
   senators: [],
@@ -380,5 +395,26 @@ describe("CommuneLookup : absences", () => {
     await search("33430");
 
     await screen.findByText(/La recherche a échoué/);
+  });
+});
+
+describe("CommuneLookup : provenance statutaire", () => {
+  it("source précisément les deux sièges et la série de Mayotte", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "cp=97600": { postalCode: "97600", communes: [MAMOUDZOU] },
+        "insee=97611": MAMOUDZOU_ANSWER,
+      })
+    );
+    render(<CommuneLookup phase="before" />);
+    await search("97600");
+
+    expect(await screen.findByText(/Mayotte : 2 sièges selon LO473/)).toBeVisible();
+    expect(screen.getByRole("link", { name: /LO473 et L474/ })).toHaveAttribute(
+      "href",
+      expect.stringContaining("LEGISCTA000006148536")
+    );
+    expect(screen.queryByRole("link", { name: /tableau n° 6/ })).toBeNull();
   });
 });

--- a/src/app/elections/senatoriales-2026/_components/__tests__/SeatsAtStake.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/SeatsAtStake.test.tsx
@@ -8,10 +8,11 @@ const GROUPS = [
   { groupName: "Union Centriste", shortName: "UC", color: "#FF9900", held: 59, atStake: 30 },
   { groupName: "CRCE-K", shortName: null, color: null, held: 18, atStake: 4 },
 ];
+const EXPOSURE = { groups: GROUPS, unattributedAtStake: 0, isConsistent: true };
 
 describe("SeatsAtStake avant le scrutin", () => {
   it("rend l'exposition de chaque groupe, calculée et non citée", () => {
-    render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    render(<SeatsAtStake exposure={EXPOSURE} phase="before" />);
     expect(screen.getByText("Ce qui est remis en jeu")).toBeInTheDocument();
     expect(screen.getByText("77")).toBeInTheDocument();
     expect(screen.getByText(/sur 131 sièges/)).toBeInTheDocument();
@@ -19,14 +20,19 @@ describe("SeatsAtStake avant le scrutin", () => {
   });
 
   it("classe par nombre de sièges remis en jeu, pas par taille de groupe", () => {
-    render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    render(<SeatsAtStake exposure={EXPOSURE} phase="before" />);
     const names = screen.getAllByRole("listitem").map((li) => li.textContent ?? "");
     expect(names[0]).toContain("Les Républicains");
     expect(names[2]).toContain("CRCE-K");
   });
 
   it("dit l'absence quand la série n'est pas encore renseignée", () => {
-    render(<SeatsAtStake groups={[]} phase="before" />);
+    render(
+      <SeatsAtStake
+        exposure={{ groups: [], unattributedAtStake: 178, isConsistent: true }}
+        phase="before"
+      />
+    );
     expect(screen.getByText(/Répartition par groupe indisponible/)).toBeInTheDocument();
   });
 
@@ -36,7 +42,7 @@ describe("SeatsAtStake avant le scrutin", () => {
    * une seule série. Même règle pour tous les groupes, chacun la sienne.
    */
   it("donne à chaque barre la couleur du groupe", () => {
-    const { container } = render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    const { container } = render(<SeatsAtStake exposure={EXPOSURE} phase="before" />);
     const bars = [...container.querySelectorAll("li div[style]")];
     expect(bars).toHaveLength(3);
     expect(bars[0]!.getAttribute("style")).toContain("rgb(0, 102, 204)");
@@ -44,11 +50,34 @@ describe("SeatsAtStake avant le scrutin", () => {
   });
 
   it("retombe sur la couleur de marque pour un groupe sans couleur, jamais sur celle d'un autre", () => {
-    const { container } = render(<SeatsAtStake groups={GROUPS} phase="before" />);
+    const { container } = render(<SeatsAtStake exposure={EXPOSURE} phase="before" />);
     const bars = [...container.querySelectorAll("li div[style]")];
     // CRCE-K porte color: null dans la fixture.
     expect(bars[2]!.getAttribute("style")).not.toContain("rgb(");
     expect(bars[2]!.className).toContain("bg-brand-on-surface");
+  });
+
+  it("laisse un siège vacant sans groupe inventé", () => {
+    render(
+      <SeatsAtStake
+        exposure={{ groups: GROUPS, unattributedAtStake: 1, isConsistent: true }}
+        phase="before"
+      />
+    );
+    expect(screen.getByText("Non attribué à un groupe dans nos données")).toBeInTheDocument();
+    expect(screen.getByText(/Siège vacant ou mandat sans série ou groupe renseigné/)).toBeVisible();
+    expect(screen.getAllByRole("listitem")).toHaveLength(GROUPS.length + 1);
+  });
+
+  it("retire une ventilation qui dépasse le total statutaire", () => {
+    render(
+      <SeatsAtStake
+        exposure={{ groups: GROUPS, unattributedAtStake: 0, isConsistent: false }}
+        phase="before"
+      />
+    );
+    expect(screen.getByText("Répartition par groupe incohérente")).toBeInTheDocument();
+    expect(screen.queryByText("77")).toBeNull();
   });
 });
 
@@ -60,7 +89,7 @@ describe("SeatsAtStake avant le scrutin", () => {
  */
 describe("SeatsAtStake après le scrutin", () => {
   it("ne présente plus la composition courante comme la composition sortante", () => {
-    render(<SeatsAtStake groups={GROUPS} phase="after" />);
+    render(<SeatsAtStake exposure={EXPOSURE} phase="after" />);
     expect(screen.getByText(/Comparaison avant et après non encore publiée/)).toBeInTheDocument();
     expect(screen.queryByText("77")).toBeNull();
     expect(screen.queryByText(/sur 131 sièges/)).toBeNull();
@@ -77,7 +106,7 @@ describe("SeatsAtStake après le scrutin", () => {
    * vraie après les lots suivants.
    */
   it("n'affirme pas que la composition sortante a été perdue, puisqu'elle est relevée", () => {
-    const { container } = render(<SeatsAtStake groups={GROUPS} phase="after" />);
+    const { container } = render(<SeatsAtStake exposure={EXPOSURE} phase="after" />);
     const text = container.textContent ?? "";
     expect(text).not.toMatch(/non conservée/i);
     expect(text).not.toMatch(/n'a pas été (conservée|relevée|capturée)/i);
@@ -85,7 +114,7 @@ describe("SeatsAtStake après le scrutin", () => {
   });
 
   it("emploie le passé dans son titre", () => {
-    render(<SeatsAtStake groups={GROUPS} phase="after" />);
+    render(<SeatsAtStake exposure={EXPOSURE} phase="after" />);
     expect(screen.getByText("Ce qui était remis en jeu")).toBeInTheDocument();
   });
 });

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -15,6 +15,10 @@
  */
 
 import { FEHF_REGIME } from "@/config/senatoriales";
+import {
+  SENATE_STATUTORY_SEATS_BY_SERIES,
+  SENATE_STATUTORY_SEATS_TOTAL,
+} from "@/config/senate-seats";
 import type { ElectionStatus } from "@/types";
 
 /**
@@ -32,8 +36,8 @@ export function getBallotPhase(status: ElectionStatus): BallotPhase {
   return "before";
 }
 
-export const SENATE_SEATS_TOTAL = 348;
-export const SENATE_SEATS_AT_STAKE = 178;
+export const SENATE_SEATS_TOTAL = SENATE_STATUTORY_SEATS_TOTAL;
+export const SENATE_SEATS_AT_STAKE = SENATE_STATUTORY_SEATS_BY_SERIES[2];
 export const SENATE_SEATS_OTHER_SERIES = SENATE_SEATS_TOTAL - SENATE_SEATS_AT_STAKE;
 
 /**
@@ -119,6 +123,12 @@ export const SOURCE_TABLEAU_5 = {
 export const SOURCE_TABLEAU_6 = {
   label: "Code électoral, tableau n° 6 annexé",
   url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006354327",
+};
+
+/** Mayotte's individual count and series, which neither table gives separately. */
+export const SOURCE_MAYOTTE_SEATS = {
+  label: "Code électoral, art. LO473 et L474",
+  url: "https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006070239/LEGISCTA000006148536",
 };
 
 /**

--- a/src/app/elections/senatoriales-2026/_content.ts
+++ b/src/app/elections/senatoriales-2026/_content.ts
@@ -115,6 +115,12 @@ export const SOURCE_TABLEAU_5 = {
   url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023260785",
 };
 
+/** Individual statutory seat count for each department. */
+export const SOURCE_TABLEAU_6 = {
+  label: "Code électoral, tableau n° 6 annexé",
+  url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006354327",
+};
+
 /**
  * The two standing texts governing the Français établis hors de France.
  *

--- a/src/app/elections/senatoriales-2026/page.tsx
+++ b/src/app/elections/senatoriales-2026/page.tsx
@@ -60,7 +60,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function SenatorialesHubPage() {
-  const [election, groups] = await Promise.all([getSenatorialesElection(), getGroupExposure()]);
+  const [election, groupExposure] = await Promise.all([
+    getSenatorialesElection(),
+    getGroupExposure(),
+  ]);
   if (!election) notFound();
 
   // Phase resolved at read time by the data layer: the stored column never
@@ -204,7 +207,7 @@ export default async function SenatorialesHubPage() {
 
           <CommuneLookup phase={phase} />
 
-          <SeatsAtStake groups={groups} phase={phase} />
+          <SeatsAtStake exposure={groupExposure} phase={phase} />
 
           {/* État 2. Present in every phase: before the window it gives the dates, after
               it says what is still possible, and throughout it says why no candidate is

--- a/src/config/__tests__/senate-seats.test.ts
+++ b/src/config/__tests__/senate-seats.test.ts
@@ -44,6 +44,14 @@ describe("référentiel statutaire des sièges du Sénat", () => {
     expect(getSenateTerritorialConstituency("13")).toEqual({ code: "13", series: 2, seats: 8 });
   });
 
+  it("fixe Mayotte à deux sièges de série 1", () => {
+    expect(getSenateTerritorialConstituency("976")).toEqual({
+      code: "976",
+      series: 1,
+      seats: 2,
+    });
+  });
+
   it("ne comble pas une vraie absence du référentiel", () => {
     expect(getSenateTerritorialConstituency("984")).toBeUndefined();
   });

--- a/src/config/__tests__/senate-seats.test.ts
+++ b/src/config/__tests__/senate-seats.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEHF_SENATE_SEATS,
+  getSenateTerritorialConstituency,
+  SENATE_TERRITORIAL_CONSTITUENCIES,
+} from "../senate-seats";
+
+describe("référentiel statutaire des sièges du Sénat", () => {
+  it("reproduit les totaux légaux nationaux et par série", () => {
+    const territorial = SENATE_TERRITORIAL_CONSTITUENCIES.reduce(
+      (totals, constituency) => {
+        totals[constituency.series] += constituency.seats;
+        return totals;
+      },
+      { 1: 0, 2: 0 }
+    );
+
+    expect(territorial).toEqual({ 1: 164, 2: 172 });
+    expect(territorial[1] + FEHF_SENATE_SEATS[1]).toBe(170);
+    expect(territorial[2] + FEHF_SENATE_SEATS[2]).toBe(178);
+    expect(territorial[1] + territorial[2] + FEHF_SENATE_SEATS[1] + FEHF_SENATE_SEATS[2]).toBe(348);
+  });
+
+  it("garde les Français établis hors de France hors des codes territoriaux", () => {
+    expect(FEHF_SENATE_SEATS).toEqual({ 1: 6, 2: 6 });
+    expect(SENATE_TERRITORIAL_CONSTITUENCIES.map(({ code }) => String(code)).includes("FEHF")).toBe(
+      false
+    );
+  });
+
+  it("couvre 107 circonscriptions territoriales sans doublon", () => {
+    const codes = SENATE_TERRITORIAL_CONSTITUENCIES.map(({ code }) => code);
+    expect(codes).toHaveLength(107);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("couvre les 63 circonscriptions territoriales renouvelées en 2026", () => {
+    expect(SENATE_TERRITORIAL_CONSTITUENCIES.filter(({ series }) => series === 2)).toHaveLength(63);
+  });
+
+  it("conserve sièges et série sans aucun mandat, y compris pour un siège unique", () => {
+    expect(getSenateTerritorialConstituency("04")).toEqual({ code: "04", series: 2, seats: 1 });
+    expect(getSenateTerritorialConstituency("2A")).toEqual({ code: "2A", series: 2, seats: 1 });
+    expect(getSenateTerritorialConstituency("13")).toEqual({ code: "13", series: 2, seats: 8 });
+  });
+
+  it("ne comble pas une vraie absence du référentiel", () => {
+    expect(getSenateTerritorialConstituency("984")).toBeUndefined();
+  });
+});

--- a/src/config/senate-seats.ts
+++ b/src/config/senate-seats.ts
@@ -1,0 +1,175 @@
+/**
+ * Statutory distribution of Senate seats by territorial constituency.
+ *
+ * A seat exists independently of its current holder. This reference therefore never reads
+ * `Mandate`: vacancies, incomplete syncs and group changes cannot alter a constituency's
+ * statutory number of seats or its renewal series.
+ *
+ * Sources in force on 12 August 2026:
+ * - Code électoral, tableau n° 5: distribution between series and special constituencies
+ *   https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023260785
+ * - Code électoral, tableau n° 6: number of senators representing each department
+ *   https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006354327
+ *
+ * Tableau n° 5 gives department ranges and aggregate totals, not every department's seat
+ * count. Tableau n° 6 supplies those individual counts. The special constituencies listed
+ * individually in tableau n° 5 complete the reference. Mayotte has two seats: its count is
+ * included in the 11 series-1 overseas seats in tableau n° 5 and is fixed by article LO 334-1.
+ */
+
+import type { SenateSeries } from "@/config/senatoriales";
+
+export interface SenateTerritorialConstituency {
+  /** INSEE-style code already used by Commune.departmentCode and Mandate.departmentCode. */
+  code: string;
+  series: SenateSeries;
+  seats: number;
+}
+
+export type SenateRenewalStatus = "renewed" | "not-renewed" | "unknown";
+
+/**
+ * The 107 territorial constituencies. French citizens abroad are deliberately separate:
+ * they have no department code and their twelve seats are split between both series.
+ */
+export const SENATE_TERRITORIAL_CONSTITUENCIES = [
+  { code: "01", series: 2, seats: 3 },
+  { code: "02", series: 2, seats: 3 },
+  { code: "03", series: 2, seats: 2 },
+  { code: "04", series: 2, seats: 1 },
+  { code: "05", series: 2, seats: 1 },
+  { code: "06", series: 2, seats: 5 },
+  { code: "07", series: 2, seats: 2 },
+  { code: "08", series: 2, seats: 2 },
+  { code: "09", series: 2, seats: 1 },
+  { code: "10", series: 2, seats: 2 },
+  { code: "11", series: 2, seats: 2 },
+  { code: "12", series: 2, seats: 2 },
+  { code: "13", series: 2, seats: 8 },
+  { code: "14", series: 2, seats: 3 },
+  { code: "15", series: 2, seats: 2 },
+  { code: "16", series: 2, seats: 2 },
+  { code: "17", series: 2, seats: 3 },
+  { code: "18", series: 2, seats: 2 },
+  { code: "19", series: 2, seats: 2 },
+  { code: "2A", series: 2, seats: 1 },
+  { code: "2B", series: 2, seats: 1 },
+  { code: "21", series: 2, seats: 3 },
+  { code: "22", series: 2, seats: 3 },
+  { code: "23", series: 2, seats: 2 },
+  { code: "24", series: 2, seats: 2 },
+  { code: "25", series: 2, seats: 3 },
+  { code: "26", series: 2, seats: 3 },
+  { code: "27", series: 2, seats: 3 },
+  { code: "28", series: 2, seats: 3 },
+  { code: "29", series: 2, seats: 4 },
+  { code: "30", series: 2, seats: 3 },
+  { code: "31", series: 2, seats: 5 },
+  { code: "32", series: 2, seats: 2 },
+  { code: "33", series: 2, seats: 6 },
+  { code: "34", series: 2, seats: 4 },
+  { code: "35", series: 2, seats: 4 },
+  { code: "36", series: 2, seats: 2 },
+  { code: "37", series: 1, seats: 3 },
+  { code: "38", series: 1, seats: 5 },
+  { code: "39", series: 1, seats: 2 },
+  { code: "40", series: 1, seats: 2 },
+  { code: "41", series: 1, seats: 2 },
+  { code: "42", series: 1, seats: 4 },
+  { code: "43", series: 1, seats: 2 },
+  { code: "44", series: 1, seats: 5 },
+  { code: "45", series: 1, seats: 3 },
+  { code: "46", series: 1, seats: 2 },
+  { code: "47", series: 1, seats: 2 },
+  { code: "48", series: 1, seats: 1 },
+  { code: "49", series: 1, seats: 4 },
+  { code: "50", series: 1, seats: 3 },
+  { code: "51", series: 1, seats: 3 },
+  { code: "52", series: 1, seats: 2 },
+  { code: "53", series: 1, seats: 2 },
+  { code: "54", series: 1, seats: 4 },
+  { code: "55", series: 1, seats: 2 },
+  { code: "56", series: 1, seats: 3 },
+  { code: "57", series: 1, seats: 5 },
+  { code: "58", series: 1, seats: 2 },
+  { code: "59", series: 1, seats: 11 },
+  { code: "60", series: 1, seats: 4 },
+  { code: "61", series: 1, seats: 2 },
+  { code: "62", series: 1, seats: 7 },
+  { code: "63", series: 1, seats: 3 },
+  { code: "64", series: 1, seats: 3 },
+  { code: "65", series: 1, seats: 2 },
+  { code: "66", series: 1, seats: 2 },
+  { code: "67", series: 2, seats: 5 },
+  { code: "68", series: 2, seats: 4 },
+  { code: "69", series: 2, seats: 7 },
+  { code: "70", series: 2, seats: 2 },
+  { code: "71", series: 2, seats: 3 },
+  { code: "72", series: 2, seats: 3 },
+  { code: "73", series: 2, seats: 2 },
+  { code: "74", series: 2, seats: 3 },
+  { code: "76", series: 2, seats: 6 },
+  { code: "77", series: 1, seats: 6 },
+  { code: "79", series: 2, seats: 2 },
+  { code: "80", series: 2, seats: 3 },
+  { code: "81", series: 2, seats: 2 },
+  { code: "82", series: 2, seats: 2 },
+  { code: "83", series: 2, seats: 4 },
+  { code: "84", series: 2, seats: 3 },
+  { code: "85", series: 2, seats: 3 },
+  { code: "86", series: 2, seats: 2 },
+  { code: "87", series: 2, seats: 2 },
+  { code: "88", series: 2, seats: 2 },
+  { code: "89", series: 2, seats: 2 },
+  { code: "90", series: 2, seats: 1 },
+  { code: "91", series: 1, seats: 5 },
+  { code: "75", series: 1, seats: 12 },
+  { code: "92", series: 1, seats: 7 },
+  { code: "93", series: 1, seats: 6 },
+  { code: "94", series: 1, seats: 6 },
+  { code: "95", series: 1, seats: 5 },
+  { code: "78", series: 1, seats: 6 },
+  { code: "971", series: 1, seats: 3 },
+  { code: "972", series: 1, seats: 2 },
+  { code: "973", series: 2, seats: 2 },
+  { code: "974", series: 1, seats: 4 },
+  { code: "976", series: 1, seats: 2 },
+  { code: "975", series: 1, seats: 1 },
+  { code: "977", series: 2, seats: 1 },
+  { code: "978", series: 2, seats: 1 },
+  { code: "986", series: 2, seats: 1 },
+  { code: "987", series: 2, seats: 2 },
+  { code: "988", series: 1, seats: 2 },
+] as const satisfies readonly SenateTerritorialConstituency[];
+
+export const FEHF_SENATE_SEATS = { 1: 6, 2: 6 } as const satisfies Record<SenateSeries, number>;
+
+export const SENATE_STATUTORY_SEATS_BY_SERIES = { 1: 170, 2: 178 } as const satisfies Record<
+  SenateSeries,
+  number
+>;
+export const SENATE_STATUTORY_SEATS_TOTAL = 348;
+
+const CONSTITUENCY_BY_CODE = new Map<string, SenateTerritorialConstituency>(
+  SENATE_TERRITORIAL_CONSTITUENCIES.map((constituency) => [constituency.code, constituency])
+);
+
+/** Undefined means a genuine absence from the statutory reference. */
+export function getSenateTerritorialConstituency(
+  code: string
+): SenateTerritorialConstituency | undefined {
+  return CONSTITUENCY_BY_CODE.get(code);
+}
+
+/** Renewal status for 2026. Unknown means the legal reference genuinely has no such code. */
+export function getSenateRenewal(code: string): SenateRenewalStatus {
+  const constituency = getSenateTerritorialConstituency(code);
+  if (!constituency) return "unknown";
+  return constituency.series === 2 ? "renewed" : "not-renewed";
+}
+
+/** Statutory seats renewed in 2026, or null outside series 2 and outside the reference. */
+export function getSenateSeatsAtStake(code: string): number | null {
+  const constituency = getSenateTerritorialConstituency(code);
+  return constituency?.series === 2 ? constituency.seats : null;
+}

--- a/src/config/senate-seats.ts
+++ b/src/config/senate-seats.ts
@@ -13,8 +13,9 @@
  *
  * Tableau n° 5 gives department ranges and aggregate totals, not every department's seat
  * count. Tableau n° 6 supplies those individual counts. The special constituencies listed
- * individually in tableau n° 5 complete the reference. Mayotte has two seats: its count is
- * included in the 11 series-1 overseas seats in tableau n° 5 and is fixed by article LO 334-1.
+ * individually in tableau n° 5 complete the reference. Mayotte has two seats under article
+ * LO473 and renews them with series 1 under article L474. Its count is included in the 11
+ * series-1 overseas seats in tableau n° 5, but neither table states that individual figure.
  */
 
 import type { SenateSeries } from "@/config/senatoriales";

--- a/src/lib/data/__tests__/senatoriales-statutory.test.ts
+++ b/src/lib/data/__tests__/senatoriales-statutory.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getSenateRenewal, getSenateSeatsAtStake } from "@/config/senate-seats";
+
+describe("propriétés statutaires des circonscriptions sénatoriales", () => {
+  it("répond sans mandat courant pour un département de série 2", () => {
+    expect(getSenateRenewal("13")).toBe("renewed");
+    expect(getSenateSeatsAtStake("13")).toBe(8);
+  });
+
+  it("garde connue la série d'un département à un seul siège vacant", () => {
+    expect(getSenateRenewal("04")).toBe("renewed");
+    expect(getSenateSeatsAtStake("04")).toBe(1);
+  });
+
+  it("distingue une circonscription de série 1 d'une référence absente", () => {
+    expect(getSenateRenewal("33")).toBe("renewed");
+    expect(getSenateSeatsAtStake("33")).toBe(6);
+    expect(getSenateRenewal("75")).toBe("not-renewed");
+    expect(getSenateSeatsAtStake("75")).toBeNull();
+    expect(getSenateRenewal("984")).toBe("unknown");
+    expect(getSenateSeatsAtStake("984")).toBeNull();
+  });
+});

--- a/src/lib/data/senatoriales.ts
+++ b/src/lib/data/senatoriales.ts
@@ -21,6 +21,12 @@ import { resolveElectionStatus } from "@/lib/elections/status";
 import { getMisEnCauseWhere } from "@/lib/affairs/public-filters";
 import { COMMUNE_DATA_SYNC_KEY } from "@/config/communes";
 import { CANDIDACY_PERIOD } from "@/config/senatoriales";
+import {
+  getSenateRenewal,
+  getSenateSeatsAtStake,
+  SENATE_STATUTORY_SEATS_BY_SERIES,
+  type SenateRenewalStatus,
+} from "@/config/senate-seats";
 import { DEPARTMENTS } from "@/config/departments";
 import { computeCommuneCollege, type CommuneCollege } from "@/lib/senatoriales/college";
 import {
@@ -28,6 +34,7 @@ import {
   isBallotDayInParis,
   type CandidacyPhase,
 } from "@/lib/senatoriales/timing";
+import { getGroupAttributionCoverage } from "@/lib/senatoriales/group-exposure";
 import type { ElectionStatus } from "@/types";
 
 export const SENATORIALES_2026_SLUG = "senatoriales-2026";
@@ -116,6 +123,14 @@ export interface GroupExposure {
   atStake: number;
 }
 
+export interface GroupExposureSummary {
+  groups: GroupExposure[];
+  /** Statutory series-2 seats with no current group attribution in our mandate data. */
+  unattributedAtStake: number;
+  /** False when dynamic group rows exceed the statutory series-2 total. */
+  isConsistent: boolean;
+}
+
 /**
  * How exposed each group is to this renewal.
  *
@@ -124,16 +139,17 @@ export interface GroupExposure {
  * (107/190 for the outgoing majority, 77/131 for Les Républicains, 4/18 for the
  * communists) fall out of this query exactly.
  */
-export const getGroupExposure = cache(async function getGroupExposure(): Promise<GroupExposure[]> {
-  const rows = await db.$queryRaw<
-    Array<{
-      groupName: string;
-      shortName: string | null;
-      color: string | null;
-      held: number;
-      atStake: number;
-    }>
-  >(Prisma.sql`
+export const getGroupExposure = cache(
+  async function getGroupExposure(): Promise<GroupExposureSummary> {
+    const rows = await db.$queryRaw<
+      Array<{
+        groupName: string;
+        shortName: string | null;
+        color: string | null;
+        held: number;
+        atStake: number;
+      }>
+    >(Prisma.sql`
     SELECT g.name AS "groupName",
            g."shortName",
            g.color,
@@ -148,36 +164,30 @@ export const getGroupExposure = cache(async function getGroupExposure(): Promise
     GROUP BY 1, 2, 3
     ORDER BY held DESC
   `);
-  return rows;
-});
+    const coverage = getGroupAttributionCoverage(
+      rows,
+      SENATE_STATUTORY_SEATS_BY_SERIES[RENEWED_SERIES]
+    );
+    return {
+      groups: rows,
+      // This deliberately remains unattributed. The gap may be a vacancy, a missing current
+      // mandate, a null series or a missing parliamentary group; none licenses inventing one.
+      ...coverage,
+    };
+  }
+);
 
 // ─── Department series ──────────────────────────────────────────────
 
-export type DepartmentRenewal = "renewed" | "not-renewed" | "unknown";
+export type DepartmentRenewal = SenateRenewalStatus;
 
 /**
  * Whether a department's seats are up on 27 September.
  *
- * A department belongs entirely to one series, so the series of its sitting senators
- * settles it. When a department carries both values, the data is inconsistent and we
- * return "unknown" rather than picking a side: the page then says it does not know.
+ * This is a statutory property of the constituency, independent of its current holders.
+ * "unknown" is reserved for a code genuinely absent from the legal reference.
  */
-export const getDepartmentRenewal = cache(async function getDepartmentRenewal(
-  departmentCode: string
-): Promise<DepartmentRenewal> {
-  const rows = await db.mandate.findMany({
-    where: {
-      type: "SENATEUR",
-      isCurrent: true,
-      departmentCode,
-      senateSeries: { not: null },
-    },
-    select: { senateSeries: true },
-    distinct: ["senateSeries"],
-  });
-  if (rows.length !== 1) return "unknown";
-  return rows[0]!.senateSeries === RENEWED_SERIES ? "renewed" : "not-renewed";
-});
+export const getDepartmentRenewal = getSenateRenewal;
 
 // ─── Sitting senators of a department ───────────────────────────────
 
@@ -320,17 +330,8 @@ export async function findCommunesByPostalCode(
   }));
 }
 
-/** Seats up for renewal in a department, counted from the sitting senators. */
-async function countSeatsAtStake(departmentCode: string): Promise<number> {
-  return db.mandate.count({
-    where: {
-      type: "SENATEUR",
-      isCurrent: true,
-      departmentCode,
-      senateSeries: RENEWED_SERIES,
-    },
-  });
-}
+/** Statutory seats renewed in 2026, independent of current holders. */
+export const getStatutorySeatsAtStake = getSenateSeatsAtStake;
 
 export const getCommuneCollege = cache(async function getCommuneCollege(
   communeId: string
@@ -347,10 +348,8 @@ export const getCommuneCollege = cache(async function getCommuneCollege(
   });
   if (!commune) return null;
 
-  const [renewal, seats] = await Promise.all([
-    getDepartmentRenewal(commune.departmentCode),
-    countSeatsAtStake(commune.departmentCode),
-  ]);
+  const renewal = getDepartmentRenewal(commune.departmentCode);
+  const seats = getStatutorySeatsAtStake(commune.departmentCode);
 
   return {
     id: commune.id,
@@ -363,7 +362,7 @@ export const getCommuneCollege = cache(async function getCommuneCollege(
       totalSeats: commune.totalSeats,
     }),
     renewal,
-    seatsAtStake: renewal === "renewed" ? seats : null,
+    seatsAtStake: seats,
   };
 });
 

--- a/src/lib/senatoriales/__tests__/group-exposure.test.ts
+++ b/src/lib/senatoriales/__tests__/group-exposure.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getGroupAttributionCoverage } from "../group-exposure";
+
+describe("couverture de l'attribution des sièges aux groupes", () => {
+  it("laisse un siège vacant non attribué", () => {
+    expect(getGroupAttributionCoverage([{ atStake: 100 }, { atStake: 77 }], 178)).toEqual({
+      unattributedAtStake: 1,
+      isConsistent: true,
+    });
+  });
+
+  it("n'invente pas de groupe quand aucun mandat n'est disponible", () => {
+    expect(getGroupAttributionCoverage([], 178)).toEqual({
+      unattributedAtStake: 178,
+      isConsistent: true,
+    });
+  });
+
+  it("signale un dépassement au lieu de masquer des mandats dupliqués", () => {
+    expect(getGroupAttributionCoverage([{ atStake: 179 }], 178)).toEqual({
+      unattributedAtStake: 0,
+      isConsistent: false,
+    });
+  });
+});

--- a/src/lib/senatoriales/group-exposure.ts
+++ b/src/lib/senatoriales/group-exposure.ts
@@ -1,0 +1,20 @@
+export interface GroupAtStakeCount {
+  atStake: number;
+}
+
+export interface GroupAttributionCoverage {
+  unattributedAtStake: number;
+  isConsistent: boolean;
+}
+
+/** Compare dynamic attribution with the statutory total without filling any gap. */
+export function getGroupAttributionCoverage(
+  groups: readonly GroupAtStakeCount[],
+  statutorySeatsAtStake: number
+): GroupAttributionCoverage {
+  const attributed = groups.reduce((total, group) => total + group.atStake, 0);
+  return {
+    unattributedAtStake: Math.max(0, statutorySeatsAtStake - attributed),
+    isConsistent: attributed <= statutorySeatsAtStake,
+  };
+}


### PR DESCRIPTION
## Problème

Le hub Sénatoriales 2026 déduisait le nombre et la série des sièges depuis les mandats courants. Une vacance pouvait donc modifier une propriété légale de la circonscription et rendre un département à siège unique inconnu.

## Solution

- ajoute un référentiel TypeScript pur des 107 circonscriptions territoriales, fondé sur les tableaux n° 5 et n° 6 annexés au Code électoral, complétés pour Mayotte par les articles LO473 et L474 ;
- conserve les Français établis hors de France hors des faux codes départementaux, avec 6 sièges dans chaque série ;
- calcule série et sièges communaux sans aucune lecture de `Mandate` ;
- dérive les totaux éditoriaux 348 et 178 du référentiel statutaire ;
- conserve l'attribution aux groupes comme donnée dynamique ;
- affiche tout écart avec les 178 sièges comme non attribué, sans inventer de groupe ;
- retire la ventilation si les mandats dépassent le total statutaire.

## Vérifications

- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- tests ciblés couvrant vacance, siège unique, Mayotte, FEHF, totaux 348/170/178, doublons et absence de mandats
- Playwright sur Paris, Alpes-de-Haute-Provence, Bouches-du-Rhône et Guyane
- CI complète verte sur le head de la PR, dont build, tests unitaires, CodeQL et contrôles d'architecture

Le snapshot immutable `senatoriales-2026-outgoing-composition` n'est ni modifié ni relu comme source légale.

Closes #704
