### PR TITLE
Corriger deux définitions du glossaire et nommer le lecteur visé

### DIFF
--- a/docs/editorial/reseaux-sociaux.md
+++ b/docs/editorial/reseaux-sociaux.md
@@ -94,3 +94,25 @@ vivant.
 Cela pèse sur la formulation. Un chiffre susceptible d'être révisé se présente par ce qui le
 produit plutôt que par sa valeur seule, et une règle se formule par le texte qui la fixe plutôt que
 par son résultat du jour.
+
+## 10. À qui nous écrivons
+
+Nos publications s'adressent à des citoyens de tous âges, adolescents et adultes, qui ont besoin de
+vulgarisation politique et civique. Ce lecteur n'a pas lu le texte dont nous parlons, ne connaît pas
+le vocabulaire de l'institution qui le produit, et n'a aucune raison de fournir un effort pour nous.
+
+Quatre conséquences, toutes vérifiables sur une publication finie.
+
+**Le vocabulaire de l'institution se traduit.** Les catégories de travail d'une administration ou
+d'une commission sont ses outils de classement, pas des explications. Un terme technique que rien ne
+remplace se définit sur place, en clair, dans la phrase où il apparaît.
+
+**La phrase complète précède la mise en forme.** Si l'information ne tient pas dans une phrase qui
+dit tout, le sujet n'est pas compris. Cette phrase ouvre la publication et le reste la détaille. Une
+publication qui ménage son effet fait de la narration, pas de la pédagogie.
+
+**Le titre s'écrit en dernier.** Rédigé avant le corps, il sort abstrait, faute d'être écrit par
+quelqu'un qui sait déjà ce qu'il a à dire. Il nomme l'objet dont il est question, jamais la
+catégorie à laquelle cet objet appartient.
+
+**Aucune métaphore en titre.** Imager, c'est renoncer à nommer.

