### PR TITLE
feat(presidentielle): partager une fiche de candidature comme les autres fiches

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
@@ -95,6 +95,36 @@ describe("page présidentielle d'une personne", () => {
     expect(screen.queryByText(/aucun programme publié/i)).not.toBeInTheDocument();
   });
 
+  it("propose le partage de la fiche une fois la porte franchie", async () => {
+    mockGetCandidacy.mockResolvedValue(candidacy({ primarySourceMeasureCount: 20 }));
+    const { default: Page } = await import("../page");
+    render(await Page({ params: Promise.resolve({ slug: "camille-riviere" }) }));
+    // Deux barres, la verticale du desktop et celle du bas sur mobile, comme sur les autres fiches.
+    expect(screen.getAllByRole("group", { name: "Partager cette page" })).toHaveLength(2);
+    const shareLink = screen.getAllByRole("link", { name: "Partager sur X" })[0]!;
+    expect(shareLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        encodeURIComponent(
+          "https://poligraph.fr/elections/presidentielle-2027/candidats/camille-riviere"
+        )
+      )
+    );
+    // Ni le statut de candidature ni le nombre de mesures : un post daté leur survit.
+    expect(shareLink.getAttribute("href")).toContain(
+      encodeURIComponent(
+        "Camille Rivière, Présidentielle 2027 (Parti Test) : ses mesures et leurs sources sur Poligraph"
+      )
+    );
+  });
+
+  it("ne propose pas le partage sous la porte de publication", async () => {
+    mockGetCandidacy.mockResolvedValue(candidacy());
+    const { default: Page } = await import("../page");
+    render(await Page({ params: Promise.resolve({ slug: "camille-riviere" }) }));
+    expect(screen.queryByRole("group", { name: "Partager cette page" })).not.toBeInTheDocument();
+  });
+
   it("présente la source comme lien externe secondaire", async () => {
     mockGetCandidacy.mockResolvedValue(candidacy());
     const { default: Page } = await import("../page");
@@ -131,5 +161,21 @@ describe("page présidentielle d'une personne", () => {
       params: Promise.resolve({ slug: "camille-riviere" }),
     });
     expect(metadata.robots).toBeUndefined();
+  });
+
+  it("décrit la fiche pour les aperçus de partage", async () => {
+    mockGetCandidacy.mockResolvedValue(candidacy({ primarySourceMeasureCount: 20 }));
+    const { generateMetadata } = await import("../page");
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "camille-riviere" }),
+    });
+    expect(metadata.openGraph?.title).toContain("Camille Rivière");
+    expect(metadata.openGraph?.url).toBe(
+      "/elections/presidentielle-2027/candidats/camille-riviere"
+    );
+    expect(metadata.twitter).toMatchObject({ card: "summary_large_image" });
+    // La carte vient de la route opengraph-image voisine, jamais d'une seconde image nommée ici.
+    expect(metadata.openGraph?.images).toBeUndefined();
+    expect(metadata.twitter?.images).toBeUndefined();
   });
 });

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -3,9 +3,12 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { ExternalLink, UserRound } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { ShareBar } from "@/components/ui/ShareBar";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import { candidacyRoleLabel } from "@/config/labels";
 import { isFicheCandidatPublishable } from "@/config/publication-gates";
+import { SITE_URL } from "@/config/site";
+import { cn } from "@/lib/utils";
 // Reuses the established politician authority rather than adding a second, lighter read for three
 // fields. It loads more than this page needs, but it is already cached under `politician:<slug>`.
 import { getPolitician } from "@/lib/data/politicians";
