### PR TITLE
feat(admin): publier une candidature et son programme depuis l'admin

### DIFF
--- a/docs/editorial/candidatures-et-mesures.md
+++ b/docs/editorial/candidatures-et-mesures.md
@@ -158,6 +158,26 @@ quelques candidates déclarées, une poignée de mesures chacune sur un ou deux 
 C'est ce qui valide la tranche verticale du lot 3 avant de multiplier les sujets. Un compteur public de
 couverture, adossé à cette réalité, vaut mieux qu'une façade de complétude.
 
+### Publier les mesures ne suffit pas : le dernier maillon
+
+Une mesure relue, publiée et sourcée reste **invisible** tant que deux interrupteurs distincts n'ont pas
+été basculés, et la file de modération des mesures ne les mentionne pas :
+
+1. `CandidacyPresidential.publicationStatus`. Toutes les surfaces présidentielles filtrent dessus (hub,
+   pages sujet, index des thèmes, priorités, fiche candidat, encart de la fiche politique). Tant qu'il
+   vaut `DRAFT`, les compteurs de mesures de la candidature valent zéro, la fiche candidat reste sous son
+   seuil de publication et passe en `noindex`. C'est ce qui a rendu invisibles les 26 mesures de Jérôme
+   Guedj, et 139 mesures au total sur six candidatures, alors que rien ne manquait côté mesures.
+2. `ProgramEdition.publicationStatus`. Il ne conditionne aucune mesure, mais il décide de la phrase
+   affichée sous le seuil : « programme identifié » plutôt que « aucun programme publié à ce jour ». Les
+   éditions créées par l'import naissent en `DRAFT`.
+
+Les deux se basculent depuis **`/admin/candidats`**, colonnes « Fiche publique » et « Programme », qui
+affichent aussi le nombre de mesures publiables retenues. Le badge de l'entrée « Candidatures » compte les
+candidatures dans cet état. Publier la fiche exige une candidature **sourcée** (statut, `sourceUrl`,
+`sourceLabel`) : sans eux la fiche publique redirige vers le profil, et publier l'extension ouvrirait le
+hub sur un candidat dont la fiche n'existe pas.
+
 ---
 
 ## Décisions arbitrées le 2026-08-06

