### PR TITLE
Improve error messages by unwrapping cause chains

### DIFF
--- a/scripts/sync-legislation-content.ts
+++ b/scripts/sync-legislation-content.ts
@@ -18,7 +18,7 @@ import { createCLI, type SyncHandler, type SyncResult } from "../src/lib/sync";
 import { db } from "../src/lib/db";
 import mammoth from "mammoth";
 import { ASSEMBLEE_DOCPARL_RATE_LIMIT_MS } from "../src/config/rate-limits";
-import { HTTPClient, HTTPError } from "../src/lib/api/http-client";
+import { HTTPClient, HTTPError, describeError } from "../src/lib/api/http-client";
 
 // Configuration
 const DOCPARL_URL_TEMPLATE =
@@ -258,7 +258,7 @@ Features:
 
         stats.processed++;
       } catch (err) {
-        const msg = `${dossier!.externalId}: ${err instanceof Error ? err.message : String(err)}`;
+        const msg = `${dossier!.externalId}: ${describeError(err)}`;
         errors.push(msg);
         stats.processed++;
       }

--- a/src/lib/api/__tests__/http-client.test.ts
+++ b/src/lib/api/__tests__/http-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { describeError, HTTPError } from "../http-client";
+import { describeError, HTTPClient, HTTPError } from "../http-client";
 
 describe("describeError", () => {
   it("returns the message of a plain error", () => {

--- a/src/lib/api/__tests__/http-client.test.ts
+++ b/src/lib/api/__tests__/http-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { describeError, HTTPError } from "../http-client";
 
 describe("describeError", () => {
@@ -85,5 +85,68 @@ describe("describeError", () => {
     expect(describeError(new HTTPError("HTTP 404: Not Found", 404, "https://example.fr"))).toBe(
       "HTTP 404: Not Found"
     );
+  });
+});
+
+describe("HTTPClient error URL redaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes credentials, query parameters, and fragments from network errors", async () => {
+    const secret = "super-secret-api-key";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const client = new HTTPClient({ retries: 0 });
+
+    const error = await client
+      .get(`https://user:password@example.fr/path?key=${secret}#fragment`)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("network down (https://example.fr/path)");
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error).message).not.toContain("password");
+  });
+
+  it("preserves a query-free endpoint in network errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const client = new HTTPClient({ retries: 0 });
+
+    const error = await client.get("https://example.fr/path").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("network down (https://example.fr/path)");
+  });
+
+  it("does not echo malformed URLs in fallback errors", async () => {
+    const secret = "super-secret-api-key";
+    const client = new HTTPClient();
+
+    const error = await client
+      .get(`not-a-url?key=${secret}`, { retries: -1 })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Failed to fetch [redacted URL]");
+    expect((error as Error).message).not.toContain(secret);
+  });
+
+  it("redacts the URL used by 429 diagnostics", async () => {
+    const secret = "super-secret-api-key";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 429, statusText: "Too Many Requests" })
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = new HTTPClient({ retries: 0 });
+
+    const error = await client
+      .get(`https://example.fr/path?key=${secret}`)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HTTPError);
+    expect(warn).toHaveBeenCalledWith(
+      "[HTTPClient] 429 Too Many Requests from https://example.fr/path (attempt 1/1)"
+    );
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(secret);
   });
 });

