### PR TITLE
docs(audit): close SEC-02

### DIFF
--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -192,7 +192,8 @@ an additional index is not the default conclusion.
 **Goal.** Reduce the amount of executed work, potentially through incremental computation,
 projection, or materialization when measurements justify it.
 
-**Closure criteria.** The work package preserves the reference query and dataset, measures before and after, verifies result freshness, and demonstrates no functional regression.
+**Closure criteria.** The work package preserves the reference query and dataset, measures before
+and after, verifies result freshness, and demonstrates no functional regression.
 
 ### DB-02: Top SQL workload remediation
 

--- a/docs/audits/security-ux-baseline-2026-08.md
+++ b/docs/audits/security-ux-baseline-2026-08.md
@@ -44,7 +44,7 @@ change marks it `Closed`. Accepted risks retain their rationale and next review 
 | Identifier | Priority           | Area                  | Current status | Owner      | Evidence                                                                    | Remediation PR                                        | Last updated |
 | ---------- | ------------------ | --------------------- | -------------- | ---------- | --------------------------------------------------------------------------- | ----------------------------------------------------- | ------------ |
 | `SEC-01`   | P0                 | Application security  | Closed         | @ironlam   | Private Security Advisory                                                   | [#692](https://github.com/ironlam/poligraph/pull/692) | 2026-08-08   |
-| `SEC-02`   | P0                 | Access control        | Verified       | @ironlam   | Private Security Advisory                                                   | [#694](https://github.com/ironlam/poligraph/pull/694) | 2026-08-09   |
+| `SEC-02`   | P0                 | Access control        | Closed         | @ironlam   | Private Security Advisory                                                   | [#694](https://github.com/ironlam/poligraph/pull/694) | 2026-08-12   |
 | `SEC-03`   | P1                 | Supabase              | To investigate | Unassigned | [Context](#sec-03-least-privilege-supabase-public-surface)                  | None                                                  | 2026-08-08   |
 | `SEC-04`   | P1                 | Authentication        | To investigate | Unassigned | [Context](#sec-04-harden-admin-authentication)                              | None                                                  | 2026-08-08   |
 | `SEC-06`   | P1                 | Database security     | To investigate | Unassigned | [Context](#sec-06-database-function-privilege-hardening)                    | None                                                  | 2026-08-08   |
@@ -192,8 +192,7 @@ an additional index is not the default conclusion.
 **Goal.** Reduce the amount of executed work, potentially through incremental computation,
 projection, or materialization when measurements justify it.
 
-**Closure criteria.** The work package preserves the reference query and dataset, measures before
-and after, verifies result freshness, and demonstrates no functional regression.
+**Closure criteria.** The work package preserves the reference query and dataset, measures before and after, verifies result freshness, and demonstrates no functional regression.
 
 ### DB-02: Top SQL workload remediation
 


### PR DESCRIPTION
## Summary

SEC-02 remediation was merged in #694 after independent verification with no remaining P0/P1/P2 findings. This follow-up updates the living audit register from `Verified` to `Closed`.

No code or production configuration changes are included.