### PR TITLE
Harden presidential program extraction gold pilot

### DIFF
--- a/scripts/import-presidential-programs.ts
+++ b/scripts/import-presidential-programs.ts
@@ -12,6 +12,15 @@ function value(name: string): string | undefined {
 async function main(): Promise<void> {
   const apply = process.argv.includes("--apply");
   const limitValue = value("limit");
+  const concurrencyValue = value("concurrency");
+  const segmentConcurrency = concurrencyValue ? Number(concurrencyValue) : undefined;
+  if (
+    segmentConcurrency !== undefined &&
+    (!Number.isInteger(segmentConcurrency) || segmentConcurrency < 1 || segmentConcurrency > 8)
+  ) {
+    throw new Error("--concurrency doit être un entier compris entre 1 et 8");
+  }
+
   const report = await runProgramImport({
     apply,
     candidate: value("candidate"),
@@ -19,15 +28,33 @@ async function main(): Promise<void> {
     source: value("source"),
     limit: limitValue ? Number(limitValue) : undefined,
     forceRefetch: process.argv.includes("--force-refetch"),
+    segmentConcurrency,
+    onProgress: (event) => {
+      if (event.kind === "document") {
+        console.log(
+          `[program-import] ${event.label}: ${event.segmentsTotal} segment(s) à extraire (${event.editionId})`
+        );
+        return;
+      }
+      console.log(
+        `[program-import] ${event.label}: ${event.completed}/${event.total} segments, ${event.proposals} propositions, ${event.failed} échec(s)`
+      );
+    },
   });
   console.log(
     `[program-import] ${report.mode}, ${report.documents.parsed}/${report.documents.known} documents parsés`
+  );
+  console.log(
+    `  segments ${report.extraction.segmentsSucceeded}/${report.extraction.segmentsTotal}, échecs ${report.extraction.segmentsFailed}`
   );
   console.log(
     `  propositions ${report.propositions.detected}, mesures ${report.propositions.measures}, objectifs ${report.propositions.objectives}`
   );
   console.log(
     `  ambiguës ${report.propositions.ambiguous}, rejetées ${report.propositions.rejected}, doublons ${report.propositions.duplicates}`
+  );
+  console.log(
+    `  fallbacks citation ${report.extraction.normalizationFallbacks}, thèmes invalides ${report.extraction.invalidThemes}`
   );
   console.log(
     `  drafts créés ${report.database.draftsCreated}, déjà présents ${report.database.alreadyPresent}`

--- a/src/services/measures/program-import/__tests__/pipeline.test.ts
+++ b/src/services/measures/program-import/__tests__/pipeline.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { normalizeForDeduplication, jaccardSimilarity } from "../deduplication";
-import { normalizedTextAddsInformation } from "../extractor";
+import {
+  normalizedTextAddsInformation,
+  prepareExtractedProposal,
+  sourceTextIsGrounded,
+} from "../extractor";
 import { classifyEdition, isAcceptedProposal } from "../policy";
-import type { ExtractedProposal } from "../types";
+import { extractionSchema, type DocumentSegment, type ExtractedProposal } from "../types";
 
 function proposal(overrides: Partial<ExtractedProposal>): ExtractedProposal {
   return {
@@ -12,10 +16,20 @@ function proposal(overrides: Partial<ExtractedProposal>): ExtractedProposal {
     theme: "ECONOMIE_BUDGET",
     confidence: 0.9,
     page: 2,
+    segmentId: "segment-1",
+    warnings: [],
+    normalization: "MODEL",
     rationale: "Action chiffrée et vérifiable.",
     ...overrides,
   };
 }
+
+const segment: DocumentSegment = {
+  id: "segment-1",
+  heading: "Travail",
+  page: 4,
+  text: "Nous créerons un statut pour les travailleuses et travailleurs essentiels.",
+};
 
 describe("classification éditoriale", () => {
   it("retient une mesure concrète", () => expect(isAcceptedProposal(proposal({}))).toBe(true));
@@ -34,6 +48,70 @@ describe("classification éditoriale", () => {
     expect(normalizedTextAddsInformation("Nous voulons réduire la TVA", "Réduire la TVA")).toBe(
       false
     );
+  });
+});
+
+describe("grounding d'extraction", () => {
+  it("retrouve une citation malgré les variantes typographiques", () => {
+    expect(
+      sourceTextIsGrounded(
+        "Nous défendrons l’État social — sans recul.",
+        "Nous défendrons l'Etat social - sans recul."
+      )
+    ).toBe(true);
+  });
+
+  it("conserve la classification mais retombe sur la citation exacte si la normalisation ajoute des tokens", () => {
+    const result = prepareExtractedProposal(segment, {
+      sourceText: segment.text,
+      normalizedText: "Créer un statut national pour les travailleurs essentiels.",
+      classification: "MEASURE",
+      theme: "SOCIAL_TRAVAIL",
+      confidence: 0.91,
+      rationale: "Engagement explicite.",
+    });
+
+    expect(result.classification).toBe("MEASURE");
+    expect(result.normalizedText).toBe(segment.text);
+    expect(result.normalization).toBe("SOURCE_FALLBACK");
+    expect(result.warnings.join(" ")).toContain("citation exacte");
+    expect(isAcceptedProposal(result)).toBe(true);
+  });
+
+  it("neutralise un thème hors enum sans faire échouer la proposition", () => {
+    const parsed = extractionSchema.parse({
+      proposals: [
+        {
+          sourceText: segment.text,
+          normalizedText: segment.text,
+          classification: "MEASURE",
+          theme: "EMPLOI",
+          confidence: 0.9,
+          rationale: "Engagement explicite.",
+        },
+      ],
+    });
+    const result = prepareExtractedProposal(segment, parsed.proposals[0]);
+
+    expect(result.theme).toBeNull();
+    expect(result.warnings.join(" ")).toContain("Thème hors enum");
+    expect(isAcceptedProposal(result)).toBe(false);
+  });
+
+  it("conserve AMBIGUOUS lorsque la citation n'est pas retrouvable", () => {
+    const result = prepareExtractedProposal(segment, {
+      sourceText: "Nous supprimerons intégralement cette taxe.",
+      normalizedText: "Supprimer cette taxe.",
+      classification: "MEASURE",
+      theme: "ECONOMIE_BUDGET",
+      confidence: 0.95,
+      rationale: "Engagement explicite.",
+    });
+
+    expect(result.classification).toBe("AMBIGUOUS");
+    expect(result.normalizedText).toBeNull();
+    expect(result.normalization).toBe("NONE");
+    expect(isAcceptedProposal(result)).toBe(false);
   });
 });
 

--- a/src/services/measures/program-import/extractor.ts
+++ b/src/services/measures/program-import/extractor.ts
@@ -1,7 +1,13 @@
+import { ThemeCategory, type ThemeCategory as ThemeCategoryValue } from "@/generated/prisma";
 import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
-import { extractionSchema, type DocumentSegment, type ExtractedProposal } from "./types";
+import {
+  extractionSchema,
+  type DocumentSegment,
+  type ExtractedProposal,
+  type RawExtractedProposal,
+} from "./types";
 
-export const EXTRACTOR_VERSION = "mistral-large-latest/presidential-program-import-2";
+export const EXTRACTOR_VERSION = "mistral-large-latest/presidential-program-import-3";
 
 export const EXTRACTION_SYSTEM_PROMPT = `Tu extrais des propositions politiques sans interprétation.
 Ton travail consiste à reconnaître les engagements présents dans le texte, pas à reconstituer le programme que l'auteur aurait pu vouloir écrire.
@@ -14,6 +20,8 @@ Exemples : « rendre du pouvoir d'achat » est GENERAL_INTENT ; « réduire la T
 const OUTPUT_FORMAT = `Réponds uniquement avec un objet JSON de cette forme :
 {"proposals":[{"sourceText":"citation exacte","normalizedText":"formulation fidèle ou null","classification":"MEASURE|OBJECTIVE|VALUE|DIAGNOSIS|GENERAL_INTENT|AMBIGUOUS","theme":"une valeur ThemeCategory ou null","confidence":0.0,"rationale":"raison courte"}]}
 Les seules valeurs de thème sont ECONOMIE_BUDGET, SOCIAL_TRAVAIL, SECURITE_JUSTICE, ENVIRONNEMENT_ENERGIE, SANTE, EDUCATION_CULTURE, INSTITUTIONS, AFFAIRES_ETRANGERES_DEFENSE, NUMERIQUE_TECH, IMMIGRATION, AGRICULTURE_ALIMENTATION, LOGEMENT_URBANISME et TRANSPORTS.`;
+
+const THEME_VALUES = new Set<string>(Object.values(ThemeCategory));
 
 function tokens(text: string): Set<string> {
   return new Set(
@@ -44,9 +52,78 @@ export function sourceTextIsGrounded(documentText: string, sourceText: string): 
   );
 }
 
+/**
+ * Conservative lexical tripwire used only to decide whether the model-authored
+ * normalization may be kept. A positive result no longer discards the proposal:
+ * we fall back to the exact grounded citation instead.
+ */
 export function normalizedTextAddsInformation(source: string, normalized: string): boolean {
   const sourceTokens = tokens(source);
   return [...tokens(normalized)].some((token) => !sourceTokens.has(token));
+}
+
+function normalizeTheme(rawTheme: string | null): {
+  theme: ThemeCategoryValue | null;
+  warning: string | null;
+} {
+  if (rawTheme === null) return { theme: null, warning: null };
+  if (THEME_VALUES.has(rawTheme)) {
+    return { theme: rawTheme as ThemeCategoryValue, warning: null };
+  }
+  return {
+    theme: null,
+    warning: `Thème hors enum retourné par l'extracteur: ${rawTheme}`,
+  };
+}
+
+export function prepareExtractedProposal(
+  segment: DocumentSegment,
+  proposal: RawExtractedProposal
+): ExtractedProposal {
+  const { theme, warning } = normalizeTheme(proposal.theme);
+  const warnings = warning ? [warning] : [];
+
+  if (!sourceTextIsGrounded(segment.text, proposal.sourceText)) {
+    warnings.push("Citation introuvable dans le segment documentaire source.");
+    return {
+      ...proposal,
+      theme,
+      normalizedText: null,
+      classification: "AMBIGUOUS",
+      rationale: "Citation introuvable dans le segment documentaire source.",
+      page: segment.page,
+      segmentId: segment.id,
+      warnings,
+      normalization: "NONE",
+    };
+  }
+
+  if (
+    proposal.normalizedText &&
+    normalizedTextAddsInformation(proposal.sourceText, proposal.normalizedText)
+  ) {
+    warnings.push(
+      "La normalisation proposée ajoutait des tokens absents de la citation; la citation exacte est conservée comme texte du draft."
+    );
+    return {
+      ...proposal,
+      theme,
+      normalizedText: proposal.sourceText,
+      page: segment.page,
+      segmentId: segment.id,
+      warnings,
+      normalization: "SOURCE_FALLBACK",
+    };
+  }
+
+  return {
+    ...proposal,
+    theme,
+    page: segment.page,
+    segmentId: segment.id,
+    warnings,
+    normalization: proposal.normalizedText ? "MODEL" : "NONE",
+  };
 }
 
 function isRateLimitError(error: unknown): boolean {
@@ -87,22 +164,5 @@ export async function extractSegment(segment: DocumentSegment): Promise<Extracte
     }
   );
   const parsed = extractionSchema.parse(parseMistralJSON<unknown>(extractMistralText(response)));
-  return parsed.proposals.map((proposal) => {
-    if (!sourceTextIsGrounded(segment.text, proposal.sourceText)) {
-      return {
-        ...proposal,
-        normalizedText: null,
-        classification: "AMBIGUOUS",
-        rationale: "Citation introuvable dans le segment documentaire source.",
-        page: segment.page,
-      };
-    }
-    if (
-      proposal.normalizedText &&
-      normalizedTextAddsInformation(proposal.sourceText, proposal.normalizedText)
-    ) {
-      return { ...proposal, normalizedText: null, classification: "AMBIGUOUS", page: segment.page };
-    }
-    return { ...proposal, page: segment.page };
-  });
+  return parsed.proposals.map((proposal) => prepareExtractedProposal(segment, proposal));
 }

--- a/src/services/measures/program-import/pipeline.ts
+++ b/src/services/measures/program-import/pipeline.ts
@@ -10,6 +10,27 @@ import { parseDocument } from "./parser";
 import { classifyEdition, isAcceptedProposal } from "./policy";
 import type { DocumentSegment, ExtractedProposal, ProgramDocumentType } from "./types";
 
+const PRIMARY_SHARE_UNAVAILABLE_REASON =
+  "ProgramEdition ne distingue pas encore explicitement source primaire et source secondaire.";
+
+export type ProgramImportProgressEvent =
+  | {
+      kind: "document";
+      editionId: string;
+      label: string;
+      documentUrl: string;
+      segmentsTotal: number;
+    }
+  | {
+      kind: "extraction";
+      editionId: string;
+      label: string;
+      completed: number;
+      total: number;
+      proposals: number;
+      failed: number;
+    };
+
 export type ProgramImportOptions = {
   apply: boolean;
   candidate?: string;
@@ -18,6 +39,8 @@ export type ProgramImportOptions = {
   limit?: number;
   forceRefetch?: boolean;
   reportDir?: string;
+  segmentConcurrency?: number;
+  onProgress?: (event: ProgramImportProgressEvent) => void;
 };
 
 type CandidateReport = {
@@ -29,9 +52,12 @@ type CandidateReport = {
   draftsExisting: number;
   draftsAdded: number;
   published: number;
-  primaryShare: number;
+  primaryShare: number | null;
+  primaryShareReason: string;
   themes: string[];
   proposals: Array<{
+    editionId: string;
+    documentUrl: string;
     sourceText: string;
     normalizedText: string | null;
     classification: ExtractedProposal["classification"];
@@ -40,6 +66,14 @@ type CandidateReport = {
     page: number | null;
     rationale: string;
     accepted: boolean;
+    warnings: string[];
+    normalization: ExtractedProposal["normalization"];
+    provenance: {
+      ownerType: "PARTY" | "CANDIDACY";
+      ownerId: string | null;
+      documentType: ProgramDocumentType;
+      segmentId: string;
+    };
   }>;
   errors: string[];
   blockers: string[];
@@ -55,6 +89,13 @@ export type ProgramImportReport = {
   generatedAt: string;
   mode: "dry-run" | "apply";
   documents: { known: number; fetched: number; parsed: number; failed: number; scannedPdf: number };
+  extraction: {
+    segmentsTotal: number;
+    segmentsSucceeded: number;
+    segmentsFailed: number;
+    normalizationFallbacks: number;
+    invalidThemes: number;
+  };
   propositions: {
     detected: number;
     measures: number;
@@ -82,6 +123,11 @@ function chunkSegments(segments: DocumentSegment[], maxCharacters = 7_000): Docu
     }
   }
   return chunks;
+}
+
+function normalizeConcurrency(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return 3;
+  return Math.min(8, Math.max(1, Math.trunc(value)));
 }
 
 export async function runProgramImport(
@@ -129,6 +175,13 @@ export async function runProgramImport(
     generatedAt: new Date().toISOString(),
     mode: options.apply ? "apply" : "dry-run",
     documents: { known: editions.length, fetched: 0, parsed: 0, failed: 0, scannedPdf: 0 },
+    extraction: {
+      segmentsTotal: 0,
+      segmentsSucceeded: 0,
+      segmentsFailed: 0,
+      normalizationFallbacks: 0,
+      invalidThemes: 0,
+    },
     propositions: {
       detected: 0,
       measures: 0,
@@ -165,7 +218,8 @@ export async function runProgramImport(
           published: candidacy.measures.filter(
             (measure) => measure.publicationStatus === "PUBLISHED"
           ).length,
-          primaryShare: 0,
+          primaryShare: null,
+          primaryShareReason: PRIMARY_SHARE_UNAVAILABLE_REASON,
           themes: [],
           proposals: [],
           errors: [],
@@ -177,6 +231,7 @@ export async function runProgramImport(
       ];
     })
   );
+  const segmentConcurrency = normalizeConcurrency(options.segmentConcurrency);
 
   for (const edition of editions) {
     const matchedCandidacy = edition.candidacyId
@@ -194,7 +249,8 @@ export async function runProgramImport(
       draftsExisting: 0,
       draftsAdded: 0,
       published: 0,
-      primaryShare: 100,
+      primaryShare: null,
+      primaryShareReason: PRIMARY_SHARE_UNAVAILABLE_REASON,
       themes: [],
       proposals: [],
       errors: [],
@@ -245,20 +301,99 @@ export async function runProgramImport(
         continue;
       }
 
+      const chunks = chunkSegments(parsed.segments);
+      report.extraction.segmentsTotal += chunks.length;
+      options.onProgress?.({
+        kind: "document",
+        editionId: edition.id,
+        label: edition.label,
+        documentUrl: edition.documentUrl,
+        segmentsTotal: chunks.length,
+      });
+
       const proposals: ExtractedProposal[] = [];
-      for (const segment of chunkSegments(parsed.segments)) {
-        proposals.push(...(await extractSegment(segment)));
+      let segmentFailures = 0;
+      let completedSegments = 0;
+      for (let start = 0; start < chunks.length; start += segmentConcurrency) {
+        const batch = chunks.slice(start, start + segmentConcurrency);
+        const results = await Promise.allSettled(batch.map((segment) => extractSegment(segment)));
+        for (let index = 0; index < results.length; index += 1) {
+          const result = results[index];
+          const segment = batch[index];
+          completedSegments += 1;
+          if (result.status === "fulfilled") {
+            proposals.push(...result.value);
+            report.extraction.segmentsSucceeded += 1;
+          } else {
+            segmentFailures += 1;
+            report.extraction.segmentsFailed += 1;
+            candidate.errors.push(
+              `Échec d'extraction du segment ${segment.id} (page ${segment.page ?? "HTML"}): ${
+                result.reason instanceof Error ? result.reason.message : String(result.reason)
+              }`
+            );
+          }
+        }
+        options.onProgress?.({
+          kind: "extraction",
+          editionId: edition.id,
+          label: edition.label,
+          completed: completedSegments,
+          total: chunks.length,
+          proposals: proposals.length,
+          failed: segmentFailures,
+        });
       }
+
+      if (segmentFailures > 0) {
+        candidate.blockers.push(
+          `Extraction partielle: ${segmentFailures}/${chunks.length} segment(s) en échec.`
+        );
+        if (options.apply) {
+          candidate.blockers.push(
+            "Application bloquée pour cette édition tant que tous les segments ne sont pas extraits avec succès."
+          );
+        }
+      }
+
       candidate.detected += proposals.length;
       report.propositions.detected += proposals.length;
       const exactSeen = new Set<string>();
+      let acceptedInEdition = 0;
       for (const proposal of proposals) {
         if (proposal.classification === "MEASURE") report.propositions.measures += 1;
         else if (proposal.classification === "OBJECTIVE") report.propositions.objectives += 1;
         else if (proposal.classification === "AMBIGUOUS") report.propositions.ambiguous += 1;
         else report.propositions.rejected += 1;
-        candidate.proposals.push({ ...proposal, accepted: isAcceptedProposal(proposal) });
-        if (!isAcceptedProposal(proposal)) continue;
+        report.extraction.normalizationFallbacks += Number(
+          proposal.normalization === "SOURCE_FALLBACK"
+        );
+        report.extraction.invalidThemes += Number(
+          proposal.warnings.some((warning) => warning.startsWith("Thème hors enum"))
+        );
+        const accepted = isAcceptedProposal(proposal);
+        candidate.proposals.push({
+          editionId: edition.id,
+          documentUrl: edition.documentUrl,
+          sourceText: proposal.sourceText,
+          normalizedText: proposal.normalizedText,
+          classification: proposal.classification,
+          theme: proposal.theme,
+          confidence: proposal.confidence,
+          page: proposal.page,
+          rationale: proposal.rationale,
+          accepted,
+          warnings: proposal.warnings,
+          normalization: proposal.normalization,
+          provenance: {
+            ownerType: edition.ownerType,
+            ownerId: edition.candidacyId ?? edition.partyId,
+            documentType,
+            segmentId: proposal.segmentId,
+          },
+        });
+        if (!accepted) continue;
+        acceptedInEdition += 1;
         const text = proposal.normalizedText!;
         const exact = normalizeForDeduplication(text);
         if (exactSeen.has(exact)) {
@@ -290,7 +425,7 @@ export async function runProgramImport(
         }
 
         candidate.themes.push(proposal.theme!);
-        if (options.apply) {
+        if (options.apply && segmentFailures === 0) {
           await createMeasure({
             politicianId: eligible.politicianId,
             electionId: eligible.electionId,
@@ -325,9 +460,11 @@ export async function runProgramImport(
         }
       }
       candidate.status =
-        candidate.draftsAdded > 0 || (!options.apply && candidate.detected > 0)
-          ? "READY_FOR_REVIEW"
-          : "PARTIAL";
+        segmentFailures > 0
+          ? "PARTIAL"
+          : acceptedInEdition > 0
+            ? "READY_FOR_REVIEW"
+            : "PARTIAL";
     } catch (error) {
       report.documents.failed += 1;
       candidate.errors.push(error instanceof Error ? error.message : String(error));
@@ -356,20 +493,25 @@ export function renderMarkdownReport(report: ProgramImportReport): string {
   const rows = report.candidates
     .map(
       (c) =>
-        `| ${c.candidate} | ${c.documentsAnalyzed} | ${c.detected} | ${c.draftsAdded} | ${c.themes.join(", ") || "-"} | ${c.status} |`
+        `| ${c.candidate} | ${c.documentsAnalyzed} | ${c.detected} | ${c.draftsAdded} | ${
+          c.primaryShare === null ? "n/a" : `${c.primaryShare.toFixed(1)} %`
+        } | ${c.themes.join(", ") || "-"} | ${c.status} |`
     )
     .join("\n");
   const proposalDetails = report.candidates
     .filter((candidate) => candidate.proposals.length > 0)
     .map((candidate) => {
       const items = candidate.proposals
-        .map(
-          (proposal) =>
-            `- ${proposal.accepted ? "RETENUE" : "ÉCARTÉE"} [${proposal.classification}, confiance ${proposal.confidence}, page ${proposal.page ?? "HTML"}] ${proposal.normalizedText ?? proposal.sourceText}`
-        )
+        .map((proposal) => {
+          const warnings =
+            proposal.warnings.length > 0
+              ? `\n  - Avertissements: ${proposal.warnings.join(" | ")}`
+              : "";
+          return `- ${proposal.accepted ? "RETENUE" : "ÉCARTÉE"} [${proposal.classification}, confiance ${proposal.confidence}, page ${proposal.page ?? "HTML"}] ${proposal.normalizedText ?? proposal.sourceText}\n  - Édition: ${proposal.editionId}\n  - Document: ${proposal.documentUrl}\n  - Segment: ${proposal.provenance.segmentId}\n  - Normalisation: ${proposal.normalization}${warnings}`;
+        })
         .join("\n");
       return `### ${candidate.candidate}\n\n${items}`;
     })
     .join("\n\n");
-  return `# Import des programmes Présidentielle 2027\n\nGénéré le ${report.generatedAt}, mode ${report.mode}.\n\n## Corpus\n\n- Documents connus: ${report.documents.known}\n- Documents parsés: ${report.documents.parsed}\n- Échecs: ${report.documents.failed}\n\n## Extraction\n\n- Propositions détectées: ${report.propositions.detected}\n- Mesures: ${report.propositions.measures}\n- Objectifs: ${report.propositions.objectives}\n- Ambiguës: ${report.propositions.ambiguous}\n- Rejetées: ${report.propositions.rejected}\n- Doublons: ${report.propositions.duplicates}\n\n## Base\n\n- Brouillons créés: ${report.database.draftsCreated}\n- Déjà présents: ${report.database.alreadyPresent}\n- Mesures publiées inchangées: ${report.database.publishedUnchanged}\n\n## Couverture par candidature ou parti\n\n| Candidat ou parti | Documents | Détectées | Drafts ajoutés | Thèmes | État |\n|---|---:|---:|---:|---|---|\n${rows}\n\n## Détail des propositions\n\n${proposalDetails || "Aucune proposition extraite."}\n`;
+  return `# Import des programmes Présidentielle 2027\n\nGénéré le ${report.generatedAt}, mode ${report.mode}.\n\n## Corpus\n\n- Documents connus: ${report.documents.known}\n- Documents parsés: ${report.documents.parsed}\n- Échecs documentaires: ${report.documents.failed}\n- Part de sources primaires: non calculable avec le schéma ProgramEdition actuel.\n\n## Extraction\n\n- Segments: ${report.extraction.segmentsSucceeded}/${report.extraction.segmentsTotal} réussis\n- Segments en échec: ${report.extraction.segmentsFailed}\n- Propositions détectées: ${report.propositions.detected}\n- Mesures: ${report.propositions.measures}\n- Objectifs: ${report.propositions.objectives}\n- Ambiguës: ${report.propositions.ambiguous}\n- Rejetées: ${report.propositions.rejected}\n- Fallbacks vers citation exacte: ${report.extraction.normalizationFallbacks}\n- Thèmes hors enum neutralisés: ${report.extraction.invalidThemes}\n- Doublons: ${report.propositions.duplicates}\n\n## Base\n\n- Brouillons créés: ${report.database.draftsCreated}\n- Déjà présents: ${report.database.alreadyPresent}\n- Mesures publiées inchangées: ${report.database.publishedUnchanged}\n\n## Couverture par candidature ou parti\n\n| Candidat ou parti | Documents | Détectées | Drafts ajoutés | Sources primaires | Thèmes | État |\n|---|---:|---:|---:|---:|---|---|\n${rows}\n\n_n/a : ${PRIMARY_SHARE_UNAVAILABLE_REASON}_\n\n## Détail des propositions\n\n${proposalDetails || "Aucune proposition extraite."}\n`;
 }

--- a/src/services/measures/program-import/types.ts
+++ b/src/services/measures/program-import/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ThemeCategory } from "@/generated/prisma";
+import type { ThemeCategory } from "@/generated/prisma";
 
 export const DOCUMENT_TYPES = [
   "CANDIDATE_PROGRAM_2027",
@@ -26,15 +26,23 @@ export const extractionSchema = z.object({
         "GENERAL_INTENT",
         "AMBIGUOUS",
       ]),
-      theme: z.enum(ThemeCategory).nullable(),
+      // Keep the extractor boundary tolerant: an unknown theme must not discard an
+      // otherwise valid segment. It is normalized to null by extractor.ts and reported.
+      theme: z.string().min(1).nullable(),
       confidence: z.number().min(0).max(1),
       rationale: z.string().min(1).max(500),
     })
   ),
 });
 
-export type ExtractedProposal = z.infer<typeof extractionSchema>["proposals"][number] & {
+export type RawExtractedProposal = z.infer<typeof extractionSchema>["proposals"][number];
+
+export type ExtractedProposal = Omit<RawExtractedProposal, "theme"> & {
+  theme: ThemeCategory | null;
   page: number | null;
+  segmentId: string;
+  warnings: string[];
+  normalization: "MODEL" | "SOURCE_FALLBACK" | "NONE";
 };
 
 export type DocumentSegment = {


### PR DESCRIPTION
## Contexte

Le dry-run François Ruffin retournait 482 propositions mais 0 `MEASURE` acceptée. Le corpus documentaire est suffisamment solide pour le pilote ; le problème est dans le pipeline d’extraction.

## Changements

- conserve le garde-fou lexical, mais lorsqu’une normalisation introduit des tokens absents de la citation, retombe sur la citation exacte au lieu de reclasser automatiquement la proposition en `AMBIGUOUS` ;
- garde `AMBIGUOUS` lorsqu’une citation n’est pas retrouvable dans le segment source ;
- rend les thèmes hors enum non bloquants au niveau du segment : ils deviennent `null`, sont signalés dans le rapport et restent donc non acceptables ;
- ajoute `editionId`, `documentUrl`, `segmentId`, type documentaire, propriétaire, avertissements et mode de normalisation à la provenance de chaque proposition ;
- ajoute une extraction par lots avec concurrence bornée (défaut 3, maximum 8) et télémétrie CLI ;
- isole les échecs par segment et marque l’extraction `PARTIAL` au lieu de perdre tout le document ;
- bloque tout `--apply` pour une édition dès qu’un de ses segments a échoué ;
- ne considère plus une candidature `READY_FOR_REVIEW` uniquement parce que des propositions ont été détectées : il faut au moins une proposition acceptée ;
- remplace le faux `primaryShare: 0` par `null` avec raison explicite, car `ProgramEdition` ne modélise actuellement pas primaire/secondaire ;
- ajoute des tests ciblés pour grounding, fallback verbatim et thème hors enum ;
- incrémente l’extracteur en `presidential-program-import-3`.

## Sécurité éditoriale

Cette PR ne relâche pas les portes de publication et ne publie rien. Une citation non grounded reste rejetée, un thème invalide ne peut pas être accepté, et aucune information ajoutée par la normalisation n’est conservée : le texte source exact devient le fallback.

Aucune écriture production, migration ou `--apply` n’a été exécuté.

## Validation

Le checkout local n’est pas disponible dans l’environnement d’exécution (résolution réseau GitHub indisponible hors connecteur), donc les tests n’ont pas été exécutés localement. La PR est volontairement ouverte en draft afin de laisser les checks GitHub valider cette première vague avant le nouveau dry-run Ruffin.