### PR TITLE
fix(synthèses) : séparer la longueur visée du plancher de refus

### DIFF
--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -1,13 +1,28 @@
 import { describe, it, expect } from "vitest";
 import {
   buildCandidateSynthesisPrompt,
+  buildSynthesisSystemPrompt,
   isSynthesisContradictedByMeasures,
   screenSynthesis,
+  synthesisFloor,
+  synthesisMaterial,
+  synthesisTargetRange,
   SYNTHESIS_MAX_WORDS,
-  SYNTHESIS_MIN_WORDS,
-  SYNTHESIS_MIN_WORDS_WITHOUT_MEASURES,
   type CandidateSynthesisInput,
+  type SynthesisMaterial,
 } from "../candidate-synthesis";
+
+/**
+ * The four shapes of material, named after the production candidacies they are drawn from. The
+ * comparison that matters is between them, not against a hard-coded number.
+ */
+const FULL: SynthesisMaterial = { mandateCount: 10, voteCount: 1767, measureCount: 16 };
+/** Nathalie Arthaud : no mandate, no recorded vote, five measures. */
+const MEASURES_ONLY: SynthesisMaterial = { mandateCount: 0, voteCount: 0, measureCount: 5 };
+/** Karim Bouamrane : one mandate, nothing else. */
+const THIN_CAREER: SynthesisMaterial = { mandateCount: 1, voteCount: 0, measureCount: 0 };
+const BARE: SynthesisMaterial = { mandateCount: 0, voteCount: 0, measureCount: 0 };
+const FULL_FLOOR = synthesisFloor(FULL);
 
 const BASE: CandidateSynthesisInput = {
   candidateName: "Jeanne Martin",
@@ -92,6 +107,60 @@ describe("buildCandidateSynthesisPrompt", () => {
   });
 });
 
