### PR TITLE
fix(sujets): lisser le repli des mesures et clarifier la mention de vote

### DIFF
--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -6,6 +6,7 @@ import {
   SOURCE_TIER_LABELS,
   THEME_ACCENT_BAR,
   THEME_CATEGORY_LABELS,
+  VOTE_RELATION_BASIS_LABELS,
 } from "@/config/labels";
 import { MeasurePrecisionBadge } from "@/components/measures/MeasurePrecisionBadge";
 import { QualifiedEmptyCell } from "@/components/measures/QualifiedEmptyCell";
@@ -321,6 +322,7 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
           <SubjectGate data={data} />
         ) : (
           <>
+            <VoteMentionLegend />
             <ComparisonTable data={data} />
             <FooterCard
               documented={documented}
@@ -376,6 +378,42 @@ function PlannedSections() {
         ))}
       </dl>
     </section>
+  );
+}
+
+/**
+ * What the mention under every measure is about, said once, before the reader meets it.
+ *
+ * The mention is the state of a rapprochement we are still building, measure by measure: which
+ * scrutins of the Assemblée nationale and the Sénat bear on the same object as a proposal. Nothing
+ * on the page said that work existed, so "à vérifier" under a measure had no antecedent, and a
+ * reader could take it for a reservation about the candidacy rather than about our own coverage.
+ *
+ * Here rather than in the method card at the bottom: a key that arrives after the table it explains
+ * is read, if at all, once the reader has already made sense of the labels on their own.
+ */
+function VoteMentionLegend() {
+  return (
+    <aside
+      aria-labelledby="legende-votes"
+      className="rounded-xl border border-border bg-muted/40 px-5 py-4"
+    >
+      <h2
+        id="legende-votes"
+        className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
+      >
+        La mention sous chaque mesure
+      </h2>
+      <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+        Nous rapprochons chaque mesure des scrutins de l&apos;Assemblée nationale et du Sénat qui
+        portent sur le même objet. Ce travail se fait mesure par mesure et il est en cours&nbsp;:
+        «&nbsp;{VOTE_RELATION_BASIS_LABELS.SEARCH_NOT_DONE}&nbsp;» signale une mesure que nous
+        n&apos;avons pas encore rapprochée, «&nbsp;
+        {VOTE_RELATION_BASIS_LABELS.NO_VOTE_IN_SCOPE}&nbsp;» une mesure pour laquelle nous avons
+        cherché sans rien trouver. Dans ce second cas, les chambres et les législatures couvertes et
+        la date de la vérification suivent la mention.
+      </p>
+    </aside>
   );
 }
 
