### PR TITLE
fix(presidentielle): rendre le code couleur des candidatures visible

### DIFF
--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -190,8 +190,13 @@ function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
   const defended = measures.filter((m) => m.measure.withdrawal === null).length;
   return (
     <span className="flex items-start gap-2.5">
+      {/* The colour code, and the neutral bar is a state of its own, not a failure: the accent is
+          resolved by `resolveCandidateAccentColor`, which returns null rather than borrowing the
+          colour of a party the candidacy is not filed under. Decorative (`aria-hidden`), because
+          the party name is written on the line below: the colour never carries a fact alone. */}
       <span
         aria-hidden="true"
+        data-accent={candidate.accentColor ?? "neutre"}
         className="mt-0.5 h-7 w-2 shrink-0 rounded-sm bg-border"
         style={candidate.accentColor !== null ? { backgroundColor: candidate.accentColor } : {}}
       />

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -21,9 +21,8 @@ import { SubjectSidebar } from "./SubjectSidebar";
  * A public subject page: for one theme, every publicly visible candidacy on one row, with what it
  * proposes, whether a close text was ever voted, and how precise the measure is.
  *
- * One measure per candidacy is quoted, the rest fold into a disclosure. Six rows each carrying a
- * dozen measures is a wall, and the comparison this page exists for happens between candidacies,
- * not inside one.
+ * Up to three measures per candidacy are quoted, the rest fold into a disclosure. The comparison
+ * this page exists for happens between candidacies, not inside one.
  *
  * Candidates come in the alphabetical order the authority returns. Below the publication gate the
  * page renders an explicit closed state.
@@ -89,11 +88,45 @@ function WithdrawalLine({ withdrawal }: { withdrawal: NonNullable<PublicMeasure[
   );
 }
 
-/** One quoted measure: its text, its source, and its withdrawal when there is one. */
+/**
+ * How precise a measure is, and whether a close text was ever voted.
+ *
+ * Both qualify ONE measure, so they sit with the measure they qualify. They used to be two columns
+ * of the table, reading `measures[0]`, which was true only as long as a row quoted exactly one
+ * measure; quoting three under a "Précision" column showing a single badge would have attributed
+ * the first measure's qualification to the two below it.
+ *
+ * A null precision is NOT "pas encore relu". Publication requires `reviewedAt` to be set
+ * (`PUBLIC_MEASURE_WHERE`), so a visible measure has been reviewed by construction and that label
+ * would contradict the very predicate that let it appear.
+ */
+function MeasureQualifiers({ entry }: { entry: SubjectCandidateEntry["measures"][number] }) {
+  return (
+    <div className="flex flex-wrap items-start gap-x-3 gap-y-1">
+      {entry.measure.precision !== null ? (
+        <MeasurePrecisionBadge precision={entry.measure.precision} />
+      ) : (
+        <QualifiedEmptyCell
+          absence={{ kind: "not_applicable", reason: "Précision non renseignée" }}
+          className="text-xs"
+        />
+      )}
+      <VoteRelationBadge
+        relation={entry.voteRelation}
+        basisDetails={
+          entry.voteReference !== null ? composeVoteBasis(entry.voteReference) : undefined
+        }
+      />
+    </div>
+  );
+}
+
+/** One quoted measure: its text, what qualifies it, its sources, and its withdrawal when there is one. */
 function QuotedMeasure({ entry }: { entry: SubjectCandidateEntry["measures"][number] }) {
   return (
     <div className="space-y-1.5">
       <p className="text-sm leading-relaxed">&laquo;&nbsp;{entry.measure.text}&nbsp;&raquo;</p>
+      <MeasureQualifiers entry={entry} />
       <MeasureSources sources={entry.measure.sources} />
       {entry.measure.withdrawal !== null && (
         <WithdrawalLine withdrawal={entry.measure.withdrawal} />
@@ -103,27 +136,38 @@ function QuotedMeasure({ entry }: { entry: SubjectCandidateEntry["measures"][num
 }
 
 /**
- * The proposal cell: the first measure quoted, the others behind a disclosure.
+ * How many measures a row quotes before folding the rest.
+ *
+ * One exposed whichever measure happened to be imported first as if it were an editorial choice.
+ * Three gives a broader view without turning the comparison into a full programme listing.
+ */
+const QUOTED_MEASURE_LIMIT = 3;
+
+/**
+ * The proposal cell: up to three measures quoted, the rest behind a disclosure.
  *
  * `<details>` rather than a state hook: the page is a server component, and the browser's own
  * disclosure is keyboard-operable and announced correctly without a line of JavaScript.
  */
 function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
-  const [first, ...rest] = entry.measures;
-  if (first === undefined) {
+  if (entry.measures.length === 0) {
     return <QualifiedEmptyCell absence={{ kind: "no_measure_published", theme }} />;
   }
+  const quoted = entry.measures.slice(0, QUOTED_MEASURE_LIMIT);
+  const folded = entry.measures.slice(QUOTED_MEASURE_LIMIT);
 
   return (
-    <div className="space-y-2">
-      <QuotedMeasure entry={first} />
-      {rest.length > 0 && (
+    <div className="space-y-3">
+      {quoted.map((measure) => (
+        <QuotedMeasure key={measure.measure.id} entry={measure} />
+      ))}
+      {folded.length > 0 && (
         <details className="group">
           <summary className="inline-flex min-h-11 cursor-pointer items-center text-xs font-semibold text-primary underline decoration-dotted underline-offset-2 hover:decoration-solid">
-            + {rest.length} {rest.length === 1 ? "autre mesure" : "autres mesures"} sur ce sujet
+            + {folded.length} {folded.length === 1 ? "autre mesure" : "autres mesures"} sur ce sujet
           </summary>
           <div className="mt-2 space-y-3 border-l-2 border-border pl-3">
-            {rest.map((other) => (
+            {folded.map((other) => (
               <QuotedMeasure key={other.measure.id} entry={other} />
             ))}
           </div>
@@ -131,56 +175,6 @@ function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: T
       )}
     </div>
   );
-}
-
-/**
- * Both cells describe THE MEASURE, so with no measure they have no subject to describe.
- *
- * The absence they state has to stay about this cell. An earlier version answered "N'a jamais
- * siégé", which is a claim about a career derived from the emptiness of one theme: false for
- * everyone who has sat, and not deducible from anything this page reads.
- */
-function VoteCell({ entry }: { entry: SubjectCandidateEntry }) {
-  const first = entry.measures[0];
-  if (first === undefined) {
-    return (
-      <QualifiedEmptyCell
-        absence={{
-          kind: "not_applicable",
-          reason: "Pas de mesure publiée à rapprocher d'un scrutin",
-        }}
-      />
-    );
-  }
-  return (
-    <VoteRelationBadge
-      relation={first.voteRelation}
-      basisDetails={
-        first.voteReference !== null ? composeVoteBasis(first.voteReference) : undefined
-      }
-    />
-  );
-}
-
-/**
- * Nothing at all when there is no measure: the proposal cell on the same row already says no measure
- * is published, and repeating it in a second column adds a line without adding a fact.
- *
- * A null precision is NOT "pas encore relu". Publication requires `reviewedAt` to be set
- * (`PUBLIC_MEASURE_WHERE`), so a visible measure has been reviewed by construction and that label
- * would contradict the very predicate that let the row appear.
- */
-function PrecisionCell({ entry }: { entry: SubjectCandidateEntry }) {
-  const first = entry.measures[0];
-  if (first === undefined) return null;
-  if (first.measure.precision === null) {
-    return (
-      <QualifiedEmptyCell
-        absence={{ kind: "not_applicable", reason: "Précision non renseignée" }}
-      />
-    );
-  }
-  return <MeasurePrecisionBadge precision={first.measure.precision} />;
 }
 
 function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
@@ -224,29 +218,27 @@ function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
 }
 
 /**
- * Four columns, and the office one is deliberately not among them.
+ * Two columns, and what used to be the other two now travels with the measure.
  *
  * "A exercé sur ce sujet" is gone: linking a mandate to a subject needs a mapping the model does not
  * carry, so the cell held the same sentence on every row. It distinguished nothing and took 190px
  * from the only column with content, which at anything under a very wide viewport squeezed the
  * quoted measure down to one word per line. It comes back the day the mapping exists.
  *
- * "Déjà soumis au vote ?" stays although it is empty today, and the difference is not arbitrary:
- * its nine states and their badge already exist, so the column starts varying the moment a scrutin
- * is linked to a measure.
+ * "Déjà soumis au vote ?" and "Précision de la mesure" are gone as COLUMNS, not as content: a column
+ * holds one value per row, and a row now quotes up to three measures with a precision and a vote
+ * relation each. Both are rendered by `MeasureQualifiers` under the sentence they qualify, which is
+ * also where a reader looks for them. The vote states keep their nine values and their badge, so
+ * they still start varying the moment a scrutin is linked to a measure.
  */
 const COLUMNS = [
   { title: "Candidat·e", hint: "Par nom de famille" },
   // Not "du programme": a measure with no `programEditionId` was taken from a speech, an interview
   // or an article, and the source line under each quote names which.
-  { title: "Ce qu'il ou elle propose", hint: "Phrase citée, avec sa source" },
   {
-    title: "Déjà soumis au vote ?",
-    hint: "Seulement si un texte proche a été voté et que la personne siégeait",
+    title: "Ce qu'il ou elle propose",
+    hint: "Jusqu'à trois mesures citées, chacune avec sa source, sa précision et sa relation aux votes",
   },
-  // The enum holds two values, "Chiffrée" and "Objectif sans chiffre". There is no dated or funded
-  // criterion anywhere in the model, so naming them here promised a qualification we never make.
-  { title: "Précision de la mesure", hint: "Chiffrée ou objectif sans chiffre" },
 ];
 
 export function SubjectComparison({ data }: { data: SubjectPageData }) {
@@ -364,21 +356,20 @@ function ComparisonTable({ data }: { data: SubjectPageData }) {
     <>
       {/* lg and up: the full table. `table-fixed` with explicit widths, so a long quote
           widens its own cell's line count instead of stretching the table past the viewport. */}
-      {/* `min-w-[860px]` is the fix for a table that crushed itself. With `table-fixed`, the three
-          side columns keep their pixel widths whatever happens, so on a container narrower than
-          their sum the flexible column collapsed towards zero and wrapped the quote one word per
-          line, headers overlapping. A minimum width makes the wrapper scroll instead. */}
+      {/* `min-w-[560px]` is what is left of the fix for a table that crushed itself. With
+          `table-fixed` the identity column keeps its pixel width whatever happens, so on a narrow
+          enough container the flexible column collapsed towards zero and wrapped the quote one word
+          per line. A minimum width makes the wrapper scroll instead. The floor came down with the
+          two side columns it used to have to fit. */}
       <div className="hidden overflow-x-auto rounded-xl border border-border bg-card lg:block">
-        <table className="w-full min-w-[860px] table-fixed border-collapse text-left">
+        <table className="w-full min-w-[560px] table-fixed border-collapse text-left">
           <caption className="sr-only">
-            Ce que chaque candidature propose sur {THEME_CATEGORY_LABELS[data.theme]}, avec sa
-            source, sa relation aux votes et la précision de la mesure.
+            Ce que chaque candidature propose sur {THEME_CATEGORY_LABELS[data.theme]}, chaque mesure
+            citée avec sa source, sa précision et sa relation aux votes.
           </caption>
           <colgroup>
             <col className="w-[200px]" />
             <col />
-            <col className="w-[180px]" />
-            <col className="w-[150px]" />
           </colgroup>
           <thead>
             <tr className="border-b border-border bg-muted/50 align-top">
@@ -406,20 +397,20 @@ function ComparisonTable({ data }: { data: SubjectPageData }) {
                 <td className="px-4 py-4">
                   <ProposalCell entry={entry} theme={data.theme} />
                 </td>
-                <td className="px-4 py-4">
-                  <VoteCell entry={entry} />
-                </td>
-                <td className="px-4 py-4">
-                  <PrecisionCell entry={entry} />
-                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
 
-      {/* Below lg: one card per candidacy. Five columns cannot be read at 390px, and shrinking the
-          type to fit would make the quote unreadable, so the layout changes rather than the content. */}
+      {/* Below lg: one card per candidacy. The two columns cannot be read side by side at 390px, and
+          shrinking the type to fit would make the quote unreadable, so the layout changes rather
+          than the content: the card carries exactly what the row carries, stacked.
+
+          The definition list of vote relation and precision is gone from here too. It used to
+          restate at the bottom of the card what the table said in its side columns; now that both
+          travel under the sentence they qualify, repeating them per card would separate a
+          qualification from the only measure it is true of. */}
       <ul className="space-y-3 lg:hidden">
         {data.candidates.map((entry) => (
           <li key={entry.candidate.id} className="rounded-xl border border-border bg-card p-4">
@@ -427,22 +418,6 @@ function ComparisonTable({ data }: { data: SubjectPageData }) {
             <div className="mt-3">
               <ProposalCell entry={entry} theme={data.theme} />
             </div>
-            {/* The precision pair drops out entirely when there is no measure. On the table an
-                empty cell sits under a header that explains it; here the term would stand alone
-                facing nothing, which reads as a value we failed to load. */}
-            <dl className="mt-4 space-y-2 border-t border-border pt-3 text-sm">
-              {[
-                { term: COLUMNS[2]!.title, cell: <VoteCell entry={entry} /> },
-                ...(entry.measures.length > 0
-                  ? [{ term: COLUMNS[3]!.title, cell: <PrecisionCell entry={entry} /> }]
-                  : []),
-              ].map(({ term, cell }) => (
-                <div key={term} className="flex flex-wrap items-start justify-between gap-2">
-                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">{term}</dt>
-                  <dd className="min-w-0 text-right">{cell}</dd>
-                </div>
-              ))}
-            </dl>
           </li>
         ))}
       </ul>
@@ -462,8 +437,8 @@ function FooterCard({
   return (
     <p className="rounded-xl border border-border bg-card px-5 py-3.5 text-sm text-muted-foreground">
       {documented} {documented === 1 ? "candidature porte" : "candidatures portent"} une mesure sur
-      ce sujet, pour {total} au total. Une seule est citée par candidature&nbsp;; les autres se
-      déplient.
+      ce sujet, pour {total} au total. Jusqu&apos;à {QUOTED_MEASURE_LIMIT} mesures sont citées par
+      candidature&nbsp;; au-delà, les suivantes se déplient.
       {withoutMeasure > 0 && (
         <>
           {" "}
@@ -484,11 +459,12 @@ function MethodCard() {
           (VOTE_RELATION_BASIS_LABELS). An earlier version quoted "aucun vote sur cet objet", a
           string that exists nowhere: a reader would have looked for a wording they never meet. */}
       <p className="max-w-3xl text-sm text-muted-foreground">
-        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote. Cette
-        colonne dit donc surtout où nous en sommes&nbsp;: «&nbsp;périmètre non examiné&nbsp;» tant
-        que nous n&apos;avons pas cherché de scrutin proche, «&nbsp;périmètre examiné sans
-        résultat&nbsp;» quand nous avons cherché sans rien trouver. Une position ne s&apos;affiche
-        que pour une candidature qui siégeait au moment où un texte proche a été soumis.
+        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote. La
+        mention portée sous chaque mesure dit donc surtout où nous en sommes&nbsp;: «&nbsp;périmètre
+        non examiné&nbsp;» tant que nous n&apos;avons pas cherché de scrutin proche,
+        «&nbsp;périmètre examiné sans résultat&nbsp;» quand nous avons cherché sans rien trouver.
+        Une position ne s&apos;affiche que pour une candidature qui siégeait au moment où un texte
+        proche a été soumis.
       </p>
       <Link
         href="/methodologie"

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -270,10 +270,11 @@ describe("SubjectComparison", () => {
 
     expect(container.querySelector('[data-absence-kind="never_sat"]')).toBeNull();
     expect(screen.queryByText(/jamais siégé/i)).not.toBeInTheDocument();
-    expect(
-      container.querySelectorAll('[data-absence-kind="not_applicable"]').length
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Pas de mesure publiée à rapprocher d'un scrutin/).length).toBe(2);
+    // Ce que la ligne dit à la place, tableau et carte : l'absence porte sur ce sujet, rien d'autre.
+    expect(container.querySelectorAll('[data-absence-kind="no_measure_published"]')).toHaveLength(
+      2
+    );
+    expect(screen.getAllByText(/Aucune mesure publiée sur Logement/).length).toBe(2);
   });
 
   it("ne dit jamais d'une mesure publiée qu'elle n'est pas relue", () => {
@@ -325,6 +326,72 @@ describe("SubjectComparison", () => {
     expect(screen.getByText(/réparties entre 1 candidature/)).toBeInTheDocument();
     // Et sous le nom de celle dont la mesure est retirée, le compte tombe à zéro.
     expect(screen.getAllByText(/aucune mesure sur ce sujet/).length).toBe(2);
+  });
+
+  it("cite jusqu'à trois mesures et ne replie que les suivantes", () => {
+    // La régression que ce test verrouille : une seule mesure était citée, et c'était `measures[0]`
+    // d'un `orderBy: createdAt asc`, donc celle importée en premier. Un artefact de pipeline
+    // présenté comme un choix éditorial.
+    const quatre = [1, 2, 3, 4].map((n) =>
+      subjectMeasure(measure({ id: `m-${n}`, text: `Mesure ${n}.` }), "SEARCH_NOT_DONE")
+    );
+    render(<SubjectComparison data={data({ candidates: [entry("Alix", quatre)] })} />);
+
+    // Trois citées d'emblée, dans les deux rendus.
+    for (const n of [1, 2, 3]) {
+      expect(screen.getAllByText(new RegExp(`Mesure ${n}\\.`))).toHaveLength(2);
+    }
+    // La quatrième est repliée : présente dans le DOM (le `<details>` reste indexable et
+    // opérable au clavier), annoncée pour ce qu'elle est.
+    expect(screen.getAllByText("+ 1 autre mesure sur ce sujet")).toHaveLength(2);
+    expect(screen.getAllByText(/Mesure 4\./)).toHaveLength(2);
+  });
+
+  it("ne replie rien quand la candidature porte trois mesures ou moins", () => {
+    const trois = [1, 2, 3].map((n) =>
+      subjectMeasure(measure({ id: `m-${n}`, text: `Mesure ${n}.` }), "SEARCH_NOT_DONE")
+    );
+    render(<SubjectComparison data={data({ candidates: [entry("Alix", trois)] })} />);
+
+    expect(screen.queryByText(/autre mesure sur ce sujet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/autres mesures sur ce sujet/)).not.toBeInTheDocument();
+  });
+
+  it("qualifie chaque mesure citée, jamais la première pour toutes", () => {
+    // Précision et relation aux votes portent sur UNE mesure. Tant qu'elles vivaient en colonnes
+    // lisant `measures[0]`, citer trois phrases aurait attribué aux deux suivantes la
+    // qualification de la première.
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(
+                measure({
+                  id: "m-1",
+                  text: "Construire 200 000 logements.",
+                  precision: "CHIFFREE",
+                }),
+                "SEARCH_NOT_DONE"
+              ),
+              subjectMeasure(
+                measure({ id: "m-2", text: "Encadrer les loyers.", precision: null }),
+                "NO_VOTE_IN_SCOPE"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+
+    // Une pastille chiffrée pour la première, une absence qualifiée pour la seconde, pas l'inverse.
+    expect(screen.getAllByText("Chiffrée")).toHaveLength(2);
+    expect(screen.getAllByText("Précision non renseignée")).toHaveLength(2);
+    // Et deux états de vote différents sur la même ligne. Portée sur la ligne du tableau : le
+    // paragraphe de méthode cite les mêmes libellés en bas de page.
+    const ligne = screen.getAllByText("Alix")[0]!.closest("tr") as HTMLElement;
+    expect(within(ligne).getAllByText(/périmètre non examiné/)).toHaveLength(1);
+    expect(within(ligne).getAllByText(/périmètre examiné sans résultat/)).toHaveLength(1);
   });
 
   it("porte le code couleur de chaque candidature, dans le tableau comme sur les cartes", () => {

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -326,4 +326,38 @@ describe("SubjectComparison", () => {
     // Et sous le nom de celle dont la mesure est retirée, le compte tombe à zéro.
     expect(screen.getAllByText(/aucune mesure sur ce sujet/).length).toBe(2);
   });
+
+  it("porte le code couleur de chaque candidature, dans le tableau comme sur les cartes", () => {
+    // Régression : la pastille existait mais n'était alimentée que par l'accent éditorial, nul sur
+    // toutes les candidatures semées, donc chaque ligne rendait le même gris. La couleur est
+    // désormais résolue par l'autorité de lecture (`resolveCandidateAccentColor`).
+    const { container } = render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ id: "m-1" }), "SEARCH_NOT_DONE")], {
+              accentColor: "#cc2443",
+            }),
+            entry("Chloe", [subjectMeasure(measure({ id: "m-2" }), "SEARCH_NOT_DONE")]),
+          ],
+        })}
+      />
+    );
+
+    // Deux rendus, tableau et cartes : la pastille doit tenir dans les deux.
+    const colorees = container.querySelectorAll('[data-accent="#cc2443"]');
+    expect(colorees).toHaveLength(2);
+    for (const pastille of colorees) {
+      expect(pastille).toHaveStyle({ backgroundColor: "#cc2443" });
+      // Décorative : le nom du parti est écrit à côté, la couleur ne porte jamais seule un fait.
+      expect(pastille).toHaveAttribute("aria-hidden", "true");
+    }
+
+    // Sans couleur résolue, la pastille reste neutre plutôt que d'emprunter celle d'un autre parti.
+    const neutres = container.querySelectorAll('[data-accent="neutre"]');
+    expect(neutres).toHaveLength(2);
+    for (const pastille of neutres) {
+      expect((pastille as HTMLElement).style.backgroundColor).toBe("");
+    }
+  });
 });

--- a/src/lib/data/__tests__/hub-fixture.ts
+++ b/src/lib/data/__tests__/hub-fixture.ts
@@ -7,7 +7,8 @@ import { assertDisposableTestDb } from "@/test/disposable-db";
  * Three populations coexist on purpose:
  * - Alpha and Bravo carry a PUBLISHED `CandidacyPresidential` extension plus a defended
  *   LOGEMENT_URBANISME measure each, so the subject page reaches its two-candidacy gate and
- *   `getHubMeasureContext` reports `hubPublishable: true`.
+ *   `getHubMeasureContext` reports `hubPublishable: true`. Alpha also carries a published
+ *   editorial accent used to verify that the hub and subject pages share the same colour priority.
  * - Charlie is ENVISAGE, has a complete source (`sourceUrl` + `sourceLabel`), and a DRAFT
  *   `CandidacyPresidential` extension carrying a published LOGEMENT_URBANISME measure. The hub
  *   field shows the whole race, not just published fiches, so Charlie must still surface from
@@ -58,7 +59,8 @@ export async function seedHubFixture(
 
   async function candidacyWithPublishedExtension(
     name: string,
-    status: "PRESSENTI" | "DECLARE"
+    status: "PRESSENTI" | "DECLARE",
+    accentColor: string | null = null
   ): Promise<{ candidacyId: string; politicianId: string }> {
     const pol = await politician(name);
     const candidacy = await db.candidacy.create({
@@ -72,7 +74,7 @@ export async function seedHubFixture(
       },
     });
     await db.candidacyPresidential.create({
-      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED" },
+      data: { candidacyId: candidacy.id, publicationStatus: "PUBLISHED", accentColor },
     });
     return { candidacyId: candidacy.id, politicianId: pol.id };
   }
@@ -114,7 +116,7 @@ export async function seedHubFixture(
     return seeded;
   }
 
-  const alpha = await candidacyWithPublishedExtension("Alpha", "PRESSENTI");
+  const alpha = await candidacyWithPublishedExtension("Alpha", "PRESSENTI", "#123456");
   const bravo = await candidacyWithPublishedExtension("Bravo", "DECLARE");
 
   await publishMeasure(
@@ -146,7 +148,11 @@ export async function seedHubFixture(
     },
   });
   await db.candidacyPresidential.create({
-    data: { candidacyId: charlieCandidacy.id, publicationStatus: "DRAFT" },
+    data: {
+      candidacyId: charlieCandidacy.id,
+      publicationStatus: "DRAFT",
+      accentColor: "#abcdef",
+    },
   });
   await publishMeasure(
     charlie.id,

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -105,6 +105,13 @@ describeIfDisposableDb("hub", () => {
         await db.politician.deleteMany({ where: { id: { in: [zoe.id, aaron.id] } } });
       }
     });
+
+    it("utilise uniquement les accents éditoriaux publiés", async () => {
+      const field = await getHubCandidacyField(SLUG);
+
+      expect(field.find((c) => c.candidateName === "Alpha Fixture")?.partyColor).toBe("#123456");
+      expect(field.find((c) => c.candidateName === "Charlie Fixture")?.partyColor).toBeNull();
+    });
   });
 
   describe("getHubMeasureContext / loadHubMeasureContext", () => {

--- a/src/lib/data/__tests__/presidential-candidates-public.integration.test.ts
+++ b/src/lib/data/__tests__/presidential-candidates-public.integration.test.ts
@@ -32,8 +32,23 @@ describeIfDisposableDb("autorité de lecture publique des candidatures présiden
     });
     electionId = election.id;
 
+    // Deux partis colorés : celui qu'Alix porte réellement, et celui dont Dana est encartée mais
+    // sous lequel elle ne se présente pas.
+    const partiAlix = await db.party.create({
+      data: { name: `${SLUG} Parti A`, shortName: `${SLUG}-PA`, color: "#cc2443" },
+    });
+    const partiDana = await db.party.create({
+      data: { name: `${SLUG} Parti D`, shortName: `${SLUG}-PD`, color: "#0d378a" },
+    });
+
     const polPub = await db.politician.create({
-      data: { slug: `${SLUG}-a`, firstName: "Alix", lastName: "Publiee", fullName: "Alix Publiee" },
+      data: {
+        slug: `${SLUG}-a`,
+        firstName: "Alix",
+        lastName: "Publiee",
+        fullName: "Alix Publiee",
+        currentPartyId: partiAlix.id,
+      },
     });
     const polDraft = await db.politician.create({
       data: { slug: `${SLUG}-b`, firstName: "Bo", lastName: "Brouillon", fullName: "Bo Brouillon" },
@@ -50,10 +65,36 @@ describeIfDisposableDb("autorité de lecture publique des candidatures présiden
         status: "DECLARE",
         sourceUrl: "https://example.org/a",
         sourceLabel: "Source A",
+        // Étiquette texte sans `partyId`, l'état réel des candidatures semées : la couleur ne peut
+        // venir que du parti actuel de la personne, et seulement parce que l'étiquette le nomme.
+        partyLabel: `${SLUG}-PA`,
       },
     });
     await db.candidacyPresidential.create({
       data: { candidacyId: candPub.id, publicationStatus: "PUBLISHED", slogan: "Slogan A" },
+    });
+
+    // Dana se présente sous une autre bannière que le parti dont elle est encartée.
+    const polDivergente = await db.politician.create({
+      data: {
+        slug: `${SLUG}-d`,
+        firstName: "Dana",
+        lastName: "Divergente",
+        fullName: "Dana Divergente",
+        currentPartyId: partiDana.id,
+      },
+    });
+    const candDivergente = await db.candidacy.create({
+      data: {
+        electionId,
+        politicianId: polDivergente.id,
+        candidateName: "Dana Divergente",
+        status: "DECLARE",
+        partyLabel: "Mouvement local",
+      },
+    });
+    await db.candidacyPresidential.create({
+      data: { candidacyId: candDivergente.id, publicationStatus: "PUBLISHED" },
     });
 
     const candDraft = await db.candidacy.create({
@@ -83,19 +124,30 @@ describeIfDisposableDb("autorité de lecture publique des candidatures présiden
     await db.candidacy.deleteMany({ where: { electionId } });
     await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
     await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.party.deleteMany({ where: { shortName: { startsWith: SLUG } } });
     await db.$disconnect();
   });
 
   it("ne renvoie que les candidatures dont l'extension est PUBLISHED", async () => {
     const result = await getPublicPresidentialCandidates(SLUG);
-    expect(result.map((c) => c.candidateName)).toEqual(["Alix Publiee"]);
+    // Par nom de famille : Divergente avant Publiee.
+    expect(result.map((c) => c.candidateName)).toEqual(["Dana Divergente", "Alix Publiee"]);
   });
 
   it("expose slogan et source, jamais un brouillon ni une candidature sans extension", async () => {
     const result = await getPublicPresidentialCandidates(SLUG);
-    expect(result).toHaveLength(1);
-    expect(result[0]?.slogan).toBe("Slogan A");
-    expect(result[0]?.sourceLabel).toBe("Source A");
-    expect(result[0]?.status).toBe("DECLARE");
+    const alix = result.find((c) => c.candidateName === "Alix Publiee");
+    expect(alix?.slogan).toBe("Slogan A");
+    expect(alix?.sourceLabel).toBe("Source A");
+    expect(alix?.status).toBe("DECLARE");
+  });
+
+  it("résout la couleur de la candidature, sans emprunter celle d'un parti qu'elle ne porte pas", async () => {
+    const result = await getPublicPresidentialCandidates(SLUG);
+
+    // Étiquette texte seule : la couleur vient du parti actuel, parce que l'étiquette le nomme.
+    expect(result.find((c) => c.candidateName === "Alix Publiee")?.accentColor).toBe("#cc2443");
+    // Étiquette divergente : rien plutôt qu'une couleur fausse.
+    expect(result.find((c) => c.candidateName === "Dana Divergente")?.accentColor).toBeNull();
   });
 });

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -3,6 +3,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isFicheCandidatPublishable, isHubPublishable } from "@/config/publication-gates";
+import { resolveCandidateAccentColor } from "@/lib/presidentielle/candidate-accent";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import {
   resolveProgrammeAbsence,
@@ -41,9 +42,8 @@ export type HubCandidacy = {
   sourceLabel: string | null;
   partyLabel: string | null;
   /**
-   * The party as an ENTITY, when the candidacy is linked to one. `partyLabel` is the wording of
-   * the source and stays authoritative for the text; these three carry the visual identity, and
-   * they are all null on a candidacy whose `partyId` was never resolved.
+   * The visual identity. The colour follows the same resolver as the subject pages, while the short
+   * name and logo still require a linked party entity.
    */
   partyColor: string | null;
   partyShortName: string | null;
@@ -117,7 +117,14 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
         sourceLabel: true,
         partyLabel: true,
         partyId: true,
-        politician: { select: { slug: true, lastName: true } },
+        presidentialData: { select: { accentColor: true, publicationStatus: true } },
+        politician: {
+          select: {
+            slug: true,
+            lastName: true,
+            currentParty: { select: { color: true, name: true, shortName: true } },
+          },
+        },
         party: { select: { color: true, shortName: true, logoUrl: true } },
       },
     }),
@@ -167,7 +174,18 @@ export async function getHubCandidacyField(electionSlug: string): Promise<HubCan
       sourceUrl: c.sourceUrl,
       sourceLabel: c.sourceLabel,
       partyLabel: c.partyLabel,
-      partyColor: c.party?.color ?? null,
+      partyColor: resolveCandidateAccentColor({
+        // The hub includes candidacies without a published presidential extension. Use an editorial
+        // accent only after that extension clears its publication gate, otherwise fall back to the
+        // candidacy's public party data.
+        accentColor:
+          c.presidentialData?.publicationStatus === "PUBLISHED"
+            ? c.presidentialData.accentColor
+            : null,
+        candidacyParty: c.party,
+        partyLabel: c.partyLabel,
+        currentParty: c.politician?.currentParty ?? null,
+      }),
       partyShortName: c.party?.shortName ?? null,
       partyLogoUrl: c.party?.logoUrl ?? null,
       measureCount,

--- a/src/lib/data/presidential-candidates-public.ts
+++ b/src/lib/data/presidential-candidates-public.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { db } from "@/lib/db";
+import { resolveCandidateAccentColor } from "@/lib/presidentielle/candidate-accent";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import type { CandidacyStatus, Prisma } from "@/generated/prisma";
 
@@ -30,6 +31,12 @@ export type PublicPresidentialCandidate = {
   sourceUrl: string | null;
   sourceLabel: string | null;
   slogan: string | null;
+  /**
+   * The colour code of the candidacy, already resolved: editorial accent, else the party it is filed
+   * under, else the linked politician's current party when the candidacy's own label names it.
+   * Null when none of the three answers, and a caller renders a neutral slot rather than a colour.
+   * See `resolveCandidateAccentColor` for why the last step is guarded.
+   */
   accentColor: string | null;
   /** Wording of the source for the party, and the linked entity's sigle when there is one. */
   partyLabel: string | null;
@@ -44,8 +51,16 @@ export async function getPublicPresidentialCandidates(
     where: { election: { slug: electionSlug }, ...PUBLIC_CANDIDACY_WHERE },
     include: {
       presidentialData: true,
-      politician: { select: { slug: true, lastName: true } },
-      party: { select: { shortName: true } },
+      // `currentParty` is read for its colour only, and only ever used when the candidacy's own
+      // `partyLabel` names that same party (see `resolveCandidateAccentColor`).
+      politician: {
+        select: {
+          slug: true,
+          lastName: true,
+          currentParty: { select: { color: true, name: true, shortName: true } },
+        },
+      },
+      party: { select: { shortName: true, color: true } },
     },
     // No `orderBy`: the order is a presidential policy, not a column. Sorting here on
     // `candidateName` would file "Édouard Philippe" under E, and would disagree with the hub field,
@@ -60,7 +75,12 @@ export async function getPublicPresidentialCandidates(
     sourceUrl: row.sourceUrl,
     sourceLabel: row.sourceLabel,
     slogan: row.presidentialData?.slogan ?? null,
-    accentColor: row.presidentialData?.accentColor ?? null,
+    accentColor: resolveCandidateAccentColor({
+      accentColor: row.presidentialData?.accentColor ?? null,
+      candidacyParty: row.party,
+      partyLabel: row.partyLabel,
+      currentParty: row.politician?.currentParty ?? null,
+    }),
     partyLabel: row.partyLabel,
     partyShortName: row.party?.shortName ?? null,
     declaredAt: row.presidentialData?.declaredAt ?? null,

--- a/src/lib/presidentielle/__tests__/candidate-accent.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-accent.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { resolveCandidateAccentColor, type CandidateAccentInput } from "../candidate-accent";
+
+function input(over: Partial<CandidateAccentInput> = {}): CandidateAccentInput {
+  return {
+    accentColor: null,
+    candidacyParty: null,
+    partyLabel: null,
+    currentParty: null,
+    ...over,
+  };
+}
+
+describe("resolveCandidateAccentColor", () => {
+  it("préfère l'accent éditorial à toute couleur déduite", () => {
+    const color = resolveCandidateAccentColor(
+      input({
+        accentColor: "#123456",
+        candidacyParty: { color: "#abcdef" },
+        partyLabel: "PS",
+        currentParty: { color: "#ff8080", name: "Parti socialiste", shortName: "PS" },
+      })
+    );
+
+    expect(color).toBe("#123456");
+  });
+
+  it("prend la couleur du parti sous lequel la candidature est déposée", () => {
+    const color = resolveCandidateAccentColor(
+      input({ candidacyParty: { color: "#0d378a" }, partyLabel: "RN" })
+    );
+
+    expect(color).toBe("#0d378a");
+  });
+
+  it("retombe sur le parti actuel quand le libellé de la candidature le nomme", () => {
+    // La régression que ce test verrouille : les candidatures semées ne portent qu'un `partyLabel`
+    // texte, sans `partyId` ni accent éditorial, donc sans cette étape chaque ligne du tableau
+    // sujet affichait le même gris.
+    const color = resolveCandidateAccentColor(
+      input({
+        partyLabel: "LFI",
+        currentParty: { color: "#cc2443", name: "La France insoumise", shortName: "LFI" },
+      })
+    );
+
+    expect(color).toBe("#cc2443");
+  });
+
+  it("accepte le nom complet du parti autant que son sigle, accents et casse compris", () => {
+    const color = resolveCandidateAccentColor(
+      input({
+        partyLabel: "les ecologistes",
+        currentParty: { color: "#00c000", name: "Les Écologistes", shortName: "EELV" },
+      })
+    );
+
+    expect(color).toBe("#00c000");
+  });
+
+  it("refuse la couleur du parti actuel quand la candidature est déposée sous une autre étiquette", () => {
+    // Le cas éditorial : une personne encartée quelque part se présente sous une autre bannière.
+    // Peindre sa ligne aux couleurs du parti qu'elle ne porte pas serait une erreur factuelle.
+    const color = resolveCandidateAccentColor(
+      input({
+        partyLabel: "Picardie Debout",
+        currentParty: { color: "#cc2443", name: "La France insoumise", shortName: "LFI" },
+      })
+    );
+
+    expect(color).toBeNull();
+  });
+
+  it("n'invente pas de couleur quand la candidature ne déclare aucune étiquette", () => {
+    const color = resolveCandidateAccentColor(
+      input({
+        partyLabel: null,
+        currentParty: { color: "#cc2443", name: "La France insoumise", shortName: "LFI" },
+      })
+    );
+
+    expect(color).toBeNull();
+  });
+
+  it("renvoie null quand aucune source de couleur n'existe", () => {
+    expect(resolveCandidateAccentColor(input({ partyLabel: "Divers" }))).toBeNull();
+    expect(
+      resolveCandidateAccentColor(
+        input({
+          partyLabel: "PS",
+          currentParty: { color: null, name: "Parti socialiste", shortName: "PS" },
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/src/lib/presidentielle/candidate-accent.ts
+++ b/src/lib/presidentielle/candidate-accent.ts
@@ -1,0 +1,64 @@
+/**
+ * The colour code that identifies a candidacy on the public presidential surfaces.
+ *
+ * The subject pages carried a colour slot from the start, fed only by `CandidacyPresidential.accentColor`.
+ * That field is set by hand in the admin and is null on every candidacy seeded so far, so every row
+ * rendered the same neutral grey: a colour code that codes nothing, and a reader coming from the hub
+ * (where the party mark is coloured) lost the key between two pages showing the same people.
+ *
+ * The resolution is a chain of decreasing certainty, and it stops rather than guessing:
+ *
+ * 1. The editorial accent, when an editor set one. An explicit decision beats anything derived.
+ * 2. The colour of the party the candidacy is FILED under (`Candidacy.partyId`, an id, not a name).
+ * 3. The colour of the party the linked politician currently belongs to, and only when the candidacy's
+ *    own `partyLabel` names that same party.
+ *
+ * Step 3 is guarded for the same reason `getAffairPartyDisplay()` refuses the
+ * `partyAtTime || currentParty` fallback: a candidacy is not always filed under the banner its author
+ * currently sits with, and painting a candidacy in the colours of a party it is not running for is a
+ * factual error about a real person, made worse by being non-partisan in intent and partisan in effect.
+ * When the label disagrees, or when there is no label to check against, the slot stays neutral. A grey
+ * bar says "we have no colour for this candidacy", which is true; the wrong colour says something false.
+ *
+ * Returning null is therefore a normal outcome, not a failure, and every caller must render a neutral
+ * slot for it. The party name is written next to the mark on every surface, so the colour is never the
+ * only carrier of the information (WCAG 1.4.1).
+ */
+
+export type CandidateAccentInput = {
+  /** Editorial accent of the presidential extension, when an editor set one. */
+  accentColor: string | null;
+  /** The party the candidacy is filed under, linked by id. */
+  candidacyParty: { color: string | null } | null;
+  /** The party as the source of the candidacy writes it, free text. */
+  partyLabel: string | null;
+  /** The party the linked politician currently belongs to. */
+  currentParty: { color: string | null; name: string; shortName: string } | null;
+};
+
+/** Lowercase, accents dropped, punctuation collapsed: "Les Écologistes" and "les ecologistes" match. */
+function normalizePartyName(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // accents
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+export function resolveCandidateAccentColor(input: CandidateAccentInput): string | null {
+  if (input.accentColor !== null) return input.accentColor;
+  if (input.candidacyParty?.color != null) return input.candidacyParty.color;
+
+  const current = input.currentParty;
+  if (current?.color == null) return null;
+  if (input.partyLabel === null) return null;
+
+  const label = normalizePartyName(input.partyLabel);
+  if (label === "") return null;
+
+  return label === normalizePartyName(current.name) ||
+    label === normalizePartyName(current.shortName)
+    ? current.color
+    : null;
+}


### PR DESCRIPTION
La pastille de couleur des candidatures reposait uniquement sur
`CandidacyPresidential.accentColor`, actuellement vide pour les candidatures semées. Le tableau
des sujets et le hub affichaient donc une identité visuelle neutre.

La couleur suit maintenant une chaîne de résolution prudente :

- accent éditorial, uniquement si l'extension présidentielle est publiée ;
- couleur du parti lié à la candidature ;
- couleur du parti actuel de la personne, seulement si le libellé de candidature désigne ce parti.

En cas de divergence, la couleur reste neutre afin de ne pas attribuer une candidature au mauvais
parti. Le hub et les pages sujet utilisent la même règle.

La comparaison cite aussi jusqu'à trois mesures par candidature avant de replier les suivantes.
La précision et la relation aux votes restent attachées à chaque mesure, ce qui évite d'appliquer
les qualifications de la première mesure aux suivantes.

Validation :

- typecheck réussi ;
- 4 276 tests réussis, 381 sautés par les gardes habituels ;
- lint ciblé réussi sur les neuf fichiers modifiés ;
- build Next.js complet réussi, avec 789 pages générées.