--- a/src/config/__tests__/glossary.test.ts
+++ b/src/config/__tests__/glossary.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  GLOSSARY,
+  INSTITUTION_TERMS,
+  LEGAL_TERMS,
+  METRIC_TERMS,
+  PARLIAMENTARY_TERMS,
+} from "../glossary";
+
+const SOURCE_BLOCKS = {
+  LEGAL_TERMS,
+  PARLIAMENTARY_TERMS,
+  INSTITUTION_TERMS,
+  METRIC_TERMS,
+} as const;
+
+describe("glossaire", () => {
+  // Regression: the entry used to read "L'abstention est comptabilisée dans les
+  // suffrages exprimés", which is the opposite of what the règlement du Sénat
+  // (art. 52) says. It was served on every scrutin page through InfoTooltip.
+  it("n'affirme pas que l'abstention entre dans les suffrages exprimés", () => {
+    expect(GLOSSARY.abstention).toContain("n'entrent pas dans le décompte des suffrages exprimés");
+    expect(GLOSSARY.abstention).not.toMatch(/est comptabilisée dans les suffrages exprimés/);
+  });
+
+  // Regression: "ferme" used to be glossed as "le condamné est incarcéré". Code
+  // pénal art. 132-25 makes an aménagement mandatory at or below six months, so a
+  // ferme sentence does not establish incarceration.
+  it("ne présente pas la peine ferme comme entraînant l'incarcération", () => {
+    expect(GLOSSARY.ferme).not.toMatch(/le condamné est incarcéré/);
+    expect(GLOSSARY.ferme).toMatch(/n'implique pas nécessairement l'incarcération/);
+  });
+
+  // Structural guard: four HATVP keys were declared in two blocks at once, so the
+  // earlier block was unreachable through GLOSSARY and its wording drifted from the
+  // one actually shown. A duplicate key is always a silently shadowed definition.
+  it("ne déclare aucune clé dans deux blocs à la fois", () => {
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const [blockName, block] of Object.entries(SOURCE_BLOCKS)) {
+      for (const key of Object.keys(block)) {
+        const previous = seen.get(key);
+        if (previous) {
+          duplicates.push(`${key} (${previous} puis ${blockName})`);
+        } else {
+          seen.set(key, blockName);
+        }
+      }
+    }
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it("expose autant de clés que la somme de ses blocs", () => {
+    const declared = Object.values(SOURCE_BLOCKS).reduce(
+      (total, block) => total + Object.keys(block).length,
+      0
+    );
+
+    expect(Object.keys(GLOSSARY)).toHaveLength(declared);
+  });
+
+  it("ne contient aucune définition vide", () => {
+    const empty = Object.entries(GLOSSARY)
+      .filter(([, definition]) => definition.trim().length === 0)
+      .map(([key]) => key);
+
+    expect(empty).toEqual([]);
+  });
+});

--- a/src/config/glossary.ts
+++ b/src/config/glossary.ts
@@ -10,8 +10,10 @@
 export const LEGAL_TERMS = {
   sursis:
     "Peine prononcée mais non exécutée, sauf en cas de nouvelle infraction dans un délai fixé par le tribunal.",
+  // Source: code pénal, art. 132-25. An aménagement is mandatory below six months
+  // and available up to one year, so "ferme" does not imply incarceration.
   ferme:
-    "Peine de prison effectivement exécutée (le condamné est incarcéré), par opposition au sursis.",
+    "Part de la peine qui doit être exécutée, par opposition au sursis. Elle n'implique pas nécessairement l'incarcération : une peine courte peut être aménagée en détention à domicile sous surveillance électronique, en semi-liberté ou en placement extérieur.",
   repartitionNonEtablie:
     "La durée totale de la peine est attestée, mais aucune source ne dit quelle part est ferme et quelle part est assortie du sursis.",
   ineligibilite:
@@ -36,8 +38,11 @@ export const PARLIAMENTARY_TERMS = {
     "Code de vote indiquant que le parlementaire ne prend pas part au scrutin. Ce code ne suffit pas à établir sa présence physique.",
   absent:
     "Code fourni par une source pour un scrutin donné. Il n'est jamais déduit de la seule absence d'une ligne de vote.",
+  // Source: règlement du Sénat, art. 52 — "conformément au droit commun en matière
+  // électorale, les abstentions n'entrent pas en compte dans le dénombrement des
+  // suffrages exprimés".
   abstention:
-    "Vote exprimé mais ni pour ni contre. L'abstention est comptabilisée dans les suffrages exprimés.",
+    "Position de vote distincte du pour et du contre. Les abstentions n'entrent pas dans le décompte des suffrages exprimés, qui ne retient que les voix pour et les voix contre.",
   scrutin: "Vote formel des parlementaires sur un texte de loi, un amendement ou une motion.",
   dossierLegislatif:
     "Ensemble des textes et débats liés à un projet ou une proposition de loi, de son dépôt à son adoption.",
@@ -70,23 +75,13 @@ export const INSTITUTION_TERMS = {
 } as const;
 
 // ============================================
-// HATVP — Déclarations de patrimoine & intérêts
-// ============================================
-
-export const HATVP_TERMS = {
-  portefeuilleTotal:
-    "Valeur totale estimée des participations financières déclarées (actions, obligations, assurance-vie…).",
-  participationsHatvp:
-    "Nombre d'entreprises ou organismes dans lesquels le déclarant détient des parts ou actions.",
-  revenusAnnuels:
-    "Montant brut des revenus perçus sur la dernière année déclarée (traitements, honoraires, dividendes…).",
-  mandatsDirections:
-    "Nombre de fonctions de direction ou mandats exercés dans des entreprises, associations ou organismes publics.",
-} as const;
-
-// ============================================
 // MÉTRIQUES & DONNÉES
 // ============================================
+// The four HATVP keys below used to be declared twice, in a separate HATVP_TERMS
+// block spread before this one. Every duplicate was therefore unreachable through
+// GLOSSARY, and the two `revenusAnnuels` texts disagreed ("brut" against "net avant
+// impôt"). The dead block is gone; the wording kept here is the one visitors were
+// already being served.
 
 export const METRIC_TERMS = {
   prominence:
@@ -108,7 +103,6 @@ export const GLOSSARY = {
   ...LEGAL_TERMS,
   ...PARLIAMENTARY_TERMS,
   ...INSTITUTION_TERMS,
-  ...HATVP_TERMS,
   ...METRIC_TERMS,
 } as const;
 


### PR DESCRIPTION
Deux corrections indépendantes, réunies parce qu'elles viennent du même travail éditorial.

## Le glossaire

`abstention` affirmait que l'abstention est comptabilisée dans les suffrages exprimés. Le règlement
du Sénat, article 52, dit l'inverse : « conformément au droit commun en matière électorale, les
abstentions n'entrent pas en compte dans le dénombrement des suffrages exprimés ». L'arithmétique
publiée par l'Assemblée le confirme, par exemple sur le scrutin n° 1500 de la 17e législature :
116 votants pour 114 suffrages exprimés et 2 abstentions. Cette définition était servie aux
visiteurs par `InfoTooltip` sur chaque page de scrutin.

`ferme` était glosée « le condamné est incarcéré ». L'article 132-25 du code pénal rend
l'aménagement obligatoire pour une peine de six mois ou moins, et possible jusqu'à un an : une peine
ferme n'établit donc pas l'incarcération, précisément pour les peines courtes, qui sont les plus
fréquentes dans les affaires que le site suit.

`HATVP_TERMS` déclarait quatre clés déjà présentes dans `METRIC_TERMS`, étalé après lui dans
`GLOSSARY`. Les quatre étaient inatteignables, et les deux définitions de `revenusAnnuels` se
contredisaient, « brut » d'un côté, « net avant impôt » de l'autre. Le bloc mort est supprimé et le
texte conservé est celui que les visiteurs recevaient déjà. Le glossaire annonçait 36 entrées, il en
servait 32.

## La doctrine éditoriale

Un paragraphe 10 dans `docs/editorial/reseaux-sociaux.md`, qui nomme le lecteur visé et en tire
quatre conséquences vérifiables sur une publication finie. Les règles existantes disaient ce que
nous publions, jamais pour qui, ce qui laissait passer le vocabulaire des institutions tel quel.

## Vérifications

`npx tsc --noEmit` est propre. C'est le contrôle qui compte pour la suppression de `HATVP_TERMS` :
`InfoTooltip` prend un `term: GlossaryKey`, donc chaque site d'appel est typé contre le jeu de clés,
et le retrait d'une clé utilisée aurait planté le typecheck.

`src/config/__tests__/glossary.test.ts` ajoute 5 tests. Deux couvrent les définitions corrigées. Le
troisième est le plus utile : il interdit qu'une clé soit déclarée dans deux blocs à la fois. En
TypeScript, `{...A, ...B}` avec une clé commune ne produit ni erreur ni avertissement, et `as const`
n'y change rien ; c'est exactement comme ça que les quatre entrées HATVP sont devenues invisibles
sans que personne ne le remarque.

Les tests de rendu React n'ont pas pu être exécutés en local : le worktree utilisé se trouve sous
`.claude/worktrees/`, donc à l'intérieur du dépôt, et Node y résout deux copies de React. Des tests
sans rapport avec cette PR échouent de la même façon. La CI tourne sur un checkout propre.

## Ce qui n'est pas fait ici

Cinq entrées restent imprécises sans être fausses : `ineligibilite` (l'inéligibilité peut aussi être
prononcée par le juge de l'élection), `nonLieu` (n'attribue pas la décision au juge d'instruction et
ne couvre qu'un des deux motifs), `tig` (omet le consentement du condamné), `sursis` (décrit le
sursis simple et pas le sursis probatoire), et `revenusAnnuels`, où il faut lire le sync HATVP pour
trancher entre brut et net.

La cause commune des deux erreurs corrigées ici est structurelle : aucune entrée ne porte de source
ni de date. Y remédier change la forme de `GLOSSARY` et touche `InfoTooltip`, donc c'est un chantier
séparé.
