### PR TITLE
Add chamber-aware SEO metadata for parliamentary pages

### DIFF
--- a/.github/workflows/sync-daily.yml
+++ b/.github/workflows/sync-daily.yml
@@ -14,6 +14,8 @@ permissions:
 
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  CRON_SECRET: ${{ secrets.CRON_SECRET }}
+  NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'https://poligraph.fr' }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
   GOOGLE_FACTCHECK_API_KEY: ${{ secrets.GOOGLE_FACTCHECK_API_KEY }}

--- a/.github/workflows/sync-scrutins-an.yml
+++ b/.github/workflows/sync-scrutins-an.yml
@@ -17,6 +17,8 @@ permissions:
 
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  CRON_SECRET: ${{ secrets.CRON_SECRET }}
+  NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'https://poligraph.fr' }}
 
 jobs:
   sync-scrutins-an:
@@ -47,6 +49,9 @@ jobs:
           else
             npm run sync:scrutins-an
           fi
+
+      - name: Revalidate votes cache
+        run: npm run cache:revalidate -- votes
 
       - name: Show sync stats
         if: always()

--- a/.github/workflows/sync-scrutins-an.yml
+++ b/.github/workflows/sync-scrutins-an.yml
@@ -43,6 +43,8 @@ jobs:
         run: npx prisma generate
 
       - name: Sync Scrutins from Official AN API
+        id: sync
+        continue-on-error: true
         run: |
           if [ -n "${{ github.event.inputs.limit }}" ]; then
             npm run sync:scrutins-an -- --limit=${{ github.event.inputs.limit }}
@@ -51,7 +53,14 @@ jobs:
           fi
 
       - name: Revalidate votes cache
+        if: ${{ !cancelled() && (steps.sync.outcome == 'success' || steps.sync.outcome == 'failure') }}
         run: npm run cache:revalidate -- votes
+
+      - name: Preserve sync failure after cache revalidation
+        if: ${{ always() && steps.sync.outcome == 'failure' }}
+        run: |
+          echo "::error::Scrutin sync failed after cache revalidation."
+          exit 1
 
       - name: Show sync stats
         if: always()

--- a/docs/DATASOURCES.md
+++ b/docs/DATASOURCES.md
@@ -838,7 +838,7 @@ npm run sync:daily -- --dry-run
 | `VOYAGE_API_KEY`           | Embeddings RAG (#19)                                 | Pour `index:embeddings`           |
 | `MAILJET_API_KEY`          | Newsletter (#19)                                     | Pour la newsletter                |
 | `MAILJET_SECRET_KEY`       | Newsletter (#19)                                     | Pour la newsletter                |
-| `CRON_SECRET`              | Cache revalidation (sync:daily)                      | Optionnel                         |
+| `CRON_SECRET`              | Cache revalidation (sync:daily en écriture)          | Requis                            |
 
 ### Configuration des URLs
 

--- a/docs/audits/seo-parlementaire-lot-b-2026-08.md
+++ b/docs/audits/seo-parlementaire-lot-b-2026-08.md
@@ -1,0 +1,55 @@
+# SEO parlementaire — Lot B (proposition, non implémenté)
+
+Note de suite du Lot A (SEO des surfaces parlementaires existantes). Rien de ce
+qui suit n'est implémenté : ce document sert de cadrage pour un chantier
+ultérieur. Le principe directeur reste inchangé — faire ranker des surfaces
+riches correspondant à des intentions de recherche réelles, pas indexer
+davantage de scrutins bruts.
+
+## B1. Enrichissement des pages thématiques
+
+1. **Dossiers législatifs associés** : lister sur `/parlement/votes/themes/[theme]`
+   les dossiers dont les scrutins portent ce thème. Lien déterministe existant
+   (`Scrutin.dossierLegislatif`), aucune agrégation nouvelle, et maillage
+   direct vers `/parlement/dossiers/[slug]`.
+2. **Votes expliqués du thème** : réutiliser le périmètre `filter=expliques`
+   (titres explicatifs APPROVED) restreint au thème. Contenu déjà validé
+   éditorialement, donc publiable sans nouvelle politique.
+3. **Derniers scrutins du thème** : déjà présents via la liste paginée ; à
+   évaluer surtout comme bloc « activité récente » en tête de page.
+4. **Thèmes voisins** : uniquement si une taxonomie explicite est introduite en
+   base. Aucune proximité ne doit être inférée statistiquement.
+
+## B2. Pages de votes des élus
+
+5. **Volume et dernier vote connu** : nombre de votes enregistrés (déjà affiché)
+   et date du dernier vote, tous deux déterministes. Aucun taux, aucune
+   participation (cf. #717).
+6. **Répartition par type de scrutin** : les compteurs d'onglets existent déjà
+   (`getPoliticianVoteTabCounts`) ; une répartition lisible ne coûte pas de
+   requête supplémentaire.
+7. **Votes marquants** : uniquement sur un critère existant et documenté
+   (`ScrutinImportance.isKeyVote`). Jamais de sélection éditoriale implicite,
+   jamais d'interprétation du comportement de vote.
+
+## B3. Jeu de données parlementaire
+
+8. **Page `/donnees/parlement`** : contenu du jeu de données, provenance
+   (data.assemblee-nationale.fr, senat.fr), couverture (législatures, chambres,
+   types de scrutins), fréquence de mise à jour, limites connues, liens vers les
+   sources officielles et vers l'API/exports publics.
+9. **JSON-LD `Dataset`** : pertinent pour cette page uniquement (éligible à
+   Google Dataset Search), avec `DataCatalog` seulement si plusieurs jeux de
+   données distincts sont décrits. À ne pas poser sur les listings existants.
+10. **Pré-requis** : la page ne doit décrire que la couverture réellement
+    servie ; toute limite non documentée doit être écrite plutôt que passée sous
+    silence.
+
+## Hors scope explicite (rappel)
+
+- Aucune archive combinatoire (thème × élu × groupe), aucune indexation de
+  facettes, aucune modification de la politique de sitemap des scrutins.
+- Aucune FAQ artificielle, aucun `FAQPage` JSON-LD, aucun texte éditorial
+  généré automatiquement.
+- Les règles globales d'indexabilité des fiches `/parlement/votes/[slug]`
+  demandent une analyse Search Console dédiée avant toute modification.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "maires:promote": "tsx scripts/promote-maires.ts",
     "sync:history:stats": "tsx scripts/sync-mandate-history.ts --stats",
     "sync:daily": "tsx scripts/sync-daily.ts",
+    "cache:revalidate": "tsx scripts/revalidate-cache.ts",
     "sync:full": "tsx scripts/sync-full.ts",
     "sync:scrutins-an": "tsx scripts/sync-scrutins-an.ts",
     "sync:scrutins-an:today": "tsx scripts/sync-scrutins-an.ts --today",

--- a/scripts/lib/revalidate-cache.test.ts
+++ b/scripts/lib/revalidate-cache.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { revalidateRemoteCache, resolveRevalidationBaseUrl } from "./revalidate-cache";
+
+describe("resolveRevalidationBaseUrl", () => {
+  it("privilégie NEXT_PUBLIC_BASE_URL sans doubler le protocole", () => {
+    expect(
+      resolveRevalidationBaseUrl({
+        NEXT_PUBLIC_BASE_URL: "https://poligraph.fr/",
+        VERCEL_URL: "preview.vercel.app",
+      })
+    ).toBe("https://poligraph.fr");
+  });
+
+  it("utilise VERCEL_URL avec HTTPS quand la base publique est absente", () => {
+    expect(resolveRevalidationBaseUrl({ VERCEL_URL: "preview.vercel.app" })).toBe(
+      "https://preview.vercel.app"
+    );
+    expect(resolveRevalidationBaseUrl({ VERCEL_URL: "https://preview.vercel.app" })).toBe(
+      "https://preview.vercel.app"
+    );
+  });
+
+  it("utilise localhost quand aucune URL n'est définie", () => {
+    expect(resolveRevalidationBaseUrl({})).toBe("http://localhost:3000");
+  });
+});
+
+describe("revalidateRemoteCache", () => {
+  it("échoue explicitement sans CRON_SECRET", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      revalidateRemoteCache(["votes"], {
+        env: { NEXT_PUBLIC_BASE_URL: "https://poligraph.fr" },
+        fetchImpl,
+      })
+    ).rejects.toThrow("CRON_SECRET is required");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([401, 500])("échoue sur une réponse HTTP %s", async (status) => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("revalidation refused", { status }));
+
+    await expect(
+      revalidateRemoteCache(["votes"], {
+        env: {
+          NEXT_PUBLIC_BASE_URL: "https://poligraph.fr",
+          CRON_SECRET: "test-secret",
+        },
+        fetchImpl,
+      })
+    ).rejects.toThrow(`HTTP ${status}`);
+  });
+
+  it("envoie les tags et l'authentification puis réussit sur HTTP 200", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{"revalidated":["votes"]}', { status: 200 }));
+
+    await expect(
+      revalidateRemoteCache(["votes"], {
+        env: {
+          NEXT_PUBLIC_BASE_URL: "https://poligraph.fr",
+          CRON_SECRET: "test-secret",
+        },
+        fetchImpl,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(fetchImpl).toHaveBeenCalledExactlyOnceWith(
+      "https://poligraph.fr/api/cron/revalidate",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-secret",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: ["votes"] }),
+      })
+    );
+  });
+});

--- a/scripts/lib/revalidate-cache.ts
+++ b/scripts/lib/revalidate-cache.ts
@@ -1,0 +1,51 @@
+export type CacheRevalidationEnv = Readonly<Record<string, string | undefined>>;
+
+interface RevalidateRemoteCacheOptions {
+  env?: CacheRevalidationEnv;
+  fetchImpl?: typeof fetch;
+}
+
+function ensureProtocol(value: string): string {
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+export function resolveRevalidationBaseUrl(env: CacheRevalidationEnv = process.env): string {
+  const configuredBaseUrl = env.NEXT_PUBLIC_BASE_URL?.trim();
+  if (configuredBaseUrl) return ensureProtocol(configuredBaseUrl).replace(/\/$/, "");
+
+  const vercelUrl = env.VERCEL_URL?.trim();
+  if (vercelUrl) return ensureProtocol(vercelUrl).replace(/\/$/, "");
+
+  return "http://localhost:3000";
+}
+
+export async function revalidateRemoteCache(
+  tags: string[],
+  options: RevalidateRemoteCacheOptions = {}
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const secret = env.CRON_SECRET?.trim();
+  if (!secret) {
+    throw new Error("CRON_SECRET is required for remote cache revalidation");
+  }
+  if (tags.length === 0) {
+    throw new Error("At least one cache tag is required for remote revalidation");
+  }
+
+  const endpoint = `${resolveRevalidationBaseUrl(env)}/api/cron/revalidate`;
+  const response = await (options.fetchImpl ?? fetch)(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ tags }),
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 500);
+    throw new Error(
+      `Remote cache revalidation failed with HTTP ${response.status}${body ? `: ${body}` : ""}`
+    );
+  }
+}