--- a/src/lib/api/__tests__/http-client.test.ts
+++ b/src/lib/api/__tests__/http-client.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { describeError, HTTPError } from "../http-client";
+
+describe("describeError", () => {
+  it("returns the message of a plain error", () => {
+    expect(describeError(new Error("boom"))).toBe("boom");
+  });
+
+  it("appends the errno code when present", () => {
+    const err = Object.assign(new Error("getaddrinfo ENOTFOUND example.fr"), {
+      code: "ENOTFOUND",
+    });
+    expect(describeError(err)).toBe("getaddrinfo ENOTFOUND example.fr [ENOTFOUND]");
+  });
+
+  it("unwraps the cause chain hidden behind an opaque fetch failure", () => {
+    const cause = Object.assign(new Error("getaddrinfo ENOTFOUND docparl.example.fr"), {
+      code: "ENOTFOUND",
+    });
+    const err = new Error("fetch failed", { cause });
+
+    expect(describeError(err)).toBe(
+      "fetch failed <- getaddrinfo ENOTFOUND docparl.example.fr [ENOTFOUND]"
+    );
+  });
+
+  it("expands an AggregateError of per-IP connection failures", () => {
+    const cause = new AggregateError(
+      [
+        Object.assign(new Error("connect ECONNREFUSED 1.2.3.4:443"), { code: "ECONNREFUSED" }),
+        Object.assign(new Error("connect ECONNREFUSED 5.6.7.8:443"), { code: "ECONNREFUSED" }),
+      ],
+      "all attempts failed"
+    );
+    const err = new Error("fetch failed", { cause });
+
+    expect(describeError(err)).toBe(
+      "fetch failed <- all attempts failed <- " +
+        "connect ECONNREFUSED 1.2.3.4:443 [ECONNREFUSED], " +
+        "connect ECONNREFUSED 5.6.7.8:443 [ECONNREFUSED]"
+    );
+  });
+
+  it("deduplicates identical aggregated failures", () => {
+    const cause = new AggregateError(
+      [new Error("connect ETIMEDOUT"), new Error("connect ETIMEDOUT")],
+      "all attempts failed"
+    );
+
+    expect(describeError(new Error("fetch failed", { cause }))).toBe(
+      "fetch failed <- all attempts failed <- connect ETIMEDOUT"
+    );
+  });
+
+  it("terminates on a cyclic cause chain", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    a.cause = b;
+
+    expect(describeError(a)).toBe("a <- b");
+  });
+
+  it("stops at the depth guard for a long chain", () => {
+    let err = new Error("root");
+    for (let i = 0; i < 10; i++) {
+      err = new Error(`level-${i}`, { cause: err });
+    }
+
+    expect(describeError(err).split(" <- ")).toHaveLength(5);
+  });
+
+  it("handles non-Error values", () => {
+    expect(describeError("plain string")).toBe("plain string");
+    expect(describeError(new Error("wrapped", { cause: "string cause" }))).toBe(
+      "wrapped <- string cause"
+    );
+  });
+
+  it("returns an empty string for a missing error", () => {
+    expect(describeError(undefined)).toBe("");
+    expect(describeError(null)).toBe("");
+  });
+
+  it("keeps HTTPError messages intact", () => {
+    expect(describeError(new HTTPError("HTTP 404: Not Found", 404, "https://example.fr"))).toBe(
+      "HTTP 404: Not Found"
+    );
+  });
+});

--- a/src/lib/api/http-client.ts
+++ b/src/lib/api/http-client.ts
@@ -56,6 +56,58 @@ export class HTTPError extends Error {
   }
 }
 
+/** Guard against a cyclic `cause` chain. */
+const MAX_CAUSE_DEPTH = 5;
+
+function errorLabel(error: Error): string {
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? `${error.message} [${code}]` : error.message;
+}
+
+/**
+ * Flatten an error and its `cause` chain into a single readable line.
+ *
+ * Node's fetch reports every connection-level problem as the opaque message
+ * "fetch failed" and hides the real reason (ENOTFOUND, ECONNREFUSED, a TLS
+ * error…) in `cause` — sometimes wrapped one more level in an AggregateError
+ * when several IPs were tried. Logging only `error.message` therefore discards
+ * the one detail needed to triage the failure.
+ *
+ * Example: `fetch failed <- getaddrinfo ENOTFOUND example.fr [ENOTFOUND]`
+ */
+export function describeError(error: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (current === undefined || current === null || seen.has(current)) break;
+    seen.add(current);
+
+    if (!(current instanceof Error)) {
+      parts.push(String(current));
+      break;
+    }
+
+    parts.push(errorLabel(current));
+
+    // undici groups per-IP connection failures into an AggregateError; the
+    // individual attempts carry the real errno, so surface them.
+    if (current instanceof AggregateError && current.errors?.length) {
+      const inner = current.errors.filter((e): e is Error => e instanceof Error).map(errorLabel);
+      const unique = [...new Set(inner)];
+      if (unique.length > 0) {
+        parts.push(unique.join(", "));
+        break;
+      }
+    }
+
+    current = current.cause;
+  }
+
+  return parts.join(" <- ");
+}
+
 const DEFAULT_OPTIONS: Required<HTTPClientOptions> = {
   baseUrl: "",
   timeout: 30000,
@@ -269,7 +321,17 @@ export class HTTPClient {
       }
     }
 
