### PR TITLE
refactor(mesures): remettre la hiérarchie de lecture d'une mesure d'aplomb

### DIFF
--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectComparison.tsx
@@ -60,14 +60,28 @@ function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
   );
 
   return (
-    <ul aria-label="Sources de la mesure" className="space-y-0.5 text-xs text-muted-foreground">
+    <ul
+      aria-label="Sources de la mesure"
+      className="space-y-0.5 text-xs leading-snug text-muted-foreground-strong"
+    >
       {ordered.map((source) => (
         <li key={source.id}>
-          <a href={source.url} className="font-semibold underline" rel="nofollow noopener">
+          <a
+            href={source.url}
+            className="rounded underline decoration-border underline-offset-2 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            rel="nofollow noopener"
+          >
             {MEASURE_SOURCE_KIND_LABELS[source.sourceKind]}
           </a>
-          {source.page !== null && `, ${source.page}`} · {SOURCE_TIER_LABELS[source.tier]} ·{" "}
-          {formatDate(source.publishedAt)}
+          {" · "}
+          {SOURCE_TIER_LABELS[source.tier]} · {formatDate(source.publishedAt)}
+          {/* `page` is free text and editors put whole proposal titles in it, which makes it the
+              longest run on the card and the least scanned. It moves to its own line so the part a
+              reader actually scans, nature then niveau then date, stays one short line. Demoting it
+              by colour instead was the obvious move and the wrong one: a lighter grey than
+              --muted-foreground-strong drops 12 px text under 4,5:1, and this repo sets that floor
+              itself. Position does the demotion, contrast stays where it was. */}
+          {source.page !== null && <span className="block">{source.page}</span>}
         </li>
       ))}
     </ul>
@@ -76,7 +90,7 @@ function MeasureSources({ sources }: { sources: PublicMeasure["sources"] }) {
 
 function WithdrawalLine({ withdrawal }: { withdrawal: NonNullable<PublicMeasure["withdrawal"]> }) {
   return (
-    <p className="text-xs text-muted-foreground">
+    <p className="text-xs text-muted-foreground-strong">
       Mesure retirée le {formatDate(withdrawal.withdrawnAt)}
       {withdrawal.sourceUrl !== null && withdrawal.sourceLabel !== null && (
         <>
@@ -104,13 +118,13 @@ function WithdrawalLine({ withdrawal }: { withdrawal: NonNullable<PublicMeasure[
  */
 function MeasureQualifiers({ entry }: { entry: SubjectCandidateEntry["measures"][number] }) {
   return (
-    <div className="flex flex-wrap items-start gap-x-3 gap-y-1">
+    <div className="flex flex-wrap items-start gap-1.5">
       {entry.measure.precision !== null ? (
         <MeasurePrecisionBadge precision={entry.measure.precision} />
       ) : (
         <QualifiedEmptyCell
           absence={{ kind: "not_applicable", reason: "Précision non renseignée" }}
-          className="text-xs"
+          className="self-center text-xs"
         />
       )}
       <VoteRelationBadge
@@ -123,16 +137,36 @@ function MeasureQualifiers({ entry }: { entry: SubjectCandidateEntry["measures"]
   );
 }
 
-/** One quoted measure: its text, what qualifies it, its sources, and its withdrawal when there is one. */
+/**
+ * One quoted measure: its text, what qualifies it, its sources, and its withdrawal when there is one.
+ *
+ * Two measurements decide the layout here.
+ *
+ * `max-w-[64ch]` caps the line. The flexible column has no width of its own, so on a wide viewport
+ * the arithmetic of the container (1536 at the 2xl stop, less the page padding, the sidebar, the
+ * gutter, the identity column and the cell padding) left about 990 px for a single line of text:
+ * roughly 120 to 130 characters where the readable band is 45 to 75. That is the defect a reader
+ * feels as "hard to read" and it has nothing to do with the typeface. It is invisible on mobile,
+ * which is how it survived.
+ *
+ * The spacing is uneven on purpose. Everything used to sit at `space-y-1.5`, so the sentence, its
+ * qualifiers and its sources read as six equidistant blocks with nothing to group them. A wider gap
+ * before the metadata and a tighter one inside it lets proximity do what it is for: one statement,
+ * then the apparatus that backs it.
+ */
 function QuotedMeasure({ entry }: { entry: SubjectCandidateEntry["measures"][number] }) {
   return (
-    <div className="space-y-1.5">
-      <p className="text-sm leading-relaxed">&laquo;&nbsp;{entry.measure.text}&nbsp;&raquo;</p>
-      <MeasureQualifiers entry={entry} />
-      <MeasureSources sources={entry.measure.sources} />
-      {entry.measure.withdrawal !== null && (
-        <WithdrawalLine withdrawal={entry.measure.withdrawal} />
-      )}
+    <div className="max-w-[64ch]">
+      <p className="text-[0.9375rem] leading-[1.55]">
+        &laquo;&nbsp;{entry.measure.text}&nbsp;&raquo;
+      </p>
+      <div className="mt-2.5 space-y-1">
+        <MeasureQualifiers entry={entry} />
+        <MeasureSources sources={entry.measure.sources} />
+        {entry.measure.withdrawal !== null && (
+          <WithdrawalLine withdrawal={entry.measure.withdrawal} />
+        )}
+      </div>
     </div>
   );
 }
@@ -177,7 +211,7 @@ function ProposalCell({ entry, theme }: { entry: SubjectCandidateEntry; theme: T
       ))}
       {folded.length > 0 && (
         <details className="group">
-          <summary className="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded text-xs font-semibold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 [&::-webkit-details-marker]:hidden">
+          <summary className="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded text-xs font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 [&::-webkit-details-marker]:hidden">
             <ChevronRight
               aria-hidden="true"
               className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90 motion-reduce:transition-none"
@@ -235,11 +269,18 @@ function CandidateIdentity({ entry }: { entry: SubjectCandidateEntry }) {
         ) : (
           <span className="text-sm font-bold">{candidate.candidateName}</span>
         )}
-        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-          {candidate.partyLabel !== null && <>{candidate.partyLabel} · </>}
-          {defended === 0
-            ? "aucune mesure sur ce sujet"
-            : `${defended} ${defended === 1 ? "mesure" : "mesures"} sur ce sujet`}
+        {/* The count is dropped when the candidacy has nothing at all, because the cell beside it
+            already says "Aucune mesure publiée sur <thème>" and that sentence is the whole content
+            of the row: saying it twice made the emptiest card the most repetitive one. It stays
+            when measures exist but none is still defended, where "aucune mesure sur ce sujet" is
+            not a repetition but the distinction between a withdrawn measure and no measure. */}
+        <span className="mt-0.5 block text-xs font-normal text-muted-foreground-strong">
+          {candidate.partyLabel}
+          {candidate.partyLabel !== null && measures.length > 0 && " · "}
+          {measures.length > 0 &&
+            (defended === 0
+              ? "aucune mesure sur ce sujet"
+              : `${defended} ${defended === 1 ? "mesure" : "mesures"} sur ce sujet`)}
         </span>
       </span>
     </span>
@@ -372,7 +413,7 @@ function PlannedSections() {
       <dl className="mt-3 grid gap-4 sm:grid-cols-3">
         {planned.map((p) => (
           <div key={p.title}>
-            <dt className="text-sm font-semibold">{p.title}</dt>
+            <dt className="text-sm font-bold">{p.title}</dt>
             <dd className="mt-1 text-sm text-muted-foreground">{p.body}</dd>
           </div>
         ))}

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectGate.tsx
@@ -31,22 +31,22 @@ export function SubjectGate({ data }: { data: SubjectPageData }) {
       aria-labelledby="gate-heading"
       className="rounded-lg border border-border bg-muted/40 p-4"
     >
-      <h2 id="gate-heading" className="text-base font-semibold">
+      <h2 id="gate-heading" className="text-base font-bold">
         Comparaison pas encore disponible sur ce sujet
       </h2>
       <div className="mt-3 space-y-2 text-sm text-muted-foreground">
-        <p className="font-medium text-foreground">Ce qui manque pour comparer</p>
+        <p className="text-foreground">Ce qui manque pour comparer</p>
         <dl className="grid gap-2 sm:grid-cols-2">
           <div>
             <dt>Candidatures avec mesure vérifiée</dt>
-            <dd className="font-medium text-foreground">
+            <dd className="text-foreground">
               {data.candidaciesWithVerifiedMeasure} sur{" "}
               {data.requiredCandidaciesWithVerifiedMeasure} requises
             </dd>
           </div>
           <div>
             <dt>Taux de couverture</dt>
-            <dd className="font-medium text-foreground">
+            <dd className="text-foreground">
               {formatCoverageRate(
                 data.candidaciesWithVerifiedMeasure,
                 data.totalSourcedCandidacies
@@ -55,23 +55,23 @@ export function SubjectGate({ data }: { data: SubjectPageData }) {
           </div>
           <div>
             <dt>Révisions en attente de relecture</dt>
-            <dd className="font-medium text-foreground">
+            <dd className="text-foreground">
               {data.pendingReviewRevisionCount} {revisionWord}
             </dd>
           </div>
           <div>
             <dt>Dernière revue publique</dt>
-            <dd className="font-medium text-foreground">
+            <dd className="text-foreground">
               {data.lastReviewedAt !== null ? formatDate(data.lastReviewedAt) : "jamais relu"}
             </dd>
           </div>
           <div>
             <dt>Éditions de programme ne couvrant pas ce sujet</dt>
-            <dd className="font-medium text-foreground">Non calculable</dd>
+            <dd className="text-foreground">Non calculable</dd>
           </div>
           <div>
             <dt>Candidatures sans programme publié</dt>
-            <dd className="font-medium text-foreground">Non calculable</dd>
+            <dd className="text-foreground">Non calculable</dd>
           </div>
         </dl>
         <p className="text-xs">

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectSidebar.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/SubjectSidebar.tsx
@@ -70,7 +70,7 @@ export function SubjectSidebar({
       {/* Below lg: a disclosure. `<details>` rather than a state hook, so it stays a server
           component and the browser gives keyboard operation and announcement for free. */}
       <details className="rounded-xl border border-border bg-card lg:hidden">
-        <summary className="flex min-h-11 cursor-pointer items-center justify-between gap-2 px-4 text-sm font-semibold">
+        <summary className="flex min-h-11 cursor-pointer items-center justify-between gap-2 px-4 text-sm font-bold">
           <span>
             Les sujets{" "}
             <span className="font-normal text-muted-foreground">

--- a/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/sujets/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -348,6 +348,152 @@ describe("SubjectComparison", () => {
     expect(screen.getAllByText(/Mesure 4\./)).toHaveLength(2);
   });
 
+  it("n'appelle aucune graisse que la fonte de texte ne publie pas", () => {
+    // La régression que ce test verrouille : Atkinson Hyperlegible est chargée en 400 et 700, les
+    // deux seules graisses de la famille. Le navigateur rabat 500 sur 400 et 600 sur 700, donc
+    // `font-medium` rendait une pastille en maigre et `font-semibold` rendait le lien de source
+    // aussi gras que le nom de la candidature. Quatre niveaux appelés, deux rendus, et une
+    // hiérarchie inversée. La fonte d'affichage (Outfit) publie 700 et 800 et n'est pas concernée.
+    const { container } = render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(
+                measure({ id: "m-1", sources: [source()], precision: "CHIFFREE" }),
+                "SEARCH_NOT_DONE"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+
+    // Et l'état fermé aussi : la carte de publication n'est pas rendue par le cas publiable.
+    const { container: ferme } = render(<SubjectComparison data={data({ publishable: false })} />);
+
+    for (const racine of [container, ferme]) {
+      const fantomes = [...racine.querySelectorAll<HTMLElement>("[class]")].filter((el) => {
+        const classes = el.className.toString();
+        return (
+          !classes.includes("font-display") &&
+          (classes.includes("font-medium") || classes.includes("font-semibold"))
+        );
+      });
+      expect(fantomes.map((el) => el.className.toString())).toEqual([]);
+    }
+  });
+
+  it("bride la longueur de ligne de la mesure et ne laisse plus la source la surclasser", () => {
+    // Deux défauts d'un coup. La colonne souple n'avait pas de largeur propre : sur un grand écran
+    // la mesure s'étalait sur environ 990 px, soit 120 à 130 caractères là où la bande lisible est
+    // 45 à 75. Et le lien de source, seul élément gras de la carte, pesait plus que la phrase qu'il
+    // source.
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(
+                measure({ id: "m-1", text: "Encadrer les loyers.", sources: [source()] }),
+                "SEARCH_NOT_DONE"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+
+    const phrase = screen.getAllByText(/Encadrer les loyers\./)[0]!;
+    expect(phrase.closest("[class*='max-w-']")).not.toBeNull();
+
+    for (const lien of screen.getAllByRole("link", { name: "Programme de parti" })) {
+      const classes = lien.className.toString();
+      expect(classes).not.toMatch(/font-(bold|semibold|medium|extrabold)/);
+      // Le soulignement reste : la couleur ne porte jamais seule l'affordance du lien.
+      expect(classes).toContain("underline");
+    }
+  });
+
+  it("range précision et état de vote dans la même famille de badges, à deux poids différents", () => {
+    // Le point de départ : une pastille pleine à côté d'un texte gris nu. Deux qualifications de la
+    // même phrase dans deux langages visuels, et celle sans forme passait pour un reste. Elles
+    // partagent maintenant une forme ; le niveau, lui, dit laquelle compte le plus.
+    const { container } = render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [
+              subjectMeasure(measure({ id: "m-1", precision: "CHIFFREE" }), "SEARCH_NOT_DONE"),
+              subjectMeasure(
+                measure({ id: "m-2", precision: "OBJECTIF_SANS_CHIFFRE" }),
+                "FAVORABLE_SAME_OBJECT"
+              ),
+            ]),
+          ],
+        })}
+      />
+    );
+
+    const ligne = screen.getAllByText("Alix")[0]!.closest("tr") as HTMLElement;
+    const niveaux = [...ligne.querySelectorAll("[data-measure-badge]")].map((el) =>
+      el.getAttribute("data-measure-badge")
+    );
+    // Deux précisions en qualification, un vote enregistré en verdict, un état de recherche en
+    // vérification : la précision ne pèse plus autant qu'une position de vote.
+    expect(niveaux.filter((n) => n === "qualification")).toHaveLength(2);
+    expect(niveaux.filter((n) => n === "verdict")).toHaveLength(1);
+    expect(niveaux.filter((n) => n === "verification")).toHaveLength(1);
+
+    // Et les deux états de précision prennent la même forme : ils se distinguent par le mot, pas
+    // par un aplat contre un contour qui se lisait comme une note.
+    const precisions = [...container.querySelectorAll<HTMLElement>("[data-measure-precision]")];
+    const formes = new Set(precisions.map((el) => el.className.toString()));
+    expect(formes.size).toBe(1);
+  });
+
+  it("ne dit qu'une fois qu'une candidature ne porte aucune mesure", () => {
+    // La carte la plus vide était la plus répétitive : « aucune mesure sur ce sujet » sous le nom,
+    // puis « Aucune mesure publiée sur ... » juste en dessous, pour tout contenu.
+    render(
+      <SubjectComparison
+        data={data({
+          candidates: [
+            entry("Alix", [subjectMeasure(measure({ id: "m-1" }), "SEARCH_NOT_DONE")]),
+            entry("Chloe", []),
+          ],
+        })}
+      />
+    );
+
+    expect(screen.queryByText(/aucune mesure sur ce sujet/)).not.toBeInTheDocument();
+    // La phrase qui reste est celle qui nomme le thème, donc la plus informative des deux.
+    expect(screen.getAllByText(/Aucune mesure publiée sur Logement & Urbanisme/)).toHaveLength(2);
+  });
+
+  it("garde la distinction entre une mesure retirée et aucune mesure", () => {
+    // Le doublon levé au-dessus ne doit pas emporter ce cas : une candidature dont tout est retiré
+    // porte bien des mesures à l'écran, et « aucune mesure sur ce sujet » y dit autre chose.
+    const retiree = measure({
+      id: "m-out",
+      withdrawal: {
+        withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+        sourceUrl: null,
+        sourceLabel: null,
+      },
+    });
+    render(
+      <SubjectComparison
+        data={data({
+          candidaciesWithVerifiedMeasure: 0,
+          candidates: [entry("Chloe", [subjectMeasure(retiree, "SEARCH_NOT_DONE")])],
+        })}
+      />
+    );
+
+    expect(screen.getAllByText(/aucune mesure sur ce sujet/)).toHaveLength(2);
+  });
+
   it("explique la mention de vote avant que le lecteur ne la rencontre, avec les libellés réels", () => {
     // La mention est l'état d'un rapprochement en cours ; rien sur la page ne disait que ce travail
     // existait, donc « à vérifier » sous une mesure pouvait passer pour une réserve sur la

--- a/src/components/measures/MeasureBadge.tsx
+++ b/src/components/measures/MeasureBadge.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+/**
+ * The three weights a fact about a measure can carry, and the only place their form is decided.
+ *
+ * The tier encodes IMPORTANCE, not category. A reader scanning the page has to meet the verdicts
+ * first and the housekeeping last, and before this component every badge on the surface set its own
+ * classes by hand: the precision pill was a dark solid fill, heavier than the vote position pills
+ * that carry the strongest fact on the page, and the verification state was bare grey text with no
+ * form at all, so two qualifications of the same sentence appeared in two visual languages and the
+ * one without a shape read as leftover rather than as information.
+ *
+ * - `verdict`: the candidacy voted on the same object. Rare, strong, the only tier allowed a colour,
+ *   which the caller passes (the AA-verified values of spec §9.2).
+ * - `qualification`: descriptive, on nearly every measure, never a judgment. Tinted ground, dark
+ *   text, no colour of its own.
+ * - `verification`: where our own work stands. The most frequent of the three, so the quietest: no
+ *   ground, a dashed rule that says "provisional" without adding weight, regular text. A tier that
+ *   appears under almost every measure must not become wallpaper.
+ *
+ * Weights are 400 and 700 and nothing else, because the body face (Atkinson Hyperlegible) publishes
+ * exactly those two. `font-medium` was rendering at 400, which is why a filled pill looked soft.
+ */
+export type MeasureBadgeTier = "verdict" | "qualification" | "verification";
+
+const TIER_CLASS: Record<MeasureBadgeTier, string> = {
+  verdict: "font-bold",
+  qualification: "border border-border/70 bg-muted font-bold text-foreground",
+  verification: "border border-dashed border-border text-muted-foreground-strong",
+};
+
+export function MeasureBadge({
+  tier,
+  icon,
+  className,
+  attrs,
+  children,
+}: {
+  tier: MeasureBadgeTier;
+  /** Decorative mark for the verification tier; the label always says the same thing in words. */
+  icon?: ReactNode;
+  className?: string;
+  /** Hooks the surface asserts on, kept out of the styling contract. */
+  attrs?: Record<string, string>;
+  children: ReactNode;
+}) {
+  const base = "inline-flex w-fit items-center gap-1.5 rounded-md px-2 py-1 text-xs leading-tight";
+  const classes = [base, TIER_CLASS[tier], className].filter(Boolean).join(" ");
+
+  return (
+    <span data-measure-badge={tier} className={classes} {...attrs}>
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/src/components/measures/MeasurePrecisionBadge.tsx
+++ b/src/components/measures/MeasurePrecisionBadge.tsx
@@ -1,12 +1,18 @@
 import type { MeasurePrecision } from "@/generated/prisma";
-import { MEASURE_PRECISION_LABELS, MEASURE_PRECISION_PILL_CLASS } from "@/config/labels";
+import { MEASURE_PRECISION_LABELS } from "@/config/labels";
+import { MeasureBadge } from "./MeasureBadge";
 
 /**
- * The two precision states of a published measure, on the same pill idiom as `VoteRelationBadge`.
+ * The two precision states of a published measure, on the `qualification` tier of `MeasureBadge`.
+ *
+ * Both states take the SAME form and differ by their word. They used to differ by their form too,
+ * a dark solid fill against a bare outline, which read as a scale: "Chiffrée" looked like a better
+ * grade than "Objectif sans chiffre", and its fill was heavier than the vote position pills that
+ * carry an actual verdict. Precision is descriptive, not a rank, so it gets one shape.
  *
  * `precision` is nullable on the revision, and a null is NOT a state this badge renders: the caller
  * decides what an unqualified measure looks like, because "we have not qualified it" is a statement
- * about our own work and belongs to `QualifiedEmptyCell`, not to a pill that would read as a third
+ * about our own work and belongs to `QualifiedEmptyCell`, not to a badge that would read as a third
  * precision level.
  */
 export function MeasurePrecisionBadge({
@@ -16,11 +22,13 @@ export function MeasurePrecisionBadge({
   precision: MeasurePrecision;
   className?: string;
 }) {
-  const base = `inline-flex w-fit items-center rounded-full px-2.5 py-1 text-xs font-medium ${MEASURE_PRECISION_PILL_CLASS[precision]}`;
-
   return (
-    <span data-measure-precision={precision} className={className ? `${base} ${className}` : base}>
+    <MeasureBadge
+      tier="qualification"
+      className={className}
+      attrs={{ "data-measure-precision": precision }}
+    >
       {MEASURE_PRECISION_LABELS[precision]}
-    </span>
+    </MeasureBadge>
   );
 }

--- a/src/components/measures/VoteRelationBadge.tsx
+++ b/src/components/measures/VoteRelationBadge.tsx
@@ -1,9 +1,12 @@
+import { Clock, History, SearchX } from "lucide-react";
 import type { VoteRelation } from "@/lib/measures/vote-relation";
 import {
+  VOTE_RELATION_BADGE_TIER,
   VOTE_RELATION_BASIS_LABELS,
   VOTE_RELATION_PILL_CLASS,
   VOTE_RELATION_POSITION_LABELS,
 } from "@/config/labels";
+import { MeasureBadge } from "./MeasureBadge";
 
 /**
  * The nine states of `deriveVoteRelation()` on two axes (spec §9.2): a short position pill (only when
@@ -13,7 +16,26 @@ import {
  * `basisDetails` carries the sourced detail (scrutin number, chamber, legislatures, verification date).
  * It is composed by the caller from the reference link, since `deriveVoteRelation()` is pure and does
  * not carry link metadata.
+ *
+ * Two renderings, decided by whether a position exists:
+ *
+ * A state WITH a position keeps the pill it always had, now on the `verdict` tier, with the basis
+ * and its sourced detail as a line underneath. That is the strongest fact the page can state and it
+ * stays the loudest thing in the row.
+ *
+ * A state WITHOUT a position used to be bare grey text sitting next to a filled pill, so a reader
+ * could not tell it was a qualification at all. It now carries the same badge form as the precision,
+ * on the tier its content deserves: `qualification` for a vote we found on a broader text, which is
+ * a finding, and `verification` for the three states that describe where our own search stands. The
+ * sourced detail moves under the badge instead of being glued to the label behind a colon, so a
+ * badge never has to hold a date and a chamber list inside itself.
  */
+const VERIFICATION_ICON: Partial<Record<VoteRelation, typeof Clock>> = {
+  SEARCH_NOT_DONE: Clock,
+  NO_VOTE_IN_SCOPE: SearchX,
+  NOT_RECHECKED_SINCE_REFORMULATION: History,
+};
+
 export function VoteRelationBadge({
   relation,
   basisDetails,
@@ -25,21 +47,42 @@ export function VoteRelationBadge({
 }) {
   const position = VOTE_RELATION_POSITION_LABELS[relation];
   const basis = VOTE_RELATION_BASIS_LABELS[relation];
-  const pill = VOTE_RELATION_PILL_CLASS[relation];
+  const wrapper = className
+    ? `flex flex-col items-start gap-1 ${className}`
+    : "flex flex-col items-start gap-1";
 
-  return (
-    <span className={className ? `flex flex-col gap-0.5 ${className}` : "flex flex-col gap-0.5"}>
-      {position !== null && (
-        <span
-          data-vote-position
-          className={`inline-flex w-fit items-center rounded-full px-2 py-0.5 text-xs font-medium ${pill}`}
+  if (position !== null) {
+    return (
+      <span className={wrapper}>
+        <MeasureBadge
+          tier="verdict"
+          className={VOTE_RELATION_PILL_CLASS[relation]}
+          attrs={{ "data-vote-position": relation }}
         >
           {position}
+        </MeasureBadge>
+        <span className="text-xs text-muted-foreground-strong">
+          {basisDetails ? `${basis} : ${basisDetails}` : basis}
         </span>
-      )}
-      <span className="text-xs text-muted-foreground">
-        {basisDetails ? `${basis} : ${basisDetails}` : basis}
       </span>
+    );
+  }
+
+  const Icon = VERIFICATION_ICON[relation];
+
+  return (
+    <span className={wrapper}>
+      <MeasureBadge
+        tier={VOTE_RELATION_BADGE_TIER[relation]}
+        icon={
+          Icon ? <Icon aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70" /> : undefined
+        }
+      >
+        {basis}
+      </MeasureBadge>
+      {basisDetails !== undefined && (
+        <span className="text-xs text-muted-foreground-strong">{basisDetails}</span>
+      )}
     </span>
   );
 }

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -49,6 +49,7 @@ import type {
   VisibilityBlocker,
 } from "@/lib/measures/moderation-state";
 import type { VoteRelation } from "@/lib/measures/vote-relation";
+import type { MeasureBadgeTier } from "@/components/measures/MeasureBadge";
 
 // Nombre de sièges à l'Assemblée nationale (XVIIe législature)
 export const AN_SEAT_COUNT = 577;
@@ -694,8 +695,25 @@ export const VOTE_RELATION_BASIS_LABELS: Record<VoteRelation, string> = {
   SEARCH_NOT_DONE: "Vote au Parlement à vérifier",
 };
 
-// Solid pill, white text. Hex values are the AA-verified variants of spec §9.2 (ratios >= 4,5:1 on white
-// text): #3d7a4e (5,13), #9e5454 (5,45), #6b7078 (4,98). Empty for the states with no position pill.
+// Which weight of `MeasureBadge` each state gets. The tier encodes importance, not category: a
+// recorded position is the strongest fact the page states, a vote found on a broader text is a
+// finding, and the last three describe where our own verification stands and appear under nearly
+// every measure, so they take the quietest form the family has.
+export const VOTE_RELATION_BADGE_TIER: Record<VoteRelation, MeasureBadgeTier> = {
+  FAVORABLE_SAME_OBJECT: "verdict",
+  DEFAVORABLE_SAME_OBJECT: "verdict",
+  ABSTENTION_SAME_OBJECT: "verdict",
+  ABSENCE_SAME_OBJECT: "verdict",
+  DIFFERENT_POSITIONS: "verdict",
+  BROADER_TEXT: "qualification",
+  NOT_RECHECKED_SINCE_REFORMULATION: "verification",
+  NO_VOTE_IN_SCOPE: "verification",
+  SEARCH_NOT_DONE: "verification",
+};
+
+// Solid fill, white text. Hex values are the AA-verified variants of spec §9.2 (ratios >= 4,5:1 on white
+// text): #3d7a4e (5,13), #9e5454 (5,45), #6b7078 (4,98). Read only for the states that carry a position
+// pill; empty for the others, which take their form from VOTE_RELATION_BADGE_TIER instead.
 export const VOTE_RELATION_PILL_CLASS: Record<VoteRelation, string> = {
   FAVORABLE_SAME_OBJECT: "bg-[#3d7a4e] text-white",
   DEFAVORABLE_SAME_OBJECT: "bg-[#9e5454] text-white",
@@ -1547,11 +1565,6 @@ export const MEASURE_PRECISION_LABELS: Record<MeasurePrecision, string> = {
 // figure is not a better measure than one stating an objective: it is a different kind of statement,
 // and grading it would be the ranking this site does not do. Same neutral slate as the vote
 // relations that state no position, distinguished by weight rather than by hue.
-export const MEASURE_PRECISION_PILL_CLASS: Record<MeasurePrecision, string> = {
-  CHIFFREE: "bg-[#6b7078] text-white",
-  OBJECTIF_SANS_CHIFFRE: "border border-border text-muted-foreground",
-};
-
 export const MEASURE_EXTRACTION_METHOD_LABELS: Record<MeasureExtractionMethod, string> = {
   MANUAL: "Saisie manuelle",
   AI_ASSISTED: "Assistée par IA",


### PR DESCRIPTION
## Description

Suite de #758, sur la même surface : la carte mesure de la page sujet. Un audit de lisibilité a sorti cinq causes à la lecture pénible, dont un vrai bug typographique.

**Graisses fantômes.** Atkinson Hyperlegible est chargée en `400` et `700`, les deux seules graisses que la famille publie. Le navigateur rabat 500 sur 400 et 600 sur 700, donc les quatre niveaux appelés par le code s'en rendaient deux, et la hiérarchie s'inversait : le lien de source, en `font-semibold`, pesait plus que la phrase qu'il source, tandis que les pastilles, en `font-medium`, se rendaient en maigre. Chaque graisse appelée sur cette surface existe maintenant. `font-semibold` devient `font-bold` (les deux se rendaient déjà en 700, c'est un no-op qui arrête de mentir) ; `font-medium` sur les valeurs du `SubjectGate` est retiré plutôt que promu, parce qu'il se rendait en 400 : le retirer ne change rien à l'écran, le promouvoir aurait été un changement visuel non demandé.

**Longueur de ligne.** La colonne souple n'avait pas de largeur propre. L'arithmétique du conteneur (1536 au palier 2xl, moins le padding de page, la barre latérale, la gouttière, la colonne identité et le padding de cellule) laissait environ 990 px pour une ligne, soit 120 à 130 caractères là où la bande lisible est 45 à 75. C'était le premier facteur de fatigue et il était invisible sur mobile, ce qui explique qu'il ait survécu. La mesure est bridée à `64ch` et passe à 15 px avec un interligne de 1,55.

**Famille de badges.** Précision et état du vote qualifient la même phrase et vivaient dans deux langages : un aplat gris foncé d'un côté, du texte gris nu de l'autre, qui passait pour un reste plutôt que pour une information. Un composant `MeasureBadge` décide seul de la forme, sur trois niveaux qui encodent l'importance et non la catégorie :

| Niveau | Contenu | Forme |
| --- | --- | --- |
| `verdict` | position enregistrée sur le même objet | aplat coloré, le seul niveau coloré |
| `qualification` | précision de la mesure, vote sur un texte plus large | fond teinté clair, filet fin |
| `verification` | les trois états de notre recherche | pas de fond, filet pointillé, icône |

Le dernier s'affiche sous la quasi-totalité des mesures, donc il prend la forme la plus discrète : une pastille pleine répétée partout serait devenue du papier peint et aurait volé l'attention aux positions de vote. `MEASURE_PRECISION_PILL_CLASS` disparaît, les deux états de précision partagent une forme et se distinguent par le mot, plus par un aplat contre un contour qui se lisait comme une note.

Effet de bord bienvenu : le détail sourcé (chambre, législature, date de vérification) n'est plus collé au libellé derrière un deux-points, il passe sous le badge.

**Rythme.** Tout était espacé au même intervalle, donc rien ne groupait la phrase et son appareil critique. Intervalle plus large avant les métadonnées, plus serré à l'intérieur.

**Sources.** Le lien perd sa graisse grasse et garde son soulignement, l'affordance ne repose jamais sur la couleur seule. Le champ `page`, texte libre qui absorbe des titres de proposition entiers, passe sur sa propre ligne : la partie réellement balayée, nature puis niveau puis date, tient sur une ligne courte. Le demander en gris plus clair était la solution évidente et la mauvaise : sous `--muted-foreground-strong`, du 12 px tombe sous 4,5:1, seuil que la charte du dépôt fixe elle-même. La position fait la relégation, le contraste ne bouge pas.

**Redondance.** Une candidature sans aucune mesure ne le dit plus deux fois, tout en gardant la distinction entre une mesure retirée et pas de mesure.

## Type de changement

- [x] Refactoring
- [x] Bug fix (les graisses appelées n'existaient pas dans la fonte chargée)

## Issue liée

Aucune.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (57 warnings `no-console` préexistants, aucun sur les fichiers touchés)
- [x] `npm run typecheck` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

### Tests

4832 tests passent sur `src/` (526 fichiers). Cinq tests de régression ajoutés :

- un garde-fou qui parcourt le DOM rendu, en état publiable **et** en état fermé, et rejette tout élément portant `font-medium` ou `font-semibold` sans `font-display` : il a d'ailleurs débusqué quatre occurrences que l'audit manuel avait ratées, dans la barre latérale et les sections à venir ;
- la longueur de ligne bridée et le lien de source qui ne surclasse plus la mesure ;
- précision et état de vote dans la même famille de badges, à des niveaux différents, et les deux états de précision sur une forme unique ;
- l'absence de mesure dite une seule fois ;
- la distinction préservée entre une mesure retirée et aucune mesure.

## Ce que cette PR ne fait pas

Le reste du site porte encore des `font-medium` et `font-semibold` fantômes ; le garde-fou ne couvre que la page sujet. Deux voies restent ouvertes et méritent leur propre décision : assumer deux graisses sur tout le site, ou charger une variante d'Atkinson publiant des graisses intermédiaires. La convention de saisie du champ `page` (un numéro et une page, ou un titre entier) est éditoriale et reste à trancher.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NimiSAptwVLYtYcDemDrV6)_