### PR TITLE
fix(affairs): vérifier les preuves judiciaires avant acceptation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,11 +20,13 @@ const eslintConfig = defineConfig([
     "scripts/**",
     // Git worktrees (contain their own .next/build artifacts):
     ".worktrees/**",
+    ".claude/worktrees/**",
+    // Local Storybook output:
+    "storybook-static/**",
   ]),
   {
     rules: {
       "no-console": "warn",
-      "react-hooks/set-state-in-effect": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -33,6 +35,14 @@ const eslintConfig = defineConfig([
           caughtErrorsIgnorePattern: "^_",
         },
       ],
+    },
+  },
+  // React Hooks is provided by eslint-config-next only for application files.
+  // Keep its rule in that same perimeter so root tooling files remain lintable.
+  {
+    files: ["src/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "react-hooks/set-state-in-effect": "warn",
     },
   },
   // Allow console in server-side code (API routes, sync services, CLI utilities)

--- a/src/app/admin/affaires/propositions/page.test.tsx
+++ b/src/app/admin/affaires/propositions/page.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PropositionsPage from "./page";
+
+const PRESS_URL = "https://www.lemonde.fr/politique/article-test.html";
+
+function listResponse() {
+  return {
+    rows: [
+      {
+        id: "proposal-press-1",
+        importer: "press-analysis",
+        extractorVersion: "v1",
+        proposedPatch: { court: "Tribunal judiciaire de Paris" },
+        observedValues: { court: null },
+        affairSnapshot: {
+          publicId: "PG000001",
+          slug: "affaire-test",
+          title: "Affaire test",
+          politicianSlug: "personne-test",
+          politicianName: "Personne Test",
+        },
+        source: "PRESSE",
+        sourceUrl: PRESS_URL,
+        sourceLink: { rawUrl: PRESS_URL, safeUrl: PRESS_URL },
+        officialId: null,
+        sourceContentHash: null,
+        sourceExcerpt: null,
+        confidence: 80,
+        riskLevel: "MEDIUM",
+        rationale: "Article soumis à une revue humaine.",
+        status: "PENDING",
+        conflictDetail: null,
+        reviewedAt: null,
+        reviewedBy: null,
+        reviewNotes: null,
+        createdAt: "2026-08-19T09:00:00.000Z",
+        officialEvidence: {
+          required: false,
+          acceptable: false,
+          canonicalUrl: null,
+          requestedUrl: null,
+          status: null,
+          checkedAt: null,
+          matchedIdentifiers: [],
+          issues: [],
+        },
+        affair: null,
+      },
+    ],
+    total: 1,
+    page: 1,
+    totalPages: 1,
+    counts: { PENDING: 1 },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("admin affair proposal ordinary sources", () => {
+  it("keeps a safe press source clickable without disabling acceptance", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(listResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+
+    render(<PropositionsPage />);
+
+    const sourceLink = await screen.findByRole("link", {
+      name: /Ouvrir la source PRESSE dans un nouvel onglet/i,
+    });
+    expect(sourceLink).toHaveAttribute("href", PRESS_URL);
+    expect(screen.getByRole("button", { name: "Accepter et appliquer" })).toBeEnabled();
+    expect(screen.queryByText(/Décision officielle non vérifiée/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/affaires/propositions/page.test.tsx
+++ b/src/app/admin/affaires/propositions/page.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PropositionsPage from "./page";
 
-const PRESS_URL = "https://www.lemonde.fr/politique/article-test.html";
+const PRESS_URL = "https://press.example.test/politique/article-test.html";
 
 function listResponse() {
   return {

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -31,6 +31,10 @@ interface ProposalRow {
   affairSnapshot: AffairSnapshot;
   source: string;
   sourceUrl: string | null;
+  sourceLink: {
+    rawUrl: string | null;
+    safeUrl: string | null;
+  };
   officialId: string | null;
   sourceContentHash: string | null;
   sourceExcerpt: string | null;
@@ -94,7 +98,7 @@ const RISK_VARIANTS: Record<ProposalRisk, "destructive" | "secondary" | "outline
 const VERIFICATION_LABELS: Record<string, string> = {
   VALID: "Décision vérifiée en direct",
   REDIRECTED: "Redirection concordante, régénération requise",
-  INDEX_VERIFIED: "Référence retrouvée dans un index, vérification humaine requise",
+  INDEX_VERIFIED: "Référence d’index déclarée, vérification humaine requise",
   BROKEN: "Lien indisponible",
   MISMATCH: "Le lien renvoie vers une autre décision",
   BLOCKED: "Vérification automatique impossible",
@@ -121,6 +125,10 @@ const VERIFICATION_ISSUE_LABELS: Record<string, string> = {
   date_decision_absente_ou_differente: "date absente ou différente",
   redirection_vers_autre_decision: "redirection vers une autre décision",
   preuve_indexee_expiree_ou_date_invalide: "preuve indexée expirée",
+  reference_indexee_declaree_concordante:
+    "référence d’index déclarée concordante, provenance non indépendante",
+  url_officielle_confirmee_par_index_exact:
+    "ancienne référence d’index déclarée, provenance non indépendante",
 };
 
 function verificationIssueLabel(issue: string): string {
@@ -310,6 +318,8 @@ export default function PropositionsPage() {
           const fields = Object.keys(row.proposedPatch);
           const evidence = row.officialEvidence;
           const evidenceDescriptionId = `preuve-officielle-${row.id}`;
+          const sourceHref = evidence.required ? evidence.canonicalUrl : row.sourceLink.safeUrl;
+          const rawSourceUrl = evidence.required ? evidence.requestedUrl : row.sourceLink.rawUrl;
           return (
             <li key={row.id}>
               <Card>
@@ -467,9 +477,9 @@ export default function PropositionsPage() {
                       </blockquote>
                     )}
                     <p className="flex flex-wrap items-center gap-3">
-                      {evidence.canonicalUrl ? (
+                      {sourceHref ? (
                         <a
-                          href={evidence.canonicalUrl}
+                          href={sourceHref}
                           target="_blank"
                           rel="noopener noreferrer"
                           aria-label={`Ouvrir la source ${row.source} dans un nouvel onglet`}
@@ -482,9 +492,7 @@ export default function PropositionsPage() {
                       ) : (
                         <span className="text-muted-foreground flex flex-col gap-1">
                           <span>{row.source}</span>
-                          {evidence.requestedUrl && (
-                            <span className="break-all">{evidence.requestedUrl}</span>
-                          )}
+                          {rawSourceUrl && <span className="break-all">{rawSourceUrl}</span>}
                         </span>
                       )}
                       {row.officialId && (

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, ShieldAlert } from "lucide-react";
+import type { OfficialDecisionVerificationStatus } from "@/lib/affairs/official-decision-verification";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
 // Every automated write to an existing affair lands here first.
@@ -52,7 +53,7 @@ interface ProposalRow {
     acceptable: boolean;
     canonicalUrl: string | null;
     requestedUrl: string | null;
-    status: string | null;
+    status: OfficialDecisionVerificationStatus | null;
     checkedAt: string | null;
     matchedIdentifiers: string[];
     issues: string[];
@@ -95,7 +96,7 @@ const RISK_VARIANTS: Record<ProposalRisk, "destructive" | "secondary" | "outline
   LOW: "outline",
 };
 
-const VERIFICATION_LABELS: Record<string, string> = {
+const VERIFICATION_LABELS: Record<OfficialDecisionVerificationStatus, string> = {
   VALID: "Décision vérifiée en direct",
   REDIRECTED: "Redirection concordante, régénération requise",
   INDEX_VERIFIED: "Référence d’index déclarée, vérification humaine requise",
@@ -354,7 +355,9 @@ export default function PropositionsPage() {
                       </Badge>
                       {evidence.required && (
                         <Badge variant={evidence.acceptable ? "outline" : "destructive"}>
-                          {VERIFICATION_LABELS[evidence.status ?? ""] ?? "Décision non vérifiée"}
+                          {evidence.status
+                            ? VERIFICATION_LABELS[evidence.status]
+                            : "Décision non vérifiée"}
                         </Badge>
                       )}
                     </div>
@@ -439,8 +442,9 @@ export default function PropositionsPage() {
                       )}
                       <div className="space-y-1">
                         <p className="font-medium">
-                          {VERIFICATION_LABELS[evidence.status ?? ""] ??
-                            "Décision officielle non vérifiée"}
+                          {evidence.status
+                            ? VERIFICATION_LABELS[evidence.status]
+                            : "Décision officielle non vérifiée"}
                         </p>
                         {evidence.matchedIdentifiers.length > 0 && (
                           <p>

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
-import { AlertTriangle, ExternalLink, Loader2 } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, ShieldAlert } from "lucide-react";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
 // Every automated write to an existing affair lands here first.
@@ -43,6 +43,15 @@ interface ProposalRow {
   reviewedBy: string | null;
   reviewNotes: string | null;
   createdAt: string;
+  officialEvidence: {
+    required: boolean;
+    acceptable: boolean;
+    canonicalUrl: string | null;
+    status: string | null;
+    checkedAt: string | null;
+    matchedIdentifiers: string[];
+    issues: string[];
+  };
   /** Null once the affair has been deleted; fall back to affairSnapshot. */
   affair: {
     id: string;
@@ -81,6 +90,43 @@ const RISK_VARIANTS: Record<ProposalRisk, "destructive" | "secondary" | "outline
   LOW: "outline",
 };
 
+const VERIFICATION_LABELS: Record<string, string> = {
+  VALID: "Décision vérifiée en direct",
+  REDIRECTED: "URL redirigée à normaliser",
+  INDEX_VERIFIED: "Index officiel concordant",
+  BROKEN: "URL cassée",
+  MISMATCH: "Décision différente",
+  BLOCKED: "Vérification bloquée",
+  UNCHECKED: "Preuve incomplète",
+};
+
+const IDENTIFIER_LABELS: Record<string, string> = {
+  officialId: "identifiant officiel",
+  pourvoi: "pourvoi",
+  ecli: "ECLI",
+  decisionDate: "date",
+};
+
+const VERIFICATION_ISSUE_LABELS: Record<string, string> = {
+  decision_officielle_candidate_absente: "métadonnées de décision absentes",
+  url_decision_absente: "URL de décision absente",
+  source_url_et_decision_candidate_differentes: "URL source différente de l'URL candidate",
+  identifiant_officiel_attendu_absent: "identifiant officiel absent",
+  date_decision_attendue_absente: "date attendue absente",
+  pourvoi_ou_ecli_attendu_absent: "pourvoi ou ECLI absent",
+  url_et_identifiant_officiel_differents: "identifiant incompatible avec l'URL",
+  pourvoi_absent_ou_different: "pourvoi absent ou différent",
+  ecli_absent_ou_different: "ECLI absent ou différent",
+  date_decision_absente_ou_differente: "date absente ou différente",
+  redirection_vers_autre_decision: "redirection vers une autre décision",
+  preuve_indexee_expiree_ou_date_invalide: "preuve indexée expirée",
+};
+
+function verificationIssueLabel(issue: string): string {
+  if (/^http_[0-9]{3}$/.test(issue)) return `réponse HTTP ${issue.slice(5)}`;
+  return VERIFICATION_ISSUE_LABELS[issue] ?? issue.replaceAll("_", " ");
+}
+
 const FIELD_LABELS: Record<string, string> = {
   status: "Statut procédural",
   involvement: "Implication",
@@ -113,8 +159,8 @@ function formatConflictValue(value: string): string {
 
 /** Values arrive as JSON, so dates are ISO strings and arrays stay arrays. */
 function formatValue(value: unknown): string {
-  if (value === null || value === undefined) return "—";
-  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "—";
+  if (value === null || value === undefined) return "non renseigné";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "non renseigné";
   if (typeof value === "boolean") return value ? "oui" : "non";
   if (typeof value === "string" && ISO_DATE.test(value)) {
     return new Date(value).toLocaleDateString("fr-FR");
@@ -165,6 +211,7 @@ export default function PropositionsPage() {
       const payload = (await res.json()) as {
         error?: string;
         conflictDetail?: Record<string, { expected: string; actual: string }>;
+        verification?: { issues?: string[] };
       };
       if (!res.ok) {
         setFeedback({
@@ -172,7 +219,9 @@ export default function PropositionsPage() {
           message:
             res.status === 409 && payload.conflictDetail
               ? "La valeur en base a changé depuis la proposition. Elle passe en conflit."
-              : (payload.error ?? "Action refusée"),
+              : [payload.error, ...(payload.verification?.issues ?? []).map(verificationIssueLabel)]
+                  .filter(Boolean)
+                  .join(" : ") || "Action refusée",
         });
       } else {
         setFeedback({
@@ -211,6 +260,7 @@ export default function PropositionsPage() {
               key={t.key}
               variant={active ? "default" : "outline"}
               size="sm"
+              className="min-h-11"
               aria-current={active ? "page" : undefined}
               onClick={() => {
                 setTab(t.key);
@@ -254,6 +304,8 @@ export default function PropositionsPage() {
       <ul className="space-y-4">
         {data?.rows.map((row) => {
           const fields = Object.keys(row.proposedPatch);
+          const evidence = row.officialEvidence;
+          const evidenceDescriptionId = `preuve-officielle-${row.id}`;
           return (
             <li key={row.id}>
               <Card>
@@ -263,7 +315,7 @@ export default function PropositionsPage() {
                       {row.affair ? (
                         <Link
                           href={`/admin/affaires/${row.affair.id}/edit`}
-                          className="font-semibold hover:underline"
+                          className="inline-flex min-h-11 items-center font-semibold hover:underline"
                         >
                           {row.affair.title}
                         </Link>
@@ -286,6 +338,11 @@ export default function PropositionsPage() {
                       <Badge variant="outline">
                         {row.importer}@{row.extractorVersion}
                       </Badge>
+                      {evidence.required && (
+                        <Badge variant={evidence.acceptable ? "outline" : "destructive"}>
+                          {VERIFICATION_LABELS[evidence.status ?? ""] ?? "Décision non vérifiée"}
+                        </Badge>
+                      )}
                     </div>
                   </div>
 
@@ -346,6 +403,55 @@ export default function PropositionsPage() {
                     </div>
                   )}
 
+                  {evidence.required && (
+                    <div
+                      id={evidenceDescriptionId}
+                      className={
+                        evidence.acceptable
+                          ? "flex gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm"
+                          : "border-destructive/40 bg-destructive/10 flex gap-2 rounded-md border px-3 py-2 text-sm"
+                      }
+                    >
+                      {evidence.acceptable ? (
+                        <CheckCircle2
+                          className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-400"
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <ShieldAlert
+                          className="text-destructive mt-0.5 h-4 w-4 shrink-0"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <div className="space-y-1">
+                        <p className="font-medium">
+                          {VERIFICATION_LABELS[evidence.status ?? ""] ??
+                            "Décision officielle non vérifiée"}
+                        </p>
+                        {evidence.matchedIdentifiers.length > 0 && (
+                          <p>
+                            Concordances :{" "}
+                            {evidence.matchedIdentifiers
+                              .map((identifier) => IDENTIFIER_LABELS[identifier] ?? identifier)
+                              .join(", ")}
+                          </p>
+                        )}
+                        {evidence.checkedAt && (
+                          <p className="text-muted-foreground">
+                            Contrôle du {new Date(evidence.checkedAt).toLocaleString("fr-FR")}
+                          </p>
+                        )}
+                        {evidence.issues.length > 0 && (
+                          <ul className="list-disc pl-4">
+                            {evidence.issues.map((issue) => (
+                              <li key={issue}>{verificationIssueLabel(issue)}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
                   <div className="space-y-2 text-sm">
                     <p>
                       <span className="text-muted-foreground">Justification : </span>
@@ -357,12 +463,13 @@ export default function PropositionsPage() {
                       </blockquote>
                     )}
                     <p className="flex flex-wrap items-center gap-3">
-                      {row.sourceUrl ? (
+                      {(evidence.canonicalUrl ?? row.sourceUrl) ? (
                         <a
-                          href={row.sourceUrl}
+                          href={evidence.canonicalUrl ?? row.sourceUrl ?? undefined}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 hover:underline"
+                          aria-label={`Ouvrir la source ${row.source} dans un nouvel onglet`}
+                          className="inline-flex min-h-11 items-center gap-1 hover:underline"
                         >
                           {row.source}
                           <ExternalLink className="h-3 w-3" aria-hidden="true" />
@@ -393,12 +500,22 @@ export default function PropositionsPage() {
                       />
                       <div className="flex gap-2">
                         <Button
+                          className="min-h-11"
                           onClick={() => void review(row.id, "accept")}
-                          disabled={busyId === row.id}
+                          disabled={
+                            busyId === row.id || (evidence.required && !evidence.acceptable)
+                          }
+                          aria-describedby={evidence.required ? evidenceDescriptionId : undefined}
+                          title={
+                            evidence.required && !evidence.acceptable
+                              ? "Acceptation bloquée tant que la décision officielle n'est pas vérifiée"
+                              : undefined
+                          }
                         >
                           Accepter et appliquer
                         </Button>
                         <Button
+                          className="min-h-11"
                           variant="outline"
                           onClick={() => void review(row.id, "reject")}
                           disabled={busyId === row.id}
@@ -412,7 +529,7 @@ export default function PropositionsPage() {
                       {row.reviewedBy && row.reviewedAt
                         ? `${row.status} par ${row.reviewedBy} le ${new Date(row.reviewedAt).toLocaleString("fr-FR")}`
                         : row.status}
-                      {row.reviewNotes ? ` — ${row.reviewNotes}` : ""}
+                      {row.reviewNotes ? ` - ${row.reviewNotes}` : ""}
                     </p>
                   )}
                 </CardContent>
@@ -427,6 +544,7 @@ export default function PropositionsPage() {
           <Button
             variant="outline"
             size="sm"
+            className="min-h-11"
             disabled={page <= 1}
             onClick={() => setPage((p) => p - 1)}
           >
@@ -438,6 +556,7 @@ export default function PropositionsPage() {
           <Button
             variant="outline"
             size="sm"
+            className="min-h-11"
             disabled={page >= data.totalPages}
             onClick={() => setPage((p) => p + 1)}
           >

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -47,6 +47,7 @@ interface ProposalRow {
     required: boolean;
     acceptable: boolean;
     canonicalUrl: string | null;
+    requestedUrl: string | null;
     status: string | null;
     checkedAt: string | null;
     matchedIdentifiers: string[];
@@ -92,12 +93,12 @@ const RISK_VARIANTS: Record<ProposalRisk, "destructive" | "secondary" | "outline
 
 const VERIFICATION_LABELS: Record<string, string> = {
   VALID: "Décision vérifiée en direct",
-  REDIRECTED: "URL redirigée à normaliser",
-  INDEX_VERIFIED: "Index officiel concordant",
-  BROKEN: "URL cassée",
-  MISMATCH: "Décision différente",
-  BLOCKED: "Vérification bloquée",
-  UNCHECKED: "Preuve incomplète",
+  REDIRECTED: "Redirection concordante, régénération requise",
+  INDEX_VERIFIED: "Référence retrouvée dans un index, vérification humaine requise",
+  BROKEN: "Lien indisponible",
+  MISMATCH: "Le lien renvoie vers une autre décision",
+  BLOCKED: "Vérification automatique impossible",
+  UNCHECKED: "Preuve incomplète ou non vérifiée",
 };
 
 const IDENTIFIER_LABELS: Record<string, string> = {
@@ -124,6 +125,9 @@ const VERIFICATION_ISSUE_LABELS: Record<string, string> = {
 
 function verificationIssueLabel(issue: string): string {
   if (/^http_[0-9]{3}$/.test(issue)) return `réponse HTTP ${issue.slice(5)}`;
+  if (issue.startsWith("url_administration_non_cliquable:")) {
+    return `URL non cliquable : ${issue.slice("url_administration_non_cliquable:".length).replaceAll("_", " ")}`;
+  }
   return VERIFICATION_ISSUE_LABELS[issue] ?? issue.replaceAll("_", " ");
 }
 
@@ -463,9 +467,9 @@ export default function PropositionsPage() {
                       </blockquote>
                     )}
                     <p className="flex flex-wrap items-center gap-3">
-                      {(evidence.canonicalUrl ?? row.sourceUrl) ? (
+                      {evidence.canonicalUrl ? (
                         <a
-                          href={evidence.canonicalUrl ?? row.sourceUrl ?? undefined}
+                          href={evidence.canonicalUrl}
                           target="_blank"
                           rel="noopener noreferrer"
                           aria-label={`Ouvrir la source ${row.source} dans un nouvel onglet`}
@@ -476,7 +480,12 @@ export default function PropositionsPage() {
                           <span className="sr-only">(nouvel onglet)</span>
                         </a>
                       ) : (
-                        <span className="text-muted-foreground">{row.source}</span>
+                        <span className="text-muted-foreground flex flex-col gap-1">
+                          <span>{row.source}</span>
+                          {evidence.requestedUrl && (
+                            <span className="break-all">{evidence.requestedUrl}</span>
+                          )}
+                        </span>
                       )}
                       {row.officialId && (
                         <span className="text-muted-foreground">{row.officialId}</span>

--- a/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
+++ b/src/app/api/admin/affaires/propositions/[id]/accept/route.ts
@@ -62,6 +62,15 @@ export const POST = withAdminAuth(
             },
             { status: 422 }
           );
+        case "evidence_unverified":
+          return NextResponse.json(
+            {
+              error:
+                "La décision officielle n'est pas suffisamment vérifiée. Vérifiez l'URL et les identifiants avant de régénérer la proposition.",
+              verification: result.verification,
+            },
+            { status: 422 }
+          );
         case "conflict":
           return NextResponse.json(
             {

--- a/src/app/api/admin/affaires/propositions/route.test.ts
+++ b/src/app/api/admin/affaires/propositions/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/api/with-admin-auth", () => ({
 
 import { GET } from "./route";
 
-const PRESS_URL = "https://www.lemonde.fr/politique/article-test.html";
+const PRESS_URL = "https://press.example.test/politique/article-test.html";
 
 function proposalRow(overrides: Record<string, unknown> = {}) {
   return {

--- a/src/app/api/admin/affaires/propositions/route.test.ts
+++ b/src/app/api/admin/affaires/propositions/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({
+  db: {
+    affairUpdateProposal: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      groupBy: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (handler: (request: NextRequest) => Promise<Response>) => handler,
+}));
+
+import { GET } from "./route";
+
+const PRESS_URL = "https://www.lemonde.fr/politique/article-test.html";
+
+function proposalRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "proposal-1",
+    importer: "press-analysis",
+    extractorVersion: "v1",
+    proposedPatch: { court: "Tribunal judiciaire de Paris" },
+    observedValues: { court: null },
+    affairSnapshot: {
+      publicId: "PG000001",
+      slug: "affaire-test",
+      title: "Affaire test",
+      politicianSlug: "personne-test",
+      politicianName: "Personne Test",
+    },
+    source: "PRESSE",
+    sourceUrl: PRESS_URL,
+    officialId: null,
+    sourceContentHash: null,
+    sourceExcerpt: null,
+    metadata: null,
+    confidence: 80,
+    riskLevel: "MEDIUM",
+    rationale: "Article de presse soumis à la revue.",
+    status: "PENDING",
+    conflictDetail: null,
+    reviewedAt: null,
+    reviewedBy: null,
+    reviewNotes: null,
+    createdAt: new Date("2026-08-19T09:00:00.000Z"),
+    affair: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.db.affairUpdateProposal.count.mockResolvedValue(2);
+  h.db.affairUpdateProposal.groupBy.mockResolvedValue([{ status: "PENDING", _count: 2 }]);
+});
+
+describe("GET admin affair proposals source links", () => {
+  it("returns a safe ordinary press link without treating it as official evidence", async () => {
+    h.db.affairUpdateProposal.findMany.mockResolvedValue([proposalRow()]);
+
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/affaires/propositions?status=PENDING"),
+      { params: Promise.resolve({}) }
+    );
+    const body = (await response.json()) as {
+      rows: Array<{
+        sourceLink: { rawUrl: string | null; safeUrl: string | null };
+        officialEvidence: { required: boolean; canonicalUrl: string | null };
+      }>;
+    };
+
+    expect(body.rows[0]).toMatchObject({
+      sourceLink: { rawUrl: PRESS_URL, safeUrl: PRESS_URL },
+      officialEvidence: { required: false, canonicalUrl: null },
+    });
+  });
+
+  it("never returns an ordinary fallback link when decision evidence is required", async () => {
+    h.db.affairUpdateProposal.findMany.mockResolvedValue([
+      proposalRow({
+        metadata: {
+          courtDecisionCandidate: {
+            canonicalUrl: "https://example.com/not-an-official-decision",
+          },
+        },
+      }),
+    ]);
+
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/affaires/propositions?status=PENDING"),
+      { params: Promise.resolve({}) }
+    );
+    const body = (await response.json()) as {
+      rows: Array<{
+        sourceLink: { safeUrl: string | null };
+        officialEvidence: { required: boolean; canonicalUrl: string | null };
+      }>;
+    };
+
+    expect(body.rows[0]).toMatchObject({
+      sourceLink: { safeUrl: null },
+      officialEvidence: { required: true, canonicalUrl: null },
+    });
+  });
+});

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { parsePagination } from "@/lib/api/pagination";
+import { summarizeProposalOfficialEvidence } from "@/lib/affairs/official-decision-verification";
 import type { Prisma, ProposalStatus } from "@/generated/prisma";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
@@ -23,7 +25,10 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   const params = request.nextUrl.searchParams;
   const status = parseStatus(params.get("status"));
   const importer = params.get("importer");
-  const page = Math.max(1, Number.parseInt(params.get("page") ?? "1", 10) || 1);
+  const { page, skip } = parsePagination(params, {
+    defaultLimit: PAGE_SIZE,
+    maxLimit: PAGE_SIZE,
+  });
 
   const where: Prisma.AffairUpdateProposalWhereInput = {
     status,
@@ -35,7 +40,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
       where,
       // riskLevel is declared LOW, MEDIUM, HIGH, so "desc" surfaces HIGH first.
       orderBy: [{ riskLevel: "desc" }, { createdAt: "desc" }],
-      skip: (page - 1) * PAGE_SIZE,
+      skip,
       take: PAGE_SIZE,
       select: {
         id: true,
@@ -51,6 +56,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
         officialId: true,
         sourceContentHash: true,
         sourceExcerpt: true,
+        metadata: true,
         confidence: true,
         riskLevel: true,
         rationale: true,
@@ -76,7 +82,15 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   ]);
 
   return NextResponse.json({
-    rows,
+    rows: rows.map(({ metadata, ...row }) => ({
+      ...row,
+      officialEvidence: summarizeProposalOfficialEvidence({
+        source: row.source,
+        sourceUrl: row.sourceUrl,
+        officialId: row.officialId,
+        metadata,
+      }),
+    })),
     total,
     page,
     pageSize: PAGE_SIZE,

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -2,7 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { parsePagination } from "@/lib/api/pagination";
-import { summarizeProposalOfficialEvidence } from "@/lib/affairs/official-decision-verification";
+import {
+  summarizeProposalOfficialEvidence,
+  summarizeProposalSourceLink,
+} from "@/lib/affairs/official-decision-verification";
 import type { Prisma, ProposalStatus } from "@/generated/prisma";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
@@ -82,15 +85,23 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   ]);
 
   return NextResponse.json({
-    rows: rows.map(({ metadata, ...row }) => ({
-      ...row,
-      officialEvidence: summarizeProposalOfficialEvidence({
+    rows: rows.map(({ metadata, ...row }) => {
+      const officialEvidence = summarizeProposalOfficialEvidence({
         source: row.source,
         sourceUrl: row.sourceUrl,
         officialId: row.officialId,
         metadata,
-      }),
-    })),
+      });
+      const sourceLink = officialEvidence.required
+        ? { rawUrl: row.sourceUrl, safeUrl: null }
+        : summarizeProposalSourceLink(row.sourceUrl);
+
+      return {
+        ...row,
+        officialEvidence,
+        sourceLink,
+      };
+    }),
     total,
     page,
     pageSize: PAGE_SIZE,

--- a/src/lib/affairs/__tests__/official-decision-verification.test.ts
+++ b/src/lib/affairs/__tests__/official-decision-verification.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isAcceptableOfficialDecisionVerification,
+  summarizeProposalOfficialEvidence,
+  verifyOfficialDecision,
+  verifyProposalOfficialEvidence,
+  type OfficialDecisionIndexedProof,
+} from "../official-decision-verification";
+
+const URL = "https://www.legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+
+function response(
+  body: string,
+  init: { status?: number; url?: string; headers?: HeadersInit } = {}
+): Response {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    url: init.url ?? URL,
+    headers: new Headers(init.headers),
+    text: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function expectation() {
+  return {
+    url: URL,
+    pourvoi: "23-82.194",
+    ecli: "FR:CCASS:2024:CR00817",
+    decisionDate: "2024-06-19",
+    officialId: "JURITEXT000049774995",
+  };
+}
+
+function indexedProof(
+  overrides: Partial<OfficialDecisionIndexedProof> = {}
+): OfficialDecisionIndexedProof {
+  return {
+    version: 1,
+    exactUrl: URL,
+    verifiedAt: "2026-08-18T08:00:00.000Z",
+    method: "EXACT_OFFICIAL_SEARCH_RESULT",
+    title: "Cour de cassation, Chambre criminelle, 19 juin 2024, 23-82.194, publié au bulletin",
+    publisher: "Légifrance",
+    pourvoi: "23-82.194",
+    ecli: "FR:CCASS:2024:CR00817",
+    decisionDate: "2024-06-19",
+    officialId: "JURITEXT000049774995",
+    ...overrides,
+  };
+}
+
+describe("official decision verification", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("validates the URL, pourvoi, ECLI, date and official identifier together", async () => {
+    const result = await verifyOfficialDecision(expectation(), {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(response("N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET")),
+    });
+
+    expect(result.status).toBe("VALID");
+    expect(result.matchedIdentifiers).toEqual(["officialId", "pourvoi", "ecli", "decisionDate"]);
+    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(isAcceptableOfficialDecisionVerification(result)).toBe(true);
+  });
+
+  it("rejects a canonical URL whose official identifier differs", async () => {
+    const fetchImpl = vi.fn();
+    const result = await verifyOfficialDecision(
+      { ...expectation(), officialId: "JURITEXT000049774999" },
+      { fetchImpl }
+    );
+
+    expect(result.status).toBe("UNCHECKED");
+    expect(result.issues).toContain("url_et_identifiant_officiel_differents");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a reachable page for another decision", async () => {
+    const result = await verifyOfficialDecision(expectation(), {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(response("N° 23-82.999 ECLI:FR:CCASS:2024:CR00999 20 JUIN 2024")),
+    });
+
+    expect(result.status).toBe("MISMATCH");
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        "pourvoi_absent_ou_different",
+        "ecli_absent_ou_different",
+        "date_decision_absente_ou_differente",
+      ])
+    );
+  });
+
+  it("classifies missing pages as broken without using an indexed fallback", async () => {
+    const result = await verifyOfficialDecision(
+      { ...expectation(), indexedProof: indexedProof() },
+      { fetchImpl: vi.fn().mockResolvedValue(response("Not found", { status: 404 })) }
+    );
+
+    expect(result.status).toBe("BROKEN");
+    expect(isAcceptableOfficialDecisionVerification(result)).toBe(false);
+  });
+
+  it("fails closed when the official response body cannot be read", async () => {
+    const unreadable = response("");
+    unreadable.text = vi.fn().mockRejectedValue(new Error("stream failure"));
+    const result = await verifyOfficialDecision(expectation(), {
+      fetchImpl: vi.fn().mockResolvedValue(unreadable),
+    });
+
+    expect(result.status).toBe("BLOCKED");
+    expect(result.issues).toContain("lecture_reponse_impossible");
+  });
+
+  it("refuses non-official hosts before any network request", async () => {
+    const fetchImpl = vi.fn();
+    const result = await verifyOfficialDecision(
+      { ...expectation(), url: "https://example.test/juri/id/JURITEXT000049774995" },
+      { fetchImpl }
+    );
+
+    expect(result.status).toBe("BLOCKED");
+    expect(result.issues).toContain("hote_officiel_non_autorise");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("does not follow a redirect to an unapproved host", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response("", {
+        status: 302,
+        headers: { location: "http://127.0.0.1/private" },
+      })
+    );
+    const result = await verifyOfficialDecision(expectation(), { fetchImpl });
+
+    expect(result.status).toBe("BLOCKED");
+    expect(result.issues[0]).toContain("redirection_non_autorisee");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a fresh exact index proof only when the official host blocks automation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T09:00:00.000Z"));
+    const result = await verifyOfficialDecision(
+      { ...expectation(), indexedProof: indexedProof() },
+      { fetchImpl: vi.fn().mockResolvedValue(response("Forbidden", { status: 403 })) }
+    );
+
+    expect(result.status).toBe("INDEX_VERIFIED");
+    expect(result.matchedIdentifiers).toEqual(["pourvoi", "ecli", "decisionDate", "officialId"]);
+    expect(isAcceptableOfficialDecisionVerification(result)).toBe(true);
+  });
+
+  it("rejects an indexed proof with a different pourvoi or an expired timestamp", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-26T09:00:00.000Z"));
+    const result = await verifyOfficialDecision(
+      {
+        ...expectation(),
+        indexedProof: indexedProof({ pourvoi: "23-82.999" }),
+      },
+      { fetchImpl: vi.fn().mockResolvedValue(response("Forbidden", { status: 403 })) }
+    );
+
+    expect(result.status).toBe("BLOCKED");
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        "preuve_indexee_pourvoi_different",
+        "preuve_indexee_expiree_ou_date_invalide",
+      ])
+    );
+  });
+
+  it("requires explicit candidate metadata for an official proposal", async () => {
+    const result = await verifyProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      officialId: "23-82.194",
+      metadata: {},
+    });
+
+    expect(result?.verification.status).toBe("UNCHECKED");
+    expect(result?.verification.issues).toContain("decision_officielle_candidate_absente");
+  });
+
+  it("rejects a source URL different from the decision candidate", async () => {
+    const result = await verifyProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      metadata: {
+        courtDecisionCandidate: {
+          url: "https://www.legifrance.gouv.fr/juri/id/JURITEXT000050868554",
+          pourvoi: "23-83.178",
+          date: "2024-12-18",
+          legifranceId: "JURITEXT000050868554",
+        },
+      },
+    });
+
+    expect(result?.verification.status).toBe("MISMATCH");
+    expect(result?.verification.issues).toContain("source_url_et_decision_candidate_differentes");
+  });
+
+  it("marks stale indexed evidence as unacceptable in the admin summary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-26T09:00:00.000Z"));
+    const proof = indexedProof();
+    const summary = summarizeProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      metadata: {
+        courtDecisionCandidate: {
+          url: URL,
+          pourvoi: "23-82.194",
+          ecli: "FR:CCASS:2024:CR00817",
+          date: "2024-06-19",
+          legifranceId: "JURITEXT000049774995",
+          indexedProof: proof,
+          verification: {
+            version: 1,
+            status: "INDEX_VERIFIED",
+            checkedAt: proof.verifiedAt,
+            requestedUrl: URL,
+            resolvedUrl: URL,
+            httpStatus: 403,
+            contentHash: null,
+            matchedIdentifiers: ["pourvoi", "ecli", "decisionDate", "officialId"],
+            issues: ["http_403"],
+            indexedProof: proof,
+          },
+        },
+      },
+    });
+
+    expect(summary.required).toBe(true);
+    expect(summary.acceptable).toBe(false);
+    expect(summary.issues).toContain("preuve_indexee_expiree_ou_date_invalide");
+  });
+});

--- a/src/lib/affairs/__tests__/official-decision-verification.test.ts
+++ b/src/lib/affairs/__tests__/official-decision-verification.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isAcceptableOfficialDecisionVerification,
   summarizeProposalOfficialEvidence,
+  summarizeProposalSourceLink,
+  verifyAndAnnotateProposalOfficialEvidence,
   verifyOfficialDecision,
   verifyProposalOfficialEvidence,
   type OfficialDecisionIndexedProof,
@@ -333,7 +335,7 @@ describe("official decision verification", () => {
     expect(result.issues[0]).toContain("redirection_non_autorisee");
   });
 
-  it("normalizes a concordant redirect on creation and validates the final URL directly", async () => {
+  it("normalizes a concordant redirect and stores a direct VALID verification", async () => {
     const normalizedUrl = "https://legifrance.gouv.fr/juri/id/JURITEXT000049774995";
     const body = "N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET";
     const input = {
@@ -349,28 +351,125 @@ describe("official decision verification", () => {
         },
       },
     };
-    const redirected = await verifyProposalOfficialEvidence(input, {
+    const verified = await verifyAndAnnotateProposalOfficialEvidence(input, {
       fetchImpl: vi
         .fn()
         .mockResolvedValueOnce(response("", { status: 302, headers: { location: normalizedUrl } }))
+        .mockResolvedValueOnce(response(body, { url: normalizedUrl }))
         .mockResolvedValueOnce(response(body, { url: normalizedUrl })),
     });
 
-    expect(redirected?.verification.status).toBe("REDIRECTED");
-    expect(redirected?.sourceUrl).toBe(normalizedUrl);
-    expect(isAcceptableOfficialDecisionVerification(redirected!.verification)).toBe(false);
-
-    const direct = await verifyProposalOfficialEvidence(
-      {
-        ...input,
-        sourceUrl: redirected!.sourceUrl,
-        metadata: redirected!.metadata,
+    expect(verified?.verification.status).toBe("VALID");
+    expect(verified?.sourceUrl).toBe(normalizedUrl);
+    expect(isAcceptableOfficialDecisionVerification(verified!.verification)).toBe(true);
+    expect(verified?.metadata).toMatchObject({
+      courtDecisionCandidate: {
+        url: normalizedUrl,
+        canonicalUrl: normalizedUrl,
+        urlNormalization: {
+          initialUrl: URL,
+          finalUrl: normalizedUrl,
+          reason: "OFFICIAL_REDIRECT",
+        },
       },
-      { fetchImpl: vi.fn().mockResolvedValue(response(body, { url: normalizedUrl })) }
-    );
+    });
+  });
 
-    expect(direct?.verification.status).toBe("VALID");
-    expect(isAcceptableOfficialDecisionVerification(direct!.verification)).toBe(true);
+  it("blocks creation when the direct verification after a redirect mismatches", async () => {
+    const normalizedUrl = "https://legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+    const matchingBody = "N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET";
+    const mismatchingBody = "N° 23-82.999 ECLI:FR:CCASS:2024:CR00999 20 JUIN 2024";
+
+    await expect(
+      verifyAndAnnotateProposalOfficialEvidence(
+        {
+          source: "LEGIFRANCE",
+          sourceUrl: URL,
+          metadata: {
+            courtDecisionCandidate: {
+              url: URL,
+              pourvoi: "23-82.194",
+              ecli: "FR:CCASS:2024:CR00817",
+              date: "2024-06-19",
+              legifranceId: "JURITEXT000049774995",
+            },
+          },
+        },
+        {
+          fetchImpl: vi
+            .fn()
+            .mockResolvedValueOnce(
+              response("", { status: 302, headers: { location: normalizedUrl } })
+            )
+            .mockResolvedValueOnce(response(matchingBody, { url: normalizedUrl }))
+            .mockResolvedValueOnce(response(mismatchingBody, { url: normalizedUrl })),
+        }
+      )
+    ).rejects.toMatchObject({ verification: { status: "MISMATCH" } });
+  });
+
+  it("does not turn a 403 after redirect normalization into VALID", async () => {
+    const normalizedUrl = "https://legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+    const matchingBody = "N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET";
+
+    await expect(
+      verifyAndAnnotateProposalOfficialEvidence(
+        {
+          source: "LEGIFRANCE",
+          sourceUrl: URL,
+          metadata: {
+            courtDecisionCandidate: {
+              url: URL,
+              pourvoi: "23-82.194",
+              ecli: "FR:CCASS:2024:CR00817",
+              date: "2024-06-19",
+              legifranceId: "JURITEXT000049774995",
+            },
+          },
+        },
+        {
+          fetchImpl: vi
+            .fn()
+            .mockResolvedValueOnce(
+              response("", { status: 302, headers: { location: normalizedUrl } })
+            )
+            .mockResolvedValueOnce(response(matchingBody, { url: normalizedUrl }))
+            .mockResolvedValueOnce(response("Forbidden", { status: 403, url: normalizedUrl })),
+        }
+      )
+    ).rejects.toMatchObject({ verification: { status: "BLOCKED" } });
+  });
+
+  it.each([
+    ["HTTPS", "https://www.lemonde.fr/politique/article-test.html", true],
+    ["HTTP", "http://www.franceinfo.fr/politique/article-test", true],
+    ["JavaScript", "javascript:alert(1)", false],
+    ["data", "data:text/html,<script>alert(1)</script>", false],
+    ["credentials", "https://user:password@example.com/article", false],
+    ["invalid syntax", "not a URL", false],
+  ])("validates an ordinary %s editorial source link", (_label, rawUrl, expectedSafe) => {
+    const summary = summarizeProposalSourceLink(rawUrl);
+
+    expect(summary.rawUrl).toBe(rawUrl);
+    expect(summary.safeUrl !== null).toBe(expectedSafe);
+  });
+
+  it("does not transform an ordinary press source into official decision evidence", async () => {
+    const sourceUrl = "https://www.lemonde.fr/politique/article-test.html";
+
+    expect(
+      await verifyProposalOfficialEvidence({
+        source: "PRESSE",
+        sourceUrl,
+        metadata: { editorialSource: "Le Monde" },
+      })
+    ).toBeNull();
+    expect(summarizeProposalOfficialEvidence({ source: "PRESSE", sourceUrl })).toMatchObject({
+      required: false,
+      canonicalUrl: null,
+      requestedUrl: null,
+    });
+    expect(summarizeProposalSourceLink(sourceUrl).safeUrl).toBe(sourceUrl);
   });
 
   it.each([

--- a/src/lib/affairs/__tests__/official-decision-verification.test.ts
+++ b/src/lib/affairs/__tests__/official-decision-verification.test.ts
@@ -98,6 +98,27 @@ describe("official decision verification", () => {
     );
   });
 
+  it("does not accept identifiers hidden in malformed script markup", async () => {
+    const result = await verifyOfficialDecision(expectation(), {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(
+          response(
+            "<script>N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024</script > N° 23-82.999"
+          )
+        ),
+    });
+
+    expect(result.status).toBe("MISMATCH");
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        "pourvoi_absent_ou_different",
+        "ecli_absent_ou_different",
+        "date_decision_absente_ou_differente",
+      ])
+    );
+  });
+
   it("classifies missing pages as broken without using an indexed fallback", async () => {
     const result = await verifyOfficialDecision(
       { ...expectation(), indexedProof: indexedProof() },

--- a/src/lib/affairs/__tests__/official-decision-verification.test.ts
+++ b/src/lib/affairs/__tests__/official-decision-verification.test.ts
@@ -56,6 +56,31 @@ describe("official decision verification", () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    "VALID",
+    "REDIRECTED",
+    "INDEX_VERIFIED",
+    "BROKEN",
+    "MISMATCH",
+    "BLOCKED",
+    "UNCHECKED",
+  ] as const)("accepts only a direct VALID verification, not %s by declaration", (status) => {
+    expect(
+      isAcceptableOfficialDecisionVerification({
+        version: 1,
+        status,
+        checkedAt: "2026-08-18T09:00:00.000Z",
+        requestedUrl: URL,
+        resolvedUrl: URL,
+        httpStatus: status === "VALID" ? 200 : null,
+        contentHash: null,
+        matchedIdentifiers: [],
+        issues: [],
+        indexedProof: null,
+      })
+    ).toBe(status === "VALID");
+  });
+
   it("validates the URL, pourvoi, ECLI, date and official identifier together", async () => {
     const result = await verifyOfficialDecision(expectation(), {
       fetchImpl: vi
@@ -140,7 +165,7 @@ describe("official decision verification", () => {
     expect(result.issues).toContain("lecture_reponse_impossible");
   });
 
-  it("refuses non-official hosts before any network request", async () => {
+  it("refuses non-official hosts before a network request", async () => {
     const fetchImpl = vi.fn();
     const result = await verifyOfficialDecision(
       { ...expectation(), url: "https://example.test/juri/id/JURITEXT000049774995" },
@@ -166,7 +191,7 @@ describe("official decision verification", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("accepts a fresh exact index proof only when the official host blocks automation", async () => {
+  it("keeps a fresh caller-provided index proof informative but unacceptable after a 403", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-18T09:00:00.000Z"));
     const result = await verifyOfficialDecision(
@@ -176,7 +201,52 @@ describe("official decision verification", () => {
 
     expect(result.status).toBe("INDEX_VERIFIED");
     expect(result.matchedIdentifiers).toEqual(["pourvoi", "ecli", "decisionDate", "officialId"]);
-    expect(isAcceptableOfficialDecisionVerification(result)).toBe(true);
+    expect(isAcceptableOfficialDecisionVerification(result)).toBe(false);
+  });
+
+  it("does not trust authority flags added by the importer to indexed proof JSON", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T09:00:00.000Z"));
+    const proof = {
+      ...indexedProof(),
+      trusted: true,
+      verifiedBy: "server",
+      official: true,
+      humanValidated: true,
+    };
+    const summary = summarizeProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      metadata: {
+        courtDecisionCandidate: {
+          url: URL,
+          pourvoi: "23-82.194",
+          ecli: "FR:CCASS:2024:CR00817",
+          date: "2024-06-19",
+          legifranceId: "JURITEXT000049774995",
+          indexedProof: proof,
+          trusted: true,
+          humanValidated: true,
+          verification: {
+            version: 1,
+            status: "INDEX_VERIFIED",
+            checkedAt: proof.verifiedAt,
+            requestedUrl: URL,
+            resolvedUrl: URL,
+            httpStatus: 403,
+            contentHash: null,
+            matchedIdentifiers: ["pourvoi", "ecli", "decisionDate", "officialId"],
+            issues: ["http_403"],
+            indexedProof: proof,
+            acceptable: true,
+            verifiedBy: "server",
+          },
+        },
+      },
+    });
+
+    expect(summary.status).toBe("INDEX_VERIFIED");
+    expect(summary.acceptable).toBe(false);
   });
 
   it("rejects an indexed proof with a different pourvoi or an expired timestamp", async () => {
@@ -209,6 +279,131 @@ describe("official decision verification", () => {
 
     expect(result?.verification.status).toBe("UNCHECKED");
     expect(result?.verification.issues).toContain("decision_officielle_candidate_absente");
+  });
+
+  it("does not construct an official URL from identifiers when no URL was supplied", async () => {
+    const fetchImpl = vi.fn();
+    const result = await verifyProposalOfficialEvidence(
+      {
+        source: "LEGIFRANCE",
+        officialId: "JURITEXT000049774995",
+        metadata: {
+          courtDecisionCandidate: {
+            pourvoi: "23-82.194",
+            ecli: "FR:CCASS:2024:CR00817",
+            date: "2024-06-19",
+            legifranceId: "JURITEXT000049774995",
+          },
+        },
+      },
+      { fetchImpl }
+    );
+
+    expect(result?.sourceUrl).toBe("");
+    expect(result?.verification.status).toBe("UNCHECKED");
+    expect(result?.verification.issues).toContain("url_decision_absente");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("classifies a redirect to another official decision as a mismatch", async () => {
+    const otherUrl = "https://www.legifrance.gouv.fr/juri/id/JURITEXT000050868554";
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response("", { status: 302, headers: { location: otherUrl } }))
+      .mockResolvedValueOnce(response("Autre décision", { url: otherUrl }));
+
+    const result = await verifyOfficialDecision(expectation(), { fetchImpl });
+
+    expect(result.status).toBe("MISMATCH");
+    expect(result.issues).toContain("redirection_vers_autre_decision");
+    expect(isAcceptableOfficialDecisionVerification(result)).toBe(false);
+  });
+
+  it("blocks a redirect to a generic official page", async () => {
+    const result = await verifyOfficialDecision(expectation(), {
+      fetchImpl: vi.fn().mockResolvedValue(
+        response("", {
+          status: 302,
+          headers: { location: "https://www.legifrance.gouv.fr/" },
+        })
+      ),
+    });
+
+    expect(result.status).toBe("BLOCKED");
+    expect(result.issues[0]).toContain("redirection_non_autorisee");
+  });
+
+  it("normalizes a concordant redirect on creation and validates the final URL directly", async () => {
+    const normalizedUrl = "https://legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+    const body = "N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET";
+    const input = {
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      metadata: {
+        courtDecisionCandidate: {
+          url: URL,
+          pourvoi: "23-82.194",
+          ecli: "FR:CCASS:2024:CR00817",
+          date: "2024-06-19",
+          legifranceId: "JURITEXT000049774995",
+        },
+      },
+    };
+    const redirected = await verifyProposalOfficialEvidence(input, {
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(response("", { status: 302, headers: { location: normalizedUrl } }))
+        .mockResolvedValueOnce(response(body, { url: normalizedUrl })),
+    });
+
+    expect(redirected?.verification.status).toBe("REDIRECTED");
+    expect(redirected?.sourceUrl).toBe(normalizedUrl);
+    expect(isAcceptableOfficialDecisionVerification(redirected!.verification)).toBe(false);
+
+    const direct = await verifyProposalOfficialEvidence(
+      {
+        ...input,
+        sourceUrl: redirected!.sourceUrl,
+        metadata: redirected!.metadata,
+      },
+      { fetchImpl: vi.fn().mockResolvedValue(response(body, { url: normalizedUrl })) }
+    );
+
+    expect(direct?.verification.status).toBe("VALID");
+    expect(isAcceptableOfficialDecisionVerification(direct!.verification)).toBe(true);
+  });
+
+  it.each([
+    ["a lookalike Légifrance host", "https://legifrance.gouv.fr.example.com/juri/id/JURITEXT1"],
+    ["a JavaScript URL", "javascript:alert(1)"],
+    ["an arbitrary candidate domain", "https://example.com/decision/123"],
+    ["a non-canonical Cour de cassation path", "https://www.courdecassation.fr/agenda"],
+  ])("never exposes %s as a clickable admin URL", (_label, rawUrl) => {
+    const summary = summarizeProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: URL,
+      metadata: { courtDecisionCandidate: { canonicalUrl: rawUrl, url: URL } },
+    });
+
+    expect(summary.canonicalUrl).toBeNull();
+    expect(summary.requestedUrl).toBe(rawUrl);
+    expect(summary.issues).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^url_administration_non_cliquable:/)])
+    );
+  });
+
+  it.each([
+    ["Légifrance", URL],
+    ["ArianeWeb", "https://www.conseil-etat.fr/fr/arianeweb/CE/decision/2024-06-19/472007"],
+  ])("keeps a canonical %s URL clickable in the admin summary", (_provider, rawUrl) => {
+    const summary = summarizeProposalOfficialEvidence({
+      source: "LEGIFRANCE",
+      sourceUrl: rawUrl,
+      metadata: { courtDecisionCandidate: { canonicalUrl: rawUrl } },
+    });
+
+    expect(summary.canonicalUrl).toBe(rawUrl);
+    expect(summary.requestedUrl).toBe(rawUrl);
   });
 
   it("rejects a source URL different from the decision candidate", async () => {

--- a/src/lib/affairs/__tests__/official-decision-verification.test.ts
+++ b/src/lib/affairs/__tests__/official-decision-verification.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  OFFICIAL_DECISION_VERIFICATION_STATUSES,
   isAcceptableOfficialDecisionVerification,
   summarizeProposalOfficialEvidence,
   summarizeProposalSourceLink,
@@ -58,30 +59,25 @@ describe("official decision verification", () => {
     vi.useRealTimers();
   });
 
-  it.each([
-    "VALID",
-    "REDIRECTED",
-    "INDEX_VERIFIED",
-    "BROKEN",
-    "MISMATCH",
-    "BLOCKED",
-    "UNCHECKED",
-  ] as const)("accepts only a direct VALID verification, not %s by declaration", (status) => {
-    expect(
-      isAcceptableOfficialDecisionVerification({
-        version: 1,
-        status,
-        checkedAt: "2026-08-18T09:00:00.000Z",
-        requestedUrl: URL,
-        resolvedUrl: URL,
-        httpStatus: status === "VALID" ? 200 : null,
-        contentHash: null,
-        matchedIdentifiers: [],
-        issues: [],
-        indexedProof: null,
-      })
-    ).toBe(status === "VALID");
-  });
+  it.each(OFFICIAL_DECISION_VERIFICATION_STATUSES)(
+    "accepts only a direct VALID verification, not %s by declaration",
+    (status) => {
+      expect(
+        isAcceptableOfficialDecisionVerification({
+          version: 1,
+          status,
+          checkedAt: "2026-08-18T09:00:00.000Z",
+          requestedUrl: URL,
+          resolvedUrl: URL,
+          httpStatus: status === "VALID" ? 200 : null,
+          contentHash: null,
+          matchedIdentifiers: [],
+          issues: [],
+          indexedProof: null,
+        })
+      ).toBe(status === "VALID");
+    }
+  );
 
   it("validates the URL, pourvoi, ECLI, date and official identifier together", async () => {
     const result = await verifyOfficialDecision(expectation(), {
@@ -441,8 +437,8 @@ describe("official decision verification", () => {
   });
 
   it.each([
-    ["HTTPS", "https://www.lemonde.fr/politique/article-test.html", true],
-    ["HTTP", "http://www.franceinfo.fr/politique/article-test", true],
+    ["HTTPS", "https://press.example.test/politique/article-test.html", true],
+    ["HTTP", "http://press.example.test/politique/article-test", true],
     ["JavaScript", "javascript:alert(1)", false],
     ["data", "data:text/html,<script>alert(1)</script>", false],
     ["credentials", "https://user:password@example.com/article", false],
@@ -455,7 +451,7 @@ describe("official decision verification", () => {
   });
 
   it("does not transform an ordinary press source into official decision evidence", async () => {
-    const sourceUrl = "https://www.lemonde.fr/politique/article-test.html";
+    const sourceUrl = "https://press.example.test/politique/article-test.html";
 
     expect(
       await verifyProposalOfficialEvidence({

--- a/src/lib/affairs/official-decision-verification.ts
+++ b/src/lib/affairs/official-decision-verification.ts
@@ -3,14 +3,28 @@ import { load } from "cheerio";
 import type { SourceType } from "@/generated/prisma";
 import { USER_AGENT } from "@/config/site";
 
+export const OFFICIAL_DECISION_VERIFICATION_STATUSES = [
+  "VALID",
+  "REDIRECTED",
+  "INDEX_VERIFIED",
+  "BROKEN",
+  "MISMATCH",
+  "BLOCKED",
+  "UNCHECKED",
+] as const;
+
 export type OfficialDecisionVerificationStatus =
-  | "VALID"
-  | "REDIRECTED"
-  | "INDEX_VERIFIED"
-  | "BROKEN"
-  | "MISMATCH"
-  | "BLOCKED"
-  | "UNCHECKED";
+  (typeof OFFICIAL_DECISION_VERIFICATION_STATUSES)[number];
+
+const OFFICIAL_DECISION_VERIFICATION_STATUS_SET: ReadonlySet<string> = new Set(
+  OFFICIAL_DECISION_VERIFICATION_STATUSES
+);
+
+function isOfficialDecisionVerificationStatus(
+  value: string
+): value is OfficialDecisionVerificationStatus {
+  return OFFICIAL_DECISION_VERIFICATION_STATUS_SET.has(value);
+}
 
 export interface OfficialDecisionIndexedProof {
   version: 1;
@@ -792,20 +806,8 @@ function verificationFromCandidate(
   candidate: Record<string, unknown>
 ): OfficialDecisionVerification | null {
   const verification = isRecord(candidate.verification) ? candidate.verification : null;
-  const status = asNonEmptyString(
-    verification?.status
-  ) as OfficialDecisionVerificationStatus | null;
-  if (!status) return null;
-  const validStatuses: OfficialDecisionVerificationStatus[] = [
-    "VALID",
-    "REDIRECTED",
-    "INDEX_VERIFIED",
-    "BROKEN",
-    "MISMATCH",
-    "BLOCKED",
-    "UNCHECKED",
-  ];
-  if (!validStatuses.includes(status)) return null;
+  const status = asNonEmptyString(verification?.status);
+  if (!status || !isOfficialDecisionVerificationStatus(status)) return null;
   return {
     version: 1,
     status,

--- a/src/lib/affairs/official-decision-verification.ts
+++ b/src/lib/affairs/official-decision-verification.ts
@@ -71,6 +71,11 @@ export interface ProposalOfficialEvidenceSummary {
   issues: string[];
 }
 
+export interface ProposalSourceLinkSummary {
+  rawUrl: string | null;
+  safeUrl: string | null;
+}
+
 type OfficialProvider = "LEGIFRANCE" | "COUR_DE_CASSATION" | "CONSEIL_ETAT";
 
 interface AllowedOfficialUrl {
@@ -104,6 +109,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Allows a moderator to open an ordinary editorial source without presenting it
+ * as verified judicial evidence. This validates URL structure only. It does not
+ * check reachability, redirects, paywalls or agreement with the proposed change.
+ */
+export function summarizeProposalSourceLink(sourceUrl: unknown): ProposalSourceLinkSummary {
+  const rawUrl = asNonEmptyString(sourceUrl);
+  if (!rawUrl) return { rawUrl: null, safeUrl: null };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { rawUrl, safeUrl: null };
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) {
+    return { rawUrl, safeUrl: null };
+  }
+
+  return { rawUrl, safeUrl: parsed.toString() };
 }
 
 function stripDiacritics(value: string): string {
@@ -358,7 +386,7 @@ function blockedOrIndexedResult(
       resolvedUrl: partial.resolvedUrl ?? url.url.toString(),
       httpStatus: partial.httpStatus ?? null,
       matchedIdentifiers: indexed.matchedIdentifiers,
-      issues: [issue, "url_officielle_confirmee_par_index_exact"],
+      issues: [issue, "reference_indexee_declaree_concordante"],
       indexedProof: indexed.proof,
     });
   }
@@ -719,7 +747,41 @@ export async function verifyAndAnnotateProposalOfficialEvidence(
   input: ProposalOfficialEvidenceInput,
   options: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}
 ): Promise<VerifiedProposalOfficialEvidence | null> {
-  const verified = await verifyProposalOfficialEvidence(input, options);
+  let verified = await verifyProposalOfficialEvidence(input, options);
+
+  if (verified?.verification.status === "REDIRECTED") {
+    const initialUrl = verified.verification.requestedUrl;
+    const direct = await verifyProposalOfficialEvidence(
+      {
+        ...input,
+        sourceUrl: verified.sourceUrl,
+        metadata: verified.metadata,
+      },
+      options
+    );
+
+    if (direct) {
+      const candidate = candidateFromMetadata(direct.metadata);
+      verified = candidate
+        ? {
+            ...direct,
+            metadata: {
+              ...direct.metadata,
+              courtDecisionCandidate: {
+                ...candidate,
+                urlNormalization: {
+                  initialUrl,
+                  finalUrl: direct.sourceUrl,
+                  normalizedAt: direct.verification.checkedAt,
+                  reason: "OFFICIAL_REDIRECT",
+                },
+              },
+            },
+          }
+        : direct;
+    }
+  }
+
   if (verified && !isSuccessfulOfficialDecisionVerification(verified.verification)) {
     throw new OfficialEvidenceVerificationError(verified.verification);
   }
@@ -773,10 +835,11 @@ export function summarizeProposalOfficialEvidence(
   const expectation = candidate ? expectationFromInput(input, candidate) : null;
   let acceptable = stored ? isAcceptableOfficialDecisionVerification(stored) : false;
   let issues = stored?.issues ?? [];
-  const requestedUrl =
-    asNonEmptyString(candidate?.canonicalUrl) ??
-    asNonEmptyString(candidate?.url) ??
-    asNonEmptyString(input.sourceUrl);
+  const requestedUrl = required
+    ? (asNonEmptyString(candidate?.canonicalUrl) ??
+      asNonEmptyString(candidate?.url) ??
+      asNonEmptyString(input.sourceUrl))
+    : null;
   const allowedLink = requestedUrl ? allowedOfficialUrl(requestedUrl) : null;
 
   if (allowedLink && !allowedLink.ok) {

--- a/src/lib/affairs/official-decision-verification.ts
+++ b/src/lib/affairs/official-decision-verification.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { load } from "cheerio";
 import type { SourceType } from "@/generated/prisma";
 import { USER_AGENT } from "@/config/site";
 
@@ -109,15 +110,11 @@ function stripDiacritics(value: string): string {
 }
 
 function normalizeText(value: string): string {
+  const $ = load(value);
+  $("script, style").remove();
   return stripDiacritics(
-    value
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
-      .replace(/<[^>]+>/g, " ")
-      .replace(/&nbsp;|&#160;/gi, " ")
-      .replace(/&amp;/gi, "&")
-      .replace(/&quot;|&#34;/gi, '"')
-      .replace(/&#39;|&apos;/gi, "'")
+    $.root()
+      .text()
       .replace(/[\u2010-\u2015\u2212]/g, "-")
   )
     .toLowerCase()

--- a/src/lib/affairs/official-decision-verification.ts
+++ b/src/lib/affairs/official-decision-verification.ts
@@ -1,0 +1,802 @@
+import { createHash } from "node:crypto";
+import type { SourceType } from "@/generated/prisma";
+import { USER_AGENT } from "@/config/site";
+
+export type OfficialDecisionVerificationStatus =
+  | "VALID"
+  | "REDIRECTED"
+  | "INDEX_VERIFIED"
+  | "BROKEN"
+  | "MISMATCH"
+  | "BLOCKED"
+  | "UNCHECKED";
+
+export interface OfficialDecisionIndexedProof {
+  version: 1;
+  exactUrl: string;
+  verifiedAt: string;
+  method: "EXACT_OFFICIAL_SEARCH_RESULT";
+  title: string;
+  publisher: string;
+  pourvoi?: string | null;
+  ecli?: string | null;
+  decisionDate?: string | null;
+  officialId?: string | null;
+}
+
+export interface OfficialDecisionExpectation {
+  url: string;
+  pourvoi?: string | null;
+  ecli?: string | null;
+  decisionDate?: string | null;
+  officialId?: string | null;
+  indexedProof?: OfficialDecisionIndexedProof | null;
+}
+
+export interface OfficialDecisionVerification {
+  version: 1;
+  status: OfficialDecisionVerificationStatus;
+  checkedAt: string;
+  requestedUrl: string;
+  resolvedUrl: string | null;
+  httpStatus: number | null;
+  contentHash: string | null;
+  matchedIdentifiers: string[];
+  issues: string[];
+  indexedProof: OfficialDecisionIndexedProof | null;
+}
+
+export interface ProposalOfficialEvidenceInput {
+  source?: SourceType | string | null;
+  sourceUrl?: string | null;
+  officialId?: string | null;
+  metadata?: unknown;
+}
+
+export interface VerifiedProposalOfficialEvidence {
+  sourceUrl: string;
+  metadata: Record<string, unknown>;
+  verification: OfficialDecisionVerification;
+}
+
+export interface ProposalOfficialEvidenceSummary {
+  required: boolean;
+  acceptable: boolean;
+  canonicalUrl: string | null;
+  status: OfficialDecisionVerificationStatus | null;
+  checkedAt: string | null;
+  matchedIdentifiers: string[];
+  issues: string[];
+}
+
+type OfficialProvider = "LEGIFRANCE" | "COUR_DE_CASSATION" | "CONSEIL_ETAT";
+
+interface AllowedOfficialUrl {
+  url: URL;
+  provider: OfficialProvider;
+  officialId: string;
+}
+
+const OFFICIAL_SOURCE_TYPES = new Set(["LEGIFRANCE", "JUDILIBRE"]);
+const INDEXED_PROOF_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_REDIRECTS = 3;
+
+const FRENCH_MONTHS = [
+  "janvier",
+  "fevrier",
+  "mars",
+  "avril",
+  "mai",
+  "juin",
+  "juillet",
+  "aout",
+  "septembre",
+  "octobre",
+  "novembre",
+  "decembre",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stripDiacritics(value: string): string {
+  return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function normalizeText(value: string): string {
+  return stripDiacritics(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&nbsp;|&#160;/gi, " ")
+      .replace(/&amp;/gi, "&")
+      .replace(/&quot;|&#34;/gi, '"')
+      .replace(/&#39;|&apos;/gi, "'")
+      .replace(/[\u2010-\u2015\u2212]/g, "-")
+  )
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compactIdentifier(value: string): string {
+  return stripDiacritics(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+function canonicalUrl(url: URL): URL {
+  const normalized = new URL(url);
+  normalized.hash = "";
+  normalized.search = "";
+  if (normalized.pathname.length > 1) {
+    normalized.pathname = normalized.pathname.replace(/\/+$/, "");
+  }
+  return normalized;
+}
+
+function sameUrl(left: string, right: string): boolean {
+  return canonicalUrl(new URL(left)).toString() === canonicalUrl(new URL(right)).toString();
+}
+
+function allowedOfficialUrl(
+  rawUrl: string
+): { ok: true; value: AllowedOfficialUrl } | { ok: false; issue: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, issue: "url_invalide" };
+  }
+
+  if (parsed.protocol !== "https:") return { ok: false, issue: "protocole_non_https" };
+  if (parsed.username || parsed.password || (parsed.port && parsed.port !== "443")) {
+    return { ok: false, issue: "autorite_url_non_autorisee" };
+  }
+
+  const url = canonicalUrl(parsed);
+  const host = url.hostname.toLowerCase();
+  let match: RegExpExecArray | null;
+
+  if (host === "legifrance.gouv.fr" || host === "www.legifrance.gouv.fr") {
+    match = /^\/juri\/id\/(JURITEXT[0-9]+)$/i.exec(url.pathname);
+    if (!match) return { ok: false, issue: "chemin_legifrance_non_canonique" };
+    return {
+      ok: true,
+      value: { url, provider: "LEGIFRANCE", officialId: match[1]!.toUpperCase() },
+    };
+  }
+
+  if (host === "courdecassation.fr" || host === "www.courdecassation.fr") {
+    match = /^\/decision\/([a-f0-9]+)$/i.exec(url.pathname);
+    if (!match) return { ok: false, issue: "chemin_judilibre_non_canonique" };
+    return {
+      ok: true,
+      value: { url, provider: "COUR_DE_CASSATION", officialId: match[1]!.toLowerCase() },
+    };
+  }
+
+  if (host === "conseil-etat.fr" || host === "www.conseil-etat.fr") {
+    match =
+      /^\/fr\/arianeweb\/(?:CE|JADE|TC)\/decision\/[0-9]{4}-[0-9]{2}-[0-9]{2}\/([A-Za-z0-9.-]+)$/i.exec(
+        url.pathname
+      );
+    if (!match) return { ok: false, issue: "chemin_arianeweb_non_canonique" };
+    return {
+      ok: true,
+      value: { url, provider: "CONSEIL_ETAT", officialId: match[1]! },
+    };
+  }
+
+  return { ok: false, issue: "hote_officiel_non_autorise" };
+}
+
+function dateVariants(rawDate: string): string[] {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(rawDate);
+  if (!match) return [normalizeText(rawDate)];
+  const [, year, month, day] = match;
+  const monthName = FRENCH_MONTHS[Number(month) - 1];
+  if (!monthName) return [normalizeText(rawDate)];
+  return [
+    `${year}-${month}-${day}`,
+    `${day}/${month}/${year}`,
+    `${day}-${month}-${year}`,
+    `${Number(day)} ${monthName} ${year}`,
+  ].map(normalizeText);
+}
+
+function verificationResult(
+  expectation: OfficialDecisionExpectation,
+  status: OfficialDecisionVerificationStatus,
+  partial: Partial<
+    Omit<OfficialDecisionVerification, "version" | "status" | "checkedAt" | "requestedUrl">
+  > = {}
+): OfficialDecisionVerification {
+  return {
+    version: 1,
+    status,
+    checkedAt: new Date().toISOString(),
+    requestedUrl: expectation.url,
+    resolvedUrl: partial.resolvedUrl ?? null,
+    httpStatus: partial.httpStatus ?? null,
+    contentHash: partial.contentHash ?? null,
+    matchedIdentifiers: partial.matchedIdentifiers ?? [],
+    issues: partial.issues ?? [],
+    indexedProof: partial.indexedProof ?? null,
+  };
+}
+
+export function isSuccessfulOfficialDecisionVerification(
+  verification: OfficialDecisionVerification
+): boolean {
+  return ["VALID", "REDIRECTED", "INDEX_VERIFIED"].includes(verification.status);
+}
+
+export function isAcceptableOfficialDecisionVerification(
+  verification: OfficialDecisionVerification
+): boolean {
+  return verification.status === "VALID" || verification.status === "INDEX_VERIFIED";
+}
+
+function expectedValues(expectation: OfficialDecisionExpectation) {
+  return {
+    pourvoi: asNonEmptyString(expectation.pourvoi),
+    ecli: asNonEmptyString(expectation.ecli),
+    decisionDate: asNonEmptyString(expectation.decisionDate),
+    officialId: asNonEmptyString(expectation.officialId),
+  };
+}
+
+function expectationIssues(
+  expectation: OfficialDecisionExpectation,
+  url: AllowedOfficialUrl
+): string[] {
+  const expected = expectedValues(expectation);
+  const issues: string[] = [];
+  if (!expected.officialId) issues.push("identifiant_officiel_attendu_absent");
+  if (!expected.decisionDate) issues.push("date_decision_attendue_absente");
+  if (!expected.pourvoi && !expected.ecli) {
+    issues.push("pourvoi_ou_ecli_attendu_absent");
+  }
+  if (
+    expected.officialId &&
+    compactIdentifier(expected.officialId) !== compactIdentifier(url.officialId)
+  ) {
+    issues.push("url_et_identifiant_officiel_differents");
+  }
+  return issues;
+}
+
+function expectedPublisher(provider: OfficialProvider): string {
+  if (provider === "LEGIFRANCE") return "legifrance";
+  if (provider === "COUR_DE_CASSATION") return "cour de cassation";
+  return "conseil d'etat";
+}
+
+function validateIndexedProof(
+  expectation: OfficialDecisionExpectation,
+  url: AllowedOfficialUrl
+): { proof: OfficialDecisionIndexedProof | null; issues: string[]; matchedIdentifiers: string[] } {
+  const proof = expectation.indexedProof ?? null;
+  if (!proof) return { proof: null, issues: ["preuve_indexee_absente"], matchedIdentifiers: [] };
+
+  const issues: string[] = [];
+  const matchedIdentifiers: string[] = [];
+  if (proof.version !== 1 || proof.method !== "EXACT_OFFICIAL_SEARCH_RESULT") {
+    issues.push("preuve_indexee_format_invalide");
+  }
+
+  const title = asNonEmptyString(proof.title);
+  const publisher = asNonEmptyString(proof.publisher);
+  if (!title || !publisher) issues.push("preuve_indexee_incomplete");
+  if (publisher && normalizeText(publisher) !== expectedPublisher(url.provider)) {
+    issues.push("preuve_indexee_editeur_different");
+  }
+
+  const verifiedAt = Date.parse(proof.verifiedAt);
+  const age = Date.now() - verifiedAt;
+  if (!Number.isFinite(verifiedAt) || age < -5 * 60 * 1000 || age > INDEXED_PROOF_MAX_AGE_MS) {
+    issues.push("preuve_indexee_expiree_ou_date_invalide");
+  }
+
+  try {
+    if (!sameUrl(expectation.url, proof.exactUrl)) issues.push("preuve_indexee_url_differente");
+  } catch {
+    issues.push("preuve_indexee_url_invalide");
+  }
+
+  const expected = expectedValues(expectation);
+  const compare = (name: keyof typeof expected, actual: string | null | undefined): void => {
+    const wanted = expected[name];
+    if (!wanted) return;
+    if (!actual || compactIdentifier(actual) !== compactIdentifier(wanted)) {
+      issues.push(`preuve_indexee_${name}_different`);
+    } else {
+      matchedIdentifiers.push(name);
+    }
+  };
+
+  compare("pourvoi", proof.pourvoi);
+  compare("ecli", proof.ecli);
+  compare("decisionDate", proof.decisionDate);
+  compare("officialId", proof.officialId);
+
+  if (
+    title &&
+    expected.pourvoi &&
+    !compactIdentifier(title).includes(compactIdentifier(expected.pourvoi))
+  ) {
+    issues.push("preuve_indexee_titre_sans_pourvoi");
+  }
+  if (
+    title &&
+    expected.decisionDate &&
+    !dateVariants(expected.decisionDate).some((variant) => normalizeText(title).includes(variant))
+  ) {
+    issues.push("preuve_indexee_titre_sans_date");
+  }
+
+  return { proof, issues, matchedIdentifiers };
+}
+
+function blockedOrIndexedResult(
+  expectation: OfficialDecisionExpectation,
+  url: AllowedOfficialUrl,
+  issue: string,
+  partial: { resolvedUrl?: string | null; httpStatus?: number | null } = {}
+): OfficialDecisionVerification {
+  const indexed = validateIndexedProof(expectation, url);
+  if (indexed.proof && indexed.issues.length === 0) {
+    return verificationResult(expectation, "INDEX_VERIFIED", {
+      resolvedUrl: partial.resolvedUrl ?? url.url.toString(),
+      httpStatus: partial.httpStatus ?? null,
+      matchedIdentifiers: indexed.matchedIdentifiers,
+      issues: [issue, "url_officielle_confirmee_par_index_exact"],
+      indexedProof: indexed.proof,
+    });
+  }
+  return verificationResult(expectation, "BLOCKED", {
+    resolvedUrl: partial.resolvedUrl ?? null,
+    httpStatus: partial.httpStatus ?? null,
+    issues: [issue, ...indexed.issues],
+    indexedProof: indexed.proof,
+  });
+}
+
+async function fetchOfficialDecision(
+  initial: AllowedOfficialUrl,
+  options: { fetchImpl?: typeof fetch; signal: AbortSignal }
+): Promise<
+  | { ok: true; response: Response; resolved: AllowedOfficialUrl; redirected: boolean }
+  | { ok: false; issue: string; resolvedUrl: string | null; httpStatus: number | null }
+> {
+  let current = initial;
+  let redirected = false;
+  const visited = new Set<string>();
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+    const currentUrl = current.url.toString();
+    if (visited.has(currentUrl)) {
+      return { ok: false, issue: "boucle_redirection", resolvedUrl: currentUrl, httpStatus: null };
+    }
+    visited.add(currentUrl);
+
+    const requestInit: RequestInit = {
+      method: "GET",
+      redirect: "manual",
+      signal: options.signal,
+      headers: { accept: "text/html,application/xhtml+xml" },
+    };
+    const response = options.fetchImpl
+      ? await options.fetchImpl(current.url, requestInit)
+      : await fetch(current.url, {
+          ...requestInit,
+          headers: { accept: "text/html,application/xhtml+xml", "User-Agent": USER_AGENT },
+        });
+
+    if (response.status < 300 || response.status >= 400) {
+      const responseUrl = response.url || currentUrl;
+      const resolved = allowedOfficialUrl(responseUrl);
+      if (!resolved.ok) {
+        return {
+          ok: false,
+          issue: `reponse_url_non_autorisee:${resolved.issue}`,
+          resolvedUrl: responseUrl,
+          httpStatus: response.status,
+        };
+      }
+      return { ok: true, response, resolved: resolved.value, redirected };
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      return {
+        ok: false,
+        issue: "redirection_sans_destination",
+        resolvedUrl: currentUrl,
+        httpStatus: response.status,
+      };
+    }
+
+    const destination = allowedOfficialUrl(new URL(location, current.url).toString());
+    if (!destination.ok) {
+      return {
+        ok: false,
+        issue: `redirection_non_autorisee:${destination.issue}`,
+        resolvedUrl: new URL(location, current.url).toString(),
+        httpStatus: response.status,
+      };
+    }
+    current = destination.value;
+    redirected = true;
+  }
+
+  return {
+    ok: false,
+    issue: "trop_de_redirections",
+    resolvedUrl: current.url.toString(),
+    httpStatus: null,
+  };
+}
+
+export async function verifyOfficialDecision(
+  expectation: OfficialDecisionExpectation,
+  options: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}
+): Promise<OfficialDecisionVerification> {
+  const allowed = allowedOfficialUrl(expectation.url);
+  if (!allowed.ok) {
+    return verificationResult(expectation, "BLOCKED", { issues: [allowed.issue] });
+  }
+
+  const missing = expectationIssues(expectation, allowed.value);
+  if (missing.length > 0) {
+    return verificationResult(expectation, "UNCHECKED", { issues: missing });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 12_000);
+  let fetched: Awaited<ReturnType<typeof fetchOfficialDecision>>;
+  try {
+    fetched = await fetchOfficialDecision(allowed.value, {
+      fetchImpl: options.fetchImpl,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const issue =
+      error instanceof Error && error.name === "AbortError" ? "delai_depasse" : "erreur_reseau";
+    return blockedOrIndexedResult(expectation, allowed.value, issue);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!fetched.ok) {
+    return verificationResult(expectation, "BLOCKED", {
+      resolvedUrl: fetched.resolvedUrl,
+      httpStatus: fetched.httpStatus,
+      issues: [fetched.issue],
+    });
+  }
+
+  const { response, resolved, redirected } = fetched;
+  const resolvedUrl = resolved.url.toString();
+  if (compactIdentifier(resolved.officialId) !== compactIdentifier(allowed.value.officialId)) {
+    return verificationResult(expectation, "MISMATCH", {
+      resolvedUrl,
+      httpStatus: response.status,
+      issues: ["redirection_vers_autre_decision"],
+    });
+  }
+
+  if (response.status === 404 || response.status === 410) {
+    return verificationResult(expectation, "BROKEN", {
+      resolvedUrl,
+      httpStatus: response.status,
+      issues: [`http_${response.status}`],
+    });
+  }
+  if ([401, 403, 429].includes(response.status) || response.status >= 500) {
+    return blockedOrIndexedResult(expectation, allowed.value, `http_${response.status}`, {
+      resolvedUrl,
+      httpStatus: response.status,
+    });
+  }
+  if (!response.ok) {
+    return verificationResult(expectation, "BROKEN", {
+      resolvedUrl,
+      httpStatus: response.status,
+      issues: [`http_${response.status}`],
+    });
+  }
+
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    return blockedOrIndexedResult(expectation, allowed.value, "lecture_reponse_impossible", {
+      resolvedUrl,
+      httpStatus: response.status,
+    });
+  }
+  const normalized = normalizeText(body);
+  const compact = compactIdentifier(normalized);
+  const expected = expectedValues(expectation);
+  const matchedIdentifiers: string[] = ["officialId"];
+  const issues: string[] = [];
+
+  if (expected.pourvoi) {
+    if (compact.includes(compactIdentifier(expected.pourvoi))) matchedIdentifiers.push("pourvoi");
+    else issues.push("pourvoi_absent_ou_different");
+  }
+  if (expected.ecli) {
+    if (normalized.includes(normalizeText(expected.ecli))) matchedIdentifiers.push("ecli");
+    else issues.push("ecli_absent_ou_different");
+  }
+  if (expected.decisionDate) {
+    if (dateVariants(expected.decisionDate).some((variant) => normalized.includes(variant))) {
+      matchedIdentifiers.push("decisionDate");
+    } else {
+      issues.push("date_decision_absente_ou_differente");
+    }
+  }
+
+  const contentHash = createHash("sha256").update(body).digest("hex");
+  if (issues.length > 0) {
+    return verificationResult(expectation, "MISMATCH", {
+      resolvedUrl,
+      httpStatus: response.status,
+      contentHash,
+      matchedIdentifiers,
+      issues,
+    });
+  }
+
+  return verificationResult(expectation, redirected ? "REDIRECTED" : "VALID", {
+    resolvedUrl,
+    httpStatus: response.status,
+    contentHash,
+    matchedIdentifiers,
+  });
+}
+
+function candidateFromMetadata(metadata: unknown): Record<string, unknown> | null {
+  if (!isRecord(metadata)) return null;
+  return isRecord(metadata.courtDecisionCandidate) ? metadata.courtDecisionCandidate : null;
+}
+
+function indexedProofFromCandidate(value: unknown): OfficialDecisionIndexedProof | null {
+  if (!isRecord(value)) return null;
+  const exactUrl = asNonEmptyString(value.exactUrl);
+  const verifiedAt = asNonEmptyString(value.verifiedAt);
+  const title = asNonEmptyString(value.title);
+  const publisher = asNonEmptyString(value.publisher);
+  if (
+    value.version !== 1 ||
+    value.method !== "EXACT_OFFICIAL_SEARCH_RESULT" ||
+    !exactUrl ||
+    !verifiedAt ||
+    !title ||
+    !publisher
+  ) {
+    return null;
+  }
+  return {
+    version: 1,
+    exactUrl,
+    verifiedAt,
+    method: "EXACT_OFFICIAL_SEARCH_RESULT",
+    title,
+    publisher,
+    pourvoi: asNonEmptyString(value.pourvoi),
+    ecli: asNonEmptyString(value.ecli),
+    decisionDate: asNonEmptyString(value.decisionDate),
+    officialId: asNonEmptyString(value.officialId),
+  };
+}
+
+function hasCanonicalOfficialUrl(value: string | null): boolean {
+  return value ? allowedOfficialUrl(value).ok : false;
+}
+
+function evidenceRequired(input: ProposalOfficialEvidenceInput): boolean {
+  return (
+    candidateFromMetadata(input.metadata) !== null ||
+    OFFICIAL_SOURCE_TYPES.has(input.source ?? "") ||
+    hasCanonicalOfficialUrl(asNonEmptyString(input.sourceUrl))
+  );
+}
+
+function expectationFromInput(
+  input: ProposalOfficialEvidenceInput,
+  candidate: Record<string, unknown>
+): OfficialDecisionExpectation | null {
+  const url =
+    asNonEmptyString(candidate.canonicalUrl) ??
+    asNonEmptyString(candidate.url) ??
+    asNonEmptyString(input.sourceUrl);
+  if (!url) return null;
+
+  const inputOfficialId = asNonEmptyString(input.officialId);
+  const providerId =
+    asNonEmptyString(candidate.legifranceId) ??
+    asNonEmptyString(candidate.judilibreId) ??
+    asNonEmptyString(candidate.officialId) ??
+    (inputOfficialId && /^(?:JURITEXT[0-9]+|[a-f0-9]{16,})$/i.test(inputOfficialId)
+      ? inputOfficialId
+      : null);
+
+  return {
+    url,
+    pourvoi: asNonEmptyString(candidate.pourvoi) ?? (providerId ? null : inputOfficialId),
+    ecli: asNonEmptyString(candidate.ecli),
+    decisionDate: asNonEmptyString(candidate.date) ?? asNonEmptyString(candidate.decisionDate),
+    officialId: providerId,
+    indexedProof: indexedProofFromCandidate(candidate.indexedProof),
+  };
+}
+
+export async function verifyProposalOfficialEvidence(
+  input: ProposalOfficialEvidenceInput,
+  options: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}
+): Promise<VerifiedProposalOfficialEvidence | null> {
+  if (!evidenceRequired(input)) return null;
+
+  const metadata = isRecord(input.metadata) ? input.metadata : {};
+  const candidate = candidateFromMetadata(metadata);
+  if (!candidate) {
+    return {
+      sourceUrl: asNonEmptyString(input.sourceUrl) ?? "",
+      metadata,
+      verification: verificationResult(
+        { url: asNonEmptyString(input.sourceUrl) ?? "" },
+        "UNCHECKED",
+        { issues: ["decision_officielle_candidate_absente"] }
+      ),
+    };
+  }
+
+  const expectation = expectationFromInput(input, candidate);
+  if (!expectation) {
+    return {
+      sourceUrl: asNonEmptyString(input.sourceUrl) ?? "",
+      metadata,
+      verification: verificationResult({ url: "" }, "UNCHECKED", {
+        issues: ["url_decision_absente"],
+      }),
+    };
+  }
+
+  const sourceUrl = asNonEmptyString(input.sourceUrl) ?? expectation.url;
+  try {
+    if (!sameUrl(sourceUrl, expectation.url)) {
+      return {
+        sourceUrl,
+        metadata,
+        verification: verificationResult(expectation, "MISMATCH", {
+          issues: ["source_url_et_decision_candidate_differentes"],
+        }),
+      };
+    }
+  } catch {
+    return {
+      sourceUrl,
+      metadata,
+      verification: verificationResult(expectation, "BLOCKED", { issues: ["url_invalide"] }),
+    };
+  }
+
+  const verification = await verifyOfficialDecision(expectation, options);
+  const resolvedUrl = verification.resolvedUrl ?? expectation.url;
+  return {
+    sourceUrl: resolvedUrl,
+    metadata: {
+      ...metadata,
+      courtDecisionCandidate: {
+        ...candidate,
+        url: resolvedUrl,
+        canonicalUrl: resolvedUrl,
+        verification,
+      },
+    },
+    verification,
+  };
+}
+
+export class OfficialEvidenceVerificationError extends Error {
+  constructor(readonly verification: OfficialDecisionVerification) {
+    super(`La décision officielle n'est pas vérifiée (${verification.status})`);
+    this.name = "OfficialEvidenceVerificationError";
+  }
+}
+
+export async function verifyAndAnnotateProposalOfficialEvidence(
+  input: ProposalOfficialEvidenceInput,
+  options: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}
+): Promise<VerifiedProposalOfficialEvidence | null> {
+  const verified = await verifyProposalOfficialEvidence(input, options);
+  if (verified && !isSuccessfulOfficialDecisionVerification(verified.verification)) {
+    throw new OfficialEvidenceVerificationError(verified.verification);
+  }
+  return verified;
+}
+
+function verificationFromCandidate(
+  candidate: Record<string, unknown>
+): OfficialDecisionVerification | null {
+  const verification = isRecord(candidate.verification) ? candidate.verification : null;
+  const status = asNonEmptyString(
+    verification?.status
+  ) as OfficialDecisionVerificationStatus | null;
+  if (!status) return null;
+  const validStatuses: OfficialDecisionVerificationStatus[] = [
+    "VALID",
+    "REDIRECTED",
+    "INDEX_VERIFIED",
+    "BROKEN",
+    "MISMATCH",
+    "BLOCKED",
+    "UNCHECKED",
+  ];
+  if (!validStatuses.includes(status)) return null;
+  return {
+    version: 1,
+    status,
+    checkedAt: asNonEmptyString(verification?.checkedAt) ?? "",
+    requestedUrl: asNonEmptyString(verification?.requestedUrl) ?? "",
+    resolvedUrl: asNonEmptyString(verification?.resolvedUrl),
+    httpStatus: typeof verification?.httpStatus === "number" ? verification.httpStatus : null,
+    contentHash: asNonEmptyString(verification?.contentHash),
+    matchedIdentifiers: Array.isArray(verification?.matchedIdentifiers)
+      ? verification.matchedIdentifiers.filter(
+          (value): value is string => typeof value === "string"
+        )
+      : [],
+    issues: Array.isArray(verification?.issues)
+      ? verification.issues.filter((value): value is string => typeof value === "string")
+      : [],
+    indexedProof: indexedProofFromCandidate(verification?.indexedProof ?? candidate.indexedProof),
+  };
+}
+
+export function summarizeProposalOfficialEvidence(
+  input: ProposalOfficialEvidenceInput
+): ProposalOfficialEvidenceSummary {
+  const required = evidenceRequired(input);
+  const candidate = candidateFromMetadata(input.metadata);
+  const stored = candidate ? verificationFromCandidate(candidate) : null;
+  const expectation = candidate ? expectationFromInput(input, candidate) : null;
+  let acceptable = stored ? isAcceptableOfficialDecisionVerification(stored) : false;
+  let issues = stored?.issues ?? [];
+
+  if (stored?.status === "INDEX_VERIFIED" && expectation) {
+    const allowed = allowedOfficialUrl(expectation.url);
+    if (!allowed.ok) {
+      acceptable = false;
+      issues = [...issues, allowed.issue];
+    } else {
+      const indexed = validateIndexedProof(expectation, allowed.value);
+      if (indexed.issues.length > 0) {
+        acceptable = false;
+        issues = [...new Set([...issues, ...indexed.issues])];
+      }
+    }
+  }
+
+  return {
+    required,
+    acceptable,
+    canonicalUrl:
+      asNonEmptyString(candidate?.canonicalUrl) ??
+      asNonEmptyString(candidate?.url) ??
+      asNonEmptyString(input.sourceUrl),
+    status: stored?.status ?? null,
+    checkedAt: asNonEmptyString(stored?.checkedAt),
+    matchedIdentifiers: stored?.matchedIdentifiers ?? [],
+    issues,
+  };
+}

--- a/src/lib/affairs/official-decision-verification.ts
+++ b/src/lib/affairs/official-decision-verification.ts
@@ -64,6 +64,7 @@ export interface ProposalOfficialEvidenceSummary {
   required: boolean;
   acceptable: boolean;
   canonicalUrl: string | null;
+  requestedUrl: string | null;
   status: OfficialDecisionVerificationStatus | null;
   checkedAt: string | null;
   matchedIdentifiers: string[];
@@ -238,7 +239,10 @@ export function isSuccessfulOfficialDecisionVerification(
 export function isAcceptableOfficialDecisionVerification(
   verification: OfficialDecisionVerification
 ): boolean {
-  return verification.status === "VALID" || verification.status === "INDEX_VERIFIED";
+  // INDEX_VERIFIED is supplied through importer-controlled metadata. Its internal
+  // consistency helps a moderator, but it is not independent provenance. A future
+  // persisted or signed official proof may introduce a separate trusted path.
+  return verification.status === "VALID";
 }
 
 function expectedValues(expectation: OfficialDecisionExpectation) {
@@ -769,6 +773,15 @@ export function summarizeProposalOfficialEvidence(
   const expectation = candidate ? expectationFromInput(input, candidate) : null;
   let acceptable = stored ? isAcceptableOfficialDecisionVerification(stored) : false;
   let issues = stored?.issues ?? [];
+  const requestedUrl =
+    asNonEmptyString(candidate?.canonicalUrl) ??
+    asNonEmptyString(candidate?.url) ??
+    asNonEmptyString(input.sourceUrl);
+  const allowedLink = requestedUrl ? allowedOfficialUrl(requestedUrl) : null;
+
+  if (allowedLink && !allowedLink.ok) {
+    issues = [...new Set([...issues, `url_administration_non_cliquable:${allowedLink.issue}`])];
+  }
 
   if (stored?.status === "INDEX_VERIFIED" && expectation) {
     const allowed = allowedOfficialUrl(expectation.url);
@@ -787,10 +800,8 @@ export function summarizeProposalOfficialEvidence(
   return {
     required,
     acceptable,
-    canonicalUrl:
-      asNonEmptyString(candidate?.canonicalUrl) ??
-      asNonEmptyString(candidate?.url) ??
-      asNonEmptyString(input.sourceUrl),
+    canonicalUrl: allowedLink?.ok ? allowedLink.value.url.toString() : null,
+    requestedUrl,
     status: stored?.status ?? null,
     checkedAt: asNonEmptyString(stored?.checkedAt),
     matchedIdentifiers: stored?.matchedIdentifiers ?? [],

--- a/src/services/affairs/__tests__/proposal-official-evidence.test.ts
+++ b/src/services/affairs/__tests__/proposal-official-evidence.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
   db: {
-    affair: { findUnique: vi.fn() },
+    affair: { findUnique: vi.fn(), update: vi.fn() },
     affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
   },
   verifyAndAnnotateProposalOfficialEvidence: vi.fn(),
@@ -19,6 +19,24 @@ vi.mock("@/lib/affairs/official-decision-verification", async (importOriginal) =
 });
 
 import { proposeAffairUpdate } from "../proposals";
+
+const INITIAL_URL = "https://www.legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+const NORMALIZED_URL = "https://legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+const DECISION_BODY = "N° 23-82.194 ECLI:FR:CCASS:2024:CR00817 19 JUIN 2024 REJET";
+
+function response(
+  body: string,
+  init: { status?: number; url?: string; headers?: HeadersInit } = {}
+): Response {
+  const status = init.status ?? 200;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url: init.url ?? INITIAL_URL,
+    headers: new Headers(init.headers),
+    text: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
 
 describe("official evidence on proposal creation", () => {
   beforeEach(() => {
@@ -104,6 +122,110 @@ describe("official evidence on proposal creation", () => {
       })
     );
   });
+
+  it("stores the final URL as VALID after a bounded direct redirect verification", async () => {
+    const actual = await vi.importActual<
+      typeof import("@/lib/affairs/official-decision-verification")
+    >("@/lib/affairs/official-decision-verification");
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response("", { status: 302, headers: { location: NORMALIZED_URL } }))
+      .mockResolvedValueOnce(response(DECISION_BODY, { url: NORMALIZED_URL }))
+      .mockResolvedValueOnce(response(DECISION_BODY, { url: NORMALIZED_URL }));
+    h.verifyAndAnnotateProposalOfficialEvidence.mockImplementation((input) =>
+      actual.verifyAndAnnotateProposalOfficialEvidence(input, { fetchImpl })
+    );
+
+    await proposeAffairUpdate({
+      affairId: "affair-1",
+      importer: "test",
+      importRunId: "run-redirect",
+      patch: { fineAmount: "50000.00" },
+      source: "LEGIFRANCE",
+      sourceUrl: INITIAL_URL,
+      officialId: "JURITEXT000049774995",
+      metadata: {
+        courtDecisionCandidate: {
+          url: INITIAL_URL,
+          pourvoi: "23-82.194",
+          ecli: "FR:CCASS:2024:CR00817",
+          date: "2024-06-19",
+          legifranceId: "JURITEXT000049774995",
+        },
+      },
+      confidence: 99,
+      rationale: "Décision officielle redirigée vers son URL canonique.",
+    });
+
+    const created = h.db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(created.sourceUrl).toBe(NORMALIZED_URL);
+    expect(created.metadata).toMatchObject({
+      courtDecisionCandidate: {
+        canonicalUrl: NORMALIZED_URL,
+        verification: { status: "VALID" },
+        urlNormalization: {
+          initialUrl: INITIAL_URL,
+          finalUrl: NORMALIZED_URL,
+          reason: "OFFICIAL_REDIRECT",
+        },
+      },
+    });
+    expect(h.db.affair.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "MISMATCH",
+      response("N° 23-82.999 ECLI:FR:CCASS:2024:CR00999 20 JUIN 2024", {
+        url: NORMALIZED_URL,
+      }),
+    ],
+    ["BLOCKED", response("Forbidden", { status: 403, url: NORMALIZED_URL })],
+  ])(
+    "does not create a proposal when direct verification after a redirect is %s",
+    async (expectedStatus, finalResponse) => {
+      const actual = await vi.importActual<
+        typeof import("@/lib/affairs/official-decision-verification")
+      >("@/lib/affairs/official-decision-verification");
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(response("", { status: 302, headers: { location: NORMALIZED_URL } }))
+        .mockResolvedValueOnce(response(DECISION_BODY, { url: NORMALIZED_URL }))
+        .mockResolvedValueOnce(finalResponse);
+      h.verifyAndAnnotateProposalOfficialEvidence.mockImplementation((input) =>
+        actual.verifyAndAnnotateProposalOfficialEvidence(input, { fetchImpl })
+      );
+
+      await expect(
+        proposeAffairUpdate({
+          affairId: "affair-1",
+          importer: "test",
+          importRunId: `run-redirect-${expectedStatus}`,
+          patch: { fineAmount: "50000.00" },
+          source: "LEGIFRANCE",
+          sourceUrl: INITIAL_URL,
+          officialId: "JURITEXT000049774995",
+          metadata: {
+            courtDecisionCandidate: {
+              url: INITIAL_URL,
+              pourvoi: "23-82.194",
+              ecli: "FR:CCASS:2024:CR00817",
+              date: "2024-06-19",
+              legifranceId: "JURITEXT000049774995",
+            },
+          },
+          confidence: 99,
+          rationale: "Décision officielle redirigée vers son URL canonique.",
+        })
+      ).rejects.toMatchObject({ verification: { status: expectedStatus } });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+      expect(h.db.affair.findUnique).not.toHaveBeenCalled();
+      expect(h.db.affairUpdateProposal.create).not.toHaveBeenCalled();
+      expect(h.db.affair.update).not.toHaveBeenCalled();
+    }
+  );
 
   it("does not query or write when evidence verification fails", async () => {
     h.verifyAndAnnotateProposalOfficialEvidence.mockRejectedValue(

--- a/src/services/affairs/__tests__/proposal-official-evidence.test.ts
+++ b/src/services/affairs/__tests__/proposal-official-evidence.test.ts
@@ -126,4 +126,38 @@ describe("official evidence on proposal creation", () => {
     expect(h.db.affair.findUnique).not.toHaveBeenCalled();
     expect(h.db.affairUpdateProposal.create).not.toHaveBeenCalled();
   });
+
+  it("does not construct an official URL when identifiers are present without a URL", async () => {
+    const actual = await vi.importActual<
+      typeof import("@/lib/affairs/official-decision-verification")
+    >("@/lib/affairs/official-decision-verification");
+    h.verifyAndAnnotateProposalOfficialEvidence.mockImplementation((input) =>
+      actual.verifyAndAnnotateProposalOfficialEvidence(input)
+    );
+
+    await expect(
+      proposeAffairUpdate({
+        affairId: "affair-1",
+        importer: "test",
+        importRunId: "run-1",
+        patch: { court: "Cour de cassation" },
+        source: "LEGIFRANCE",
+        officialId: "JURITEXT000049774995",
+        metadata: {
+          courtDecisionCandidate: {
+            pourvoi: "23-82.194",
+            ecli: "FR:CCASS:2024:CR00817",
+            date: "2024-06-19",
+            legifranceId: "JURITEXT000049774995",
+          },
+        },
+        confidence: 99,
+        rationale: "Identifiants officiels sans URL vérifiable.",
+      })
+    ).rejects.toThrow("UNCHECKED");
+
+    expect(h.verifyAndAnnotateProposalOfficialEvidence.mock.calls[0]![0].sourceUrl).toBeUndefined();
+    expect(h.db.affair.findUnique).not.toHaveBeenCalled();
+    expect(h.db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/affairs/__tests__/proposal-official-evidence.test.ts
+++ b/src/services/affairs/__tests__/proposal-official-evidence.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  db: {
+    affair: { findUnique: vi.fn() },
+    affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+  },
+  verifyAndAnnotateProposalOfficialEvidence: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/lib/affairs/official-decision-verification", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/affairs/official-decision-verification")>();
+  return {
+    ...actual,
+    verifyAndAnnotateProposalOfficialEvidence: h.verifyAndAnnotateProposalOfficialEvidence,
+  };
+});
+
+import { proposeAffairUpdate } from "../proposals";
+
+describe("official evidence on proposal creation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.db.affair.findUnique.mockResolvedValue({
+      id: "affair-1",
+      slug: "affair-1",
+      publicId: null,
+      title: "Affaire test",
+      politician: { slug: "personne", fullName: "Personne" },
+      status: "CONDAMNATION_DEFINITIVE",
+      verdictDate: null,
+      court: null,
+      sentence: null,
+      prisonMonths: null,
+      prisonFirmMonths: null,
+      fineAmount: null,
+      ineligibilityMonths: null,
+      ineligibilityFirmMonths: null,
+      communityService: null,
+      otherSentence: null,
+    });
+    h.db.affairUpdateProposal.findFirst.mockResolvedValue(null);
+    h.db.affairUpdateProposal.create.mockResolvedValue({ id: "proposal-v2" });
+    h.verifyAndAnnotateProposalOfficialEvidence.mockResolvedValue(null);
+  });
+
+  it("stores the canonical URL, verification metadata and live content hash", async () => {
+    const canonicalUrl = "https://www.legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+    h.verifyAndAnnotateProposalOfficialEvidence.mockResolvedValue({
+      sourceUrl: canonicalUrl,
+      metadata: {
+        courtDecisionCandidate: {
+          canonicalUrl,
+          verification: { status: "VALID" },
+        },
+      },
+      verification: {
+        version: 1,
+        status: "VALID",
+        checkedAt: "2026-08-18T09:00:00.000Z",
+        requestedUrl: canonicalUrl,
+        resolvedUrl: canonicalUrl,
+        httpStatus: 200,
+        contentHash: "a".repeat(64),
+        matchedIdentifiers: ["officialId", "pourvoi", "decisionDate"],
+        issues: [],
+        indexedProof: null,
+      },
+    });
+
+    await proposeAffairUpdate({
+      affairId: "affair-1",
+      importer: "test",
+      importRunId: "run-1",
+      patch: { fineAmount: "50000.00" },
+      source: "LEGIFRANCE",
+      sourceUrl: `${canonicalUrl}/`,
+      officialId: "23-82.194",
+      metadata: {
+        courtDecisionCandidate: {
+          url: `${canonicalUrl}/`,
+          pourvoi: "23-82.194",
+        },
+      },
+      confidence: 99,
+      rationale: "Décision officielle identifiée.",
+    });
+
+    expect(h.db.affairUpdateProposal.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          sourceUrl: canonicalUrl,
+          sourceContentHash: "a".repeat(64),
+          observedValues: { fineAmount: null },
+          metadata: expect.objectContaining({
+            courtDecisionCandidate: expect.objectContaining({
+              verification: { status: "VALID" },
+            }),
+          }),
+        }),
+        select: { id: true },
+      })
+    );
+  });
+
+  it("does not query or write when evidence verification fails", async () => {
+    h.verifyAndAnnotateProposalOfficialEvidence.mockRejectedValue(
+      new Error("La décision officielle n'est pas vérifiée (MISMATCH)")
+    );
+
+    await expect(
+      proposeAffairUpdate({
+        affairId: "affair-1",
+        importer: "test",
+        importRunId: "run-1",
+        patch: { court: "Cour de cassation" },
+        source: "LEGIFRANCE",
+        sourceUrl: "https://www.legifrance.gouv.fr/juri/id/JURITEXT000049774995",
+        confidence: 99,
+        rationale: "Décision officielle supposée.",
+      })
+    ).rejects.toThrow("MISMATCH");
+
+    expect(h.db.affair.findUnique).not.toHaveBeenCalled();
+    expect(h.db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -51,6 +51,18 @@ const LIVE_AFFAIR = {
   caseNumbers: [],
 };
 
+const LEGIFRANCE_URL = "https://www.legifrance.gouv.fr/juri/id/JURITEXT000049774995";
+
+function forbiddenOfficialResponse(): Response {
+  return {
+    status: 403,
+    ok: false,
+    url: LEGIFRANCE_URL,
+    headers: new Headers(),
+    text: vi.fn().mockResolvedValue("Forbidden"),
+  } as unknown as Response;
+}
+
 function pendingProposal(overrides: Record<string, unknown> = {}) {
   return {
     id: "prop_1",
@@ -116,6 +128,74 @@ describe("acceptProposal", () => {
       verification: { status: "MISMATCH" },
     });
     expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("refuse une preuve INDEX_VERIFIED déclarative après une revérification HTTP 403", async () => {
+    const verifiedAt = new Date().toISOString();
+    const indexedProof = {
+      version: 1,
+      exactUrl: LEGIFRANCE_URL,
+      verifiedAt,
+      method: "EXACT_OFFICIAL_SEARCH_RESULT",
+      title: "Cour de cassation, Chambre criminelle, 19 juin 2024, 23-82.194",
+      publisher: "Légifrance",
+      pourvoi: "23-82.194",
+      ecli: "FR:CCASS:2024:CR00817",
+      decisionDate: "2024-06-19",
+      officialId: "JURITEXT000049774995",
+    };
+    db.affairUpdateProposal.findUnique.mockResolvedValue(
+      pendingProposal({
+        source: "LEGIFRANCE",
+        sourceUrl: LEGIFRANCE_URL,
+        officialId: "JURITEXT000049774995",
+        metadata: {
+          courtDecisionCandidate: {
+            url: LEGIFRANCE_URL,
+            canonicalUrl: LEGIFRANCE_URL,
+            pourvoi: "23-82.194",
+            ecli: "FR:CCASS:2024:CR00817",
+            date: "2024-06-19",
+            legifranceId: "JURITEXT000049774995",
+            indexedProof,
+            verification: {
+              version: 1,
+              status: "INDEX_VERIFIED",
+              checkedAt: verifiedAt,
+              requestedUrl: LEGIFRANCE_URL,
+              resolvedUrl: LEGIFRANCE_URL,
+              httpStatus: 403,
+              contentHash: null,
+              matchedIdentifiers: ["pourvoi", "ecli", "decisionDate", "officialId"],
+              issues: ["http_403", "url_officielle_confirmee_par_index_exact"],
+              indexedProof,
+            },
+          },
+        },
+      })
+    );
+    const actual = await vi.importActual<
+      typeof import("@/lib/affairs/official-decision-verification")
+    >("@/lib/affairs/official-decision-verification");
+    const fetchImpl = vi.fn().mockResolvedValue(forbiddenOfficialResponse());
+    h.verifyProposalOfficialEvidence.mockImplementation((input) =>
+      actual.verifyProposalOfficialEvidence(input, { fetchImpl })
+    );
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "evidence_unverified",
+      verification: { status: "INDEX_VERIFIED", httpStatus: 403 },
+    });
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.updateMany).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.update).not.toHaveBeenCalled();
+    expect(db.moderationReview.create).not.toHaveBeenCalled();
+    expect(db.auditLog.create).not.toHaveBeenCalled();
   });
 
   it("applique le patch, trace, et renvoie les slugs à invalider", async () => {

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -13,12 +13,18 @@ const h = vi.hoisted(() => ({
     $transaction: vi.fn(),
   },
   trackStatusChange: vi.fn(),
+  verifyProposalOfficialEvidence: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({ db: h.db }));
 vi.mock("@/services/affairs/status-tracking", () => ({
   trackStatusChange: h.trackStatusChange,
 }));
+vi.mock("@/lib/affairs/official-decision-verification", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/affairs/official-decision-verification")>();
+  return { ...actual, verifyProposalOfficialEvidence: h.verifyProposalOfficialEvidence };
+});
 
 import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-review";
 
@@ -79,9 +85,39 @@ beforeEach(() => {
   db.auditLog.create.mockResolvedValue({});
   db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(db));
   h.trackStatusChange.mockResolvedValue(undefined);
+  h.verifyProposalOfficialEvidence.mockResolvedValue(null);
 });
 
 describe("acceptProposal", () => {
+  it("refuse avant la transaction quand la décision officielle ne concorde pas", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
+    h.verifyProposalOfficialEvidence.mockResolvedValue({
+      sourceUrl: "https://www.courdecassation.fr/decision/1",
+      metadata: {},
+      verification: {
+        version: 1,
+        status: "MISMATCH",
+        checkedAt: "2026-08-18T09:00:00.000Z",
+        requestedUrl: "https://www.courdecassation.fr/decision/1",
+        resolvedUrl: "https://www.courdecassation.fr/decision/1",
+        httpStatus: 200,
+        contentHash: "a".repeat(64),
+        matchedIdentifiers: ["officialId"],
+        issues: ["pourvoi_absent_ou_different"],
+        indexedProof: null,
+      },
+    });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "evidence_unverified",
+      verification: { status: "MISMATCH" },
+    });
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
   it("applique le patch, trace, et renvoie les slugs à invalider", async () => {
     db.affairUpdateProposal.findUnique.mockResolvedValue(pendingProposal());
 

--- a/src/services/affairs/__tests__/proposals-select.test.ts
+++ b/src/services/affairs/__tests__/proposals-select.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { AFFAIR_PROPOSABLE_SELECT } from "../proposals";
+
+const judicialFields = [
+  "status",
+  "verdictDate",
+  "court",
+  "sentence",
+  "prisonMonths",
+  "prisonFirmMonths",
+  "fineAmount",
+  "ineligibilityMonths",
+  "ineligibilityFirmMonths",
+  "communityService",
+  "otherSentence",
+] as const;
+
+describe("AFFAIR_PROPOSABLE_SELECT", () => {
+  it.each(judicialFields)("captures %s for proposal drift detection", (field) => {
+    expect(AFFAIR_PROPOSABLE_SELECT[field]).toBe(true);
+  });
+});

--- a/src/services/affairs/proposal-review.ts
+++ b/src/services/affairs/proposal-review.ts
@@ -3,6 +3,11 @@ import type { AffairStatus, ProposalStatus } from "@/generated/prisma";
 import { isValidSentenceSplit } from "@/lib/affairs/sentence-split";
 import { trackStatusChange } from "@/services/affairs/status-tracking";
 import {
+  isAcceptableOfficialDecisionVerification,
+  verifyProposalOfficialEvidence,
+  type OfficialDecisionVerification,
+} from "@/lib/affairs/official-decision-verification";
+import {
   AFFAIR_PROPOSABLE_SELECT,
   buildPrismaData,
   detectDrift,
@@ -36,6 +41,11 @@ export type AcceptResult =
   | { ok: false; reason: "not_pending"; status: ProposalStatus }
   | { ok: false; reason: "invalid_patch"; issues: string[] }
   | { ok: false; reason: "invalid_split"; issues: string[] }
+  | {
+      ok: false;
+      reason: "evidence_unverified";
+      verification: OfficialDecisionVerification;
+    }
   | { ok: false; reason: "conflict"; conflictDetail: ConflictDetail };
 
 export type RejectResult =
@@ -117,6 +127,8 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       rationale: true,
       source: true,
       sourceUrl: true,
+      officialId: true,
+      metadata: true,
       affair: {
         select: {
           id: true,
@@ -146,6 +158,23 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       return { ok: false, reason: "invalid_patch", issues: error.issues };
     }
     throw error;
+  }
+
+  const officialEvidence = await verifyProposalOfficialEvidence({
+    source: proposal.source,
+    sourceUrl: proposal.sourceUrl,
+    officialId: proposal.officialId,
+    metadata: proposal.metadata,
+  });
+  if (
+    officialEvidence &&
+    !isAcceptableOfficialDecisionVerification(officialEvidence.verification)
+  ) {
+    return {
+      ok: false,
+      reason: "evidence_unverified",
+      verification: officialEvidence.verification,
+    };
   }
 
   const affairId = proposal.affairId;

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -10,6 +10,7 @@ import {
   type AffairPatch,
   type ProposableField,
 } from "@/lib/security/schemas/affair-proposal";
+import { verifyAndAnnotateProposalOfficialEvidence } from "@/lib/affairs/official-decision-verification";
 
 // Affaires v2, lot 1.
 //
@@ -68,6 +69,7 @@ export const AFFAIR_PROPOSABLE_SELECT = {
   sentence: true,
   prisonMonths: true,
   prisonFirmMonths: true,
+  fineAmount: true,
   ineligibilityMonths: true,
   ineligibilityFirmMonths: true,
   communityService: true,
@@ -288,14 +290,24 @@ export async function proposeAffairUpdate(
 ): Promise<ProposeAffairUpdateResult> {
   const patch = validatePatch(input.patch);
   const fields = patchFields(patch);
-  const extractorVersion = input.extractorVersion ?? "v1";
+  const verifiedEvidence = await verifyAndAnnotateProposalOfficialEvidence(input);
+  const normalizedInput: ProposeAffairUpdateInput = verifiedEvidence
+    ? {
+        ...input,
+        sourceUrl: verifiedEvidence.sourceUrl,
+        sourceContentHash: input.sourceContentHash ?? verifiedEvidence.verification.contentHash,
+        metadata: toJson(verifiedEvidence.metadata),
+      }
+    : input;
+
+  const extractorVersion = normalizedInput.extractorVersion ?? "v1";
 
   const affair = await db.affair.findUnique({
-    where: { id: input.affairId },
+    where: { id: normalizedInput.affairId },
     select: AFFAIR_PROPOSABLE_SELECT,
   });
   if (!affair) {
-    throw new Error(`Affaire introuvable : ${input.affairId}`);
+    throw new Error(`Affaire introuvable : ${normalizedInput.affairId}`);
   }
   const live = affair as unknown as LiveAffair;
 
@@ -310,7 +322,12 @@ export async function proposeAffairUpdate(
   };
 
   if (Object.keys(reviewPatch).length > 0) {
-    const outcome = await recordPendingProposal(input, extractorVersion, reviewPatch, live);
+    const outcome = await recordPendingProposal(
+      normalizedInput,
+      extractorVersion,
+      reviewPatch,
+      live
+    );
     result.pendingProposalId = outcome.proposalId;
     result.deduped = outcome.deduped;
   }


### PR DESCRIPTION
## Objet

Cette PR extrait le socle durable du chantier #566 depuis une branche historique qui mélangeait code produit, workflows d'écriture et scripts one-shot. Elle part du `origin/main` courant et ne reprend aucun artefact d'exécution.

Liée à #566, #580, #734 et #569.

## Cause racine

Une proposition pouvait présenter une URL de décision officielle sans que l'acceptation revérifie que cette URL existait et correspondait réellement au pourvoi, à l'ECLI, à la date et à l'identifiant officiel attendus. L'administration n'exposait pas clairement cet état. Le snapshot utilisé pour détecter la dérive omettait aussi `fineAmount`.

Une première version considérait `INDEX_VERIFIED` comme automatiquement acceptable lorsque des métadonnées importeur cohérentes accompagnaient une réponse officielle bloquée. Cette cohérence interne ne prouve pas une provenance indépendante : le même importeur peut fournir tous les champs de la preuve.

## Changements

- ajoute un vérificateur strict pour Légifrance, Judilibre et ArianeWeb ;
- limite les hôtes et chemins officiels acceptés, suit les redirections manuellement et refuse toute destination non autorisée ;
- compare l'identifiant contenu dans l'URL, le pourvoi, l'ECLI, la date et l'identifiant officiel ;
- classe explicitement les résultats `VALID`, `REDIRECTED`, `INDEX_VERIFIED`, `BROKEN`, `MISMATCH`, `BLOCKED` ou `UNCHECKED` ;
- autorise automatiquement l'acceptation pour le seul statut `VALID`, obtenu par vérification directe ;
- conserve `INDEX_VERIFIED` comme référence d'index déclarée, visible pour le modérateur, mais jamais automatiquement acceptable ;
- documente qu'une intervention humaine explicite ou un futur mécanisme de provenance officielle persistée ou signée sera nécessaire pour accorder davantage de confiance à cet état ;
- refuse `REDIRECTED` à l'acceptation d'une proposition ancienne ;
- lors de la création, effectue une seule seconde vérification directe de l'URL officielle finale après une redirection concordante ;
- persiste `VALID` et l'URL finale uniquement si ce second contrôle concorde, tout en conservant l'URL initiale et la normalisation dans les métadonnées ;
- vérifie et annote la preuve à la création, puis la revérifie avant toute transaction d'acceptation ;
- bloque l'acceptation côté service et côté interface quand la preuve officielle est insuffisante ;
- sépare l'URL de preuve judiciaire officielle de l'URL de source éditoriale ordinaire dans le contrat de l'API d'administration ;
- conserve une source éditoriale `http` ou `https` cliquable après validation syntaxique côté serveur, sans identifiants de connexion ;
- ne crée un lien officiel cliquable qu'après validation de l'hôte et du chemin judiciaires ;
- affiche le nouveau libellé prudent « Référence d'index déclarée, vérification humaine requise » ;
- remet `fineAmount` dans `AFFAIR_PROPOSABLE_SELECT` et le couvre par un test de non-régression ;
- conserve le parseur JSON sécurisé, le contrôle de dérive, l'idempotence, le hash canonique, le compare-and-set transactionnel et les wrappers d'authentification, de validation et de pagination.

Aucun workflow, script de correction, manifeste ou snapshot temporaire du lot #566 n'est inclus.

## Limite documentée pour les sources éditoriales

La validation des liens de presse est structurelle. Elle garantit seulement une URL `http` ou `https` syntaxiquement valide et dépourvue de username ou password. Elle ne prétend pas vérifier automatiquement le contenu, la disponibilité, les paywalls, les protections 403 ou robots, les redirections de rubrique, les reprises de dépêches ni les pages supprimées. Un contrôle automatique de santé et de concordance des sources éditoriales ordinaires relève d'une PR distincte.

## Références vérifiées

- `origin/main` : `12a7f9e290e61ae2b7eef6375e0c0b5878c16576`, identique à l'état annoncé lors de la création de la PR ;
- branche historique : `4c4c0f1bdcd5989947d69fe5a45fbfdb857f812f`, avancée depuis le HEAD annoncé `522e17cbafed500fc677f6976f8a0268b812d3e6` ;
- aucune PR existante depuis `affaires/amazing-fermat-qbwars`.

## Validation

- preuve indexée fournie par l'appelant, entièrement concordante et récente, puis réponse Légifrance 403 : statut `INDEX_VERIFIED`, mais non acceptable ;
- tentative de rendre cette preuve acceptable avec des champs JSON déclaratifs : refusée ;
- chemin `acceptProposal()` avec preuve stockée `INDEX_VERIFIED` et revérification 403 : `evidence_unverified`, aucune transaction ni écriture ;
- matrice des sept statuts : seul `VALID` est acceptable ;
- source de presse HTTPS et HTTP sûre : lien conservé et bouton d'acceptation actif ;
- sources `javascript:`, `data:`, avec identifiants ou syntaxiquement invalides : jamais cliquables ;
- URL arbitraire dans `courtDecisionCandidate` : jamais cliquable ;
- URLs officielles canoniques Légifrance et ArianeWeb : cliquables ;
- aucune source de presse transformée en `CourtDecision` ;
- redirection A vers B avec identifiants concordants, puis contrôle direct de B : URL B et statut `VALID` persistés, URL A traçable ;
- second contrôle direct `MISMATCH` ou HTTP 403 : création bloquée, aucune écriture `Affair` ni proposition ;
- redirection vers une autre décision : `MISMATCH` ;
- redirection vers une destination non autorisée : bloquée ;
- identifiants officiels sans URL : aucune URL construite, proposition refusée comme `UNCHECKED`.

Commandes exécutées :

- `npm ci` : OK ;
- `npx prisma generate` : OK ;
- `npm run typecheck` : OK ;
- cinq suites ciblées : 106 tests, OK ;
- tests du contrat API et du composant admin : 3 tests, OK ;
- quatre guards d'architecture : 21 tests, OK ;
- `npm run lint` : OK ;
- Prettier ciblé, y compris les nouveaux tests : OK ;
- `git diff --check` : OK ;
- recherche des échappatoires de typage : aucun résultat ;
- recherche des écritures interdites dans le vérificateur : aucun résultat ;
- hooks de pre-commit ESLint et Prettier : OK.

Le build Next.js local supplémentaire ne peut pas démarrer dans cet environnement : Turbopack échoue lors de la création de son processus interne et de l'ouverture de son port avec `EPERM`, y compris après relance hors sandbox. Les commandes de validation demandées ci-dessus passent toutes.

## Données

Aucune écriture Supabase production n'a été exécutée pendant ce chantier. Les scripts de mise en file et de correction ponctuelle n'ont pas été relancés. Aucune proposition existante n'a été acceptée, rejetée, modifiée ou recréée.
