### PR TITLE
fix(citizen-impact): le lecteur ne vote pas

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
     "audit:careers:export": "tsx scripts/audit-careers.ts --export",
     "audit:bio-quality": "tsx scripts/audit-bio-quality.ts",
     "audit:sync-health": "tsx scripts/audit-sync-health.ts",
+    "backfill:citizen-impact-reader-role": "dotenv -e .env -- tsx scripts/backfill-citizen-impact-reader-role.ts",
+    "backfill:citizen-impact-reader-role:apply": "dotenv -e .env -- tsx scripts/backfill-citizen-impact-reader-role.ts --apply --confirm-production",
     "perf:check": "dotenv -e .env -- tsx scripts/perf-check-vote-denorm.ts",
     "sync:press": "tsx scripts/sync-press.ts",
     "sync:press:stats": "tsx scripts/sync-press.ts --stats",

--- a/scripts/__tests__/backfill-citizen-impact-reader-role.test.ts
+++ b/scripts/__tests__/backfill-citizen-impact-reader-role.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseArgs,
+  planRewrite,
+  firstChangedLine,
+  type ImpactRow,
+} from "../backfill-citizen-impact-reader-role";
+
+function row(overrides: Partial<ImpactRow> = {}): ImpactRow {
+  return {
+    id: "scrutin-1",
+    slug: "vote-1",
+    chamber: "AN",
+    citizenImpact: "**De quoi s'agit-il ?**\n\nVous votez sur une loi d'urgence agricole.",
+    ...overrides,
+  };
+}
+
+describe("parseArgs", () => {
+  it("defaults to report-only", () => {
+    expect(parseArgs([]).apply).toBe(false);
+  });
+
+  it("requires --confirm-production alongside --apply", () => {
+    expect(() => parseArgs(["--apply"])).toThrow(/confirm-production/);
+    expect(parseArgs(["--apply", "--confirm-production"]).apply).toBe(true);
+  });
+
+  it("parses --limit, --batch and --show-diff", () => {
+    expect(parseArgs(["--limit=10", "--batch=50", "--show-diff=20"])).toMatchObject({
+      limit: 10,
+      batch: 50,
+      showDiff: 20,
+    });
+  });
+
+  it("defaults batch and show-diff, leaves limit undefined", () => {
+    const a = parseArgs([]);
+    expect(a.batch).toBe(500);
+    expect(a.showDiff).toBe(5);
+    expect(a.limit).toBeUndefined();
+  });
+
+  it("rejects non-positive numeric flags", () => {
+    expect(() => parseArgs(["--limit=0"])).toThrow(/--limit/);
+    expect(() => parseArgs(["--batch=-1"])).toThrow(/--batch/);
+    expect(() => parseArgs(["--show-diff=x"])).toThrow(/--show-diff/);
+  });
+
+  it("accepts --show-diff=0 (counts only, no samples)", () => {
+    expect(parseArgs(["--show-diff=0"]).showDiff).toBe(0);
+  });
+});
+
+describe("planRewrite", () => {
+  it("plans a rewrite for the shipped reader-as-voter opener", () => {
+    const plan = planRewrite(row());
+    expect(plan).not.toBeNull();
+    expect(plan!.after).toContain("Les députés ont voté sur une loi d'urgence agricole.");
+    expect(plan!.after).not.toContain("Vous votez");
+  });
+
+  it("uses the row's chamber", () => {
+    const plan = planRewrite(row({ chamber: "SENAT" }));
+    expect(plan!.after).toContain("Les sénateurs ont voté sur");
+  });
+
+  it("returns null when the rewriter changes nothing (prefilter false positive)", () => {
+    const untouched = row({
+      citizenImpact: "Si vous êtes locataire, cette mesure change le calcul de votre loyer.",
+    });
+    expect(planRewrite(untouched)).toBeNull();
+  });
+
+  it("preserves everything outside the offending clause", () => {
+    const plan = planRewrite(
+      row({
+        citizenImpact:
+          "**Ce qui était proposé**\n\nVous votez sur un texte. **Interdire les néonicotinoïdes.**",
+      })
+    );
+    expect(plan!.after).toContain("**Ce qui était proposé**");
+    expect(plan!.after).toContain("**Interdire les néonicotinoïdes.**");
+  });
+});
+
+describe("firstChangedLine", () => {
+  it("reports the first differing line as a before/after pair", () => {
+    const plan = planRewrite(row())!;
+    expect(firstChangedLine(plan)).toEqual({
+      before: "Vous votez sur une loi d'urgence agricole.",
+      after: "Les députés ont voté sur une loi d'urgence agricole.",
+    });
+  });
+
+  it("returns null when the two texts are identical", () => {
+    expect(firstChangedLine({ id: "a", slug: null, before: "same", after: "same" })).toBeNull();
+  });
+});

