### PR TITLE
fix(présidentielle): retirer une synthèse démentie par les mesures publiées depuis

### DIFF
--- a/scripts/generate-candidate-syntheses.ts
+++ b/scripts/generate-candidate-syntheses.ts
@@ -8,71 +8,23 @@
  *
  * Dry run by default: it prints the text it would store and writes nothing.
  *
- * Only declared candidacies are considered. A candidacy that is merely rumoured has
- * not asked anyone to read a summary of its programme, and saying so on its page would
- * lend it a substance its own status denies.
+ * The generation itself lives in `@/services/candidate-synthesis`, which the admin button calls
+ * too. This file is the batch shell around it: which candidacies to walk, and what to print.
  */
 
 import { db } from "@/lib/db";
-import { callAnthropic } from "@/lib/api/anthropic";
-import { callMistral, extractMistralText } from "@/lib/api/mistral";
 import {
-  buildCandidateSynthesisPrompt,
-  screenSynthesis,
-  SYNTHESIS_SYSTEM_PROMPT,
-  type CandidateSynthesisInput,
-} from "@/lib/presidentielle/candidate-synthesis";
+  generateCandidateSynthesis,
+  type SynthesisGenerationResult,
+} from "@/services/candidate-synthesis";
 
 const ELECTION_SLUG = "presidentielle-2027";
-/** Mandates kept in the prompt, most recent first. Enough for a career, short of a list. */
-const MANDATE_LIMIT = 8;
 
 const apply = process.argv.includes("--apply");
 const only = process.argv.find((a) => a.startsWith("--only="))?.split("=")[1];
 