--- a/scripts/revalidate-cache.ts
+++ b/scripts/revalidate-cache.ts
@@ -1,0 +1,13 @@
+import "dotenv/config";
+import { revalidateRemoteCache } from "./lib/revalidate-cache";
+
+async function main() {
+  const tags = process.argv.slice(2).filter(Boolean);
+  await revalidateRemoteCache(tags);
+  console.log(`Cache revalidation completed for: ${tags.join(", ")}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -14,14 +14,10 @@
 
 import "dotenv/config";
 import { execSync } from "child_process";
+import { revalidateRemoteCache } from "./lib/revalidate-cache";
 
 const DRY_RUN = process.argv.includes("--dry-run");
 const dryRunFlag = DRY_RUN ? " --dry-run" : "";
-const BASE_URL =
-  process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
-const CRON_SECRET = process.env.CRON_SECRET;
 
 // Pause between retry attempts so a still-ongoing transient blip (e.g. a
 // Supabase connection drop) has time to clear instead of the retry hitting it
@@ -32,6 +28,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 interface SyncStep {
   name: string;
   command: string;
+  run?: () => Promise<void>;
   /**
    * When true, a failure on this step is recorded but does not mark the whole
    * run as failed. Use sparingly — reserved for steps that depend on unreliable
@@ -140,7 +137,7 @@ const steps: SyncStep[] = [
     command: `npx tsx scripts/notify-press-backlog.ts${dryRunFlag}`,
     allowFailure: true,
   },
-  ...(CRON_SECRET
+  ...(!DRY_RUN
     ? [
         {
           // Scoped tags only — never use { all: true }. See Phase 4 of
@@ -149,7 +146,8 @@ const steps: SyncStep[] = [
           // daily sync. Adding "elections" or "factchecks" here would purge
           // caches that the daily sync did NOT update.
           name: "Cache revalidation",
-          command: `curl -s -X POST "${BASE_URL}/api/cron/revalidate" -H "Authorization: Bearer ${CRON_SECRET}" -H "Content-Type: application/json" -d '{"tags":["votes","dossiers","stats","politicians"]}'`,
+          command: "POST /api/cron/revalidate (votes, dossiers, stats, politicians)",
+          run: () => revalidateRemoteCache(["votes", "dossiers", "stats", "politicians"]),
         },
       ]
     : []),
@@ -194,11 +192,15 @@ async function main() {
       }
       const attemptStart = Date.now();
       try {
-        execSync(step.command, {
-          stdio: "inherit",
-          env: { ...process.env },
-          timeout: 10 * 60 * 1000, // 10 minutes max per step
-        });
+        if (step.run) {
+          await step.run();
+        } else {
+          execSync(step.command, {
+            stdio: "inherit",
+            env: { ...process.env },
+            timeout: 10 * 60 * 1000, // 10 minutes max per step
+          });
+        }
         success = true;
         break;
       } catch (err) {

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -53,6 +53,15 @@ const steps: SyncStep[] = [
     name: "Votes Sénat (today)",
     command: `npx tsx scripts/sync-scrutins-senat.ts --today${dryRunFlag}`,
   },
+  ...(!DRY_RUN
+    ? [
+        {
+          name: "Votes cache revalidation",
+          command: "POST /api/cron/revalidate (votes)",
+          run: () => revalidateRemoteCache(["votes"]),
+        },
+      ]
+    : []),
   {
     name: "Législation (active, 3j)",
     command: `npx tsx scripts/sync-legislation.ts --active --since-days=3${dryRunFlag}`,
@@ -142,12 +151,14 @@ const steps: SyncStep[] = [
         {
           // Scoped tags only — never use { all: true }. See Phase 4 of
           // docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md.
-          // The four tags below match the four data domains touched by the
-          // daily sync. Adding "elections" or "factchecks" here would purge
+          // The three tags below match the remaining data domains touched by
+          // the daily sync. Votes are invalidated immediately after both vote
+          // syncs, before the longer steps below can time out the workflow.
+          // Adding "elections" or "factchecks" here would purge
           // caches that the daily sync did NOT update.
           name: "Cache revalidation",
-          command: "POST /api/cron/revalidate (votes, dossiers, stats, politicians)",
-          run: () => revalidateRemoteCache(["votes", "dossiers", "stats", "politicians"]),
+          command: "POST /api/cron/revalidate (dossiers, stats, politicians)",
+          run: () => revalidateRemoteCache(["dossiers", "stats", "politicians"]),
         },
       ]
     : []),

--- a/src/__tests__/architecture/vote-cache-invalidation.test.ts
+++ b/src/__tests__/architecture/vote-cache-invalidation.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function normalized(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+function expectInOrder(source: string, markers: string[]): void {
+  let previousIndex = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, previousIndex + 1);
+    expect(index, `Marqueur absent ou mal ordonné: ${marker}`).toBeGreaterThan(previousIndex);
+    previousIndex = index;
+  }
+}
+
+describe("architecture d'invalidation du cache des votes", () => {
+  const grouped = withoutComments(read("src/inngest/functions/sync-scrutins.ts"));
+  const dailyInngest = withoutComments(read("src/inngest/functions/sync-daily.ts"));
+  const wrappers = withoutComments(read("src/inngest/index.ts"));
+  const localInvalidation = withoutComments(read("src/inngest/vote-cache.ts"));
+  const dailyScript = withoutComments(read("scripts/sync-daily.ts"));
+  const remoteInvalidation = withoutComments(read("scripts/lib/revalidate-cache.ts"));
+  const remoteCli = withoutComments(read("scripts/revalidate-cache.ts"));
+  const dailyWorkflow = read(".github/workflows/sync-daily.yml");
+  const weeklyWorkflow = read(".github/workflows/sync-scrutins-an.yml");
+
+  it("lie les deux writes du sync Inngest groupé à l'invalidation", () => {
+    expect(normalized(grouped)).toContain(
+      "runVoteSyncWithCacheInvalidation(() => syncScrutinsAN(undefined, false, true) )"
+    );
+    expect(normalized(grouped)).toContain(
+      "runVoteSyncWithCacheInvalidation(() => syncScrutinsSenat(null, false, true))"
+    );
+  });
+
+  it("lie les étapes AN et Sénat du daily Inngest à l'invalidation", () => {
+    expect(normalized(dailyInngest)).toContain(
+      "runVoteSyncWithCacheInvalidation(() => syncScrutinsAN(undefined, false, true))"
+    );
+    expect(normalized(dailyInngest)).toContain(
+      "runVoteSyncWithCacheInvalidation(() => syncScrutinsSenat(null, false, true))"
+    );
+  });
+
+  it("lie les wrappers individuels AN et Sénat à l'invalidation", () => {
+    const anWrapper = wrappers.slice(
+      wrappers.indexOf('createSyncFunction("sync-scrutins-an"'),
+      wrappers.indexOf('createSyncFunction("sync-scrutins-senat"')
+    );
+    const senatWrapper = wrappers.slice(
+      wrappers.indexOf('createSyncFunction("sync-scrutins-senat"'),
+      wrappers.indexOf('createSyncFunction("sync-press-analysis"')
+    );
+
+    expect(anWrapper).toContain("runVoteSyncWithCacheInvalidation");
+    expect(anWrapper).toContain("syncScrutinsAN(undefined, false, todayOnly)");
+    expect(senatWrapper).toContain("runVoteSyncWithCacheInvalidation");
+    expect(senatWrapper).toContain("syncScrutinsSenat(null, false, todayOnly)");
+  });
+
+  it("invalide seulement après la résolution réussie du service Inngest", () => {
+    expectInOrder(localInvalidation, [
+      "const result = await sync()",
+      'revalidateTags(["votes"], "max")',
+      "return result",
+    ]);
+  });
+
+  it("lie le GitHub Daily à une revalidation distante authentifiée et obligatoire", () => {
+    expect(dailyWorkflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
+    expect(dailyWorkflow).toContain("NEXT_PUBLIC_BASE_URL:");
+    expect(dailyWorkflow).toContain("run: npm run sync:daily");
+    expectInOrder(dailyScript, [
+      "scripts/sync-scrutins-an.ts --today",
+      "scripts/sync-scrutins-senat.ts --today",
+      'name: "Cache revalidation"',
+      'revalidateRemoteCache(["votes", "dossiers", "stats", "politicians"])',
+    ]);
+    expect(dailyScript).toContain("...(!DRY_RUN");
+  });
+
+  it("lie le GitHub weekly AN à la revalidation distante après succès", () => {
+    expect(weeklyWorkflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
+    expect(weeklyWorkflow).toContain("NEXT_PUBLIC_BASE_URL:");
+    expectInOrder(weeklyWorkflow, [
+      "npm run sync:scrutins-an",
+      "name: Revalidate votes cache",
+      "run: npm run cache:revalidate -- votes",
+    ]);
+  });
+
+  it("impose endpoint, tag, authentification et échec HTTP fail-closed", () => {
+    expect(remoteCli).toContain("revalidateRemoteCache(tags)");
+    expect(remoteCli).toContain("process.exit(1)");
+    expect(remoteInvalidation).toContain("/api/cron/revalidate");
+    expect(remoteInvalidation).toContain("Authorization: `Bearer ${secret}`");
+    expect(remoteInvalidation).toContain("body: JSON.stringify({ tags })");
+    expect(remoteInvalidation).toContain("if (!response.ok)");
+    expect(remoteInvalidation).toContain("if (!secret)");
+    expect(remoteInvalidation).not.toContain("all: true");
+  });
+});

--- a/src/__tests__/architecture/vote-cache-invalidation.test.ts
+++ b/src/__tests__/architecture/vote-cache-invalidation.test.ts
@@ -75,28 +75,96 @@ describe("architecture d'invalidation du cache des votes", () => {
     ]);
   });
 
-  it("lie le GitHub Daily à une revalidation distante authentifiée et obligatoire", () => {
+  it("invalide les votes du GitHub Daily avant la législation et les traitements longs", () => {
     expect(dailyWorkflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
     expect(dailyWorkflow).toContain("NEXT_PUBLIC_BASE_URL:");
     expect(dailyWorkflow).toContain("run: npm run sync:daily");
     expectInOrder(dailyScript, [
       "scripts/sync-scrutins-an.ts --today",
       "scripts/sync-scrutins-senat.ts --today",
-      'name: "Cache revalidation"',
-      'revalidateRemoteCache(["votes", "dossiers", "stats", "politicians"])',
+      'name: "Votes cache revalidation"',
+      'revalidateRemoteCache(["votes"])',
+      'name: "Législation (active, 3j)"',
     ]);
+    expect(dailyScript).toContain('revalidateRemoteCache(["dossiers", "stats", "politicians"])');
     expect(dailyScript).toContain("...(!DRY_RUN");
   });
 
-  it("lie le GitHub weekly AN à la revalidation distante après succès", () => {
+  it("le Daily continue jusqu'à la revalidation après une erreur de sync partielle", () => {
+    const executionLoop = dailyScript.slice(
+      dailyScript.indexOf("for (const step of steps)"),
+      dailyScript.indexOf("const totalDuration")
+    );
+    const errorHandler = executionLoop.slice(
+      executionLoop.indexOf("} catch (err)"),
+      executionLoop.indexOf("const duration")
+    );
+
+    expect(errorHandler).toContain("lastError =");
+    expect(errorHandler).not.toContain("throw");
+    expect(errorHandler).not.toContain("process.exit");
+  });
+
+  it("le weekly revalide après une sync réussie ou échouée", () => {
     expect(weeklyWorkflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
     expect(weeklyWorkflow).toContain("NEXT_PUBLIC_BASE_URL:");
+    const syncStep = weeklyWorkflow.slice(
+      weeklyWorkflow.indexOf("- name: Sync Scrutins from Official AN API"),
+      weeklyWorkflow.indexOf("- name: Revalidate votes cache")
+    );
+    const revalidationStep = weeklyWorkflow.slice(
+      weeklyWorkflow.indexOf("- name: Revalidate votes cache"),
+      weeklyWorkflow.indexOf("- name: Preserve sync failure after cache revalidation")
+    );
+
+    expect(syncStep).toContain("id: sync");
+    expect(syncStep).toContain("continue-on-error: true");
+    expect(revalidationStep).toContain(
+      "if: ${{ !cancelled() && (steps.sync.outcome == 'success' || steps.sync.outcome == 'failure') }}"
+    );
+    expect(revalidationStep).toContain("run: npm run cache:revalidate -- votes");
     expectInOrder(weeklyWorkflow, [
       "npm run sync:scrutins-an",
       "name: Revalidate votes cache",
-      "run: npm run cache:revalidate -- votes",
+      "name: Preserve sync failure after cache revalidation",
     ]);
   });
+
+  it("le weekly conserve l'échec de sync après avoir tenté la revalidation", () => {
+    const failureStep = weeklyWorkflow.slice(
+      weeklyWorkflow.indexOf("- name: Preserve sync failure after cache revalidation"),
+      weeklyWorkflow.indexOf("- name: Show sync stats")
+    );
+
+    expect(failureStep).toContain("if: ${{ always() && steps.sync.outcome == 'failure' }}");
+    expect(failureStep).toContain("exit 1");
+  });
+
+  it.each([
+    ["success", "success", true, false],
+    ["failure", "success", true, true],
+    ["success", "failure", true, true],
+    ["failure", "failure", true, true],
+  ] as const)(
+    "weekly: sync %s et revalidation %s donnent revalidation=%s et jobFailure=%s",
+    (syncOutcome, revalidationOutcome, expectedRevalidation, expectedJobFailure) => {
+      const syncContinuesOnError = weeklyWorkflow.includes("continue-on-error: true");
+      const revalidationAcceptsFailure = weeklyWorkflow.includes(
+        "steps.sync.outcome == 'success' || steps.sync.outcome == 'failure'"
+      );
+      const syncFailureIsRestored = weeklyWorkflow.includes(
+        "always() && steps.sync.outcome == 'failure'"
+      );
+      const revalidationRuns =
+        syncOutcome === "success" ||
+        (syncOutcome === "failure" && syncContinuesOnError && revalidationAcceptsFailure);
+      const jobFails =
+        revalidationOutcome === "failure" || (syncOutcome === "failure" && syncFailureIsRestored);
+
+      expect(revalidationRuns).toBe(expectedRevalidation);
+      expect(jobFails).toBe(expectedJobFailure);
+    }
+  );
 
   it("impose endpoint, tag, authentification et échec HTTP fail-closed", () => {
     expect(remoteCli).toContain("revalidateRemoteCache(tags)");

--- a/src/__tests__/services/voteStats.chamber-coverage.test.ts
+++ b/src/__tests__/services/voteStats.chamber-coverage.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  vote: { groupBy: vi.fn() },
+}));
+const cacheTag = vi.hoisted(() => vi.fn());
+const cacheLife = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({ cacheTag, cacheLife }));
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+
+import { getPoliticianVoteChamberCoverage } from "@/services/voteStats";
+
+describe("getPoliticianVoteChamberCoverage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads the denormalized Vote.chamber field without a Scrutin join", async () => {
+    dbMock.vote.groupBy.mockResolvedValue([{ chamber: "AN" }, { chamber: "SENAT" }]);
+
+    await expect(getPoliticianVoteChamberCoverage("politician-1")).resolves.toEqual([
+      "AN",
+      "SENAT",
+    ]);
+    expect(dbMock.vote.groupBy).toHaveBeenCalledWith({
+      by: ["chamber"],
+      where: { politicianId: "politician-1" },
+    });
+    expect(cacheTag).toHaveBeenCalledWith("votes", "politicians");
+    expect(cacheLife).toHaveBeenCalledWith("synced");
+  });
+
+  it("returns an empty coverage when no vote is recorded", async () => {
+    dbMock.vote.groupBy.mockResolvedValue([]);
+
+    await expect(getPoliticianVoteChamberCoverage("politician-2")).resolves.toEqual([]);
+  });
+});

--- a/src/app/parlement/groupes/[slug]/__tests__/metadata.test.ts
+++ b/src/app/parlement/groupes/[slug]/__tests__/metadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The page's data layer builds a Prisma client and uses Next cache primitives
+// at import time; generateMetadata only needs the group payload.
+const getGroupeDetail = vi.fn();
+vi.mock("@/lib/data/groupes", () => ({
+  getGroupeDetail: (slug: string) => getGroupeDetail(slug),
+  getGroupKeyVotes: vi.fn(async () => []),
+  getScrutinGroupPositions: vi.fn(async () => []),
+  getScrutinAnalysis: vi.fn(async () => null),
+}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { generateMetadata } from "@/app/parlement/groupes/[slug]/page";
+
+const group = (over: Record<string, unknown> = {}) => ({
+  name: "Groupe Les Démocrates",
+  code: "DEM",
+  chamber: "AN",
+  seatCount: 36,
+  stats: [{ cohesionPct: 91 }],
+  ...over,
+});
+
+const metadataFor = async (over: Record<string, unknown> = {}) => {
+  getGroupeDetail.mockResolvedValue(group(over));
+  return generateMetadata({ params: Promise.resolve({ slug: "dem" }) });
+};
+
+describe("/parlement/groupes/[slug] metadata", () => {
+  it("names the Assemblée nationale for an AN group", async () => {
+    const m = await metadataFor();
+    expect(m.title).toBe("Groupe Les Démocrates à l'Assemblée nationale : membres et votes");
+    expect(m.alternates?.canonical).toBe("/parlement/groupes/dem");
+  });
+
+  it("names the Sénat for a Senate group", async () => {
+    const m = await metadataFor({ name: "Groupe Les Républicains", code: "LR", chamber: "SENAT" });
+    expect(m.title).toBe("Groupe Les Républicains au Sénat : membres et votes");
+    expect(m.title).not.toContain("Assemblée nationale");
+  });
+
+  it("advertises no participation rate, in either chamber (issue #717)", async () => {
+    for (const chamber of ["AN", "SENAT"]) {
+      const m = await metadataFor({ chamber });
+      expect(String(m.title).toLowerCase()).not.toContain("participation");
+      expect(String(m.description).toLowerCase()).not.toContain("participation");
+    }
+  });
+
+  it("promises no statistic when the group has none computed", async () => {
+    const m = await metadataFor({ stats: [] });
+    expect(String(m.description)).not.toContain("cohésion");
+  });
+});

--- a/src/app/parlement/groupes/[slug]/__tests__/senate-vote-card.test.tsx
+++ b/src/app/parlement/groupes/[slug]/__tests__/senate-vote-card.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getGroupeDetail: vi.fn(),
+  getGroupKeyVotes: vi.fn(),
+  voteCard: vi.fn(),
+}));
+
+vi.mock("@/lib/data/groupes", () => ({
+  getGroupeDetail: (slug: string) => mocks.getGroupeDetail(slug),
+  getGroupKeyVotes: (groupId: string) => mocks.getGroupKeyVotes(groupId),
+}));
+vi.mock("@/components/votes", () => ({
+  VoteCard: (props: Record<string, unknown>) => {
+    mocks.voteCard(props);
+    return <div data-testid="vote-card" />;
+  },
+}));
+
+import GroupeDetailPage from "@/app/parlement/groupes/[slug]/page";
+
+describe("/parlement/groupes/[slug] cartes de votes", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("transmet les attributs réels d'un scrutin sénatorial à VoteCard", async () => {
+    mocks.getGroupeDetail.mockResolvedValue({
+      id: "group-senat",
+      name: "Groupe du Sénat",
+      shortName: "GS",
+      code: "GS",
+      chamber: "SENAT",
+      color: null,
+      seatCount: 12,
+      stats: [],
+      members: [],
+    });
+    mocks.getGroupKeyVotes.mockResolvedValue([
+      {
+        scrutin: {
+          id: "scrutin-senat",
+          externalId: "2026-42",
+          slug: "2026-08-14-scrutin-senat",
+          title: "Scrutin sénatorial de test",
+          votingDate: new Date("2026-08-14T10:00:00Z"),
+          legislature: 2026,
+          chamber: "SENAT",
+          votesFor: 180,
+          votesAgainst: 120,
+          votesAbstain: 10,
+          result: "ADOPTED",
+          sourceUrl: "https://www.senat.fr/scrutin-public/2026/scrutin-42.html",
+          theme: null,
+          policyTitle: null,
+        },
+      },
+    ]);
+
+    render(await GroupeDetailPage({ params: Promise.resolve({ slug: "groupe-senat" }) }));
+
+    expect(mocks.voteCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalId: "2026-42",
+        legislature: 2026,
+        chamber: "SENAT",
+        sourceUrl: "https://www.senat.fr/scrutin-public/2026/scrutin-42.html",
+      })
+    );
+  });
+});

--- a/src/app/parlement/groupes/[slug]/page.tsx
+++ b/src/app/parlement/groupes/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { GOVERNMENT_GROUP_CODE, SENATE_GOVERNMENT_GROUP_CODE } from "@/config/sc
 import { InfoTooltip } from "@/components/ui/info-tooltip";
 import { Users, TrendingUp, Target, Activity, FileCheck2 } from "lucide-react";
 import { ParliamentaryGroupJsonLd } from "@/components/seo/JsonLd";
+import { buildGroupeSeo } from "@/lib/seo/groupe-metadata";
 
 export const revalidate = 3600;
 
@@ -25,9 +26,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const group = await getGroupeDetail(slug);
   if (!group) return { title: "Groupe non trouvé" };
 
+  const seo = buildGroupeSeo({
+    name: group.name,
+    code: group.code,
+    chamber: group.chamber,
+    seatCount: group.seatCount,
+    hasStats: group.stats.length > 0,
+  });
+
   return {
-    title: `${group.name} - Groupe parlementaire`,
-    description: `${group.name} (${group.code}) : ${group.seatCount} membres, cohésion et statistiques de vote.`,
+    title: seo.title,
+    description: seo.description,
     alternates: { canonical: `/parlement/groupes/${slug}` },
   };
 }
@@ -42,6 +51,15 @@ export default async function GroupeDetailPage({ params }: PageProps) {
   const stats = group.stats[0];
 
   const chamberLabel = group.chamber === "AN" ? "Assemblée nationale" : "Sénat";
+  // Same string as the meta description: the JSON-LD must not describe the group
+  // differently from the page (and must not promise a stat the page cannot show).
+  const seo = buildGroupeSeo({
+    name: group.name,
+    code: group.code,
+    chamber: group.chamber,
+    seatCount: group.seatCount,
+    hasStats: group.stats.length > 0,
+  });
   const referenceGroupCode =
     group.chamber === "AN" ? GOVERNMENT_GROUP_CODE : SENATE_GOVERNMENT_GROUP_CODE;
   const concordanceVotesTooltip = `${GLOSSARY.concordanceVotesGroupes} Groupe de référence pour cette chambre : ${referenceGroupCode}.`;
@@ -52,7 +70,7 @@ export default async function GroupeDetailPage({ params }: PageProps) {
       <ParliamentaryGroupJsonLd
         name={group.name}
         alternateName={group.shortName ?? undefined}
-        description={`${group.name} (${group.code}) : ${group.seatCount} membres, cohésion et statistiques de vote.`}
+        description={seo.description}
         url={`https://poligraph.fr/parlement/groupes/${slug}`}
         memberOf={{ name: chamberLabel, url: "https://poligraph.fr/parlement" }}
       />

--- a/src/app/parlement/groupes/[slug]/page.tsx
+++ b/src/app/parlement/groupes/[slug]/page.tsx
@@ -163,17 +163,17 @@ export default async function GroupeDetailPage({ params }: PageProps) {
               <VoteCard
                 key={gp.scrutin.id}
                 id={gp.scrutin.id}
-                externalId=""
+                externalId={gp.scrutin.externalId}
                 slug={gp.scrutin.slug}
                 title={gp.scrutin.title}
                 votingDate={gp.scrutin.votingDate}
-                legislature={0}
-                chamber="AN"
+                legislature={gp.scrutin.legislature}
+                chamber={gp.scrutin.chamber}
                 votesFor={gp.scrutin.votesFor}
                 votesAgainst={gp.scrutin.votesAgainst}
                 votesAbstain={gp.scrutin.votesAbstain}
                 result={gp.scrutin.result}
-                sourceUrl={null}
+                sourceUrl={gp.scrutin.sourceUrl}
                 theme={gp.scrutin.theme}
                 policy={gp.scrutin.policyTitle}
               />

--- a/src/app/parlement/votes/[slug]/page.tsx
+++ b/src/app/parlement/votes/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { db } from "@/lib/db";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { VotingResultBadge, VotePositionBadge } from "@/components/votes";
+import { ThemeVotesLink } from "@/components/votes/ThemeVotesLink";
 import { DailyVotesPage } from "@/components/votes/DailyVotesPage";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import { formatDate } from "@/lib/utils";
@@ -600,6 +601,14 @@ export default async function ScrutinPage({ params }: PageProps) {
             )}
           </CardContent>
         </Card>
+
+        {/* Contextual link to the thematic landing (descriptive anchor: the
+            theme badge above only carries the bare label). */}
+        {scrutin.theme && (
+          <div className="mt-8 text-center">
+            <ThemeVotesLink theme={scrutin.theme} />
+          </div>
+        )}
 
         {/* Back link */}
         <div className="mt-8 text-center">

--- a/src/app/parlement/votes/aujourd-hui/__tests__/metadata.test.ts
+++ b/src/app/parlement/votes/aujourd-hui/__tests__/metadata.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The page imports the daily-votes surface, whose data layer builds a Prisma
+// client at module load. generateMetadata itself only formats today's date.
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { generateMetadata } from "@/app/parlement/votes/aujourd-hui/page";
+import * as page from "@/app/parlement/votes/aujourd-hui/page";
+
+describe("/parlement/votes/aujourd-hui metadata", () => {
+  it("states the intent and the date in the title", async () => {
+    const m = await generateMetadata();
+    expect(m.title).toMatch(/^Votes du Parlement aujourd'hui — \d{1,2} \S+ \d{4}$/);
+    expect(m.description).toMatch(
+      /^Consultez les scrutins de l'Assemblée nationale et du Sénat du .+ : résultats et détails des votes parlementaires\.$/
+    );
+  });
+
+  it("keeps its canonical on the bare URL", async () => {
+    const m = await generateMetadata();
+    expect(m.alternates?.canonical).toBe("/parlement/votes/aujourd-hui");
+  });
+
+  it("keeps the ISR contract: revalidate exported, no server searchParams", async () => {
+    // The `type` tab is read client-side precisely so this route stays ISR;
+    // re-adding a server searchParams prop would make it dynamic again.
+    expect(page.revalidate).toBe(300);
+    expect(page.default.length).toBe(0);
+  });
+});

--- a/src/app/parlement/votes/aujourd-hui/page.tsx
+++ b/src/app/parlement/votes/aujourd-hui/page.tsx
@@ -13,9 +13,11 @@ export async function generateMetadata(): Promise<Metadata> {
     timeZone: "UTC",
   });
 
+  // "Votes du jour" reads as a section name; naming the Parliament makes the
+  // intent readable in a SERP without touching the ISR contract below.
   return {
-    title: `Votes du jour — ${formatted}`,
-    description: `Scrutins de l'Assemblée nationale et du Sénat du ${formatted}. Résultats, résumés et détails des votes parlementaires.`,
+    title: `Votes du Parlement aujourd'hui — ${formatted}`,
+    description: `Consultez les scrutins de l'Assemblée nationale et du Sénat du ${formatted} : résultats et détails des votes parlementaires.`,
     alternates: { canonical: "/parlement/votes/aujourd-hui" },
   };
 }

--- a/src/app/parlement/votes/themes/[theme]/__tests__/metadata.test.ts
+++ b/src/app/parlement/votes/themes/[theme]/__tests__/metadata.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// generateMetadata reads a single type × chamber groupBy; the listing queries
+// never run here. Stub Prisma so the module imports with no DATABASE_URL.
+const groupBy = vi.fn();
+vi.mock("@/lib/db", () => ({ db: { scrutin: { groupBy: () => groupBy() } } }));
+
+import { generateMetadata } from "@/app/parlement/votes/themes/[theme]/page";
+
+const BOTH_CHAMBERS = [
+  { type: "ORDINAIRE", chamber: "AN", _count: 80 },
+  { type: "AMENDEMENT", chamber: "AN", _count: 40 },
+  { type: "ORDINAIRE", chamber: "SENAT", _count: 22 },
+];
+
+const metadataFor = (slug: string, counts = BOTH_CHAMBERS, sp: Record<string, string> = {}) => {
+  groupBy.mockResolvedValue(counts);
+  return generateMetadata({
+    params: Promise.resolve({ theme: slug }),
+    searchParams: Promise.resolve(sp),
+  });
+};
+
+beforeEach(() => groupBy.mockReset());
+
+describe("/parlement/votes/themes/[theme] metadata", () => {
+  it("builds a descriptive title for a feminine theme", async () => {
+    const m = await metadataFor("sante");
+    expect(m.title).toBe("Votes sur la santé à l'Assemblée nationale et au Sénat");
+    expect(m.description).toBe(
+      "Consultez les votes du Parlement sur la santé : scrutins de l'Assemblée nationale et du Sénat, résultats, textes de loi et amendements."
+    );
+    expect(m.alternates?.canonical).toBe("/parlement/votes/themes/sante");
+  });
+
+  it("elides correctly instead of injecting the raw label", async () => {
+    expect((await metadataFor("economie-budget")).title).toBe(
+      "Votes sur l'économie et le budget à l'Assemblée nationale et au Sénat"
+    );
+    expect((await metadataFor("immigration")).title).toBe(
+      "Votes sur l'immigration à l'Assemblée nationale et au Sénat"
+    );
+    expect((await metadataFor("environnement-energie")).title).toBe(
+      "Votes sur l'environnement et l'énergie à l'Assemblée nationale et au Sénat"
+    );
+    expect((await metadataFor("securite-justice")).title).toBe(
+      "Votes sur la sécurité et la justice à l'Assemblée nationale et au Sénat"
+    );
+  });
+
+  it("never claims Senate coverage a theme does not have", async () => {
+    const m = await metadataFor("immigration", [{ type: "ORDINAIRE", chamber: "AN", _count: 12 }]);
+    expect(m.title).toBe("Votes sur l'immigration à l'Assemblée nationale");
+    expect(String(m.description)).not.toContain("Sénat");
+  });
+
+  it("keeps the bare landing indexable and its tab variants noindex", async () => {
+    const bare = await metadataFor("sante");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((bare.robots as any)?.index).not.toBe(false);
+
+    const tab = await metadataFor("sante", BOTH_CHAMBERS, { type: "amendements" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((tab.robots as any)?.index).toBe(false);
+    expect(tab.alternates?.canonical).toBe("/parlement/votes/themes/sante");
+
+    const paginated = await metadataFor("sante", BOTH_CHAMBERS, { page: "2" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((paginated.robots as any)?.index).toBe(false);
+  });
+
+  it("does not query the database for an unknown theme", async () => {
+    const m = await generateMetadata({
+      params: Promise.resolve({ theme: "theme-inexistant" }),
+      searchParams: Promise.resolve({}),
+    });
+    expect(m.title).toBe("Thème introuvable");
+    expect(groupBy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/parlement/votes/themes/[theme]/page.tsx
+++ b/src/app/parlement/votes/themes/[theme]/page.tsx
@@ -1,8 +1,17 @@
+import { cache } from "react";
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
 import { themeFromSlug, getAllThemeSlugs, themeToSlug } from "@/lib/theme-utils";
+import {
+  buildThemeTitle,
+  buildThemeDescription,
+  buildThemeH1,
+  buildThemeIntro,
+  type ThemeChamberCoverage,
+} from "@/lib/seo/theme-metadata";
+import type { ThemeCategory } from "@/generated/prisma";
 import { VoteCard } from "@/components/votes";
 import { ScrutinTypeTabs } from "@/components/votes/ScrutinTypeTabs";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
@@ -26,6 +35,34 @@ export async function generateStaticParams() {
   return getAllThemeSlugs().map((theme) => ({ theme }));
 }
 
+/**
+ * Scrutin counts for the whole theme, split by type AND chamber.
+ *
+ * Replaces the previous `by: ["type"]` groupBy at the same query cost: the
+ * chamber breakdown is what lets the title, the description and the intro name
+ * only the chambers this theme actually covers, instead of promising Senate
+ * scrutins that may not exist here. React `cache` dedupes the call between
+ * generateMetadata and the render of the same request, so metadata adds no query.
+ */
+const getThemeTypeChamberCounts = cache(async function getThemeTypeChamberCounts(
+  theme: ThemeCategory
+) {
+  return db.scrutin.groupBy({
+    by: ["type", "chamber"],
+    where: { theme },
+    _count: true,
+  });
+});
+
+function coverageOf(
+  counts: ReadonlyArray<{ chamber: string; _count: number }>
+): ThemeChamberCoverage {
+  return {
+    hasAN: counts.some((c) => c.chamber === "AN" && c._count > 0),
+    hasSenat: counts.some((c) => c.chamber === "SENAT" && c._count > 0),
+  };
+}
+
 export async function generateMetadata({
   params,
   searchParams,
@@ -38,11 +75,11 @@ export async function generateMetadata({
   const theme = themeFromSlug(slug);
   if (!theme) return { title: "Thème introuvable" };
 
-  const label = THEME_CATEGORY_LABELS[theme];
+  const coverage = coverageOf(await getThemeTypeChamberCounts(theme));
 
   return {
-    title: `Votes ${label}`,
-    description: `Tous les scrutins parlementaires sur le thème ${label}. Résultats des votes de l'Assemblée nationale et du Sénat.`,
+    title: buildThemeTitle(theme, coverage),
+    description: buildThemeDescription(theme, coverage),
     // Tab/paginated variants: noindex,follow, canonical consolidates on the
     // bare theme page (which stays indexable).
     ...listingRobotsMetadata(hasActiveListingFilter(sp, ["type"])),
@@ -104,11 +141,7 @@ export default async function ThemePage({
       orderBy: { votingDate: "desc" },
       select: { votingDate: true },
     }),
-    db.scrutin.groupBy({
-      by: ["type"],
-      where: { theme },
-      _count: true,
-    }),
+    getThemeTypeChamberCounts(theme),
   ]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
@@ -124,18 +157,23 @@ export default async function ThemePage({
   const rejected = stats.REJECTED || 0;
   const adoptedPercent = total > 0 ? Math.round((adopted / total) * 100) : 0;
 
-  const introText = [
-    `${total.toLocaleString("fr-FR")} scrutins sur le thème ${label}.`,
-    total > 0 ? `${adoptedPercent}% adoptés.` : "",
-    lastScrutin ? `Dernier vote : ${formatDate(lastScrutin.votingDate)}.` : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  // Chambers actually covered by this theme: what the copy is allowed to name.
+  const coverage = coverageOf(typeCounts);
 
-  // Type tab counts
-  const typeCountMap = new Map(typeCounts.map((c) => [c.type, c._count]));
+  const introText = buildThemeIntro({
+    theme,
+    total,
+    adoptedPercent,
+    lastVoteDateLabel: lastScrutin ? formatDate(lastScrutin.votingDate) : null,
+    coverage,
+  });
+
+  // Type tab counts, summed over the chambers of the type × chamber groupBy.
   const totalAll = typeCounts.reduce((sum, c) => sum + c._count, 0);
-  const amendementCount = typeCountMap.get("AMENDEMENT") ?? 0;
+  const amendementCount = typeCounts.reduce(
+    (sum, c) => sum + (c.type === "AMENDEMENT" ? c._count : 0),
+    0
+  );
   const votesCount = totalAll - amendementCount;
 
   const buildPageUrl = (p: number, currentTypeTab: string) => {
@@ -176,7 +214,7 @@ export default async function ThemePage({
       />
 
       <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">
-        {icon} {label}
+        <span aria-hidden="true">{icon}</span> {buildThemeH1(theme)}
       </h1>
       <SeoIntro text={introText} />
 

--- a/src/app/politiques/[slug]/votes/__tests__/metadata.test.ts
+++ b/src/app/politiques/[slug]/votes/__tests__/metadata.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// generateMetadata only reads the politician row and the index signals; the
+// listing queries below it never run here. Stub the Prisma client so the module
+// imports with no DATABASE_URL, and the signals loader so no cache primitive
+// runs outside a Next request.
+const findUnique = vi.fn();
+vi.mock("@/lib/db", () => ({ db: { politician: { findUnique: () => findUnique() } } }));
+vi.mock("@/lib/seo/politician-index-signals", () => ({
+  getPoliticianIndexSignals: vi.fn(async () => null),
+}));
+
+import { generateMetadata } from "@/app/politiques/[slug]/votes/page";
+
+type Mandate = { type: string; isCurrent: boolean; role: string | null };
+
+const metadataFor = (fullName: string, mandates: Mandate[]) => {
+  findUnique.mockResolvedValue({
+    id: "p1",
+    slug: "jean-dupont",
+    fullName,
+    firstName: "Jean",
+    lastName: "Dupont",
+    photoUrl: null,
+    civility: "M.",
+    currentParty: null,
+    mandates,
+  });
+  return generateMetadata({
+    params: Promise.resolve({ slug: "jean-dupont" }),
+    searchParams: Promise.resolve({}),
+  });
+};
+
+beforeEach(() => findUnique.mockReset());
+
+describe("/politiques/[slug]/votes metadata", () => {
+  it("a sitting deputy gets the Assemblée nationale", async () => {
+    const m = await metadataFor("Jean Dupont", [{ type: "DEPUTE", isCurrent: true, role: null }]);
+    expect(m.title).toBe("Votes de Jean Dupont à l'Assemblée nationale");
+    expect(m.description).toContain("à l'Assemblée nationale");
+    expect(m.alternates?.canonical).toBe("/politiques/jean-dupont/votes");
+  });
+
+  it("a sitting senator gets the Sénat, never the Assemblée nationale", async () => {
+    const m = await metadataFor("Marie Martin", [
+      { type: "SENATEUR", isCurrent: true, role: null },
+    ]);
+    expect(m.title).toBe("Votes de Marie Martin au Sénat");
+    expect(m.title).not.toContain("Assemblée nationale");
+    expect(String(m.description)).not.toContain("Assemblée nationale");
+  });
+
+  it("an undetermined chamber falls back to a neutral wording", async () => {
+    const m = await metadataFor("Camille Durand", [
+      { type: "MINISTRE", isCurrent: true, role: null },
+    ]);
+    expect(m.title).toBe("Votes parlementaires de Camille Durand");
+    expect(String(m.description)).not.toContain("Assemblée nationale");
+    expect(String(m.description)).not.toContain("Sénat");
+  });
+
+  it("an ambiguous mandate set claims no chamber at all", async () => {
+    const m = await metadataFor("Camille Durand", [
+      { type: "DEPUTE", isCurrent: true, role: null },
+      { type: "SENATEUR", isCurrent: true, role: null },
+    ]);
+    expect(m.title).toBe("Votes parlementaires de Camille Durand");
+  });
+
+  it("keeps the canonical of an unknown politician untouched", async () => {
+    findUnique.mockResolvedValue(null);
+    const m = await generateMetadata({
+      params: Promise.resolve({ slug: "inconnu" }),
+      searchParams: Promise.resolve({}),
+    });
+    expect(m.title).toBe("Politicien non trouvé");
+  });
+});

--- a/src/app/politiques/[slug]/votes/__tests__/metadata.test.ts
+++ b/src/app/politiques/[slug]/votes/__tests__/metadata.test.ts
@@ -5,7 +5,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // imports with no DATABASE_URL, and the signals loader so no cache primitive
 // runs outside a Next request.
 const findUnique = vi.fn();
+const getPoliticianVoteChamberCoverage = vi.fn();
 vi.mock("@/lib/db", () => ({ db: { politician: { findUnique: () => findUnique() } } }));
+vi.mock("@/services/voteStats", () => ({
+  getPoliticianVoteChamberCoverage: (politicianId: string) =>
+    getPoliticianVoteChamberCoverage(politicianId),
+  getPoliticianVotingStats: vi.fn(),
+  getPoliticianVoteTabCounts: vi.fn(),
+}));
 vi.mock("@/lib/seo/politician-index-signals", () => ({
   getPoliticianIndexSignals: vi.fn(async () => null),
 }));
@@ -14,7 +21,7 @@ import { generateMetadata } from "@/app/politiques/[slug]/votes/page";
 
 type Mandate = { type: string; isCurrent: boolean; role: string | null };
 
-const metadataFor = (fullName: string, mandates: Mandate[]) => {
+const metadataFor = (fullName: string, mandates: Mandate[], chambers: Array<"AN" | "SENAT">) => {
   findUnique.mockResolvedValue({
     id: "p1",
     slug: "jean-dupont",
@@ -26,46 +33,83 @@ const metadataFor = (fullName: string, mandates: Mandate[]) => {
     currentParty: null,
     mandates,
   });
+  getPoliticianVoteChamberCoverage.mockResolvedValue(chambers);
   return generateMetadata({
     params: Promise.resolve({ slug: "jean-dupont" }),
     searchParams: Promise.resolve({}),
   });
 };
 
-beforeEach(() => findUnique.mockReset());
+beforeEach(() => {
+  findUnique.mockReset();
+  getPoliticianVoteChamberCoverage.mockReset();
+});
 
 describe("/politiques/[slug]/votes metadata", () => {
   it("a sitting deputy gets the Assemblée nationale", async () => {
-    const m = await metadataFor("Jean Dupont", [{ type: "DEPUTE", isCurrent: true, role: null }]);
+    const m = await metadataFor(
+      "Jean Dupont",
+      [{ type: "DEPUTE", isCurrent: true, role: null }],
+      ["AN"]
+    );
     expect(m.title).toBe("Votes de Jean Dupont à l'Assemblée nationale");
     expect(m.description).toContain("à l'Assemblée nationale");
     expect(m.alternates?.canonical).toBe("/politiques/jean-dupont/votes");
   });
 
   it("a sitting senator gets the Sénat, never the Assemblée nationale", async () => {
-    const m = await metadataFor("Marie Martin", [
-      { type: "SENATEUR", isCurrent: true, role: null },
-    ]);
+    const m = await metadataFor(
+      "Marie Martin",
+      [{ type: "SENATEUR", isCurrent: true, role: null }],
+      ["SENAT"]
+    );
     expect(m.title).toBe("Votes de Marie Martin au Sénat");
     expect(m.title).not.toContain("Assemblée nationale");
     expect(String(m.description)).not.toContain("Assemblée nationale");
   });
 
   it("an undetermined chamber falls back to a neutral wording", async () => {
-    const m = await metadataFor("Camille Durand", [
-      { type: "MINISTRE", isCurrent: true, role: null },
-    ]);
+    const m = await metadataFor(
+      "Camille Durand",
+      [{ type: "MINISTRE", isCurrent: true, role: null }],
+      []
+    );
     expect(m.title).toBe("Votes parlementaires de Camille Durand");
     expect(String(m.description)).not.toContain("Assemblée nationale");
     expect(String(m.description)).not.toContain("Sénat");
   });
 
-  it("an ambiguous mandate set claims no chamber at all", async () => {
-    const m = await metadataFor("Camille Durand", [
-      { type: "DEPUTE", isCurrent: true, role: null },
-      { type: "SENATEUR", isCurrent: true, role: null },
-    ]);
+  it("a mixed vote corpus claims no chamber at all", async () => {
+    const m = await metadataFor("Camille Durand", [], ["AN", "SENAT"]);
     expect(m.title).toBe("Votes parlementaires de Camille Durand");
+  });
+
+  it("does not let a current Senate mandate override a mixed vote corpus", async () => {
+    const m = await metadataFor(
+      "Marie Martin",
+      [
+        { type: "DEPUTE", isCurrent: false, role: null },
+        { type: "SENATEUR", isCurrent: true, role: null },
+      ],
+      ["AN", "SENAT"]
+    );
+    expect(m.title).toBe("Votes parlementaires de Marie Martin");
+    expect(String(m.description)).not.toContain("Sénat");
+    expect(String(m.description)).not.toContain("Assemblée nationale");
+  });
+
+  it("does not let a current AN mandate override a mixed vote corpus", async () => {
+    const m = await metadataFor(
+      "Jean Dupont",
+      [
+        { type: "SENATEUR", isCurrent: false, role: null },
+        { type: "DEPUTE", isCurrent: true, role: null },
+      ],
+      ["AN", "SENAT"]
+    );
+    expect(m.title).toBe("Votes parlementaires de Jean Dupont");
+    expect(String(m.description)).not.toContain("Sénat");
+    expect(String(m.description)).not.toContain("Assemblée nationale");
   });
 
   it("keeps the canonical of an unknown politician untouched", async () => {

--- a/src/app/politiques/[slug]/votes/__tests__/page-copy.test.tsx
+++ b/src/app/politiques/[slug]/votes/__tests__/page-copy.test.tsx
@@ -1,0 +1,178 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findPolitician: vi.fn(),
+  findVotes: vi.fn(),
+  getCoverage: vi.fn(),
+  getStats: vi.fn(),
+  getCounts: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    politician: { findUnique: (...args: unknown[]) => mocks.findPolitician(...args) },
+    vote: { findMany: (...args: unknown[]) => mocks.findVotes(...args) },
+  },
+}));
+vi.mock("@/services/voteStats", () => ({
+  getPoliticianVoteChamberCoverage: (...args: unknown[]) => mocks.getCoverage(...args),
+  getPoliticianVotingStats: (...args: unknown[]) => mocks.getStats(...args),
+  getPoliticianVoteTabCounts: (...args: unknown[]) => mocks.getCounts(...args),
+}));
+vi.mock("@/lib/seo/politician-index-signals", () => ({
+  getPoliticianIndexSignals: vi.fn(async () => null),
+}));
+vi.mock("@/components/votes", () => ({
+  VoteStats: () => null,
+  VotePositionBadge: () => null,
+  VotingResultBadge: () => null,
+}));
+
+import PoliticianVotesPage, { generateMetadata } from "@/app/politiques/[slug]/votes/page";
+
+type Chamber = "AN" | "SENAT";
+type Mandate = { type: string; isCurrent: boolean; role: string | null };
+
+const cases: Array<{
+  caseName: string;
+  slug: string;
+  chambers: Chamber[];
+  mandates: Mandate[];
+  totalVotes: number;
+  title: string;
+  descriptionChamber: string | null;
+  heading: string;
+  intro: string;
+}> = [
+  {
+    caseName: "votes AN uniquement",
+    slug: "camille-an",
+    chambers: ["AN"],
+    mandates: [{ type: "DEPUTE", isCurrent: true, role: null }],
+    totalVotes: 4,
+    title: "Votes de Camille Durand à l'Assemblée nationale",
+    descriptionChamber: "Assemblée nationale",
+    heading: "Votes de Camille Durand à l'Assemblée nationale",
+    intro: "Au total, 4 votes de Camille Durand sont enregistrés à l'Assemblée nationale.",
+  },
+  {
+    caseName: "votes Sénat uniquement",
+    slug: "camille-senat",
+    chambers: ["SENAT"],
+    mandates: [{ type: "SENATEUR", isCurrent: true, role: null }],
+    totalVotes: 4,
+    title: "Votes de Camille Durand au Sénat",
+    descriptionChamber: "Sénat",
+    heading: "Votes de Camille Durand au Sénat",
+    intro: "Au total, 4 votes de Camille Durand sont enregistrés au Sénat.",
+  },
+  {
+    caseName: "votes AN et Sénat",
+    slug: "camille-mixte",
+    chambers: ["AN", "SENAT"],
+    mandates: [],
+    totalVotes: 4,
+    title: "Votes parlementaires de Camille Durand",
+    descriptionChamber: null,
+    heading: "Votes parlementaires de Camille Durand",
+    intro: "Au total, 4 votes de Camille Durand sont enregistrés.",
+  },
+  {
+    caseName: "sénateur courant et ancien député avec corpus mixte",
+    slug: "camille-senatrice",
+    chambers: ["AN", "SENAT"],
+    mandates: [
+      { type: "DEPUTE", isCurrent: false, role: null },
+      { type: "SENATEUR", isCurrent: true, role: null },
+    ],
+    totalVotes: 4,
+    title: "Votes parlementaires de Camille Durand",
+    descriptionChamber: null,
+    heading: "Votes parlementaires de Camille Durand",
+    intro: "Au total, 4 votes de Camille Durand sont enregistrés.",
+  },
+  {
+    caseName: "député courant et ancien sénateur avec corpus mixte",
+    slug: "camille-deputee",
+    chambers: ["AN", "SENAT"],
+    mandates: [
+      { type: "SENATEUR", isCurrent: false, role: null },
+      { type: "DEPUTE", isCurrent: true, role: null },
+    ],
+    totalVotes: 4,
+    title: "Votes parlementaires de Camille Durand",
+    descriptionChamber: null,
+    heading: "Votes parlementaires de Camille Durand",
+    intro: "Au total, 4 votes de Camille Durand sont enregistrés.",
+  },
+  {
+    caseName: "aucun vote",
+    slug: "camille-sans-vote",
+    chambers: [],
+    mandates: [{ type: "SENATEUR", isCurrent: true, role: null }],
+    totalVotes: 0,
+    title: "Votes parlementaires de Camille Durand",
+    descriptionChamber: null,
+    heading: "Votes parlementaires de Camille Durand",
+    intro: "Aucun vote parlementaire n'est enregistré pour Camille Durand.",
+  },
+];
+
+describe("/politiques/[slug]/votes copie fondée sur le corpus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findVotes.mockResolvedValue([]);
+    mocks.getStats.mockResolvedValue({
+      total: 0,
+      pour: 0,
+      contre: 0,
+      abstention: 0,
+      nonVotant: 0,
+      eligibleScrutins: null,
+      scrutinsSansVoteEnregistre: null,
+      participationRate: null,
+      participationStatus: "COMPUTATION_INCOMPLETE",
+    });
+  });
+
+  it.each(cases)(
+    "$caseName: title, description, H1 et intro restent factuels",
+    async ({ slug, chambers, mandates, totalVotes, title, descriptionChamber, heading, intro }) => {
+      mocks.findPolitician.mockResolvedValue({
+        id: `politician-${slug}`,
+        slug,
+        fullName: "Camille Durand",
+        firstName: "Camille",
+        lastName: "Durand",
+        photoUrl: null,
+        civility: "Mme",
+        currentParty: null,
+        mandates,
+      });
+      mocks.getCoverage.mockResolvedValue(chambers);
+      mocks.getCounts.mockResolvedValue({
+        totalAll: totalVotes,
+        amendmentCount: 0,
+        nonAmendmentCount: totalVotes,
+      });
+
+      const props = {
+        params: Promise.resolve({ slug }),
+        searchParams: Promise.resolve({}),
+      };
+      const metadata = await generateMetadata(props);
+      const view = render(await PoliticianVotesPage(props));
+
+      expect(metadata.title).toBe(title);
+      if (descriptionChamber) {
+        expect(metadata.description).toContain(descriptionChamber);
+      } else {
+        expect(metadata.description).not.toContain("Assemblée nationale");
+        expect(metadata.description).not.toContain("Sénat");
+      }
+      expect(view.getByRole("heading", { level: 1, name: heading })).toBeInTheDocument();
+      expect(view.getByText(intro)).toBeInTheDocument();
+    }
+  );
+});

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -14,12 +14,16 @@ import { formatDate } from "@/lib/utils";
 import { ArrowLeft, ExternalLink, Info } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { feminizeRole, SCRUTIN_TYPE_LABELS, SCRUTIN_TYPE_COLORS } from "@/config/labels";
-import { getPoliticianVotingStats, getPoliticianVoteTabCounts } from "@/services/voteStats";
+import {
+  getPoliticianVotingStats,
+  getPoliticianVoteTabCounts,
+  getPoliticianVoteChamberCoverage,
+} from "@/services/voteStats";
 import { politicianRobotsMetadata } from "@/lib/seo/politician-robots";
 import { getPoliticianIndexSignals } from "@/lib/seo/politician-index-signals";
 import { SeoIntro } from "@/components/seo/SeoIntro";
 import {
-  resolveParliamentaryChamber,
+  resolveVoteCorpusChamber,
   buildPoliticianVotesSeo,
   buildPoliticianVotesIntro,
 } from "@/lib/seo/politician-votes-metadata";
@@ -59,14 +63,8 @@ const getPolitician = cache(async function getPolitician(slug: string) {
       photoUrl: true,
       civility: true,
       currentParty: true,
-      // Two needs, one relation read: the chamber-president note wants current
-      // mandates carrying a role, and the chamber resolution wants every
-      // parliamentary mandate (current or not). Consumers filter on `isCurrent`
-      // themselves rather than the query narrowing it for one of the two.
       mandates: {
-        where: {
-          OR: [{ isCurrent: true, role: { not: null } }, { type: { in: ["DEPUTE", "SENATEUR"] } }],
-        },
+        where: { isCurrent: true, role: { not: null } },
         select: { role: true, type: true, isCurrent: true },
       },
     },
@@ -151,10 +149,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return { title: "Politicien non trouvé" };
   }
 
-  // The chamber is derived from the mandates, never assumed: asserting
-  // "à l'Assemblée nationale" for a senator (or for anyone whose parliamentary
-  // mandate is not established) is a factual error, not an SEO detail.
-  const chamber = resolveParliamentaryChamber(politician.mandates);
+  const voteChambers = await getPoliticianVoteChamberCoverage(politician.id);
+  const chamber = resolveVoteCorpusChamber(voteChambers);
   const seo = buildPoliticianVotesSeo(politician.fullName, chamber);
 
   return {
@@ -182,8 +178,11 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
   }
 
   const typeFilter = TYPE_TAB_MAP[typeTab] ?? {};
-  const { votes, total, totalPages, stats, totalAll, amendmentCount, nonAmendmentCount } =
-    await getVotes(politician.id, page, limit, typeFilter);
+  const [voteData, voteChambers] = await Promise.all([
+    getVotes(politician.id, page, limit, typeFilter),
+    getPoliticianVoteChamberCoverage(politician.id),
+  ]);
+  const { votes, total, totalPages, stats, totalAll, amendmentCount, nonAmendmentCount } = voteData;
 
   const buildUrl = (p: number, tabKey: string) => {
     const params = new URLSearchParams();
@@ -211,7 +210,7 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
 
   const hasMultipleTypes = amendmentCount > 0 && nonAmendmentCount > 0;
 
-  const chamber = resolveParliamentaryChamber(politician.mandates);
+  const chamber = resolveVoteCorpusChamber(voteChambers);
   const seo = buildPoliticianVotesSeo(politician.fullName, chamber);
   // Deterministic, built from the tab counts already loaded above: no extra
   // query, no participation rate, no reading of the voting behaviour.

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -17,6 +17,12 @@ import { feminizeRole, SCRUTIN_TYPE_LABELS, SCRUTIN_TYPE_COLORS } from "@/config
 import { getPoliticianVotingStats, getPoliticianVoteTabCounts } from "@/services/voteStats";
 import { politicianRobotsMetadata } from "@/lib/seo/politician-robots";
 import { getPoliticianIndexSignals } from "@/lib/seo/politician-index-signals";
+import { SeoIntro } from "@/components/seo/SeoIntro";
+import {
+  resolveParliamentaryChamber,
+  buildPoliticianVotesSeo,
+  buildPoliticianVotesIntro,
+} from "@/lib/seo/politician-votes-metadata";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
 
@@ -53,9 +59,15 @@ const getPolitician = cache(async function getPolitician(slug: string) {
       photoUrl: true,
       civility: true,
       currentParty: true,
+      // Two needs, one relation read: the chamber-president note wants current
+      // mandates carrying a role, and the chamber resolution wants every
+      // parliamentary mandate (current or not). Consumers filter on `isCurrent`
+      // themselves rather than the query narrowing it for one of the two.
       mandates: {
-        where: { isCurrent: true, role: { not: null } },
-        select: { role: true, type: true },
+        where: {
+          OR: [{ isCurrent: true, role: { not: null } }, { type: { in: ["DEPUTE", "SENATEUR"] } }],
+        },
+        select: { role: true, type: true, isCurrent: true },
       },
     },
   });
@@ -139,9 +151,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return { title: "Politicien non trouvé" };
   }
 
+  // The chamber is derived from the mandates, never assumed: asserting
+  // "à l'Assemblée nationale" for a senator (or for anyone whose parliamentary
+  // mandate is not established) is a factual error, not an SEO detail.
+  const chamber = resolveParliamentaryChamber(politician.mandates);
+  const seo = buildPoliticianVotesSeo(politician.fullName, chamber);
+
   return {
-    title: `Votes de ${politician.fullName}`,
-    description: `Historique complet des votes parlementaires de ${politician.fullName} à l'Assemblée nationale.`,
+    title: seo.title,
+    description: seo.description,
     // A sub-tab is never richer than its profile: when the profile is noindexed
     // for lack of content (issue #385), the votes tab — empty for anyone who
     // never sat in parliament — must not stay crawlable on its own.
@@ -193,6 +211,17 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
 
   const hasMultipleTypes = amendmentCount > 0 && nonAmendmentCount > 0;
 
+  const chamber = resolveParliamentaryChamber(politician.mandates);
+  const seo = buildPoliticianVotesSeo(politician.fullName, chamber);
+  // Deterministic, built from the tab counts already loaded above: no extra
+  // query, no participation rate, no reading of the voting behaviour.
+  const introText = buildPoliticianVotesIntro({
+    fullName: politician.fullName,
+    chamber,
+    totalVotes: totalAll,
+    amendmentVotes: amendmentCount,
+  });
+
   return (
     <div className="container mx-auto px-4 pt-4 pb-8">
       <Breadcrumb
@@ -220,17 +249,17 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
           size="md"
         />
         <div>
-          <h1 className="text-2xl font-display font-extrabold tracking-tight">
-            Votes de {politician.fullName}
-          </h1>
+          <h1 className="text-2xl font-display font-extrabold tracking-tight">{seo.heading}</h1>
           <p className="text-muted-foreground">{total} votes enregistrés</p>
         </div>
       </div>
 
+      {introText && <SeoIntro text={introText} />}
+
       {/* NON_VOTANT context note for president of chamber */}
       {(() => {
         const presidentMandate = politician.mandates.find(
-          (m) => m.role && /^Président /.test(m.role)
+          (m) => m.isCurrent && m.role && /^Président /.test(m.role)
         );
         if (presidentMandate) {
           const roleLabel = feminizeRole(presidentMandate.role!, politician.civility);
@@ -330,7 +359,7 @@ export default async function PoliticianVotesPage({ params, searchParams }: Page
           <VoteStats
             stats={stats}
             isChamberPresident={politician.mandates.some(
-              (m) => m.role != null && /^Président /.test(m.role)
+              (m) => m.isCurrent && m.role != null && /^Président /.test(m.role)
             )}
           />
         </div>

--- a/src/components/parlement/ParlementHub.tsx
+++ b/src/components/parlement/ParlementHub.tsx
@@ -258,7 +258,7 @@ export async function ParlementHub() {
             className="inline-flex items-center gap-1.5 rounded-md border px-3 py-2 text-sm hover:bg-muted transition-colors"
           >
             <Tag className="h-3.5 w-3.5" aria-hidden="true" />
-            Par thèmes
+            Votes par thème
           </Link>
           <Link
             href={ROUTES.voteStats}

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -214,7 +214,7 @@ export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsLi
                 <li key={themeCategory}>
                   <Link
                     href={`/parlement/votes/themes/${themeToSlug(themeCategory)}`}
-                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+                    className="inline-flex min-h-11 items-center gap-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted transition-colors"
                   >
                     Votes sur {themeSeoPhrase(themeCategory)}
                     <span className="text-xs text-muted-foreground tabular-nums">

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/data/scrutins";
 import { getScrutinGroupPositionsBatch } from "@/lib/data/groupes";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { themeToSlug } from "@/lib/theme-utils";
+import { themeSeoPhrase } from "@/lib/seo/theme-metadata";
 import { SITE_URL } from "@/config/site";
 import { statsHref } from "@/config/routes";
 import type { VotingResult, Chamber, ThemeCategory, ScrutinType } from "@/types";
@@ -131,6 +133,10 @@ export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsLi
   // Showcase renders only on the default, unfiltered "votes" view (not paginated,
   // not the explained-only listing, default sort) so it doesn't duplicate results
   // the user already filtered for.
+  // Internal links to the thematic landings: bare listing only, so the crawlable
+  // link block sits on the indexable variant and does not repeat on every facet.
+  const showThemeLandings = !explainedOnly && !hasActiveFilters && page === 1;
+
   const showShowcase =
     !explainedOnly &&
     !search &&
@@ -195,6 +201,31 @@ export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsLi
             typeCounts,
           }}
         />
+
+        {/* Thematic landings. The `?theme=` chips in the filter bar above are
+            crawl-blocked facets: these descriptive links point at the indexable
+            /parlement/votes/themes/[theme] pages instead. Rendered only on the
+            bare listing, which is the variant that stays indexable. */}
+        {showThemeLandings && (
+          <nav aria-label="Votes par thème" className="mb-6">
+            <p className="text-sm text-muted-foreground mb-2">Explorer les votes par thème</p>
+            <ul className="flex flex-wrap gap-2">
+              {themeCounts.map(({ theme: themeCategory, _count }) => (
+                <li key={themeCategory}>
+                  <Link
+                    href={`/parlement/votes/themes/${themeToSlug(themeCategory)}`}
+                    className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+                  >
+                    Votes sur {themeSeoPhrase(themeCategory)}
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {_count.toLocaleString("fr-FR")}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
 
         {/* Results summary */}
         <div className="flex items-center justify-between mb-4 pb-3 border-b">

--- a/src/components/parlement/__tests__/ScrutinsListing.test.tsx
+++ b/src/components/parlement/__tests__/ScrutinsListing.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/data/scrutins", () => ({
+  getScrutins: vi.fn().mockResolvedValue({
+    scrutins: [],
+    total: 0,
+    totalPages: 0,
+    stats: {},
+  }),
+  getLegislatures: vi.fn().mockResolvedValue([]),
+  getChambers: vi.fn().mockResolvedValue([]),
+  getThemeCounts: vi.fn().mockResolvedValue([
+    { theme: "SANTE", _count: 12 },
+    { theme: "ECONOMIE_BUDGET", _count: 8 },
+  ]),
+  getTypeCounts: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/data/groupes", () => ({
+  getScrutinGroupPositionsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("@/components/votes", () => ({ VoteCard: () => null }));
+vi.mock("@/components/votes/VotesFilterBar", () => ({ VotesFilterBar: () => null }));
+vi.mock("../ExplainedVotesModule", () => ({ ExplainedVotesModule: () => null }));
+vi.mock("@/components/seo/JsonLd", () => ({ CollectionPageJsonLd: () => null }));
+
+import { ScrutinsListing } from "../ScrutinsListing";
+
+describe("ScrutinsListing thematic landings", () => {
+  it("rend des liens naturels avec une hauteur tactile minimale", async () => {
+    render(await ScrutinsListing({ searchParams: {}, sort: "recent" }));
+
+    const healthLink = screen.getByRole("link", { name: "Votes sur la santé 12" });
+    expect(healthLink).toHaveAttribute("href", "/parlement/votes/themes/sante");
+    expect(healthLink).toHaveClass("inline-flex", "min-h-11", "items-center");
+
+    const economyLink = screen.getByRole("link", {
+      name: "Votes sur l'économie et le budget 8",
+    });
+    expect(economyLink).toHaveAttribute("href", "/parlement/votes/themes/economie-budget");
+  });
+});

--- a/src/components/politicians/VotesSection.tsx
+++ b/src/components/politicians/VotesSection.tsx
@@ -77,14 +77,14 @@ export function VotesSection({
       {voteData.stats.total > 0 && (
         <Card id="votes">
           <CardHeader>
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
               <h2 className="leading-none font-semibold">Votes parlementaires</h2>
               <Link
                 href={`/politiques/${slug}/votes`}
                 prefetch={false}
-                className="text-sm text-primary hover:underline"
+                className="inline-flex min-h-11 items-center text-sm text-primary hover:underline"
               >
-                Voir tout →
+                Voir tous les votes parlementaires
               </Link>
             </div>
           </CardHeader>

--- a/src/components/politicians/__tests__/VotesSection.links.test.tsx
+++ b/src/components/politicians/__tests__/VotesSection.links.test.tsx
@@ -39,6 +39,16 @@ const renderSection = (scrutin: { id: string; slug: string | null }) =>
   );
 
 describe("VotesSection : liens des derniers votes", () => {
+  it("utilise une ancre descriptive vers tous les votes parlementaires", () => {
+    const { getByRole, queryByText } = renderSection({ id: "scrutin-an", slug: "scrutin-an" });
+
+    expect(getByRole("link", { name: "Voir tous les votes parlementaires" })).toHaveAttribute(
+      "href",
+      "/politiques/jean-dupont/votes"
+    );
+    expect(queryByText("Voir tout →")).not.toBeInTheDocument();
+  });
+
   it("affiche l'indisponibilité plutôt qu'un taux pour un sénateur", () => {
     const senateData = {
       ...voteData({ id: "scrutin-senat", slug: "scrutin-senat" }),

--- a/src/components/votes/ThemeVotesLink.tsx
+++ b/src/components/votes/ThemeVotesLink.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { themeToSlug } from "@/lib/theme-utils";
+import { themeSeoPhrase } from "@/lib/seo/theme-metadata";
+import type { ThemeCategory } from "@/generated/prisma";
+
+interface ThemeVotesLinkProps {
+  theme: ThemeCategory;
+  className?: string;
+}
+
+/**
+ * Contextual link from a themed surface (scrutin page, dossier) to its thematic
+ * landing, with a descriptive anchor ("Voir tous les votes sur la santé") rather
+ * than the bare label already carried by the theme badge.
+ */
+export function ThemeVotesLink({ theme, className }: ThemeVotesLinkProps) {
+  return (
+    <Link
+      href={`/parlement/votes/themes/${themeToSlug(theme)}`}
+      className={`inline-flex items-center gap-1.5 text-primary hover:underline ${className ?? ""}`}
+    >
+      Voir tous les votes sur {themeSeoPhrase(theme)}
+      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+    </Link>
+  );
+}

--- a/src/components/votes/ThemeVotesLink.tsx
+++ b/src/components/votes/ThemeVotesLink.tsx
@@ -18,7 +18,7 @@ export function ThemeVotesLink({ theme, className }: ThemeVotesLinkProps) {
   return (
     <Link
       href={`/parlement/votes/themes/${themeToSlug(theme)}`}
-      className={`inline-flex items-center gap-1.5 text-primary hover:underline ${className ?? ""}`}
+      className={`inline-flex min-h-11 items-center gap-1.5 text-primary hover:underline ${className ?? ""}`}
     >
       Voir tous les votes sur {themeSeoPhrase(theme)}
       <ArrowRight className="h-4 w-4" aria-hidden="true" />

--- a/src/components/votes/VoteCard.tsx
+++ b/src/components/votes/VoteCard.tsx
@@ -179,11 +179,11 @@ export function VoteCard({
                 href={sourceUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-muted-foreground hover:text-foreground"
-                title="Voir sur NosDéputés.fr"
-                aria-label="Voir le scrutin sur NosDéputés.fr (nouvelle fenêtre)"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center text-muted-foreground hover:text-foreground"
+                title="Voir le scrutin à la source"
+                aria-label="Voir le scrutin à la source (nouvelle fenêtre)"
               >
-                <ExternalLink className="h-4 w-4" />
+                <ExternalLink className="h-4 w-4" aria-hidden="true" />
               </a>
             )}
           </div>

--- a/src/components/votes/__tests__/ThemeVotesLink.test.tsx
+++ b/src/components/votes/__tests__/ThemeVotesLink.test.tsx
@@ -7,6 +7,7 @@ describe("ThemeVotesLink", () => {
     render(<ThemeVotesLink theme="SANTE" />);
     const link = screen.getByRole("link", { name: /Voir tous les votes sur la santé/ });
     expect(link).toHaveAttribute("href", "/parlement/votes/themes/sante");
+    expect(link).toHaveClass("inline-flex", "min-h-11", "items-center");
   });
 
   it("uses a descriptive anchor, not a bare label", () => {

--- a/src/components/votes/__tests__/ThemeVotesLink.test.tsx
+++ b/src/components/votes/__tests__/ThemeVotesLink.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ThemeVotesLink } from "@/components/votes/ThemeVotesLink";
+
+describe("ThemeVotesLink", () => {
+  it("is a crawlable link to the thematic landing", () => {
+    render(<ThemeVotesLink theme="SANTE" />);
+    const link = screen.getByRole("link", { name: /Voir tous les votes sur la santé/ });
+    expect(link).toHaveAttribute("href", "/parlement/votes/themes/sante");
+  });
+
+  it("uses a descriptive anchor, not a bare label", () => {
+    render(<ThemeVotesLink theme="ECONOMIE_BUDGET" />);
+    const link = screen.getByRole("link", {
+      name: /Voir tous les votes sur l'économie et le budget/,
+    });
+    expect(link).toHaveAttribute("href", "/parlement/votes/themes/economie-budget");
+  });
+});

--- a/src/components/votes/__tests__/VoteCard.test.tsx
+++ b/src/components/votes/__tests__/VoteCard.test.tsx
@@ -89,6 +89,30 @@ describe("VoteCard", () => {
     expect(screen.queryByText("RE")).not.toBeInTheDocument();
   });
 
+  it.each([
+    ["AN", "https://www.assemblee-nationale.fr/dyn/17/scrutins/123"],
+    ["SENAT", "https://www.senat.fr/scrutin-public/2024/scr123.html"],
+  ] as const)(
+    "affiche une source %s générique avec une cible tactile accessible",
+    (chamber, sourceUrl) => {
+      const { container } = render(<VoteCard {...base} chamber={chamber} sourceUrl={sourceUrl} />);
+
+      const sourceLink = screen.getByRole("link", {
+        name: "Voir le scrutin à la source (nouvelle fenêtre)",
+      });
+      expect(sourceLink).toHaveAttribute("href", sourceUrl);
+      expect(sourceLink).toHaveAttribute("title", "Voir le scrutin à la source");
+      expect(sourceLink).toHaveClass(
+        "inline-flex",
+        "min-h-11",
+        "min-w-11",
+        "items-center",
+        "justify-center"
+      );
+      expect(container.innerHTML).not.toContain("NosDéputés");
+    }
+  );
+
   it("motion de censure : pas de cadrage majorité simple, voix pour + note de règle", () => {
     render(
       <VoteCard

--- a/src/components/votes/index.ts
+++ b/src/components/votes/index.ts
@@ -5,3 +5,4 @@ export { ParliamentaryCard } from "./ParliamentaryCard";
 export { DailyVotesPage } from "./DailyVotesPage";
 export { DateNavigation } from "./DateNavigation";
 export { ScrutinTypeTabs } from "./ScrutinTypeTabs";
+export { ThemeVotesLink } from "./ThemeVotesLink";

--- a/src/inngest/__tests__/vote-cache.test.ts
+++ b/src/inngest/__tests__/vote-cache.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidateTags = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/cache", () => ({ revalidateTags }));
+
+import { runVoteSyncWithCacheInvalidation } from "../vote-cache";
+
+describe("runVoteSyncWithCacheInvalidation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    [["AN"], "SENAT"],
+    [["SENAT"], "AN"],
+  ] as const)(
+    "invalide une couverture %j quand le premier vote %s est synchronisé",
+    async (initialCoverage, addedChamber) => {
+      const corpus = [...initialCoverage];
+      let cachedCoverage: readonly string[] | null = [...initialCoverage];
+      const readCoverage = () => {
+        cachedCoverage ??= [...corpus];
+        return cachedCoverage;
+      };
+      revalidateTags.mockImplementation(() => {
+        cachedCoverage = null;
+      });
+
+      expect(readCoverage()).toEqual(initialCoverage);
+      await runVoteSyncWithCacheInvalidation(async () => {
+        corpus.push(addedChamber);
+        return { votesCreated: 1 };
+      });
+
+      expect(revalidateTags).toHaveBeenCalledExactlyOnceWith(["votes"], "max");
+      expect(new Set(readCoverage())).toEqual(new Set(["AN", "SENAT"]));
+    }
+  );
+
+  it("n'invalide pas avant une synchronisation réussie", async () => {
+    await expect(
+      runVoteSyncWithCacheInvalidation(async () => {
+        throw new Error("sync failed");
+      })
+    ).rejects.toThrow("sync failed");
+    expect(revalidateTags).not.toHaveBeenCalled();
+  });
+});

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -4,6 +4,7 @@ import { syncMetadata } from "@/lib/sync/sync-metadata";
 import { revalidateTags } from "@/lib/cache";
 import { isIngestionAnomaly } from "@/lib/monitoring/amendment-link-freshness";
 import { linkableUnlinkedVoteWhere } from "@/lib/monitoring/amendment-link-query";
+import { runVoteSyncWithCacheInvalidation } from "../vote-cache";
 
 interface DailyStep {
   name: string;
@@ -30,14 +31,14 @@ const DAILY_STEPS: DailyStep[] = [
     name: "scrutins-an",
     run: async () => {
       const { syncScrutinsAN } = await import("@/services/sync/scrutins-an");
-      return syncScrutinsAN(undefined, false, true);
+      return runVoteSyncWithCacheInvalidation(() => syncScrutinsAN(undefined, false, true));
     },
   },
   {
     name: "scrutins-senat",
     run: async () => {
       const { syncScrutinsSenat } = await import("@/services/sync/scrutins-senat");
-      return syncScrutinsSenat(null, false, true);
+      return runVoteSyncWithCacheInvalidation(() => syncScrutinsSenat(null, false, true));
     },
   },
   {

--- a/src/inngest/functions/sync-scrutins.ts
+++ b/src/inngest/functions/sync-scrutins.ts
@@ -1,5 +1,6 @@
 import { inngest } from "../client";
 import { markJobRunning, markJobCompleted, markJobFailed, updateJobProgress } from "../job-helper";
+import { runVoteSyncWithCacheInvalidation } from "../vote-cache";
 
 export const syncScrutins = inngest.createFunction(
   {
@@ -15,14 +16,16 @@ export const syncScrutins = inngest.createFunction(
     try {
       const anStats = await step.run("scrutins-an", async () => {
         const { syncScrutinsAN } = await import("@/services/sync/scrutins-an");
-        const stats = await syncScrutinsAN(undefined, false, true);
+        const stats = await runVoteSyncWithCacheInvalidation(() =>
+          syncScrutinsAN(undefined, false, true)
+        );
         if (jobId) await updateJobProgress(jobId, 50);
         return stats;
       });
 
       const senatStats = await step.run("scrutins-senat", async () => {
         const { syncScrutinsSenat } = await import("@/services/sync/scrutins-senat");
-        return syncScrutinsSenat(null, false, true);
+        return runVoteSyncWithCacheInvalidation(() => syncScrutinsSenat(null, false, true));
       });
 
       if (jobId)

--- a/src/inngest/index.ts
+++ b/src/inngest/index.ts
@@ -16,6 +16,7 @@ import { syncPress } from "./functions/sync-press";
 import { syncScrutins } from "./functions/sync-scrutins";
 import { syncPlatformUpdates } from "./functions/sync-platform-updates";
 import { pipelineDigest } from "./functions/pipeline-digest";
+import { runVoteSyncWithCacheInvalidation } from "./vote-cache";
 
 // --- Grouped multi-step functions ---
 const groupedFunctions = [
@@ -46,12 +47,12 @@ const migratedFunctions = [
   createSyncFunction("sync-scrutins-an", async (data) => {
     const { syncScrutinsAN } = await import("@/services/sync/scrutins-an");
     const todayOnly = !data.flags || !(data.flags as string).includes("--all");
-    return syncScrutinsAN(undefined, false, todayOnly);
+    return runVoteSyncWithCacheInvalidation(() => syncScrutinsAN(undefined, false, todayOnly));
   }),
   createSyncFunction("sync-scrutins-senat", async (data) => {
     const { syncScrutinsSenat } = await import("@/services/sync/scrutins-senat");
     const todayOnly = !data.flags || !(data.flags as string).includes("--all");
-    return syncScrutinsSenat(null, false, todayOnly);
+    return runVoteSyncWithCacheInvalidation(() => syncScrutinsSenat(null, false, todayOnly));
   }),
   createSyncFunction("sync-press-analysis", async (data) => {
     const { syncPressAnalysis } = await import("@/services/sync/press-analysis");

--- a/src/inngest/vote-cache.ts
+++ b/src/inngest/vote-cache.ts
@@ -1,0 +1,11 @@
+import { revalidateTags } from "@/lib/cache";
+
+/**
+ * Run a scrutin sync and invalidate cached vote-derived views only after the
+ * database write completed successfully.
+ */
+export async function runVoteSyncWithCacheInvalidation<T>(sync: () => Promise<T>): Promise<T> {
+  const result = await sync();
+  revalidateTags(["votes"], "max");
+  return result;
+}

--- a/src/lib/data/__tests__/groupes-participation-safety.test.ts
+++ b/src/lib/data/__tests__/groupes-participation-safety.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => ({
   parliamentaryGroup: { findMany: vi.fn(), findUnique: vi.fn() },
+  scrutinGroupPosition: { findMany: vi.fn() },
 }));
 
 vi.mock("next/cache", () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }));
 vi.mock("@/lib/db", () => ({ db: dbMock }));
 
-import { getGroupeDetail, getGroupesListing } from "@/lib/data/groupes";
+import { getGroupeDetail, getGroupesListing, getGroupKeyVotes } from "@/lib/data/groupes";
 
 const staleStats = {
   id: "stats-1",
@@ -61,5 +62,26 @@ describe("frontières publiques des groupes parlementaires", () => {
 
     expect(group?.stats[0]?.averageParticipationPct).toBeNull();
     expect(group?.stats[0]?.cohesionPct).toBe(88);
+  });
+
+  it("sélectionne les attributs réels nécessaires aux cartes de scrutins", async () => {
+    dbMock.scrutinGroupPosition.findMany.mockResolvedValue([]);
+
+    await getGroupKeyVotes("group-1");
+
+    expect(dbMock.scrutinGroupPosition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          scrutin: {
+            select: expect.objectContaining({
+              externalId: true,
+              legislature: true,
+              chamber: true,
+              sourceUrl: true,
+            }),
+          },
+        },
+      })
+    );
   });
 });

--- a/src/lib/data/groupes.ts
+++ b/src/lib/data/groupes.ts
@@ -197,13 +197,17 @@ export async function getGroupKeyVotes(groupId: string, limit = 5) {
       scrutin: {
         select: {
           id: true,
+          externalId: true,
           slug: true,
           title: true,
           votingDate: true,
+          legislature: true,
+          chamber: true,
           votesFor: true,
           votesAgainst: true,
           votesAbstain: true,
           result: true,
+          sourceUrl: true,
           theme: true,
           // Plan 6: public policy title (shown only when APPROVED + valid).
           policyTitle: {

--- a/src/lib/seo/__tests__/groupe-metadata.test.ts
+++ b/src/lib/seo/__tests__/groupe-metadata.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildGroupeSeo } from "@/lib/seo/groupe-metadata";
+
+describe("buildGroupeSeo", () => {
+  it("names the Assemblée nationale for an AN group", () => {
+    const seo = buildGroupeSeo({
+      name: "Groupe Les Démocrates",
+      code: "DEM",
+      chamber: "AN",
+      seatCount: 36,
+      hasStats: true,
+    });
+    expect(seo.title).toBe("Groupe Les Démocrates à l'Assemblée nationale : membres et votes");
+    expect(seo.description).toBe(
+      "Groupe Les Démocrates (DEM) à l'Assemblée nationale : 36 membres, votes parlementaires, cohésion du groupe."
+    );
+  });
+
+  it("names the Sénat for a Senate group", () => {
+    const seo = buildGroupeSeo({
+      name: "Groupe Les Républicains",
+      code: "LR",
+      chamber: "SENAT",
+      seatCount: 132,
+      hasStats: true,
+    });
+    expect(seo.title).toBe("Groupe Les Républicains au Sénat : membres et votes");
+    expect(seo.description).toContain("au Sénat : 132 membres");
+    expect(seo.title).not.toContain("Assemblée nationale");
+    expect(seo.description).not.toContain("Assemblée nationale");
+  });
+
+  it("never advertises participation, available or not (issue #717)", () => {
+    for (const hasStats of [true, false]) {
+      const seo = buildGroupeSeo({
+        name: "Groupe X",
+        code: "X",
+        chamber: "SENAT",
+        seatCount: 10,
+        hasStats,
+      });
+      expect(seo.description.toLowerCase()).not.toContain("participation");
+      expect(seo.title.toLowerCase()).not.toContain("participation");
+    }
+  });
+
+  it("promises no statistic when no stats row exists", () => {
+    const seo = buildGroupeSeo({
+      name: "Groupe X",
+      code: "X",
+      chamber: "AN",
+      seatCount: 10,
+      hasStats: false,
+    });
+    expect(seo.description).toBe(
+      "Groupe X (X) à l'Assemblée nationale : 10 membres, votes parlementaires."
+    );
+    expect(seo.description).not.toContain("cohésion");
+  });
+
+  it("omits the seat count rather than claiming zero members", () => {
+    const seo = buildGroupeSeo({
+      name: "Groupe X",
+      code: "X",
+      chamber: "AN",
+      seatCount: 0,
+      hasStats: false,
+    });
+    expect(seo.description).toBe("Groupe X (X) à l'Assemblée nationale : votes parlementaires.");
+    expect(seo.description).not.toContain("0 membre");
+  });
+
+  it("agrees in number on a single-member group", () => {
+    const seo = buildGroupeSeo({
+      name: "Groupe X",
+      code: "X",
+      chamber: "AN",
+      seatCount: 1,
+      hasStats: false,
+    });
+    expect(seo.description).toContain("1 membre,");
+  });
+});

--- a/src/lib/seo/__tests__/politician-votes-metadata.test.ts
+++ b/src/lib/seo/__tests__/politician-votes-metadata.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveParliamentaryChamber,
+  buildPoliticianVotesSeo,
+  buildPoliticianVotesIntro,
+} from "@/lib/seo/politician-votes-metadata";
+
+describe("resolveParliamentaryChamber", () => {
+  it("resolves a sitting deputy to the Assemblée nationale", () => {
+    expect(resolveParliamentaryChamber([{ type: "DEPUTE", isCurrent: true }])).toBe("AN");
+  });
+
+  it("resolves a sitting senator to the Sénat", () => {
+    expect(resolveParliamentaryChamber([{ type: "SENATEUR", isCurrent: true }])).toBe("SENAT");
+  });
+
+  it("ignores non-parliamentary mandates", () => {
+    expect(
+      resolveParliamentaryChamber([
+        { type: "MAIRE", isCurrent: true },
+        { type: "SENATEUR", isCurrent: true },
+      ])
+    ).toBe("SENAT");
+    expect(
+      resolveParliamentaryChamber([
+        { type: "MAIRE", isCurrent: true },
+        { type: "MINISTRE", isCurrent: true },
+      ])
+    ).toBeNull();
+  });
+
+  it("returns null when no parliamentary mandate is recorded", () => {
+    expect(resolveParliamentaryChamber([])).toBeNull();
+  });
+
+  it("returns null rather than picking one when two current chambers appear", () => {
+    // Legally impossible: this is a data defect, and a defect must not become
+    // an assertion about where the person sits.
+    expect(
+      resolveParliamentaryChamber([
+        { type: "DEPUTE", isCurrent: true },
+        { type: "SENATEUR", isCurrent: true },
+      ])
+    ).toBeNull();
+  });
+
+  it("falls back to past mandates only when they agree", () => {
+    expect(resolveParliamentaryChamber([{ type: "DEPUTE", isCurrent: false }])).toBe("AN");
+    expect(
+      resolveParliamentaryChamber([
+        { type: "DEPUTE", isCurrent: false },
+        { type: "SENATEUR", isCurrent: false },
+      ])
+    ).toBeNull();
+  });
+
+  it("prefers the current mandate over a past one in the other chamber", () => {
+    expect(
+      resolveParliamentaryChamber([
+        { type: "DEPUTE", isCurrent: false },
+        { type: "SENATEUR", isCurrent: true },
+      ])
+    ).toBe("SENAT");
+  });
+});
+
+describe("buildPoliticianVotesSeo", () => {
+  it("targets the Assemblée nationale for a deputy", () => {
+    const seo = buildPoliticianVotesSeo("Jean Dupont", "AN");
+    expect(seo.title).toBe("Votes de Jean Dupont à l'Assemblée nationale");
+    expect(seo.description).toBe(
+      "Consultez les votes parlementaires de Jean Dupont à l'Assemblée nationale : textes de loi, amendements et positions enregistrées."
+    );
+    expect(seo.heading).toBe("Votes de Jean Dupont à l'Assemblée nationale");
+  });
+
+  it("targets the Sénat for a senator and never says Assemblée nationale", () => {
+    const seo = buildPoliticianVotesSeo("Marie Martin", "SENAT");
+    expect(seo.title).toBe("Votes de Marie Martin au Sénat");
+    expect(seo.description).toBe(
+      "Consultez les votes parlementaires de Marie Martin au Sénat : textes de loi, amendements et positions enregistrées."
+    );
+    expect(seo.heading).toBe("Votes de Marie Martin au Sénat");
+    expect(seo.title).not.toContain("Assemblée nationale");
+    expect(seo.description).not.toContain("Assemblée nationale");
+  });
+
+  it("falls back to a chamber-free wording when the chamber is unknown", () => {
+    const seo = buildPoliticianVotesSeo("Camille Durand", null);
+    expect(seo.title).toBe("Votes parlementaires de Camille Durand");
+    expect(seo.description).toBe(
+      "Consultez les votes parlementaires enregistrés pour Camille Durand : textes de loi, amendements et positions enregistrées."
+    );
+    expect(seo.heading).toBe("Votes de Camille Durand");
+    for (const value of [seo.title, seo.description, seo.heading]) {
+      expect(value).not.toContain("Assemblée nationale");
+      expect(value).not.toContain("Sénat");
+    }
+  });
+});
+
+describe("buildPoliticianVotesIntro", () => {
+  it("states the recorded volume and the chamber", () => {
+    expect(
+      buildPoliticianVotesIntro({
+        fullName: "Jean Dupont",
+        chamber: "AN",
+        totalVotes: 204,
+        amendmentVotes: 112,
+      })
+    ).toBe(
+      "204 votes de Jean Dupont sont enregistrés à l'Assemblée nationale. 112 portent sur des amendements."
+    );
+  });
+
+  it("omits the chamber when it is unknown", () => {
+    const intro = buildPoliticianVotesIntro({
+      fullName: "Camille Durand",
+      chamber: null,
+      totalVotes: 3,
+      amendmentVotes: 0,
+    });
+    expect(intro).toBe("3 votes de Camille Durand sont enregistrés.");
+    expect(intro).not.toContain("Assemblée nationale");
+    expect(intro).not.toContain("Sénat");
+  });
+
+  it("returns null when nothing is recorded, rather than writing a zero", () => {
+    expect(
+      buildPoliticianVotesIntro({
+        fullName: "Camille Durand",
+        chamber: "AN",
+        totalVotes: 0,
+        amendmentVotes: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("carries no participation claim (issue #717)", () => {
+    const intro = buildPoliticianVotesIntro({
+      fullName: "Jean Dupont",
+      chamber: "AN",
+      totalVotes: 100,
+      amendmentVotes: 20,
+    });
+    expect(intro?.toLowerCase()).not.toContain("participation");
+    expect(intro).not.toContain("%");
+  });
+});

--- a/src/lib/seo/__tests__/politician-votes-metadata.test.ts
+++ b/src/lib/seo/__tests__/politician-votes-metadata.test.ts
@@ -1,66 +1,25 @@
 import { describe, it, expect } from "vitest";
 import {
-  resolveParliamentaryChamber,
+  resolveVoteCorpusChamber,
   buildPoliticianVotesSeo,
   buildPoliticianVotesIntro,
 } from "@/lib/seo/politician-votes-metadata";
 
-describe("resolveParliamentaryChamber", () => {
-  it("resolves a sitting deputy to the Assemblée nationale", () => {
-    expect(resolveParliamentaryChamber([{ type: "DEPUTE", isCurrent: true }])).toBe("AN");
+describe("resolveVoteCorpusChamber", () => {
+  it("resolves an AN-only corpus", () => {
+    expect(resolveVoteCorpusChamber(["AN"])).toBe("AN");
   });
 
-  it("resolves a sitting senator to the Sénat", () => {
-    expect(resolveParliamentaryChamber([{ type: "SENATEUR", isCurrent: true }])).toBe("SENAT");
+  it("resolves a Sénat-only corpus", () => {
+    expect(resolveVoteCorpusChamber(["SENAT"])).toBe("SENAT");
   });
 
-  it("ignores non-parliamentary mandates", () => {
-    expect(
-      resolveParliamentaryChamber([
-        { type: "MAIRE", isCurrent: true },
-        { type: "SENATEUR", isCurrent: true },
-      ])
-    ).toBe("SENAT");
-    expect(
-      resolveParliamentaryChamber([
-        { type: "MAIRE", isCurrent: true },
-        { type: "MINISTRE", isCurrent: true },
-      ])
-    ).toBeNull();
+  it("returns null for a mixed corpus", () => {
+    expect(resolveVoteCorpusChamber(["AN", "SENAT"])).toBeNull();
   });
 
-  it("returns null when no parliamentary mandate is recorded", () => {
-    expect(resolveParliamentaryChamber([])).toBeNull();
-  });
-
-  it("returns null rather than picking one when two current chambers appear", () => {
-    // Legally impossible: this is a data defect, and a defect must not become
-    // an assertion about where the person sits.
-    expect(
-      resolveParliamentaryChamber([
-        { type: "DEPUTE", isCurrent: true },
-        { type: "SENATEUR", isCurrent: true },
-      ])
-    ).toBeNull();
-  });
-
-  it("falls back to past mandates only when they agree", () => {
-    expect(resolveParliamentaryChamber([{ type: "DEPUTE", isCurrent: false }])).toBe("AN");
-    expect(
-      resolveParliamentaryChamber([
-        { type: "DEPUTE", isCurrent: false },
-        { type: "SENATEUR", isCurrent: false },
-      ])
-    ).toBeNull();
-  });
-
-  it("prefers the current mandate over a past one in the other chamber", () => {
-    expect(
-      resolveParliamentaryChamber([
-        { type: "DEPUTE", isCurrent: false },
-        { type: "SENATEUR", isCurrent: true },
-      ])
-    ).toBe("SENAT");
+  it("returns null for an empty corpus", () => {
+    expect(resolveVoteCorpusChamber([])).toBeNull();
   });
 });
 
@@ -91,7 +50,7 @@ describe("buildPoliticianVotesSeo", () => {
     expect(seo.description).toBe(
       "Consultez les votes parlementaires enregistrés pour Camille Durand : textes de loi, amendements et positions enregistrées."
     );
-    expect(seo.heading).toBe("Votes de Camille Durand");
+    expect(seo.heading).toBe("Votes parlementaires de Camille Durand");
     for (const value of [seo.title, seo.description, seo.heading]) {
       expect(value).not.toContain("Assemblée nationale");
       expect(value).not.toContain("Sénat");
@@ -109,7 +68,7 @@ describe("buildPoliticianVotesIntro", () => {
         amendmentVotes: 112,
       })
     ).toBe(
-      "204 votes de Jean Dupont sont enregistrés à l'Assemblée nationale. 112 portent sur des amendements."
+      "Au total, 204 votes de Jean Dupont sont enregistrés à l'Assemblée nationale. 112 portent sur des amendements."
     );
   });
 
@@ -120,12 +79,12 @@ describe("buildPoliticianVotesIntro", () => {
       totalVotes: 3,
       amendmentVotes: 0,
     });
-    expect(intro).toBe("3 votes de Camille Durand sont enregistrés.");
+    expect(intro).toBe("Au total, 3 votes de Camille Durand sont enregistrés.");
     expect(intro).not.toContain("Assemblée nationale");
     expect(intro).not.toContain("Sénat");
   });
 
-  it("returns null when nothing is recorded, rather than writing a zero", () => {
+  it("uses a neutral fallback when no vote is recorded", () => {
     expect(
       buildPoliticianVotesIntro({
         fullName: "Camille Durand",
@@ -133,7 +92,7 @@ describe("buildPoliticianVotesIntro", () => {
         totalVotes: 0,
         amendmentVotes: 0,
       })
-    ).toBeNull();
+    ).toBe("Aucun vote parlementaire n'est enregistré pour Camille Durand.");
   });
 
   it("carries no participation claim (issue #717)", () => {

--- a/src/lib/seo/__tests__/theme-metadata.test.ts
+++ b/src/lib/seo/__tests__/theme-metadata.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  THEME_SEO_PHRASES,
+  buildThemeTitle,
+  buildThemeDescription,
+  buildThemeH1,
+  buildThemeIntro,
+} from "@/lib/seo/theme-metadata";
+import { getAllThemeSlugs, themeFromSlug } from "@/lib/theme-utils";
+
+const BOTH = { hasAN: true, hasSenat: true } as const;
+const AN_ONLY = { hasAN: true, hasSenat: false } as const;
+const SENAT_ONLY = { hasAN: false, hasSenat: true } as const;
+const NONE = { hasAN: false, hasSenat: false } as const;
+
+describe("theme SEO phrases", () => {
+  it("covers every routable theme", () => {
+    for (const slug of getAllThemeSlugs()) {
+      const theme = themeFromSlug(slug);
+      expect(theme).not.toBeNull();
+      expect(THEME_SEO_PHRASES[theme!]).toBeTruthy();
+    }
+  });
+
+  it("is a prepositional form, never the bare display label", () => {
+    // "Votes sur Économie" is what this config exists to prevent: no phrase may
+    // start with a capital letter (i.e. be a raw label injected in a sentence).
+    for (const phrase of Object.values(THEME_SEO_PHRASES)) {
+      expect(phrase).toBe(phrase.toLocaleLowerCase("fr-FR"));
+    }
+  });
+});
+
+describe("buildThemeTitle", () => {
+  it("names both chambers when both are covered", () => {
+    expect(buildThemeTitle("SANTE", BOTH)).toBe(
+      "Votes sur la santé à l'Assemblée nationale et au Sénat"
+    );
+  });
+
+  it("keeps the grammar correct on elided themes", () => {
+    expect(buildThemeTitle("ECONOMIE_BUDGET", BOTH)).toBe(
+      "Votes sur l'économie et le budget à l'Assemblée nationale et au Sénat"
+    );
+    expect(buildThemeTitle("IMMIGRATION", BOTH)).toBe(
+      "Votes sur l'immigration à l'Assemblée nationale et au Sénat"
+    );
+    expect(buildThemeTitle("ENVIRONNEMENT_ENERGIE", BOTH)).toBe(
+      "Votes sur l'environnement et l'énergie à l'Assemblée nationale et au Sénat"
+    );
+  });
+
+  it("does not claim a chamber the theme does not cover", () => {
+    expect(buildThemeTitle("SANTE", AN_ONLY)).toBe("Votes sur la santé à l'Assemblée nationale");
+    expect(buildThemeTitle("SANTE", SENAT_ONLY)).toBe("Votes sur la santé au Sénat");
+    expect(buildThemeTitle("SANTE", NONE)).toBe("Votes parlementaires sur la santé");
+    expect(buildThemeTitle("SANTE", AN_ONLY)).not.toContain("Sénat");
+  });
+});
+
+describe("buildThemeDescription", () => {
+  it("follows the target wording when both chambers are covered", () => {
+    expect(buildThemeDescription("SANTE", BOTH)).toBe(
+      "Consultez les votes du Parlement sur la santé : scrutins de l'Assemblée nationale et du Sénat, résultats, textes de loi et amendements."
+    );
+  });
+
+  it("drops the Senate when it is not covered", () => {
+    const description = buildThemeDescription("IMMIGRATION", AN_ONLY);
+    expect(description).toContain("scrutins de l'Assemblée nationale,");
+    expect(description).not.toContain("Sénat");
+  });
+});
+
+describe("buildThemeH1", () => {
+  it("is explicit rather than the bare label", () => {
+    expect(buildThemeH1("SANTE")).toBe("Votes parlementaires sur la santé");
+    expect(buildThemeH1("ECONOMIE_BUDGET")).toBe(
+      "Votes parlementaires sur l'économie et le budget"
+    );
+  });
+});
+
+describe("buildThemeIntro", () => {
+  it("states deterministic counts and the covered chambers", () => {
+    expect(
+      buildThemeIntro({
+        theme: "SANTE",
+        total: 142,
+        adoptedPercent: 58,
+        lastVoteDateLabel: "12 mars 2026",
+        coverage: BOTH,
+      })
+    ).toBe(
+      "142 scrutins parlementaires sur la santé sont référencés, dont 58 % adoptés. Dernier scrutin : 12 mars 2026. Retrouvez les votes de l'Assemblée nationale et du Sénat, les textes de loi et les amendements concernés."
+    );
+  });
+
+  it("agrees in number and omits an unknown last vote date", () => {
+    expect(
+      buildThemeIntro({
+        theme: "TRANSPORTS",
+        total: 1,
+        adoptedPercent: 100,
+        lastVoteDateLabel: null,
+        coverage: AN_ONLY,
+      })
+    ).toBe(
+      "1 scrutin parlementaire sur les transports est référencé, dont 100 % adoptés. Retrouvez les votes de l'Assemblée nationale, les textes de loi et les amendements concernés."
+    );
+  });
+
+  it("never mentions the Senate on an AN-only theme", () => {
+    const intro = buildThemeIntro({
+      theme: "IMMIGRATION",
+      total: 12,
+      adoptedPercent: 25,
+      lastVoteDateLabel: "3 février 2026",
+      coverage: AN_ONLY,
+    });
+    expect(intro).not.toContain("Sénat");
+  });
+
+  it("does not invent content when the theme is empty", () => {
+    expect(
+      buildThemeIntro({
+        theme: "SANTE",
+        total: 0,
+        adoptedPercent: 0,
+        lastVoteDateLabel: null,
+        coverage: NONE,
+      })
+    ).toBe("Aucun scrutin sur la santé n'est référencé à ce jour.");
+  });
+
+  it("is not a repetition of the title", () => {
+    const intro = buildThemeIntro({
+      theme: "SANTE",
+      total: 42,
+      adoptedPercent: 50,
+      lastVoteDateLabel: "1 janvier 2026",
+      coverage: BOTH,
+    });
+    expect(intro).not.toContain(buildThemeTitle("SANTE", BOTH));
+  });
+
+  it("carries no participation claim (issue #717)", () => {
+    const intro = buildThemeIntro({
+      theme: "SANTE",
+      total: 42,
+      adoptedPercent: 50,
+      lastVoteDateLabel: "1 janvier 2026",
+      coverage: BOTH,
+    });
+    expect(intro.toLowerCase()).not.toContain("participation");
+  });
+});

--- a/src/lib/seo/groupe-metadata.ts
+++ b/src/lib/seo/groupe-metadata.ts
@@ -1,0 +1,52 @@
+import type { Chamber } from "@/generated/prisma";
+
+/**
+ * SEO strings for /parlement/groupes/[slug].
+ *
+ * The chamber is a stored property of the group, so it is always named. What
+ * the description may promise is limited to what the page can actually show:
+ * the seat count only when members are attached, and the cohesion only when a
+ * stats row exists. Participation is deliberately absent — its publication
+ * policy is being hardened in #717 and it must not become an SEO claim.
+ */
+
+export interface GroupeSeoInput {
+  name: string;
+  code: string;
+  chamber: Chamber;
+  /** Current members attached to the group; 0 means "none recorded", not "none". */
+  seatCount: number;
+  /** True when a computed stats row exists (cohesion is then displayed). */
+  hasStats: boolean;
+}
+
+export interface GroupeSeo {
+  title: string;
+  description: string;
+}
+
+function chamberPreposition(chamber: Chamber): string {
+  return chamber === "AN" ? "à l'Assemblée nationale" : "au Sénat";
+}
+
+export function buildGroupeSeo({
+  name,
+  code,
+  chamber,
+  seatCount,
+  hasStats,
+}: GroupeSeoInput): GroupeSeo {
+  const preposition = chamberPreposition(chamber);
+
+  // A group with no recorded member says nothing about its real size: leave the
+  // count out rather than advertise "0 membres".
+  const items: string[] = [];
+  if (seatCount > 0) items.push(`${seatCount} membre${seatCount > 1 ? "s" : ""}`);
+  items.push("votes parlementaires");
+  if (hasStats) items.push("cohésion du groupe");
+
+  return {
+    title: `${name} ${preposition} : membres et votes`,
+    description: `${name} (${code}) ${preposition} : ${items.join(", ")}.`,
+  };
+}

--- a/src/lib/seo/politician-votes-metadata.ts
+++ b/src/lib/seo/politician-votes-metadata.ts
@@ -1,0 +1,130 @@
+/**
+ * Chamber-aware SEO strings for /politiques/[slug]/votes.
+ *
+ * The page used to assert "à l'Assemblée nationale" for everyone, which is
+ * wrong for senators and unverifiable for anyone whose parliamentary mandate is
+ * not established. Chamber is now resolved from the mandates and, when it stays
+ * ambiguous, the copy simply says nothing about it (unknown != false).
+ */
+
+export type ParliamentaryChamber = "AN" | "SENAT";
+
+/** Minimal mandate shape needed to resolve a chamber. */
+export interface ChamberMandateSignal {
+  type: string;
+  isCurrent: boolean;
+}
+
+const CHAMBER_BY_MANDATE_TYPE: Readonly<Record<string, ParliamentaryChamber>> = {
+  DEPUTE: "AN",
+  SENATEUR: "SENAT",
+};
+
+function chambersOf(mandates: ReadonlyArray<ChamberMandateSignal>): Set<ParliamentaryChamber> {
+  const chambers = new Set<ParliamentaryChamber>();
+  for (const mandate of mandates) {
+    const chamber = CHAMBER_BY_MANDATE_TYPE[mandate.type];
+    if (chamber) chambers.add(chamber);
+  }
+  return chambers;
+}
+
+/**
+ * The chamber a politician's votes belong to, or null when it cannot be
+ * established without guessing.
+ *
+ * Current parliamentary mandates win. Holding a seat in both chambers at once
+ * is legally impossible, so two current chambers means the data is wrong, not
+ * that the person sits twice: the answer is null, never a pick. Without any
+ * current parliamentary mandate, past ones are used only when they all point at
+ * the same chamber — a former deputy who later became a senator stays null
+ * rather than being attributed to whichever mandate looks most recent.
+ */
+export function resolveParliamentaryChamber(
+  mandates: ReadonlyArray<ChamberMandateSignal>
+): ParliamentaryChamber | null {
+  const current = chambersOf(mandates.filter((m) => m.isCurrent));
+  if (current.size === 1) return [...current][0] ?? null;
+  if (current.size > 1) return null;
+
+  const past = chambersOf(mandates);
+  return past.size === 1 ? ([...past][0] ?? null) : null;
+}
+
+/** "à l'Assemblée nationale" / "au Sénat" — null when the chamber is unknown. */
+export function chamberPreposition(chamber: ParliamentaryChamber | null): string | null {
+  if (chamber === "AN") return "à l'Assemblée nationale";
+  if (chamber === "SENAT") return "au Sénat";
+  return null;
+}
+
+export interface PoliticianVotesSeo {
+  title: string;
+  description: string;
+  /** Visible H1, enriched only when the chamber is established. */
+  heading: string;
+}
+
+export function buildPoliticianVotesSeo(
+  fullName: string,
+  chamber: ParliamentaryChamber | null
+): PoliticianVotesSeo {
+  const preposition = chamberPreposition(chamber);
+
+  if (!preposition) {
+    return {
+      title: `Votes parlementaires de ${fullName}`,
+      description: `Consultez les votes parlementaires enregistrés pour ${fullName} : textes de loi, amendements et positions enregistrées.`,
+      heading: `Votes de ${fullName}`,
+    };
+  }
+
+  return {
+    title: `Votes de ${fullName} ${preposition}`,
+    description: `Consultez les votes parlementaires de ${fullName} ${preposition} : textes de loi, amendements et positions enregistrées.`,
+    heading: `Votes de ${fullName} ${preposition}`,
+  };
+}
+
+export interface PoliticianVotesIntroInput {
+  fullName: string;
+  chamber: ParliamentaryChamber | null;
+  /** All recorded votes, every scrutin type included. */
+  totalVotes: number;
+  /** Subset cast on amendments. */
+  amendmentVotes: number;
+}
+
+/**
+ * Short visible intro, built from the tab counts the page already loads: no
+ * extra query, no participation rate (issue #717), no reading of the voting
+ * behaviour. Returns null when there is nothing recorded to describe.
+ */
+export function buildPoliticianVotesIntro({
+  fullName,
+  chamber,
+  totalVotes,
+  amendmentVotes,
+}: PoliticianVotesIntroInput): string | null {
+  if (totalVotes <= 0) return null;
+
+  const preposition = chamberPreposition(chamber);
+  const where = preposition ? ` ${preposition}` : "";
+  const count = totalVotes.toLocaleString("fr-FR");
+
+  const sentences: string[] = [
+    totalVotes > 1
+      ? `${count} votes de ${fullName} sont enregistrés${where}.`
+      : `${count} vote de ${fullName} est enregistré${where}.`,
+  ];
+
+  if (amendmentVotes > 0) {
+    sentences.push(
+      amendmentVotes > 1
+        ? `${amendmentVotes.toLocaleString("fr-FR")} portent sur des amendements.`
+        : `${amendmentVotes.toLocaleString("fr-FR")} porte sur un amendement.`
+    );
+  }
+
+  return sentences.join(" ");
+}

--- a/src/lib/seo/politician-votes-metadata.ts
+++ b/src/lib/seo/politician-votes-metadata.ts
@@ -1,54 +1,22 @@
 /**
  * Chamber-aware SEO strings for /politiques/[slug]/votes.
  *
- * The page used to assert "à l'Assemblée nationale" for everyone, which is
- * wrong for senators and unverifiable for anyone whose parliamentary mandate is
- * not established. Chamber is now resolved from the mandates and, when it stays
- * ambiguous, the copy simply says nothing about it (unknown != false).
+ * Metadata must describe the votes actually rendered by the page. The chamber
+ * therefore comes from the denormalized Vote.chamber corpus, never from a
+ * current or historical mandate. Mixed and empty corpora stay neutral.
  */
 
 export type ParliamentaryChamber = "AN" | "SENAT";
 
-/** Minimal mandate shape needed to resolve a chamber. */
-export interface ChamberMandateSignal {
-  type: string;
-  isCurrent: boolean;
-}
-
-const CHAMBER_BY_MANDATE_TYPE: Readonly<Record<string, ParliamentaryChamber>> = {
-  DEPUTE: "AN",
-  SENATEUR: "SENAT",
-};
-
-function chambersOf(mandates: ReadonlyArray<ChamberMandateSignal>): Set<ParliamentaryChamber> {
-  const chambers = new Set<ParliamentaryChamber>();
-  for (const mandate of mandates) {
-    const chamber = CHAMBER_BY_MANDATE_TYPE[mandate.type];
-    if (chamber) chambers.add(chamber);
-  }
-  return chambers;
-}
-
 /**
- * The chamber a politician's votes belong to, or null when it cannot be
- * established without guessing.
- *
- * Current parliamentary mandates win. Holding a seat in both chambers at once
- * is legally impossible, so two current chambers means the data is wrong, not
- * that the person sits twice: the answer is null, never a pick. Without any
- * current parliamentary mandate, past ones are used only when they all point at
- * the same chamber — a former deputy who later became a senator stays null
- * rather than being attributed to whichever mandate looks most recent.
+ * Resolve a chamber only when every recorded vote belongs to the same one.
+ * Mixed and empty corpora return null so the copy cannot overstate its scope.
  */
-export function resolveParliamentaryChamber(
-  mandates: ReadonlyArray<ChamberMandateSignal>
+export function resolveVoteCorpusChamber(
+  chambers: ReadonlyArray<ParliamentaryChamber>
 ): ParliamentaryChamber | null {
-  const current = chambersOf(mandates.filter((m) => m.isCurrent));
-  if (current.size === 1) return [...current][0] ?? null;
-  if (current.size > 1) return null;
-
-  const past = chambersOf(mandates);
-  return past.size === 1 ? ([...past][0] ?? null) : null;
+  const uniqueChambers = new Set(chambers);
+  return uniqueChambers.size === 1 ? ([...uniqueChambers][0] ?? null) : null;
 }
 
 /** "à l'Assemblée nationale" / "au Sénat" — null when the chamber is unknown. */
@@ -75,7 +43,7 @@ export function buildPoliticianVotesSeo(
     return {
       title: `Votes parlementaires de ${fullName}`,
       description: `Consultez les votes parlementaires enregistrés pour ${fullName} : textes de loi, amendements et positions enregistrées.`,
-      heading: `Votes de ${fullName}`,
+      heading: `Votes parlementaires de ${fullName}`,
     };
   }
 
@@ -98,7 +66,7 @@ export interface PoliticianVotesIntroInput {
 /**
  * Short visible intro, built from the tab counts the page already loads: no
  * extra query, no participation rate (issue #717), no reading of the voting
- * behaviour. Returns null when there is nothing recorded to describe.
+ * behaviour.
  */
 export function buildPoliticianVotesIntro({
   fullName,
@@ -106,7 +74,9 @@ export function buildPoliticianVotesIntro({
   totalVotes,
   amendmentVotes,
 }: PoliticianVotesIntroInput): string | null {
-  if (totalVotes <= 0) return null;
+  if (totalVotes <= 0) {
+    return `Aucun vote parlementaire n'est enregistré pour ${fullName}.`;
+  }
 
   const preposition = chamberPreposition(chamber);
   const where = preposition ? ` ${preposition}` : "";
@@ -114,8 +84,8 @@ export function buildPoliticianVotesIntro({
 
   const sentences: string[] = [
     totalVotes > 1
-      ? `${count} votes de ${fullName} sont enregistrés${where}.`
-      : `${count} vote de ${fullName} est enregistré${where}.`,
+      ? `Au total, ${count} votes de ${fullName} sont enregistrés${where}.`
+      : `Au total, ${count} vote de ${fullName} est enregistré${where}.`,
   ];
 
   if (amendmentVotes > 0) {

--- a/src/lib/seo/theme-metadata.ts
+++ b/src/lib/seo/theme-metadata.ts
@@ -1,0 +1,143 @@
+import type { ThemeCategory } from "@/generated/prisma";
+
+/**
+ * SEO grammar for the thematic vote landings (/parlement/votes/themes/[theme]).
+ *
+ * The display labels (THEME_CATEGORY_LABELS) are noun phrases meant for badges
+ * and cards ("Santé", "Économie & Budget"). Injected into a sentence they give
+ * incorrect French ("Votes sur Économie"), so the prepositional form lives here
+ * instead of being patched case by case inside the page.
+ *
+ * Every phrase is written to read after "sur" ("Votes sur la santé"), which is
+ * also the form used by the visible intro and by the contextual links pointing
+ * at these landings.
+ */
+export const THEME_SEO_PHRASES: Record<ThemeCategory, string> = {
+  ECONOMIE_BUDGET: "l'économie et le budget",
+  SOCIAL_TRAVAIL: "les questions sociales et le travail",
+  SECURITE_JUSTICE: "la sécurité et la justice",
+  ENVIRONNEMENT_ENERGIE: "l'environnement et l'énergie",
+  SANTE: "la santé",
+  EDUCATION_CULTURE: "l'éducation et la culture",
+  INSTITUTIONS: "les institutions",
+  AFFAIRES_ETRANGERES_DEFENSE: "les affaires étrangères et la défense",
+  NUMERIQUE_TECH: "le numérique et les technologies",
+  IMMIGRATION: "l'immigration",
+  AGRICULTURE_ALIMENTATION: "l'agriculture et l'alimentation",
+  LOGEMENT_URBANISME: "le logement et l'urbanisme",
+  TRANSPORTS: "les transports",
+};
+
+/** Prepositional form of a theme, to be used after "sur". */
+export function themeSeoPhrase(theme: ThemeCategory): string {
+  return THEME_SEO_PHRASES[theme];
+}
+
+/**
+ * Chambers actually represented among the scrutins referenced under a theme.
+ * Derived from the data, never assumed: a theme covered only by the Assemblée
+ * nationale must not advertise Senate scrutins it does not carry.
+ */
+export interface ThemeChamberCoverage {
+  hasAN: boolean;
+  hasSenat: boolean;
+}
+
+/** "à l'Assemblée nationale et au Sénat" — null when no chamber is covered. */
+function chamberSuffix(coverage: ThemeChamberCoverage): string | null {
+  if (coverage.hasAN && coverage.hasSenat) return "à l'Assemblée nationale et au Sénat";
+  if (coverage.hasAN) return "à l'Assemblée nationale";
+  if (coverage.hasSenat) return "au Sénat";
+  return null;
+}
+
+/** "les votes de l'Assemblée nationale et du Sénat" — null when no chamber is covered. */
+function chamberVotesClause(coverage: ThemeChamberCoverage): string | null {
+  if (coverage.hasAN && coverage.hasSenat) return "les votes de l'Assemblée nationale et du Sénat";
+  if (coverage.hasAN) return "les votes de l'Assemblée nationale";
+  if (coverage.hasSenat) return "les votes du Sénat";
+  return null;
+}
+
+/** "scrutins de l'Assemblée nationale et du Sénat" — null when no chamber is covered. */
+function chamberScrutinsClause(coverage: ThemeChamberCoverage): string | null {
+  if (coverage.hasAN && coverage.hasSenat) return "scrutins de l'Assemblée nationale et du Sénat";
+  if (coverage.hasAN) return "scrutins de l'Assemblée nationale";
+  if (coverage.hasSenat) return "scrutins du Sénat";
+  return null;
+}
+
+/**
+ * Landing title. Names the chambers actually covered, so the page answers the
+ * real query ("votes sur la santé à l'Assemblée nationale") instead of the bare
+ * label. Falls back to a chamber-free form when the theme carries no scrutin.
+ */
+export function buildThemeTitle(theme: ThemeCategory, coverage: ThemeChamberCoverage): string {
+  const phrase = themeSeoPhrase(theme);
+  const suffix = chamberSuffix(coverage);
+  return suffix ? `Votes sur ${phrase} ${suffix}` : `Votes parlementaires sur ${phrase}`;
+}
+
+export function buildThemeDescription(
+  theme: ThemeCategory,
+  coverage: ThemeChamberCoverage
+): string {
+  const phrase = themeSeoPhrase(theme);
+  const scrutins = chamberScrutinsClause(coverage);
+  return scrutins
+    ? `Consultez les votes du Parlement sur ${phrase} : ${scrutins}, résultats, textes de loi et amendements.`
+    : `Consultez les votes du Parlement sur ${phrase} : scrutins, résultats, textes de loi et amendements.`;
+}
+
+/** Explicit H1, kept short: the theme label alone says nothing about the page. */
+export function buildThemeH1(theme: ThemeCategory): string {
+  return `Votes parlementaires sur ${themeSeoPhrase(theme)}`;
+}
+
+export interface ThemeIntroInput {
+  theme: ThemeCategory;
+  /** Scrutins referenced in the currently displayed perimeter. */
+  total: number;
+  /** Share of adopted scrutins in that same perimeter, already rounded. */
+  adoptedPercent: number;
+  /** Formatted date of the most recent scrutin, or null when unknown. */
+  lastVoteDateLabel: string | null;
+  coverage: ThemeChamberCoverage;
+}
+
+/**
+ * Visible intro: deterministic, derived from counts already displayed on the
+ * page. No interpretation of the votes, no generated editorial text, and no
+ * chamber mentioned that the data does not cover.
+ */
+export function buildThemeIntro({
+  theme,
+  total,
+  adoptedPercent,
+  lastVoteDateLabel,
+  coverage,
+}: ThemeIntroInput): string {
+  const phrase = themeSeoPhrase(theme);
+
+  if (total <= 0) {
+    return `Aucun scrutin sur ${phrase} n'est référencé à ce jour.`;
+  }
+
+  const count = total.toLocaleString("fr-FR");
+  const sentences: string[] = [
+    total > 1
+      ? `${count} scrutins parlementaires sur ${phrase} sont référencés, dont ${adoptedPercent} % adoptés.`
+      : `${count} scrutin parlementaire sur ${phrase} est référencé, dont ${adoptedPercent} % adoptés.`,
+  ];
+
+  if (lastVoteDateLabel) {
+    sentences.push(`Dernier scrutin : ${lastVoteDateLabel}.`);
+  }
+
+  const votes = chamberVotesClause(coverage);
+  if (votes) {
+    sentences.push(`Retrouvez ${votes}, les textes de loi et les amendements concernés.`);
+  }
+
+  return sentences.join(" ");
+}

--- a/src/services/voteStats.ts
+++ b/src/services/voteStats.ts
@@ -493,6 +493,27 @@ export async function getPoliticianVoteTabCounts(
   return { totalAll, amendmentCount, nonAmendmentCount };
 }
 
+/**
+ * Chambers represented in a politician's recorded vote corpus.
+ *
+ * Vote.chamber is denormalized and covered by the
+ * [politicianId, chamber, votingDate] index, so this query needs no Scrutin join.
+ * Consumers must treat [] and ["AN", "SENAT"] as neutral rather than inferring
+ * a chamber from the politician's mandates.
+ */
+export async function getPoliticianVoteChamberCoverage(politicianId: string): Promise<Chamber[]> {
+  "use cache";
+  cacheTag("votes", "politicians");
+  cacheLife("synced");
+
+  const rows = await db.vote.groupBy({
+    by: ["chamber"],
+    where: { politicianId },
+  });
+
+  return rows.map(({ chamber }) => chamber);
+}
+
 // ============================================
 // Participation ranking
 // ============================================


### PR DESCRIPTION
## Description

Cette PR améliore le référencement et le maillage interne des pages parlementaires existantes, avec des formulations fondées sur le corpus réellement affiché.

### Pages de votes des élus

La chambre de `/politiques/[slug]/votes` est déterminée depuis le corpus réel `Vote.chamber` :

- corpus uniquement AN : Assemblée nationale ;
- corpus uniquement Sénat : Sénat ;
- corpus mixte AN et Sénat : formulation parlementaire neutre ;
- corpus vide : formulation parlementaire neutre.

Les mandats ne servent pas à enrichir artificiellement les metadata de cet onglet. Le titre, la description, le H1 et l’introduction décrivent donc les votes effectivement présentés.

### Thèmes et groupes

- Les landings thématiques utilisent la couverture réelle des scrutins par chambre.
- Les titres thématiques conservent leurs formulations grammaticales dédiées.
- Les groupes utilisent des metadata sans participation.
- Les cartes de scrutins de groupe reflètent la chambre et la source réelles du scrutin.

### Cache après synchronisation

Le tag `votes` est invalidé après chaque synchronisation réussie des scrutins sur les chemins Inngest groupés, quotidiens et individuels.

Les workflows GitHub Daily et weekly invalident le cache de l’application déployée via `/api/cron/revalidate`, avec `CRON_SECRET`. L’appel distant échoue explicitement si le secret manque ou si l’endpoint retourne une réponse non-2xx.

### Liens et accessibilité

- Les liens vers les landings thématiques restent descriptifs et crawlables.
- Les nouvelles cibles interactives respectent une hauteur tactile minimale de 44 px.
- Le lien source des cartes de vote utilise un libellé générique exact pour l’Assemblée nationale comme pour le Sénat.

### Invariants de la PR #717

La participation reste exclue du SEO. Les taux individuels du Sénat et les agrégats de participation non publiables ne sont ni recalculés ni réintroduits. Les champs de participation groupe restent indisponibles et nullables conformément à #717.

### Indexation

Les canonicals, les variantes `noindex,follow`, l’indexabilité des fiches scrutin et la stratégie globale du sitemap restent inchangés.
