### PR TITLE
Ajouter les règles d'accroche et l'interdit des étiquettes

### DIFF
--- a/docs/editorial/reseaux-sociaux.md
+++ b/docs/editorial/reseaux-sociaux.md
@@ -101,7 +101,7 @@ Nos publications s'adressent à des citoyens de tous âges, adolescents et adult
 vulgarisation politique et civique. Ce lecteur n'a pas lu le texte dont nous parlons, ne connaît pas
 le vocabulaire de l'institution qui le produit, et n'a aucune raison de fournir un effort pour nous.
 
-Quatre conséquences, toutes vérifiables sur une publication finie.
+Sept conséquences, toutes vérifiables sur une publication finie.
 
 **Le vocabulaire de l'institution se traduit.** Les catégories de travail d'une administration ou
 d'une commission sont ses outils de classement, pas des explications. Un terme technique que rien ne
@@ -116,3 +116,32 @@ quelqu'un qui sait déjà ce qu'il a à dire. Il nomme l'objet dont il est quest
 catégorie à laquelle cet objet appartient.
 
 **Aucune métaphore en titre.** Imager, c'est renoncer à nommer.
+
+**Une suite de titres doit s'enchaîner.** Chaque titre répond à la question que le précédent laisse
+ouverte. Relus seuls, dans l'ordre, ils forment le raisonnement de la publication. Un titre qui
+annonce un contenu au lieu de le porter fait défiler le lecteur sans rien lui apprendre.
+
+**Une accroche ne présuppose pas ce qu'elle existe pour expliquer.** Lue seule, par quelqu'un qui
+ignore le sujet, elle doit délivrer une information. Si elle n'est claire que pour qui connaît déjà,
+elle est à réécrire.
+
+**Une accroche énonce une condition nécessaire, jamais une condition suffisante.** « Quand X, alors
+Y » se lit mieux que « pour Y, il faut X », et affirme beaucoup plus. Chercher un contre-exemple à
+sa propre accroche avant de la valider : sur un compte dont l'argument est la vérifiabilité,
+publier une phrase logiquement fausse est le pire endroit où se tromper.
+
+## 11. Ce qui ne devient jamais une étiquette
+
+Les pastilles, mots-clés et vignettes d'une publication portent nos propres rubriques, c'est-à-dire
+la taxonomie du site. Elles n'accueillent jamais une catégorie de personnes : diagnostic, handicap,
+origine, situation sociale.
+
+Une pastille est un objet décoratif. Y placer une catégorie de personnes transforme la situation de
+quelqu'un en élément de communication, sur un visuel que l'intéressé verra passer dans son fil. Le
+tort est réel et il est évitable.
+
+Cela déplace aussi le sujet. Quand une publication porte sur le fonctionnement d'une institution,
+classer des personnes en marge lui fait dire autre chose que ce qu'elle démontre.
+
+Quand un terme désignant des personnes est nécessaire, il vit dans une phrase, avec sa source, et il
+énonce ce qu'il recouvre plutôt que de servir de rubrique.

--- a/docs/editorial/reseaux-sociaux.md
+++ b/docs/editorial/reseaux-sociaux.md
@@ -101,7 +101,7 @@ Nos publications s'adressent à des citoyens de tous âges, adolescents et adult
 vulgarisation politique et civique. Ce lecteur n'a pas lu le texte dont nous parlons, ne connaît pas
 le vocabulaire de l'institution qui le produit, et n'a aucune raison de fournir un effort pour nous.
 
-Sept conséquences, toutes vérifiables sur une publication finie.
+Chacune des conséquences ci-dessous se vérifie sur une publication finie.
 
 **Le vocabulaire de l'institution se traduit.** Les catégories de travail d'une administration ou
 d'une commission sont ses outils de classement, pas des explications. Un terme technique que rien ne
@@ -125,10 +125,12 @@ annonce un contenu au lieu de le porter fait défiler le lecteur sans rien lui a
 ignore le sujet, elle doit délivrer une information. Si elle n'est claire que pour qui connaît déjà,
 elle est à réécrire.
 
-**Une accroche énonce une condition nécessaire, jamais une condition suffisante.** « Quand X, alors
-Y » se lit mieux que « pour Y, il faut X », et affirme beaucoup plus. Chercher un contre-exemple à
-sa propre accroche avant de la valider : sur un compte dont l'argument est la vérifiabilité,
-publier une phrase logiquement fausse est le pire endroit où se tromper.
+**Quand une accroche énonce une condition, c'est une condition nécessaire.** Beaucoup d'accroches
+n'énoncent aucune condition, et cette règle ne les concerne pas. Mais « quand X, alors Y » se lit
+mieux que « pour Y, il faut X » tout en affirmant bien davantage, puisque la première forme prétend
+que X suffit. Chercher un contre-exemple à sa propre accroche avant de la valider. Sur un compte
+dont l'argument est la vérifiabilité, publier une phrase logiquement fausse est le pire endroit où
+se tromper.
 
 ## 11. Ce qui ne devient jamais une étiquette
 


### PR DESCRIPTION
Quatre règles apprises en produisant les posts #3 et #4, ajoutées à `docs/editorial/reseaux-sociaux.md`.
Trois étendent le §10 sur le lecteur visé, la quatrième ouvre un §11.

## Les trois règles d'accroche

**Une suite de titres doit s'enchaîner.** Sur le post #3, les titres de slides étaient des intitulés
de rubrique : « Un examen obligatoire, deux fois », « La loi ne dit pas tout », « La chronologie ».
Chacun annonçait un contenu au lieu de le porter, et le lecteur faisait défiler une suite d'annonces
sans jamais lire ce qui était annoncé. Le test est mécanique : relire les titres seuls, dans l'ordre.

**Une accroche ne présuppose pas ce qu'elle existe pour expliquer.** Trois accroches successives ont
échoué de la même façon, en n'étant claires que pour qui connaissait déjà le sujet.

**Une accroche énonce une condition nécessaire, jamais une condition suffisante.** Le post #4 a
failli publier « un chiffre se vérifie quand on peut lire le calcul qui l'a produit ». C'est faux
deux fois : lire le calcul ne suffit pas, faute des données consommées et de la version exacte du
code, et ce n'est pas non plus nécessaire, puisqu'un chiffre issu d'un décret se vérifie dans le
décret. La forme « quand X, alors Y » se lit mieux que « pour Y, il faut X » et affirme beaucoup
plus. Sur un compte dont l'argument est la vérifiabilité, c'est le pire endroit où se tromper.

## Le §11, sur les étiquettes

Une version du post #4 portait `Autisme`, `Troubles dys`, `TDAH` et `Trouble du développement
intellectuel` en pastilles de couverture.

Deux torts distincts. Une pastille est un objet décoratif : y placer une catégorie de personnes
transforme la situation de quelqu'un en élément de communication, sur un visuel que l'intéressé
verra passer dans son fil. Et ces pastilles portent la taxonomie du site : y mettre de la nosologie
médicale déplace le sujet d'une publication qui traite de l'application des lois.

La règle est écrite au-delà du handicap, parce que le mécanisme vaut pour toute catégorie de
personnes.

## Portée

Document éditorial uniquement, aucun changement de code. Les règles sont rédigées pour être
vérifiables sur une publication finie plutôt que sur l'intention de son auteur.