-    throw lastError ?? new Error(`Failed to fetch ${url}`);
+    if (!lastError) {
+      throw new Error(`Failed to fetch ${url}`);
+    }
+
+    // HTTPError already carries a precise status; only opaque network errors
+    // need their `cause` chain unwrapped into the message.
+    if (lastError instanceof HTTPError) {
+      throw lastError;
+    }
+
+    throw new Error(`${describeError(lastError)} (${url})`, { cause: lastError });
   }
 
   /**

--- a/src/lib/api/http-client.ts
+++ b/src/lib/api/http-client.ts
@@ -64,6 +64,18 @@ function errorLabel(error: Error): string {
   return typeof code === "string" ? `${error.message} [${code}]` : error.message;
 }
 
+function redactUrlForError(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "[redacted URL]";
+    }
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return "[redacted URL]";
+  }
+}
+
 /**
  * Flatten an error and its `cause` chain into a single readable line.
  *
@@ -235,6 +247,7 @@ export class HTTPClient {
   ): Promise<HTTPResponse<T>> {
     const maxRetries = options.retries ?? this.options.retries;
     const timeout = options.timeout ?? this.options.timeout;
+    const safeUrl = redactUrlForError(url);
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -269,7 +282,7 @@ export class HTTPClient {
 
           // Log 429 with source name for observability
           if (response.status === 429) {
-            const source = this.options.sourceName || url;
+            const source = this.options.sourceName || safeUrl;
             console.warn(
               `[HTTPClient] 429 Too Many Requests from ${source} (attempt ${attempt + 1}/${maxRetries + 1})`
             );
@@ -322,7 +335,7 @@ export class HTTPClient {
     }
 
     if (!lastError) {
-      throw new Error(`Failed to fetch ${url}`);
+      throw new Error(`Failed to fetch ${safeUrl}`);
     }
 
     // HTTPError already carries a precise status; only opaque network errors
@@ -331,7 +344,7 @@ export class HTTPClient {
       throw lastError;
     }
 
-    throw new Error(`${describeError(lastError)} (${url})`, { cause: lastError });
+    throw new Error(`${describeError(lastError)} (${safeUrl})`, { cause: lastError });
   }
 
   /**

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -2,7 +2,7 @@
  * API module exports
  */
 
-export { HTTPClient, HTTPError, httpClient } from "./http-client";
+export { HTTPClient, HTTPError, httpClient, describeError } from "./http-client";
 export type { HTTPClientOptions, HTTPResponse, RequestOptions } from "./http-client";
 
 export {

--- a/src/services/sync/legislation-content.ts
+++ b/src/services/sync/legislation-content.ts
@@ -6,7 +6,7 @@
 import { db } from "@/lib/db";
 import mammoth from "mammoth";
 import { ASSEMBLEE_DOCPARL_RATE_LIMIT_MS } from "@/config/rate-limits";
-import { HTTPClient, HTTPError } from "@/lib/api/http-client";
+import { HTTPClient, HTTPError, describeError } from "@/lib/api/http-client";
 
 const DOCPARL_URL_TEMPLATE =
   "https://docparl.assemblee-nationale.fr/base/{id}?format=application/vnd.openxmlformats-officedocument.wordprocessingml.document";
@@ -149,9 +149,7 @@ export async function syncLegislationContent(options?: {
 
       stats.processed++;
     } catch (err) {
-      stats.errors.push(
-        `${dossier.externalId}: ${err instanceof Error ? err.message : String(err)}`
-      );
+      stats.errors.push(`${dossier.externalId}: ${describeError(err)}`);
       stats.processed++;
     }
   }


### PR DESCRIPTION
## Description

Ajoute une fonction `describeError()` qui aplatit les chaînes de `cause` des erreurs en un seul message lisible. Cela améliore significativement les messages d'erreur réseau en révélant les détails cachés (ENOTFOUND, ECONNREFUSED, etc.) que Node.js fetch enveloppe dans des messages opaques comme "fetch failed".

La fonction gère plusieurs cas complexes :
- Déverrouille les chaînes de `cause` imbriquées
- Développe les `AggregateError` contenant les tentatives de connexion par IP
- Déduplique les erreurs identiques
- Protège contre les chaînes cycliques et les chaînes très longues
- Préserve les codes d'erreur (errno) quand disponibles
- Retire les credentials, paramètres de requête et fragments des URL de diagnostic

Les messages d'erreur réseau passent de :
```
Failed to fetch https://example.fr
```

À :
```
fetch failed <- getaddrinfo ENOTFOUND example.fr [ENOTFOUND] (https://example.fr)
```

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Refactoring
- [x] Correction de sécurité

## Détails techniques

- Nouvelle fonction `describeError()` exportée depuis `http-client.ts`
- Intégration dans `HTTPClient.request()` pour les erreurs réseau opaques
- Utilisation dans les services de synchronisation pour un meilleur logging
- Diagnostic limité à l'origine et au chemin de l'URL
- Redaction appliquée également aux logs HTTP 429
- Suite de tests couvrant les chaînes de causes, cycles, profondeur, `AggregateError` et non-divulgation des secrets

## Checklist

- [x] Le code suit les conventions du projet
- [x] Les changements sont testés
- [x] Aucun secret n'est inclus dans les diagnostics réseau