@@ -483,17 +521,15 @@ function FooterCard({
 function MethodCard() {
   return (
     <section className="flex flex-col gap-4 rounded-xl border border-border bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-      {/* The two states quoted here are the ones the badge actually renders today
-          (VOTE_RELATION_BASIS_LABELS). An earlier version quoted "aucun vote sur cet objet", a
-          string that exists nowhere: a reader would have looked for a wording they never meet. */}
+      {/* What the two search states mean is stated by `VoteMentionLegend`, above the table, where a
+          reader meets the mention for the first time. What is left here is the rule that decides
+          whether a POSITION can appear at all, which is a different fact and belongs next to the
+          link to the method page. */}
       <p className="max-w-3xl text-sm text-muted-foreground">
-        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote. La
-        mention portée sous chaque mesure dit donc surtout où en est notre recherche de scrutin
-        proche&nbsp;: «&nbsp;vote au Parlement pas encore recherché&nbsp;» tant que nous ne
-        l&apos;avons pas faite, «&nbsp;vote au Parlement recherché, aucun trouvé&nbsp;» quand nous
-        avons cherché sans rien trouver, suivi du périmètre couvert et de la date de vérification.
-        Une position ne s&apos;affiche que pour une candidature qui siégeait au moment où un texte
-        proche a été soumis.
+        En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote, et une
+        position pour ou contre ne s&apos;affiche que pour une candidature qui siégeait au moment où
+        un texte proche a été soumis. Une mesure sans position n&apos;est donc pas une mesure sans
+        travail de notre part.
       </p>
       <Link
         href="/methodologie"

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import {
   CHAMBER_SHORT_LABELS,
@@ -148,6 +149,16 @@ const QUOTED_MEASURE_LIMIT = 3;
  *
  * `<details>` rather than a state hook: the page is a server component, and the browser's own
  * disclosure is keyboard-operable and announced correctly without a line of JavaScript.
+ *
+ * The folded measures are rendered exactly like the quoted ones, in the same divided column. They
+ * used to sit in an indented block with its own left rule, which read as a quotation inside the
+ * quotation: opening the disclosure broke the reading of one candidacy in two, the first three
+ * measures at one indent and the rest at another, when the two groups are the same kind of thing
+ * and the split between them is an arbitrary display limit. One hairline between every measure,
+ * folded or not, and the disclosure becomes one more row of that column instead of a seam.
+ *
+ * The summary states both directions, because a control that keeps saying "voir les 2 autres" once
+ * they are already on screen leaves the reader with no visible way back to the short form.
  */
 function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: ThemeCategory }) {
   if (entry.measures.length === 0) {
@@ -157,18 +168,35 @@ function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: T
   const folded = entry.measures.slice(QUOTED_MEASURE_LIMIT);
 
   return (
-    <div className="space-y-3">
+    <div className="divide-y divide-border/70">
       {quoted.map((measure) => (
-        <QuotedMeasure key={measure.measure.id} entry={measure} />
+        <div key={measure.measure.id} className="py-3 first:pt-0 last:pb-0">
+          <QuotedMeasure entry={measure} />
+        </div>
       ))}
       {folded.length > 0 && (
         <details className="group">
-          <summary className="inline-flex min-h-11 cursor-pointer items-center text-xs font-semibold text-primary underline decoration-dotted underline-offset-2 hover:decoration-solid">
-            + {folded.length} {folded.length === 1 ? "autre mesure" : "autres mesures"} sur ce sujet
+          <summary className="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded text-xs font-semibold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 [&::-webkit-details-marker]:hidden">
+            <ChevronRight
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90 motion-reduce:transition-none"
+            />
+            <span className="group-open:hidden">
+              {folded.length === 1
+                ? "Lire la dernière mesure sur ce sujet"
+                : `Lire les ${folded.length} autres mesures sur ce sujet`}
+            </span>
+            <span className="hidden group-open:inline">
+              {folded.length === 1
+                ? "Replier cette mesure"
+                : `Replier ces ${folded.length} mesures`}
+            </span>
           </summary>
-          <div className="mt-2 space-y-3 border-l-2 border-border pl-3">
+          <div className="divide-y divide-border/70">
             {folded.map((other) => (
-              <QuotedMeasure key={other.measure.id} entry={other} />
+              <div key={other.measure.id} className="py-3 last:pb-0">
+                <QuotedMeasure entry={other} />
+              </div>
             ))}
           </div>
         </details>
@@ -460,9 +488,10 @@ function MethodCard() {
           string that exists nowhere: a reader would have looked for a wording they never meet. */}
       <p className="max-w-3xl text-sm text-muted-foreground">
         En présidentielle, la plupart des mesures n&apos;ont jamais été soumises à un vote. La
-        mention portée sous chaque mesure dit donc surtout où nous en sommes&nbsp;: «&nbsp;périmètre
-        non examiné&nbsp;» tant que nous n&apos;avons pas cherché de scrutin proche,
-        «&nbsp;périmètre examiné sans résultat&nbsp;» quand nous avons cherché sans rien trouver.
+        mention portée sous chaque mesure dit donc surtout où en est notre recherche de scrutin
+        proche&nbsp;: «&nbsp;vote au Parlement pas encore recherché&nbsp;» tant que nous ne
+        l&apos;avons pas faite, «&nbsp;vote au Parlement recherché, aucun trouvé&nbsp;» quand nous
+        avons cherché sans rien trouver, suivi du périmètre couvert et de la date de vérification.
         Une position ne s&apos;affiche que pour une candidature qui siégeait au moment où un texte
         proche a été soumis.
       </p>

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import { VOTE_RELATION_BASIS_LABELS } from "@/config/labels";
 import { describe, expect, it } from "vitest";
 import type { PublicMeasure } from "@/lib/data/measures";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
@@ -210,7 +211,7 @@ describe("SubjectComparison", () => {
     // La fixture n'a pas de slug de politicien, donc le nom est un texte et non un lien.
     const ligne = screen.getAllByText("Alix")[0]!.closest("tr");
     expect(
-      within(ligne as HTMLElement).getByText(/Vote au Parlement recherché, aucun trouvé/)
+      within(ligne as HTMLElement).getByText(/Vote au Parlement vérifié, aucun scrutin proche/)
     ).toBeInTheDocument();
   });
 
@@ -347,6 +348,36 @@ describe("SubjectComparison", () => {
     expect(screen.getAllByText(/Mesure 4\./)).toHaveLength(2);
   });
 
+  it("explique la mention de vote avant que le lecteur ne la rencontre, avec les libellés réels", () => {
+    // La mention est l'état d'un rapprochement en cours ; rien sur la page ne disait que ce travail
+    // existait, donc « à vérifier » sous une mesure pouvait passer pour une réserve sur la
+    // candidature plutôt que sur notre couverture. La légende cite les libellés depuis la source de
+    // vérité : un libellé changé sans elle laisserait une clé qui ne correspond à rien.
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [entry("Alix", [subjectMeasure(measure({ id: "m-1" }), "SEARCH_NOT_DONE")])],
+        })}
+      />
+    );
+
+    const legende = screen.getByRole("complementary", { name: /La mention sous chaque mesure/ });
+    expect(within(legende).getByText(/rapprochons chaque mesure des scrutins/)).toBeInTheDocument();
+    expect(within(legende).getByText(/travail se fait mesure par mesure/)).toBeInTheDocument();
+    for (const libelle of [
+      VOTE_RELATION_BASIS_LABELS.SEARCH_NOT_DONE,
+      VOTE_RELATION_BASIS_LABELS.NO_VOTE_IN_SCOPE,
+    ]) {
+      expect(legende.textContent).toContain(libelle);
+    }
+
+    // Et la légende précède le tableau qu'elle explique, au lieu de le suivre.
+    const tableau = screen.getByRole("table");
+    expect(
+      legende.compareDocumentPosition(tableau) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("rend les mesures repliées comme les autres, sans bloc indenté qui casse la lecture", () => {
     // Régression : les mesures dépliées vivaient dans un `border-l-2 pl-3`, une citation dans la
     // citation. Ouvrir le repli coupait la lecture d'une candidature en deux blocs de mise en forme
@@ -417,8 +448,10 @@ describe("SubjectComparison", () => {
     // Et deux états de vote différents sur la même ligne. Portée sur la ligne du tableau : le
     // paragraphe de méthode cite les mêmes libellés en bas de page.
     const ligne = screen.getAllByText("Alix")[0]!.closest("tr") as HTMLElement;
-    expect(within(ligne).getAllByText(/Vote au Parlement pas encore recherché/)).toHaveLength(1);
-    expect(within(ligne).getAllByText(/Vote au Parlement recherché, aucun trouvé/)).toHaveLength(1);
+    expect(within(ligne).getAllByText(/Vote au Parlement à vérifier/)).toHaveLength(1);
+    expect(
+      within(ligne).getAllByText(/Vote au Parlement vérifié, aucun scrutin proche/)
+    ).toHaveLength(1);
   });
 
   it("porte le code couleur de chaque candidature, dans le tableau comme sur les cartes", () => {

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -210,7 +210,7 @@ describe("SubjectComparison", () => {
     // La fixture n'a pas de slug de politicien, donc le nom est un texte et non un lien.
     const ligne = screen.getAllByText("Alix")[0]!.closest("tr");
     expect(
-      within(ligne as HTMLElement).getByText(/périmètre examiné sans résultat/)
+      within(ligne as HTMLElement).getByText(/Vote au Parlement recherché, aucun trouvé/)
     ).toBeInTheDocument();
   });
 
@@ -343,8 +343,34 @@ describe("SubjectComparison", () => {
     }
     // La quatrième est repliée : présente dans le DOM (le `<details>` reste indexable et
     // opérable au clavier), annoncée pour ce qu'elle est.
-    expect(screen.getAllByText("+ 1 autre mesure sur ce sujet")).toHaveLength(2);
+    expect(screen.getAllByText("Lire la dernière mesure sur ce sujet")).toHaveLength(2);
     expect(screen.getAllByText(/Mesure 4\./)).toHaveLength(2);
+  });
+
+  it("rend les mesures repliées comme les autres, sans bloc indenté qui casse la lecture", () => {
+    // Régression : les mesures dépliées vivaient dans un `border-l-2 pl-3`, une citation dans la
+    // citation. Ouvrir le repli coupait la lecture d'une candidature en deux blocs de mise en forme
+    // différente, alors que la coupure entre les deux n'est qu'une limite d'affichage.
+    const cinq = [1, 2, 3, 4, 5].map((n) =>
+      subjectMeasure(measure({ id: `m-${n}`, text: `Mesure ${n}.` }), "SEARCH_NOT_DONE")
+    );
+    const { container } = render(
+      <SubjectComparison data={data({ candidates: [entry("Alix", cinq)] })} />
+    );
+
+    // Le repli des mesures, pas celui de la barre latérale des sujets.
+    const details = [...container.querySelectorAll("details")].filter((d) =>
+      d.textContent?.includes("Replier ces 2 mesures")
+    );
+    expect(details).toHaveLength(2);
+    for (const bloc of details) {
+      expect(bloc.querySelector(".border-l-2")).toBeNull();
+      expect(bloc.querySelector(".pl-3")).toBeNull();
+    }
+    // Et le repli propose les deux sens : sans « Replier », les mesures ouvertes n'ont plus de
+    // chemin de retour visible vers la forme courte.
+    expect(screen.getAllByText("Lire les 2 autres mesures sur ce sujet")).toHaveLength(2);
+    expect(screen.getAllByText("Replier ces 2 mesures")).toHaveLength(2);
   });
 
   it("ne replie rien quand la candidature porte trois mesures ou moins", () => {
@@ -353,8 +379,9 @@ describe("SubjectComparison", () => {
     );
     render(<SubjectComparison data={data({ candidates: [entry("Alix", trois)] })} />);
 
-    expect(screen.queryByText(/autre mesure sur ce sujet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lire la dernière mesure sur ce sujet/)).not.toBeInTheDocument();
     expect(screen.queryByText(/autres mesures sur ce sujet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Replier/)).not.toBeInTheDocument();
   });
 
   it("qualifie chaque mesure citée, jamais la première pour toutes", () => {
@@ -390,8 +417,8 @@ describe("SubjectComparison", () => {
     // Et deux états de vote différents sur la même ligne. Portée sur la ligne du tableau : le
     // paragraphe de méthode cite les mêmes libellés en bas de page.
     const ligne = screen.getAllByText("Alix")[0]!.closest("tr") as HTMLElement;
-    expect(within(ligne).getAllByText(/périmètre non examiné/)).toHaveLength(1);
-    expect(within(ligne).getAllByText(/périmètre examiné sans résultat/)).toHaveLength(1);
+    expect(within(ligne).getAllByText(/Vote au Parlement pas encore recherché/)).toHaveLength(1);
+    expect(within(ligne).getAllByText(/Vote au Parlement recherché, aucun trouvé/)).toHaveLength(1);
   });
 
   it("porte le code couleur de chaque candidature, dans le tableau comme sur les cartes", () => {

--- a/src/components/measures/VoteRelationBadge.test.tsx
+++ b/src/components/measures/VoteRelationBadge.test.tsx
@@ -48,10 +48,23 @@ describe("VoteRelationBadge", () => {
     expect(abs.queryByText("Contre")).toBeNull();
   });
 
-  it("recherche non effectuée s'affiche comme périmètre non examiné, jamais comme une position", () => {
+  it("recherche non effectuée nomme son sujet et ne rend jamais une position", () => {
     const { container } = render(<VoteRelationBadge relation="SEARCH_NOT_DONE" />);
     expect(container.querySelector("[data-vote-position]")).toBeNull();
-    expect(screen.getByText(/périmètre non examiné/)).toBeInTheDocument();
+    expect(screen.getByText(/Vote au Parlement pas encore recherché/)).toBeInTheDocument();
+  });
+
+  it("distingue en clair la recherche non faite de la recherche sans résultat", () => {
+    // Les deux états ne se distinguaient que par le mot « périmètre », le seul de la paire qu'un
+    // lecteur ne pouvait pas résoudre depuis la page. Chacun dit maintenant de quoi il parle.
+    const pasFaite = render(<VoteRelationBadge relation="SEARCH_NOT_DONE" />);
+    expect(pasFaite.container.textContent).toContain("pas encore recherché");
+    expect(pasFaite.container.textContent).not.toContain("périmètre");
+    pasFaite.unmount();
+
+    const sansResultat = render(<VoteRelationBadge relation="NO_VOTE_IN_SCOPE" />);
+    expect(sansResultat.container.textContent).toContain("recherché, aucun trouvé");
+    expect(sansResultat.container.textContent).not.toContain("périmètre");
   });
 
   it("le détail sourcé est rendu quand il est fourni", () => {

--- a/src/components/measures/VoteRelationBadge.test.tsx
+++ b/src/components/measures/VoteRelationBadge.test.tsx
@@ -51,19 +51,19 @@ describe("VoteRelationBadge", () => {
   it("recherche non effectuée nomme son sujet et ne rend jamais une position", () => {
     const { container } = render(<VoteRelationBadge relation="SEARCH_NOT_DONE" />);
     expect(container.querySelector("[data-vote-position]")).toBeNull();
-    expect(screen.getByText(/Vote au Parlement pas encore recherché/)).toBeInTheDocument();
+    expect(screen.getByText(/Vote au Parlement à vérifier/)).toBeInTheDocument();
   });
 
   it("distingue en clair la recherche non faite de la recherche sans résultat", () => {
     // Les deux états ne se distinguaient que par le mot « périmètre », le seul de la paire qu'un
     // lecteur ne pouvait pas résoudre depuis la page. Chacun dit maintenant de quoi il parle.
     const pasFaite = render(<VoteRelationBadge relation="SEARCH_NOT_DONE" />);
-    expect(pasFaite.container.textContent).toContain("pas encore recherché");
+    expect(pasFaite.container.textContent).toContain("Vote au Parlement à vérifier");
     expect(pasFaite.container.textContent).not.toContain("périmètre");
     pasFaite.unmount();
 
     const sansResultat = render(<VoteRelationBadge relation="NO_VOTE_IN_SCOPE" />);
-    expect(sansResultat.container.textContent).toContain("recherché, aucun trouvé");
+    expect(sansResultat.container.textContent).toContain("vérifié, aucun scrutin proche");
     expect(sansResultat.container.textContent).not.toContain("périmètre");
   });
 

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -671,16 +671,23 @@ export const VOTE_RELATION_POSITION_LABELS: Record<VoteRelation, string | null> 
   SEARCH_NOT_DONE: null,
 };
 
+// Each basis names its own subject, parliamentary votes, and says what we know about them in words a
+// reader meets nowhere else on the page. The previous wording was written from the inside: "périmètre
+// non examiné" and "périmètre examiné sans résultat" name an editorial workflow, not a fact about the
+// measure, and sitting next to a precision pill they read as a second qualification of the sentence
+// rather than as the state of our search for a vote. "Périmètre" also carried the whole distinction
+// between the two while being the one word in the pair a reader cannot resolve from the page.
+// The nine states are unchanged; only what they say is.
 export const VOTE_RELATION_BASIS_LABELS: Record<VoteRelation, string> = {
-  FAVORABLE_SAME_OBJECT: "même objet",
-  DEFAVORABLE_SAME_OBJECT: "même objet",
-  ABSTENTION_SAME_OBJECT: "même objet",
-  ABSENCE_SAME_OBJECT: "même objet",
-  DIFFERENT_POSITIONS: "même objet, plusieurs scrutins",
-  BROADER_TEXT: "texte plus large",
-  NOT_RECHECKED_SINCE_REFORMULATION: "reformulée depuis",
-  NO_VOTE_IN_SCOPE: "périmètre examiné sans résultat",
-  SEARCH_NOT_DONE: "périmètre non examiné",
+  FAVORABLE_SAME_OBJECT: "Vote sur le même objet",
+  DEFAVORABLE_SAME_OBJECT: "Vote sur le même objet",
+  ABSTENTION_SAME_OBJECT: "Vote sur le même objet",
+  ABSENCE_SAME_OBJECT: "Vote sur le même objet",
+  DIFFERENT_POSITIONS: "Plusieurs votes sur le même objet",
+  BROADER_TEXT: "Vote sur un texte plus large",
+  NOT_RECHECKED_SINCE_REFORMULATION: "Mesure reformulée depuis le vote trouvé",
+  NO_VOTE_IN_SCOPE: "Vote au Parlement recherché, aucun trouvé",
+  SEARCH_NOT_DONE: "Vote au Parlement pas encore recherché",
 };
 
 // Solid pill, white text. Hex values are the AA-verified variants of spec §9.2 (ratios >= 4,5:1 on white

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -671,13 +671,17 @@ export const VOTE_RELATION_POSITION_LABELS: Record<VoteRelation, string | null> 
   SEARCH_NOT_DONE: null,
 };
 
-// Each basis names its own subject, parliamentary votes, and says what we know about them in words a
-// reader meets nowhere else on the page. The previous wording was written from the inside: "périmètre
-// non examiné" and "périmètre examiné sans résultat" name an editorial workflow, not a fact about the
-// measure, and sitting next to a precision pill they read as a second qualification of the sentence
-// rather than as the state of our search for a vote. "Périmètre" also carried the whole distinction
-// between the two while being the one word in the pair a reader cannot resolve from the page.
-// The nine states are unchanged; only what they say is.
+// Each basis names its own subject, parliamentary votes, and says where the verification stands in
+// words a reader meets nowhere else on the page. The previous wording was written from the inside:
+// "périmètre non examiné" and "périmètre examiné sans résultat" name an editorial workflow, not a
+// fact about the measure, and sitting next to a precision pill they read as a second qualification
+// of the sentence rather than as the state of our work. "Périmètre" also carried the whole
+// distinction between the two while being the one word in the pair a reader cannot resolve from the
+// page. The two search states now share a prefix and differ only in their tail, "à vérifier" against
+// "vérifié", which is also the verb the sourced detail already uses ("vérifié le ..."). What that
+// verification is, and that it is ongoing, is stated once by the legend above the comparison rather
+// than crammed into a label repeated under every measure. The nine states are unchanged; only what
+// they say is.
 export const VOTE_RELATION_BASIS_LABELS: Record<VoteRelation, string> = {
   FAVORABLE_SAME_OBJECT: "Vote sur le même objet",
   DEFAVORABLE_SAME_OBJECT: "Vote sur le même objet",
@@ -685,9 +689,9 @@ export const VOTE_RELATION_BASIS_LABELS: Record<VoteRelation, string> = {
   ABSENCE_SAME_OBJECT: "Vote sur le même objet",
   DIFFERENT_POSITIONS: "Plusieurs votes sur le même objet",
   BROADER_TEXT: "Vote sur un texte plus large",
-  NOT_RECHECKED_SINCE_REFORMULATION: "Mesure reformulée depuis le vote trouvé",
-  NO_VOTE_IN_SCOPE: "Vote au Parlement recherché, aucun trouvé",
-  SEARCH_NOT_DONE: "Vote au Parlement pas encore recherché",
+  NOT_RECHECKED_SINCE_REFORMULATION: "Mesure reformulée depuis, vote à revérifier",
+  NO_VOTE_IN_SCOPE: "Vote au Parlement vérifié, aucun scrutin proche",
+  SEARCH_NOT_DONE: "Vote au Parlement à vérifier",
 };
 
 // Solid pill, white text. Hex values are the AA-verified variants of spec §9.2 (ratios >= 4,5:1 on white


### PR DESCRIPTION
Deux ruptures de lecture sur la page sujet.

Les mesures repliées vivaient dans un bloc indenté avec son propre filet
gauche, une citation dans la citation : ouvrir le repli coupait la lecture
d'une candidature en deux mises en forme différentes, alors que la coupure
entre les deux groupes n'est qu'une limite d'affichage (trois mesures citées).
Toutes les mesures partagent maintenant la même colonne, séparées par un
filet unique, et le repli devient une ligne de cette colonne au lieu d'une
couture. Le libellé dit les deux sens : sans « Replier », les mesures
ouvertes n'avaient plus de chemin de retour visible.

La mention de relation aux votes était écrite depuis l'intérieur :
« périmètre non examiné » et « périmètre examiné sans résultat » nomment un
processus éditorial, pas un fait sur la mesure, et « périmètre » portait
toute la distinction entre les deux tout en étant le seul mot de la paire
qu'un lecteur ne peut pas résoudre depuis la page. Posée à côté d'une
pastille de précision, elle se lisait comme une seconde qualification de la
phrase. Chaque libellé nomme désormais son sujet (« Vote au Parlement pas
encore recherché », « Vote au Parlement recherché, aucun trouvé »). Les neuf
états sont inchangés, seul ce qu'ils disent change, et le paragraphe de
méthode cite le nouveau libellé.