--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { CandidatePresidentialRow } from "@/lib/data/candidates";
+import type { CandidacyStatus, PublicationStatus } from "@/generated/prisma";
+import { Badge } from "@/components/ui/badge";
+import { PUBLICATION_STATUS_LABELS, PUBLICATION_STATUS_STYLES } from "@/config/labels";
+import type { CandidacyMeasureReadiness } from "@/lib/data/measures";
+import { setCandidacyPublicationAction, setProgramEditionPublicationAction } from "./actions";
 
 const STATUS_LABELS: Record<string, string> = {
   DECLARE: "Déclaré",
@@ -12,16 +16,47 @@ const STATUS_LABELS: Record<string, string> = {
   RETIRE: "Retiré",
 };
 
-interface Props {
-  initialCandidates: CandidatePresidentialRow[];
+export type ProgramEditionView = {
+  id: string;
+  label: string;
+  version: number;
+  publicationStatus: PublicationStatus;
+};
+
+export type CandidateRowView = {
+  candidacyId: string;
+  candidateName: string;
+  politicianSlug: string | null;
+  partyLabel: string | null;
+  status: CandidacyStatus | null;
+  /** Status, source URL and source label all present: the condition the public fiche imposes. */
+  sourced: boolean;
+  /** Null when the candidacy carries no `CandidacyPresidential` row yet. */
+  presidentialId: string | null;
+  publicationStatus: PublicationStatus | null;
+  slogan: string | null;
+  rank: number | null;
+  readiness: CandidacyMeasureReadiness;
+  editions: ProgramEditionView[];
+};
+
+/** A candidacy whose measures are ready to be read and whose extension still hides them. */
+function isHoldingBackMeasures(row: CandidateRowView): boolean {
+  return row.readiness.measureCount > 0 && row.publicationStatus !== "PUBLISHED";
 }
 
-export function CandidatesListClient({ initialCandidates }: Props) {
+export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
   const router = useRouter();
   const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const held = rows.filter(isHoldingBackMeasures);
+  const heldMeasureCount = held.reduce((total, row) => total + row.readiness.measureCount, 0);
 
   async function patchPresidential(id: string, body: Record<string, unknown>) {
     setBusy(id);
+    setError(null);
     try {
       const res = await fetch(`/api/admin/candidats/${id}`, {
         method: "PATCH",
@@ -31,105 +66,242 @@ export function CandidatesListClient({ initialCandidates }: Props) {
       if (!res.ok) throw new Error(await res.text());
       router.refresh();
     } catch (err) {
-      alert(`Erreur : ${err instanceof Error ? err.message : String(err)}`);
+      setError(`Erreur : ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setBusy(null);
     }
   }
 
+  function runAction(key: string, action: () => Promise<{ ok: boolean; message?: string }>) {
+    setBusy(key);
+    setError(null);
+    startTransition(async () => {
+      const result = await action();
+      if (!result.ok) setError(result.message ?? "L'opération a échoué.");
+      setBusy(null);
+      router.refresh();
+    });
+  }
+
   return (
-    <div className="rounded-lg border overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50">
-          <tr>
-            <th className="text-left px-3 py-2">Rang</th>
-            <th className="text-left px-3 py-2">Candidat</th>
-            <th className="text-left px-3 py-2">Parti</th>
-            <th className="text-left px-3 py-2">Statut</th>
-            <th className="text-left px-3 py-2">Slogan</th>
-            <th className="text-left px-3 py-2">
-              <span className="sr-only">Actions</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {initialCandidates.map((c) => {
-            const pres = c.presidentialData;
-            const slug = c.politician?.slug;
-            return (
-              <tr key={c.id} className="border-t">
-                <td className="px-3 py-2 w-12">
-                  <input
-                    type="number"
-                    min={0}
-                    defaultValue={pres?.rank ?? ""}
-                    onBlur={(e) => {
-                      const value = e.target.value ? Number(e.target.value) : null;
-                      if (pres) patchPresidential(pres.id, { rank: value });
-                    }}
-                    className="w-12 rounded border px-1 py-0.5 text-sm dark:bg-slate-800"
-                    aria-label={`Rang de ${c.candidateName}`}
-                    disabled={busy === pres?.id || !pres}
-                  />
-                </td>
-                <td className="px-3 py-2 whitespace-nowrap">
-                  {slug ? (
-                    <Link
-                      href={`/admin/candidats/${slug}`}
-                      className="text-primary hover:underline"
-                    >
-                      {c.candidateName}
-                    </Link>
-                  ) : (
-                    <span>{c.candidateName}</span>
-                  )}
-                </td>
-                <td className="px-3 py-2 whitespace-nowrap">
-                  {c.party?.shortName ?? c.partyLabel ?? "-"}
-                </td>
-                <td className="px-3 py-2 whitespace-nowrap">
-                  {STATUS_LABELS[c.status ?? ""] ?? c.status ?? ""}
-                </td>
-                <td className="px-3 py-2 max-w-md">
-                  <input
-                    type="text"
-                    defaultValue={pres?.slogan ?? ""}
-                    onBlur={(e) => {
-                      const value = e.target.value.trim() || null;
-                      if (pres) patchPresidential(pres.id, { slogan: value });
-                    }}
-                    className="w-full rounded border px-2 py-0.5 text-sm dark:bg-slate-800"
-                    aria-label={`Slogan de ${c.candidateName}`}
-                    disabled={busy === pres?.id || !pres}
-                    placeholder={pres ? "ex : Vous protéger" : "Métadonnées absentes"}
-                  />
-                </td>
-                <td className="px-3 py-2">
-                  {slug && (
-                    <Link
-                      href={`/admin/candidats/${slug}`}
-                      className="text-primary hover:underline"
-                    >
-                      Voir profil
-                    </Link>
-                  )}
+    <div className="space-y-4">
+      {/* The signal that was missing entirely. Once every measure of a candidate is published, the
+          moderation queue empties and nothing else said that the candidacy itself still hid them. */}
+      {held.length > 0 && (
+        <div
+          role="status"
+          className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+        >
+          <p className="font-semibold">
+            {held.length === 1
+              ? "1 candidature retient des mesures prêtes"
+              : `${held.length} candidatures retiennent des mesures prêtes`}
+          </p>
+          <p className="mt-1">
+            {heldMeasureCount} mesures relues, publiées et sourcées ne sortent sur aucune surface
+            publique tant que la fiche candidature reste en brouillon :{" "}
+            {held.map((row) => row.candidateName).join(", ")}.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <p
+          role="alert"
+          className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="rounded-lg border overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left px-3 py-2">Rang</th>
+              <th className="text-left px-3 py-2">Candidat</th>
+              <th className="text-left px-3 py-2">Parti</th>
+              <th className="text-left px-3 py-2">Statut</th>
+              <th className="text-left px-3 py-2">Mesures prêtes</th>
+              <th className="text-left px-3 py-2">Fiche publique</th>
+              <th className="text-left px-3 py-2">Programme</th>
+              <th className="text-left px-3 py-2">Slogan</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const publicationKey = `publication:${row.candidacyId}`;
+              const published = row.publicationStatus === "PUBLISHED";
+              const locked = busy !== null || pending;
+              return (
+                <tr key={row.candidacyId} className="border-t align-top">
+                  <td className="px-3 py-2 w-12">
+                    <input
+                      type="number"
+                      min={0}
+                      defaultValue={row.rank ?? ""}
+                      onBlur={(e) => {
+                        const value = e.target.value ? Number(e.target.value) : null;
+                        if (row.presidentialId)
+                          patchPresidential(row.presidentialId, { rank: value });
+                      }}
+                      className="w-12 rounded border px-1 py-0.5 text-sm dark:bg-slate-800"
+                      aria-label={`Rang de ${row.candidateName}`}
+                      disabled={locked || !row.presidentialId}
+                    />
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {row.politicianSlug ? (
+                      <Link
+                        href={`/admin/candidats/${row.politicianSlug}`}
+                        className="text-primary hover:underline"
+                      >
+                        {row.candidateName}
+                      </Link>
+                    ) : (
+                      <span>{row.candidateName}</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">{row.partyLabel ?? "Sans parti"}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {STATUS_LABELS[row.status ?? ""] ?? "Statut non renseigné"}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {row.readiness.measureCount === 0 ? (
+                      <span className="text-muted-foreground">Aucune</span>
+                    ) : (
+                      <>
+                        <span className="font-semibold">{row.readiness.measureCount}</span>
+                        <span className="text-muted-foreground">
+                          {" "}
+                          · {row.readiness.themesCoveredCount} thèmes ·{" "}
+                          {row.readiness.primarySourceMeasureCount} sourcées 1re main
+                        </span>
+                      </>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-col gap-1.5">
+                      <Badge
+                        variant="outline"
+                        className={
+                          row.publicationStatus
+                            ? PUBLICATION_STATUS_STYLES[row.publicationStatus]
+                            : ""
+                        }
+                      >
+                        {row.publicationStatus
+                          ? PUBLICATION_STATUS_LABELS[row.publicationStatus]
+                          : "Métadonnées absentes"}
+                      </Badge>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          runAction(publicationKey, () =>
+                            setCandidacyPublicationAction({
+                              candidacyId: row.candidacyId,
+                              status: published ? "DRAFT" : "PUBLISHED",
+                            })
+                          )
+                        }
+                        disabled={locked || (!published && !row.sourced)}
+                        title={
+                          !published && !row.sourced
+                            ? "Renseigner le statut et la source de la candidature avant publication"
+                            : undefined
+                        }
+                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
+                      >
+                        {busy === publicationKey
+                          ? "En cours..."
+                          : published
+                            ? "Dépublier"
+                            : "Publier la fiche"}
+                      </button>
+                      {!published && !row.sourced && (
+                        <span className="text-xs text-muted-foreground">
+                          Statut et source obligatoires
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 max-w-xs">
+                    {row.editions.length === 0 ? (
+                      <span className="text-muted-foreground">Aucune édition</span>
+                    ) : (
+                      <ul className="space-y-2">
+                        {row.editions.map((edition) => {
+                          const editionKey = `edition:${edition.id}`;
+                          const editionPublished = edition.publicationStatus === "PUBLISHED";
+                          return (
+                            <li key={edition.id} className="space-y-1">
+                              <p className="line-clamp-2">
+                                {edition.label}{" "}
+                                <span className="text-muted-foreground">(v{edition.version})</span>
+                              </p>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge
+                                  variant="outline"
+                                  className={PUBLICATION_STATUS_STYLES[edition.publicationStatus]}
+                                >
+                                  {PUBLICATION_STATUS_LABELS[edition.publicationStatus]}
+                                </Badge>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    runAction(editionKey, () =>
+                                      setProgramEditionPublicationAction({
+                                        programEditionId: edition.id,
+                                        status: editionPublished ? "DRAFT" : "PUBLISHED",
+                                      })
+                                    )
+                                  }
+                                  disabled={locked}
+                                  aria-label={`${editionPublished ? "Dépublier" : "Publier"} l'édition ${edition.label} de ${row.candidateName}`}
+                                  className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
+                                >
+                                  {busy === editionKey
+                                    ? "En cours..."
+                                    : editionPublished
+                                      ? "Dépublier"
+                                      : "Publier"}
+                                </button>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 max-w-md">
+                    <input
+                      type="text"
+                      defaultValue={row.slogan ?? ""}
+                      onBlur={(e) => {
+                        const value = e.target.value.trim() || null;
+                        if (row.presidentialId)
+                          patchPresidential(row.presidentialId, { slogan: value });
+                      }}
+                      className="w-full rounded border px-2 py-0.5 text-sm dark:bg-slate-800"
+                      aria-label={`Slogan de ${row.candidateName}`}
+                      disabled={locked || !row.presidentialId}
+                      placeholder={
+                        row.presidentialId ? "ex : Vous protéger" : "Métadonnées absentes"
+                      }
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={8} className="px-3 py-6 text-center text-muted-foreground">
+                  Aucune candidature enregistrée.
                 </td>
               </tr>
-            );
-          })}
-          {initialCandidates.length === 0 && (
-            <tr>
-              <td colSpan={6} className="px-3 py-8 text-center text-muted-foreground">
-                Aucun candidat enregistré pour le moment.
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-      <div className="border-t bg-muted/30 p-3 text-xs text-foreground">
-        Pour ajouter un candidat manquant (ex : Dominique de Villepin), recherche-le via la barre de
-        recherche admin et utilise le bouton « Désigner comme candidat 2027 » depuis sa fiche
-        politicien. Cette mécanique sera affinée dans une itération suivante.
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CandidatesListClient, type CandidateRowView } from "../CandidatesListClient";
+
+type ActionResult = { ok: true } | { ok: false; message: string };
+
+const setCandidacyPublicationMock = vi.fn<(input: unknown) => Promise<ActionResult>>(async () => ({
+  ok: true,
+}));
+const setProgramEditionPublicationMock = vi.fn<(input: unknown) => Promise<ActionResult>>(
+  async () => ({ ok: true })
+);
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("../actions", () => ({
+  setCandidacyPublicationAction: (input: unknown) => setCandidacyPublicationMock(input),
+  setProgramEditionPublicationAction: (input: unknown) => setProgramEditionPublicationMock(input),
+}));
+
+function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
+  return {
+    candidacyId: "cand-1",
+    candidateName: "Alix Démonstration",
+    politicianSlug: "alix-demonstration",
+    partyLabel: "PD",
+    status: "DECLARE",
+    sourced: true,
+    presidentialId: "pres-1",
+    publicationStatus: "DRAFT",
+    slogan: null,
+    rank: null,
+    readiness: { measureCount: 26, themesCoveredCount: 11, primarySourceMeasureCount: 26 },
+    editions: [
+      { id: "ed-1", label: "Premiers engagements", version: 1, publicationStatus: "DRAFT" },
+    ],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CandidatesListClient", () => {
+  it("nomme les candidatures qui retiennent des mesures prêtes", () => {
+    // Le signal qui manquait : une fois toutes les mesures publiées, la file de modération se vide
+    // et plus rien ne disait que la candidature elle-même les gardait invisibles.
+    render(<CandidatesListClient rows={[row()]} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "1 candidature retient des mesures prêtes"
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Alix Démonstration");
+  });
+
+  it("ne signale rien quand la fiche est déjà publiée", () => {
+    render(<CandidatesListClient rows={[row({ publicationStatus: "PUBLISHED" })]} />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dépublier" })).toBeInTheDocument();
+  });
+
+  it("publie la fiche depuis la liste", async () => {
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Publier la fiche" }));
+
+    expect(setCandidacyPublicationMock).toHaveBeenCalledWith({
+      candidacyId: "cand-1",
+      status: "PUBLISHED",
+    });
+  });
+
+  it("publie une édition de programme depuis la liste", async () => {
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Publier l'édition Premiers engagements de Alix Démonstration",
+      })
+    );
+
+    expect(setProgramEditionPublicationMock).toHaveBeenCalledWith({
+      programEditionId: "ed-1",
+      status: "PUBLISHED",
+    });
+  });
+
+  it("bloque la publication d'une candidature non sourcée et dit pourquoi", () => {
+    render(<CandidatesListClient rows={[row({ sourced: false })]} />);
+
+    expect(screen.getByRole("button", { name: "Publier la fiche" })).toBeDisabled();
+    expect(screen.getByText("Statut et source obligatoires")).toBeInTheDocument();
+  });
+
+  it("affiche l'échec d'une action au lieu de le taire", async () => {
+    setCandidacyPublicationMock.mockResolvedValueOnce({
+      ok: false,
+      message: "La candidature doit porter un statut et une source.",
+    });
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Publier la fiche" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "La candidature doit porter un statut et une source."
+    );
+  });
+
+  it("garde une cellule qualifiée quand une candidature n'a ni mesure ni métadonnées", () => {
+    render(
+      <CandidatesListClient
+        rows={[
+          row({
+            presidentialId: null,
+            publicationStatus: null,
+            readiness: { measureCount: 0, themesCoveredCount: 0, primarySourceMeasureCount: 0 },
+            editions: [],
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Aucune")).toBeInTheDocument();
+    expect(screen.getByText("Métadonnées absentes")).toBeInTheDocument();
+    expect(screen.getByText("Aucune édition")).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The two publication switches of a presidential candidacy.
+ *
+ * A server action is a network endpoint: the page guard does not protect it, so each test starts
+ * by checking that an unauthenticated call writes NOTHING. Asserting only that it throws would not
+ * be enough, since a throw after the write would look identical.
+ */
+
+const isAuthenticatedMock = vi.fn<() => Promise<boolean>>();
+const revalidatePathMock = vi.fn();
+const invalidateEntityMock = vi.fn();
+const invalidateCandidacyTagsMock = vi.fn();
+
+const dbMock = {
+  candidacy: { findUnique: vi.fn() },
+  candidacyPresidential: { upsert: vi.fn() },
+  programEdition: { findUnique: vi.fn(), update: vi.fn() },
+  auditLog: { create: vi.fn() },
+};
+
+vi.mock("@/lib/auth", () => ({ isAuthenticated: () => isAuthenticatedMock() }));
+vi.mock("next/cache", () => ({ revalidatePath: (path: string) => revalidatePathMock(path) }));
+vi.mock("@/lib/cache", () => ({
+  invalidateEntity: (...args: unknown[]) => invalidateEntityMock(...args),
+}));
+vi.mock("@/lib/presidentielle/candidacy-cache", () => ({
+  invalidatePresidentialCandidacyTags: (id: string) => invalidateCandidacyTagsMock(id),
+}));
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+
+const SOURCED_CANDIDACY = {
+  id: "cand-1",
+  electionId: "elec-1",
+  status: "DECLARE",
+  sourceUrl: "https://example.org/annonce",
+  sourceLabel: "Annonce de candidature",
+  presidentialData: { id: "pres-1", publicationStatus: "DRAFT" },
+};
+
+async function actions() {
+  return import("../actions");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isAuthenticatedMock.mockResolvedValue(true);
+  dbMock.candidacy.findUnique.mockResolvedValue(SOURCED_CANDIDACY);
+  dbMock.candidacyPresidential.upsert.mockResolvedValue({ id: "pres-1" });
+  dbMock.programEdition.findUnique.mockResolvedValue({
+    id: "ed-1",
+    electionId: "elec-1",
+    publicationStatus: "DRAFT",
+  });
+  dbMock.programEdition.update.mockResolvedValue({ id: "ed-1" });
+  dbMock.auditLog.create.mockResolvedValue({ id: "audit-1" });
+});
+
+describe("actions de publication des candidatures", () => {
+  it("n'écrit rien sans session", async () => {
+    isAuthenticatedMock.mockResolvedValue(false);
+    const a = await actions();
+
+    await expect(
+      a.setCandidacyPublicationAction({ candidacyId: "cand-1", status: "PUBLISHED" })
+    ).rejects.toThrow("Non autorisé");
+    await expect(
+      a.setProgramEditionPublicationAction({ programEditionId: "ed-1", status: "PUBLISHED" })
+    ).rejects.toThrow("Non autorisé");
+
+    expect(dbMock.candidacyPresidential.upsert).not.toHaveBeenCalled();
+    expect(dbMock.programEdition.update).not.toHaveBeenCalled();
+    expect(dbMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("publie l'extension et invalide le tag que les surfaces du hub lisent", async () => {
+    const a = await actions();
+
+    const result = await a.setCandidacyPublicationAction({
+      candidacyId: "cand-1",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(dbMock.candidacyPresidential.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { candidacyId: "cand-1" },
+        create: { candidacyId: "cand-1", publicationStatus: "PUBLISHED" },
+        update: { publicationStatus: "PUBLISHED" },
+      })
+    );
+    expect(invalidateCandidacyTagsMock).toHaveBeenCalledWith("elec-1");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/candidats");
+  });
+
+  it("crée l'extension absente au lieu d'échouer", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue({ ...SOURCED_CANDIDACY, presidentialData: null });
+    dbMock.candidacyPresidential.upsert.mockResolvedValue({ id: "pres-nouveau" });
+    const a = await actions();
+
+    const result = await a.setCandidacyPublicationAction({
+      candidacyId: "cand-1",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(dbMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: "CREATE", entityType: "CandidacyPresidential" }),
+      })
+    );
+  });
+
+  it("refuse de publier une candidature non sourcée", async () => {
+    // La fiche publique écarte une candidature sans statut ni source : publier l'extension
+    // ouvrirait le hub sur un candidat dont la fiche redirige.
+    dbMock.candidacy.findUnique.mockResolvedValue({
+      ...SOURCED_CANDIDACY,
+      sourceUrl: null,
+      sourceLabel: null,
+    });
+    const a = await actions();
+
+    const result = await a.setCandidacyPublicationAction({
+      candidacyId: "cand-1",
+      status: "PUBLISHED",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(dbMock.candidacyPresidential.upsert).not.toHaveBeenCalled();
+  });
+
+  it("dépublie une candidature non sourcée sans la bloquer", async () => {
+    // La garde protège la mise en ligne, pas le retrait : refuser le retour au brouillon
+    // enfermerait une candidature publiée dont la source a été effacée.
+    dbMock.candidacy.findUnique.mockResolvedValue({
+      ...SOURCED_CANDIDACY,
+      sourceUrl: null,
+      sourceLabel: null,
+      presidentialData: { id: "pres-1", publicationStatus: "PUBLISHED" },
+    });
+    const a = await actions();
+
+    const result = await a.setCandidacyPublicationAction({
+      candidacyId: "cand-1",
+      status: "DRAFT",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(dbMock.candidacyPresidential.upsert).toHaveBeenCalled();
+  });
+
+  it("signale une candidature introuvable sans rien écrire", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue(null);
+    const a = await actions();
+
+    const result = await a.setCandidacyPublicationAction({
+      candidacyId: "inconnue",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Candidature introuvable." });
+    expect(dbMock.candidacyPresidential.upsert).not.toHaveBeenCalled();
+  });
+
+  it("publie une édition de programme et trace le statut précédent", async () => {
+    const a = await actions();
+
+    const result = await a.setProgramEditionPublicationAction({
+      programEditionId: "ed-1",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(dbMock.programEdition.update).toHaveBeenCalledWith({
+      where: { id: "ed-1" },
+      data: { publicationStatus: "PUBLISHED" },
+    });
+    expect(dbMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entityType: "ProgramEdition",
+          changes: { publicationStatus: "PUBLISHED", previousPublicationStatus: "DRAFT" },
+        }),
+      })
+    );
+    expect(invalidateCandidacyTagsMock).toHaveBeenCalledWith("elec-1");
+  });
+
+  it("rejette un statut de publication inconnu", async () => {
+    const a = await actions();
+
+    const result = await a.setProgramEditionPublicationAction({
+      programEditionId: "ed-1",
+      // @ts-expect-error une action serveur reçoit ce que le réseau lui envoie
+      status: "EN_LIGNE",
+    });
+
+    expect(result).toEqual({ ok: false, message: "Requête invalide." });
+    expect(dbMock.programEdition.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -1,0 +1,175 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { PublicationStatus } from "@/generated/prisma";
+import { isAuthenticated } from "@/lib/auth";
+import { invalidateEntity } from "@/lib/cache";
+import { db } from "@/lib/db";
+import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
+
+/**
+ * The publication switches of a presidential candidacy.
+ *
+ * Two rows decide what the public sees of a candidate, and until now neither had a control in the
+ * admin. `CandidacyPresidential.publicationStatus` was reachable only by hand-crafting a PATCH on
+ * `/api/admin/candidats/[id]`, and `ProgramEdition.publicationStatus` had no writer at all in the
+ * application: the import pipeline creates editions at their `DRAFT` default and nothing ever
+ * flipped them. The result was measures fully reviewed, published, primary-sourced, and invisible,
+ * with the candidate fiche stating that no programme had been identified.
+ *
+ * A server action is a network endpoint, not a form detail: the page guard does not protect it, so
+ * each action re-checks the session as its first statement, and validates its own input.
+ */
+
+/** Business errors are returned so the moderator reads the reason on screen; auth failures throw. */
+export type CandidacyActionResult = { ok: true } | { ok: false; message: string };
+
+const publicationStatusSchema = z.enum(["DRAFT", "PUBLISHED", "ARCHIVED", "EXCLUDED", "REJECTED"]);
+
+const candidacyPublicationSchema = z
+  .object({ candidacyId: z.string().min(1), status: publicationStatusSchema })
+  .strict();
+
+const programEditionPublicationSchema = z
+  .object({ programEditionId: z.string().min(1), status: publicationStatusSchema })
+  .strict();
+
+async function assertAuthenticated(): Promise<void> {
+  if (!(await isAuthenticated())) throw new Error("Non autorisé");
+}
+
+function revalidate(): void {
+  revalidatePath("/admin/candidats");
+}
+
+/**
+ * Publishes, or withdraws, the editorial extension that gates every public presidential surface.
+ *
+ * The extension is UPSERTED and not updated: twelve candidacies carry no `CandidacyPresidential`
+ * row at all, and without a create path a moderator facing "métadonnées absentes" has nowhere to
+ * go. Creating it here writes nothing else than the status, so the row stays what it is, an
+ * editorial extension, and the candidacy keeps its own columns.
+ *
+ * Publishing requires the candidacy to be sourced. That is not a duplicate of the fiche's own
+ * check: `loadPoliticianPresidentialCandidacy` drops a candidacy whose status, source URL or source
+ * label is null, so publishing an unsourced one would open the hub surfaces on a candidate whose
+ * fiche redirects away. The state would be inconsistent rather than merely incomplete.
+ */
+export async function setCandidacyPublicationAction(input: {
+  candidacyId: string;
+  status: PublicationStatus;
+}): Promise<CandidacyActionResult> {
+  await assertAuthenticated();
+
+  const parsed = candidacyPublicationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, message: "Requête invalide." };
+  }
+  const { candidacyId, status } = parsed.data;
+
+  const candidacy = await db.candidacy.findUnique({
+    where: { id: candidacyId },
+    select: {
+      id: true,
+      electionId: true,
+      status: true,
+      sourceUrl: true,
+      sourceLabel: true,
+      presidentialData: { select: { id: true, publicationStatus: true } },
+    },
+  });
+  if (!candidacy) {
+    return { ok: false, message: "Candidature introuvable." };
+  }
+  if (
+    status === "PUBLISHED" &&
+    (!candidacy.status || !candidacy.sourceUrl || !candidacy.sourceLabel)
+  ) {
+    return {
+      ok: false,
+      message:
+        "La candidature doit porter un statut et une source (URL et libellé) avant publication. " +
+        "Sans eux, la fiche publique renvoie vers le profil et les mesures restent invisibles.",
+    };
+  }
+
+  const extension = await db.candidacyPresidential.upsert({
+    where: { candidacyId },
+    create: { candidacyId, publicationStatus: status },
+    update: { publicationStatus: status },
+    select: { id: true },
+  });
+
+  await db.auditLog.create({
+    data: {
+      action: candidacy.presidentialData ? "UPDATE" : "CREATE",
+      entityType: "CandidacyPresidential",
+      entityId: extension.id,
+      changes: {
+        candidacyId,
+        publicationStatus: status,
+        previousPublicationStatus: candidacy.presidentialData?.publicationStatus ?? null,
+      },
+    },
+  });
+
+  invalidateEntity("election");
+  // The four hub reads, the candidate fiche and the politician notice all gate on this status and
+  // carry this tag alone. `invalidateEntity("election")` purges `elections`, which none of them use.
+  invalidatePresidentialCandidacyTags(candidacy.electionId);
+  revalidate();
+
+  return { ok: true };
+}
+
+/**
+ * Publishes, or withdraws, a programme edition.
+ *
+ * The edition's status does not gate a measure: a measure carries its own. What it drives is the
+ * sentence the candidate fiche shows below its gate, "programme identifié" against "aucun programme
+ * publié à ce jour", and the corpus nature the priorities page reads. Leaving every edition at its
+ * `DRAFT` default made the fiche deny a document we had already extracted 26 measures from.
+ */
+export async function setProgramEditionPublicationAction(input: {
+  programEditionId: string;
+  status: PublicationStatus;
+}): Promise<CandidacyActionResult> {
+  await assertAuthenticated();
+
+  const parsed = programEditionPublicationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, message: "Requête invalide." };
+  }
+  const { programEditionId, status } = parsed.data;
+
+  const edition = await db.programEdition.findUnique({
+    where: { id: programEditionId },
+    select: { id: true, electionId: true, publicationStatus: true },
+  });
+  if (!edition) {
+    return { ok: false, message: "Édition de programme introuvable." };
+  }
+
+  await db.programEdition.update({
+    where: { id: programEditionId },
+    data: { publicationStatus: status },
+  });
+
+  await db.auditLog.create({
+    data: {
+      action: "UPDATE",
+      entityType: "ProgramEdition",
+      entityId: programEditionId,
+      changes: {
+        publicationStatus: status,
+        previousPublicationStatus: edition.publicationStatus,
+      },
+    },
+  });
+
+  invalidatePresidentialCandidacyTags(edition.electionId);
+  revalidate();
+
+  return { ok: true };
+}

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -1,5 +1,7 @@
 import { getCandidates2027ForModeration } from "@/lib/data/candidates";
-import { CandidatesListClient } from "./CandidatesListClient";
+import { EMPTY_MEASURE_READINESS, getMeasureReadinessByCandidacies } from "@/lib/data/measures";
+import { db } from "@/lib/db";
+import { CandidatesListClient, type CandidateRowView } from "./CandidatesListClient";
 
 export const metadata = {
   title: "Candidats présidentielle 2027 (admin) | Poligraph",
@@ -8,6 +10,40 @@ export const metadata = {
 
 export default async function AdminCandidatsPage() {
   const candidates = await getCandidates2027ForModeration();
+  const candidacyIds = candidates.map((candidacy) => candidacy.id);
+
+  // Both reads are keyed on the candidacies already loaded, so the page stays at three queries
+  // whatever the size of the field.
+  const [readiness, editions] = await Promise.all([
+    getMeasureReadinessByCandidacies(candidacyIds),
+    db.programEdition.findMany({
+      where: { candidacyId: { in: candidacyIds } },
+      select: { id: true, candidacyId: true, label: true, version: true, publicationStatus: true },
+      orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
+    }),
+  ]);
+
+  const rows: CandidateRowView[] = candidates.map((candidacy) => ({
+    candidacyId: candidacy.id,
+    candidateName: candidacy.candidateName,
+    politicianSlug: candidacy.politician?.slug ?? null,
+    partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
+    status: candidacy.status,
+    sourced: Boolean(candidacy.status && candidacy.sourceUrl && candidacy.sourceLabel),
+    presidentialId: candidacy.presidentialData?.id ?? null,
+    publicationStatus: candidacy.presidentialData?.publicationStatus ?? null,
+    slogan: candidacy.presidentialData?.slogan ?? null,
+    rank: candidacy.presidentialData?.rank ?? null,
+    readiness: readiness.get(candidacy.id) ?? EMPTY_MEASURE_READINESS,
+    editions: editions
+      .filter((edition) => edition.candidacyId === candidacy.id)
+      .map((edition) => ({
+        id: edition.id,
+        label: edition.label,
+        version: edition.version,
+        publicationStatus: edition.publicationStatus,
+      })),
+  }));
 
   return (
     <div className="space-y-6">
@@ -16,12 +52,12 @@ export default async function AdminCandidatsPage() {
           Candidats présidentielle 2027
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          {candidates.length} candidatures enregistrées. Ajouter, modifier le slogan ou le rang, ou
-          retirer un candidat.
+          {candidates.length} candidatures enregistrées. Publier une candidature, publier son
+          programme, modifier le slogan ou le rang.
         </p>
       </header>
 
-      <CandidatesListClient initialCandidates={candidates} />
+      <CandidatesListClient rows={rows} />
 
       <p className="text-xs text-muted-foreground">
         Note : cette page est admin-only. La surface publique{" "}

--- a/src/app/api/admin/badges/route.test.ts
+++ b/src/app/api/admin/badges/route.test.ts
@@ -14,11 +14,17 @@ const h = vi.hoisted(() => ({
   },
   duplicates: vi.fn(),
   pipelines: vi.fn(),
+  candidaciesHoldingBack: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({ db: h.db }));
 vi.mock("@/services/affairs/reconciliation", () => ({ findPotentialDuplicates: h.duplicates }));
 vi.mock("@/lib/data/pipelines", () => ({ getPipelineHealthAll: h.pipelines }));
+// Le compteur des candidatures vit dans la couche mesures : c'est elle qui porte le prédicat de
+// visibilité publique, la route ne fait que l'appeler.
+vi.mock("@/lib/data/measures", () => ({
+  countCandidaciesHoldingBackMeasures: h.candidaciesHoldingBack,
+}));
 vi.mock("@/lib/api/with-admin-auth", () => ({
   withAdminAuth: (handler: () => Promise<Response>) => handler,
 }));
@@ -38,6 +44,7 @@ beforeEach(() => {
   h.db.pressAnalysisRejection.count.mockResolvedValue(9);
   h.db.syncJob.count.mockResolvedValue(10);
   h.duplicates.mockResolvedValue([{ id: "duplicate-1" }, { id: "duplicate-2" }]);
+  h.candidaciesHoldingBack.mockResolvedValue(6);
   h.pipelines.mockResolvedValue([
     { status: "critical" },
     { status: "healthy" },
@@ -54,6 +61,7 @@ describe("GET /api/admin/badges", () => {
       drafts: { affairs: 3, politicians: 4 },
       moderation: { proposalsPending: 5, proposalsConflict: 2, reviewsPending: 7 },
       matching: { decisionsPending: 8, articlesPending: 11, duplicatesPending: 2 },
+      candidacies: { publicationPending: 6 },
       press: { rejectionsPending: 9 },
       operations: { failedPipelines: 2, failedSyncs: 10 },
     });

--- a/src/app/api/admin/badges/route.ts
+++ b/src/app/api/admin/badges/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
 import { getPipelineHealthAll } from "@/lib/data/pipelines";
+import { countCandidaciesHoldingBackMeasures } from "@/lib/data/measures";
 
 export interface AdminBadgeContract {
   drafts: { affairs: number; politicians: number };
@@ -12,6 +13,8 @@ export interface AdminBadgeContract {
     reviewsPending: number;
   };
   matching: { decisionsPending: number; articlesPending: number; duplicatesPending: number };
+  /** Candidatures dont les mesures publiables restent derrière une extension non publiée. */
+  candidacies: { publicationPending: number };
   press: { rejectionsPending: number };
   operations: { failedPipelines: number; failedSyncs: number };
 }
@@ -29,6 +32,7 @@ export const GET = withAdminAuth(async () => {
     rejectionsPending,
     failedSyncs,
     pipelineHealth,
+    candidaciesPublicationPending,
   ] = await Promise.all([
     db.affair.count({ where: { publicationStatus: "DRAFT" } }),
     db.politician.count({ where: { publicationStatus: "DRAFT" } }),
@@ -45,12 +49,14 @@ export const GET = withAdminAuth(async () => {
     db.pressAnalysisRejection.count(),
     db.syncJob.count({ where: { status: "FAILED" } }),
     getPipelineHealthAll(),
+    countCandidaciesHoldingBackMeasures(),
   ]);
 
   const response: AdminBadgeContract = {
     drafts: { affairs, politicians },
     moderation: { proposalsPending, proposalsConflict, reviewsPending },
     matching: { decisionsPending, articlesPending, duplicatesPending: duplicates.length },
+    candidacies: { publicationPending: candidaciesPublicationPending },
     press: { rejectionsPending },
     operations: {
       failedPipelines: pipelineHealth.filter((pipeline) => pipeline.status === "critical").length,

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -17,6 +17,9 @@ type BadgeResponse = {
   drafts: { affairs: number; politicians: number };
   moderation: { proposalsPending: number; proposalsConflict: number; reviewsPending: number };
   matching: { decisionsPending: number; articlesPending: number; duplicatesPending: number };
+  // Optionnel : pendant un déploiement progressif, l'API peut encore être la version qui ne
+  // renvoie pas ce compteur, et la barre latérale ne doit pas casser pour un badge.
+  candidacies?: { publicationPending: number };
   press: { rejectionsPending: number };
   operations: { failedPipelines: number; failedSyncs: number };
 };
@@ -25,6 +28,7 @@ const EMPTY_BADGES: BadgeResponse = {
   drafts: { affairs: 0, politicians: 0 },
   moderation: { proposalsPending: 0, proposalsConflict: 0, reviewsPending: 0 },
   matching: { decisionsPending: 0, articlesPending: 0, duplicatesPending: 0 },
+  candidacies: { publicationPending: 0 },
   press: { rejectionsPending: 0 },
   operations: { failedPipelines: 0, failedSyncs: 0 },
 };
@@ -39,6 +43,7 @@ function flattenBadges(badges: BadgeResponse): Record<string, number> {
     "matching.decisionsPending": badges.matching.decisionsPending,
     "matching.articlesPending": badges.matching.articlesPending,
     "matching.duplicatesPending": badges.matching.duplicatesPending,
+    "candidacies.publicationPending": badges.candidacies?.publicationPending ?? 0,
     "press.rejectionsPending": badges.press.rejectionsPending,
     "operations.failedPipelines": badges.operations.failedPipelines,
     "operations.failedSyncs": badges.operations.failedSyncs,

--- a/src/config/admin-navigation.test.ts
+++ b/src/config/admin-navigation.test.ts
@@ -35,6 +35,13 @@ describe("admin navigation registry", () => {
     expect(isAdminNavigationActive("/admin/audit/bio-quality", audit)).toBe(true);
   });
 
+  it("badges the candidacies entry with its pending publications", () => {
+    // Une candidature qui retient des mesures publiables demande une décision humaine, et rien
+    // dans l'admin ne le disait : la file des mesures se vide quand elles sont toutes publiées.
+    const candidates = ADMIN_NAVIGATION.find((entry) => entry.id === "candidates")!;
+    expect(candidates.counterKey).toBe("candidacies.publicationPending");
+  });
+
   it("points both relationship entries to explicit workbenches with distinct counters", () => {
     const articles = ADMIN_NAVIGATION.find((entry) => entry.id === "articles-affairs")!;
     const politicians = ADMIN_NAVIGATION.find((entry) => entry.id === "affairs-politicians")!;

--- a/src/config/admin-navigation.ts
+++ b/src/config/admin-navigation.ts
@@ -33,6 +33,7 @@ export type AdminCounterKey =
   | "moderation.proposalsPending"
   | "moderation.proposalsConflict"
   | "moderation.reviewsPending"
+  | "candidacies.publicationPending"
   | "matching.decisionsPending"
   | "matching.articlesPending"
   | "matching.duplicatesPending"
@@ -128,6 +129,7 @@ const entries: readonly AdminNavigationEntry[] = [
     description: "Candidatures et comparaisons.",
     group: "content",
     icon: CheckSquare,
+    counterKey: "candidacies.publicationPending",
   },
   {
     id: "mayors",

--- a/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
@@ -3,6 +3,7 @@ import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard"
 
 let db: typeof import("@/lib/db").db;
 let getPublicMeasureStatsByCandidacy: typeof import("../measures").getPublicMeasureStatsByCandidacy;
+let getMeasureReadinessByCandidacies: typeof import("../measures").getMeasureReadinessByCandidacies;
 
 const SLUG = "stats-by-candidacy";
 
@@ -23,7 +24,8 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
   beforeAll(async () => {
     assertDisposableTestDb();
     ({ db } = await import("@/lib/db"));
-    ({ getPublicMeasureStatsByCandidacy } = await import("../measures"));
+    ({ getPublicMeasureStatsByCandidacy, getMeasureReadinessByCandidacies } =
+      await import("../measures"));
     const { createMeasure, reviewMeasureRevision, publishMeasureRevision, draftMeasureRevision } =
       await import("@/lib/measures/transitions");
 
@@ -176,5 +178,43 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
     const stats = await getPublicMeasureStatsByCandidacy(secondarySourceCandidacyId);
     expect(stats.measureCount).toBe(1);
     expect(stats.primarySourceMeasureCount).toBe(0);
+  });
+
+  // La lecture d'administration répond à l'autre question : ce que la publication de l'extension
+  // rendrait visible. C'est le cas Guedj, 26 mesures relues, publiées et sourcées, comptées zéro
+  // par les surfaces publiques parce que l'extension est restée en brouillon.
+  it("compte pour l'admin les mesures qu'une extension DRAFT retient", async () => {
+    const readiness = await getMeasureReadinessByCandidacies([draftExtensionCandidacyId]);
+
+    expect(readiness.get(draftExtensionCandidacyId)).toEqual({
+      measureCount: 1,
+      themesCoveredCount: 1,
+      primarySourceMeasureCount: 1,
+    });
+  });
+
+  it("agrège plusieurs candidatures en une lecture", async () => {
+    const readiness = await getMeasureReadinessByCandidacies([
+      publishedCandidacyId,
+      draftExtensionCandidacyId,
+      secondarySourceCandidacyId,
+    ]);
+
+    expect(readiness.get(publishedCandidacyId)).toEqual({
+      measureCount: 2,
+      themesCoveredCount: 2,
+      primarySourceMeasureCount: 1,
+    });
+    // Même piège de révision que la lecture publique : la source primaire du brouillon ne compte pas.
+    expect(readiness.get(secondarySourceCandidacyId)).toEqual({
+      measureCount: 1,
+      themesCoveredCount: 1,
+      primarySourceMeasureCount: 0,
+    });
+  });
+
+  it("ne lance aucune requête sans candidature", async () => {
+    const readiness = await getMeasureReadinessByCandidacies([]);
+    expect(readiness.size).toBe(0);
   });
 });

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -313,6 +313,97 @@ export async function getPublicMeasureStatsByCandidacy(
 }
 
 /**
+ * The same measure population as the public reads, for a set of candidacies, WITHOUT the
+ * `PUBLIC_CANDIDACY_WHERE` gate.
+ *
+ * It answers the one question the public reads cannot: how many measures WOULD become visible if
+ * the candidacy's editorial extension were published. `getPublicMeasureStatsByCandidacy` returns
+ * zero on a DRAFT extension, which is correct for a page and useless for the moderator deciding
+ * whether to publish it: the whole point of the admin screen is to see the measures the gate is
+ * currently holding back.
+ *
+ * The measure-level conditions are NOT rewritten here, they are `PUBLIC_MEASURE_WHERE` plus the
+ * withdrawal filter. A hand-rolled copy is how the hub's count and its review date drifted apart
+ * (see `getLatestPresidentialReviewDate`), and here it would announce a number the fiche does not
+ * honour once published.
+ *
+ * One grouped query for the whole page rather than one read per row: the candidates screen lists
+ * every candidacy of the election, and a per-row read turns it into thirty round trips.
+ */
+export type CandidacyMeasureReadiness = {
+  measureCount: number;
+  themesCoveredCount: number;
+  primarySourceMeasureCount: number;
+};
+
+export const EMPTY_MEASURE_READINESS: CandidacyMeasureReadiness = {
+  measureCount: 0,
+  themesCoveredCount: 0,
+  primarySourceMeasureCount: 0,
+};
+
+/**
+ * How many candidacies hold publishable measures behind a closed extension.
+ *
+ * The badge of the candidates screen, and the reason this file owns the count: the predicate is
+ * the negation of `PUBLIC_CANDIDACY_WHERE` applied to the population `PUBLIC_MEASURE_WHERE`
+ * describes, and neither belongs on a route handler. `NOT` on the public gate also catches a
+ * candidacy with no extension row at all, which is the state twelve of them are in.
+ */
+export async function countCandidaciesHoldingBackMeasures(): Promise<number> {
+  return db.candidacy.count({
+    where: {
+      NOT: PUBLIC_CANDIDACY_WHERE,
+      measures: { some: { withdrawnAt: null, ...PUBLIC_MEASURE_WHERE } },
+    },
+  });
+}
+
+export async function getMeasureReadinessByCandidacies(
+  candidacyIds: string[]
+): Promise<Map<string, CandidacyMeasureReadiness>> {
+  const readiness = new Map<string, CandidacyMeasureReadiness>();
+  if (candidacyIds.length === 0) return readiness;
+
+  const scope: Prisma.MeasureWhereInput = {
+    candidacyId: { in: candidacyIds },
+    withdrawnAt: null,
+    ...PUBLIC_MEASURE_WHERE,
+  };
+
+  const [byTheme, byPrimarySource] = await Promise.all([
+    db.measure.groupBy({ by: ["candidacyId", "theme"], where: scope, _count: { _all: true } }),
+    db.measure.groupBy({
+      by: ["candidacyId"],
+      where: {
+        ...scope,
+        publishedRevision: {
+          ...PUBLIC_MEASURE_WHERE.publishedRevision,
+          sources: { some: { tier: "PRIMARY" } },
+        },
+      },
+      _count: { _all: true },
+    }),
+  ]);
+
+  for (const row of byTheme) {
+    if (row.candidacyId === null) continue;
+    const current = readiness.get(row.candidacyId) ?? { ...EMPTY_MEASURE_READINESS };
+    current.measureCount += row._count._all;
+    current.themesCoveredCount += 1;
+    readiness.set(row.candidacyId, current);
+  }
+  for (const row of byPrimarySource) {
+    if (row.candidacyId === null) continue;
+    const current = readiness.get(row.candidacyId) ?? { ...EMPTY_MEASURE_READINESS };
+    current.primarySourceMeasureCount = row._count._all;
+    readiness.set(row.candidacyId, current);
+  }
+
+  return readiness;
+}
+
+/**
  * The revision publicly in force on a given day. The condition on publishedAt is not
  * optional: without it the query can select a draft that was never published, and make the
  * site report a text it never displayed.


### PR DESCRIPTION
Les 26 mesures de Jérôme Guedj sont relues, publiées, sourcées en première
main sur 11 thèmes, et invisibles partout : son CandidacyPresidential est
resté en DRAFT, donc PUBLIC_CANDIDACY_WHERE l'écarte, les compteurs valent
zéro et la fiche candidat reste sous son seuil de publication. Son édition
de programme est en DRAFT aussi, ce qui fait dire à la fiche qu'aucun
programme n'a été identifié. Même situation pour Ruffin, Cazeneuve, Kazib,
Arthaud, Egger et Mikolajczak : 139 mesures publiables retenues.

Aucun des deux interrupteurs n'avait de contrôle dans l'admin.
CandidacyPresidential.publicationStatus n'était joignable que par un PATCH
fabriqué à la main, et ProgramEdition.publicationStatus n'avait aucun
écrivain dans l'application : l'import crée les éditions à leur défaut
DRAFT et rien ne les basculait.

- /admin/candidats gagne trois colonnes : mesures prêtes (le compte que la
  publication rendrait visible), fiche publique et programme, chacune avec
  son bouton publier/dépublier, plus un encart nommant les candidatures qui
  retiennent des mesures.
- Deux actions serveur, gardées par la session et validées, tracées dans
  auditLog, qui purgent le tag election-candidacies que les surfaces lisent.
  L'extension est upsertée : douze candidatures n'en ont aucune, et sans
  chemin de création l'admin restait bloqué sur « métadonnées absentes ».
- Publier exige une candidature sourcée : sans statut ni source la fiche
  publique redirige vers le profil, l'état serait incohérent.
- L'entrée « Candidatures » de la barre latérale porte le compte des
  candidatures en attente : la file des mesures se vide quand elles sont
  toutes publiées et plus rien ne signalait le dernier maillon.