### PR TITLE
fix(votes): fiabiliser la participation sénatoriale (#722)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "visual": "tsx scripts/visual-test-runner.ts",
     "audit:affairs": "tsx scripts/audit-affairs.ts",
     "audit:senateurs-series": "tsx scripts/audit-senateurs-series.ts",
+    "audit:senate-participation": "tsx scripts/audit-senate-participation.ts",
     "senat:capture-composition": "tsx scripts/capture-senate-composition.ts",
     "audit:compliance": "tsx scripts/audit-affairs-compliance.ts",
     "remediate:unverified": "tsx scripts/remediate-unverified-published-affairs.ts",

--- a/prisma/migrations/20260827120000_add_vote_source_completeness/migration.sql
+++ b/prisma/migrations/20260827120000_add_vote_source_completeness/migration.sql
@@ -1,0 +1,53 @@
+-- CreateEnum
+CREATE TYPE "IndividualVoteDataStatus" AS ENUM (
+  'UNVERIFIED',
+  'COMPLETE',
+  'INCOMPLETE',
+  'INVALID'
+);
+
+-- AlterTable
+ALTER TABLE "PoliticianParticipation"
+ADD COLUMN "computationVersion" TEXT;
+
+-- CreateTable
+CREATE TABLE "ScrutinVoteImport" (
+  "id" TEXT NOT NULL,
+  "scrutinId" TEXT NOT NULL,
+  "sourceUrl" TEXT NOT NULL,
+  "fetchedAt" TIMESTAMP(3) NOT NULL,
+  "expectedCount" INTEGER NOT NULL,
+  "observedCount" INTEGER NOT NULL,
+  "resolvedCount" INTEGER NOT NULL,
+  "sourceHash" TEXT NOT NULL,
+  "status" "IndividualVoteDataStatus" NOT NULL DEFAULT 'UNVERIFIED',
+  "statusReason" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "ScrutinVoteImport_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ScrutinVoteImport_counts_check" CHECK (
+    "expectedCount" >= 0
+    AND "observedCount" >= 0
+    AND "resolvedCount" >= 0
+    AND "resolvedCount" <= "observedCount"
+  ),
+  CONSTRAINT "ScrutinVoteImport_complete_check" CHECK (
+    "status" <> 'COMPLETE'
+    OR ("observedCount" = "expectedCount" AND "statusReason" IS NULL)
+  )
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScrutinVoteImport_scrutinId_key" ON "ScrutinVoteImport"("scrutinId");
+
+-- CreateIndex
+CREATE INDEX "ScrutinVoteImport_status_idx" ON "ScrutinVoteImport"("status");
+
+-- AddForeignKey
+ALTER TABLE "ScrutinVoteImport"
+ADD CONSTRAINT "ScrutinVoteImport_scrutinId_fkey"
+FOREIGN KEY ("scrutinId") REFERENCES "Scrutin"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Internal audit data is not exposed through the Supabase Data API.
+ALTER TABLE "ScrutinVoteImport" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -958,7 +958,8 @@ model Scrutin {
   votesHash String?
 
   // Relations
-  votes               Vote[]
+  votes                 Vote[]
+  individualVotesImport ScrutinVoteImport?
   dossierLegislatifId String?
   dossierLegislatif   LegislativeDossier? @relation(fields: [dossierLegislatifId], references: [id])
 
@@ -1017,6 +1018,26 @@ model Vote {
   // (Issue #377): index-only scan, drops the JOIN on Scrutin. Created in prod via
   // CREATE INDEX CONCURRENTLY.
   @@index([politicianId, scrutinType, votingDate(sort: Desc)])
+}
+
+/// Provenance and completeness of the official nominative vote source.
+/// Internal-only: individual identity coverage is recorded separately from official completeness.
+model ScrutinVoteImport {
+  id            String   @id @default(cuid())
+  scrutinId     String   @unique
+  scrutin       Scrutin  @relation(fields: [scrutinId], references: [id], onDelete: Cascade)
+  sourceUrl     String
+  fetchedAt     DateTime
+  expectedCount Int
+  observedCount Int
+  resolvedCount Int
+  sourceHash    String
+  status        IndividualVoteDataStatus @default(UNVERIFIED)
+  statusReason  String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([status])
 }
 
 model ScrutinImportance {
@@ -1110,6 +1131,13 @@ enum VotePosition {
   ABSTENTION
   NON_VOTANT
   ABSENT
+}
+
+enum IndividualVoteDataStatus {
+  UNVERIFIED
+  COMPLETE
+  INCOMPLETE
+  INVALID
 }
 
 enum VotingResult {
@@ -2167,6 +2195,7 @@ model PoliticianParticipation {
   votesCount        Int
   eligibleScrutins  Int
   participationRate Float // 0-100, pre-computed
+  computationVersion String?
 
   // Denormalized display fields (avoid JOINs in read queries)
   firstName      String

--- a/scripts/audit-senate-participation.ts
+++ b/scripts/audit-senate-participation.ts
@@ -1,0 +1,74 @@
+/**
+ * Read-only production validation for Senate public-scrutin participation.
+ *
+ * This script never writes candidates or enables a public reader. It reports source
+ * completeness, per-senator coverage, aggregate parity, and the fail-closed state.
+ */
+
+import "dotenv/config";
+import { db } from "@/lib/db";
+import { aggregateSenateParticipation } from "@/lib/votes/senate-participation";
+import { PARTICIPATION_METHOD_VERSION } from "@/lib/votes/participation-publication";
+import { computeSenateParticipationAuditRows } from "@/services/senate-participation-audit";
+
+async function main() {
+  const [statusCounts, rows, persistedSenateRows, senateSnapshots] = await Promise.all([
+    db.scrutinVoteImport.groupBy({
+      by: ["status"],
+      where: { scrutin: { chamber: "SENAT" } },
+      _count: true,
+    }),
+    computeSenateParticipationAuditRows(),
+    db.politicianParticipation.count({ where: { chamber: "SENAT" } }),
+    db.statsSnapshot.findMany({
+      where: { key: { in: ["party-participation-SENAT", "group-participation-SENAT"] } },
+      select: { key: true, data: true },
+    }),
+  ]);
+
+  const candidates = rows.flatMap((row) => (row.candidate ? [row.candidate] : []));
+  const neutralized = rows.filter((row) => row.candidate === null);
+  const partyAggregates = aggregateSenateParticipation(candidates, "party");
+  const groupAggregates = aggregateSenateParticipation(candidates, "group");
+  const nonEmptySenateSnapshots = senateSnapshots.filter(
+    (snapshot) => Array.isArray(snapshot.data) && snapshot.data.length > 0
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        methodVersion: PARTICIPATION_METHOD_VERSION,
+        sourceCompleteness: statusCounts.map((row) => ({
+          status: row.status,
+          count: row._count,
+        })),
+        individualCoverage: {
+          evaluated: rows.length,
+          candidates: candidates.length,
+          neutralized: neutralized.length,
+          neutralizedPoliticianIds: neutralized.map((row) => row.politicianId),
+        },
+        aggregateParity: {
+          partyMembers: partyAggregates.reduce((sum, row) => sum + row.memberCount, 0),
+          groupMembers: groupAggregates.reduce((sum, row) => sum + row.memberCount, 0),
+          partyAggregates: partyAggregates.length,
+          groupAggregates: groupAggregates.length,
+        },
+        failClosed: {
+          persistedSenateRows,
+          nonEmptySenateSnapshots: nonEmptySenateSnapshots.map((snapshot) => snapshot.key),
+          valid: persistedSenateRows === 0 && nonEmptySenateSnapshots.length === 0,
+        },
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/__tests__/architecture/participation-publication.test.ts
+++ b/src/__tests__/architecture/participation-publication.test.ts
@@ -35,6 +35,17 @@ describe("architecture de publication de la participation", () => {
     expect(producer).toContain("HAVING COUNT(*) = 1");
     expect(producer).toContain("COUNT(*) FILTER (WHERE m.type = 'DEPUTE'::\"MandateType\") = 1");
     expect(producer).not.toMatch(/ROUND\([^)]*participationRate/);
+    expect(producer).toContain("computationVersion: PARTICIPATION_METHOD_VERSION");
+  });
+
+  it("valide la source nominative Sénat avant toute réécriture locale", () => {
+    const source = withoutComments(readFileSync("src/services/sync/scrutins-senat.ts", "utf8"));
+
+    expect(source).toContain("assessSenateVoteSource(votes, officialTotals)");
+    expect(source).toContain('sourceAssessment.status !== "COMPLETE"');
+    expect(source).toContain("mapSenateVotePosition(vote.vote)");
+    expect(source).toContain('status: "COMPLETE"');
+    expect(source).not.toMatch(/default:\s*return\s+["']ABSENT["']/);
   });
 
   it("la frontière API réutilise le service fail-closed sans recalcul local", () => {
@@ -93,6 +104,11 @@ describe("architecture de publication de la participation", () => {
       .filter(([, source]) => /(?:party|group)-participation/.test(source));
 
     expect(consumers).toEqual([]);
+
+    const producer = withoutComments(readFileSync("src/services/sync/compute-stats.ts", "utf8"));
+    expect(producer).toContain('key: { in: ["party-participation-SENAT"');
+    expect(producer).not.toContain('upsertStatsSnapshot("party-participation-SENAT"');
+    expect(producer).not.toContain('upsertStatsSnapshot("group-participation-SENAT"');
   });
 
   it("utilise des comptages Prisma explicites pour les résultats par chambre", () => {

--- a/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
+++ b/src/app/elections/senatoriales-2026/_components/CommuneLookup.tsx
@@ -392,12 +392,12 @@ function SenatorsList({ senators, where }: { senators: SittingSenator[]; where: 
           </li>
         ))}
       </ul>
-      {/* One discreet line for an absence that applies to the whole section, per the
-          MissingData pattern: senator vote participation is not shown because 323 of
-          339 sit at exactly 100 %, the Senate scrutin import recording no absences. */}
+      {/* One discreet line for an unavailable metric that applies to the whole section.
+          Public cutover waits for production validation of source and identity coverage. */}
       <p className="text-xs text-muted-foreground">
-        La participation aux scrutins n{"'"}est pas affichée pour les sénateurs : les données dont
-        nous disposons ne distinguent pas encore les absences.
+        La participation aux scrutins publics n{"'"}est pas affichée pour les sénateurs pendant la
+        validation de la complétude des listes officielles et des identités reliées. Elle ne mesure
+        pas la présence physique.
       </p>
     </div>
   );

--- a/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
+++ b/src/app/elections/senatoriales-2026/_components/__tests__/CommuneLookup.test.tsx
@@ -244,7 +244,7 @@ describe("CommuneLookup : département renouvelable", () => {
     expect(screen.queryByText(/sénatrice depuis|sénateur depuis/i)).toBeNull();
     expect(screen.queryByText(/Participation\s*\d/)).toBeNull();
     expect(
-      screen.getByText(/La participation aux scrutins n'est pas affichée/)
+      screen.getByText(/La participation aux scrutins publics n'est pas affichée/)
     ).toBeInTheDocument();
   });
 });

--- a/src/components/stats/ParticipationSection.test.tsx
+++ b/src/components/stats/ParticipationSection.test.tsx
@@ -8,7 +8,8 @@ describe("statistiques de participation", () => {
       <ParticipationSection groupDissidenceAN={[]} groupDissidenceSENAT={[]} chamber="SENAT" />
     );
 
-    expect(screen.getByText(/Le Sénat ne publie pas actuellement/)).toBeInTheDocument();
+    expect(screen.getByText(/reste indisponible pendant la validation/)).toBeInTheDocument();
+    expect(screen.getByText(/Elle ne mesure jamais la présence physique/)).toBeInTheDocument();
     expect(screen.getByText(/Aucun classement, taux moyen ou taux par parti/)).toBeInTheDocument();
     expect(screen.queryByText(/\d+\s*%/)).not.toBeInTheDocument();
   });

--- a/src/components/stats/ParticipationSection.tsx
+++ b/src/components/stats/ParticipationSection.tsx
@@ -13,7 +13,7 @@ interface ParticipationSectionProps {
 
 function participationNotice(chamber?: Chamber): string {
   if (chamber === "SENAT") {
-    return "Le Sénat ne publie pas actuellement une donnée permettant de mesurer la présence individuelle de façon suffisamment fiable.";
+    return "La participation aux scrutins publics du Sénat reste indisponible pendant la validation de la complétude officielle et des identités reliées. Elle ne mesure jamais la présence physique.";
   }
   return "Les agrégats de participation ne sont pas publiés tant qu'ils ne peuvent pas être dérivés du même périmètre d'éligibilité que l'indicateur individuel.";
 }
@@ -29,7 +29,7 @@ export function ParticipationSection({
 
       <Card className="mb-8">
         <CardHeader>
-          <CardTitle id="participation-heading">Participation aux scrutins</CardTitle>
+          <CardTitle id="participation-heading">Participation aux scrutins publics</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">{participationNotice(chamber)}</p>
@@ -70,8 +70,10 @@ export function ParticipationSection({
               méthode supportée et au moins un scrutin éligible.
             </p>
             <p>
-              Les positions pour, contre et abstention alimentent le numérateur. NON_VOTANT ne
-              constitue pas une preuve de présence.
+              Pour le Sénat, les positions pour, contre et abstention alimentent le numérateur. Le
+              dénominateur ajoute NON_VOTANT, uniquement sur les scrutins dont la liste nominative
+              est officiellement complète et pendant le mandat. NON_VOTANT signifie « n&apos;a pas
+              pris part au vote », pas une absence physique.
             </p>
           </div>
         }

--- a/src/components/stats/StatsTabs.tsx
+++ b/src/components/stats/StatsTabs.tsx
@@ -68,7 +68,7 @@ function StatsTabsInner({
         </TabsTrigger>
         <TabsTrigger value="participation">
           <BarChart3 className="h-4 w-4" />
-          <span className="hidden sm:inline">Participation</span>
+          <span className="hidden sm:inline">Participation aux scrutins publics</span>
           <span className="sm:hidden">Votes</span>
         </TabsTrigger>
       </TabsList>

--- a/src/lib/votes/__tests__/senate-participation.test.ts
+++ b/src/lib/votes/__tests__/senate-participation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateSenateParticipation,
+  assessSenateVoteSource,
+  computeSenateParticipationCandidate,
+  mapSenateVotePosition,
+  type SenateSourceVote,
+} from "@/lib/votes/senate-participation";
+
+const votes: SenateSourceVote[] = [
+  { matricule: "A", vote: "p", siege: 1 },
+  { matricule: "B", vote: "c", siege: 2 },
+  { matricule: "C", vote: "a", siege: 3 },
+  { matricule: "D", vote: "n", siege: 4 },
+];
+
+const official = {
+  voters: 3,
+  nonVoters: 1,
+  votesFor: 1,
+  votesAgainst: 1,
+  votesAbstain: 1,
+};
+
+describe("source nominative des scrutins publics du Sénat", () => {
+  it("valide la liste complète par rapport aux totaux officiels", () => {
+    expect(assessSenateVoteSource(votes, official)).toEqual({
+      status: "COMPLETE",
+      expectedCount: 4,
+      observedCount: 4,
+      reason: null,
+    });
+  });
+
+  it("refuse tout code inconnu au lieu de le convertir en ABSENT", () => {
+    expect(assessSenateVoteSource([{ ...votes[0]!, vote: "x" }], official)).toMatchObject({
+      status: "INVALID",
+      reason: "unknown_vote_code:x",
+    });
+    expect(() => mapSenateVotePosition("x")).toThrow("Code de vote Sénat inconnu");
+  });
+
+  it("refuse une ligne JSON mal formée", () => {
+    const malformed = [{ ...votes[0]!, matricule: "" }, ...votes.slice(1)];
+    expect(assessSenateVoteSource(malformed, official)).toMatchObject({
+      status: "INVALID",
+      reason: "vote_row_invalid",
+    });
+  });
+
+  it.each([
+    [[...votes.slice(0, 3)], "row_count_mismatch"],
+    [[...votes, { matricule: "A", vote: "p", siege: 5 }], "duplicate_identity"],
+    [[...votes, { matricule: "E", vote: "p", siege: 4 }], "duplicate_identity"],
+  ] as const)("neutralise une liste incomplète ou ambiguë", (sourceVotes, reason) => {
+    expect(assessSenateVoteSource([...sourceVotes], official)).toMatchObject({ reason });
+  });
+
+  it("contrôle aussi la parité de chaque position avec la page officielle", () => {
+    expect(assessSenateVoteSource(votes, { ...official, votesFor: 2 })).toMatchObject({
+      status: "INCOMPLETE",
+      reason: "totals_mismatch",
+    });
+  });
+});
+
+describe("parité des agrégats sénatoriaux candidats", () => {
+  it("calcule groupes et snapshots à partir des mêmes taux individuels", () => {
+    const rows = [50, 75, 100].map((participationRate, index) => ({
+      votesCount: index + 1,
+      eligibleScrutins: 4,
+      participationRate,
+      partyId: "party-1",
+      partyName: "Parti test",
+      partyShortName: "PT",
+      partyColor: null,
+      partySlug: "parti-test",
+      groupId: "group-1",
+      groupName: "Groupe test",
+      groupCode: "GT",
+      groupColor: null,
+    }));
+
+    expect(aggregateSenateParticipation(rows, "party")[0]).toMatchObject({
+      id: "party-1",
+      avgParticipationRate: 75,
+      memberCount: 3,
+    });
+    expect(aggregateSenateParticipation(rows, "group")[0]).toMatchObject({
+      id: "group-1",
+      avgParticipationRate: 75,
+      memberCount: 3,
+    });
+  });
+});
+
+describe("candidat de participation sénatoriale", () => {
+  it("utilise POUR + CONTRE + ABSTENTION sur ces positions plus NON_VOTANT", () => {
+    expect(
+      computeSenateParticipationCandidate({
+        expressed: 3,
+        nonVoting: 1,
+        eligibleScrutins: 4,
+        recordedRows: 4,
+      })
+    ).toEqual({ votesCount: 3, eligibleScrutins: 4, participationRate: 75 });
+  });
+
+  it.each([
+    { expressed: 2, nonVoting: 1, eligibleScrutins: 4, recordedRows: 3 },
+    { expressed: 2, nonVoting: 1, eligibleScrutins: 4, recordedRows: 4 },
+    { expressed: 0, nonVoting: 0, eligibleScrutins: 0, recordedRows: 0 },
+  ])("neutralise une identité ou un périmètre incomplet", (counts) => {
+    expect(computeSenateParticipationCandidate(counts)).toBeNull();
+  });
+});

--- a/src/lib/votes/participation-publication.ts
+++ b/src/lib/votes/participation-publication.ts
@@ -1,5 +1,7 @@
 import type { Chamber, MandateType } from "@/generated/prisma";
 
+export const PARTICIPATION_METHOD_VERSION = "public-scrutins-v2";
+
 export const PARTICIPATION_SOURCE_INSUFFICIENT = "SOURCE_INSUFFICIENT" as const;
 export const PARTICIPATION_AVAILABLE = "AVAILABLE" as const;
 export const PARTICIPATION_COMPUTATION_INCOMPLETE = "COMPUTATION_INCOMPLETE" as const;

--- a/src/lib/votes/senate-participation.ts
+++ b/src/lib/votes/senate-participation.ts
@@ -1,0 +1,225 @@
+import type { VotePosition } from "@/generated/prisma";
+import { PARTICIPATION_METHOD_VERSION } from "@/lib/votes/participation-publication";
+
+export const SENATE_VOTE_SOURCE_CODES = ["p", "c", "a", "n"] as const;
+export type SenateVoteSourceCode = (typeof SENATE_VOTE_SOURCE_CODES)[number];
+
+export interface SenateSourceVote {
+  matricule: string;
+  vote: string;
+  siege: number;
+}
+
+export interface SenateOfficialVoteTotals {
+  voters: number;
+  nonVoters: number;
+  votesFor: number;
+  votesAgainst: number;
+  votesAbstain: number;
+}
+
+export interface SenateVoteSourceAssessment {
+  status: "COMPLETE" | "INCOMPLETE" | "INVALID";
+  expectedCount: number;
+  observedCount: number;
+  reason: string | null;
+}
+
+const POSITION_BY_CODE: Record<SenateVoteSourceCode, VotePosition> = {
+  p: "POUR",
+  c: "CONTRE",
+  a: "ABSTENTION",
+  n: "NON_VOTANT",
+};
+
+export function isSenateVoteSourceCode(code: unknown): code is SenateVoteSourceCode {
+  return (
+    typeof code === "string" &&
+    (SENATE_VOTE_SOURCE_CODES as readonly string[]).includes(code.toLowerCase())
+  );
+}
+
+/** Strict mapping: an unknown official code must never become an absence. */
+export function mapSenateVotePosition(code: string): VotePosition {
+  const normalized = code.toLowerCase();
+  if (!isSenateVoteSourceCode(normalized)) {
+    throw new Error(`Code de vote Sénat inconnu: ${code}`);
+  }
+  return POSITION_BY_CODE[normalized];
+}
+
+/**
+ * Validate the nominative JSON against the totals published on the official HTML page.
+ * `nonVoters` means "n'a pas pris part au vote", never physical absence.
+ */
+export function assessSenateVoteSource(
+  votes: SenateSourceVote[],
+  official: SenateOfficialVoteTotals
+): SenateVoteSourceAssessment {
+  const expectedCount = official.voters + official.nonVoters;
+  const observedCount = votes.length;
+
+  if (
+    !Number.isInteger(expectedCount) ||
+    expectedCount <= 0 ||
+    Object.values(official).some((value) => !Number.isInteger(value) || value < 0)
+  ) {
+    return { status: "INVALID", expectedCount, observedCount, reason: "official_totals_invalid" };
+  }
+
+  const malformedVote = votes.find(
+    (vote) =>
+      typeof vote.matricule !== "string" ||
+      vote.matricule.trim() === "" ||
+      !Number.isInteger(vote.siege) ||
+      vote.siege <= 0 ||
+      typeof vote.vote !== "string"
+  );
+  if (malformedVote) {
+    return { status: "INVALID", expectedCount, observedCount, reason: "vote_row_invalid" };
+  }
+
+  const unknownCode = votes.find((vote) => !isSenateVoteSourceCode(vote.vote));
+  if (unknownCode) {
+    return {
+      status: "INVALID",
+      expectedCount,
+      observedCount,
+      reason: `unknown_vote_code:${unknownCode.vote}`,
+    };
+  }
+
+  const uniqueMatricules = new Set(votes.map((vote) => vote.matricule));
+  const uniqueSeats = new Set(votes.map((vote) => vote.siege));
+  if (uniqueMatricules.size !== observedCount || uniqueSeats.size !== observedCount) {
+    return { status: "INVALID", expectedCount, observedCount, reason: "duplicate_identity" };
+  }
+
+  if (observedCount !== expectedCount) {
+    return { status: "INCOMPLETE", expectedCount, observedCount, reason: "row_count_mismatch" };
+  }
+
+  const counts = { p: 0, c: 0, a: 0, n: 0 };
+  for (const vote of votes) counts[vote.vote.toLowerCase() as SenateVoteSourceCode]++;
+
+  if (
+    counts.p !== official.votesFor ||
+    counts.c !== official.votesAgainst ||
+    counts.a !== official.votesAbstain ||
+    counts.p + counts.c + counts.a !== official.voters ||
+    counts.n !== official.nonVoters
+  ) {
+    return { status: "INCOMPLETE", expectedCount, observedCount, reason: "totals_mismatch" };
+  }
+
+  return { status: "COMPLETE", expectedCount, observedCount, reason: null };
+}
+
+export interface SenateParticipationCounts {
+  expressed: number;
+  nonVoting: number;
+  eligibleScrutins: number;
+  recordedRows: number;
+}
+
+export interface SenateParticipationCandidate {
+  votesCount: number;
+  eligibleScrutins: number;
+  participationRate: number;
+}
+
+export interface SenateParticipationAggregateInput extends SenateParticipationCandidate {
+  partyId: string | null;
+  partyName: string | null;
+  partyShortName: string | null;
+  partyColor: string | null;
+  partySlug: string | null;
+  groupId: string | null;
+  groupName: string | null;
+  groupCode: string | null;
+  groupColor: string | null;
+}
+
+export interface SenateParticipationAggregate {
+  id: string;
+  name: string;
+  shortName: string;
+  color: string | null;
+  slug: string | null;
+  avgParticipationRate: number;
+  memberCount: number;
+  computationVersion: string;
+}
+
+/**
+ * Return a candidate only when every officially complete eligible scrutin has one
+ * mapped row for this senator. Missing identity coverage stays unknown, never 0%.
+ */
+export function computeSenateParticipationCandidate(
+  counts: SenateParticipationCounts
+): SenateParticipationCandidate | null {
+  const { expressed, nonVoting, eligibleScrutins, recordedRows } = counts;
+  if (
+    ![expressed, nonVoting, eligibleScrutins, recordedRows].every(
+      (value) => Number.isInteger(value) && value >= 0
+    ) ||
+    eligibleScrutins <= 0 ||
+    recordedRows !== eligibleScrutins ||
+    expressed + nonVoting !== recordedRows
+  ) {
+    return null;
+  }
+
+  return {
+    votesCount: expressed,
+    eligibleScrutins,
+    participationRate: Math.round((expressed / eligibleScrutins) * 100),
+  };
+}
+
+export function aggregateSenateParticipation(
+  rows: SenateParticipationAggregateInput[],
+  dimension: "party" | "group"
+): SenateParticipationAggregate[] {
+  const aggregates = new Map<
+    string,
+    {
+      name: string;
+      shortName: string;
+      color: string | null;
+      slug: string | null;
+      rates: number[];
+    }
+  >();
+
+  for (const row of rows) {
+    const id = dimension === "party" ? row.partyId : row.groupId;
+    if (!id) continue;
+    const current = aggregates.get(id) ?? {
+      name: (dimension === "party" ? row.partyName : row.groupName) ?? "",
+      shortName: (dimension === "party" ? row.partyShortName : row.groupCode) ?? "",
+      color: dimension === "party" ? row.partyColor : row.groupColor,
+      slug: dimension === "party" ? row.partySlug : null,
+      rates: [],
+    };
+    current.rates.push(row.participationRate);
+    aggregates.set(id, current);
+  }
+
+  return [...aggregates.entries()]
+    .filter(([, aggregate]) => aggregate.rates.length >= 3)
+    .map(([id, aggregate]) => ({
+      id,
+      name: aggregate.name,
+      shortName: aggregate.shortName,
+      color: aggregate.color,
+      slug: aggregate.slug,
+      avgParticipationRate:
+        Math.round(
+          (aggregate.rates.reduce((sum, rate) => sum + rate, 0) / aggregate.rates.length) * 10
+        ) / 10,
+      memberCount: aggregate.rates.length,
+      computationVersion: PARTICIPATION_METHOD_VERSION,
+    }))
+    .sort((a, b) => a.avgParticipationRate - b.avgParticipationRate || a.id.localeCompare(b.id));
+}

--- a/src/services/__tests__/senate-participation-audit.test.ts
+++ b/src/services/__tests__/senate-participation-audit.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({ $queryRaw: vi.fn() }));
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+
+import { computeSenateParticipationAuditRows } from "@/services/senate-participation-audit";
+
+function rawRow(recordedRows: number) {
+  return {
+    politicianId: `senator-${recordedRows}`,
+    firstName: "Sénatrice",
+    lastName: "Test",
+    partyId: null,
+    partyName: null,
+    partyShortName: null,
+    partyColor: null,
+    partySlug: null,
+    groupId: null,
+    groupName: null,
+    groupCode: null,
+    groupColor: null,
+    identityComplete: true,
+    expressed: 3,
+    nonVoting: recordedRows - 3,
+    totalScrutins: 4,
+    eligibleScrutins: 4,
+    recordedRows,
+  };
+}
+
+describe("audit en lecture seule de la participation sénatoriale", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("produit un candidat uniquement avec une couverture individuelle complète", async () => {
+    dbMock.$queryRaw.mockResolvedValue([rawRow(4), rawRow(3)]);
+
+    const rows = await computeSenateParticipationAuditRows();
+
+    expect(rows[0]?.candidate).toMatchObject({
+      votesCount: 3,
+      eligibleScrutins: 4,
+      participationRate: 75,
+    });
+    expect(rows[1]?.candidate).toBeNull();
+  });
+
+  it("neutralise un sénateur dont l'identité Sénat n'est pas reliée", async () => {
+    dbMock.$queryRaw.mockResolvedValue([{ ...rawRow(4), identityComplete: false }]);
+
+    const rows = await computeSenateParticipationAuditRows();
+
+    expect(rows[0]?.candidate).toBeNull();
+  });
+
+  it("neutralise une période de mandat contenant un scrutin non vérifié", async () => {
+    dbMock.$queryRaw.mockResolvedValue([{ ...rawRow(4), totalScrutins: 5 }]);
+
+    const rows = await computeSenateParticipationAuditRows();
+
+    expect(rows[0]?.candidate).toBeNull();
+  });
+});

--- a/src/services/senate-participation-audit.ts
+++ b/src/services/senate-participation-audit.ts
@@ -1,0 +1,117 @@
+import { db } from "@/lib/db";
+import {
+  computeSenateParticipationCandidate,
+  type SenateParticipationAggregateInput,
+} from "@/lib/votes/senate-participation";
+
+interface RawSenateParticipationRow {
+  politicianId: string;
+  firstName: string;
+  lastName: string;
+  partyId: string | null;
+  partyName: string | null;
+  partyShortName: string | null;
+  partyColor: string | null;
+  partySlug: string | null;
+  groupId: string | null;
+  groupName: string | null;
+  groupCode: string | null;
+  groupColor: string | null;
+  identityComplete: boolean;
+  expressed: number;
+  nonVoting: number;
+  totalScrutins: number;
+  eligibleScrutins: number;
+  recordedRows: number;
+}
+
+export interface SenateParticipationAuditRow extends RawSenateParticipationRow {
+  candidate: SenateParticipationAggregateInput | null;
+}
+
+/**
+ * Read-only candidate computation. It is intentionally separate from every public
+ * reader and persistent producer until production validation authorizes a cutover.
+ */
+export async function computeSenateParticipationAuditRows(): Promise<
+  SenateParticipationAuditRow[]
+> {
+  const rows = await db.$queryRaw<RawSenateParticipationRow[]>`
+    WITH unambiguous_current_senators AS (
+      SELECT m."politicianId", MIN(m.id) AS "mandateId"
+      FROM "Mandate" m
+      WHERE m."isCurrent" = true
+        AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
+      GROUP BY m."politicianId"
+      HAVING COUNT(*) = 1
+        AND COUNT(*) FILTER (WHERE m.type = 'SENATEUR'::"MandateType") = 1
+    )
+    SELECT
+      pol.id AS "politicianId",
+      pol."firstName",
+      pol."lastName",
+      p.id AS "partyId",
+      p.name AS "partyName",
+      p."shortName" AS "partyShortName",
+      p.color AS "partyColor",
+      p.slug AS "partySlug",
+      pg.id AS "groupId",
+      pg.name AS "groupName",
+      pg.code AS "groupCode",
+      pg.color AS "groupColor",
+      EXISTS (
+        SELECT 1
+        FROM "ExternalId" eid
+        WHERE eid."politicianId" = pol.id
+          AND eid.source = 'SENAT'::"DataSource"
+      ) AS "identityComplete",
+      COUNT(v.id) FILTER (
+        WHERE v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
+      )::int AS expressed,
+      COUNT(v.id) FILTER (WHERE v.position = 'NON_VOTANT')::int AS "nonVoting",
+      COUNT(s.id)::int AS "totalScrutins",
+      COUNT(s.id) FILTER (WHERE svi.status = 'COMPLETE')::int AS "eligibleScrutins",
+      COUNT(v.id)::int AS "recordedRows"
+    FROM unambiguous_current_senators scope
+    JOIN "Mandate" m ON m.id = scope."mandateId"
+    JOIN "Politician" pol ON pol.id = m."politicianId"
+    LEFT JOIN "Party" p ON p.id = pol."currentPartyId"
+    LEFT JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
+    LEFT JOIN "ParliamentaryGroup" pg ON pg.id = mp."parliamentaryGroupId"
+    LEFT JOIN "Scrutin" s ON s.chamber = 'SENAT'::"Chamber"
+      AND s."votingDate" >= m."startDate"
+      AND (m."endDate" IS NULL OR s."votingDate" <= m."endDate")
+    LEFT JOIN "ScrutinVoteImport" svi ON svi."scrutinId" = s.id
+    LEFT JOIN "Vote" v ON v."scrutinId" = s.id
+      AND v."politicianId" = pol.id
+      AND svi.status = 'COMPLETE'::"IndividualVoteDataStatus"
+    WHERE pol."publicationStatus" = 'PUBLISHED'
+    GROUP BY pol.id, p.id, pg.id
+    ORDER BY pol.id
+  `;
+
+  return rows.map((row) => {
+    const sourcePeriodComplete = row.totalScrutins === row.eligibleScrutins;
+    const computed =
+      row.identityComplete && sourcePeriodComplete
+        ? computeSenateParticipationCandidate(row)
+        : null;
+    return {
+      ...row,
+      candidate: computed
+        ? {
+            ...computed,
+            partyId: row.partyId,
+            partyName: row.partyName,
+            partyShortName: row.partyShortName,
+            partyColor: row.partyColor,
+            partySlug: row.partySlug,
+            groupId: row.groupId,
+            groupName: row.groupName,
+            groupCode: row.groupCode,
+            groupColor: row.groupColor,
+          }
+        : null,
+    };
+  });
+}

--- a/src/services/sync/__tests__/compute-stats.participation.test.ts
+++ b/src/services/sync/__tests__/compute-stats.participation.test.ts
@@ -79,7 +79,11 @@ describe("producteur persistant de participation", () => {
     const result = await computePoliticianParticipation();
 
     expect(
-      result.map(({ politicianId, participationRate }) => [politicianId, participationRate])
-    ).toEqual(cases.map(([id, , , expected]) => [id, expected]));
+      result.map(({ politicianId, participationRate, computationVersion }) => [
+        politicianId,
+        participationRate,
+        computationVersion,
+      ])
+    ).toEqual(cases.map(([id, , , expected]) => [id, expected, "public-scrutins-v2"]));
   });
 });

--- a/src/services/sync/__tests__/scrutins-senat.test.ts
+++ b/src/services/sync/__tests__/scrutins-senat.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { parseScrutinMetadata } from "@/services/sync/scrutins-senat";
+
+describe("import des scrutins publics du Sénat", () => {
+  it("extrait le total de contrôle officiel sans supposer 348 sièges", () => {
+    const html = `
+      <p class="page-lead">Projet de loi de test</p>
+      <p>Séance du 10 octobre 2024</p>
+      <strong>331</strong> votants
+      <strong>267</strong> suffrages exprimés
+      <strong>34</strong> pour
+      <strong>233</strong> contre
+      Abstention : 64
+      N'ont pas pris part au vote : 16
+      Le Sénat a adopté
+    `;
+
+    expect(parseScrutinMetadata(html, 2024, "1")).toMatchObject({
+      votesFor: 34,
+      votesAgainst: 233,
+      votesAbstain: 64,
+      officialVoters: 331,
+      officialNonVoters: 16,
+      result: "ADOPTED",
+      sourceUrl: "https://www.senat.fr/scrutin-public/2024/scr2024-1.html",
+    });
+  });
+
+  it("laisse les totaux de contrôle absents non démontrés", () => {
+    expect(parseScrutinMetadata("<h1>Scrutin n°2</h1>", 2024, "2")).toMatchObject({
+      officialVoters: null,
+      officialNonVoters: null,
+    });
+  });
+});

--- a/src/services/sync/compute-stats.ts
+++ b/src/services/sync/compute-stats.ts
@@ -21,6 +21,7 @@ import { Prisma } from "@/generated/prisma";
 import type { Chamber, ThemeCategory } from "@/generated/prisma";
 import { THEME_CATEGORY_LABELS, THEME_CATEGORY_ICONS } from "@/config/labels";
 import {
+  PARTICIPATION_METHOD_VERSION,
   resolveCurrentParliamentaryMandate,
   roundParticipationRate,
 } from "@/lib/votes/participation-publication";
@@ -56,9 +57,10 @@ interface PoliticianRow {
   votesCount: number;
   eligibleScrutins: number;
   participationRate: number;
+  computationVersion: string;
 }
 
-type RawPoliticianRow = Omit<PoliticianRow, "participationRate">;
+type RawPoliticianRow = Omit<PoliticianRow, "participationRate" | "computationVersion">;
 
 interface CurrentParliamentaryMandateRow {
   politicianId: string;
@@ -75,6 +77,7 @@ interface PartyAggRow {
   partySlug: string | null;
   avgParticipationRate: number;
   memberCount: number;
+  computationVersion: string;
 }
 
 interface GroupAggRow {
@@ -85,6 +88,7 @@ interface GroupAggRow {
   groupChamber: string;
   avgParticipationRate: number;
   memberCount: number;
+  computationVersion: string;
 }
 
 interface ThemeDistributionRow {
@@ -274,6 +278,7 @@ export async function computePoliticianParticipation(verbose = false): Promise<P
     .map((row) => ({
       ...row,
       participationRate: roundParticipationRate(row.votesCount, row.eligibleScrutins),
+      computationVersion: PARTICIPATION_METHOD_VERSION,
     }));
 
   if (verbose) console.log(`  → ${rows.length} politicians computed`);
@@ -433,6 +438,7 @@ function aggregateByParty(rows: PoliticianRow[]): PartyAggRow[] {
       avgParticipationRate:
         Math.round((v.rates.reduce((a, b) => a + b, 0) / v.rates.length) * 10) / 10,
       memberCount: v.rates.length,
+      computationVersion: PARTICIPATION_METHOD_VERSION,
     }))
     .sort((a, b) => a.avgParticipationRate - b.avgParticipationRate);
 }
@@ -468,6 +474,7 @@ function aggregateByGroup(rows: PoliticianRow[]): GroupAggRow[] {
       avgParticipationRate:
         Math.round((v.rates.reduce((a, b) => a + b, 0) / v.rates.length) * 10) / 10,
       memberCount: v.rates.length,
+      computationVersion: PARTICIPATION_METHOD_VERSION,
     }))
     .sort((a, b) => a.avgParticipationRate - b.avgParticipationRate);
 }
@@ -511,6 +518,7 @@ async function upsertPoliticianParticipation(
               votesCount: r.votesCount,
               eligibleScrutins: r.eligibleScrutins,
               participationRate: r.participationRate,
+              computationVersion: r.computationVersion,
               firstName: r.firstName,
               lastName: r.lastName,
               slug: r.slug,
@@ -788,7 +796,6 @@ export async function computeStats(
 
   await upsertStatsSnapshot("party-participation", anPartyAgg, d1, dryRun, verbose);
   await upsertStatsSnapshot("party-participation-AN", anPartyAgg, d1, dryRun, verbose);
-  await upsertStatsSnapshot("party-participation-SENAT", [], d1, dryRun, verbose);
 
   // 4. Aggregate and persist group participation
   if (verbose) console.log("\n[4/8] Computing group participation aggregates...");
@@ -796,7 +803,15 @@ export async function computeStats(
 
   await upsertStatsSnapshot("group-participation", anGroupAgg, d1, dryRun, verbose);
   await upsertStatsSnapshot("group-participation-AN", anGroupAgg, d1, dryRun, verbose);
-  await upsertStatsSnapshot("group-participation-SENAT", [], d1, dryRun, verbose);
+
+  // Old Senate snapshots must not survive the fail-closed candidate phase.
+  if (!dryRun) {
+    await db.statsSnapshot.deleteMany({
+      where: {
+        key: { in: ["party-participation-SENAT", "group-participation-SENAT"] },
+      },
+    });
+  }
 
   // 4b. Aggregate and persist group dissidence
   if (verbose) console.log("\n[4b/8] Computing group dissidence aggregates...");

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -7,7 +7,7 @@
  */
 
 import { db } from "@/lib/db";
-import { syncMetadata, hashVotes, ProgressTracker } from "@/lib/sync";
+import { syncMetadata, hashContent, hashVotes, ProgressTracker } from "@/lib/sync";
 import { computeGroupPositionsForScrutin } from "@/services/sync/compute-group-positions";
 import { writeVotesForScrutin } from "@/services/sync/scrutins-vote-writer";
 import { HTTPClient } from "@/lib/api/http-client";
@@ -16,6 +16,11 @@ import { generateDateSlug, generateUniqueSlug } from "@/lib/utils";
 import { VotePosition, VotingResult, DataSource, Chamber } from "@/generated/prisma";
 import { classifyScrutinTitle } from "@/lib/scrutin-type";
 import { SENAT_RATE_LIMIT_MS } from "@/config/rate-limits";
+import {
+  assessSenateVoteSource,
+  mapSenateVotePosition,
+  type SenateSourceVote,
+} from "@/lib/votes/senate-participation";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -46,14 +51,10 @@ interface ScrutinMetadata {
   votesFor: number;
   votesAgainst: number;
   votesAbstain: number;
+  officialVoters: number | null;
+  officialNonVoters: number | null;
   result: VotingResult;
   sourceUrl: string;
-}
-
-interface SenatVote {
-  matricule: string;
-  vote: string; // "p" = pour, "c" = contre, "a" = abstention, "n" = non-votant
-  siege: number;
 }
 
 export interface ScrutinsSenatSyncStats {
@@ -96,7 +97,7 @@ async function getScrutinListForSession(session: number): Promise<string[]> {
 /**
  * Parse scrutin metadata from HTML page
  */
-function parseScrutinMetadata(
+export function parseScrutinMetadata(
   html: string,
   session: number,
   number: string
@@ -152,6 +153,10 @@ function parseScrutinMetadata(
     const votesFor = forMatch ? parseInt(forMatch[1]!) : 0;
     const votesAgainst = againstMatch ? parseInt(againstMatch[1]!) : 0;
     const votesAbstain = abstainMatch ? parseInt(abstainMatch[1]!) : 0;
+    const votersMatch = textContent.match(/(\d+)\s+votants/i);
+    const nonVotersMatch = textContent.match(
+      /N['’]ont\s+pas\s+pris\s+part\s+au\s+vote\s*:?\s*(\d+)/i
+    );
 
     // Determine result
     const hasAdoption = /Le\s+Sénat\s+a\s+adopté|a\s+été\s+adopté/i.test(textContent);
@@ -165,6 +170,8 @@ function parseScrutinMetadata(
       votesFor,
       votesAgainst,
       votesAbstain,
+      officialVoters: votersMatch ? parseInt(votersMatch[1]!, 10) : null,
+      officialNonVoters: nonVotersMatch ? parseInt(nonVotersMatch[1]!, 10) : null,
       result,
       sourceUrl: `${BASE_URL}/scrutin-public/${session}/scr${session}-${number}.html`,
     };
@@ -177,35 +184,23 @@ function parseScrutinMetadata(
 /**
  * Fetch individual votes from JSON endpoint
  */
-async function fetchVotesJson(session: number, number: string): Promise<SenatVote[]> {
-  try {
-    const { data } = await senatClient.get<{ votes?: SenatVote[] }>(
-      `/scrutin-public/${session}/scr${session}-${number}.json`,
-      { skipCache: true }
-    );
-    return data.votes || [];
-  } catch (error) {
-    console.error(`Error fetching votes JSON: ${error}`);
-    return [];
+async function fetchVotesJson(session: number, number: string): Promise<SenateSourceVote[]> {
+  const { data } = await senatClient.get<{ votes?: SenateSourceVote[] }>(
+    `/scrutin-public/${session}/scr${session}-${number}.json`,
+    { skipCache: true }
+  );
+  if (!Array.isArray(data.votes)) {
+    throw new Error("Réponse JSON Sénat sans liste de votes");
   }
+  return data.votes;
 }
 
-/**
- * Map Senate vote code to VotePosition
- */
-function mapVotePosition(code: string): VotePosition {
-  switch (code.toLowerCase()) {
-    case "p":
-      return "POUR";
-    case "c":
-      return "CONTRE";
-    case "a":
-      return "ABSTENTION";
-    case "n":
-      return "NON_VOTANT";
-    default:
-      return "ABSENT";
-  }
+function senateVotesSourceUrl(session: number, number: string): string {
+  return `${BASE_URL}/scrutin-public/${session}/scr${session}-${number}.json`;
+}
+
+function hashSenateSourceVotes(votes: SenateSourceVote[]): string {
+  return hashContent(JSON.stringify(votes));
 }
 
 /**
@@ -372,6 +367,27 @@ export async function syncScrutinsSenat(
 
           // Fetch votes JSON
           const votes = await fetchVotesJson(currentSession, number!);
+          const officialTotals =
+            metadata.officialVoters == null || metadata.officialNonVoters == null
+              ? null
+              : {
+                  voters: metadata.officialVoters,
+                  nonVoters: metadata.officialNonVoters,
+                  votesFor: metadata.votesFor,
+                  votesAgainst: metadata.votesAgainst,
+                  votesAbstain: metadata.votesAbstain,
+                };
+          const sourceAssessment = officialTotals
+            ? assessSenateVoteSource(votes, officialTotals)
+            : {
+                status: "INVALID" as const,
+                expectedCount: 0,
+                observedCount: votes.length,
+                reason: "official_totals_missing",
+              };
+          const sourceUrl = senateVotesSourceUrl(currentSession, number!);
+          const sourceHash = hashSenateSourceVotes(votes);
+          const fetchedAt = new Date();
 
           const externalId = `SENAT-${currentSession}-${number}`;
 
@@ -414,7 +430,39 @@ export async function syncScrutinsSenat(
               stats.scrutinsCreated++;
             }
 
-            // Process votes
+            const pendingImport = {
+              sourceUrl,
+              fetchedAt,
+              expectedCount: sourceAssessment.expectedCount,
+              observedCount: sourceAssessment.observedCount,
+              resolvedCount: 0,
+              sourceHash,
+              // COMPLETE is set only after the local vote rewrite succeeds.
+              status:
+                sourceAssessment.status === "COMPLETE"
+                  ? ("INCOMPLETE" as const)
+                  : sourceAssessment.status,
+              statusReason:
+                sourceAssessment.status === "COMPLETE"
+                  ? "pending_local_vote_rewrite"
+                  : sourceAssessment.reason,
+            };
+            await db.scrutinVoteImport.upsert({
+              where: { scrutinId: scrutin.id },
+              create: { scrutinId: scrutin.id, ...pendingImport },
+              update: pendingImport,
+            });
+
+            if (sourceAssessment.status !== "COMPLETE") {
+              stats.scrutinsSkipped++;
+              stats.errors.push(
+                `Session ${currentSession} n°${number}: source nominative ${sourceAssessment.status.toLowerCase()} (${sourceAssessment.reason})`
+              );
+              progress.tick();
+              continue;
+            }
+
+            // Process only validated source rows. Unknown codes cannot reach this mapping.
             const votesToCreate: { politicianId: string; position: VotePosition }[] = [];
 
             for (const vote of votes) {
@@ -422,7 +470,7 @@ export async function syncScrutinsSenat(
               if (politicianId) {
                 votesToCreate.push({
                   politicianId,
-                  position: mapVotePosition(vote.vote),
+                  position: mapSenateVotePosition(vote.vote),
                 });
               } else {
                 stats.senatorsNotFound.add(vote.matricule);
@@ -430,29 +478,35 @@ export async function syncScrutinsSenat(
             }
 
             // Check votes hash to skip unchanged scrutins
-            if (votesToCreate.length > 0) {
-              const newHash = hashVotes(votesToCreate);
+            const newHash = hashVotes(votesToCreate);
 
-              if (scrutin.votesHash === newHash) {
-                stats.votesSkipped += votesToCreate.length;
-              } else {
-                await writeVotesForScrutin({
-                  scrutinId: scrutin.id,
-                  votingDate: scrutin.votingDate,
-                  chamber: scrutin.chamber,
-                  scrutinType: scrutin.type,
-                  votes: votesToCreate,
-                });
+            if (scrutin.votesHash === newHash) {
+              stats.votesSkipped += votesToCreate.length;
+            } else {
+              await writeVotesForScrutin({
+                scrutinId: scrutin.id,
+                votingDate: scrutin.votingDate,
+                chamber: scrutin.chamber,
+                scrutinType: scrutin.type,
+                votes: votesToCreate,
+              });
 
-                await db.scrutin.update({
-                  where: { id: scrutin.id },
-                  data: { votesHash: newHash },
-                });
-
-                await computeGroupPositionsForScrutin(scrutin.id);
-                stats.votesCreated += votesToCreate.length;
-              }
+              await computeGroupPositionsForScrutin(scrutin.id);
+              stats.votesCreated += votesToCreate.length;
             }
+
+            await db.scrutinVoteImport.update({
+              where: { scrutinId: scrutin.id },
+              data: {
+                resolvedCount: votesToCreate.length,
+                status: "COMPLETE",
+                statusReason: null,
+              },
+            });
+            await db.scrutin.update({
+              where: { id: scrutin.id },
+              data: { votesHash: newHash },
+            });
 
             // Track max processed number for cursor
             if (numInt > maxProcessedNumber) {
@@ -461,12 +515,19 @@ export async function syncScrutinsSenat(
           } else {
             // Dry run: just count
             stats.scrutinsCreated++;
-            for (const vote of votes) {
-              if (!matriculeToId.has(vote.matricule)) {
-                stats.senatorsNotFound.add(vote.matricule);
-              } else {
-                stats.votesCreated++;
+            if (sourceAssessment.status === "COMPLETE") {
+              for (const vote of votes) {
+                if (!matriculeToId.has(vote.matricule)) {
+                  stats.senatorsNotFound.add(vote.matricule);
+                } else {
+                  stats.votesCreated++;
+                }
               }
+            } else {
+              stats.scrutinsSkipped++;
+              stats.errors.push(
+                `Session ${currentSession} n°${number}: source nominative ${sourceAssessment.status.toLowerCase()} (${sourceAssessment.reason})`
+              );
             }
           }
 

--- a/src/services/sync/scrutins-vote-writer.ts
+++ b/src/services/sync/scrutins-vote-writer.ts
@@ -38,15 +38,17 @@ export async function writeVotesForScrutin(params: WriteVotesParams): Promise<vo
     where: { scrutinId: params.scrutinId },
   });
 
-  await db.vote.createMany({
-    data: params.votes.map((v) => ({
-      scrutinId: params.scrutinId,
-      politicianId: v.politicianId,
-      position: v.position,
-      votingDate: params.votingDate,
-      chamber: params.chamber,
-      scrutinType: params.scrutinType,
-    })),
-    skipDuplicates: true,
-  });
+  if (params.votes.length > 0) {
+    await db.vote.createMany({
+      data: params.votes.map((v) => ({
+        scrutinId: params.scrutinId,
+        politicianId: v.politicianId,
+        position: v.position,
+        votingDate: params.votingDate,
+        chamber: params.chamber,
+        scrutinType: params.scrutinType,
+      })),
+      skipDuplicates: true,
+    });
+  }
 }


### PR DESCRIPTION
## Résumé

- valide chaque import Sénat par rapport aux totaux officiels et rejette les codes inconnus
- conserve la source, son empreinte et l'état de complétude dans une table d'audit interne
- calcule un candidat individuel sur `POUR + CONTRE + ABSTENTION` rapporté à ces positions plus `NON_VOTANT`
- neutralise les identités, mandats ou périodes incomplets et vérifie la parité des agrégats
- renomme le libellé public en « Participation aux scrutins publics » avec une définition explicite
- maintient la publication Sénat en fail-closed jusqu'à l'audit indépendant en production

## Validation

- `npx tsc --noEmit`
- `npm run test:run`: 4 963 tests réussis, 393 ignorés
- tests ciblés finaux: 35 réussis
- `npx prisma validate`
- `npm run build`: 786 pages générées
- `git diff --check`

## Déploiement et validation production

1. appliquer la migration `ScrutinVoteImport` et le champ de version du calcul
2. rejouer la synchronisation des scrutins du Sénat pour peupler les preuves de complétude
3. exécuter `npm run audit:senate-participation` en lecture seule
4. faire valider indépendamment les neutralisations et la parité avant tout cutover public

Cette PR ne publie pas la métrique du Sénat. L'historicisation des appartenances aux groupes reste une étape séparée après validation de #722.

Refs #722