-/**
- * Anthropic first, Mistral if it fails, same broad fallback as `classify-theme`.
- *
- * Falling back on any error rather than on a quota signal is deliberate and copied
- * from there: telling a spent balance apart from a rate limit or a bad request is
- * brittle, and the output goes through `screenSynthesis` whatever produced it. The
- * failure this actually covers is the recurring one on this project, an Anthropic
- * balance at zero, which returns a plain 400.
- *
- * Both errors are carried into the throw. A run that dies with only the second one
- * would hide the reason the first provider was skipped.
- */
-async function generate(system: string, user: string): Promise<{ text: string; provider: string }> {
-  let anthropicError: string;
-  try {
-    const response = await callAnthropic([{ role: "user", content: user }], {
-      system,
-      maxTokens: 900,
-    });
-    return {
-      text: response.content.find((c) => c.type === "text")?.text ?? "",
-      provider: "anthropic",
-    };
-  } catch (error) {
-    anthropicError = error instanceof Error ? error.message : String(error);
-    console.warn(`[synthèses] anthropic indisponible (${anthropicError}), repli sur mistral`);
-  }
-
-  try {
-    const response = await callMistral(
-      [
-        { role: "system", content: system },
-        { role: "user", content: user },
-      ],
-      { maxTokens: 900 }
-    );
-    return { text: extractMistralText(response), provider: "mistral" };
-  } catch (error) {
-    const mistralError = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Génération impossible — anthropic : ${anthropicError} ; mistral : ${mistralError}`
-    );
-  }
+function describeRefusal(result: Extract<SynthesisGenerationResult, { ok: false }>): string {
+  return `${result.reason} — ${result.message}`;
 }
 
 async function main(): Promise<void> {
@@ -88,17 +40,14 @@ async function main(): Promise<void> {
       status: "DECLARE",
       ...(only ? { politician: { slug: only } } : {}),
     },
-    select: {
-      id: true,
-      candidateName: true,
-      partyLabel: true,
-      politicianId: true,
-      party: { select: { name: true } },
-      presidentialData: { select: { id: true } },
-    },
+    select: { id: true, candidateName: true },
     orderBy: { candidateName: "asc" },
   });
 
+  // Which syntheses are STALE is not asked here. That question needs the public measure population,
+  // which lives behind `server-only` and cannot be imported under tsx, and the admin candidates
+  // screen already answers it per row with a button beside the answer. This script stays what it
+  // was: the whole field, in one pass.
   console.log(
     `${apply ? "APPLY (écrit en base)" : "dry run"} — ${candidacies.length} candidature(s) déclarée(s)\n`
   );
@@ -107,98 +56,19 @@ async function main(): Promise<void> {
   let rejected = 0;
 
   for (const candidacy of candidacies) {
-    if (!candidacy.politicianId) {
-      console.log(`SKIP ${candidacy.candidateName} : candidature sans politicien`);
-      continue;
-    }
+    const result = await generateCandidateSynthesis(candidacy.id, { persist: apply });
 
-    const [mandates, voteCount, measures] = await Promise.all([
-      db.mandate.findMany({
-        where: { politicianId: candidacy.politicianId },
-        select: { role: true, title: true, institution: true, startDate: true, endDate: true },
-        orderBy: { startDate: "desc" },
-        take: MANDATE_LIMIT,
-      }),
-      db.vote.count({ where: { politicianId: candidacy.politicianId } }),
-      db.measure.findMany({
-        where: {
-          candidacyId: candidacy.id,
-          publicationStatus: "PUBLISHED",
-          withdrawnAt: null,
-          publishedRevision: { reviewedAt: { not: null } },
-        },
-        select: { theme: true, publishedRevision: { select: { text: true } } },
-      }),
-    ]);
-
-    const input: CandidateSynthesisInput = {
-      candidateName: candidacy.candidateName,
-      partyLabel: candidacy.party?.name ?? candidacy.partyLabel,
-      mandates: mandates.map((m) => ({
-        // `title` carries the constituency, `role` only exists for offices within the
-        // institution. Preferring title is what keeps "Députée de la 3e du Rhône"
-        // rather than a bare null.
-        role: m.role ?? m.title,
-        institution: m.institution,
-        startYear: m.startDate.getUTCFullYear(),
-        endYear: m.endDate?.getUTCFullYear() ?? null,
-      })),
-      voteCount,
-      measures: measures.flatMap((m) =>
-        m.publishedRevision ? [{ theme: m.theme, text: m.publishedRevision.text }] : []
-      ),
-    };
-
-    const hasMeasures = input.measures.length > 0;
-    const prompt = buildCandidateSynthesisPrompt(input);
-
-    let attempt = await generate(SYNTHESIS_SYSTEM_PROMPT, prompt);
-    let screened = screenSynthesis(attempt.text, { hasMeasures });
-
-    // One retry, naming the rule that was broken. Measured on a first full run: the
-    // model obeys the rules it is reminded of and slips on the ones it is only told
-    // once, the long dash above all. Retrying blind would just roll the dice again,
-    // and retrying twice would paper over a prompt that genuinely needs fixing.
-    if (!screened.ok) {
-      console.log(
-        `   reprise ${candidacy.candidateName} : ${screened.reason} (${screened.detail})`
-      );
-      attempt = await generate(
-        SYNTHESIS_SYSTEM_PROMPT,
-        `${prompt}\n\nTa réponse précédente a été refusée : ${screened.detail}. Recommence en respectant cette règle.`
-      );
-      screened = screenSynthesis(attempt.text, { hasMeasures });
-    }
-
-    if (!screened.ok) {
+    if (!result.ok) {
       rejected++;
-      console.log(`REFUSÉ ${candidacy.candidateName} : ${screened.reason} (${screened.detail})`);
-      console.log(`   texte : ${attempt.text.slice(0, 160)}\n`);
+      console.log(`REFUSÉ ${candidacy.candidateName} : ${describeRefusal(result)}\n`);
       continue;
     }
-    const provider = attempt.provider;
 
     console.log(
-      `OK ${candidacy.candidateName} (${mandates.length} mandats, ${input.measures.length} mesures, ${provider})`
+      `OK ${candidacy.candidateName} (${result.mandateCount} mandats, ${result.measureCount} mesures, ${result.provider})`
     );
-    console.log(`${screened.text}\n`);
-
-    if (!apply) continue;
-
-    // The synthesis belongs to the presidential extension, which may not exist yet for
-    // a candidacy nobody has curated. Creating it here would publish nothing on its own
-    // (it defaults to DRAFT), but it would still be a row this script has no mandate to
-    // invent, so a missing extension is reported rather than filled in.
-    if (!candidacy.presidentialData) {
-      console.log(`   NON ÉCRIT : pas d'extension présidentielle pour cette candidature\n`);
-      continue;
-    }
-
-    await db.candidacyPresidential.update({
-      where: { id: candidacy.presidentialData.id },
-      data: { synthesis: screened.text, synthesisGeneratedAt: new Date() },
-    });
-    written++;
+    console.log(`${result.text}\n`);
+    if (result.persisted) written++;
   }
 
   console.log(

--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -6,8 +6,13 @@ import { useRouter } from "next/navigation";
 import type { CandidacyStatus, PublicationStatus } from "@/generated/prisma";
 import { Badge } from "@/components/ui/badge";
 import { PUBLICATION_STATUS_LABELS, PUBLICATION_STATUS_STYLES } from "@/config/labels";
+import { formatDate } from "@/lib/utils";
 import type { CandidacyMeasureReadiness } from "@/lib/data/measures";
-import { setCandidacyPublicationAction, setProgramEditionPublicationAction } from "./actions";
+import {
+  regenerateCandidateSynthesisAction,
+  setCandidacyPublicationAction,
+  setProgramEditionPublicationAction,
+} from "./actions";
 
 const STATUS_LABELS: Record<string, string> = {
   DECLARE: "Déclaré",
@@ -21,6 +26,25 @@ export type ProgramEditionView = {
   label: string;
   version: number;
   publicationStatus: PublicationStatus;
+};
+
+/**
+ * What the fiche does with the stored synthesis, decided server-side by the same predicate the
+ * public read applies. Three states and not a date, because a date is not readable as a verdict:
+ * "7 août" tells a moderator nothing until they also know when the measures were published.
+ */
+export type SynthesisState = "MISSING" | "CONTRADICTED" | "CURRENT";
+
+const SYNTHESIS_LABELS: Record<SynthesisState, string> = {
+  MISSING: "Absente",
+  CONTRADICTED: "Démentie",
+  CURRENT: "À jour",
+};
+
+const SYNTHESIS_STYLES: Record<SynthesisState, string> = {
+  MISSING: "",
+  CONTRADICTED: "border-amber-400 text-amber-900 dark:border-amber-600 dark:text-amber-100",
+  CURRENT: "border-emerald-400 text-emerald-900 dark:border-emerald-600 dark:text-emerald-100",
 };
 
 export type CandidateRowView = {
@@ -37,6 +61,8 @@ export type CandidateRowView = {
   slogan: string | null;
   rank: number | null;
   readiness: CandidacyMeasureReadiness;
+  synthesisState: SynthesisState;
+  synthesisGeneratedAt: Date | null;
   editions: ProgramEditionView[];
 };
 
@@ -53,6 +79,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
 
   const held = rows.filter(isHoldingBackMeasures);
   const heldMeasureCount = held.reduce((total, row) => total + row.readiness.measureCount, 0);
+  const contradicted = rows.filter((row) => row.synthesisState === "CONTRADICTED");
 
   async function patchPresidential(id: string, body: Record<string, unknown>) {
     setBusy(id);
@@ -105,6 +132,27 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
         </div>
       )}
 
+      {/* The state the fiche is actually in, which nothing on this screen used to say. A moderator
+          publishing measures has no reason to suspect that a text generated weeks earlier now
+          denies them, and the public page shows no summary at all until it is regenerated. */}
+      {contradicted.length > 0 && (
+        <div
+          role="status"
+          className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+        >
+          <p className="font-semibold">
+            {contradicted.length === 1
+              ? "1 synthèse démentie par les mesures publiées depuis"
+              : `${contradicted.length} synthèses démenties par les mesures publiées depuis`}
+          </p>
+          <p className="mt-1">
+            Écrites quand la candidature n&apos;avait aucune mesure, elles affirment un programme
+            vide. La fiche publique n&apos;affiche donc aucun résumé tant qu&apos;elles ne sont pas
+            régénérées : {contradicted.map((row) => row.candidateName).join(", ")}.
+          </p>
+        </div>
+      )}
+
       {error && (
         <p
           role="alert"
@@ -125,12 +173,14 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
               <th className="text-left px-3 py-2">Mesures prêtes</th>
               <th className="text-left px-3 py-2">Fiche publique</th>
               <th className="text-left px-3 py-2">Programme</th>
+              <th className="text-left px-3 py-2">Synthèse</th>
               <th className="text-left px-3 py-2">Slogan</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((row) => {
               const publicationKey = `publication:${row.candidacyId}`;
+              const synthesisKey = `synthese:${row.candidacyId}`;
               const published = row.publicationStatus === "PUBLISHED";
               const locked = busy !== null || pending;
               return (
@@ -273,6 +323,38 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                       </ul>
                     )}
                   </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-col gap-1.5">
+                      <Badge variant="outline" className={SYNTHESIS_STYLES[row.synthesisState]}>
+                        {SYNTHESIS_LABELS[row.synthesisState]}
+                      </Badge>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          runAction(synthesisKey, () =>
+                            regenerateCandidateSynthesisAction({ candidacyId: row.candidacyId })
+                          )
+                        }
+                        disabled={locked || row.status !== "DECLARE" || !row.presidentialId}
+                        title={
+                          row.status !== "DECLARE"
+                            ? "Seule une candidature déclarée porte une synthèse"
+                            : !row.presidentialId
+                              ? "Publier la fiche crée les métadonnées où la synthèse est écrite"
+                              : undefined
+                        }
+                        aria-label={`Régénérer la synthèse de ${row.candidateName}`}
+                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
+                      >
+                        {busy === synthesisKey ? "Génération..." : "Régénérer"}
+                      </button>
+                      {row.synthesisGeneratedAt !== null && (
+                        <span className="text-xs text-muted-foreground">
+                          {formatDate(row.synthesisGeneratedAt)}
+                        </span>
+                      )}
+                    </div>
+                  </td>
                   <td className="px-3 py-2 max-w-md">
                     <input
                       type="text"
@@ -295,7 +377,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
             })}
             {rows.length === 0 && (
               <tr>
-                <td colSpan={8} className="px-3 py-6 text-center text-muted-foreground">
+                <td colSpan={9} className="px-3 py-6 text-center text-muted-foreground">
                   Aucune candidature enregistrée.
                 </td>
               </tr>

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -11,11 +11,15 @@ const setCandidacyPublicationMock = vi.fn<(input: unknown) => Promise<ActionResu
 const setProgramEditionPublicationMock = vi.fn<(input: unknown) => Promise<ActionResult>>(
   async () => ({ ok: true })
 );
+const regenerateCandidateSynthesisMock = vi.fn<(input: unknown) => Promise<ActionResult>>(
+  async () => ({ ok: true })
+);
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 vi.mock("../actions", () => ({
   setCandidacyPublicationAction: (input: unknown) => setCandidacyPublicationMock(input),
   setProgramEditionPublicationAction: (input: unknown) => setProgramEditionPublicationMock(input),
+  regenerateCandidateSynthesisAction: (input: unknown) => regenerateCandidateSynthesisMock(input),
 }));
 
 function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
@@ -30,7 +34,14 @@ function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
     publicationStatus: "DRAFT",
     slogan: null,
     rank: null,
-    readiness: { measureCount: 26, themesCoveredCount: 11, primarySourceMeasureCount: 26 },
+    readiness: {
+      measureCount: 26,
+      themesCoveredCount: 11,
+      primarySourceMeasureCount: 26,
+      firstPublishedAt: new Date("2026-08-01T00:00:00.000Z"),
+    },
+    synthesisState: "CURRENT",
+    synthesisGeneratedAt: new Date("2026-08-07T00:00:00.000Z"),
     editions: [
       { id: "ed-1", label: "Premiers engagements", version: 1, publicationStatus: "DRAFT" },
     ],
@@ -118,7 +129,14 @@ describe("CandidatesListClient", () => {
           row({
             presidentialId: null,
             publicationStatus: null,
-            readiness: { measureCount: 0, themesCoveredCount: 0, primarySourceMeasureCount: 0 },
+            readiness: {
+              measureCount: 0,
+              themesCoveredCount: 0,
+              primarySourceMeasureCount: 0,
+              firstPublishedAt: null,
+            },
+            synthesisState: "MISSING",
+            synthesisGeneratedAt: null,
             editions: [],
           }),
         ]}
@@ -128,5 +146,60 @@ describe("CandidatesListClient", () => {
     expect(screen.getByText("Aucune")).toBeInTheDocument();
     expect(screen.getByText("Métadonnées absentes")).toBeInTheDocument();
     expect(screen.getByText("Aucune édition")).toBeInTheDocument();
+    expect(screen.getByText("Absente")).toBeInTheDocument();
+  });
+
+  it("régénère la synthèse d'une candidature depuis la liste", async () => {
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
+    );
+
+    expect(regenerateCandidateSynthesisMock).toHaveBeenCalledWith({ candidacyId: "cand-1" });
+  });
+
+  // Le bug d'origine : la synthèse d'Arthaud, écrite sur une candidature vide, niait les cinq
+  // mesures publiées deux semaines plus tard. Rien sur cet écran ne le disait.
+  it("nomme les candidatures dont la synthèse est démentie", () => {
+    render(
+      <CandidatesListClient
+        rows={[row({ publicationStatus: "PUBLISHED", synthesisState: "CONTRADICTED" })]}
+      />
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "1 synthèse démentie par les mesures publiées depuis"
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Alix Démonstration");
+    expect(screen.getByText("Démentie")).toBeInTheDocument();
+  });
+
+  it("refuse la régénération sur une candidature qui n'est pas déclarée", () => {
+    // La règle du service : une candidature pressentie n'a demandé à personne de lire un résumé de
+    // son programme. Le bouton la porte aussi, plutôt que de laisser l'action répondre par un refus.
+    render(<CandidatesListClient rows={[row({ status: "PRESSENTI" })]} />);
+
+    expect(
+      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
+    ).toBeDisabled();
+  });
+
+  it("affiche l'échec d'une régénération au lieu de le taire", async () => {
+    regenerateCandidateSynthesisMock.mockResolvedValueOnce({
+      ok: false,
+      message: "Texte refusé par le contrôle : tiret_long.",
+    });
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Texte refusé par le contrôle : tiret_long."
+    );
   });
 });

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -30,6 +30,11 @@ vi.mock("@/lib/presidentielle/candidacy-cache", () => ({
 }));
 vi.mock("@/lib/db", () => ({ db: dbMock }));
 