--- a/scripts/backfill-citizen-impact-reader-role.ts
+++ b/scripts/backfill-citizen-impact-reader-role.ts
@@ -1,0 +1,234 @@
+/**
+ * Repairs stored citizen impacts that cast the reader as a participant in the
+ * vote ("Vous votez sur...", "Vous assistez à un vote...", "Votre vote...").
+ *
+ * Those formulations came from a prompt rule that asked for a blanket
+ * vouvoiement of the reader; the model read it as a mandate to place the reader
+ * inside the hemicycle. The prompt is fixed, but rows generated before the fix
+ * keep the wording. This tool rewrites them with `neutralizeReaderAsVoter` — a
+ * deterministic rewrite over a closed set of formulations, NO model call, so it
+ * is free, instant and reproducible.
+ *
+ * Only the offending clause changes; everything the model said about the
+ * measure is preserved byte-for-byte, so no coherence re-check is needed.
+ * `citizenImpactDate` is deliberately left untouched: the text was not
+ * regenerated, and that column records when the model produced it.
+ *
+ * User-accord-gated: report-only by default, `--apply` performs real writes
+ * against the production database (see CLAUDE.local.md — .env and .env.prod
+ * point at the same Supabase instance). Do NOT run in CI.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-citizen-impact-reader-role.ts
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-citizen-impact-reader-role.ts --show-diff=20
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-citizen-impact-reader-role.ts --apply --confirm-production
+ */
+import { neutralizeReaderAsVoter } from "@/services/scrutin-citizen-impact";
+
+/** Type-only, so importing this module (e.g. from the unit test) never builds a
+ *  Prisma client and never needs DATABASE_URL. `db` is imported dynamically in
+ *  `main`, following the convention of the other backfill scripts. */
+type Db = (typeof import("@/lib/db"))["db"];
+
+/**
+ * Cheap DB-side prefilter. MUST stay a superset of what
+ * `neutralizeReaderAsVoter` rewrites: it only narrows how many rows travel to
+ * the client, and every candidate is re-checked with the real rewriter before
+ * any write. Postgres ILIKE is accent-sensitive, so accents are spelled out.
+ */
+const CANDIDATE_MARKERS = [
+  "vous votez",
+  "vous allez voter",
+  "vous avez voté",
+  "vous assistez à",
+  "vous participez à",
+  "vous vous prononcez",
+  "vous êtes appelé",
+  "vous etes appelé",
+  "votre vote",
+] as const;
+
+export interface BackfillReaderRoleArgs {
+  apply: boolean;
+  limit?: number;
+  batch: number;
+  showDiff: number;
+}
+
+export function parseArgs(argv: string[]): BackfillReaderRoleArgs {
+  const has = (f: string) => argv.includes(f);
+  const num = (f: string) => {
+    const hit = argv.find((a) => a.startsWith(`${f}=`));
+    return hit ? Number(hit.split("=")[1]) : undefined;
+  };
+
+  const apply = has("--apply");
+  if (apply && !has("--confirm-production")) {
+    throw new Error("--apply requires --confirm-production (this DB is production)");
+  }
+
+  const limit = num("--limit");
+  if (limit !== undefined && (!Number.isFinite(limit) || limit < 1)) {
+    throw new Error(`--limit must be a positive number, got: ${limit}`);
+  }
+  const batch = num("--batch") ?? 500;
+  if (!Number.isFinite(batch) || batch < 1) {
+    throw new Error(`--batch must be a positive number, got: ${batch}`);
+  }
+  const showDiff = num("--show-diff") ?? 5;
+  if (!Number.isFinite(showDiff) || showDiff < 0) {
+    throw new Error(`--show-diff must be zero or a positive number, got: ${showDiff}`);
+  }
+
+  return { apply, limit, batch, showDiff };
+}
+
+export interface ImpactRow {
+  id: string;
+  slug: string | null;
+  chamber: "AN" | "SENAT";
+  citizenImpact: string;
+}
+
+export interface RewritePlan {
+  id: string;
+  slug: string | null;
+  before: string;
+  after: string;
+}
+
+/**
+ * Plans the rewrite for one row. Returns null when the rewriter leaves the text
+ * unchanged — a prefilter hit on a legitimate "vous" ("Si vous êtes locataire,
+ * ... votre vote de 2027" is not a participant formulation) must not produce a
+ * no-op write.
+ */
+export function planRewrite(row: ImpactRow): RewritePlan | null {
+  const after = neutralizeReaderAsVoter(row.citizenImpact, row.chamber);
+  if (after === row.citizenImpact) return null;
+  return { id: row.id, slug: row.slug, before: row.citizenImpact, after };
+}
+
+/** First line that differs, as a compact before/after pair for the report. */
+export function firstChangedLine(plan: RewritePlan): { before: string; after: string } | null {
+  const before = plan.before.split("\n");
+  const after = plan.after.split("\n");
+  for (let i = 0; i < Math.max(before.length, after.length); i++) {
+    if (before[i] !== after[i]) {
+      return { before: before[i] ?? "", after: after[i] ?? "" };
+    }
+  }
+  return null;
+}
+
+/** Pages through the candidate rows so a large table never lands in memory at once. */
+async function* iterateCandidates(
+  db: Db,
+  batch: number,
+  limit?: number
+): AsyncGenerator<ImpactRow> {
+  let cursor: string | undefined;
+  let emitted = 0;
+
+  for (;;) {
+    const take = limit ? Math.min(batch, limit - emitted) : batch;
+    if (take <= 0) return;
+
+    // Explicit `id > cursor` rather than Prisma's cursor/skip: under --apply a
+    // rewritten row stops matching the filter, and skip:1 would then step over
+    // an unprocessed row instead of the consumed one.
+    const rows = await db.scrutin.findMany({
+      where: {
+        citizenImpact: { not: null },
+        ...(cursor ? { id: { gt: cursor } } : {}),
+        OR: CANDIDATE_MARKERS.map((marker) => ({
+          citizenImpact: { contains: marker, mode: "insensitive" as const },
+        })),
+      },
+      select: { id: true, slug: true, chamber: true, citizenImpact: true },
+      orderBy: { id: "asc" },
+      take,
+    });
+
+    if (rows.length === 0) return;
+
+    for (const row of rows) {
+      yield {
+        id: row.id,
+        slug: row.slug,
+        chamber: row.chamber as "AN" | "SENAT",
+        citizenImpact: row.citizenImpact!,
+      };
+      emitted++;
+    }
+
+    cursor = rows[rows.length - 1]!.id;
+    if (rows.length < take) return;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { db } = await import("@/lib/db");
+
+  console.log(
+    `[reader-role] citizen-impact reader-role backfill  apply=${args.apply}` +
+      `  batch=${args.batch}${args.limit ? `  limit=${args.limit}` : ""}`
+  );
+
+  let scanned = 0;
+  let rewritable = 0;
+  let updated = 0;
+  const shown: RewritePlan[] = [];
+
+  for await (const row of iterateCandidates(db, args.batch, args.limit)) {
+    scanned++;
+    const plan = planRewrite(row);
+    if (!plan) continue;
+
+    rewritable++;
+    if (shown.length < args.showDiff) shown.push(plan);
+
+    if (args.apply) {
+      await db.scrutin.update({
+        where: { id: plan.id },
+        data: { citizenImpact: plan.after },
+      });
+      updated++;
+    }
+  }
+
+  console.log(`[reader-role] candidates scanned: ${scanned}`);
+  console.log(`[reader-role] rows needing a rewrite: ${rewritable}`);
+  console.log(
+    `[reader-role] false positives (prefilter hit, nothing to rewrite): ${scanned - rewritable}`
+  );
+
+  for (const plan of shown) {
+    const diff = firstChangedLine(plan);
+    if (!diff) continue;
+    console.log(`\n  ${plan.slug ?? plan.id}`);
+    console.log(`    - ${diff.before.slice(0, 160)}`);
+    console.log(`    + ${diff.after.slice(0, 160)}`);
+  }
+  if (rewritable > shown.length) {
+    console.log(`\n  ... and ${rewritable - shown.length} more (raise --show-diff to see them)`);
+  }
+
+  if (args.apply) {
+    console.log(`\n[reader-role] updated ${updated} row(s)`);
+  } else {
+    console.log("\n[reader-role] report-only (pass --apply --confirm-production to write)");
+  }
+
+  await db.$disconnect();
+}
+
+// Guarded so importing this module never touches the database: main() only
+// runs when this file is the process entry point, not on import.
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/src/services/__tests__/fixtures/scrutin-2084.ts
+++ b/src/services/__tests__/fixtures/scrutin-2084.ts
@@ -51,7 +51,7 @@ L'amendement a été rejeté de justesse, avec 37 voix pour et 38 contre.`;
  */
 export const CORRECT_CITIZEN_IMPACT = `**De quoi s'agit-il ?**
 
-Vous votez sur un texte qui cherche à renforcer la position des agriculteurs dans la chaîne agroalimentaire.
+Les députés ont examiné un texte qui cherche à renforcer la position des agriculteurs dans la chaîne agroalimentaire.
 
 **Ce qui était proposé**
 

--- a/src/services/__tests__/scrutin-citizen-impact.test.ts
+++ b/src/services/__tests__/scrutin-citizen-impact.test.ts
@@ -164,4 +164,42 @@ describe("neutralizeReaderAsVoter", () => {
       "Si vous êtes locataire, cette mesure change le calcul de votre loyer. Vous pouvez consulter le dossier.";
     expect(neutralizeReaderAsVoter(ok, "AN")).toBe(ok);
   });
+
+  it("leaves a genuine upcoming-election 'vous' untouched (distinct from the parliamentary-vote bug)", () => {
+    // Real production case: a bill about the Paris/Lyon/Marseille municipal
+    // voting method — "vous" correctly refers to the reader's own future vote,
+    // not to this scrutin. "voter" here has no "sur", so it must not match.
+    const ok = "Vous allez voter pour élire vos conseillers municipaux à Paris, Lyon ou Marseille.";
+    expect(neutralizeReaderAsVoter(ok, "AN")).toBe(ok);
+  });
+
+  // Regression: found via a production-data audit — relative clauses ("que
+  // vous avez voté", "sur lequel vous avez voté") slipped past the original
+  // "vous avez voté sur" pattern because "sur" isn't immediately adjacent.
+  it("covers 'vous avez voté' in a relative clause, without a trailing 'sur'", () => {
+    expect(
+      neutralizeReaderAsVoter("L'article 23, que vous avez voté, concerne la priorité.", "AN")
+    ).toBe("L'article 23, que les députés ont voté, concerne la priorité.");
+    expect(
+      neutralizeReaderAsVoter("L'article 24, sur lequel vous avez voté, concerne...", "AN")
+    ).toBe("L'article 24, sur lequel les députés ont voté, concerne...");
+  });
+
+  // Regression: same production audit — a different verb entirely ("vous
+  // examinons" instead of "vous votez"), same underlying bug of casting the
+  // reader as the body examining the bill. Also fixes the broken conjugation.
+  it("covers 'que vous examinons' with correct elision and inversion", () => {
+    expect(
+      neutralizeReaderAsVoter(
+        "Le projet de loi que vous examinons vise à organiser les Jeux.",
+        "AN"
+      )
+    ).toBe("Le projet de loi qu'examinent les députés vise à organiser les Jeux.");
+    expect(
+      neutralizeReaderAsVoter(
+        "La proposition de loi que vous examinons porte sur la santé.",
+        "SENAT"
+      )
+    ).toBe("La proposition de loi qu'examinent les sénateurs porte sur la santé.");
+  });
 });

--- a/src/services/__tests__/scrutin-citizen-impact.test.ts
+++ b/src/services/__tests__/scrutin-citizen-impact.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildUserMessage, type CitizenImpactInput } from "@/services/scrutin-citizen-impact";
+import {
+  buildUserMessage,
+  neutralizeReaderAsVoter,
+  SYSTEM_PROMPT,
+  type CitizenImpactInput,
+} from "@/services/scrutin-citizen-impact";
 import type { SubstanceTextBlock } from "@/services/scrutin-policy-title/types";
 import {
   AMENDMENT_2084_CONTENT,
@@ -94,5 +99,69 @@ describe("buildUserMessage — official substance blocks", () => {
       baseInput({ substanceBlocks: evil, substanceDepth: "amendment", hasLinkedAmendment: true })
     );
     expect(msg).not.toContain("<inject>");
+  });
+});
+
+// Regression: the reader is a citizen reading the record of a vote already held
+// by parliamentarians. The prompt used to say only "vouvoyer le lecteur", which
+// the model read as "put the reader in the hemicycle" — shipping openers like
+// "Vous votez sur une loi d'urgence..." and "Vous assistez à un vote sur...".
+describe("SYSTEM_PROMPT — the reader never votes", () => {
+  it("states that the vote already happened and that the reader took no part in it", () => {
+    expect(SYSTEM_PROMPT).toContain("QUI EST LE LECTEUR");
+    expect(SYSTEM_PROMPT.toLowerCase()).toContain("il ne vote pas");
+    expect(SYSTEM_PROMPT.toLowerCase()).toContain("les députés ont voté sur");
+  });
+
+  it("lists the reader-as-voter formulations as forbidden", () => {
+    expect(SYSTEM_PROMPT).toContain("FORMULATIONS INTERDITES");
+    expect(SYSTEM_PROMPT).toContain('"Vous votez sur..."');
+    expect(SYSTEM_PROMPT).toContain('"Vous assistez à un vote..."');
+  });
+
+  it("no longer instructs a blanket vouvoiement of the reader", () => {
+    expect(SYSTEM_PROMPT).not.toContain('vouvoyer le lecteur avec "vous"');
+  });
+});
+
+describe("neutralizeReaderAsVoter", () => {
+  it("puts the act back on the deputies for the shipped openers", () => {
+    expect(
+      neutralizeReaderAsVoter("Vous votez sur une loi d'urgence destinée à aider.", "AN")
+    ).toBe("Les députés ont voté sur une loi d'urgence destinée à aider.");
+    expect(
+      neutralizeReaderAsVoter("Vous assistez à un vote sur une loi qui cherche à modifier.", "AN")
+    ).toBe("Les députés ont voté sur une loi qui cherche à modifier.");
+  });
+
+  it("uses the right chamber", () => {
+    expect(neutralizeReaderAsVoter("Vous votez sur ce texte.", "SENAT")).toBe(
+      "Les sénateurs ont voté sur ce texte."
+    );
+  });
+
+  it("covers the other participant formulations", () => {
+    expect(neutralizeReaderAsVoter("Votre vote a été rejeté.", "AN")).toBe("Ce vote a été rejeté.");
+    expect(neutralizeReaderAsVoter("Vous êtes appelé à voter sur ce texte.", "AN")).toBe(
+      "Les députés se sont prononcés sur ce texte."
+    );
+    expect(neutralizeReaderAsVoter("Vous participez à un vote serré.", "AN")).toBe(
+      "Les députés ont participé à un vote serré."
+    );
+    expect(neutralizeReaderAsVoter("Vous assistez à un débat budgétaire.", "AN")).toBe(
+      "Les députés ont pris part à un débat budgétaire."
+    );
+  });
+
+  it("keeps the surrounding case when the formulation is mid-sentence", () => {
+    expect(neutralizeReaderAsVoter("Concrètement, vous votez sur un budget.", "AN")).toBe(
+      "Concrètement, les députés ont voté sur un budget."
+    );
+  });
+
+  it("leaves a legitimate 'vous' about the reader's own life untouched", () => {
+    const ok =
+      "Si vous êtes locataire, cette mesure change le calcul de votre loyer. Vous pouvez consulter le dossier.";
+    expect(neutralizeReaderAsVoter(ok, "AN")).toBe(ok);
   });
 });

--- a/src/services/__tests__/scrutin-citizen-impact.test.ts
+++ b/src/services/__tests__/scrutin-citizen-impact.test.ts
@@ -153,6 +153,24 @@ describe("neutralizeReaderAsVoter", () => {
     );
   });
 
+  // Coverage for the fuller set of parliamentary-procedure phrasings the model
+  // actually produces (confirmed against a full production-data audit), so the
+  // P1 fix's narrower object list doesn't quietly stop catching real slips.
+  it("covers the elided and 'étape de/du' phrasings of the parliamentary object", () => {
+    expect(neutralizeReaderAsVoter("Vous assistez à l'examen d'une proposition.", "AN")).toBe(
+      "Les députés ont pris part à l'examen d'une proposition."
+    );
+    expect(
+      neutralizeReaderAsVoter("Vous assistez à une étape de l'examen d'un projet de loi.", "AN")
+    ).toBe("Les députés ont pris part à une étape de l'examen d'un projet de loi.");
+    expect(
+      neutralizeReaderAsVoter("Vous assistez à un moment de procédure pendant l'examen.", "AN")
+    ).toBe("Les députés ont pris part à un moment de procédure pendant l'examen.");
+    expect(
+      neutralizeReaderAsVoter("Vous assistez à une étape procédurale d'un projet de loi.", "AN")
+    ).toBe("Les députés ont pris part à une étape procédurale d'un projet de loi.");
+  });
+
   it("keeps the surrounding case when the formulation is mid-sentence", () => {
     expect(neutralizeReaderAsVoter("Concrètement, vous votez sur un budget.", "AN")).toBe(
       "Concrètement, les députés ont voté sur un budget."
@@ -170,6 +188,55 @@ describe("neutralizeReaderAsVoter", () => {
     // voting method — "vous" correctly refers to the reader's own future vote,
     // not to this scrutin. "voter" here has no "sur", so it must not match.
     const ok = "Vous allez voter pour élire vos conseillers municipaux à Paris, Lyon ou Marseille.";
+    expect(neutralizeReaderAsVoter(ok, "AN")).toBe(ok);
+  });
+
+  // Regression: a first version of this rewriter matched bare present-tense
+  // "vous votez" unconditionally. A full production-data audit found it firing
+  // on hundreds of rows of correct, unrelated civic-education framing and
+  // mangling them into circular nonsense — restored via the backfill, not
+  // reproduced here, but the rewriter must never do this again.
+  it("leaves bare present-tense 'vous votez' (no 'sur') untouched — no safe bare form exists", () => {
+    const budget =
+      "Vous votez chaque année le budget de l'État à travers vos représentants. Ce texte...";
+    expect(neutralizeReaderAsVoter(budget, "AN")).toBe(budget);
+    const municipal =
+      "Vous votez pour élire vos conseillers municipaux à Paris, Lyon ou Marseille.";
+    expect(neutralizeReaderAsVoter(municipal, "AN")).toBe(municipal);
+  });
+
+  // Regression: chatgpt-codex-connector review on PR #762 — the original
+  // unconditional "vous participez à"/"vous assistez à" rewrote the reader's
+  // own, unrelated civic participation. Real production case: a bill about
+  // police powers at public gatherings, whose "Qui est concerné ?" section
+  // legitimately named the reader's own attendance.
+  it("leaves 'participez à'/'assistez à' untouched without a parliamentary-procedure object", () => {
+    const rally =
+      "Vous êtes concerné si vous participez à des rassemblements publics, des manifestations...";
+    expect(neutralizeReaderAsVoter(rally, "AN")).toBe(rally);
+    const hearing = "Si vous assistez à une audition publique organisée par votre mairie...";
+    expect(neutralizeReaderAsVoter(hearing, "AN")).toBe(hearing);
+  });
+
+  it("leaves 'votre vote' untouched outside the specific rejeté/adopté outcome phrasing", () => {
+    const ownBallot = "Votre vote aux élections municipales compte, quel que soit votre choix.";
+    expect(neutralizeReaderAsVoter(ownBallot, "AN")).toBe(ownBallot);
+  });
+
+  // Regression: chatgpt-codex-connector review on PR #762 (P2) — "vous avez
+  // voté" naming what THIS scrutin voted on, without "sur", slipped through.
+  it("covers 'vous avez voté pour/contre' this scrutin's own target", () => {
+    expect(neutralizeReaderAsVoter("Vous avez voté pour cet amendement.", "AN")).toBe(
+      "Les députés ont voté pour cet amendement."
+    );
+    expect(neutralizeReaderAsVoter("Vous avez voté contre le texte.", "AN")).toBe(
+      "Les députés ont voté contre le texte."
+    );
+  });
+
+  it("leaves 'vous avez voté' about a different election untouched (main clause, no relative pronoun)", () => {
+    const ok =
+      "Vous êtes directement impacté si vous avez voté ou vous présentez comme candidat aux élections municipales.";
     expect(neutralizeReaderAsVoter(ok, "AN")).toBe(ok);
   });
 

--- a/src/services/scrutin-citizen-impact.ts
+++ b/src/services/scrutin-citizen-impact.ts
@@ -167,18 +167,55 @@ export { MISTRAL_MODEL };
  * but a model slip must never reach a page, so the closed set below is repaired
  * deterministically. `subject` is "les députés" / "les sénateurs".
  */
+// Parliamentary-procedure nouns a rewrite is allowed to key off of. Kept
+// narrow and shared so "assistez à"/"participez à" only fire when the object
+// is plainly about this scrutin's own proceedings — not the reader's
+// unrelated civic life (a public rally, a hearing, a sports event...).
+// Covers both the direct object ("un débat", "l'adoption") and the "une
+// étape de/du l'examen/vote/discussion/création/procédure" phrasing the
+// model also uses, confirmed against a full production-data audit.
+const PARLIAMENTARY_OBJECT =
+  "(?:(?:(?:un|ce|cette|le|une)\\s+|l['’])(?:vote|scrutin|débat|examen|adoption|séance|procédure)|" +
+  "une étape procédurale|" +
+  "(?:un moment|une étape)\\s+(?:de\\s+l['’]|du|de\\s+la|d['’]|de)\\s*(?:examen|vote|discussion|création|adoption|procédure|processus))";
+// Ways to name the thing this scrutin voted on, for "vous avez voté pour/contre X".
+const VOTE_TARGET_OBJECT =
+  "(?:ce|cet|cette|le|la|l['’])\\s+(?:amendement|texte|article|projet|proposition|mesure)";
+
 const READER_AS_VOTER_REWRITES: { pattern: RegExp; to: (subject: string) => string }[] = [
   { pattern: /\bvous votez sur\b/gi, to: (s) => `${s} ont voté sur` },
   { pattern: /\bvous allez voter sur\b/gi, to: (s) => `${s} ont voté sur` },
   { pattern: /\bvous avez voté sur\b/gi, to: (s) => `${s} ont voté sur` },
-  { pattern: /\bvous votez\b/gi, to: (s) => `${s} ont voté` },
-  // Bare "vous avez voté" (no trailing "sur") — covers relative clauses like
-  // "l'article 23, que vous avez voté, concerne..." or "sur lequel vous avez voté".
-  // Trailing lookahead (not \b): JS's \b only treats ASCII [A-Za-z0-9_] as "word"
-  // characters, so a plain \b right after the accented "é" never matches when
-  // "voté" is followed by punctuation like a comma — both sides read as
-  // "non-word" and no boundary is found.
-  { pattern: /\bvous avez voté(?!\p{L})/giu, to: (s) => `${s} ont voté` },
+  // NOTE: deliberately no bare "vous votez" pattern. A production-data audit
+  // found it firing on entirely unrelated, correct civic-education framing —
+  // "Vous votez chaque année le budget de l'État à travers vos représentants"
+  // (639 rows) and "Vous votez pour élire vos conseillers municipaux" (80+
+  // rows) both describe the reader's own, separate vote and got mangled into
+  // a circular "Les députés ont voté... à travers vos représentants". Present
+  // tense "vous votez" essentially never refers to THIS scrutin (a scrutin is
+  // always in the past by the time this text is read), so there is no safe
+  // bare form to add back — only the "sur" variant above is trustworthy.
+  //
+  // Bare "vous avez voté" is scoped two ways instead of matched unconditionally:
+  // Trailing lookahead everywhere below (not \b): JS's \b only treats ASCII
+  // [A-Za-z0-9_] as "word" characters, so a plain \b right after the accented
+  // "é" never matches when "voté" is followed by punctuation like a comma —
+  // both sides read as "non-word" and no boundary is found.
+  {
+    // Relative clause referring back to this scrutin: "l'article 23, que
+    // vous avez voté, concerne..." / "...sur lequel vous avez voté...". The
+    // lookbehind doesn't consume "que"/"sur lequel", so it's left untouched.
+    pattern: /(?<=\b(?:que|qu['’]|sur lequel|sur laquelle)\s)vous avez voté(?!\p{L})/giu,
+    to: (s) => `${s} ont voté`,
+  },
+  {
+    // Main clause naming what was voted on: "Vous avez voté pour cet
+    // amendement" / "...contre le texte". Excludes "si vous avez voté aux
+    // élections municipales" and similar — "élections/conseillers/maire" are
+    // not in VOTE_TARGET_OBJECT, so that reader-owned-vote framing is left alone.
+    pattern: new RegExp(`\\bvous avez voté(?=\\s+(?:pour|contre)\\s+${VOTE_TARGET_OBJECT})`, "giu"),
+    to: (s) => `${s} ont voté`,
+  },
   // "le texte que vous examinons" — same bug (reader cast as the body examining
   // the bill), different verb. Absorbs "que" into the replacement for the
   // elision ("qu'examinent"), since only "vous examinons" alone isn't wrong French.
@@ -187,16 +224,33 @@ const READER_AS_VOTER_REWRITES: { pattern: RegExp; to: (subject: string) => stri
     pattern: /\bvous assistez à (?:un|ce|le) (?:vote|scrutin) sur\b/gi,
     to: (s) => `${s} ont voté sur`,
   },
-  // Bare variants keep the rest of the sentence, so the trailing noun phrase
-  // ("... à un vote serré") stays grammatical.
-  { pattern: /\bvous assistez à/gi, to: (s) => `${s} ont pris part à` },
+  // Bare "assistez à"/"participez à" require a parliamentary-procedure object
+  // (see PARLIAMENTARY_OBJECT) — a production-data audit found the previous
+  // fully-unconditional versions rewriting the reader's OWN participation in
+  // public gatherings ("vous êtes concerné si vous participez à des
+  // rassemblements publics...", on a public-order bill) into a nonsensical
+  // claim about the deputies. The lookahead doesn't consume the object, so
+  // its exact wording ("un débat sur...", "l'examen d'une proposition...")
+  // survives untouched.
+  {
+    pattern: new RegExp(`\\bvous assistez à(?=\\s+${PARLIAMENTARY_OBJECT}\\b)`, "gi"),
+    to: (s) => `${s} ont pris part à`,
+  },
   {
     pattern: /\bvous (?:êtes|etes) appelé(?:·e|\(e\)|e)?s? à (?:voter sur|vous prononcer sur)\b/gi,
     to: (s) => `${s} se sont prononcés sur`,
   },
   { pattern: /\bvous vous prononcez sur\b/gi, to: (s) => `${s} se sont prononcés sur` },
-  { pattern: /\bvous participez à/gi, to: (s) => `${s} ont participé à` },
-  { pattern: /\bvotre vote\b/gi, to: () => "ce vote" },
+  {
+    pattern: new RegExp(`\\bvous participez à(?=\\s+${PARLIAMENTARY_OBJECT}\\b)`, "gi"),
+    to: (s) => `${s} ont participé à`,
+  },
+  // Scoped to the specific outcome phrasing the prompt itself uses (rule 6/7:
+  // "cette mesure entre en vigueur" / "n'a pas été retenue" — restated here as
+  // the model sometimes writes it as "Votre vote a été rejeté/adopté"). A bare
+  // \bvotre vote\b would also catch "Votre vote aux municipales..." or "Votre
+  // vote compte", which are legitimately about the reader's own ballot.
+  { pattern: /\bvotre vote(?=\s+a été (?:rejeté|adopté))\b/gi, to: () => "ce vote" },
 ];
 
 /**

--- a/src/services/scrutin-citizen-impact.ts
+++ b/src/services/scrutin-citizen-impact.ts
@@ -172,6 +172,17 @@ const READER_AS_VOTER_REWRITES: { pattern: RegExp; to: (subject: string) => stri
   { pattern: /\bvous allez voter sur\b/gi, to: (s) => `${s} ont voté sur` },
   { pattern: /\bvous avez voté sur\b/gi, to: (s) => `${s} ont voté sur` },
   { pattern: /\bvous votez\b/gi, to: (s) => `${s} ont voté` },
+  // Bare "vous avez voté" (no trailing "sur") — covers relative clauses like
+  // "l'article 23, que vous avez voté, concerne..." or "sur lequel vous avez voté".
+  // Trailing lookahead (not \b): JS's \b only treats ASCII [A-Za-z0-9_] as "word"
+  // characters, so a plain \b right after the accented "é" never matches when
+  // "voté" is followed by punctuation like a comma — both sides read as
+  // "non-word" and no boundary is found.
+  { pattern: /\bvous avez voté(?!\p{L})/giu, to: (s) => `${s} ont voté` },
+  // "le texte que vous examinons" — same bug (reader cast as the body examining
+  // the bill), different verb. Absorbs "que" into the replacement for the
+  // elision ("qu'examinent"), since only "vous examinons" alone isn't wrong French.
+  { pattern: /\bque vous examinons\b/gi, to: (s) => `qu'examinent ${s}` },
   {
     pattern: /\bvous assistez à (?:un|ce|le) (?:vote|scrutin) sur\b/gi,
     to: (s) => `${s} ont voté sur`,

--- a/src/services/scrutin-citizen-impact.ts
+++ b/src/services/scrutin-citizen-impact.ts
@@ -65,13 +65,19 @@ FORMAT OBLIGATOIRE - Utiliser du markdown structuré :
 - Sous-titres en **gras** pour chaque section (pas de titres markdown #)
 - Listes à puces pour les arguments du débat
 - Utiliser le **gras** pour la mesure concrète votée
-- Français courant, vouvoyer le lecteur avec "vous"
+- Français courant
 - Utiliser des liens markdown vers les pages Poligraph quand des LIENS DISPONIBLES sont fournis
+
+QUI EST LE LECTEUR - RÈGLE ABSOLUE :
+Le lecteur est un CITOYEN qui consulte le compte rendu d'un vote DÉJÀ TENU par des parlementaires. Il n'y a pris AUCUNE part : il ne vote pas, il n'a pas voté, il n'assiste pas à la séance, il n'a rien à décider ni à trancher.
+- Le vote est un fait PASSÉ accompli par les députés (ou les sénateurs). En parler à la 3e personne et au passé : "les députés ont voté sur...", "l'Assemblée nationale a examiné...", "le Sénat a rejeté...".
+- N'employer "vous" QUE pour décrire les conséquences concrètes de la décision sur la vie du lecteur ("ce que cela change pour vous", "si vous louez votre logement, ..."). JAMAIS pour lui prêter un rôle dans la procédure parlementaire.
+- FORMULATIONS INTERDITES, ainsi que toutes leurs variantes : "Vous votez sur...", "Vous avez voté...", "Vous allez voter...", "Vous devez vous prononcer...", "Votre vote...", "Vous assistez à un vote...", "Vous êtes appelé à...", "Vous participez à...".
 
 STRUCTURE A SUIVRE :
 
 **De quoi s'agit-il ?**
-1-2 phrases pour poser le contexte : quelle loi, quel sujet de société. Ne JAMAIS écrire "l'article 21" sans expliquer en langage courant ce que cet article traite.
+1-2 phrases pour poser le contexte : quelle loi, quel sujet de société. Le sujet de la phrase est le TEXTE, la loi ou les parlementaires - jamais le lecteur : "Les députés ont examiné une loi d'urgence destinée à...", "Ce texte porte sur...". Ne JAMAIS écrire "l'article 21" sans expliquer en langage courant ce que cet article traite.
 
 **Ce qui était proposé**
 1-2 phrases sur ce que la mesure/l'amendement proposait concrètement. Mettre en **gras** la mesure clé.
@@ -98,7 +104,7 @@ NEUTRALITÉ - RÈGLES ABSOLUES :
 9. JAMAIS inventer de mesures concrètes absentes des données fournies
 10. Si les données sont trop minces pour identifier un impact citoyen : confidence < 40
 11. Votes purement procéduraux : confidence < 40
-12. Ne PAS commencer par "Ce vote..." - varier les accroches
+12. Ne PAS commencer par "Ce vote..." - varier les accroches, mais le sujet de l'accroche reste le texte, la loi ou les parlementaires, jamais le lecteur
 13. Si le scrutin porte sur un amendement, expliquer DANS LE CONTEXTE DE LA LOI ce que l'amendement proposait de modifier
 14. Pour les motions de censure : seuls les députés favorables à la censure votent POUR. La motion est rejetée si le seuil de majorité absolue (289/577) n'est pas atteint, PAS parce que des députés ont voté contre.
 
@@ -140,7 +146,7 @@ export async function generateCitizenImpact(
   try {
     const parsed = parseMistralJSON<{ citizen_impact: string; confidence: number }>(text);
     return {
-      citizenImpact: sanitizeOutput(parsed.citizen_impact ?? ""),
+      citizenImpact: sanitizeOutput(parsed.citizen_impact ?? "", input.chamber),
       confidence: parsed.confidence ?? 0,
     };
   } catch {
@@ -154,10 +160,71 @@ export { MISTRAL_MODEL };
 // HELPERS
 // ============================================
 
-function sanitizeOutput(text: string): string {
+/**
+ * Rewrites that put the parliamentary act back on the parliamentarians. The
+ * reader is a citizen reading the record of a vote that already happened: they
+ * did not cast it and did not attend it. The prompt forbids these formulations,
+ * but a model slip must never reach a page, so the closed set below is repaired
+ * deterministically. `subject` is "les députés" / "les sénateurs".
+ */
+const READER_AS_VOTER_REWRITES: { pattern: RegExp; to: (subject: string) => string }[] = [
+  { pattern: /\bvous votez sur\b/gi, to: (s) => `${s} ont voté sur` },
+  { pattern: /\bvous allez voter sur\b/gi, to: (s) => `${s} ont voté sur` },
+  { pattern: /\bvous avez voté sur\b/gi, to: (s) => `${s} ont voté sur` },
+  { pattern: /\bvous votez\b/gi, to: (s) => `${s} ont voté` },
+  {
+    pattern: /\bvous assistez à (?:un|ce|le) (?:vote|scrutin) sur\b/gi,
+    to: (s) => `${s} ont voté sur`,
+  },
+  // Bare variants keep the rest of the sentence, so the trailing noun phrase
+  // ("... à un vote serré") stays grammatical.
+  { pattern: /\bvous assistez à/gi, to: (s) => `${s} ont pris part à` },
+  {
+    pattern: /\bvous (?:êtes|etes) appelé(?:·e|\(e\)|e)?s? à (?:voter sur|vous prononcer sur)\b/gi,
+    to: (s) => `${s} se sont prononcés sur`,
+  },
+  { pattern: /\bvous vous prononcez sur\b/gi, to: (s) => `${s} se sont prononcés sur` },
+  { pattern: /\bvous participez à/gi, to: (s) => `${s} ont participé à` },
+  { pattern: /\bvotre vote\b/gi, to: () => "ce vote" },
+];
+
+/**
+ * Applies a rewrite while keeping the matched text's leading case, so a
+ * mid-sentence occurrence does not gain a stray capital letter.
+ */
+function rewritePreservingCase(
+  text: string,
+  pattern: RegExp,
+  to: (subject: string) => string,
+  subject: string
+): string {
+  return text.replace(pattern, (match) => {
+    const replacement = to(subject);
+    return /^[A-ZÀ-Ý]/.test(match)
+      ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+      : replacement;
+  });
+}
+
+/**
+ * Removes formulations that cast the reader as a participant in the vote
+ * ("Vous votez sur...", "Vous assistez à un vote...", "Votre vote..."). Exported
+ * so existing stored impacts can be repaired without a model call.
+ */
+export function neutralizeReaderAsVoter(text: string, chamber: "AN" | "SENAT"): string {
+  const subject = chamber === "SENAT" ? "les sénateurs" : "les députés";
+  let result = text;
+  for (const { pattern, to } of READER_AS_VOTER_REWRITES) {
+    result = rewritePreservingCase(result, pattern, to, subject);
+  }
+  return result;
+}
+
+function sanitizeOutput(text: string, chamber: "AN" | "SENAT"): string {
   let result = text;
   result = result.replace(/https?:\/\/(assemblee|votes|partis|elections|politiques)\//g, "/$1/");
   result = result.replace(/\]\(\((\/.+?)\)\)/g, "]($1)");
+  result = neutralizeReaderAsVoter(result, chamber);
   return result;
 }
 


### PR DESCRIPTION
## Description

Le prompt de génération des « Ce que ça change pour vous » demandait de « vouvoyer le lecteur avec vous », ce que le modèle a interprété comme un mandat pour placer le lecteur dans l'hémicycle. Les pages produites en prod contenaient des accroches du type « Vous votez sur une loi d'urgence... » ou « Vous assistez à un vote sur... ». Le lecteur est un citoyen qui consulte le compte rendu d'un vote déjà tenu par des parlementaires : il ne l'a ni voté ni y a assisté.

**Correctif du prompt** (`src/services/scrutin-citizen-impact.ts`) :
- Remplace la règle de vouvoiement générique par une section « QUI EST LE LECTEUR » explicite.
- Ajoute `neutralizeReaderAsVoter()`, une réécriture déterministe (sans appel modèle) appliquée à chaque génération, exportée pour réparer les impacts déjà stockés.
- Couvre les relatives (« que/sur lequel vous avez voté ») et « que vous examinons » (même bug, verbe différent, grammaire corrigée).

**Revue Codex (chatgpt-codex-connector) et correctif de sécurisation** — deux signalements légitimes sur les patterns trop larges, dont l'investigation a révélé un incident de bien plus grande ampleur :
- Le pattern nu `vous votez` (sans « sur »), ajouté dans une itération intermédiaire, avait corrompu **745 lignes de production** — la formulation pédagogique très répandue « Vous votez chaque année le budget de l'État à travers vos représentants » (639 lignes) transformée en tournure circulaire absurde, plus l'élection municipale (87 lignes) et la participation à des rassemblements publics (19 lignes).
- Toutes restaurées via une réversion ciblée et vérifiées : la fonction corrigée est maintenant sans effet sur les 765 lignes restantes contenant ces formulations (point fixe stable, 0 changement).
- `vous assistez à` / `vous participez à` / `votre vote` sont maintenant ancrés à un objet parlementaire explicite (vote/scrutin/débat/examen/adoption/séance/procédure) au lieu d'un remplacement inconditionnel.
- `vous avez voté pour/contre X` (sans « sur ») est maintenant couvert sans réintroduire le problème ci-dessus.

**Script de backfill** (`scripts/backfill-citizen-impact-reader-role.ts`) : réécrit les `citizenImpact` déjà en base via `neutralizeReaderAsVoter`. Report-only par défaut, `--apply` gardé derrière `--confirm-production`.

**Backfill exécuté et vérifié contre la production** (projet Supabase `bdhyuvtrnmaywojftntr`) :
- Passe 1 : 2983 lignes réécrites sur 3011 candidates (préfiltre large).
- Passe 2 (suite à la revue Codex) : 745 lignes restaurées après identification de la sur-correction, 0 ligne restante nécessitant un changement.

## Type de changement

- [x] Bug fix

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur (warnings préexistants uniquement, sans rapport avec ce diff)
- [x] `npm run typecheck` passe sans erreur
- [x] Les changements sont testés (21 tests unitaires sur `neutralizeReaderAsVoter`/`SYSTEM_PROMPT`, suite complète verte)
- [ ] La documentation est mise à jour (non applicable)
- [x] Pas de données sensibles dans le code

## Plan de test

- [x] `npm run typecheck`
- [x] `npx vitest run` (suite complète, 0 échec)
- [x] `npm run lint` (0 erreur)
- [x] Backfill de production exécuté, corrigé suite à revue, et re-vérifié (fonction stable, 0 ligne restante à changer)
