### PR TITLE
feat(presidentielle): donner son portrait à la carte de partage d'une candidature

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/opengraph-image.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/opengraph-image.test.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  imageResponses: [] as Array<{ element: ReactNode; options: unknown }>,
+  findUnique: vi.fn(),
+  loadOgPortrait: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/og", () => ({
+  ImageResponse: class {
+    element: ReactNode;
+    options: unknown;
+
+    constructor(element: ReactNode, options: unknown) {
+      this.element = element;
+      this.options = options;
+      mocks.imageResponses.push({ element, options });
+    }
+  },
+}));
+vi.mock("@/lib/og-utils", () => ({
+  OG_SIZE: { width: 1200, height: 630 },
+  OgLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
+  loadOgPortrait: (url: string | null | undefined) => mocks.loadOgPortrait(url),
+}));
+vi.mock("@/lib/db", () => ({
+  db: { politician: { findUnique: mocks.findUnique } },
+}));
+
+import Image from "../opengraph-image";
+
+function textContent(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join(" ");
+  if (!node || typeof node === "boolean") return "";
+  if (typeof node === "object" && "props" in node) {
+    return textContent((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+function imgSources(node: ReactNode): string[] {
+  if (Array.isArray(node)) return node.flatMap(imgSources);
+  if (!node || typeof node !== "object" || !("props" in node)) return [];
+  const props = node.props as { children?: ReactNode; src?: string };
+  const own = node.type === "img" && props.src ? [props.src] : [];
+  return [...own, ...imgSources(props.children)];
+}
+
+const politician = (overrides: Record<string, unknown> = {}) => ({
+  fullName: "Camille Rivière",
+  firstName: "Camille",
+  lastName: "Rivière",
+  civility: "Mme",
+  photoUrl: "https://source.test/camille.jpg",
+  blobPhotoUrl: "https://blob.test/camille-portrait.jpg",
+  candidacies: [{ id: "cand-1" }],
+  ...overrides,
+});
+
+describe("Open Graph d'une fiche de candidature", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.imageResponses.length = 0;
+    mocks.loadOgPortrait.mockResolvedValue("data:image/jpeg;base64,portrait");
+  });
+
+  it("rend le portrait du candidat, en préférant la copie Blob recadrée", async () => {
+    mocks.findUnique.mockResolvedValue(politician());
+
+    await Image({ params: Promise.resolve({ slug: "camille-riviere" }) });
+
+    expect(mocks.loadOgPortrait).toHaveBeenCalledWith("https://blob.test/camille-portrait.jpg");
+    const element = mocks.imageResponses[0]?.element;
+    expect(imgSources(element)).toContain("data:image/jpeg;base64,portrait");
+    const rendered = textContent(element);
+    expect(rendered).toContain("Camille Rivière");
+    expect(rendered).toContain("Candidate à la présidentielle");
+  });
+
+  it("retombe sur les initiales quand la photo est absente ou illisible", async () => {
+    mocks.findUnique.mockResolvedValue(politician({ photoUrl: null, blobPhotoUrl: null }));
+    mocks.loadOgPortrait.mockResolvedValue(null);
+
+    await Image({ params: Promise.resolve({ slug: "camille-riviere" }) });
+
+    const element = mocks.imageResponses[0]?.element;
+    expect(imgSources(element)).toHaveLength(0);
+    expect(textContent(element)).toContain("CR");
+  });
+
+  it("n'expose aucune donnée périssable : ni statut, ni parti, ni compteur de mesures", async () => {
+    mocks.findUnique.mockResolvedValue(politician());
+
+    await Image({ params: Promise.resolve({ slug: "camille-riviere" }) });
+
+    const selected = JSON.stringify(mocks.findUnique.mock.calls[0]?.[0]?.select ?? {});
+    expect(selected).not.toContain("partyLabel");
+    const rendered = textContent(mocks.imageResponses[0]?.element);
+    expect(rendered).not.toContain("Candidature annoncée");
+    expect(rendered).not.toContain("mesure");
+  });
+
+  it("n'expose pas l'identité d'une personne sans candidature sourcée", async () => {
+    mocks.findUnique.mockResolvedValue(politician({ candidacies: [] }));
+
+    await Image({ params: Promise.resolve({ slug: "camille-riviere" }) });
+
+    const rendered = textContent(mocks.imageResponses[0]?.element);
+    expect(rendered).toContain("Candidature non trouvée");
+    expect(rendered).not.toContain("Camille Rivière");
+  });
+
+  it("ne lit que les personnes publiées", async () => {
+    mocks.findUnique.mockResolvedValue(null);
+
+    await Image({ params: Promise.resolve({ slug: "brouillon" }) });
+
+    expect(JSON.stringify(mocks.findUnique.mock.calls[0]?.[0]?.where)).toContain("PUBLISHED");
+    expect(textContent(mocks.imageResponses[0]?.element)).toContain("Candidature non trouvée");
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/opengraph-image.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/opengraph-image.tsx
@@ -1,0 +1,181 @@
+import { ImageResponse } from "next/og";
+import { candidacyRoleLabel } from "@/config/labels";
+import { PUBLIC_POLITICIAN_WHERE } from "@/lib/api/public-contract";
+import { db } from "@/lib/db";
+import { loadOgPortrait, OgLayout, OG_SIZE } from "@/lib/og-utils";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+
+/**
+ * Preview card for ONE candidacy fiche, with the candidate's portrait.
+ *
+ * The hub's `opengraph-image` covers every descendant segment that does not define its
+ * own, and the comment there explains why we create as few of these routes as possible
+ * (each one is crawl budget spent on an image URL). This is the one exception: a fiche
+ * is about a person, and a shared card showing the hub's headline is what a reader sees
+ * when the link is pasted anywhere. The face is the whole content of the preview.
+ *
+ * Nothing perishable is rendered. No measure count, no candidacy status, no party: a
+ * card is cached by every platform that ever fetched it, so a candidacy announced today
+ * and withdrawn in March would keep being shared as "annoncée" with no way to correct
+ * it. Name, gender-agreed role and portrait are the parts that stay true — the same
+ * reasoning as the hub's card, restated because the temptation here is stronger.
+ *
+ * As on the hub, no `twitter-image` beside it: that is a different route family which
+ * neither the X-Robots-Tag rule nor the robots.txt rule would match. X falls back to
+ * og:image and crops it to 2:1, so nothing that must be read sits in the top or bottom
+ * 20 pixels.
+ */
+
+export const alt = "Fiche de candidature à la présidentielle 2027 sur Poligraph";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+/** Same window as the fiche: a portrait changes at the pace of a sync, not of a request. */
+export const revalidate = 86400;
+
+const ACCENT = "#7dd3fc";
+
+/** Called, not rendered as an element: the fallback shares the layout, not a component. */
+function fallbackCard(message: string) {
+  return (
+    <OgLayout>
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+          fontSize: 32,
+        }}
+      >
+        {message}
+      </div>
+    </OgLayout>
+  );
+}
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  // A deliberately narrow read rather than `getPolitician`: that one loads the whole
+  // fiche (mandates, affairs, declarations) for four fields, and its cache entry is
+  // warmed by the page, not by a crawler hitting the image URL on its own.
+  const politician = await db.politician.findUnique({
+    where: { slug, ...PUBLIC_POLITICIAN_WHERE },
+    select: {
+      fullName: true,
+      firstName: true,
+      lastName: true,
+      civility: true,
+      photoUrl: true,
+      blobPhotoUrl: true,
+      candidacies: {
+        // The same three conditions that make a candidacy sayable at all, see
+        // `loadPoliticianPresidentialCandidacy`. Without one of them the fiche redirects
+        // to /politiques/[slug] and this card describes a page nobody can reach.
+        where: {
+          election: { slug: PRESIDENTIELLE_2027_SLUG },
+          status: { not: null },
+          sourceUrl: { not: null },
+          sourceLabel: { not: null },
+        },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  });
+
+  if (!politician || politician.candidacies.length === 0) {
+    return new ImageResponse(fallbackCard("Candidature non trouvée"), { ...OG_SIZE });
+  }
+
+  // The Blob copy wins when there is one, exactly as in `PoliticianAvatar`: it is the
+  // portrait cropped on the face, and it is served from our own CDN.
+  const portrait = await loadOgPortrait(politician.blobPhotoUrl ?? politician.photoUrl);
+  const initials = `${politician.firstName[0] ?? ""}${politician.lastName[0] ?? ""}`.toUpperCase();
+
+  return new ImageResponse(
+    <OgLayout>
+      <div style={{ display: "flex", flex: 1, alignItems: "center", gap: 56 }}>
+        {portrait ? (
+          <img
+            src={portrait}
+            alt=""
+            width={280}
+            height={280}
+            style={{
+              flexShrink: 0,
+              borderRadius: "50%",
+              objectFit: "cover",
+              border: `8px solid ${ACCENT}`,
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              width: 280,
+              height: 280,
+              flexShrink: 0,
+              borderRadius: "50%",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "#1e293b",
+              border: `8px solid ${ACCENT}`,
+              color: "white",
+              fontSize: 104,
+              fontWeight: 700,
+            }}
+          >
+            {initials}
+          </div>
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            justifyContent: "center",
+            gap: 18,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 24,
+              fontWeight: 700,
+              letterSpacing: 4,
+              textTransform: "uppercase",
+              color: ACCENT,
+            }}
+          >
+            Présidentielle 2027
+          </span>
+
+          {/* Sized for a 500px-wide card in a feed, which is the only place this is seen.
+              Long names ("Jean-Luc Mélenchon") still fit on two lines at this size. */}
+          <span
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              lineHeight: 1.03,
+              letterSpacing: -2,
+              color: "white",
+            }}
+          >
+            {politician.fullName}
+          </span>
+
+          <span style={{ fontSize: 30, color: "#cbd5e1" }}>
+            {candidacyRoleLabel(politician.civility)}
+          </span>
+
+          <span style={{ fontSize: 26, color: "#94a3b8" }}>
+            Ses propositions, par sujet, avec leurs sources.
+          </span>
+        </div>
+      </div>
+    </OgLayout>,
+    { ...OG_SIZE }
+  );
+}

--- a/src/app/elections/presidentielle-2027/opengraph-image.tsx
+++ b/src/app/elections/presidentielle-2027/opengraph-image.tsx
@@ -5,11 +5,16 @@ import { OgLayout, OG_SIZE } from "@/lib/og-utils";
  * Shared preview card for the whole presidential hub.
  *
  * Next inherits a route's `opengraph-image` down every descendant segment that does
- * not define its own, so this one file covers the hub, the 13 subject pages, the 25
- * candidate pages and /priorites. That inheritance is the point rather than a side
- * effect: one image URL for the section instead of forty. Search Console attributed
- * the large majority of the site's "crawled, currently not indexed" bucket to
- * `opengraph-image` routes, so every one we do not create is crawl budget we keep.
+ * not define its own, so this one file covers the hub, the 13 subject pages and
+ * /priorites. That inheritance is the point rather than a side effect: one image URL
+ * for the section instead of forty. Search Console attributed the large majority of
+ * the site's "crawled, currently not indexed" bucket to `opengraph-image` routes, so
+ * every one we do not create is crawl budget we keep.
+ *
+ * The candidate fiches are the one segment that defines its own, because a fiche is
+ * about a person and its shared card has to carry that person's face; see the comment
+ * in candidats/[slug]/opengraph-image.tsx.
+ *
  * The route is covered without further work by OG_IMAGE_ROBOTS_SOURCE (X-Robots-Tag)
  * and OG_IMAGE_DISALLOW_PATHS (robots.txt), both matching any path ending in
  * `/opengraph-image`.

--- a/src/lib/__tests__/og-portrait.test.ts
+++ b/src/lib/__tests__/og-portrait.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadOgPortrait } from "../og-utils";
+
+function imageResponse(contentType: string, bytes: Uint8Array = new Uint8Array([1, 2, 3])) {
+  return {
+    ok: true,
+    headers: new Headers({ "content-type": contentType }),
+    arrayBuffer: async () => bytes.buffer.slice(0),
+  } as unknown as Response;
+}
+
+describe("loadOgPortrait", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renvoie une data URI pour un format que Satori sait décoder", async () => {
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/jpeg"));
+
+    await expect(loadOgPortrait("https://blob.test/portrait.jpg")).resolves.toBe(
+      `data:image/jpeg;base64,${Buffer.from([1, 2, 3]).toString("base64")}`
+    );
+  });
+
+  it("tolère un content-type paramétré", async () => {
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/PNG; charset=binary"));
+
+    await expect(loadOgPortrait("https://blob.test/portrait.png")).resolves.toContain(
+      "data:image/png;base64,"
+    );
+  });
+
+  it("passe une source http en https plutôt que de la refuser", async () => {
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/jpeg"));
+
+    await loadOgPortrait("http://source.test/portrait.jpg");
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe("https://source.test/portrait.jpg");
+  });
+
+  it("refuse un format que le rendu ne sait pas décoder", async () => {
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/webp"));
+
+    await expect(loadOgPortrait("https://blob.test/portrait.webp")).resolves.toBeNull();
+  });
+
+  it("refuse une réponse en erreur, vide ou hors gabarit", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      headers: new Headers(),
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response);
+    await expect(loadOgPortrait("https://blob.test/404.jpg")).resolves.toBeNull();
+
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/jpeg", new Uint8Array(0)));
+    await expect(loadOgPortrait("https://blob.test/empty.jpg")).resolves.toBeNull();
+
+    vi.mocked(fetch).mockResolvedValue(imageResponse("image/jpeg", new Uint8Array(5_000_001)));
+    await expect(loadOgPortrait("https://blob.test/huge.jpg")).resolves.toBeNull();
+  });
+
+  it("avale l'échec réseau : une photo indisponible n'est pas une image cassée", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("timeout"));
+
+    await expect(loadOgPortrait("https://source.test/portrait.jpg")).resolves.toBeNull();
+  });
+
+  it("ne tente rien sans URL exploitable", async () => {
+    await expect(loadOgPortrait(null)).resolves.toBeNull();
+    await expect(loadOgPortrait("")).resolves.toBeNull();
+    await expect(loadOgPortrait("/photos/local.jpg")).resolves.toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/og-utils.tsx
+++ b/src/lib/og-utils.tsx
@@ -144,3 +144,50 @@ export function OgBadge({ label, color }: { label: string; color: string }) {
 export function truncateOg(text: string, max: number): string {
   return text.length > max ? text.slice(0, max - 3) + "..." : text;
 }
+
+/**
+ * Content types a portrait may have to be embedded in an OG image.
+ *
+ * `next/og` rasterises through Satori + resvg, which decode PNG, JPEG and GIF and
+ * nothing else. A WebP or an AVIF does not degrade, it throws while the image is
+ * being generated, and the route then returns a 500 to a social crawler that will
+ * cache the failure. Unknown types are therefore dropped before rendering, and the
+ * caller falls back to initials.
+ */
+const OG_PORTRAIT_TYPES = new Set(["image/jpeg", "image/png", "image/gif"]);
+
+/** A portrait is a few dozen kilobytes. Anything past this is not one. */
+const OG_PORTRAIT_MAX_BYTES = 5_000_000;
+
+/**
+ * Download a portrait and return it as a data URI, or null when anything is off.
+ *
+ * Satori can fetch a remote `src` itself, but a slow or dead upstream host then
+ * takes the whole image route down with it — the portraits we hold point at
+ * external sources as often as at our own Blob CDN. Fetching here bounds the wait,
+ * checks what came back, and turns every failure into "no photo" rather than into
+ * a broken preview card.
+ */
+export async function loadOgPortrait(url: string | null | undefined): Promise<string | null> {
+  if (!url) return null;
+  const httpsUrl = url.startsWith("http://") ? `https://${url.slice("http://".length)}` : url;
+  if (!httpsUrl.startsWith("https://")) return null;
+
+  try {
+    const response = await fetch(httpsUrl, { signal: AbortSignal.timeout(5000) });
+    if (!response.ok) return null;
+
+    const contentType = (response.headers.get("content-type") ?? "")
+      .split(";")[0]
+      ?.trim()
+      .toLowerCase();
+    if (!contentType || !OG_PORTRAIT_TYPES.has(contentType)) return null;
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > OG_PORTRAIT_MAX_BYTES) return null;
+
+    return `data:${contentType};base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/seo/__tests__/og-image-robots.test.ts
+++ b/src/lib/seo/__tests__/og-image-robots.test.ts
@@ -34,6 +34,9 @@ describe("opengraph-image noindex header", () => {
     "/partis/renaissance/programme/opengraph-image",
     "/politiques/jean-dupont/opengraph-image",
     "/elections/presidentielle-2027/opengraph-image",
+    // Four segments deep, the deepest OG route on the site: the `:path*` prefix has to
+    // stay unbounded, or every candidacy card would be crawled and indexed as an image.
+    "/elections/presidentielle-2027/candidats/marine-tondelier/opengraph-image",
   ])("noindexes OG image path %s", (path) => {
     expect(source.test(path)).toBe(true);
   });
@@ -44,6 +47,7 @@ describe("opengraph-image noindex header", () => {
     "/parlement/dossiers/reforme-des-retraites",
     "/parlement",
     "/politiques/jean-dupont",
+    "/elections/presidentielle-2027/candidats/marine-tondelier",
     "/opengraph-image-gallery",
   ])("leaves real page %s indexable", (path) => {
     expect(source.test(path)).toBe(false);


### PR DESCRIPTION
Ajoute un opengraph-image propre aux fiches de candidature : portrait du candidat
(copie Blob recadrée quand elle existe, source externe sinon, initiales à défaut),
nom et rôle accordé. Rien de périssable n'est gravé dans l'image — ni statut, ni
parti, ni compteur de mesures — puisqu'une carte reste en cache chez chaque
plateforme qui l'a récupérée. La photo est téléchargée et vérifiée avant rendu, un
format que Satori ne décode pas ou un hôte injoignable retombant sur les initiales
plutôt que sur une image en erreur.