@@ -40,6 +43,14 @@ import {
 export const revalidate = 86400;
 
 /**
+ * One place for the fiche path. The canonical, the share link and the link the OG card is attached
+ * to are the same URL, and a reader who copies the address bar must land on what they shared.
+ */
+function fichePath(slug: string): string {
+  return `/elections/presidentielle-2027/candidats/${slug}`;
+}
+
+/**
  * No pre-generation. The publishable population changes with EDITORIAL WRITES, not with deployments:
  * pre-generating at build time would freeze a list that a publication invalidates hours later, and
  * would make a fiche's going live depend on a redeploy. Fiches are therefore generated on demand
@@ -66,13 +77,27 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       verifiedMeasuresWithPrimarySource: candidacy.primarySourceMeasureCount,
     });
 
+  const title = `${politician.fullName}, candidature à la présidentielle 2027 | Poligraph`;
+  const description = `Les mesures documentées de ${politician.fullName} pour la présidentielle 2027, par sujet, avec leurs sources.`;
+
   return {
-    title: `${politician.fullName}, candidature à la présidentielle 2027 | Poligraph`,
-    description: `Les mesures documentées de ${politician.fullName} pour la présidentielle 2027, par sujet, avec leurs sources.`,
+    title,
+    description,
     // A surface below its gate stays out of search results (spec §4.2). `follow: true` so the links
     // out of the page keep their value.
     robots: publishable ? undefined : { index: false, follow: true },
-    alternates: { canonical: `/elections/presidentielle-2027/candidats/${slug}` },
+    alternates: { canonical: fichePath(slug) },
+    // A pasted link must show the fiche, not the tab title a platform guesses from the document.
+    // No `images` here: the `opengraph-image` route beside this file already provides the card, and
+    // naming a second image would let the two drift. `summary_large_image` is what that 1200x630
+    // card is drawn for, and X falls back to `og:image` since we ship no `twitter-image` route.
+    openGraph: {
+      title,
+      description,
+      type: "profile",
+      url: fichePath(slug),
+    },
+    twitter: { card: "summary_large_image", title, description },
   };
 }
 
@@ -99,8 +124,34 @@ export default async function CandidateFichePage({ params }: PageProps) {
 
   return (
     <>
+      {/* Sharing a fiche is the same gesture as sharing any other Poligraph page, so it is the same
+          bar, with the same platforms and the same copy control. It only appears above the
+          publication gate: below it the page carries a sourced status and nothing else, stays
+          `noindex` by policy, and handing readers buttons to spread a page we keep out of search
+          would contradict that policy rather than serve them. */}
+      {publishable && (
+        <ShareBar
+          data={{
+            title: politician.fullName,
+            // Name, election, party: the three facts that stay true. Deliberately no candidacy
+            // status and no measure count, for the reason the OG card states at length. A post
+            // outlives the day it was written, and a withdrawn candidacy shared as "annoncée"
+            // cannot be corrected once it is out.
+            text: `${politician.fullName}, ${candidacy.electionShortTitle}${candidacy.partyLabel ? ` (${candidacy.partyLabel})` : ""} : ses mesures et leurs sources sur Poligraph`,
+            url: `${SITE_URL}${fichePath(slug)}`,
+          }}
+        />
+      )}
       <CandidacyBackBar electionSlug={candidacy.electionSlug} />
-      <div className="container mx-auto space-y-8 px-4 pb-8 pt-4">
+      {/* The mobile share bar is fixed to the bottom of the viewport, so the last control of the
+          page needs room to clear it. The extra padding goes away at `2xl`, where that bar becomes
+          the vertical one on the left. */}
+      <div
+        className={cn(
+          "container mx-auto space-y-8 px-4 pt-4",
+          publishable ? "pb-24 2xl:pb-8" : "pb-8"
+        )}
+      >
         <Breadcrumb
           items={[
             { label: "Élections", href: "/elections" },


### PR DESCRIPTION
La barre de partage des fiches Poligraph (X, Bluesky, Facebook, WhatsApp,
copie du lien) arrive sur la fiche de candidature à la présidentielle.

- Barre affichée au-dessus de la porte de publication seulement : sous la
  porte la page reste noindex, on ne pousse pas au partage d'une page tenue
  hors de l'index.
- Texte partagé limité aux faits stables (nom, élection, parti) : ni statut
  de candidature ni nombre de mesures, un post survit à leur mise à jour.
- Métadonnées openGraph et twitter ajoutées pour l'aperçu du lien collé, la
  carte restant celle de la route opengraph-image voisine.
- Chemin de la fiche centralisé pour que canonical, lien partagé et carte ne
  divergent pas ; padding bas ajusté pour dégager la barre mobile.
- Tests : présence et absence de la barre selon la porte, métadonnées de
  partage.