+describe("buildSynthesisSystemPrompt", () => {
+  // La seconde moitié du correctif. Le plancher peut suivre la matière ; tant que le modèle lit
+  // « entre 90 et 200 mots » sur une candidature jugée à 60, il meuble ou s'arrête court.
+  it("annonce la longueur que la matière porte, pas une longueur fixe", () => {
+    for (const material of [FULL, MEASURES_ONLY, THIN_CAREER, BARE]) {
+      const range = synthesisTargetRange(material);
+      expect(buildSynthesisSystemPrompt(material)).toContain(
+        `Entre ${range.min} et ${range.max} mots`
+      );
+    }
+  });
+
+  it("garde 90 mots pour une candidature entièrement documentée", () => {
+    // Rien ne change pour les candidatures qui passaient déjà : leurs textes font 124 à 169 mots.
+    expect(synthesisTargetRange(FULL).min).toBe(90);
+  });
+
+  it("demande moins à une candidature dont un pan est vide", () => {
+    expect(synthesisTargetRange(MEASURES_ONLY).min).toBeLessThan(synthesisTargetRange(FULL).min);
+    expect(synthesisTargetRange(THIN_CAREER).min).toBeLessThan(synthesisTargetRange(FULL).min);
+    expect(synthesisTargetRange(BARE).min).toBeLessThan(synthesisTargetRange(THIN_CAREER).min);
+  });
+
+  it("compte un millier de votes comme un parcours à décrire, sur trois mandats", () => {
+    // François Ruffin : trois mandats et mille votes, un dossier à décrire quoi qu'en dise le
+    // compte de mandats.
+    const ruffin: SynthesisMaterial = { mandateCount: 3, voteCount: 1003, measureCount: 79 };
+    expect(synthesisTargetRange(ruffin).min).toBe(synthesisTargetRange(FULL).min);
+  });
+
+  it("garde les règles absolues quelle que soit la matière", () => {
+    const prompt = buildSynthesisSystemPrompt(BARE);
+    expect(prompt).toContain("Ne mentionne AUCUNE affaire judiciaire");
+    expect(prompt).toContain("Aucun tiret cadratin");
+  });
+});
+
+describe("synthesisMaterial", () => {
+  it("reprend les trois comptes du prompt tel qu'il a été construit", () => {
+    expect(synthesisMaterial({ ...BASE, mandates: [], voteCount: 412 })).toEqual({
+      mandateCount: 0,
+      voteCount: 412,
+      measureCount: BASE.measures.length,
+    });
+  });
+
+  it("ne voit aucun parcours sans mandat ni vote", () => {
+    // Un suppléant qui a voté sans jamais figurer dans Mandate a bien un premier paragraphe ; sans
+    // ni l'un ni l'autre, il n'y en a pas.
+    const bare = synthesisMaterial({ ...BASE, mandates: [], voteCount: 0 });
+    expect(synthesisFloor(bare)).toBe(synthesisFloor({ ...BARE, measureCount: bare.measureCount }));
+  });
+});
+
 describe("screenSynthesis", () => {
   const good = `${words(120)}`;
 
@@ -134,7 +203,7 @@ describe("screenSynthesis", () => {
   });
 
   it("rejects a text below the floor", () => {
-    expect(screenSynthesis(words(SYNTHESIS_MIN_WORDS - 1))).toMatchObject({
+    expect(screenSynthesis(words(FULL_FLOOR - 1))).toMatchObject({
       ok: false,
       reason: "trop_court",
     });
@@ -148,45 +217,70 @@ describe("screenSynthesis", () => {
   });
 
   it("accepts exactly at both bounds", () => {
-    expect(screenSynthesis(words(SYNTHESIS_MIN_WORDS)).ok).toBe(true);
+    expect(screenSynthesis(words(FULL_FLOOR)).ok).toBe(true);
     expect(screenSynthesis(words(SYNTHESIS_MAX_WORDS)).ok).toBe(true);
   });
 
-  describe("floor follows the material", () => {
-    // The contradiction this closes: the model is told to state an empty record in one
-    // sentence rather than pad, and a single high floor then rejected it for obeying.
-    // Thirteen of twenty candidacies failed that way on the first full run.
-    const short = words(40);
+  it("names the floor that applied, not a fixed one", () => {
+    const result = screenSynthesis(words(5), MEASURES_ONLY);
+    expect(result).toMatchObject({ ok: false, reason: "trop_court" });
+    expect(result.ok === false && result.detail).toBe(
+      `5 mots, minimum ${synthesisFloor(MEASURES_ONLY)}`
+    );
+  });
 
-    it("rejects a short text when there are measures to summarise", () => {
-      expect(screenSynthesis(short, { hasMeasures: true })).toMatchObject({
+  describe("le plancher refuse une non-réponse, il ne juge pas la longueur", () => {
+    // La contradiction supprimée : le plancher était la longueur voulue, donc tout texte plus court
+    // que l'idéal était jeté. Il ne retient plus que ce qui n'est pas une réponse.
+
+    it("accepte les 81 mots honnêtes d'une candidature sans parcours", () => {
+      // Le cas Arthaud, qui a échoué deux fois contre un plancher de 90 et laissé la fiche sans
+      // résumé.
+      expect(screenSynthesis(words(81), MEASURES_ONLY).ok).toBe(true);
+    });
+
+    it("accepte les textes courts que la production a déjà stockés", () => {
+      // Les plus courts en base : 27 mots (Clara Egger), 31 (Florian Philippot), 37 (Arthaud). Un
+      // plancher qui les refuse refuse du travail juste.
+      expect(screenSynthesis(words(27), { ...MEASURES_ONLY, measureCount: 2 }).ok).toBe(true);
+      expect(screenSynthesis(words(31), THIN_CAREER).ok).toBe(true);
+      expect(screenSynthesis(words(37), MEASURES_ONLY).ok).toBe(true);
+    });
+
+    it("refuse une réponse d'une ligne, quelle que soit la matière", () => {
+      for (const material of [FULL, MEASURES_ONLY, THIN_CAREER, BARE]) {
+        expect(screenSynthesis(words(5), material)).toMatchObject({
+          ok: false,
+          reason: "trop_court",
+        });
+      }
+    });
+
+    it("reste sous la longueur visée, partout", () => {
+      // La propriété qui empêche la régression de revenir : un texte pile à la cible ne peut
+      // jamais être refusé pour sa longueur.
+      for (const material of [FULL, MEASURES_ONLY, THIN_CAREER, BARE]) {
+        expect(synthesisFloor(material)).toBeLessThan(synthesisTargetRange(material).min);
+        expect(screenSynthesis(words(synthesisTargetRange(material).min), material).ok).toBe(true);
+      }
+    });
+
+    it("applique le plafond et les autres règles quelle que soit la matière", () => {
+      expect(screenSynthesis(words(SYNTHESIS_MAX_WORDS + 1), BARE)).toMatchObject({
+        ok: false,
+        reason: "trop_long",
+      });
+      expect(screenSynthesis(`Une condamnation a été prononcée. ${words(40)}`, BARE)).toMatchObject(
+        { ok: false, reason: "judiciaire" }
+      );
+    });
+
+    it("retient le plancher le plus haut quand l'appelant ne dit rien", () => {
+      // Un appelant qui oublie de décrire sa matière obtient la réponse exigeante, pas un passe-droit.
+      expect(screenSynthesis(words(FULL_FLOOR - 1))).toMatchObject({
         ok: false,
         reason: "trop_court",
       });
-    });
-
-    it("accepts the same text when there is no measure", () => {
-      expect(screenSynthesis(short, { hasMeasures: false }).ok).toBe(true);
-    });
-
-    it("still refuses a near-empty text without measures", () => {
-      expect(
-        screenSynthesis(words(SYNTHESIS_MIN_WORDS_WITHOUT_MEASURES - 1), { hasMeasures: false })
-      ).toMatchObject({ ok: false, reason: "trop_court" });
-    });
-
-    it("applies the ceiling and the other rules whatever the material", () => {
-      expect(screenSynthesis(words(SYNTHESIS_MAX_WORDS + 1), { hasMeasures: false })).toMatchObject(
-        { ok: false, reason: "trop_long" }
-      );
-      expect(
-        screenSynthesis(`Une condamnation a été prononcée. ${words(40)}`, { hasMeasures: false })
-      ).toMatchObject({ ok: false, reason: "judiciaire" });
-    });
-
-    it("keeps the strict floor when the caller says nothing", () => {
-      // Defaulting to the low floor would silently accept thin texts everywhere.
-      expect(screenSynthesis(short)).toMatchObject({ ok: false, reason: "trop_court" });
     });
   });
 });

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -19,21 +19,97 @@ import { THEME_CATEGORY_LABELS } from "@/config/labels";
 const FIELD_LIMIT = 240;
 
 /**
- * Word bounds, and why there are two floors rather than one.
+ * Word bounds. Two numbers, and the whole point is that they are two.
  *
- * A single high floor contradicts the instruction the model is given. It is told to
- * state an empty record in one sentence rather than pad, and a candidacy we have not
- * yet documented has nothing to say about its programme: on a first run, thirteen of
- * twenty candidacies came back between 27 and 75 words, all of them correct, all of
- * them rejected by a 90-word floor. The floor was punishing the model for obeying.
+ * A single number played both roles and could not: the prompt asked for "entre 90 et 200 mots",
+ * and the screen refused anything under 90. So the length we WANT was also the length below which
+ * we threw the text away. On a first run thirteen of twenty candidacies came back between 27 and
+ * 75 words, all correct, all rejected. Nathalie Arthaud, who has no mandate, no recorded vote and
+ * five measures, wrote 81 honest words, was told the minimum was 90, had nothing left but filler,
+ * failed twice, and her fiche kept no summary at all.
  *
- * So the floor follows the material. With measures to summarise, a text under 90
- * words is thin and something went wrong. Without them, brevity is the honest answer
- * and only an empty one is a failure.
+ * Splitting the roles dissolves it:
+ *
+ * - {@link synthesisTargetRange} is what the prompt asks for. It is a target, and being under it is
+ *   a disappointment, not a fault. It follows the material, one term per thing there is to say, so
+ *   a candidacy with a one-line career is not asked for the paragraph it cannot fill.
+ * - {@link synthesisFloor} is what the screen refuses. It catches an answer that is not an answer:
+ *   an empty reply, one line, a truncation. It sits far below the target on purpose, because every
+ *   attempt to make it double as a quality bar has rejected honest work.
+ *
+ * The full-material target is still 90, so nothing changes for the candidacies that were already
+ * passing. Checked against the twenty declared candidacies in production, every stored synthesis
+ * clears its own floor, the tightest margin being 27 words against a floor of 25.
  */
-export const SYNTHESIS_MIN_WORDS = 90;
-export const SYNTHESIS_MIN_WORDS_WITHOUT_MEASURES = 25;
 export const SYNTHESIS_MAX_WORDS = 200;
+
+/** Target terms: the identity sentence, then a paragraph per section, in two steps each. */
+export const TARGET_BASE = 25;
+export const TARGET_THIN_CAREER = 15;
+export const TARGET_CAREER = 30;
+export const TARGET_FEW_MEASURES = 15;
+export const TARGET_MEASURES = 35;
+
+/**
+ * Where a section stops being a sentence and becomes a paragraph.
+ *
+ * A career counts as substantial on mandates OR on recorded votes: François Ruffin holds three
+ * mandates and a thousand votes, which is a record to describe whatever the mandate count says.
+ */
+export const SUBSTANTIAL_MANDATES = 4;
+export const SUBSTANTIAL_VOTES = 100;
+export const SUBSTANTIAL_MEASURES = 4;
+
+/** Floor terms: one clause of identity, one sentence per section that exists. */
+export const FLOOR_BASE = 15;
+export const FLOOR_PER_SECTION = 10;
+
+/**
+ * What the prompt was built from, reduced to what decides the length.
+ *
+ * The three counts and not three booleans: both bounds distinguish a section that is a sentence
+ * from one that is a paragraph, and a boolean cannot carry that.
+ */
+export type SynthesisMaterial = {
+  mandateCount: number;
+  voteCount: number;
+  measureCount: number;
+};
+
+function hasCareer(material: SynthesisMaterial): boolean {
+  return material.mandateCount > 0 || material.voteCount > 0;
+}
+
+/** The length the prompt asks for. Stated to the model, never enforced against it. */
+export function synthesisTargetRange(material: SynthesisMaterial): { min: number; max: number } {
+  const career = !hasCareer(material)
+    ? 0
+    : material.mandateCount >= SUBSTANTIAL_MANDATES || material.voteCount >= SUBSTANTIAL_VOTES
+      ? TARGET_CAREER
+      : TARGET_THIN_CAREER;
+  const programme =
+    material.measureCount === 0
+      ? 0
+      : material.measureCount >= SUBSTANTIAL_MEASURES
+        ? TARGET_MEASURES
+        : TARGET_FEW_MEASURES;
+  return { min: TARGET_BASE + career + programme, max: SYNTHESIS_MAX_WORDS };
+}
+
+/** The length below which there is no answer to keep. Enforced; deliberately far under the target. */
+export function synthesisFloor(material: SynthesisMaterial): number {
+  const sections = (hasCareer(material) ? 1 : 0) + (material.measureCount > 0 ? 1 : 0);
+  return FLOOR_BASE + sections * FLOOR_PER_SECTION;
+}
+
+/** The material of a built prompt, so a caller never has to restate it. */
+export function synthesisMaterial(input: CandidateSynthesisInput): SynthesisMaterial {
+  return {
+    mandateCount: input.mandates.length,
+    voteCount: input.voteCount,
+    measureCount: input.measures.length,
+  };
+}
 
 export type SynthesisMandate = {
   role: string;
@@ -85,7 +161,17 @@ function formatMandate(mandate: SynthesisMandate): string {
   return `- ${safe(mandate.role)}${where}, ${from} à ${to}`;
 }
 
-export const SYNTHESIS_SYSTEM_PROMPT = `Tu rédiges pour Poligraph, un site français de transparence politique. Ta tâche est une synthèse factuelle du parcours et du programme d'une candidature à l'élection présidentielle.
+/**
+ * The rules, with the length the material actually supports.
+ *
+ * A function and no longer a constant, and that is the half of the fix the screen alone cannot
+ * make: telling every candidacy "entre 90 et 200 mots" while accepting 60 from some of them leaves
+ * the model aiming at a number it has no material for. It then pads, which the rules forbid, or
+ * stops short, which the screen used to punish. The prompt and the screen now read the same
+ * `synthesisMinWords`.
+ */
+export function buildSynthesisSystemPrompt(material: SynthesisMaterial): string {
+  return `Tu rédiges pour Poligraph, un site français de transparence politique. Ta tâche est une synthèse factuelle du parcours et du programme d'une candidature à l'élection présidentielle.
 
 Règles absolues :
 - N'écris RIEN qui ne figure pas dans les données fournies. Aucune connaissance extérieure, aucune inférence sur les intentions, aucune prévision.
@@ -97,12 +183,13 @@ Règles absolues :
 Forme :
 - Français, avec tous les accents.
 - Deux paragraphes : le parcours d'abord, le programme ensuite.
-- Entre ${SYNTHESIS_MIN_WORDS} et ${SYNTHESIS_MAX_WORDS} mots au total.
+- Entre ${synthesisTargetRange(material).min} et ${synthesisTargetRange(material).max} mots au total.
 - Aucun tiret cadratin ni demi-cadratin. Utilise virgules, parenthèses ou deux-points.
 - Pas de phrase de conclusion générale du type « une candidature qui entend peser ». Termine sur un fait.
 - Si le parcours ou le programme est vide, dis-le en une phrase simple plutôt que de meubler.
 
 Réponds uniquement par le texte de la synthèse, sans titre ni préambule.`;
+}
 
 export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): string {
   const mandates =
@@ -161,10 +248,17 @@ export type SynthesisScreen =
  */
 export function screenSynthesis(
   raw: string,
-  options: { hasMeasures?: boolean } = {}
+  /**
+   * The material the text was written from. Omitted, it defaults to the richest case, which is the
+   * strictest floor: a caller that forgets to say gets the demanding answer rather than a free pass.
+   */
+  material: SynthesisMaterial = {
+    mandateCount: SUBSTANTIAL_MANDATES,
+    voteCount: SUBSTANTIAL_VOTES,
+    measureCount: SUBSTANTIAL_MEASURES,
+  }
 ): SynthesisScreen {
-  const minWords =
-    options.hasMeasures === false ? SYNTHESIS_MIN_WORDS_WITHOUT_MEASURES : SYNTHESIS_MIN_WORDS;
+  const minWords = synthesisFloor(material);
   const text = raw.trim();
   if (text === "") return { ok: false, reason: "vide", detail: "le modèle n'a rien renvoyé" };
 

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -112,6 +112,30 @@ describe("generateCandidateSynthesis", () => {
     expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
   });
 
+  // Le cas Arthaud, bout en bout : aucun mandat, aucun vote, cinq mesures. Le service doit demander
+  // au modèle la longueur que cette matière porte, et juger sur la même.
+  it("annonce au modèle le plancher que la matière porte, et juge sur le même", async () => {
+    dbMock.measure.findMany.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({
+        theme: "SANTE",
+        publishedRevision: { text: `Mesure ${i}.` },
+      }))
+    );
+    callAnthropicMock.mockResolvedValue(
+      anthropicText(`${Array.from({ length: 81 }, (_, i) => `mot${i}`).join(" ")}.`)
+    );
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    // 25 de base + 0 de parcours + 35 de programme : 81 mots passent, là où le plancher fixe de 90
+    // les refusait deux fois de suite et laissait la fiche sans résumé.
+    expect(result).toMatchObject({ ok: true });
+    const system = callAnthropicMock.mock.calls[0]![1].system as string;
+    expect(system).toContain("Entre 60 et 200 mots");
+    expect(callAnthropicMock).toHaveBeenCalledTimes(1);
+  });
+
   it("bascule sur Mistral quand Anthropic échoue", async () => {
     // Le repli couvre la panne récurrente du projet : un solde Anthropic à zéro, qui rend un 400.
     callAnthropicMock.mockRejectedValue(new Error("credit balance is too low"));

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -18,8 +18,9 @@ import { callMistral, extractMistralText } from "@/lib/api/mistral";
 import { db } from "@/lib/db";
 import {
   buildCandidateSynthesisPrompt,
+  buildSynthesisSystemPrompt,
   screenSynthesis,
-  SYNTHESIS_SYSTEM_PROMPT,
+  synthesisMaterial,
   type CandidateSynthesisInput,
 } from "@/lib/presidentielle/candidate-synthesis";
 
@@ -205,12 +206,16 @@ export async function generateCandidateSynthesis(
     ),
   };
 
-  const hasMeasures = input.measures.length > 0;
+  // One reading of the material, handed to both halves. The prompt states the length the material
+  // supports and the screen enforces that same number: a model told 90 and judged at 60 pads, a
+  // model told 60 and judged at 90 fails for obeying.
+  const material = synthesisMaterial(input);
+  const system = buildSynthesisSystemPrompt(material);
   const prompt = buildCandidateSynthesisPrompt(input);
 
   let attempt: { text: string; provider: string };
   try {
-    attempt = await generate(SYNTHESIS_SYSTEM_PROMPT, prompt);
+    attempt = await generate(system, prompt);
   } catch (error) {
     return {
       ok: false,
@@ -218,7 +223,7 @@ export async function generateCandidateSynthesis(
       message: error instanceof Error ? error.message : String(error),
     };
   }
-  let screened = screenSynthesis(attempt.text, { hasMeasures });
+  let screened = screenSynthesis(attempt.text, material);
 
   // One retry, naming the rule that was broken. Measured on a first full run: the model obeys the
   // rules it is reminded of and slips on the ones it is only told once, the long dash above all.
@@ -227,7 +232,7 @@ export async function generateCandidateSynthesis(
   if (!screened.ok) {
     try {
       attempt = await generate(
-        SYNTHESIS_SYSTEM_PROMPT,
+        system,
         `${prompt}\n\nTa réponse précédente a été refusée : ${screened.detail}. Recommence en respectant cette règle.`
       );
     } catch (error) {
@@ -237,7 +242,7 @@ export async function generateCandidateSynthesis(
         message: error instanceof Error ? error.message : String(error),
       };
     }
-    screened = screenSynthesis(attempt.text, { hasMeasures });
+    screened = screenSynthesis(attempt.text, material);
   }
 
   if (!screened.ok) {


### PR DESCRIPTION
## Description

Le contrôle des synthèses refusait tout texte sous la longueur voulue. La longueur qu'on **souhaite** et celle sous laquelle on **jette** le texte étaient le même nombre, 90, donc un texte plus court que l'idéal était détruit au lieu d'être simplement moins bon.

Constaté depuis le bouton « Régénérer » ajouté en #756, sur Nathalie Arthaud : aucun mandat, aucun vote enregistré, cinq mesures, donc un premier paragraphe qui tient en une phrase par construction. Le modèle a écrit 81 mots justes, s'est vu opposer un minimum de 90, et n'avait plus que du remplissage à ajouter — ce que les règles du prompt lui interdisent explicitement. Il a échoué deux fois et la fiche est restée sans résumé.

Un plancher que la génération ne peut pas atteindre n'est pas une exigence de qualité, c'est un bug déguisé en exigence.

### Deux nombres au lieu d'un

| | rôle | plein | Arthaud | 1 mandat seul | vide |
|---|---|---|---|---|---|
| `synthesisTargetRange` | ce que le prompt demande | 90 | 60 | 40 | 25 |
| `synthesisFloor` | ce que le contrôle refuse | 35 | 25 | 25 | 15 |

- **La cible** suit la matière, un terme par chose à dire, deux paliers chacun : deux mesures et vingt-cinq ne portent pas la même longueur, un mandat et onze non plus. Être en dessous est une déception, pas une faute. Une candidature entièrement documentée reste à 90 mots, donc rien ne change pour celles qui passaient déjà (leurs textes font 124 à 169 mots).
- **Le plancher** ne retient qu'une réponse qui n'en est pas une : vide, une ligne, tronquée. Il est très en dessous de la cible, parce que chaque tentative de lui faire aussi tenir la barre de qualité a refusé du travail juste.

Le prompt système devient une fonction de la matière. Lui annoncer 90 mots tout en en acceptant 60 laissait le modèle viser un chiffre sans matière pour l'atteindre. Le prompt et le contrôle lisent désormais la même lecture de la matière, faite une fois par le service. Le message d'erreur nomme le plancher qui s'est appliqué, plus un 90 fixe.

### Vérification sur les données de production

Les vingt candidatures déclarées ont été passées dans les nouvelles bornes : **chaque synthèse stockée passe son propre plancher**, la marge la plus courte étant 27 mots contre un plancher de 25.

Un test fige la propriété plutôt que les chiffres — *un texte pile à la cible ne peut jamais être refusé pour sa longueur, quelle que soit la matière* — pour que la régression ne revienne pas une troisième fois : le plancher unique de 90 avait déjà été scindé en deux une première fois, et la panne était revenue par l'autre côté.

## Type de changement

- [x] Bug fix

## Issue liée

Aucune.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (57 warnings préexistants, 0 erreur)
- [x] `npm run build` passe sans erreur — compilation et TypeScript OK ; la collecte de page data s'arrête sur l'absence de `DATABASE_URL` dans l'environnement de vérification, pas sur le code
- [x] Les changements sont testés — 4910 tests passent, dont 11 nouveaux sur les bornes et l'accord prompt/contrôle
- [ ] La documentation est mise à jour (sans objet)
- [x] Pas de données sensibles dans le code

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtS57FrNZ84Z5in93guMdd)_