+const generateSynthesisMock = vi.fn<(id: string, options: unknown) => Promise<unknown>>();
+vi.mock("@/services/candidate-synthesis", () => ({
+  generateCandidateSynthesis: (id: string, options: unknown) => generateSynthesisMock(id, options),
+}));
+
 const SOURCED_CANDIDACY = {
   id: "cand-1",
   electionId: "elec-1",
@@ -55,6 +60,14 @@ beforeEach(() => {
   });
   dbMock.programEdition.update.mockResolvedValue({ id: "ed-1" });
   dbMock.auditLog.create.mockResolvedValue({ id: "audit-1" });
+  generateSynthesisMock.mockResolvedValue({
+    ok: true,
+    text: "Une synthèse.",
+    provider: "anthropic",
+    measureCount: 5,
+    mandateCount: 0,
+    persisted: true,
+  });
 });
 
 describe("actions de publication des candidatures", () => {
@@ -199,5 +212,68 @@ describe("actions de publication des candidatures", () => {
 
     expect(result).toEqual({ ok: false, message: "Requête invalide." });
     expect(dbMock.programEdition.update).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Same doctrine as the two switches above: the action is a network endpoint, so an unauthenticated
+ * call must reach neither the provider nor the database.
+ */
+describe("régénération de la synthèse d'une candidature", () => {
+  it("n'appelle pas le générateur sans session", async () => {
+    isAuthenticatedMock.mockResolvedValue(false);
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    await expect(regenerateCandidateSynthesisAction({ candidacyId: "cand-1" })).rejects.toThrow();
+    expect(generateSynthesisMock).not.toHaveBeenCalled();
+  });
+
+  it("écrit la synthèse et purge le tag des surfaces présidentielles", async () => {
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
+
+    expect(result).toEqual({ ok: true });
+    expect(generateSynthesisMock).toHaveBeenCalledWith("cand-1", { persist: true });
+    // Sans cette purge, la fiche sert l'ancien texte jusqu'au filet ISR de 24 h.
+    expect(invalidateCandidacyTagsMock).toHaveBeenCalledWith("elec-1");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/candidats");
+  });
+
+  it("rend le refus du service au lieu de le traduire en échec générique", async () => {
+    generateSynthesisMock.mockResolvedValue({
+      ok: false,
+      reason: "non_declaree",
+      message: "Seule une candidature déclarée porte une synthèse.",
+    });
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Seule une candidature déclarée porte une synthèse.",
+    });
+    // Rien n'a changé : purger ferait recalculer les surfaces pour rien.
+    expect(invalidateCandidacyTagsMock).not.toHaveBeenCalled();
+  });
+
+  it("refuse une candidature introuvable sans appeler le générateur", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue(null);
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
+
+    expect(result).toEqual({ ok: false, message: "Candidature introuvable." });
+    expect(generateSynthesisMock).not.toHaveBeenCalled();
+  });
+
+  it("rejette une entrée qui ne porte pas d'identifiant", async () => {
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    const result = await regenerateCandidateSynthesisAction({ candidacyId: "" });
+
+    expect(result).toEqual({ ok: false, message: "Requête invalide." });
+    expect(generateSynthesisMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -7,6 +7,7 @@ import { isAuthenticated } from "@/lib/auth";
 import { invalidateEntity } from "@/lib/cache";
 import { db } from "@/lib/db";
 import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
+import { generateCandidateSynthesis } from "@/services/candidate-synthesis";
 
 /**
  * The publication switches of a presidential candidacy.
@@ -34,6 +35,8 @@ const candidacyPublicationSchema = z
 const programEditionPublicationSchema = z
   .object({ programEditionId: z.string().min(1), status: publicationStatusSchema })
   .strict();
+
+const synthesisSchema = z.object({ candidacyId: z.string().min(1) }).strict();
 
 async function assertAuthenticated(): Promise<void> {
   if (!(await isAuthenticated())) throw new Error("Non autorisé");
@@ -169,6 +172,50 @@ export async function setProgramEditionPublicationAction(input: {
   });
 
   invalidatePresidentialCandidacyTags(edition.electionId);
+  revalidate();
+
+  return { ok: true };
+}
+
+/**
+ * Regenerates the synthesis of one candidacy, inline, on the moderator's click.
+ *
+ * Inline and not queued, following `regenerateScrutinPolicyTitle`: one candidacy is one or two
+ * provider calls, the moderator is watching the row, and a queue would put a job board between them
+ * and a text they want to read now. The batch is the script, which is why there is no "regenerate
+ * all" here — twenty candidacies inline is the request that times out.
+ *
+ * The generation itself, including the rule that only a DECLARED candidacy carries a synthesis,
+ * belongs to `@/services/candidate-synthesis`. This action adds what an admin surface owes: the
+ * session check, the input validation, the cache purge, and a refusal the moderator can read.
+ */
+export async function regenerateCandidateSynthesisAction(input: {
+  candidacyId: string;
+}): Promise<CandidacyActionResult> {
+  await assertAuthenticated();
+
+  const parsed = synthesisSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, message: "Requête invalide." };
+  }
+  const { candidacyId } = parsed.data;
+
+  const candidacy = await db.candidacy.findUnique({
+    where: { id: candidacyId },
+    select: { electionId: true },
+  });
+  if (!candidacy) {
+    return { ok: false, message: "Candidature introuvable." };
+  }
+
+  const result = await generateCandidateSynthesis(candidacyId, { persist: true });
+  if (!result.ok) {
+    return { ok: false, message: result.message };
+  }
+
+  // The fiche reads the synthesis through `getPoliticianPresidentialCandidacy`, which carries this
+  // tag: without the purge the new text waits out the 24h ISR backstop behind the old one.
+  invalidatePresidentialCandidacyTags(candidacy.electionId);
   revalidate();
 
   return { ok: true };

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -1,12 +1,20 @@
 import { getCandidates2027ForModeration } from "@/lib/data/candidates";
 import { EMPTY_MEASURE_READINESS, getMeasureReadinessByCandidacies } from "@/lib/data/measures";
 import { db } from "@/lib/db";
+import { isSynthesisContradictedByMeasures } from "@/lib/presidentielle/candidate-synthesis";
 import { CandidatesListClient, type CandidateRowView } from "./CandidatesListClient";
 
 export const metadata = {
   title: "Candidats présidentielle 2027 (admin) | Poligraph",
   robots: { index: false },
 };
+
+/**
+ * The regenerate button calls a provider inline, and the default serverless budget on this project
+ * is shorter than an Anthropic call plus its one retry. Declared on the segment because a server
+ * action runs on the route that renders the form, not on a route of its own.
+ */
+export const maxDuration = 120;
 
 export default async function AdminCandidatsPage() {
   const candidates = await getCandidates2027ForModeration();
@@ -23,27 +31,42 @@ export default async function AdminCandidatsPage() {
     }),
   ]);
 
-  const rows: CandidateRowView[] = candidates.map((candidacy) => ({
-    candidacyId: candidacy.id,
-    candidateName: candidacy.candidateName,
-    politicianSlug: candidacy.politician?.slug ?? null,
-    partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
-    status: candidacy.status,
-    sourced: Boolean(candidacy.status && candidacy.sourceUrl && candidacy.sourceLabel),
-    presidentialId: candidacy.presidentialData?.id ?? null,
-    publicationStatus: candidacy.presidentialData?.publicationStatus ?? null,
-    slogan: candidacy.presidentialData?.slogan ?? null,
-    rank: candidacy.presidentialData?.rank ?? null,
-    readiness: readiness.get(candidacy.id) ?? EMPTY_MEASURE_READINESS,
-    editions: editions
-      .filter((edition) => edition.candidacyId === candidacy.id)
-      .map((edition) => ({
-        id: edition.id,
-        label: edition.label,
-        version: edition.version,
-        publicationStatus: edition.publicationStatus,
-      })),
-  }));
+  const rows: CandidateRowView[] = candidates.map((candidacy) => {
+    const measures = readiness.get(candidacy.id) ?? EMPTY_MEASURE_READINESS;
+    return {
+      candidacyId: candidacy.id,
+      candidateName: candidacy.candidateName,
+      politicianSlug: candidacy.politician?.slug ?? null,
+      partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
+      status: candidacy.status,
+      sourced: Boolean(candidacy.status && candidacy.sourceUrl && candidacy.sourceLabel),
+      presidentialId: candidacy.presidentialData?.id ?? null,
+      publicationStatus: candidacy.presidentialData?.publicationStatus ?? null,
+      slogan: candidacy.presidentialData?.slogan ?? null,
+      rank: candidacy.presidentialData?.rank ?? null,
+      readiness: measures,
+      // The same predicate the public fiche applies, on the admin population (see
+      // `CandidacyMeasureReadiness.firstPublishedAt`): the moderator sees the state the fiche is in,
+      // or the state publishing the extension would put it in, rather than a date to interpret.
+      synthesisState: !candidacy.presidentialData?.synthesis
+        ? "MISSING"
+        : isSynthesisContradictedByMeasures({
+              generatedAt: candidacy.presidentialData.synthesisGeneratedAt,
+              firstMeasurePublishedAt: measures.firstPublishedAt,
+            })
+          ? "CONTRADICTED"
+          : "CURRENT",
+      synthesisGeneratedAt: candidacy.presidentialData?.synthesisGeneratedAt ?? null,
+      editions: editions
+        .filter((edition) => edition.candidacyId === candidacy.id)
+        .map((edition) => ({
+          id: edition.id,
+          label: edition.label,
+          version: edition.version,
+          publicationStatus: edition.publicationStatus,
+        })),
+    };
+  });
 
   return (
     <div className="space-y-6">

--- a/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
@@ -167,11 +167,26 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
     expect(stats.lastReviewedAt).toBeInstanceOf(Date);
   });
 
+  // Sert à dater le programme lui-même, pas la dernière retouche : c'est ce qui permet de savoir
+  // si une synthèse écrite tel jour l'a été sur une candidature encore vide.
+  it("rend la date de publication de la plus ancienne mesure visible", async () => {
+    const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+    expect(stats.firstPublishedAt).toBeInstanceOf(Date);
+
+    const publications = await db.measureRevision.findMany({
+      where: { publishedOf: { candidacyId: publishedCandidacyId } },
+      select: { publishedAt: true },
+    });
+    const earliest = Math.min(...publications.map((r) => r.publishedAt!.getTime()));
+    expect(stats.firstPublishedAt!.getTime()).toBe(earliest);
+  });
+
   it("ne compte rien pour une candidature à extension DRAFT", async () => {
     const stats = await getPublicMeasureStatsByCandidacy(draftExtensionCandidacyId);
     expect(stats.measureCount).toBe(0);
     expect(stats.primarySourceMeasureCount).toBe(0);
     expect(stats.lastReviewedAt).toBeNull();
+    expect(stats.firstPublishedAt).toBeNull();
   });
 
   it("ignore une source primaire portée par un brouillon non publié", async () => {

--- a/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
@@ -201,11 +201,14 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
   it("compte pour l'admin les mesures qu'une extension DRAFT retient", async () => {
     const readiness = await getMeasureReadinessByCandidacies([draftExtensionCandidacyId]);
 
-    expect(readiness.get(draftExtensionCandidacyId)).toEqual({
+    expect(readiness.get(draftExtensionCandidacyId)).toMatchObject({
       measureCount: 1,
       themesCoveredCount: 1,
       primarySourceMeasureCount: 1,
     });
+    // Datée alors même que la lecture publique compte zéro : c'est ce qui permet à l'écran d'admin
+    // de dire si la synthèse survivra à la publication de l'extension.
+    expect(readiness.get(draftExtensionCandidacyId)?.firstPublishedAt).toBeInstanceOf(Date);
   });
 
   it("agrège plusieurs candidatures en une lecture", async () => {
@@ -215,13 +218,13 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
       secondarySourceCandidacyId,
     ]);
 
-    expect(readiness.get(publishedCandidacyId)).toEqual({
+    expect(readiness.get(publishedCandidacyId)).toMatchObject({
       measureCount: 2,
       themesCoveredCount: 2,
       primarySourceMeasureCount: 1,
     });
     // Même piège de révision que la lecture publique : la source primaire du brouillon ne compte pas.
-    expect(readiness.get(secondarySourceCandidacyId)).toEqual({
+    expect(readiness.get(secondarySourceCandidacyId)).toMatchObject({
       measureCount: 1,
       themesCoveredCount: 1,
       primarySourceMeasureCount: 0,

--- a/src/lib/data/__tests__/politician-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/politician-candidacy.integration.test.ts
@@ -91,6 +91,64 @@ describeIfDisposableDb("loadPoliticianPresidentialCandidacy", () => {
       sourceUrl: "https://example.org/partyonly",
       sourceLabel: "Déclaration",
     });
+    await seed("stale", {
+      status: "DECLARE",
+      sourceUrl: "https://example.org/stale",
+      sourceLabel: "Déclaration",
+    });
+    await seed("fresh", {
+      status: "DECLARE",
+      sourceUrl: "https://example.org/fresh",
+      sourceLabel: "Déclaration",
+    });
+
+    // Two candidacies with the same programme, published at the same instant, whose syntheses were
+    // written on either side of that instant. Everything else is equal, so the only thing the two
+    // assertions below can be reading is the staleness rule.
+    const { createMeasure, reviewMeasureRevision, publishMeasureRevision } =
+      await import("@/lib/measures/transitions");
+    async function publishMeasureFor(name: string, synthesisGeneratedAt: Date) {
+      await db.candidacyPresidential.create({
+        data: {
+          candidacyId: ids[`${name}Candidacy`]!,
+          publicationStatus: "PUBLISHED",
+          synthesis: "Aucune mesure n'est publiée dans le cadre de son programme.",
+          synthesisGeneratedAt,
+        },
+      });
+      const { measureId, revisionId } = await createMeasure({
+        politicianId: ids[name]!,
+        electionId: election.id,
+        candidacyId: ids[`${name}Candidacy`]!,
+        programEditionId: null,
+        attribution: "PERSONAL",
+        theme: "SANTE",
+        precedingMeasureId: null,
+        revision: {
+          text: `Mesure de test ${name}`,
+          precision: null,
+          validFrom: new Date("2026-01-01T00:00:00.000Z"),
+          extractionMethod: "MANUAL",
+          extractionConfidence: null,
+          extractorVersion: null,
+        },
+        sources: [
+          {
+            sourceKind: "PROGRAMME_PARTI",
+            tier: "PRIMARY",
+            url: `https://example.org/${name}-mesure`,
+            page: null,
+            publishedAt: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        ],
+      });
+      await reviewMeasureRevision({ measureId, revisionId, reviewedBy: "test" });
+      await publishMeasureRevision({ measureId, revisionId });
+    }
+    // `publishMeasureRevision` stamps `publishedAt` with the clock, so the two dates straddle it by
+    // a year rather than by milliseconds.
+    await publishMeasureFor("stale", new Date("2020-01-01T00:00:00.000Z"));
+    await publishMeasureFor("fresh", new Date("2099-01-01T00:00:00.000Z"));
 
     const party = await db.party.create({
       data: {
@@ -129,6 +187,7 @@ describeIfDisposableDb("loadPoliticianPresidentialCandidacy", () => {
   });
 
   afterAll(async () => {
+    await db.measure.deleteMany({ where: { electionId } });
     await db.candidacy.deleteMany({ where: { electionId } });
     await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
     await db.election.deleteMany({ where: { id: electionId } });
@@ -165,6 +224,23 @@ describeIfDisposableDb("loadPoliticianPresidentialCandidacy", () => {
     const found = await loadPoliticianPresidentialCandidacy(ids.declared!);
     expect(found?.publishedMeasureCount).toBe(0);
     expect(found?.primarySourceMeasureCount).toBe(0);
+  });
+
+  // Le bug signalé sur la fiche de Nathalie Arthaud : la synthèse, écrite le 7 août sur une
+  // candidature encore vide, se terminait sur « aucune mesure n'est publiée dans le cadre de son
+  // programme » et restait affichée au-dessus des cinq mesures publiées le 20.
+  it("retire une synthèse écrite avant la première mesure publiée", async () => {
+    const found = await loadPoliticianPresidentialCandidacy(ids.stale!);
+    expect(found?.publishedMeasureCount).toBe(1);
+    expect(found?.synthesis).toBeNull();
+    expect(found?.synthesisGeneratedAt).toBeNull();
+  });
+
+  it("garde une synthèse écrite après la première mesure publiée", async () => {
+    const found = await loadPoliticianPresidentialCandidacy(ids.fresh!);
+    expect(found?.publishedMeasureCount).toBe(1);
+    expect(found?.synthesis).not.toBeNull();
+    expect(found?.synthesisGeneratedAt).not.toBeNull();
   });
 
   it("n'attribue pas à la personne une édition appartenant seulement à son parti", async () => {

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -352,12 +352,24 @@ export type CandidacyMeasureReadiness = {
   measureCount: number;
   themesCoveredCount: number;
   primarySourceMeasureCount: number;
+  /**
+   * When the OLDEST of those measures was published. Null when there are none.
+   *
+   * The admin counterpart of `PublicMeasureStats.firstPublishedAt`, and it answers the same
+   * question `isSynthesisContradictedByMeasures` asks: would the fiche still display the stored
+   * synthesis. Read WITHOUT the candidacy gate like the rest of this shape, which is the useful
+   * reading for the screen it feeds: a moderator about to publish an extension needs to know
+   * whether the synthesis will survive that publication, and gating the date on the extension
+   * would answer "no measure, so nothing contradicts it" right up until the moment it does.
+   */
+  firstPublishedAt: Date | null;
 };
 
 export const EMPTY_MEASURE_READINESS: CandidacyMeasureReadiness = {
   measureCount: 0,
   themesCoveredCount: 0,
   primarySourceMeasureCount: 0,
+  firstPublishedAt: null,
 };
 
 /**
@@ -389,7 +401,7 @@ export async function getMeasureReadinessByCandidacies(
     ...PUBLIC_MEASURE_WHERE,
   };
 
-  const [byTheme, byPrimarySource] = await Promise.all([
+  const [byTheme, byPrimarySource, publications] = await Promise.all([
     db.measure.groupBy({ by: ["candidacyId", "theme"], where: scope, _count: { _all: true } }),
     db.measure.groupBy({
       by: ["candidacyId"],
@@ -401,6 +413,13 @@ export async function getMeasureReadinessByCandidacies(
         },
       },
       _count: { _all: true },
+    }),
+    // Rows rather than an aggregate: the date lives on the published REVISION, and Prisma's
+    // `groupBy` aggregates columns of the model it groups, not of a relation. Two scalars per
+    // measure, for a field that holds a few hundred, on an admin screen.
+    db.measure.findMany({
+      where: scope,
+      select: { candidacyId: true, publishedRevision: { select: { publishedAt: true } } },
     }),
   ]);
 
@@ -415,6 +434,15 @@ export async function getMeasureReadinessByCandidacies(
     if (row.candidacyId === null) continue;
     const current = readiness.get(row.candidacyId) ?? { ...EMPTY_MEASURE_READINESS };
     current.primarySourceMeasureCount = row._count._all;
+    readiness.set(row.candidacyId, current);
+  }
+  for (const row of publications) {
+    const publishedAt = row.publishedRevision?.publishedAt;
+    if (row.candidacyId === null || !publishedAt) continue;
+    const current = readiness.get(row.candidacyId) ?? { ...EMPTY_MEASURE_READINESS };
+    if (current.firstPublishedAt === null || publishedAt < current.firstPublishedAt) {
+      current.firstPublishedAt = publishedAt;
+    }
     readiness.set(row.candidacyId, current);
   }
 

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -272,6 +272,15 @@ export type PublicMeasureStats = {
   themesCoveredCount: number;
   primarySourceMeasureCount: number;
   lastReviewedAt: Date | null;
+  /**
+   * When the OLDEST measure the candidacy currently shows was published. Null when it shows none.
+   *
+   * The one date that answers "did this candidacy have a programme on day X", which is what
+   * `isSynthesisContradictedByMeasures` needs and what `lastReviewedAt` cannot say: a candidacy
+   * documented for months and reviewed again yesterday has the same `lastReviewedAt` as one whose
+   * whole programme landed yesterday.
+   */
+  firstPublishedAt: Date | null;
 };
 
 export async function getPublicMeasureStatsByCandidacy(
@@ -286,7 +295,7 @@ export async function getPublicMeasureStatsByCandidacy(
     ...PUBLIC_MEASURE_WHERE,
   };
 
-  const [byTheme, primarySourceMeasureCount, lastReviewed] = await Promise.all([
+  const [byTheme, primarySourceMeasureCount, lastReviewed, firstPublished] = await Promise.all([
     db.measure.groupBy({ by: ["theme"], where: scope, _count: { _all: true } }),
     db.measure.count({
       where: {
@@ -302,6 +311,14 @@ export async function getPublicMeasureStatsByCandidacy(
       orderBy: { publishedRevision: { reviewedAt: "desc" } },
       select: { publishedRevision: { select: { reviewedAt: true } } },
     }),
+    // Same scope, opposite end. Ordering on the revision's `publishedAt` and not on the measure's
+    // `createdAt`: a measure can be extracted in March and published in August, and the question
+    // this answers is when the fiche started SHOWING something, not when we started working on it.
+    db.measure.findFirst({
+      where: scope,
+      orderBy: { publishedRevision: { publishedAt: "asc" } },
+      select: { publishedRevision: { select: { publishedAt: true } } },
+    }),
   ]);
 
   return {
@@ -309,6 +326,7 @@ export async function getPublicMeasureStatsByCandidacy(
     themesCoveredCount: byTheme.length,
     primarySourceMeasureCount,
     lastReviewedAt: lastReviewed?.publishedRevision?.reviewedAt ?? null,
+    firstPublishedAt: firstPublished?.publishedRevision?.publishedAt ?? null,
   };
 }
 

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus, ThemeCategory, VotePosition } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { isSynthesisContradictedByMeasures } from "@/lib/presidentielle/candidate-synthesis";
 import { pickMeasureSourceUrl } from "@/lib/presidentielle/measure-source";
 import { PRESIDENTIELLE_2027_SLUG, themeToSlug } from "@/lib/presidentielle/themes";
 import {
@@ -43,7 +44,11 @@ export type PoliticianCandidacy = {
   programmeIdentified: boolean;
   declaredAt: Date | null;
   withdrewAt: Date | null;
-  /** Generated summary of this candidacy, null until a generation pass has produced one. */
+  /**
+   * Generated summary of this candidacy, null until a generation pass has produced one — and null
+   * again once the measures published since have contradicted it. See
+   * `isSynthesisContradictedByMeasures`: the fiche shows no summary rather than a stale one.
+   */
   synthesis: string | null;
   synthesisGeneratedAt: Date | null;
   publishedMeasureCount: number;
@@ -115,6 +120,13 @@ export async function loadPoliticianPresidentialCandidacy(
     }),
   ]);
 
+  // Dropped together. The block's own caption dates the text ("Texte généré ... le 7 août"), so a
+  // date left behind without the text it dates has nothing to describe.
+  const synthesisContradicted = isSynthesisContradictedByMeasures({
+    generatedAt: row.presidentialData?.synthesisGeneratedAt ?? null,
+    firstMeasurePublishedAt: stats.firstPublishedAt,
+  });
+
   return {
     candidacyId: row.id,
     electionSlug: row.election.slug,
@@ -129,8 +141,10 @@ export async function loadPoliticianPresidentialCandidacy(
     programmeIdentified: programme !== null,
     declaredAt: row.presidentialData?.declaredAt ?? null,
     withdrewAt: row.presidentialData?.withdrewAt ?? null,
-    synthesis: row.presidentialData?.synthesis ?? null,
-    synthesisGeneratedAt: row.presidentialData?.synthesisGeneratedAt ?? null,
+    synthesis: synthesisContradicted ? null : (row.presidentialData?.synthesis ?? null),
+    synthesisGeneratedAt: synthesisContradicted
+      ? null
+      : (row.presidentialData?.synthesisGeneratedAt ?? null),
     publishedMeasureCount: stats.measureCount,
     themesCoveredCount: stats.themesCoveredCount,
     primarySourceMeasureCount: stats.primarySourceMeasureCount,

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildCandidateSynthesisPrompt,
+  isSynthesisContradictedByMeasures,
   screenSynthesis,
   SYNTHESIS_MAX_WORDS,
   SYNTHESIS_MIN_WORDS,
@@ -187,5 +188,61 @@ describe("screenSynthesis", () => {
       // Defaulting to the low floor would silently accept thin texts everywhere.
       expect(screenSynthesis(short)).toMatchObject({ ok: false, reason: "trop_court" });
     });
+  });
+});
+
+describe("isSynthesisContradictedByMeasures", () => {
+  const generatedAt = new Date("2026-08-07T22:08:33.000Z");
+
+  it("drops a synthesis written before the candidacy had any published measure", () => {
+    // The reported bug: the synthesis of Nathalie Arthaud, generated on 7 August with an empty
+    // programme, ended on "aucune mesure n'est publiée dans le cadre de son programme" and stayed
+    // on the fiche after five measures were published on 20 August, directly above them.
+    expect(
+      isSynthesisContradictedByMeasures({
+        generatedAt,
+        firstMeasurePublishedAt: new Date("2026-08-20T21:23:10.000Z"),
+      })
+    ).toBe(true);
+  });
+
+  it("keeps a synthesis whose candidacy was already documented when it was written", () => {
+    // Measures published SINCE are drift, not a contradiction: the text describes a programme that
+    // still exists, it just describes less of it, and the block carries its own date for that.
+    expect(
+      isSynthesisContradictedByMeasures({
+        generatedAt,
+        firstMeasurePublishedAt: new Date("2026-08-07T10:26:46.000Z"),
+      })
+    ).toBe(false);
+  });
+
+  it("keeps a synthesis on a candidacy that still shows no measure", () => {
+    // Here "aucune mesure publiée" is what the page shows. Dropping the text would delete the
+    // accurate half about the person's record.
+    expect(isSynthesisContradictedByMeasures({ generatedAt, firstMeasurePublishedAt: null })).toBe(
+      false
+    );
+  });
+
+  it("drops an undated synthesis as soon as a measure is published", () => {
+    // Nothing dates the claim, so nothing can clear it against the measures below it.
+    expect(
+      isSynthesisContradictedByMeasures({
+        generatedAt: null,
+        firstMeasurePublishedAt: new Date("2026-08-20T21:23:10.000Z"),
+      })
+    ).toBe(true);
+    expect(
+      isSynthesisContradictedByMeasures({ generatedAt: null, firstMeasurePublishedAt: null })
+    ).toBe(false);
+  });
+
+  it("treats a measure published in the same instant as covered by the text", () => {
+    // Equality is not "after": the generation pass reads the measures and then writes its date, so
+    // an identical timestamp means the measure was in the prompt.
+    expect(
+      isSynthesisContradictedByMeasures({ generatedAt, firstMeasurePublishedAt: generatedAt })
+    ).toBe(false);
   });
 });

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -210,3 +210,44 @@ export function screenSynthesis(
 
   return { ok: true, text };
 }
+
+/**
+ * Whether a stored synthesis has been contradicted by the measures published since.
+ *
+ * The synthesis is a snapshot: it is written from the measures the candidacy held on the day it
+ * was generated, and nothing rewrites it when new ones are published. Most of that drift is
+ * harmless — a text written from thirty measures and read beside forty is incomplete, not false,
+ * and the block already dates itself so the reader can see how old it is.
+ *
+ * ONE case is not drift, it is an error: a synthesis written when the candidacy had NO published
+ * measure. The system prompt tells the model to state an empty programme in one sentence rather
+ * than pad, so those texts end on "aucune mesure n'est publiée dans le cadre de son programme" —
+ * and the fiche went on printing that sentence directly above the five measures it had published
+ * a fortnight later (observed on `nathalie-arthaud`, and on six other candidacies the same day).
+ *
+ * That state is detectable without storing anything extra, and exactly: if the EARLIEST currently
+ * public measure of the candidacy was published after the synthesis was generated, then the
+ * candidacy had none at all when the prompt was built, so its programme paragraph was written
+ * about an empty programme. Checked against production, the predicate agreed with the seventeen
+ * stored texts row for row — every one it flags claims an empty programme, and every one it keeps
+ * describes measures.
+ *
+ * A contradicted synthesis is not repaired here and not shown with a caveat: it is dropped, and
+ * the fiche renders without the block until a regeneration pass replaces it
+ * (`scripts/generate-candidate-syntheses.ts`). Hedged wording around a false sentence still
+ * publishes the false sentence.
+ */
+export function isSynthesisContradictedByMeasures(params: {
+  generatedAt: Date | null;
+  /** Publication date of the oldest measure the candidacy currently shows. Null when it shows none. */
+  firstMeasurePublishedAt: Date | null;
+}): boolean {
+  // No measure on the fiche: an empty programme paragraph is what the page shows, so nothing
+  // contradicts it.
+  if (params.firstMeasurePublishedAt === null) return false;
+  // A text we cannot date cannot be cleared. Every synthesis is written with its date by the
+  // generation script, so a null here means a hand write or a partial one, and the measures below
+  // are the surer thing.
+  if (params.generatedAt === null) return true;
+  return params.firstMeasurePublishedAt > params.generatedAt;
+}

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The generation shared by the script and the admin button.
+ *
+ * What is worth pinning here is not the prompt (tested pure in
+ * `@/lib/presidentielle/candidate-synthesis`) but the decisions this module owns: which candidacies
+ * may carry a synthesis at all, what a dry run must NOT write, when the second provider is tried,
+ * and that a screened-out text is never stored.
+ */
+
+const callAnthropicMock = vi.fn();
+const callMistralMock = vi.fn();
+
+const dbMock = {
+  candidacy: { findUnique: vi.fn() },
+  mandate: { findMany: vi.fn() },
+  vote: { count: vi.fn() },
+  measure: { findMany: vi.fn() },
+  candidacyPresidential: { update: vi.fn() },
+  auditLog: { create: vi.fn() },
+};
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/lib/api/anthropic", () => ({
+  callAnthropic: (...args: unknown[]) => callAnthropicMock(...args),
+}));
+vi.mock("@/lib/api/mistral", () => ({
+  callMistral: (...args: unknown[]) => callMistralMock(...args),
+  extractMistralText: (response: { text: string }) => response.text,
+}));
+
+/** A text that clears every rule of `screenSynthesis`: no long dash, no judicial term, 90+ words. */
+const ACCEPTED = `${Array.from({ length: 120 }, (_, i) => `mot${i}`).join(" ")}.`;
+
+function anthropicText(text: string) {
+  return { content: [{ type: "text", text }] };
+}
+
+const CANDIDACY = {
+  id: "cand-1",
+  candidateName: "Alix Démonstration",
+  partyLabel: "Parti de démonstration",
+  politicianId: "pol-1",
+  status: "DECLARE",
+  electionId: "elec-1",
+  party: null,
+  presidentialData: { id: "pres-1" },
+};
+
+async function service() {
+  return import("../index");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.candidacy.findUnique.mockResolvedValue(CANDIDACY);
+  dbMock.mandate.findMany.mockResolvedValue([]);
+  dbMock.vote.count.mockResolvedValue(0);
+  dbMock.measure.findMany.mockResolvedValue([
+    { theme: "SANTE", publishedRevision: { text: "Rouvrir des maternités de proximité." } },
+  ]);
+  dbMock.candidacyPresidential.update.mockResolvedValue({ id: "pres-1" });
+  dbMock.auditLog.create.mockResolvedValue({ id: "audit-1" });
+  callAnthropicMock.mockResolvedValue(anthropicText(ACCEPTED));
+});
+
+describe("generateCandidateSynthesis", () => {
+  it("écrit le texte et sa date sur l'extension présidentielle", async () => {
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true, provider: "anthropic", measureCount: 1 });
+    const write = dbMock.candidacyPresidential.update.mock.calls[0]![0];
+    expect(write.where).toEqual({ id: "pres-1" });
+    expect(write.data.synthesis).toBe(ACCEPTED);
+    expect(write.data.synthesisGeneratedAt).toBeInstanceOf(Date);
+    expect(dbMock.auditLog.create).toHaveBeenCalled();
+  });
+
+  it("n'écrit rien en dry run", async () => {
+    // Le mode par défaut du script : imprimer ce qui SERAIT stocké.
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: false });
+
+    expect(result).toMatchObject({ ok: true, persisted: false });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+    expect(dbMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une candidature qui n'est pas déclarée", async () => {
+    // Une candidature pressentie n'a demandé à personne de lire un résumé de son programme. La
+    // règle vit ici et pas dans la requête du script, sinon le bouton la contournerait.
+    dbMock.candidacy.findUnique.mockResolvedValue({ ...CANDIDACY, status: "PRESSENTI" });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "non_declaree" });
+    expect(callAnthropicMock).not.toHaveBeenCalled();
+  });
+
+  it("refuse d'inventer l'extension présidentielle manquante", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue({ ...CANDIDACY, presidentialData: null });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "sans_extension" });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
+
+  it("bascule sur Mistral quand Anthropic échoue", async () => {
+    // Le repli couvre la panne récurrente du projet : un solde Anthropic à zéro, qui rend un 400.
+    callAnthropicMock.mockRejectedValue(new Error("credit balance is too low"));
+    callMistralMock.mockResolvedValue({ text: ACCEPTED });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true, provider: "mistral" });
+  });
+
+  it("porte les deux erreurs quand les deux fournisseurs tombent", async () => {
+    callAnthropicMock.mockRejectedValue(new Error("solde à zéro"));
+    callMistralMock.mockRejectedValue(new Error("429"));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "generation" });
+    // Ne garder que la seconde cacherait pourquoi le premier fournisseur a été sauté.
+    expect(result.ok === false && result.message).toContain("solde à zéro");
+    expect(result.ok === false && result.message).toContain("429");
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
+
+  it("réessaie une fois en nommant la règle enfreinte, puis stocke", async () => {
+    callAnthropicMock
+      .mockResolvedValueOnce(anthropicText(`Un tiret cadratin — interdit. ${ACCEPTED}`))
+      .mockResolvedValueOnce(anthropicText(ACCEPTED));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    const retryPrompt = callAnthropicMock.mock.calls[1]![0][0].content as string;
+    expect(retryPrompt).toContain("Ta réponse précédente a été refusée");
+  });
+
+  it("ne stocke rien quand le texte est refusé deux fois", async () => {
+    callAnthropicMock.mockResolvedValue(anthropicText("Trop court."));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "refuse" });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -1,0 +1,296 @@
+/**
+ * Generation of the synthesis shown on a presidential candidate's fiche.
+ *
+ * Extracted from `scripts/generate-candidate-syntheses.ts`, which was its only caller and is now a
+ * loop over this module. The move is what lets the admin regenerate ONE candidacy from a button:
+ * the rule about which candidacies may carry a synthesis, the provider fallback, the screening and
+ * the retry are editorial decisions, and duplicating them behind a button would let the two paths
+ * drift — a button that produced a text the script would have refused is worse than no button.
+ *
+ * The prompt and the screen stay in `@/lib/presidentielle/candidate-synthesis`, pure and testable
+ * without a network. This module owns everything that touches the database or a provider.
+ *
+ * No `server-only`: the script imports it under tsx.
+ */
+
+import { callAnthropic } from "@/lib/api/anthropic";
+import { callMistral, extractMistralText } from "@/lib/api/mistral";
+import { db } from "@/lib/db";
+import {
+  buildCandidateSynthesisPrompt,
+  screenSynthesis,
+  SYNTHESIS_SYSTEM_PROMPT,
+  type CandidateSynthesisInput,
+} from "@/lib/presidentielle/candidate-synthesis";
+
+/** Mandates kept in the prompt, most recent first. Enough for a career, short of a list. */
+const MANDATE_LIMIT = 8;
+
+/**
+ * Why a refusal is a RETURNED value and never a throw.
+ *
+ * Every one of these is a state the moderator can read and act on — publish the extension, source
+ * the candidacy, wait for the status to be declared — so each has to reach the screen as itself.
+ * A thrown error would arrive as "l'opération a échoué" and say none of it.
+ *
+ * `generation` and `refuse` are the two that are not the caller's fault: the providers are both
+ * down, or the model produced a text the screen rejected twice. They are still returned rather
+ * than thrown, because the moderator's next move (retry now, retry later) depends on which.
+ */
+export type SynthesisRefusal =
+  | "candidature_introuvable"
+  | "sans_politicien"
+  | "non_declaree"
+  | "sans_extension"
+  | "refuse"
+  | "generation";
+
+export type SynthesisGenerationResult =
+  | {
+      ok: true;
+      text: string;
+      provider: string;
+      /** What the prompt was built from, for the script's log and the action's message. */
+      measureCount: number;
+      mandateCount: number;
+      /** False on a dry run: the text was produced and screened, nothing was written. */
+      persisted: boolean;
+    }
+  | { ok: false; reason: SynthesisRefusal; message: string };
+
+/**
+ * Anthropic first, Mistral if it fails, same broad fallback as `classify-theme`.
+ *
+ * Falling back on any error rather than on a quota signal is deliberate and copied from there:
+ * telling a spent balance apart from a rate limit or a bad request is brittle, and the output goes
+ * through `screenSynthesis` whatever produced it. The failure this actually covers is the recurring
+ * one on this project, an Anthropic balance at zero, which returns a plain 400.
+ *
+ * Both errors are carried into the throw. A run that dies with only the second one would hide the
+ * reason the first provider was skipped.
+ */
+async function generate(system: string, user: string): Promise<{ text: string; provider: string }> {
+  let anthropicError: string;
+  try {
+    const response = await callAnthropic([{ role: "user", content: user }], {
+      system,
+      maxTokens: 900,
+    });
+    return {
+      text: response.content.find((c) => c.type === "text")?.text ?? "",
+      provider: "anthropic",
+    };
+  } catch (error) {
+    anthropicError = error instanceof Error ? error.message : String(error);
+  }
+
+  try {
+    const response = await callMistral(
+      [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      { maxTokens: 900 }
+    );
+    return { text: extractMistralText(response), provider: "mistral" };
+  } catch (error) {
+    const mistralError = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Génération impossible — anthropic : ${anthropicError} ; mistral : ${mistralError}`
+    );
+  }
+}
+
+/**
+ * Everything the prompt is built from, in one read.
+ *
+ * The measure population is the one the script has always used: PUBLISHED and reviewed, withdrawals
+ * excluded. Deliberately NOT the public population of `@/lib/data/measures`, which also requires the
+ * candidacy's extension to be published: a moderator preparing a fiche generates its synthesis
+ * BEFORE publishing the extension, and gating the prompt on the extension would hand the model an
+ * empty programme and produce the exact sentence this whole lot exists to stop.
+ */
+async function loadInput(candidacyId: string) {
+  const candidacy = await db.candidacy.findUnique({
+    where: { id: candidacyId },
+    select: {
+      id: true,
+      candidateName: true,
+      partyLabel: true,
+      politicianId: true,
+      status: true,
+      electionId: true,
+      party: { select: { name: true } },
+      presidentialData: { select: { id: true } },
+    },
+  });
+  return candidacy;
+}
+
+export type GenerateCandidateSynthesisOptions = {
+  /**
+   * Write the result on the candidacy's presidential extension. False is the script's dry run: the
+   * text is produced and screened so the operator can read what WOULD be stored.
+   */
+  persist: boolean;
+};
+
+/**
+ * Produces the synthesis of one candidacy, and stores it when asked to.
+ *
+ * Only DECLARED candidacies are considered. A candidacy that is merely rumoured has not asked
+ * anyone to read a summary of its programme, and saying so on its page would lend it a substance
+ * its own status denies. The rule lives here rather than in the script's query so the button
+ * cannot bypass it.
+ */
+export async function generateCandidateSynthesis(
+  candidacyId: string,
+  options: GenerateCandidateSynthesisOptions
+): Promise<SynthesisGenerationResult> {
+  const candidacy = await loadInput(candidacyId);
+  if (!candidacy) {
+    return { ok: false, reason: "candidature_introuvable", message: "Candidature introuvable." };
+  }
+  if (!candidacy.politicianId) {
+    return {
+      ok: false,
+      reason: "sans_politicien",
+      message: "Candidature sans politique rattaché : ni mandats ni votes à résumer.",
+    };
+  }
+  if (candidacy.status !== "DECLARE") {
+    return {
+      ok: false,
+      reason: "non_declaree",
+      message:
+        "Seule une candidature déclarée porte une synthèse. Une candidature pressentie n'a demandé " +
+        "à personne de lire un résumé de son programme.",
+    };
+  }
+
+  const politicianId = candidacy.politicianId;
+  const [mandates, voteCount, measures] = await Promise.all([
+    db.mandate.findMany({
+      where: { politicianId },
+      select: { role: true, title: true, institution: true, startDate: true, endDate: true },
+      orderBy: { startDate: "desc" },
+      take: MANDATE_LIMIT,
+    }),
+    db.vote.count({ where: { politicianId } }),
+    db.measure.findMany({
+      where: {
+        candidacyId: candidacy.id,
+        publicationStatus: "PUBLISHED",
+        withdrawnAt: null,
+        publishedRevision: { reviewedAt: { not: null } },
+      },
+      select: { theme: true, publishedRevision: { select: { text: true } } },
+    }),
+  ]);
+
+  const input: CandidateSynthesisInput = {
+    candidateName: candidacy.candidateName,
+    partyLabel: candidacy.party?.name ?? candidacy.partyLabel,
+    mandates: mandates.map((m) => ({
+      // `title` carries the constituency, `role` only exists for offices within the institution.
+      // Preferring title is what keeps "Députée de la 3e du Rhône" rather than a bare null.
+      role: m.role ?? m.title,
+      institution: m.institution,
+      startYear: m.startDate.getUTCFullYear(),
+      endYear: m.endDate?.getUTCFullYear() ?? null,
+    })),
+    voteCount,
+    measures: measures.flatMap((m) =>
+      m.publishedRevision ? [{ theme: m.theme, text: m.publishedRevision.text }] : []
+    ),
+  };
+
+  const hasMeasures = input.measures.length > 0;
+  const prompt = buildCandidateSynthesisPrompt(input);
+
+  let attempt: { text: string; provider: string };
+  try {
+    attempt = await generate(SYNTHESIS_SYSTEM_PROMPT, prompt);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "generation",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+  let screened = screenSynthesis(attempt.text, { hasMeasures });
+
+  // One retry, naming the rule that was broken. Measured on a first full run: the model obeys the
+  // rules it is reminded of and slips on the ones it is only told once, the long dash above all.
+  // Retrying blind would just roll the dice again, and retrying twice would paper over a prompt
+  // that genuinely needs fixing.
+  if (!screened.ok) {
+    try {
+      attempt = await generate(
+        SYNTHESIS_SYSTEM_PROMPT,
+        `${prompt}\n\nTa réponse précédente a été refusée : ${screened.detail}. Recommence en respectant cette règle.`
+      );
+    } catch (error) {
+      return {
+        ok: false,
+        reason: "generation",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    screened = screenSynthesis(attempt.text, { hasMeasures });
+  }
+
+  if (!screened.ok) {
+    return {
+      ok: false,
+      reason: "refuse",
+      message: `Texte refusé par le contrôle : ${screened.reason} (${screened.detail}).`,
+    };
+  }
+
+  const base = {
+    ok: true as const,
+    text: screened.text,
+    provider: attempt.provider,
+    measureCount: input.measures.length,
+    mandateCount: mandates.length,
+  };
+
+  if (!options.persist) return { ...base, persisted: false };
+
+  // The synthesis belongs to the presidential extension, which may not exist yet for a candidacy
+  // nobody has curated. Creating it here would publish nothing on its own (it defaults to DRAFT),
+  // but it would still be a row this module has no mandate to invent, so a missing extension is
+  // reported rather than filled in — the moderator creates it by publishing the fiche.
+  if (!candidacy.presidentialData) {
+    return {
+      ok: false,
+      reason: "sans_extension",
+      message:
+        "Pas d'extension présidentielle pour cette candidature. Publier la fiche la crée, " +
+        "et la synthèse pourra alors être écrite.",
+    };
+  }
+
+  const generatedAt = new Date();
+  await db.candidacyPresidential.update({
+    where: { id: candidacy.presidentialData.id },
+    data: { synthesis: screened.text, synthesisGeneratedAt: generatedAt },
+  });
+
+  await db.auditLog.create({
+    data: {
+      action: "UPDATE",
+      entityType: "CandidacyPresidential",
+      entityId: candidacy.presidentialData.id,
+      changes: {
+        synthesisGeneratedAt: generatedAt.toISOString(),
+        provider: attempt.provider,
+        measureCount: input.measures.length,
+        mandateCount: mandates.length,
+      },
+    },
+  });
+
+  return { ...base, persisted: true };
+}


### PR DESCRIPTION
La fiche candidat de Nathalie Arthaud affichait « Aucune mesure n'est
publiée dans le cadre de son programme » juste au-dessus des cinq mesures
qu'elle publie. La synthèse avait été générée le 7 août sur une candidature
encore vide, les mesures ont été publiées le 20, et rien ne réécrit ni
n'invalide le texte stocké.

Six autres candidatures étaient dans le même état en production : Kazib,
Mikolajczak, Cazeneuve, Egger, Ruffin et Guedj.

La dérive ordinaire (texte écrit sur trente mesures, lu à côté de quarante)
reste acceptable : le bloc porte sa propre date et le texte n'est
qu'incomplet. Un seul cas est une erreur, celui où la synthèse a été écrite
sur un programme vide, et il se détecte sans rien stocker de plus : si la
plus ancienne mesure actuellement visible a été publiée après la génération,
la candidature n'en avait aucune quand le prompt a été construit. Vérifié
sur les dix-sept synthèses en base, le prédicat les classe ligne pour ligne.

- `isSynthesisContradictedByMeasures`, pur et testé, dans candidate-synthesis
- `PublicMeasureStats.firstPublishedAt`, l'autre extrémité de la lecture qui
  rend déjà `lastReviewedAt`
- `loadPoliticianPresidentialCandidacy` rend `synthesis` et
  `synthesisGeneratedAt` à null quand le texte est démenti : la fiche affiche
  ses mesures sans bloc « En résumé » plutôt qu'une phrase fausse

Les textes concernés reviendront à la prochaine passe de
scripts/generate-candidate-syntheses.ts.