### PR TITLE
feat(admin): remplacer les listes massives par un sélecteur recherché

### DIFF
--- a/src/app/admin/affair-matching/review/page.tsx
+++ b/src/app/admin/affair-matching/review/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, ChevronRight, LinkIcon, Loader2, Search } from "lucide-react";
 import { BlockedAffairs } from "@/components/admin/BlockedAffairs";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { PoliticianPicker } from "@/components/admin/PoliticianPicker";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -39,14 +40,6 @@ interface DecisionRow {
   chosenPolitician: { id: string; fullName: string; slug: string } | null;
   affairId: string | null;
   affair: { id: string; title: string; publicationStatus: string } | null;
-}
-
-interface PoliticianSearchResult {
-  id: string;
-  fullName: string;
-  slug: string;
-  party: string | null;
-  mandate: string | null;
 }
 
 interface ReviewResponse {
@@ -598,43 +591,11 @@ function NoMatchActions({
   ) => Promise<void>;
 }) {
   const [showSearch, setShowSearch] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<PoliticianSearchResult[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isOutOfScopeLoading = actionInProgress === `no-match-${decisionId}-OUT_OF_SCOPE`;
   const isManualPickLoading = actionInProgress === `no-match-${decisionId}-MANUAL_PICK`;
   const isCreatingLoading = actionInProgress === `no-match-${decisionId}-CREATE_POLITICIAN`;
   const anyLoading = actionInProgress !== null;
-
-  const handleSearchChange = (value: string) => {
-    setSearchQuery(value);
-    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-    if (value.length < 2) {
-      setSearchResults([]);
-      return;
-    }
-    searchTimeoutRef.current = setTimeout(async () => {
-      setSearchLoading(true);
-      try {
-        const res = await fetch(`/api/search/politicians?q=${encodeURIComponent(value)}`);
-        if (res.ok) {
-          const data = (await res.json()) as PoliticianSearchResult[];
-          setSearchResults(data);
-        }
-      } finally {
-        setSearchLoading(false);
-      }
-    }, 300);
-  };
-
-  const handlePickPolitician = (politicianId: string) => {
-    setShowSearch(false);
-    setSearchQuery("");
-    setSearchResults([]);
-    void onResolve(decisionId, "MANUAL_PICK", politicianId);
-  };
 
   return (
     <div className="space-y-3 pt-1">
@@ -678,61 +639,16 @@ function NoMatchActions({
             use "Choisir manuellement" to pick the newly-created politician. */}
       </div>
 
-      {/* Inline politician search */}
+      {/* Shared, bounded politician search */}
       {showSearch && (
-        <div className="space-y-2">
-          <div className="relative">
-            <Search
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <input
-              type="search"
-              placeholder="Rechercher un politicien..."
-              value={searchQuery}
-              onChange={(e) => handleSearchChange(e.target.value)}
-              className="w-full pl-8 pr-3 py-1.5 text-sm rounded-md border border-input bg-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-              aria-label="Rechercher un politicien par nom"
-              autoFocus
-            />
-            {searchLoading && (
-              <Loader2
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 animate-spin text-muted-foreground"
-                aria-hidden="true"
-              />
-            )}
-          </div>
-
-          {searchResults.length > 0 && (
-            <ul
-              className="rounded-md border border-border bg-popover shadow-sm divide-y divide-border overflow-hidden"
-              role="listbox"
-              aria-label="Résultats de recherche"
-            >
-              {searchResults.map((p) => (
-                <li key={p.id} role="option" aria-selected={false}>
-                  <button
-                    type="button"
-                    className="w-full text-left px-3 py-2 hover:bg-muted transition-colors"
-                    onClick={() => handlePickPolitician(p.id)}
-                    aria-label={`Sélectionner ${p.fullName}`}
-                  >
-                    <span className="text-sm font-medium">{p.fullName}</span>
-                    {(p.party || p.mandate) && (
-                      <span className="ml-2 text-xs text-muted-foreground">
-                        {[p.party, p.mandate].filter(Boolean).join(" - ")}
-                      </span>
-                    )}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-
-          {searchQuery.length >= 2 && !searchLoading && searchResults.length === 0 && (
-            <p className="text-xs text-muted-foreground px-1">Aucun résultat.</p>
-          )}
-        </div>
+        <PoliticianPicker
+          value={null}
+          onChange={(politicianId) => {
+            if (politicianId) void onResolve(decisionId, "MANUAL_PICK", politicianId);
+          }}
+          label="Choisir une personnalité politique"
+          description="Les candidats sont affichés avec leur parti, mandat, statut et slug."
+        />
       )}
     </div>
   );

--- a/src/app/admin/affaires/[id]/edit/page.tsx
+++ b/src/app/admin/affaires/[id]/edit/page.tsx
@@ -20,16 +20,9 @@ async function getAffair(id: string) {
   });
 }
 
-async function getPoliticians() {
-  return db.politician.findMany({
-    select: { id: true, fullName: true, slug: true },
-    orderBy: { lastName: "asc" },
-  });
-}
-
 export default async function EditAffairPage({ params }: PageProps) {
   const { id } = await params;
-  const [affair, politicians] = await Promise.all([getAffair(id), getPoliticians()]);
+  const affair = await getAffair(id);
 
   if (!affair) {
     notFound();
@@ -104,7 +97,7 @@ export default async function EditAffairPage({ params }: PageProps) {
           />
         </div>
       )}
-      <AffairForm politicians={politicians} initialData={initialData} />
+      <AffairForm initialData={initialData} />
     </div>
   );
 }

--- a/src/app/admin/affaires/nouveau/page.tsx
+++ b/src/app/admin/affaires/nouveau/page.tsx
@@ -1,20 +1,15 @@
-import { db } from "@/lib/db";
 import { AffairForm } from "@/components/admin/AffairForm";
-
-async function getPoliticians() {
-  return db.politician.findMany({
-    select: { id: true, fullName: true, slug: true },
-    orderBy: { lastName: "asc" },
-  });
+interface PageProps {
+  searchParams: Promise<{ politicianId?: string }>;
 }
 
-export default async function NewAffairPage() {
-  const politicians = await getPoliticians();
+export default async function NewAffairPage({ searchParams }: PageProps) {
+  const { politicianId } = await searchParams;
 
   return (
     <div className="max-w-3xl">
       <h1 className="text-2xl font-bold mb-6">Nouvelle affaire judiciaire</h1>
-      <AffairForm politicians={politicians} />
+      <AffairForm initialPoliticianId={politicianId} />
     </div>
   );
 }

--- a/src/app/api/admin/affaires/[id]/route.test.ts
+++ b/src/app/api/admin/affaires/[id]/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({
+  db: { affair: { findUnique: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/lib/api/with-admin-auth", () => ({ withAdminAuth: (handler: unknown) => handler }));
+vi.mock("@/lib/cache", () => ({ invalidateEntity: vi.fn() }));
+vi.mock("@/lib/utils", () => ({ generateAffairSlug: vi.fn() }));
+vi.mock("@/services/affairs/status-tracking", () => ({ trackStatusChange: vi.fn() }));
+vi.mock("@/lib/affairs/publish-guard", () => ({
+  assertPublishable: vi.fn(),
+  PublishGuardError: class PublishGuardError extends Error {},
+  VERIFIED_BY_MODERATION: "Poligraph Moderation",
+  PUBLISHED_STATUS: "PUBLISHED",
+}));
+
+import { PUT } from "./route";
+
+describe("PUT admin affair politician guard", () => {
+  it("rejects changing the politician of a published affair before writes", async () => {
+    h.db.affair.findUnique.mockResolvedValue({
+      id: "affair-1",
+      politicianId: "politician-1",
+      publicationStatus: "PUBLISHED",
+      title: "Affaire test",
+      slug: "affaire-test",
+      politician: { slug: "jean-test" },
+    });
+    const body = {
+      politicianId: "politician-2",
+      title: "Affaire test",
+      description: "Description",
+      status: "ENQUETE_PRELIMINAIRE",
+      category: "AUTRE",
+      appeal: false,
+      sources: [
+        {
+          url: "https://example.test/source",
+          title: "Source",
+          publisher: "Example",
+          publishedAt: "2026-01-01",
+        },
+      ],
+    };
+    const response = await PUT(
+      new NextRequest("https://poligraph.fr/api/admin/affaires/affair-1", {
+        method: "PUT",
+        body: JSON.stringify(body),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ id: "affair-1" }) }
+    );
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      code: "PUBLISHED_AFFAIR_POLITICIAN_CHANGE_REQUIRES_DEDICATED_WORKFLOW",
+    });
+  });
+});

--- a/src/app/api/admin/affaires/[id]/route.ts
+++ b/src/app/api/admin/affaires/[id]/route.ts
@@ -52,18 +52,35 @@ export const PUT = withAdminAuth(async (request: NextRequest, context) => {
     return NextResponse.json({ error: "Affaire non trouvée" }, { status: 404 });
   }
 
+  if (existing.publicationStatus === "PUBLISHED" && data.politicianId !== existing.politicianId) {
+    return NextResponse.json(
+      {
+        error: "Réattribution interdite depuis le formulaire générique",
+        code: "PUBLISHED_AFFAIR_POLITICIAN_CHANGE_REQUIRES_DEDICATED_WORKFLOW",
+        message: "La réattribution d’une affaire publiée est une opération éditoriale dédiée.",
+      },
+      { status: 409 }
+    );
+  }
+
+  const selectedPolitician = await db.politician.findUnique({
+    where: { id: data.politicianId },
+    select: { slug: true },
+  });
+  if (!selectedPolitician) {
+    return NextResponse.json(
+      { error: "Personnalité politique introuvable", code: "POLITICIAN_NOT_FOUND" },
+      { status: 404 }
+    );
+  }
+
   // Regenerate slug if title or politician changed
   let newSlug: string | undefined;
   let oldSlugToSave: string | undefined;
   if (existing.title !== data.title || existing.politicianId !== data.politicianId) {
     const politicianSlug =
       existing.politicianId !== data.politicianId
-        ? ((
-            await db.politician.findUnique({
-              where: { id: data.politicianId },
-              select: { slug: true },
-            })
-          )?.slug ?? existing.politician.slug)
+        ? selectedPolitician.slug
         : existing.politician.slug;
 
     const baseSlug = generateAffairSlug(politicianSlug, data.title);

--- a/src/app/api/admin/entities/politicians/route.test.ts
+++ b/src/app/api/admin/entities/politicians/route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({
+  db: {
+    $queryRaw: vi.fn(),
+    politician: { findMany: vi.fn(), findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ db: h.db }));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (handler: (request: NextRequest) => Promise<Response>) => handler,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({}) };
+
+const politician = {
+  id: "p-1",
+  fullName: "François Fillon",
+  slug: "francois-fillon",
+  publicationStatus: "PUBLISHED",
+  currentParty: { shortName: "LR", name: "Les Républicains" },
+  mandates: [
+    {
+      type: "DEPUTE",
+      title: "Député",
+      institution: "Assemblée nationale",
+      constituency: "Sarthe (2ème)",
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.db.$queryRaw.mockResolvedValue([{ id: "p-1" }]);
+  h.db.politician.findMany.mockResolvedValue([politician]);
+  h.db.politician.findUnique.mockResolvedValue(politician);
+});
+
+describe("GET /api/admin/entities/politicians", () => {
+  it("returns at most 20 contextualized results", async () => {
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/entities/politicians?q=francois&limit=20"),
+      context
+    );
+    const body = await response.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toMatchObject({
+      id: "p-1",
+      fullName: "François Fillon",
+      slug: "francois-fillon",
+      publicationStatus: "PUBLISHED",
+      party: { shortName: "LR", name: "Les Républicains" },
+      mandate: { type: "DEPUTE", institution: "Assemblée nationale" },
+    });
+    expect(h.db.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves the current value by id without searching the corpus", async () => {
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/entities/politicians?id=p-1"),
+      context
+    );
+    expect(await response.json()).toMatchObject({ result: { id: "p-1", slug: "francois-fillon" } });
+    expect(h.db.politician.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "p-1" } })
+    );
+    expect(h.db.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid or underspecified parameters", async () => {
+    expect(
+      (
+        await GET(
+          new NextRequest("https://poligraph.fr/api/admin/entities/politicians?limit=21"),
+          context
+        )
+      ).status
+    ).toBe(400);
+    await expect(
+      (
+        await GET(
+          new NextRequest("https://poligraph.fr/api/admin/entities/politicians?q=f"),
+          context
+        )
+      ).json()
+    ).resolves.toMatchObject({ results: [] });
+    expect(h.db.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("passes the accent-tolerant search term through the parameterized query", async () => {
+    await GET(
+      new NextRequest("https://poligraph.fr/api/admin/entities/politicians?q=François"),
+      context
+    );
+    expect(h.db.$queryRaw.mock.calls[0]?.[0]).toBeDefined();
+  });
+});

--- a/src/app/api/admin/entities/politicians/route.ts
+++ b/src/app/api/admin/entities/politicians/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { MANDATE_TYPE_LABELS } from "@/config/labels";
+
+const querySchema = z.object({
+  q: z.string().trim().max(100).optional(),
+  id: z.string().trim().min(1).max(100).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(20).default(20),
+});
+
+const politicianSelect = {
+  id: true,
+  fullName: true,
+  slug: true,
+  publicationStatus: true,
+  currentParty: { select: { shortName: true, name: true } },
+  mandates: {
+    where: { isCurrent: true },
+    orderBy: { startDate: "desc" as const },
+    take: 1,
+    select: { type: true, title: true, institution: true, constituency: true },
+  },
+} as const;
+
+function formatResult(politician: {
+  id: string;
+  fullName: string;
+  slug: string;
+  publicationStatus: string;
+  currentParty: { shortName: string | null; name: string } | null;
+  mandates: Array<{
+    type: keyof typeof MANDATE_TYPE_LABELS;
+    title: string;
+    institution: string;
+    constituency: string | null;
+  }>;
+}) {
+  return {
+    id: politician.id,
+    fullName: politician.fullName,
+    slug: politician.slug,
+    publicationStatus: politician.publicationStatus,
+    party: politician.currentParty,
+    mandate: politician.mandates[0] ?? null,
+  };
+}
+
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  const parsed = querySchema.safeParse(Object.fromEntries(request.nextUrl.searchParams.entries()));
+  if (!parsed.success)
+    return NextResponse.json({ error: "Paramètres de recherche invalides" }, { status: 400 });
+  const { q, id, page, limit } = parsed.data;
+
+  if (id) {
+    const politician = await db.politician.findUnique({ where: { id }, select: politicianSelect });
+    return NextResponse.json({ result: politician ? formatResult(politician) : null });
+  }
+  if (!q || q.length < 2) return NextResponse.json({ results: [], page, limit, hasMore: false });
+
+  const offset = (page - 1) * limit;
+  const search = `%${q.replace(/[%_]/g, "\\$&")}%`;
+  const rows = await db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT p.id
+    FROM "Politician" p
+    LEFT JOIN "Party" party ON party.id = p."currentPartyId"
+    WHERE lower(unaccent(concat_ws(' ', p."firstName", p."lastName", p."fullName", p.slug,
+      coalesce(p."normalizedLastName", ''), coalesce(party.name, ''), coalesce(party."shortName", ''))))
+      LIKE lower(unaccent(${search})) ESCAPE '\\'
+    ORDER BY p."prominenceScore" DESC, p."lastName" ASC, p."firstName" ASC
+    OFFSET ${offset}
+    LIMIT ${limit + 1}
+  `);
+  const hasMore = rows.length > limit;
+  const ids = rows.slice(0, limit).map((row) => row.id);
+  if (!ids.length) return NextResponse.json({ results: [], page, limit, hasMore: false });
+
+  const politicians = await db.politician.findMany({
+    where: { id: { in: ids } },
+    select: politicianSelect,
+  });
+  const byId = new Map(politicians.map((politician) => [politician.id, politician]));
+  return NextResponse.json({
+    results: ids.flatMap((politicianId) => {
+      const politician = byId.get(politicianId);
+      return politician ? [formatResult(politician)] : [];
+    }),
+    page,
+    limit,
+    hasMore,
+  });
+});

--- a/src/app/api/admin/entities/politicians/route.ts
+++ b/src/app/api/admin/entities/politicians/route.ts
@@ -62,7 +62,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
   if (!q || q.length < 2) return NextResponse.json({ results: [], page, limit, hasMore: false });
 
   const offset = (page - 1) * limit;
-  const search = `%${q.replace(/[%_]/g, "\\$&")}%`;
+  const search = `%${q.replace(/[\\%_]/g, "\\$&")}%`;
   const rows = await db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
     SELECT p.id
     FROM "Politician" p

--- a/src/components/admin/AdminEntityPicker.tsx
+++ b/src/components/admin/AdminEntityPicker.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Check, ChevronDown, Loader2, Search, X } from "lucide-react";
+
+export interface AdminEntityPickerResult {
+  id: string;
+}
+
+export interface AdminEntityPickerProps<T extends AdminEntityPickerResult> {
+  value: string | null;
+  onChange: (value: string | null, result: T | null) => void;
+  onResolved?: (result: T | null) => void;
+  search: (query: string, signal: AbortSignal) => Promise<T[]>;
+  resolve: (id: string, signal: AbortSignal) => Promise<T | null>;
+  renderResult: (result: T) => React.ReactNode;
+  renderSelected?: (result: T) => React.ReactNode;
+  label: string;
+  placeholder: string;
+  clearable?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  maxResults?: number;
+  description?: string;
+}
+
+export function AdminEntityPicker<T extends AdminEntityPickerResult>({
+  value,
+  onChange,
+  onResolved,
+  search,
+  resolve,
+  renderResult,
+  renderSelected = renderResult,
+  label,
+  placeholder,
+  clearable = true,
+  disabled = false,
+  readOnly = false,
+  maxResults = 20,
+  description,
+}: AdminEntityPickerProps<T>) {
+  const inputId = useId();
+  const listboxId = `${inputId}-listbox`;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const requestRef = useRef(0);
+  const resolveControllerRef = useRef<AbortController | null>(null);
+  const searchControllerRef = useRef<AbortController | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<T | null>(null);
+  const [results, setResults] = useState<T[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (!value) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronize controlled value removal
+      setSelected(null);
+      return;
+    }
+    if (selected?.id === value) return;
+    resolveControllerRef.current?.abort();
+    const controller = new AbortController();
+    resolveControllerRef.current = controller;
+    setLoading(true);
+    setError(null);
+    void resolve(value, controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) {
+          setSelected(result);
+          onResolved?.(result);
+        }
+      })
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(reason instanceof Error ? reason.message : "Impossible de charger la sélection");
+          setSelected(null);
+          onResolved?.(null);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [onResolved, resolve, selected?.id, value]);
+
+  useEffect(() => {
+    function closeOnOutside(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", closeOnOutside);
+    return () => document.removeEventListener("mousedown", closeOnOutside);
+  }, []);
+
+  useEffect(() => {
+    if (!open || readOnly || query.trim().length < 2) {
+      searchControllerRef.current?.abort();
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear stale results when the query is no longer searchable
+      setResults([]);
+      setActiveIndex(-1);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      searchControllerRef.current?.abort();
+      const controller = new AbortController();
+      searchControllerRef.current = controller;
+      const requestId = ++requestRef.current;
+      setLoading(true);
+      setError(null);
+      void search(query.trim(), controller.signal)
+        .then((items) => {
+          if (controller.signal.aborted || requestId !== requestRef.current) return;
+          const bounded = items.slice(0, maxResults);
+          setResults(bounded);
+          setActiveIndex(bounded.length ? 0 : -1);
+          setAnnouncement(
+            bounded.length ? `${bounded.length} résultats disponibles` : "Aucun résultat"
+          );
+        })
+        .catch((reason: unknown) => {
+          if (!controller.signal.aborted && requestId === requestRef.current) {
+            setError(
+              reason instanceof Error ? reason.message : "Impossible de charger les résultats"
+            );
+            setResults([]);
+            setAnnouncement("Impossible de charger les résultats");
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted && requestId === requestRef.current) setLoading(false);
+        });
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [maxResults, open, query, readOnly, search]);
+
+  function selectResult(result: T) {
+    setSelected(result);
+    setQuery("");
+    setResults([]);
+    setOpen(false);
+    setActiveIndex(-1);
+    setAnnouncement("Sélection enregistrée");
+    onChange(result.id, result);
+  }
+
+  function clearSelection() {
+    setSelected(null);
+    setQuery("");
+    setResults([]);
+    setOpen(false);
+    setActiveIndex(-1);
+    setAnnouncement("Sélection effacée");
+    onResolved?.(null);
+    onChange(null, null);
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setActiveIndex((index) => (results.length ? (index + 1) % results.length : -1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        results.length ? (index - 1 + results.length) % results.length : -1
+      );
+    } else if (event.key === "Enter" && open && activeIndex >= 0 && results[activeIndex]) {
+      event.preventDefault();
+      selectResult(results[activeIndex]);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      setResults([]);
+      setActiveIndex(-1);
+    } else if (event.key === "Tab") {
+      setOpen(false);
+    }
+  }
+
+  const activeOptionId = activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined;
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      <label htmlFor={inputId} className="text-sm font-medium">
+        {label}
+      </label>
+      {description && (
+        <p id={`${inputId}-description`} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {selected && (
+        <div
+          className="flex items-start gap-3 rounded-lg border bg-muted/50 p-3"
+          aria-label="Sélection actuelle"
+        >
+          <div className="min-w-0 flex-1">{renderSelected(selected)}</div>
+          {clearable && !disabled && !readOnly && (
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="min-h-11 min-w-11 inline-flex items-center justify-center rounded-md hover:bg-accent"
+              aria-label="Effacer la sélection"
+              title="Effacer la sélection"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
+      {!readOnly && !disabled && (
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <input
+            id={inputId}
+            type="search"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listboxId}
+            aria-activedescendant={activeOptionId}
+            aria-autocomplete="list"
+            aria-describedby={description ? `${inputId}-description` : undefined}
+            className="min-h-11 w-full rounded-lg border bg-background py-2 pl-10 pr-10 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          {loading ? (
+            <Loader2
+              className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+              aria-hidden="true"
+            />
+          ) : (
+            <ChevronDown
+              className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+          )}
+          {open && (query.trim().length >= 2 || loading || error) && (
+            <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-lg border bg-popover shadow-md">
+              <div className="sr-only" aria-live="polite">
+                {announcement}
+              </div>
+              {error && (
+                <p role="alert" className="p-3 text-sm text-destructive">
+                  Impossible de charger les résultats
+                </p>
+              )}
+              {!error && loading && <p className="p-3 text-sm text-muted-foreground">Recherche…</p>}
+              {!error && !loading && query.trim().length >= 2 && results.length === 0 && (
+                <p className="p-3 text-sm text-muted-foreground">Aucun résultat</p>
+              )}
+              {!error && results.length > 0 && (
+                <ul
+                  id={listboxId}
+                  role="listbox"
+                  aria-label={label}
+                  className="max-h-80 overflow-auto py-1"
+                >
+                  {results.map((result, index) => (
+                    <li
+                      key={result.id}
+                      id={`${listboxId}-option-${index}`}
+                      role="option"
+                      aria-selected={index === activeIndex}
+                      className={index === activeIndex ? "bg-accent" : ""}
+                    >
+                      <button
+                        type="button"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => selectResult(result)}
+                        className="min-h-11 w-full px-3 py-2 text-left"
+                      >
+                        {renderResult(result)}
+                        {index === activeIndex && (
+                          <Check className="float-right mt-1 h-4 w-4" aria-hidden="true" />
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {readOnly && <p className="text-xs text-muted-foreground">Sélection en lecture seule.</p>}
+      <div className="sr-only" aria-live="polite">
+        {announcement}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AffairForm.tsx
+++ b/src/components/admin/AffairForm.tsx
@@ -16,16 +16,11 @@ import {
   PUBLICATION_STATUS_OPTIONS,
 } from "@/config/labels";
 import { LinkedAffairSelect } from "@/components/admin/LinkedAffairSelect";
+import { PoliticianPicker } from "@/components/admin/PoliticianPicker";
 import { involvementRequiresNote } from "@/lib/affairs/involvement-note";
 import { formatAffairFormError } from "@/lib/admin/moderation-payload";
 import type { AffairStatus, AffairCategory, Involvement, SourceType } from "@/types";
 import type { PublicationStatus } from "@/generated/prisma";
-
-interface Politician {
-  id: string;
-  fullName: string;
-  slug: string;
-}
 
 interface Source {
   id?: string;
@@ -73,8 +68,8 @@ interface AffairFormData {
 }
 
 interface AffairFormProps {
-  politicians: Politician[];
   initialData?: AffairFormData;
+  initialPoliticianId?: string;
 }
 
 const emptySource: Source = {
@@ -86,13 +81,14 @@ const emptySource: Source = {
   sourceType: "MANUAL" as SourceType,
 };
 
-export function AffairForm({ politicians, initialData }: AffairFormProps) {
+export function AffairForm({ initialData, initialPoliticianId }: AffairFormProps) {
   const router = useRouter();
   const isEditing = !!initialData?.id;
+  const isPublished = initialData?.publicationStatus === "PUBLISHED";
 
   const [formData, setFormData] = useState<AffairFormData>(
     initialData || {
-      politicianId: "",
+      politicianId: initialPoliticianId ?? "",
       title: "",
       description: "",
       status: "ENQUETE_PRELIMINAIRE" as AffairStatus,
@@ -138,7 +134,7 @@ export function AffairForm({ politicians, initialData }: AffairFormProps) {
 
     // Validation
     if (!formData.politicianId) {
-      setError("Veuillez sélectionner un politique");
+      setError("Veuillez sélectionner une personnalité politique");
       return;
     }
     if (!formData.title.trim()) {
@@ -203,20 +199,17 @@ export function AffairForm({ politicians, initialData }: AffairFormProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           <div>
-            <Label htmlFor="politicianId">Politique concerné *</Label>
-            <Select
-              id="politicianId"
-              value={formData.politicianId}
-              onChange={(e) => updateField("politicianId", e.target.value)}
-              required
-            >
-              <option value="">Sélectionner un politique</option>
-              {politicians.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.fullName}
-                </option>
-              ))}
-            </Select>
+            <PoliticianPicker
+              value={formData.politicianId || null}
+              onChange={(value) => updateField("politicianId", value ?? "")}
+              readOnly={isPublished}
+              label="Personnalité politique concernée *"
+              description={
+                isPublished
+                  ? "La réattribution d’une affaire publiée est une opération éditoriale dédiée."
+                  : undefined
+              }
+            />
           </div>
 
           <div>

--- a/src/components/admin/LinkedAffairSelect.tsx
+++ b/src/components/admin/LinkedAffairSelect.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Search, X, AlertTriangle } from "lucide-react";
+import { useCallback, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { AdminEntityPicker } from "@/components/admin/AdminEntityPicker";
 import { INVOLVEMENT_LABELS } from "@/config/labels";
 import type { Involvement } from "@/generated/prisma";
 
@@ -22,118 +23,74 @@ interface Props {
 }
 
 export function LinkedAffairSelect({ value, onChange, excludeId, currentInvolvement }: Props) {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<LinkedAffair[]>([]);
   const [selected, setSelected] = useState<LinkedAffair | null>(null);
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (value && !selected) {
-      fetch(`/api/admin/affaires/search?id=${value}`)
-        .then((r) => r.json())
-        .then((data) => {
-          if (data.results[0]) setSelected(data.results[0]);
-        });
-    }
-  }, [value, selected]);
-
   const search = useCallback(
-    async (q: string) => {
-      if (q.length < 2) {
-        setResults([]);
-        return;
-      }
-      const params = new URLSearchParams({ q });
+    async (query: string, signal: AbortSignal) => {
+      const params = new URLSearchParams({ q: query });
       if (excludeId) params.set("excludeId", excludeId);
-      const res = await fetch(`/api/admin/affaires/search?${params}`);
-      const data = await res.json();
-      setResults(data.results);
+      const response = await fetch(`/api/admin/affaires/search?${params.toString()}`, { signal });
+      if (!response.ok) throw new Error("Recherche d’affaire indisponible");
+      const data = (await response.json()) as { results: LinkedAffair[] };
+      return data.results;
     },
     [excludeId]
   );
+  const resolve = useCallback(async (id: string, signal: AbortSignal) => {
+    const response = await fetch(`/api/admin/affaires/search?id=${encodeURIComponent(id)}`, {
+      signal,
+    });
+    if (!response.ok) throw new Error("Impossible de charger l’affaire sélectionnée");
+    const data = (await response.json()) as { results: LinkedAffair[] };
+    return data.results[0] ?? null;
+  }, []);
 
-  useEffect(() => {
-    const timer = setTimeout(() => search(query), 300);
-    return () => clearTimeout(timer);
-  }, [query, search]);
-
-  const handleSelect = (affair: LinkedAffair) => {
-    setSelected(affair);
-    onChange(affair.id);
-    setIsOpen(false);
-    setQuery("");
-  };
-
-  const handleClear = () => {
-    setSelected(null);
-    onChange(null);
-  };
-
-  const showSameInvolvementWarning =
-    selected && currentInvolvement && selected.involvement === currentInvolvement;
-  const showChainWarning = selected && selected.linkedAffairId !== null;
+  const showSameInvolvementWarning = Boolean(
+    selected && currentInvolvement && selected.involvement === currentInvolvement
+  );
+  const showChainWarning = Boolean(selected?.linkedAffairId);
 
   return (
     <div className="space-y-2">
-      <label className="text-sm font-medium">Affaire liee (optionnel)</label>
-      {selected ? (
-        <div className="flex items-center gap-2 rounded-lg border bg-muted/50 p-3">
-          <div className="flex-1 text-sm">
-            <p className="font-medium">{selected.title}</p>
-            <p className="text-muted-foreground">
-              {selected.politician.fullName} - {INVOLVEMENT_LABELS[selected.involvement]}
+      <AdminEntityPicker<LinkedAffair>
+        value={value}
+        onChange={(id, result) => {
+          setSelected(result);
+          onChange(id);
+        }}
+        onResolved={setSelected}
+        search={search}
+        resolve={resolve}
+        renderResult={(affair) => (
+          <div className="pr-5">
+            <p className="font-medium">{affair.title}</p>
+            <p className="text-xs text-muted-foreground">
+              {affair.politician.fullName} · {INVOLVEMENT_LABELS[affair.involvement]}
             </p>
+            <p className="text-xs text-muted-foreground">{affair.slug}</p>
           </div>
-          <button type="button" onClick={handleClear} className="rounded p-1 hover:bg-accent">
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      ) : (
-        <div className="relative">
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setIsOpen(true);
-            }}
-            onFocus={() => setIsOpen(true)}
-            placeholder="Rechercher une affaire par titre..."
-            className="w-full rounded-lg border bg-background py-2 pl-9 pr-3 text-sm"
-          />
-          {isOpen && results.length > 0 && (
-            <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg border bg-popover shadow-md">
-              {results.map((affair) => (
-                <li key={affair.id}>
-                  <button
-                    type="button"
-                    onClick={() => handleSelect(affair)}
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
-                  >
-                    <p className="font-medium">{affair.title}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {affair.politician.fullName} - {INVOLVEMENT_LABELS[affair.involvement]}
-                    </p>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
+        )}
+        label="Affaire liée (optionnel)"
+        placeholder="Rechercher une affaire par titre..."
+        description="La liaison conserve son sens actuel et exclut l’affaire en cours."
+      />
       {showSameInvolvementWarning && (
-        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
-          <AlertTriangle className="h-3.5 w-3.5" />
-          Les deux affaires ont le meme role ({INVOLVEMENT_LABELS[currentInvolvement]}). Verifiez la
-          coherence.
-        </div>
+        <p
+          role="alert"
+          className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400"
+        >
+          <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+          Les deux affaires ont le même rôle ({INVOLVEMENT_LABELS[currentInvolvement!]}). Vérifiez
+          la cohérence.
+        </p>
       )}
       {showChainWarning && (
-        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
-          <AlertTriangle className="h-3.5 w-3.5" />
-          Cette affaire est deja liee a une autre affaire. Lier creera une chaine.
-        </div>
+        <p
+          role="alert"
+          className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400"
+        >
+          <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+          Cette affaire est déjà liée à une autre affaire. La liaison créerait une chaîne.
+        </p>
       )}
     </div>
   );

--- a/src/components/admin/PoliticianPicker.tsx
+++ b/src/components/admin/PoliticianPicker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  AdminEntityPicker,
+  type AdminEntityPickerResult,
+} from "@/components/admin/AdminEntityPicker";
+import { MANDATE_TYPE_LABELS } from "@/config/labels";
+import type { MandateType, PublicationStatus } from "@/generated/prisma";
+
+export interface PoliticianPickerResult extends AdminEntityPickerResult {
+  fullName: string;
+  slug: string;
+  publicationStatus: PublicationStatus;
+  party: { shortName: string | null; name: string } | null;
+  mandate: {
+    type: MandateType;
+    title: string;
+    institution: string;
+    constituency: string | null;
+  } | null;
+}
+
+async function requestPoliticians(
+  url: string,
+  signal: AbortSignal
+): Promise<PoliticianPickerResult[]> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) throw new Error("Recherche indisponible");
+  const data = (await response.json()) as {
+    results?: PoliticianPickerResult[];
+    result?: PoliticianPickerResult | null;
+  };
+  return data.results ?? (data.result ? [data.result] : []);
+}
+
+function renderPolitician(politician: PoliticianPickerResult) {
+  return (
+    <div className="pr-5">
+      <p className="font-medium">{politician.fullName}</p>
+      <p className="text-xs text-muted-foreground">
+        {politician.party?.shortName || politician.party?.name || "Sans parti"} ·{" "}
+        {politician.mandate
+          ? MANDATE_TYPE_LABELS[politician.mandate.type]
+          : "Fonction non renseignée"}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {politician.slug} · {politician.publicationStatus}
+      </p>
+    </div>
+  );
+}
+
+export function PoliticianPicker({
+  value,
+  onChange,
+  readOnly = false,
+  disabled = false,
+  label = "Personnalité politique",
+  description,
+}: {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  readOnly?: boolean;
+  disabled?: boolean;
+  label?: string;
+  description?: string;
+}) {
+  const search = useCallback(
+    (query: string, signal: AbortSignal) =>
+      requestPoliticians(
+        `/api/admin/entities/politicians?q=${encodeURIComponent(query)}&page=1&limit=20`,
+        signal
+      ),
+    []
+  );
+  const resolve = useCallback(
+    (id: string, signal: AbortSignal) =>
+      requestPoliticians(
+        `/api/admin/entities/politicians?id=${encodeURIComponent(id)}`,
+        signal
+      ).then((items) => items[0] ?? null),
+    []
+  );
+
+  return (
+    <AdminEntityPicker<PoliticianPickerResult>
+      value={value}
+      onChange={(next) => onChange(next)}
+      search={search}
+      resolve={resolve}
+      renderResult={renderPolitician}
+      label={label}
+      placeholder="Rechercher par nom, prénom, parti ou slug..."
+      readOnly={readOnly}
+      disabled={disabled}
+      description={description}
+    />
+  );
+}

--- a/src/components/admin/__tests__/AdminEntityPicker.test.tsx
+++ b/src/components/admin/__tests__/AdminEntityPicker.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AdminEntityPicker } from "@/components/admin/AdminEntityPicker";
+
+type Result = { id: string; name: string };
+
+beforeEach(() => vi.useRealTimers());
+
+describe("AdminEntityPicker", () => {
+  it("debounces, ignores an obsolete response and selects with Enter", async () => {
+    let firstResolve: ((value: Result[]) => void) | undefined;
+    const search = vi.fn((query: string) =>
+      query === "ab"
+        ? new Promise<Result[]>((resolve) => {
+            firstResolve = resolve;
+          })
+        : Promise.resolve([{ id: "new", name: "Nouveau résultat" }])
+    );
+    const onChange = vi.fn();
+    render(
+      <AdminEntityPicker<Result>
+        value={null}
+        onChange={onChange}
+        search={search}
+        resolve={async () => null}
+        renderResult={(result) => <span>{result.name}</span>}
+        label="Politicien"
+        placeholder="Rechercher..."
+      />
+    );
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "ab" } });
+    await waitFor(() => expect(search).toHaveBeenCalledWith("ab", expect.anything()));
+    fireEvent.change(input, { target: { value: "abc" } });
+    await waitFor(() => expect(search).toHaveBeenCalledWith("abc", expect.anything()));
+    firstResolve?.([{ id: "old", name: "Ancien résultat" }]);
+    await waitFor(() => expect(screen.queryByText("Ancien résultat")).not.toBeInTheDocument());
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(
+      "new",
+      expect.objectContaining({ name: "Nouveau résultat" })
+    );
+  });
+
+  it("supports arrows, Escape and clearing the current value", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <AdminEntityPicker<Result>
+        value="p-1"
+        onChange={onChange}
+        search={async () => []}
+        resolve={async (id) => ({ id, name: "Jean Dupont" })}
+        renderResult={(result) => <span>{result.name}</span>}
+        label="Politicien"
+        placeholder="Rechercher..."
+      />
+    );
+    await waitFor(() => expect(screen.getByText("Jean Dupont")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Effacer la sélection" }));
+    expect(onChange).toHaveBeenCalledWith(null, null);
+    rerender(
+      <AdminEntityPicker<Result>
+        value={null}
+        onChange={onChange}
+        search={async () => [{ id: "p-2", name: "Autre" }]}
+        resolve={async () => null}
+        renderResult={(result) => <span>{result.name}</span>}
+        label="Politicien"
+        placeholder="Rechercher..."
+      />
+    );
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "au" } });
+    await waitFor(() => expect(screen.getByText("Autre")).toBeInTheDocument());
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/admin/__tests__/AffairForm.test.tsx
+++ b/src/components/admin/__tests__/AffairForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 vi.mock("next/navigation", () => ({
@@ -7,7 +7,24 @@ vi.mock("next/navigation", () => ({
 
 import { AffairForm } from "@/components/admin/AffairForm";
 
-const POLITICIANS = [{ id: "pol_1", fullName: "Jean Testeur", slug: "jean-testeur" }];
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          id: "pol_1",
+          fullName: "Politicien de test",
+          slug: "politicien-de-test",
+          publicationStatus: "PUBLISHED",
+          party: { shortName: "TEST", name: "Parti de test" },
+          mandate: { type: "DEPUTE", title: "Député", institution: "Assemblée nationale" },
+        },
+      }),
+    })
+  );
+});
 
 // `initialData` bypasses the component's own defaults, so the shape has to be complete.
 const BASE = {
@@ -44,7 +61,7 @@ describe("AffairForm — part ferme (#576)", () => {
   it("affiche 0 au lieu d'un champ vide", () => {
     render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, prisonMonths: 48, prisonFirmMonths: 0 } as never}
       />
     );
@@ -55,7 +72,7 @@ describe("AffairForm — part ferme (#576)", () => {
   it("laisse le champ vide quand la répartition n'est pas établie", () => {
     render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, prisonMonths: 48, prisonFirmMonths: null } as never}
       />
     );
@@ -66,7 +83,7 @@ describe("AffairForm — part ferme (#576)", () => {
   it("distingue les deux états sur l'inéligibilité aussi", () => {
     const { unmount } = render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, ineligibilityMonths: 45, ineligibilityFirmMonths: 0 } as never}
       />
     );
@@ -77,7 +94,7 @@ describe("AffairForm — part ferme (#576)", () => {
 
     render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, ineligibilityMonths: 45, ineligibilityFirmMonths: null } as never}
       />
     );
@@ -96,7 +113,7 @@ describe("AffairForm — note d'implication selon l'implication", () => {
   it("marque la note obligatoire pour une simple mention", () => {
     render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, involvement: "MENTIONED_ONLY" } as never}
       />
     );
@@ -106,10 +123,31 @@ describe("AffairForm — note d'implication selon l'implication", () => {
   it("n'impose pas la note pour une victime", () => {
     render(
       <AffairForm
-        politicians={POLITICIANS}
+        initialPoliticianId="pol_1"
         initialData={{ ...BASE, involvement: "VICTIM" } as never}
       />
     );
     expect(screen.queryByText(/obligatoire à la publication/)).not.toBeInTheDocument();
+  });
+});
+
+describe("AffairForm — réattribution éditoriale", () => {
+  it("keeps a published affair politician in read-only mode", () => {
+    render(<AffairForm initialData={{ ...BASE, publicationStatus: "PUBLISHED" } as never} />);
+    expect(
+      screen.getByText(
+        "La réattribution d’une affaire publiée est une opération éditoriale dédiée."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: /personnalité politique concernée/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the politician picker editable for a draft", () => {
+    render(<AffairForm initialData={{ ...BASE, publicationStatus: "DRAFT" } as never} />);
+    expect(
+      screen.getByRole("combobox", { name: /personnalité politique concernée/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/admin/__tests__/LinkedAffairSelect.test.tsx
+++ b/src/components/admin/__tests__/LinkedAffairSelect.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { LinkedAffairSelect } from "@/components/admin/LinkedAffairSelect";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => ({
+        results: url.includes("id=")
+          ? [
+              {
+                id: "a-2",
+                title: "Affaire liée",
+                slug: "affaire-liee",
+                involvement: "DIRECT",
+                linkedAffairId: "a-3",
+                politician: { id: "p-2", fullName: "Jean Dupont", slug: "jean-dupont" },
+              },
+            ]
+          : [
+              {
+                id: "a-2",
+                title: "Affaire liée",
+                slug: "affaire-liee",
+                involvement: "DIRECT",
+                linkedAffairId: "a-3",
+                politician: { id: "p-2", fullName: "Jean Dupont", slug: "jean-dupont" },
+              },
+            ],
+      }),
+    }))
+  );
+});
+
+describe("LinkedAffairSelect", () => {
+  it("keeps the current warnings and supports a searchable selection", async () => {
+    const onChange = vi.fn();
+    render(<LinkedAffairSelect value={null} onChange={onChange} currentInvolvement="DIRECT" />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "Affaire" } });
+    await waitFor(() => expect(screen.getByText("Affaire liée")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /Affaire liée/ }));
+    expect(onChange).toHaveBeenCalledWith("a-2");
+    expect(screen.getByText(/même rôle/)).toBeInTheDocument();
+    expect(screen.getByText(/créerait une chaîne/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Référence

Référence #744. Cette PR couvre le lot 2 uniquement.

## Problème initial

AffairForm chargeait le corpus complet des personnalités et affichait un select natif. Le matching et les affaires liées avaient aussi des recherches ad hoc avec un contexte et une accessibilité incomplets.

## Changements

- AdminEntityPicker générique avec recherche serveur, debounce de 300 ms, annulation, neutralisation des réponses obsolètes, maximum de 20 résultats et pattern ARIA combobox/listbox.
- Endpoint admin authentifié `GET /api/admin/entities/politicians`, recherche bornée et résolution par id. Les résultats exposent nom, slug, parti, mandat et statut.
- AffairForm et la revue du matching utilisent PoliticianPicker. LinkedAffairSelect utilise le même shell tout en conservant ses avertissements métier.
- Les pages de création et d’édition ne chargent plus la liste complète. Une création peut résoudre `politicianId` depuis l’URL.
- Une affaire DRAFT reste modifiable. Une affaire PUBLISHED est en lecture seule et son changement de personnalité est refusé côté serveur avec une erreur structurée.

## Validation

Tests ciblés et suite complète, typecheck, lint et build exécutés. Aucun changement Prisma ni aucune écriture Supabase.

## Limites lot 3

Aucun atelier article ↔ affaire, aucun workflow de réattribution publié et aucun modèle AffairParticipant ne sont ajoutés. Le contrat générique permet les futurs adaptateurs sans créer de composant mort.
