### PR TITLE
feat(admin): organiser la navigation autour des dossiers de travail

### DIFF
--- a/src/app/admin/affair-matching/review/page.tsx
+++ b/src/app/admin/affair-matching/review/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, ChevronRight, LinkIcon, Loader2, Search } from "lucide-react";
 import { BlockedAffairs } from "@/components/admin/BlockedAffairs";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -195,17 +196,11 @@ export default function AffairMatchingReviewPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-display font-bold tracking-tight">
-          Révision des décisions de liaison
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Les onglets listent l{"'"}ensemble du registre, qui compte plusieurs milliers de lignes.
-          La plupart ne retiennent rien : seules celles reprises ci-dessous empêchent une
-          publication.
-        </p>
-      </div>
+      <AdminPageHeader
+        title="Révision des décisions de liaison"
+        description="Confirmer ou rejeter les rapprochements qui empêchent une publication."
+        help="La file En attente correspond aux décisions UNDECIDED non révisées."
+      />
 
       {/* What actually has to be settled, before the full registry. */}
       <BlockedAffairs />

--- a/src/app/admin/affaires/page.tsx
+++ b/src/app/admin/affaires/page.tsx
@@ -25,6 +25,7 @@ import {
   Scale,
 } from "lucide-react";
 import { AffairesPageSkeleton } from "./_components/AffairesPageSkeleton";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import {
   buildApplyAiPayload,
   buildBulkPayload,
@@ -129,6 +130,7 @@ export default function AdminAffairsPage() {
     if (searchQuery) params.set("search", searchQuery);
     if (categoryFilter) params.set("category", categoryFilter);
     if (filterParam === "no-ecli") params.set("hasEcli", "false");
+    if (filterParam === "moderation-pending") params.set("moderation", "pending");
     params.set("page", String(currentPage));
     params.set("limit", "50");
 
@@ -236,16 +238,18 @@ export default function AdminAffairsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-display font-bold tracking-tight">Affaires judiciaires</h1>
-        <Button asChild>
-          <Link href="/admin/affaires/nouveau">
-            <Plus className="w-4 h-4 mr-2" aria-hidden="true" />
-            Nouvelle affaire
-          </Link>
-        </Button>
-      </div>
+      <AdminPageHeader
+        title="Affaires judiciaires"
+        description="Affaires à vérifier, documenter et publier."
+        action={
+          <Button asChild>
+            <Link href="/admin/affaires/nouveau">
+              <Plus className="w-4 h-4 mr-2" aria-hidden="true" />
+              Nouvelle affaire
+            </Link>
+          </Button>
+        }
+      />
 
       {/* Moderation feedback (surfaces publish-guard failures, #364) */}
       {feedback && (

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, ShieldAlert } from "lucide-react";
 import type { OfficialDecisionVerificationStatus } from "@/lib/affairs/official-decision-verification";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
 // Every automated write to an existing affair lands here first.
@@ -182,7 +184,11 @@ function formatValue(value: unknown): string {
 }
 
 export default function PropositionsPage() {
-  const [tab, setTab] = useState<ProposalStatus>("PENDING");
+  const searchParams = useSearchParams();
+  const initialStatus = searchParams.get("status");
+  const [tab, setTab] = useState<ProposalStatus>(
+    initialStatus === "CONFLICT" ? "CONFLICT" : "PENDING"
+  );
   const [data, setData] = useState<ListResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -255,14 +261,10 @@ export default function PropositionsPage() {
 
   return (
     <div className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-bold">Propositions de modification</h1>
-        <p className="text-muted-foreground max-w-3xl text-sm">
-          Les synchroniseurs ne modifient plus directement une affaire existante. Chaque changement
-          arrive ici avec sa source, son extrait justificatif et la valeur actuelle, pour être
-          accepté ou rejeté explicitement.
-        </p>
-      </header>
+      <AdminPageHeader
+        title="Propositions de modification"
+        description="Chaque changement arrive avec sa source, son extrait justificatif et la valeur actuelle, pour être accepté ou rejeté explicitement."
+      />
 
       <nav aria-label="Filtrer par état" className="flex flex-wrap gap-2">
         {TABS.map((t) => {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,31 +2,33 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
+import { getPipelineHealthAll } from "@/lib/data/pipelines";
 import {
-  ImageOff,
-  FileWarning,
-  Scale,
-  FileQuestion,
-  EyeOff,
-  Plus,
-  Clock,
-  AlertCircle,
   CheckCircle2,
+  CopyCheck,
+  FileCheck2,
+  FileText,
+  Fingerprint,
+  GitPullRequestArrow,
+  HeartPulse,
+  Newspaper,
+  Plus,
   RefreshCw,
-  XCircle,
+  Scale,
+  ShieldAlert,
 } from "lucide-react";
 
-interface DataHealthItem {
+type QueueCard = {
   label: string;
   count: number;
-  total?: number;
-  icon: React.ComponentType<{ className?: string }>;
+  description: string;
   href: string;
-  color: string;
-}
+  icon: typeof Scale;
+};
 
 async function getDashboardData() {
-  // Single SQL for all counts — prevents pool starvation (8 parallel counts → 1 query)
   const counts = await db.$queryRaw<
     [
       {
@@ -42,365 +44,318 @@ async function getDashboardData() {
     ]
   >`
     SELECT
-      COUNT(*)                                                                           AS total_politicians,
-      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED')                          AS published_politicians,
-      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED' AND "photoUrl" IS NULL)   AS without_photo,
-      COUNT(*) FILTER (WHERE "publicationStatus" = 'DRAFT')                              AS draft_politicians,
-      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED' AND "biography" IS NULL)  AS without_bio,
-      (SELECT COUNT(*) FROM "Affair")                                                    AS total_affairs,
-      (SELECT COUNT(*) FROM "Affair" WHERE "publicationStatus" = 'DRAFT')                AS draft_affairs,
-      -- « Sans référence judiciaire » se mesure sur les décisions rattachées : la
-      -- colonne ecli a été retirée d'Affair (#545).
-      (SELECT COUNT(*) FROM "Affair" a
-        WHERE a."publicationStatus" = 'PUBLISHED'
-          AND NOT EXISTS (SELECT 1 FROM "AffairCourtDecision" acd WHERE acd."affairId" = a.id)
-      ) AS without_ecli
+      COUNT(*) AS total_politicians,
+      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED') AS published_politicians,
+      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED' AND "photoUrl" IS NULL) AS without_photo,
+      COUNT(*) FILTER (WHERE "publicationStatus" = 'DRAFT') AS draft_politicians,
+      COUNT(*) FILTER (WHERE "publicationStatus" = 'PUBLISHED' AND "biography" IS NULL) AS without_bio,
+      (SELECT COUNT(*) FROM "Affair") AS total_affairs,
+      (SELECT COUNT(*) FROM "Affair" WHERE "publicationStatus" = 'DRAFT') AS draft_affairs,
+      (SELECT COUNT(*) FROM "Affair" a WHERE a."publicationStatus" = 'PUBLISHED' AND NOT EXISTS (SELECT 1 FROM "AffairCourtDecision" acd WHERE acd."affairId" = a.id)) AS without_ecli
     FROM "Politician"
   `;
-
-  const c = counts[0];
+  const c = counts[0]!;
+  const [
+    proposalsPending,
+    proposalsConflict,
+    reviewsPending,
+    decisionsPending,
+    duplicates,
+    rejectionsPending,
+    failedSyncs,
+    pipelines,
+    recentActivity,
+    syncHistory,
+  ] = await Promise.all([
+    db.affairUpdateProposal.count({ where: { status: "PENDING" } }),
+    db.affairUpdateProposal.count({ where: { status: "CONFLICT" } }),
+    db.moderationReview.count({ where: { appliedAt: null } }),
+    db.affairPoliticianDecision.count({ where: { judgment: "UNDECIDED", reviewedAt: null } }),
+    findPotentialDuplicates(),
+    db.pressAnalysisRejection.count(),
+    db.syncJob.count({ where: { status: "FAILED" } }),
+    getPipelineHealthAll(),
+    db.auditLog.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
+    db.syncJob.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
+  ]);
   const totalPoliticians = Number(c.total_politicians);
   const publishedPoliticians = Number(c.published_politicians);
-  const politiciansWithoutPhoto = Number(c.without_photo);
-  const politiciansDraft = Number(c.draft_politicians);
-  const biographiesMissing = Number(c.without_bio);
-  const totalAffairs = Number(c.total_affairs);
-  const affairsDraft = Number(c.draft_affairs);
-  const affairsWithoutEcli = Number(c.without_ecli);
-
-  // These 2 queries need actual rows, not counts — run in parallel (2 = fine with max:2 pool)
-  const [recentActivity, syncHistory] = await Promise.all([
-    db.auditLog.findMany({
-      take: 20,
-      orderBy: { createdAt: "desc" },
-    }),
-    db.syncJob.findMany({
-      take: 10,
-      orderBy: { createdAt: "desc" },
-    }),
-  ]);
-
-  const withPhoto = publishedPoliticians - politiciansWithoutPhoto;
-  const withBio = publishedPoliticians - biographiesMissing;
-  const completeness =
-    publishedPoliticians > 0
-      ? Math.round(((withPhoto + withBio) / (publishedPoliticians * 2)) * 100)
-      : 0;
-
+  const withoutPhoto = Number(c.without_photo);
+  const withoutBio = Number(c.without_bio);
+  const withPhoto = publishedPoliticians - withoutPhoto;
+  const withBio = publishedPoliticians - withoutBio;
   return {
     totalPoliticians,
     publishedPoliticians,
-    politiciansWithoutPhoto,
-    politiciansDraft,
-    biographiesMissing,
-    totalAffairs,
-    affairsDraft,
-    affairsWithoutEcli,
-    completeness,
+    politiciansDraft: Number(c.draft_politicians),
+    totalAffairs: Number(c.total_affairs),
+    affairsDraft: Number(c.draft_affairs),
+    affairsWithoutEcli: Number(c.without_ecli),
+    politiciansWithoutPhoto: withoutPhoto,
+    biographiesMissing: withoutBio,
+    completeness: publishedPoliticians
+      ? Math.round(((withPhoto + withBio) / (publishedPoliticians * 2)) * 100)
+      : 0,
+    queues: {
+      proposalsPending,
+      proposalsConflict,
+      reviewsPending,
+      decisionsPending,
+      duplicates: duplicates.length,
+      rejectionsPending,
+      failedPipelines: pipelines.filter((p) => p.status === "critical").length,
+      failedSyncs,
+    },
     recentActivity,
     syncHistory,
   };
 }
 
-function formatRelativeTime(date: Date): string {
-  const now = new Date();
-  const diffMs = now.getTime() - new Date(date).getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  const diffH = Math.floor(diffMin / 60);
-  const diffD = Math.floor(diffH / 24);
-
-  if (diffMin < 1) return "à l'instant";
-  if (diffMin < 60) return `il y a ${diffMin}min`;
-  if (diffH < 24) return `il y a ${diffH}h`;
-  if (diffD < 7) return `il y a ${diffD}j`;
-  return new Date(date).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
+function relativeTime(value: Date): string {
+  const minutes = Math.floor((Date.now() - new Date(value).getTime()) / 60000);
+  if (minutes < 1) return "à l’instant";
+  if (minutes < 60) return `il y a ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `il y a ${hours} h`;
+  return new Date(value).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
 }
-
-function formatDuration(start: Date | null, end: Date | null): string {
-  if (!start || !end) return "-";
-  const ms = new Date(end).getTime() - new Date(start).getTime();
-  const sec = Math.floor(ms / 1000);
-  if (sec < 60) return `${sec}s`;
-  return `${Math.floor(sec / 60)}min ${sec % 60}s`;
-}
-
-const ACTION_ICONS: Record<string, { icon: typeof Plus; className: string }> = {
-  CREATE: { icon: Plus, className: "text-emerald-600 bg-emerald-50" },
-  UPDATE: { icon: RefreshCw, className: "text-primary bg-primary/10" },
-  DELETE: { icon: XCircle, className: "text-red-600 bg-red-50" },
-};
-
-const SYNC_STATUS_STYLES: Record<string, string> = {
-  COMPLETED: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  RUNNING: "bg-blue-50 text-blue-700 border-blue-200",
-  FAILED: "bg-red-50 text-red-700 border-red-200",
-  PENDING: "bg-amber-50 text-amber-700 border-amber-200",
-};
 
 export default async function AdminDashboard() {
   const data = await getDashboardData();
-
-  const healthItems: DataHealthItem[] = [
+  const queueCards: QueueCard[] = [
     {
-      label: "Affaires à modérer",
+      label: "Affaires DRAFT",
       count: data.affairsDraft,
-      icon: Scale,
+      description: "Vérifier les sources et décider de la publication.",
       href: "/admin/affaires?status=DRAFT",
-      color: "oklch(0.52 0.2 25)",
+      icon: Scale,
     },
     {
-      label: "Politiciens sans photo",
-      count: data.politiciansWithoutPhoto,
-      total: data.publishedPoliticians,
-      icon: ImageOff,
-      href: "/admin/politiques?filter=no-photo",
-      color: "oklch(0.55 0.15 250)",
+      label: "Propositions en attente",
+      count: data.queues.proposalsPending,
+      description: "Examiner les modifications proposées.",
+      href: "/admin/affaires/propositions?status=PENDING",
+      icon: GitPullRequestArrow,
     },
     {
-      label: "Biographies manquantes",
-      count: data.biographiesMissing,
-      total: data.publishedPoliticians,
-      icon: FileQuestion,
-      href: "/admin/politiques?filter=no-bio",
-      color: "oklch(0.55 0.15 310)",
+      label: "Propositions en conflit",
+      count: data.queues.proposalsConflict,
+      description: "Résoudre les écarts avec la donnée actuelle.",
+      href: "/admin/affaires/propositions?status=CONFLICT",
+      icon: ShieldAlert,
     },
     {
-      label: "Affaires sans ECLI",
-      count: data.affairsWithoutEcli,
-      icon: FileWarning,
-      href: "/admin/affaires?filter=no-ecli",
-      color: "oklch(0.55 0.18 65)",
+      label: "Revues de modération",
+      count: data.queues.reviewsPending,
+      description: "Appliquer ou écarter la recommandation, avec preuve.",
+      href: "/admin/affaires?filter=moderation-pending",
+      icon: FileCheck2,
     },
     {
-      label: "Politiciens DRAFT",
-      count: data.politiciansDraft,
-      icon: EyeOff,
-      href: "/admin/politiques?status=DRAFT",
-      color: "oklch(0.5 0.12 200)",
+      label: "Liaisons à confirmer",
+      count: data.queues.decisionsPending,
+      description: "Confirmer ou rejeter les rapprochements.",
+      href: "/admin/affair-matching/review?tab=UNDECIDED",
+      icon: Fingerprint,
+    },
+    {
+      label: "Doublons à trancher",
+      count: data.queues.duplicates,
+      description: "Comparer les paires proposées.",
+      href: "/admin/affaires/doublons",
+      icon: CopyCheck,
+    },
+    {
+      label: "Rejets presse",
+      count: data.queues.rejectionsPending,
+      description: "Prendre une décision éditoriale sur les rejets.",
+      href: "/admin/press/rejections",
+      icon: Newspaper,
+    },
+    {
+      label: "Pipelines en échec",
+      count: data.queues.failedPipelines,
+      description: "Diagnostiquer les pipelines critiques.",
+      href: "/admin/pipelines?status=critical",
+      icon: HeartPulse,
+    },
+    {
+      label: "Synchronisations en échec",
+      count: data.queues.failedSyncs,
+      description: "Inspecter les exécutions interrompues.",
+      href: "/admin/syncs?status=FAILED",
+      icon: RefreshCw,
     },
   ];
 
   return (
     <div className="space-y-8">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+      <AdminPageHeader
+        title="À traiter maintenant"
+        description={`${data.totalPoliticians} personnalités politiques, ${data.totalAffairs} affaires`}
+        action={
+          <Link
+            href="/admin/affaires/nouveau"
+            className="min-h-11 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-lg"
+            style={{ backgroundColor: "oklch(0.52 0.2 25)" }}
+          >
+            <Plus className="w-4 h-4" aria-hidden="true" />
+            Nouvelle affaire
+          </Link>
+        }
+      />
+
+      <section aria-labelledby="todo-title" className="space-y-4">
         <div>
-          <h1 className="text-2xl font-display font-bold tracking-tight">Dashboard</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            {data.totalPoliticians} politiciens &middot; {data.totalAffairs} affaires
+          <h2 id="todo-title" className="text-lg font-display font-semibold">
+            À traiter maintenant
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Chaque compteur correspond à une file distincte et ouvre son filtre de travail.
           </p>
         </div>
-        <Link
-          href="/admin/affaires/nouveau"
-          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
-          style={{ backgroundColor: "oklch(0.52 0.2 25)" }}
-        >
-          <Plus className="w-4 h-4" aria-hidden="true" />
-          Nouvelle affaire
-        </Link>
-      </div>
-
-      {/* Data Health + Activity Grid */}
-      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-        {/* Data Health — 2 cols */}
-        <div className="xl:col-span-2 space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-display font-semibold">Santé des données</h2>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <div className="w-24 h-2 bg-muted rounded-full overflow-hidden">
-                <div
-                  className="h-full rounded-full transition-all"
-                  style={{
-                    width: `${data.completeness}%`,
-                    backgroundColor:
-                      data.completeness > 80
-                        ? "oklch(0.6 0.18 145)"
-                        : data.completeness > 50
-                          ? "oklch(0.6 0.15 80)"
-                          : "oklch(0.6 0.18 25)",
-                  }}
-                />
-              </div>
-              <span>{data.completeness}% complet</span>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {healthItems.map((item) => {
-              const Icon = item.icon;
-              return (
-                <Link key={item.label} href={item.href}>
-                  <Card className="hover:shadow-md transition-shadow cursor-pointer group">
-                    <CardContent className="p-4">
-                      <div className="flex items-start justify-between">
-                        <div
-                          className="p-2 rounded-lg"
-                          style={{
-                            backgroundColor: `color-mix(in oklch, ${item.color} 12%, transparent)`,
-                          }}
-                        >
-                          <span style={{ color: item.color }}>
-                            <Icon className="w-4 h-4" aria-hidden="true" />
-                          </span>
-                        </div>
-                        <span
-                          className="text-2xl font-bold font-display"
-                          style={{ color: item.count > 0 ? item.color : undefined }}
-                        >
-                          {item.count}
-                        </span>
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+          {queueCards.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Link key={card.label} href={card.href}>
+                <Card className="h-full hover:shadow-md transition-shadow">
+                  <CardContent className="p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="p-2 rounded-lg bg-primary/10">
+                        <Icon className="w-4 h-4 text-primary" aria-hidden="true" />
                       </div>
-                      <p className="text-sm text-muted-foreground mt-2 group-hover:text-foreground transition-colors">
-                        {item.label}
-                      </p>
-                      {item.total && (
-                        <div className="mt-2 w-full h-1.5 bg-muted rounded-full overflow-hidden">
-                          <div
-                            className="h-full rounded-full"
-                            style={{
-                              width: `${Math.max(2, ((item.total - item.count) / item.total) * 100)}%`,
-                              backgroundColor: item.color,
-                            }}
-                          />
-                        </div>
-                      )}
-                    </CardContent>
-                  </Card>
-                </Link>
-              );
-            })}
-          </div>
+                      <span
+                        className={`text-2xl font-bold font-display ${card.count ? "text-primary" : "text-muted-foreground"}`}
+                      >
+                        {card.count}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium mt-3">{card.label}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {card.count ? card.description : "File vide, aucune action en attente."}
+                    </p>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
         </div>
+      </section>
 
-        {/* Activity Timeline — 1 col */}
+      <section aria-labelledby="health-title" className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 id="health-title" className="text-lg font-display font-semibold">
+            Santé des données
+          </h2>
+          <span className="text-sm text-muted-foreground">{data.completeness}% complet</span>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {[
+            [
+              "Personnalités sans photo",
+              data.politiciansWithoutPhoto,
+              "/admin/politiques?filter=no-photo",
+              FileText,
+            ],
+            [
+              "Biographies manquantes",
+              data.biographiesMissing,
+              "/admin/politiques?filter=no-bio",
+              FileText,
+            ],
+            [
+              "Affaires sans décision",
+              data.affairsWithoutEcli,
+              "/admin/affaires?filter=no-ecli",
+              Scale,
+            ],
+            [
+              "Personnalités DRAFT",
+              data.politiciansDraft,
+              "/admin/politiques?status=DRAFT",
+              FileText,
+            ],
+          ].map(([label, count, href]) => (
+            <Link key={String(label)} href={String(href)}>
+              <Card className="hover:shadow-md transition-shadow">
+                <CardContent className="p-4">
+                  <div className="text-2xl font-bold">{String(count)}</div>
+                  <p className="text-sm text-muted-foreground mt-1">{String(label)}</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="activity-title" className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         <div className="space-y-4">
-          <h2 className="text-lg font-display font-semibold">Activité récente</h2>
+          <h2 id="activity-title" className="text-lg font-display font-semibold">
+            Activité récente
+          </h2>
           <Card>
             <CardContent className="p-0">
-              {data.recentActivity.length > 0 ? (
+              {data.recentActivity.length ? (
                 <ul className="divide-y divide-border">
-                  {data.recentActivity.slice(0, 10).map((entry) => {
-                    const actionMeta = ACTION_ICONS[entry.action] || ACTION_ICONS.UPDATE;
-                    const ActionIcon = actionMeta!.icon;
-                    return (
-                      <li key={entry.id} className="px-4 py-3 flex items-start gap-3">
-                        <div
-                          className={`p-1.5 rounded-md shrink-0 mt-0.5 ${actionMeta!.className}`}
-                        >
-                          <ActionIcon className="w-3 h-3" aria-hidden="true" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm truncate">
-                            <span className="font-medium">{entry.action}</span>{" "}
-                            <span className="text-muted-foreground">{entry.entityType}</span>
-                          </p>
-                          <p className="text-xs text-muted-foreground mt-0.5">
-                            {formatRelativeTime(entry.createdAt)}
-                          </p>
-                        </div>
-                      </li>
-                    );
-                  })}
+                  {data.recentActivity.map((entry) => (
+                    <li key={entry.id} className="px-4 py-3 flex items-center gap-3">
+                      <CheckCircle2
+                        className="w-4 h-4 text-emerald-600 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm flex-1 truncate">
+                        {entry.action}{" "}
+                        <span className="text-muted-foreground">{entry.entityType}</span>
+                      </span>
+                      <time
+                        className="text-xs text-muted-foreground"
+                        dateTime={entry.createdAt.toISOString()}
+                      >
+                        {relativeTime(entry.createdAt)}
+                      </time>
+                    </li>
+                  ))}
                 </ul>
               ) : (
-                <div className="p-6 text-center text-sm text-muted-foreground">
+                <p className="p-6 text-sm text-muted-foreground text-center">
                   Aucune activité récente
-                </div>
+                </p>
               )}
             </CardContent>
           </Card>
-
-          {data.recentActivity.length > 10 && (
+        </div>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-display font-semibold">Activité et opérations</h2>
             <Link
-              href="/admin/audit"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              href="/admin/syncs"
+              className="text-sm text-muted-foreground hover:text-foreground"
             >
-              Voir tout l&apos;historique &rarr;
+              Voir les synchronisations
             </Link>
-          )}
-        </div>
-      </div>
-
-      {/* Sync History */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-display font-semibold">Dernières synchronisations</h2>
-          <Link
-            href="/admin/syncs"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Gérer les syncs &rarr;
-          </Link>
-        </div>
-
-        {data.syncHistory.length > 0 ? (
+          </div>
           <Card>
             <CardContent className="p-0">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border text-left">
-                      <th className="px-4 py-3 font-medium text-muted-foreground">Script</th>
-                      <th className="px-4 py-3 font-medium text-muted-foreground">Statut</th>
-                      <th className="px-4 py-3 font-medium text-muted-foreground hidden sm:table-cell">
-                        Durée
-                      </th>
-                      <th className="px-4 py-3 font-medium text-muted-foreground hidden md:table-cell">
-                        Stats
-                      </th>
-                      <th className="px-4 py-3 font-medium text-muted-foreground">Date</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {data.syncHistory.map((job) => (
-                      <tr key={job.id} className="hover:bg-muted/30 transition-colors">
-                        <td className="px-4 py-3 font-mono text-xs">{job.script}</td>
-                        <td className="px-4 py-3">
-                          <Badge variant="outline" className={SYNC_STATUS_STYLES[job.status] || ""}>
-                            {job.status === "COMPLETED" && (
-                              <CheckCircle2 className="w-3 h-3 mr-1" aria-hidden="true" />
-                            )}
-                            {job.status === "FAILED" && (
-                              <AlertCircle className="w-3 h-3 mr-1" aria-hidden="true" />
-                            )}
-                            {job.status === "RUNNING" && (
-                              <RefreshCw className="w-3 h-3 mr-1 animate-spin" aria-hidden="true" />
-                            )}
-                            {job.status === "PENDING" && (
-                              <Clock className="w-3 h-3 mr-1" aria-hidden="true" />
-                            )}
-                            {job.status}
-                          </Badge>
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">
-                          {formatDuration(job.startedAt, job.completedAt)}
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground hidden md:table-cell">
-                          {job.processed != null && job.total != null
-                            ? `${job.processed}/${job.total}`
-                            : "-"}
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground">
-                          {formatRelativeTime(job.createdAt)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              {data.syncHistory.length ? (
+                <ul className="divide-y divide-border">
+                  {data.syncHistory.map((job) => (
+                    <li key={job.id} className="px-4 py-3 flex items-center gap-3">
+                      <RefreshCw className="w-4 h-4 shrink-0" aria-hidden="true" />
+                      <span className="font-mono text-xs flex-1 truncate">{job.script}</span>
+                      <Badge variant="outline">{job.status}</Badge>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="p-6 text-sm text-muted-foreground text-center">
+                  Aucune synchronisation enregistrée
+                </p>
+              )}
             </CardContent>
           </Card>
-        ) : (
-          <Card>
-            <CardContent className="p-6 text-center text-sm text-muted-foreground">
-              Aucune synchronisation enregistrée.{" "}
-              <Link href="/admin/syncs" className="text-foreground hover:underline">
-                Lancer une sync
-              </Link>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/admin/presse/page.tsx
+++ b/src/app/admin/presse/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatDateShort } from "@/lib/utils";
 import { AdminDeleteButton } from "@/components/admin/AdminDeleteButton";
 import { PressPurgeButton } from "@/components/admin/PressPurgeButton";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import type { Prisma } from "@/generated/prisma";
 
 interface PageProps {
@@ -112,14 +113,13 @@ export default async function AdminPressePage({ searchParams }: PageProps) {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-display font-bold tracking-tight">Presse</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {stats.total} articles — {stats.totalMentions} mentions
-        </p>
-        {stats.purgeableCount > 0 && <PressPurgeButton count={stats.purgeableCount} />}
-      </div>
+      <AdminPageHeader
+        title="Presse et articles"
+        description={`${stats.total} articles, ${stats.totalMentions} mentions`}
+        action={
+          stats.purgeableCount > 0 ? <PressPurgeButton count={stats.purgeableCount} /> : undefined
+        }
+      />
 
       {/* Stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/app/api/admin/affaires/route.ts
+++ b/src/app/api/admin/affaires/route.ts
@@ -25,6 +25,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   const status = validateEnum(searchParams.get("status"), VALID_AFFAIR_STATUSES);
   const search = searchParams.get("search");
   const hasEcli = searchParams.get("hasEcli");
+  const moderation = searchParams.get("moderation");
   const { page, limit, skip } = parsePagination(searchParams);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,6 +42,9 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   }
   if (hasEcli === "false") {
     where.courtDecisions = { none: { courtDecision: { ecli: { not: null } } } };
+  }
+  if (moderation === "pending") {
+    where.moderationReviews = { some: { appliedAt: null } };
   }
   if (search) {
     where.OR = [

--- a/src/app/api/admin/badges/route.test.ts
+++ b/src/app/api/admin/badges/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({
+  db: {
+    affair: { count: vi.fn() },
+    politician: { count: vi.fn() },
+    affairUpdateProposal: { count: vi.fn() },
+    moderationReview: { count: vi.fn() },
+    affairPoliticianDecision: { count: vi.fn() },
+    pressAnalysisRejection: { count: vi.fn() },
+    syncJob: { count: vi.fn() },
+  },
+  duplicates: vi.fn(),
+  pipelines: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/services/affairs/reconciliation", () => ({ findPotentialDuplicates: h.duplicates }));
+vi.mock("@/lib/data/pipelines", () => ({ getPipelineHealthAll: h.pipelines }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (handler: () => Promise<Response>) => handler,
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.db.affair.count.mockResolvedValue(3);
+  h.db.politician.count.mockResolvedValue(4);
+  h.db.affairUpdateProposal.count.mockImplementation(
+    async ({ where }: { where: { status: string } }) => (where.status === "PENDING" ? 5 : 2)
+  );
+  h.db.moderationReview.count.mockResolvedValue(7);
+  h.db.affairPoliticianDecision.count.mockResolvedValue(8);
+  h.db.pressAnalysisRejection.count.mockResolvedValue(9);
+  h.db.syncJob.count.mockResolvedValue(10);
+  h.duplicates.mockResolvedValue([{ id: "duplicate-1" }, { id: "duplicate-2" }]);
+  h.pipelines.mockResolvedValue([
+    { status: "critical" },
+    { status: "healthy" },
+    { status: "critical" },
+  ]);
+});
+
+describe("GET /api/admin/badges", () => {
+  it("returns distinct counts for each actionable queue", async () => {
+    const response = await GET(new NextRequest("https://poligraph.fr/api/admin/badges"), {
+      params: Promise.resolve({}),
+    });
+    expect(await response.json()).toEqual({
+      drafts: { affairs: 3, politicians: 4 },
+      moderation: { proposalsPending: 5, proposalsConflict: 2, reviewsPending: 7 },
+      matching: { decisionsPending: 8, duplicatesPending: 2 },
+      press: { rejectionsPending: 9 },
+      operations: { failedPipelines: 2, failedSyncs: 10 },
+    });
+  });
+});

--- a/src/app/api/admin/badges/route.ts
+++ b/src/app/api/admin/badges/route.ts
@@ -1,12 +1,58 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
+import { getPipelineHealthAll } from "@/lib/data/pipelines";
+
+export interface AdminBadgeContract {
+  drafts: { affairs: number; politicians: number };
+  moderation: {
+    proposalsPending: number;
+    proposalsConflict: number;
+    reviewsPending: number;
+  };
+  matching: { decisionsPending: number; duplicatesPending: number };
+  press: { rejectionsPending: number };
+  operations: { failedPipelines: number; failedSyncs: number };
+}
 
 export const GET = withAdminAuth(async () => {
-  const [affairsDraft, politiciansDraft] = await Promise.all([
+  const [
+    affairs,
+    politicians,
+    proposalsPending,
+    proposalsConflict,
+    reviewsPending,
+    decisionsPending,
+    duplicates,
+    rejectionsPending,
+    failedSyncs,
+    pipelineHealth,
+  ] = await Promise.all([
     db.affair.count({ where: { publicationStatus: "DRAFT" } }),
     db.politician.count({ where: { publicationStatus: "DRAFT" } }),
+    db.affairUpdateProposal.count({ where: { status: "PENDING" } }),
+    db.affairUpdateProposal.count({ where: { status: "CONFLICT" } }),
+    db.moderationReview.count({ where: { appliedAt: null } }),
+    db.affairPoliticianDecision.count({
+      where: { judgment: "UNDECIDED", reviewedAt: null },
+    }),
+    findPotentialDuplicates(),
+    db.pressAnalysisRejection.count(),
+    db.syncJob.count({ where: { status: "FAILED" } }),
+    getPipelineHealthAll(),
   ]);
 
-  return NextResponse.json({ affairsDraft, politiciansDraft });
+  const response: AdminBadgeContract = {
+    drafts: { affairs, politicians },
+    moderation: { proposalsPending, proposalsConflict, reviewsPending },
+    matching: { decisionsPending, duplicatesPending: duplicates.length },
+    press: { rejectionsPending },
+    operations: {
+      failedPipelines: pipelineHealth.filter((pipeline) => pipeline.status === "critical").length,
+      failedSyncs,
+    },
+  };
+
+  return NextResponse.json(response);
 });

--- a/src/components/admin/AdminBreadcrumb.tsx
+++ b/src/components/admin/AdminBreadcrumb.tsx
@@ -3,21 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChevronRight, Home } from "lucide-react";
-
-const SEGMENT_LABELS: Record<string, string> = {
-  admin: "Dashboard",
-  affaires: "Affaires",
-  politiques: "Politiques",
-  partis: "Partis",
-  dossiers: "Dossiers",
-  elections: "Élections",
-  syncs: "Syncs",
-  "feature-toggles": "Feature Toggles",
-  audit: "Audit Log",
-  parametres: "Paramètres",
-  edit: "Modifier",
-  nouveau: "Nouveau",
-};
+import { findAdminNavigationEntry } from "@/config/admin-navigation";
 
 interface Crumb {
   label: string;
@@ -25,28 +11,23 @@ interface Crumb {
 }
 
 function buildCrumbs(pathname: string): Crumb[] {
+  const entry = findAdminNavigationEntry(pathname);
   const segments = pathname.split("/").filter(Boolean);
-  const crumbs: Crumb[] = [];
+  const crumbs: Crumb[] = [{ label: "À traiter", href: "/admin" }];
 
-  for (let i = 0; i < segments.length; i++) {
+  if (entry && entry.href !== "/admin") {
+    crumbs.push({
+      label: entry.breadcrumb ?? entry.label,
+      href: entry.href.split("?")[0] ?? "/admin",
+    });
+  }
+
+  const base = entry?.href.split("?")[0] ?? "/admin";
+  const baseSegments = base.split("/").filter(Boolean).length;
+  for (let i = baseSegments; i < segments.length; i++) {
     const segment = segments[i]!;
     const href = "/" + segments.slice(0, i + 1).join("/");
-
-    // Skip "admin" as first segment — it becomes "Dashboard"
-    if (i === 0 && segment === "admin") {
-      crumbs.push({ label: "Dashboard", href: "/admin" });
-      continue;
-    }
-
-    // Known labels
-    const knownLabel = SEGMENT_LABELS[segment];
-    if (knownLabel) {
-      crumbs.push({ label: knownLabel, href });
-      continue;
-    }
-
-    // Dynamic segments (IDs, slugs) — show as-is, truncated
-    const label = segment.length > 20 ? segment.slice(0, 17) + "..." : segment;
+    const label = segment.length > 20 ? `${segment.slice(0, 17)}...` : segment;
     crumbs.push({ label, href });
   }
 
@@ -54,26 +35,22 @@ function buildCrumbs(pathname: string): Crumb[] {
 }
 
 export function AdminBreadcrumb() {
-  const pathname = usePathname();
-  const crumbs = buildCrumbs(pathname);
-
+  const crumbs = buildCrumbs(usePathname());
   if (crumbs.length <= 1) return null;
 
   return (
-    <nav aria-label="Fil d'Ariane" className="flex items-center gap-1 text-sm">
+    <nav aria-label="Fil d’Ariane" className="flex items-center gap-1 text-sm">
       <Link
         href="/admin"
-        className="text-muted-foreground hover:text-foreground transition-colors p-1 -ml-1 rounded"
-        aria-label="Dashboard"
+        className="text-muted-foreground hover:text-foreground transition-colors min-h-11 min-w-11 inline-flex items-center justify-center rounded"
+        aria-label="À traiter"
       >
         <Home className="w-3.5 h-3.5" aria-hidden="true" />
       </Link>
-
       {crumbs.slice(1).map((crumb, i) => {
         const isLast = i === crumbs.length - 2;
-
         return (
-          <span key={crumb.href} className="flex items-center gap-1">
+          <span key={`${crumb.href}-${crumb.label}`} className="flex items-center gap-1">
             <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/50" aria-hidden="true" />
             {isLast ? (
               <span className="font-medium text-foreground" aria-current="page">

--- a/src/components/admin/AdminPageHeader.tsx
+++ b/src/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { AdminBreadcrumb } from "@/components/admin/AdminBreadcrumb";
+
+export function AdminPageHeader({
+  title,
+  description,
+  action,
+  help,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  help?: string;
+}) {
+  return (
+    <header className="space-y-2">
+      <AdminBreadcrumb />
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-display font-bold tracking-tight">{title}</h1>
+          {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+          {help && <p className="text-xs text-muted-foreground mt-2">{help}</p>}
+        </div>
+        {action}
+      </div>
+    </header>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,79 +1,47 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ChevronsLeft, ChevronsRight, ExternalLink, Menu, X } from "lucide-react";
 import {
-  LayoutDashboard,
-  Scale,
-  Users,
-  Building2,
-  FileText,
-  RefreshCw,
-  ToggleLeft,
-  History,
-  HeartPulse,
-  Settings,
-  ChevronsLeft,
-  ChevronsRight,
-  Menu,
-  X,
-  ExternalLink,
-  ShieldX,
-  Newspaper,
-  ShieldCheck,
-  Crown,
-  Share2,
-  Fingerprint,
-  BarChart3,
-  Vote,
-  CopyCheck,
-  GitPullRequestArrow,
-  ListChecks,
-} from "lucide-react";
+  ADMIN_NAVIGATION_GROUPS,
+  getCounterValue,
+  isAdminNavigationActive,
+  type AdminCounterKey,
+} from "@/config/admin-navigation";
 
 const STORAGE_KEY = "admin-sidebar-collapsed";
 
-interface NavItem {
-  href: string;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  badge?: number;
-}
+type BadgeResponse = {
+  drafts: { affairs: number; politicians: number };
+  moderation: { proposalsPending: number; proposalsConflict: number; reviewsPending: number };
+  matching: { decisionsPending: number; duplicatesPending: number };
+  press: { rejectionsPending: number };
+  operations: { failedPipelines: number; failedSyncs: number };
+};
 
-const contentItems: NavItem[] = [
-  { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/admin/affaires", label: "Affaires", icon: Scale },
-  { href: "/admin/affaires/propositions", label: "Propositions", icon: GitPullRequestArrow },
-  { href: "/admin/affaires/doublons", label: "Doublons", icon: CopyCheck },
-  { href: "/admin/politiques", label: "Politiques", icon: Users },
-  { href: "/admin/partis", label: "Partis", icon: Building2 },
-  { href: "/admin/maires", label: "Maires", icon: Crown },
-  { href: "/admin/dossiers", label: "Dossiers", icon: FileText },
-  { href: "/admin/policy-titles", label: "Titres de scrutins", icon: Vote },
-  { href: "/admin/mesures", label: "Mesures", icon: ListChecks },
-  { href: "/admin/affair-matching/review", label: "Liaison affaires", icon: Fingerprint },
-  { href: "/admin/affair-matching/dashboard", label: "Liaison — activité", icon: BarChart3 },
-];
+const EMPTY_BADGES: BadgeResponse = {
+  drafts: { affairs: 0, politicians: 0 },
+  moderation: { proposalsPending: 0, proposalsConflict: 0, reviewsPending: 0 },
+  matching: { decisionsPending: 0, duplicatesPending: 0 },
+  press: { rejectionsPending: 0 },
+  operations: { failedPipelines: 0, failedSyncs: 0 },
+};
 
-const mediaItems: NavItem[] = [
-  { href: "/admin/presse", label: "Presse", icon: Newspaper },
-  { href: "/admin/press/rejections", label: "Rejets presse", icon: ShieldX },
-  { href: "/admin/factchecks", label: "Fact-checks", icon: ShieldCheck },
-  { href: "/admin/social", label: "Social", icon: Share2 },
-];
-
-const systemItems: NavItem[] = [
-  { href: "/admin/pipelines", label: "Pipelines", icon: HeartPulse },
-  { href: "/admin/syncs", label: "Syncs", icon: RefreshCw },
-  { href: "/admin/feature-toggles", label: "Feature Toggles", icon: ToggleLeft },
-  { href: "/admin/audit", label: "Audit Log", icon: History },
-  { href: "/admin/parametres", label: "Paramètres", icon: Settings },
-];
-
-function isActive(pathname: string, href: string): boolean {
-  if (href === "/admin") return pathname === "/admin";
-  return pathname.startsWith(href);
+function flattenBadges(badges: BadgeResponse): Record<string, number> {
+  return {
+    "drafts.affairs": badges.drafts.affairs,
+    "drafts.politicians": badges.drafts.politicians,
+    "moderation.proposalsPending": badges.moderation.proposalsPending,
+    "moderation.proposalsConflict": badges.moderation.proposalsConflict,
+    "moderation.reviewsPending": badges.moderation.reviewsPending,
+    "matching.decisionsPending": badges.matching.decisionsPending,
+    "matching.duplicatesPending": badges.matching.duplicatesPending,
+    "press.rejectionsPending": badges.press.rejectionsPending,
+    "operations.failedPipelines": badges.operations.failedPipelines,
+    "operations.failedSyncs": badges.operations.failedSyncs,
+  };
 }
 
 export function AdminSidebar() {
@@ -83,49 +51,64 @@ export function AdminSidebar() {
     return localStorage.getItem(STORAGE_KEY) === "true";
   });
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [badges, setBadges] = useState<{ affairsDraft: number }>({ affairsDraft: 0 });
+  const [badges, setBadges] = useState<BadgeResponse>(EMPTY_BADGES);
 
-  // Fetch badge counts
   useEffect(() => {
-    fetch("/api/admin/badges")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (data) setBadges(data);
-      })
-      .catch(() => {});
-
-    const interval = setInterval(() => {
+    const refresh = () => {
       fetch("/api/admin/badges")
-        .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          if (data) setBadges(data);
-        })
+        .then((response) => (response.ok ? response.json() : null))
+        .then((data: BadgeResponse | null) => data && setBadges(data))
         .catch(() => {});
-    }, 60_000);
+    };
+    refresh();
+    const interval = setInterval(refresh, 60_000);
     return () => clearInterval(interval);
   }, []);
 
-  // Close mobile sidebar on route change
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- sync with navigation
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- close the mobile drawer after navigation
   useEffect(() => setMobileOpen(false), [pathname]);
 
-  function toggleCollapse() {
+  const toggleCollapse = () => {
     const next = !collapsed;
     setCollapsed(next);
     localStorage.setItem(STORAGE_KEY, String(next));
-  }
+  };
 
-  // Inject badge into Affaires item
-  const itemsWithBadges = contentItems.map((item) => {
-    if (item.href === "/admin/affaires" && badges.affairsDraft > 0) {
-      return { ...item, badge: badges.affairsDraft };
-    }
-    return item;
-  });
+  const counters = flattenBadges(badges);
+  const navigation = (
+    <nav role="navigation" aria-label="Administration" className="flex-1 overflow-y-auto py-3 px-2">
+      {ADMIN_NAVIGATION_GROUPS.map((group) => (
+        <section
+          key={group.id}
+          aria-labelledby={`admin-group-${group.id}`}
+          className="mb-4 last:mb-0"
+        >
+          {!collapsed && (
+            <h2
+              id={`admin-group-${group.id}`}
+              className="px-3 mb-1 text-[10px] uppercase tracking-wider text-white/45"
+            >
+              {group.label}
+            </h2>
+          )}
+          <ul className="space-y-0.5">
+            {group.items.map((item) => (
+              <NavLink
+                key={item.id}
+                item={item}
+                active={isAdminNavigationActive(pathname, item)}
+                collapsed={collapsed}
+                badge={getCounterValue(counters, item.counterKey)}
+              />
+            ))}
+          </ul>
+        </section>
+      ))}
+    </nav>
+  );
 
   const sidebarContent = (
     <>
-      {/* Logo / Brand */}
       <div className="flex items-center gap-3 px-4 h-14 border-b border-white/10 shrink-0">
         <div
           className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold shrink-0"
@@ -139,80 +122,32 @@ export function AdminSidebar() {
           </span>
         )}
       </div>
-
-      {/* Navigation */}
-      <nav
-        role="navigation"
-        aria-label="Administration"
-        className="flex-1 overflow-y-auto py-3 px-2"
-      >
-        <ul className="space-y-0.5">
-          {itemsWithBadges.map((item) => (
-            <NavLink
-              key={item.href}
-              item={item}
-              active={isActive(pathname, item.href)}
-              collapsed={collapsed}
-            />
-          ))}
-        </ul>
-
-        {/* Separator */}
-        <div className="my-3 mx-2 border-t border-white/10" role="separator" />
-
-        <ul className="space-y-0.5">
-          {mediaItems.map((item) => (
-            <NavLink
-              key={item.href}
-              item={item}
-              active={isActive(pathname, item.href)}
-              collapsed={collapsed}
-            />
-          ))}
-        </ul>
-
-        {/* Separator */}
-        <div className="my-3 mx-2 border-t border-white/10" role="separator" />
-
-        <ul className="space-y-0.5">
-          {systemItems.map((item) => (
-            <NavLink
-              key={item.href}
-              item={item}
-              active={isActive(pathname, item.href)}
-              collapsed={collapsed}
-            />
-          ))}
-        </ul>
-      </nav>
-
-      {/* Footer */}
+      {navigation}
       <div className="border-t border-white/10 p-2 shrink-0 space-y-1">
         <Link
           href="/"
           target="_blank"
-          className="flex items-center gap-2 px-3 py-2 text-xs text-white/50 hover:text-white/80 rounded-md hover:bg-white/5 transition-colors"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 min-h-11 px-3 py-2 text-xs text-white/60 hover:text-white/90 rounded-md hover:bg-white/5"
+          title={collapsed ? "Voir le site" : undefined}
         >
           <ExternalLink className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
           {!collapsed && <span>Voir le site</span>}
         </Link>
-
         <form action="/api/admin/logout" method="POST">
           <button
             type="submit"
-            className={`w-full flex items-center gap-2 px-3 py-2 text-xs text-white/50 hover:text-white/80 rounded-md hover:bg-white/5 transition-colors ${collapsed ? "justify-center" : ""}`}
+            className={`w-full min-h-11 flex items-center gap-2 px-3 py-2 text-xs text-white/60 hover:text-white/90 rounded-md hover:bg-white/5 ${collapsed ? "justify-center" : ""}`}
           >
             {!collapsed && <span>Déconnexion</span>}
+            {collapsed && <span className="sr-only">Déconnexion</span>}
           </button>
         </form>
-
-        {/* Collapse toggle — desktop only */}
         <button
           onClick={toggleCollapse}
-          // text-white/60 et pas /40 : sur le fond oklch(0.18 0.015 250), 40 % de blanc donne 4,06:1,
-          // sous le seuil AA de 4,5:1 pour du texte de 12 px. 60 % donne environ 7,9:1.
-          className="hidden lg:flex w-full items-center gap-2 px-3 py-2 text-xs text-white/60 hover:text-white/90 rounded-md hover:bg-white/5 transition-colors"
+          className="hidden lg:flex w-full min-h-11 items-center gap-2 px-3 py-2 text-xs text-white/60 hover:text-white/90 rounded-md hover:bg-white/5"
           aria-label={collapsed ? "Développer la sidebar" : "Réduire la sidebar"}
+          title={collapsed ? "Développer la sidebar" : "Réduire la sidebar"}
         >
           {collapsed ? (
             <ChevronsRight className="w-4 h-4 mx-auto" aria-hidden="true" />
@@ -229,16 +164,14 @@ export function AdminSidebar() {
 
   return (
     <>
-      {/* Mobile trigger */}
       <button
         onClick={() => setMobileOpen(true)}
-        className="lg:hidden fixed top-3 left-3 z-50 p-2 rounded-lg bg-background border border-border shadow-md"
+        className="lg:hidden fixed top-2 left-2 z-50 h-11 w-11 inline-flex items-center justify-center rounded-lg bg-background border border-border shadow-md"
         aria-label="Ouvrir le menu"
+        title="Ouvrir le menu"
       >
         <Menu className="w-5 h-5" aria-hidden="true" />
       </button>
-
-      {/* Mobile overlay */}
       {mobileOpen && (
         <div
           className="lg:hidden fixed inset-0 z-50 bg-black/60"
@@ -246,29 +179,22 @@ export function AdminSidebar() {
           aria-hidden="true"
         />
       )}
-
-      {/* Mobile sidebar */}
       <aside
-        className={`lg:hidden fixed inset-y-0 left-0 z-50 w-64 flex flex-col transition-transform duration-200 ${
-          mobileOpen ? "translate-x-0" : "-translate-x-full"
-        }`}
+        className={`lg:hidden fixed inset-y-0 left-0 z-50 w-64 flex flex-col transition-transform duration-200 ${mobileOpen ? "translate-x-0" : "-translate-x-full"}`}
         style={{ backgroundColor: "oklch(0.18 0.015 250)" }}
       >
         <button
           onClick={() => setMobileOpen(false)}
-          className="absolute top-3 right-3 p-1 text-white/50 hover:text-white"
+          className="absolute top-2 right-2 h-11 w-11 inline-flex items-center justify-center text-white/60 hover:text-white"
           aria-label="Fermer le menu"
+          title="Fermer le menu"
         >
           <X className="w-5 h-5" aria-hidden="true" />
         </button>
         {sidebarContent}
       </aside>
-
-      {/* Desktop sidebar */}
       <aside
-        className={`hidden lg:flex flex-col shrink-0 sticky top-0 h-screen transition-[width] duration-200 ${
-          collapsed ? "w-16" : "w-56"
-        }`}
+        className={`hidden lg:flex flex-col shrink-0 sticky top-0 h-screen transition-[width] duration-200 ${collapsed ? "w-16" : "w-56"}`}
         style={{ backgroundColor: "oklch(0.18 0.015 250)" }}
       >
         {sidebarContent}
@@ -281,46 +207,47 @@ function NavLink({
   item,
   active,
   collapsed,
+  badge,
 }: {
-  item: NavItem;
+  item: {
+    href: string;
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+    counterKey?: AdminCounterKey;
+  };
   active: boolean;
   collapsed: boolean;
+  badge?: number;
 }) {
   const Icon = item.icon;
-
   return (
     <li>
       <Link
         href={item.href}
         aria-current={active ? "page" : undefined}
-        className={`group flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors ${
-          active
-            ? "bg-white/12 text-white font-medium"
-            : "text-white/60 hover:text-white hover:bg-white/6"
-        } ${collapsed ? "justify-center" : ""}`}
+        aria-label={collapsed ? item.label : undefined}
         title={collapsed ? item.label : undefined}
+        className={`relative min-h-11 flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors ${active ? "bg-white/12 text-white font-medium" : "text-white/60 hover:text-white hover:bg-white/6"} ${collapsed ? "justify-center" : ""}`}
       >
         <Icon className="w-4.5 h-4.5 shrink-0" aria-hidden="true" />
         {!collapsed && (
           <>
             <span className="truncate">{item.label}</span>
-            {item.badge !== undefined && item.badge > 0 && (
+            {badge !== undefined && badge > 0 && (
               <span
                 className="ml-auto text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
-                style={{
-                  backgroundColor: "oklch(0.52 0.2 25)",
-                  color: "white",
-                }}
+                style={{ backgroundColor: "oklch(0.52 0.2 25)", color: "white" }}
               >
-                {item.badge}
+                {badge}
               </span>
             )}
           </>
         )}
-        {collapsed && item.badge !== undefined && item.badge > 0 && (
+        {collapsed && badge !== undefined && badge > 0 && (
           <span
-            className="absolute -top-1 -right-1 w-2 h-2 rounded-full"
+            className="absolute top-2 right-2 w-2 h-2 rounded-full"
             style={{ backgroundColor: "oklch(0.52 0.2 25)" }}
+            aria-label={`${badge} élément${badge > 1 ? "s" : ""} en attente`}
           />
         )}
       </Link>

--- a/src/config/admin-navigation.test.ts
+++ b/src/config/admin-navigation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADMIN_NAVIGATION_GROUPS,
+  ADMIN_NAVIGATION,
+  isAdminNavigationActive,
+} from "./admin-navigation";
+
+describe("admin navigation registry", () => {
+  it("exposes the four work-oriented groups", () => {
+    expect(ADMIN_NAVIGATION_GROUPS.map((group) => group.label)).toEqual([
+      "À traiter",
+      "Contenus",
+      "Qualité et liaisons",
+      "Opérations",
+    ]);
+  });
+
+  it("keeps important routes unique and uses the unambiguous politician label", () => {
+    const routes = ADMIN_NAVIGATION.map((entry) => entry.href);
+    expect(new Set(routes).size).toBe(routes.length);
+    expect(ADMIN_NAVIGATION.find((entry) => entry.id === "politicians")?.label).toBe(
+      "Personnalités politiques"
+    );
+  });
+
+  it("does not activate Affairs for its proposal sub-route", () => {
+    const affairs = ADMIN_NAVIGATION.find((entry) => entry.id === "affairs")!;
+    const proposals = ADMIN_NAVIGATION.find((entry) => entry.id === "proposals")!;
+    expect(isAdminNavigationActive("/admin/affaires/propositions", affairs)).toBe(false);
+    expect(isAdminNavigationActive("/admin/affaires/propositions", proposals)).toBe(true);
+  });
+
+  it("activates the audit entry for its quality sub-route", () => {
+    const audit = ADMIN_NAVIGATION.find((entry) => entry.id === "audit")!;
+    expect(isAdminNavigationActive("/admin/audit/bio-quality", audit)).toBe(true);
+  });
+});

--- a/src/config/admin-navigation.ts
+++ b/src/config/admin-navigation.ts
@@ -1,0 +1,347 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Activity,
+  BarChart3,
+  Building2,
+  CheckSquare,
+  CopyCheck,
+  FileCheck2,
+  FileText,
+  HeartPulse,
+  History,
+  LayoutDashboard,
+  ListChecks,
+  Newspaper,
+  RefreshCw,
+  Scale,
+  Settings,
+  ShieldCheck,
+  ShieldX,
+  Share2,
+  ToggleLeft,
+  Users,
+  Vote,
+  Crown,
+  Fingerprint,
+} from "lucide-react";
+
+export type AdminNavigationGroupId = "todo" | "content" | "quality" | "operations";
+
+export type AdminCounterKey =
+  | "drafts.affairs"
+  | "drafts.politicians"
+  | "moderation.proposalsPending"
+  | "moderation.proposalsConflict"
+  | "moderation.reviewsPending"
+  | "matching.decisionsPending"
+  | "matching.duplicatesPending"
+  | "press.rejectionsPending"
+  | "operations.failedPipelines"
+  | "operations.failedSyncs";
+
+export interface AdminNavigationEntry {
+  id: string;
+  href: string;
+  label: string;
+  description: string;
+  group: AdminNavigationGroupId;
+  icon: LucideIcon;
+  counterKey?: AdminCounterKey;
+  aliases?: readonly string[];
+  breadcrumb?: string;
+  query?: Readonly<Record<string, string>>;
+}
+
+export interface AdminNavigationGroup {
+  id: AdminNavigationGroupId;
+  label: string;
+  description: string;
+  items: readonly AdminNavigationEntry[];
+}
+
+const entries: readonly AdminNavigationEntry[] = [
+  {
+    id: "dashboard",
+    href: "/admin",
+    label: "À traiter",
+    description: "Les files qui demandent une décision humaine.",
+    group: "todo",
+    icon: LayoutDashboard,
+    breadcrumb: "À traiter maintenant",
+  },
+  {
+    id: "politicians",
+    href: "/admin/politiques",
+    label: "Personnalités politiques",
+    description: "Profils, mandats et données biographiques.",
+    group: "content",
+    icon: Users,
+    counterKey: "drafts.politicians",
+  },
+  {
+    id: "parties",
+    href: "/admin/partis",
+    label: "Partis",
+    description: "Partis politiques et rattachements.",
+    group: "content",
+    icon: Building2,
+  },
+  {
+    id: "affairs",
+    href: "/admin/affaires",
+    label: "Affaires",
+    description: "Affaires judiciaires et publication.",
+    group: "content",
+    icon: Scale,
+    counterKey: "drafts.affairs",
+    aliases: ["/admin/affaires/[id]"],
+  },
+  {
+    id: "press",
+    href: "/admin/presse",
+    label: "Presse et articles",
+    description: "Articles de presse et mentions détectées.",
+    group: "content",
+    icon: Newspaper,
+  },
+  {
+    id: "legislative-files",
+    href: "/admin/dossiers",
+    label: "Dossiers législatifs",
+    description: "Dossiers et textes parlementaires.",
+    group: "content",
+    icon: FileText,
+  },
+  {
+    id: "measures",
+    href: "/admin/mesures",
+    label: "Mesures et programmes",
+    description: "Mesures, programmes et engagements.",
+    group: "content",
+    icon: ListChecks,
+  },
+  {
+    id: "candidates",
+    href: "/admin/candidats",
+    label: "Candidatures",
+    description: "Candidatures et comparaisons.",
+    group: "content",
+    icon: CheckSquare,
+  },
+  {
+    id: "mayors",
+    href: "/admin/maires",
+    label: "Maires",
+    description: "Données municipales.",
+    group: "content",
+    icon: Crown,
+  },
+  {
+    id: "factchecks",
+    href: "/admin/factchecks",
+    label: "Fact-checks",
+    description: "Fact-checks issus de sources autorisées.",
+    group: "content",
+    icon: ShieldCheck,
+  },
+  {
+    id: "social",
+    href: "/admin/social",
+    label: "Social",
+    description: "Sources et publications sociales.",
+    group: "content",
+    icon: Share2,
+  },
+  {
+    id: "promises",
+    href: "/admin/promises",
+    label: "Promesses",
+    description: "Promesses de campagne à vérifier.",
+    group: "content",
+    icon: FileCheck2,
+  },
+  {
+    id: "newsletter",
+    href: "/admin/newsletter",
+    label: "Newsletter",
+    description: "Éditions de la newsletter.",
+    group: "content",
+    icon: Newspaper,
+  },
+  {
+    id: "articles-affairs",
+    href: "/admin/presse?mention=none",
+    label: "Articles ↔ affaires",
+    description: "Articles analysés sans liaison détectée.",
+    group: "quality",
+    icon: FileCheck2,
+    counterKey: "matching.decisionsPending",
+    query: { mention: "none" },
+  },
+  {
+    id: "affairs-politicians",
+    href: "/admin/affair-matching/review",
+    label: "Affaires ↔ personnalités",
+    description: "Décisions de liaison à confirmer.",
+    group: "quality",
+    icon: Fingerprint,
+    counterKey: "matching.decisionsPending",
+  },
+  {
+    id: "affairs-decisions",
+    href: "/admin/affaires?filter=no-ecli",
+    label: "Affaires ↔ décisions judiciaires",
+    description: "Propositions issues des références judiciaires.",
+    group: "quality",
+    icon: Scale,
+  },
+  {
+    id: "proposals",
+    href: "/admin/affaires/propositions",
+    label: "Propositions",
+    description: "Modifications à examiner avant application.",
+    group: "quality",
+    icon: Activity,
+    counterKey: "moderation.proposalsPending",
+  },
+  {
+    id: "duplicates",
+    href: "/admin/affaires/doublons",
+    label: "Doublons",
+    description: "Paires d’affaires à comparer et trancher.",
+    group: "quality",
+    icon: CopyCheck,
+    counterKey: "matching.duplicatesPending",
+  },
+  {
+    id: "scrutin-titles",
+    href: "/admin/policy-titles",
+    label: "Titres de scrutins",
+    description: "Titres et liaisons des scrutins.",
+    group: "quality",
+    icon: Vote,
+  },
+  {
+    id: "press-rejections",
+    href: "/admin/press/rejections",
+    label: "Rejets presse",
+    description: "Rejets nécessitant une décision éditoriale.",
+    group: "quality",
+    icon: ShieldX,
+    counterKey: "press.rejectionsPending",
+  },
+  {
+    id: "matching-dashboard",
+    href: "/admin/affair-matching/dashboard",
+    label: "Activité des liaisons",
+    description: "Suivi agrégé du registre de liaison.",
+    group: "quality",
+    icon: BarChart3,
+  },
+  {
+    id: "pipelines",
+    href: "/admin/pipelines",
+    label: "Pipelines",
+    description: "Santé et échecs des pipelines.",
+    group: "operations",
+    icon: HeartPulse,
+    counterKey: "operations.failedPipelines",
+  },
+  {
+    id: "syncs",
+    href: "/admin/syncs",
+    label: "Synchronisations",
+    description: "Exécutions et échecs de synchronisation.",
+    group: "operations",
+    icon: RefreshCw,
+    counterKey: "operations.failedSyncs",
+  },
+  {
+    id: "audit",
+    href: "/admin/audit",
+    label: "Journal d’audit",
+    description: "Historique des actions administratives.",
+    group: "operations",
+    icon: History,
+    aliases: ["/admin/audit/bio-quality"],
+  },
+  {
+    id: "feature-toggles",
+    href: "/admin/feature-toggles",
+    label: "Fonctionnalités expérimentales",
+    description: "Activation contrôlée des fonctionnalités en test.",
+    group: "operations",
+    icon: ToggleLeft,
+  },
+  {
+    id: "settings",
+    href: "/admin/parametres",
+    label: "Paramètres",
+    description: "Configuration de l’administration.",
+    group: "operations",
+    icon: Settings,
+  },
+];
+
+export const ADMIN_NAVIGATION_GROUPS: readonly AdminNavigationGroup[] = [
+  {
+    id: "todo",
+    label: "À traiter",
+    description: "Files de travail",
+    items: entries.filter((e) => e.group === "todo"),
+  },
+  {
+    id: "content",
+    label: "Contenus",
+    description: "Production éditoriale",
+    items: entries.filter((e) => e.group === "content"),
+  },
+  {
+    id: "quality",
+    label: "Qualité et liaisons",
+    description: "Contrôles et rapprochements",
+    items: entries.filter((e) => e.group === "quality"),
+  },
+  {
+    id: "operations",
+    label: "Opérations",
+    description: "Santé et administration",
+    items: entries.filter((e) => e.group === "operations"),
+  },
+];
+
+export const ADMIN_NAVIGATION = entries;
+
+function pathMatches(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
+export function isAdminNavigationActive(pathname: string, entry: AdminNavigationEntry): boolean {
+  const route = entry.href.split("?")[0] ?? "/admin";
+  if (route === "/admin") return pathname === "/admin";
+  if (entry.id === "affairs") {
+    return (
+      pathMatches(pathname, route) &&
+      !["/admin/affaires/propositions", "/admin/affaires/doublons", "/admin/affaires/nouveau"].some(
+        (excluded) => pathMatches(pathname, excluded)
+      )
+    );
+  }
+  return (
+    pathMatches(pathname, route) ||
+    (entry.aliases ?? []).some((alias) => pathMatches(pathname, alias))
+  );
+}
+
+export function findAdminNavigationEntry(pathname: string): AdminNavigationEntry | undefined {
+  return [...ADMIN_NAVIGATION]
+    .filter((entry) => isAdminNavigationActive(pathname, entry))
+    .sort((a, b) => b.href.length - a.href.length)[0];
+}
+
+export function getCounterValue(
+  counters: Record<string, number>,
+  key: AdminCounterKey | undefined
+): number | undefined {
+  return key ? (counters[key] ?? 0) : undefined;
+}


### PR DESCRIPTION
## Résumé

Lot 1 de #744 : navigation admin organisée par responsabilités, files d’action, compteurs typés, breadcrumbs, en-têtes communs et dashboard À traiter.

## Vérifications

- npm ci

- npx prisma generate
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- gardes source SEC-03 et SEC-06

- Les gardes Docker SEC-02, SEC-03 et SEC-06 ne peuvent pas exécuter leur partie base dans cet environnement sans Docker

## Périmètre laissé aux lots suivants

Le sélecteur recherché, l’atelier article-affaire, la réattribution affaire-personnalité et AffairParticipant restent hors périmètre.

Aucune route supprimée, aucun changement Prisma, aucune écriture Supabase de production et aucun merge.