### PR TITLE
feat(affaires): router les évolutions vers la revue humaine (#763)

### DIFF
--- a/prisma/migrations/20260827150000_add_affair_event_identity_key/migration.sql
+++ b/prisma/migrations/20260827150000_add_affair_event_identity_key/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "AffairEvent" ADD COLUMN "identityKey" TEXT;
+
+CREATE UNIQUE INDEX "AffairEvent_affairId_identityKey_key"
+ON "AffairEvent"("affairId", "identityKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -659,9 +659,10 @@ model Affair {
 
 // Timeline events for an affair
 model AffairEvent {
-  id       String @id @default(cuid())
-  affair   Affair @relation(fields: [affairId], references: [id], onDelete: Cascade)
-  affairId String
+  id          String  @id @default(cuid())
+  affair      Affair  @relation(fields: [affairId], references: [id], onDelete: Cascade)
+  affairId    String
+  identityKey String? // Stable importer identity; null for historical/manual events
 
   date        DateTime
   type        AffairEventType
@@ -676,6 +677,7 @@ model AffairEvent {
 
   @@index([affairId])
   @@index([date])
+  @@unique([affairId, identityKey])
 }
 
 enum AffairEventType {

--- a/scripts/discover-affairs.ts
+++ b/scripts/discover-affairs.ts
@@ -24,15 +24,17 @@ import { WD_PROPS } from "../src/config/wikidata";
 import { mapWikidataOffense, getOffenseLabel } from "../src/config/wikidata-affairs";
 import { wikipediaService } from "../src/lib/api/wikipedia";
 import { extractAffairsFromWikipedia } from "../src/services/wikipedia-affair-extraction";
-import { findMatchingAffairs } from "../src/services/affairs/matching";
+import { classifyAffairMatches, findMatchingAffairs } from "../src/services/affairs/matching";
 import { createDraftAffairFromDiscovery } from "../src/services/affairs/create-draft";
 import { clampConfidenceScore } from "../src/services/affairs/confidence";
-import { extractDateFromUrl } from "../src/lib/extract-date-from-url";
 import {
   getDiscoverAffairsCursor,
   saveDiscoverAffairsCursor,
 } from "../src/services/sync/discover-affairs";
 import type { AffairCategory, AffairStatus, Involvement } from "../src/generated/prisma";
+import { hashSourceContent, proposeAffairEvent } from "../src/services/affairs/proposals";
+import { IMPORTER_DISCOVER_AFFAIRS, withImportRun } from "../src/services/affairs/import-run";
+import { findVerifiedAffairPressEventSource } from "../src/config/affair-sources";
 
 // ============================================
 // TYPES
@@ -56,6 +58,7 @@ interface DiscoveredAffair {
     publisher: string;
     sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
     publishedAt: Date | null;
+    excerpt?: string | null;
   }>;
   phase: "wikidata" | "wikipedia";
 }
@@ -72,6 +75,10 @@ interface DiscoveryStats {
   affairsCreated: number;
   /** Toujours égal à affairsCreated : un importeur ne crée que des brouillons. */
   affairsDraft: number;
+  proposalsPending: number;
+  proposalsDeduped: number;
+  ambiguousMatches: number;
+  insufficientSourceProvenance: number;
   errors: number;
 }
 
@@ -320,7 +327,8 @@ async function runPhase2Wikipedia(
               title: extracted.title,
               publisher: extractPublisherFromUrl(sourceUrl),
               sourceType: "PRESSE",
-              publishedAt: extractDateFromUrl(sourceUrl),
+              // A date embedded in the URL is not verified publication metadata.
+              publishedAt: null,
             });
           }
 
@@ -372,7 +380,8 @@ async function runPhase3Reconciliation(
   allAffairs: DiscoveredAffair[],
   stats: DiscoveryStats,
   dryRun: boolean,
-  verbose: boolean
+  verbose: boolean,
+  importRunId: string | null
 ): Promise<void> {
   console.log(`\n  Phase 3: Réconciliation — ${allAffairs.length} affaires à traiter`);
   const progress = new ProgressTracker({
@@ -387,17 +396,77 @@ async function runPhase3Reconciliation(
         politicianId: affair.politicianId,
         title: affair.title,
         category: affair.category,
+        status: affair.status,
       });
 
-      const highMatch = matches.find((m) => m.confidence === "HIGH" || m.confidence === "CERTAIN");
+      const routing = classifyAffairMatches(matches);
+      let insufficientEvolutionProvenance = false;
 
-      if (highMatch) {
+      if (routing.kind === "CONFIDENT_MATCH") {
         stats.duplicatesSkipped++;
         if (verbose) {
           console.log(
-            `    [SKIP] Doublon détecté (${highMatch.confidence}, ${highMatch.matchedBy}): ${affair.title}`
+            `    [SKIP] Doublon détecté (${routing.match.confidence}, ${routing.match.matchedBy}): ${affair.title}`
           );
         }
+        progress.tick();
+        continue;
+      }
+
+      if (routing.kind === "CONFIDENT_AMBIGUOUS" || routing.kind === "POSSIBLE_AMBIGUOUS") {
+        stats.ambiguousMatches++;
+      }
+
+      if (routing.kind === "UNIQUE_EVOLUTION") {
+        const pressSource = findVerifiedAffairPressEventSource(
+          affair.sources.filter((source) => source.sourceType === "PRESSE")
+        );
+        if (pressSource?.publishedAt) {
+          if (dryRun) {
+            console.log(`    [DRY] Proposerait un événement sur ${routing.match.affairId}`);
+            stats.proposalsPending++;
+            progress.tick();
+            continue;
+          }
+          if (!importRunId) throw new Error("ImportRun discover-affairs absent");
+          const proposal = await proposeAffairEvent({
+            affairId: routing.match.affairId,
+            importer: IMPORTER_DISCOVER_AFFAIRS,
+            importRunId,
+            sourceUrl: pressSource.url,
+            sourceTitle: pressSource.title,
+            publishedAt: pressSource.publishedAt,
+            publisher: pressSource.publisher,
+            sourceExcerpt: pressSource.excerpt!,
+            sourceContentHash: hashSourceContent({
+              sourceUrl: pressSource.url,
+              publishedAt: pressSource.publishedAt,
+              title: affair.title,
+              status: affair.status,
+            }),
+            confidence: Math.round(routing.match.score * 100),
+            rationale:
+              `Candidat d’évolution unique (${routing.match.matchedBy}) avec une source de presse ` +
+              `datée. La publication est proposée comme événement médiatique, sans déduire la ` +
+              `date d’un acte judiciaire.`,
+            extractorVersion: "discover-evolution-v1",
+          });
+          if (proposal.outcome === "CREATED") stats.proposalsPending++;
+          if (proposal.deduped) stats.proposalsDeduped++;
+          if (proposal.outcome !== "TARGET_INELIGIBLE") {
+            progress.tick();
+            continue;
+          }
+        } else {
+          insufficientEvolutionProvenance = true;
+        }
+      }
+
+      if (insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
+
+      const datedSources = affair.sources.filter((source) => source.publishedAt !== null);
+      if (datedSources.length === 0) {
+        if (!insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
         progress.tick();
         continue;
       }
@@ -423,11 +492,11 @@ async function runPhase3Reconciliation(
         confidenceScore: affair.confidenceScore,
         factsDate: affair.factsDate,
         court: affair.court,
-        sources: affair.sources.map((s) => ({
+        sources: datedSources.map((s) => ({
           url: s.url,
           title: s.title,
           publisher: s.publisher,
-          publishedAt: s.publishedAt ?? affair.factsDate ?? new Date(),
+          publishedAt: s.publishedAt!,
           sourceType: s.sourceType,
         })),
       });
@@ -559,6 +628,10 @@ Environnement :
       duplicatesSkipped: 0,
       affairsCreated: 0,
       affairsDraft: 0,
+      proposalsPending: 0,
+      proposalsDeduped: 0,
+      ambiguousMatches: 0,
+      insufficientSourceProvenance: 0,
       errors: 0,
     };
 
@@ -595,7 +668,7 @@ Environnement :
     stats.politiciansProcessed = politicians.length;
     console.log(`\n  ${politicians.length} politicien(s) trouvé(s)`);
 
-    if (cursorActive) {
+    if (cursorActive && !dryRun) {
       if (politicians.length === 0 || (typeof limit === "number" && politicians.length < limit)) {
         console.log(
           `[discover-affairs] cursor: ${cursor ?? "(start)"} -> (end), processed ${politicians.length}; alphabet exhausted, cursor reset`
@@ -635,7 +708,21 @@ Environnement :
     const allAffairs = [...phase1Affairs, ...phase2Affairs];
 
     if (allAffairs.length > 0) {
-      await runPhase3Reconciliation(allAffairs, stats, dryRun, verbose);
+      if (dryRun) {
+        await runPhase3Reconciliation(allAffairs, stats, true, verbose, null);
+      } else {
+        await withImportRun(IMPORTER_DISCOVER_AFFAIRS, async ({ importRunId, setStats }) => {
+          await runPhase3Reconciliation(allAffairs, stats, false, verbose, importRunId);
+          setStats({
+            duplicatesSkipped: stats.duplicatesSkipped,
+            affairsCreated: stats.affairsCreated,
+            proposalsPending: stats.proposalsPending,
+            proposalsDeduped: stats.proposalsDeduped,
+            ambiguousMatches: stats.ambiguousMatches,
+            insufficientSourceProvenance: stats.insufficientSourceProvenance,
+          });
+        });
+      }
     } else {
       console.log("\n  Phase 3: Aucune affaire découverte — rien à réconcilier.");
     }
@@ -651,6 +738,9 @@ Environnement :
     console.log(`  Doublons ignorés :          ${stats.duplicatesSkipped}`);
     console.log(`  Affaires créées :           ${stats.affairsCreated}`);
     console.log(`    — Brouillons (toutes) :   ${stats.affairsDraft}`);
+    console.log(`  Propositions d’événement :  ${stats.proposalsPending}`);
+    console.log(`  Rapprochements ambigus :    ${stats.ambiguousMatches}`);
+    console.log(`  Provenance insuffisante :   ${stats.insufficientSourceProvenance}`);
     console.log(`  Erreurs :                   ${stats.errors}`);
 
     return {

--- a/scripts/discover-affairs.ts
+++ b/scripts/discover-affairs.ts
@@ -1,580 +1,57 @@
 /**
- * CLI script to discover historical judicial affairs from Wikidata and Wikipedia
+ * CLI adapter for the shared Wikidata and Wikipedia affair discovery service.
  *
- * Phase 1: Wikidata — Checks P1399 (convicted of) and P1595 (charge) claims
- * Phase 2: Wikipedia — Finds judicial sections and extracts affairs via AI
- * Phase 3: Reconciliation — Deduplicates and persists to database
- *
- * Usage:
- *   npm run discover:affairs                          # Full discovery
- *   npm run discover:affairs -- --stats               # Show current stats
- *   npm run discover:affairs -- --dry-run             # Preview without saving
- *   npm run discover:affairs -- --limit=10            # Limit to N politicians
- *   npm run discover:affairs -- --politician="Sarkozy"  # Filter by name
- *   npm run discover:affairs -- --wikidata-only       # Phase 1 only
- *   npm run discover:affairs -- --wikipedia-only      # Phase 2 only
+ * Keeping orchestration in src/services/sync/discover-affairs.ts guarantees that
+ * CLI runs and Inngest runs use the same matcher inputs, resolver decisions,
+ * enrichments, proposal previews, statistics and cursor rules.
  */
-
 import "dotenv/config";
-import { createCLI, ProgressTracker, type SyncHandler, type SyncResult } from "../src/lib/sync";
+import { createCLI, type SyncHandler, type SyncResult } from "../src/lib/sync";
 import { db } from "../src/lib/db";
-import { generateSlug } from "../src/lib/utils";
-import { WikidataService } from "../src/lib/api/wikidata";
-import { WD_PROPS } from "../src/config/wikidata";
-import { mapWikidataOffense, getOffenseLabel } from "../src/config/wikidata-affairs";
-import { wikipediaService } from "../src/lib/api/wikipedia";
-import { extractAffairsFromWikipedia } from "../src/services/wikipedia-affair-extraction";
-import { classifyAffairMatches, findMatchingAffairs } from "../src/services/affairs/matching";
-import { createDraftAffairFromDiscovery } from "../src/services/affairs/create-draft";
-import { clampConfidenceScore } from "../src/services/affairs/confidence";
-import {
-  getDiscoverAffairsCursor,
-  saveDiscoverAffairsCursor,
-} from "../src/services/sync/discover-affairs";
-import type { AffairCategory, AffairStatus, Involvement } from "../src/generated/prisma";
-import { hashSourceContent, proposeAffairEvent } from "../src/services/affairs/proposals";
-import { IMPORTER_DISCOVER_AFFAIRS, withImportRun } from "../src/services/affairs/import-run";
-import { findVerifiedAffairPressEventSource } from "../src/config/affair-sources";
-
-// ============================================
-// TYPES
-// ============================================
-
-interface DiscoveredAffair {
-  politicianId: string;
-  politicianName: string;
-  title: string;
-  description: string;
-  category: AffairCategory;
-  status: AffairStatus;
-  involvement: Involvement;
-  factsDate: Date | null;
-  court: string | null;
-  charges: string[];
-  confidenceScore: number;
-  sources: Array<{
-    url: string;
-    title: string;
-    publisher: string;
-    sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
-    publishedAt: Date | null;
-    excerpt?: string | null;
-  }>;
-  phase: "wikidata" | "wikipedia";
-}
-
-interface DiscoveryStats {
-  politiciansProcessed: number;
-  politiciansWithQid: number;
-  politiciansWithWikipedia: number;
-  wikidataAffairsFound: number;
-  wikipediaSectionsFound: number;
-  wikipediaAiCalls: number;
-  wikipediaAffairsFound: number;
-  duplicatesSkipped: number;
-  affairsCreated: number;
-  /** Toujours égal à affairsCreated : un importeur ne crée que des brouillons. */
-  affairsDraft: number;
-  proposalsPending: number;
-  proposalsDeduped: number;
-  ambiguousMatches: number;
-  insufficientSourceProvenance: number;
-  errors: number;
-}
-
-// ============================================
-// HELPERS
-// ============================================
-
-function extractPublisherFromUrl(url: string): string {
-  try {
-    const hostname = new URL(url).hostname.replace(/^www\./, "");
-    const PUBLISHER_MAP: Record<string, string> = {
-      "lemonde.fr": "Le Monde",
-      "liberation.fr": "Libération",
-      "mediapart.fr": "Mediapart",
-      "lefigaro.fr": "Le Figaro",
-      "francetvinfo.fr": "France Info",
-      "bfmtv.com": "BFM TV",
-      "leparisien.fr": "Le Parisien",
-      "20minutes.fr": "20 Minutes",
-      "lexpress.fr": "L'Express",
-      "lepoint.fr": "Le Point",
-      "nouvelobs.com": "L'Obs",
-      "europe1.fr": "Europe 1",
-      "rtl.fr": "RTL",
-      "rfi.fr": "RFI",
-    };
-    return PUBLISHER_MAP[hostname] || hostname;
-  } catch {
-    return "Source inconnue";
-  }
-}
-
-// ============================================
-// PHASE 1: WIKIDATA
-// ============================================
-
-async function runPhase1Wikidata(
-  politicians: Array<{
-    id: string;
-    fullName: string;
-    externalIds: Array<{ externalId: string }>;
-  }>,
-  stats: DiscoveryStats,
-  verbose: boolean
-): Promise<DiscoveredAffair[]> {
-  const discovered: DiscoveredAffair[] = [];
-  const wikidataService = new WikidataService();
-
-  // Filter politicians with Wikidata Q-IDs
-  const withQid = politicians.filter((p) => p.externalIds.length > 0);
-  stats.politiciansWithQid = withQid.length;
-
-  if (withQid.length === 0) {
-    console.log("\n  Phase 1: Aucun politicien avec Q-ID Wikidata trouvé.");
-    return discovered;
-  }
-
-  console.log(`\n  Phase 1: Wikidata — ${withQid.length} politiciens avec Q-ID`);
-  const progress = new ProgressTracker({ total: withQid.length, label: "Phase 1 — Wikidata" });
-
-  for (const politician of withQid) {
-    const qid = politician.externalIds[0]!.externalId;
-
-    try {
-      const entities = await wikidataService.getEntities([qid]);
-      const entity = entities.get(qid);
-
-      if (!entity) {
-        progress.tick();
-        continue;
-      }
-
-      // Check P1399 (convicted of) and P1595 (charge)
-      const properties: Array<{ prop: "P1399" | "P1595"; claims: (typeof entity.claims)[string] }> =
-        [
-          { prop: "P1399", claims: entity.claims[WD_PROPS.CONVICTED_OF] },
-          { prop: "P1595", claims: entity.claims[WD_PROPS.CHARGE] },
-        ];
-
-      for (const { prop, claims } of properties) {
-        if (!claims) continue;
-
-        for (const claim of claims) {
-          const value = claim.mainsnak?.datavalue?.value;
-          if (!value || typeof value !== "object" || !("id" in value)) continue;
-
-          const offenseQid = value.id;
-          const { category, status } = mapWikidataOffense(offenseQid, prop);
-          const label = getOffenseLabel(offenseQid);
-
-          // Le score sert à prioriser la revue humaine, pas à décider d'une
-          // mise en ligne : toute affaire découverte reste un brouillon.
-          const isConviction = prop === "P1399";
-          const confidence = isConviction ? 95 : 75;
-          const titlePrefix = isConviction ? "" : "[À VÉRIFIER] ";
-          const title = `${titlePrefix}${label} — ${politician.fullName}`;
-
-          discovered.push({
-            politicianId: politician.id,
-            politicianName: politician.fullName,
-            title,
-            description: `${label} (${isConviction ? "condamnation" : "mise en cause"}) — source Wikidata (${qid}, propriété ${prop}).`,
-            category,
-            status,
-            involvement: isConviction ? "DIRECT" : "MENTIONED_ONLY",
-            factsDate: null,
-            court: null,
-            charges: [label],
-            confidenceScore: clampConfidenceScore(confidence),
-            sources: [
-              {
-                url: `https://www.wikidata.org/wiki/${qid}`,
-                title: `Wikidata — ${politician.fullName}`,
-                publisher: "Wikidata",
-                sourceType: "WIKIDATA",
-                publishedAt: null,
-              },
-            ],
-            phase: "wikidata",
-          });
-
-          stats.wikidataAffairsFound++;
-
-          if (verbose) {
-            console.log(
-              `    [WD] ${politician.fullName}: ${label} (${prop}, ${category}, ${status})`
-            );
-          }
-        }
-      }
-    } catch (error) {
-      stats.errors++;
-      console.error(
-        `    [WD] Erreur pour ${politician.fullName} (${qid}):`,
-        error instanceof Error ? error.message : error
-      );
-    }
-
-    progress.tick();
-  }
-
-  progress.finish();
-  return discovered;
-}
-
-// ============================================
-// PHASE 2: WIKIPEDIA
-// ============================================
-
-async function runPhase2Wikipedia(
-  politicians: Array<{
-    id: string;
-    fullName: string;
-    externalIds: Array<{ externalId: string }>;
-  }>,
-  phase1Affairs: DiscoveredAffair[],
-  stats: DiscoveryStats,
-  verbose: boolean
-): Promise<DiscoveredAffair[]> {
-  const discovered: DiscoveredAffair[] = [];
-
-  console.log(`\n  Phase 2: Wikipedia — ${politicians.length} politiciens`);
-  const progress = new ProgressTracker({ total: politicians.length, label: "Phase 2 — Wikipedia" });
-
-  // Build a set of (politicianId, category) from Phase 1 for cross-phase dedup
-  const phase1Keys = new Set(phase1Affairs.map((a) => `${a.politicianId}:${a.category}`));
-
-  for (const politician of politicians) {
-    try {
-      const sections = await wikipediaService.findJudicialSections(politician.fullName);
-
-      if (sections.length === 0) {
-        progress.tick();
-        continue;
-      }
-
-      stats.politiciansWithWikipedia++;
-      stats.wikipediaSectionsFound += sections.length;
-
-      if (verbose) {
-        console.log(`    [WP] ${politician.fullName}: ${sections.length} section(s) judiciaire(s)`);
-      }
-
-      for (const section of sections) {
-        stats.wikipediaAiCalls++;
-        const pageUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(politician.fullName.replace(/ /g, "_"))}`;
-
-        const result = await extractAffairsFromWikipedia({
-          politicianName: politician.fullName,
-          sectionTitle: section.title,
-          wikitext: section.wikitext,
-          pageUrl,
-        });
-
-        for (const extracted of result.affairs) {
-          // Skip affairs where the politician has no significant role
-          // Keep DIRECT (accused/convicted), VICTIM (threatened/attacked), PLAINTIFF (filed complaint)
-          if (
-            extracted.involvement !== "DIRECT" &&
-            extracted.involvement !== "VICTIM" &&
-            extracted.involvement !== "PLAINTIFF"
-          ) {
-            if (verbose) {
-              console.log(
-                `    [WP] Skip (${extracted.involvement}, pas mis en cause/victime): ${extracted.title}`
-              );
-            }
-            continue;
-          }
-
-          // Skip low confidence
-          if (extracted.confidenceScore < 40) {
-            if (verbose) {
-              console.log(
-                `    [WP] Skip (confiance ${extracted.confidenceScore} < 40): ${extracted.title}`
-              );
-            }
-            continue;
-          }
-
-          // Cross-phase dedup: skip if same politician+category found in Phase 1
-          const dedupKey = `${politician.id}:${extracted.category}`;
-          if (phase1Keys.has(dedupKey)) {
-            if (verbose) {
-              console.log(
-                `    [WP] Skip (déjà trouvé en Phase 1): ${extracted.title} (${extracted.category})`
-              );
-            }
-            continue;
-          }
-
-          // Build sources array: Wikipedia + press URLs
-          const sources: DiscoveredAffair["sources"] = [
-            {
-              url: pageUrl,
-              title: `Wikipedia — ${politician.fullName}`,
-              publisher: "Wikipedia",
-              sourceType: "WIKIPEDIA",
-              publishedAt: null,
-            },
-          ];
-
-          for (const sourceUrl of extracted.sourceUrls) {
-            sources.push({
-              url: sourceUrl,
-              title: extracted.title,
-              publisher: extractPublisherFromUrl(sourceUrl),
-              sourceType: "PRESSE",
-              // A date embedded in the URL is not verified publication metadata.
-              publishedAt: null,
-            });
-          }
-
-          discovered.push({
-            politicianId: politician.id,
-            politicianName: politician.fullName,
-            title: `[À VÉRIFIER] ${extracted.title}`,
-            description: extracted.description,
-            category: extracted.category as AffairCategory,
-            status: extracted.status as AffairStatus,
-            involvement: extracted.involvement,
-            factsDate: extracted.factsDate ? new Date(extracted.factsDate) : null,
-            court: extracted.court,
-            charges: extracted.charges,
-            confidenceScore: clampConfidenceScore(extracted.confidenceScore),
-            sources,
-            phase: "wikipedia",
-          });
-
-          stats.wikipediaAffairsFound++;
-
-          if (verbose) {
-            console.log(
-              `    [WP] ${politician.fullName}: ${extracted.title} (${extracted.category}, confiance ${extracted.confidenceScore})`
-            );
-          }
-        }
-      }
-    } catch (error) {
-      stats.errors++;
-      console.error(
-        `    [WP] Erreur pour ${politician.fullName}:`,
-        error instanceof Error ? error.message : error
-      );
-    }
-
-    progress.tick();
-  }
-
-  progress.finish();
-  return discovered;
-}
-
-// ============================================
-// PHASE 3: RECONCILIATION + PERSISTENCE
-// ============================================
-
-async function runPhase3Reconciliation(
-  allAffairs: DiscoveredAffair[],
-  stats: DiscoveryStats,
-  dryRun: boolean,
-  verbose: boolean,
-  importRunId: string | null
-): Promise<void> {
-  console.log(`\n  Phase 3: Réconciliation — ${allAffairs.length} affaires à traiter`);
-  const progress = new ProgressTracker({
-    total: allAffairs.length,
-    label: "Phase 3 — Réconciliation",
-  });
-
-  for (const affair of allAffairs) {
-    try {
-      // Check for duplicates
-      const matches = await findMatchingAffairs({
-        politicianId: affair.politicianId,
-        title: affair.title,
-        category: affair.category,
-        status: affair.status,
-      });
-
-      const routing = classifyAffairMatches(matches);
-      let insufficientEvolutionProvenance = false;
-
-      if (routing.kind === "CONFIDENT_MATCH") {
-        stats.duplicatesSkipped++;
-        if (verbose) {
-          console.log(
-            `    [SKIP] Doublon détecté (${routing.match.confidence}, ${routing.match.matchedBy}): ${affair.title}`
-          );
-        }
-        progress.tick();
-        continue;
-      }
-
-      if (routing.kind === "CONFIDENT_AMBIGUOUS" || routing.kind === "POSSIBLE_AMBIGUOUS") {
-        stats.ambiguousMatches++;
-      }
-
-      if (routing.kind === "UNIQUE_EVOLUTION") {
-        const pressSource = findVerifiedAffairPressEventSource(
-          affair.sources.filter((source) => source.sourceType === "PRESSE")
-        );
-        if (pressSource?.publishedAt) {
-          if (dryRun) {
-            console.log(`    [DRY] Proposerait un événement sur ${routing.match.affairId}`);
-            stats.proposalsPending++;
-            progress.tick();
-            continue;
-          }
-          if (!importRunId) throw new Error("ImportRun discover-affairs absent");
-          const proposal = await proposeAffairEvent({
-            affairId: routing.match.affairId,
-            importer: IMPORTER_DISCOVER_AFFAIRS,
-            importRunId,
-            sourceUrl: pressSource.url,
-            sourceTitle: pressSource.title,
-            publishedAt: pressSource.publishedAt,
-            publisher: pressSource.publisher,
-            sourceExcerpt: pressSource.excerpt!,
-            sourceContentHash: hashSourceContent({
-              sourceUrl: pressSource.url,
-              publishedAt: pressSource.publishedAt,
-              title: affair.title,
-              status: affair.status,
-            }),
-            confidence: Math.round(routing.match.score * 100),
-            rationale:
-              `Candidat d’évolution unique (${routing.match.matchedBy}) avec une source de presse ` +
-              `datée. La publication est proposée comme événement médiatique, sans déduire la ` +
-              `date d’un acte judiciaire.`,
-            extractorVersion: "discover-evolution-v1",
-          });
-          if (proposal.outcome === "CREATED") stats.proposalsPending++;
-          if (proposal.deduped) stats.proposalsDeduped++;
-          if (proposal.outcome !== "TARGET_INELIGIBLE") {
-            progress.tick();
-            continue;
-          }
-        } else {
-          insufficientEvolutionProvenance = true;
-        }
-      }
-
-      if (insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
-
-      const datedSources = affair.sources.filter((source) => source.publishedAt !== null);
-      if (datedSources.length === 0) {
-        if (!insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
-        progress.tick();
-        continue;
-      }
-
-      if (dryRun) {
-        console.log(`    [DRY] Créerait (DRAFT): ${affair.title} (${affair.category})`);
-        stats.affairsCreated++;
-        stats.affairsDraft++;
-        progress.tick();
-        continue;
-      }
-
-      // Sas unique de création côté importeur : force DRAFT et verifiedAt
-      // null. La mise en ligne relève ensuite d'assertPublishable().
-      await createDraftAffairFromDiscovery({
-        politicianId: affair.politicianId,
-        title: affair.title,
-        baseSlug: generateSlug(affair.title),
-        description: affair.description,
-        status: affair.status,
-        category: affair.category,
-        involvement: affair.involvement,
-        confidenceScore: affair.confidenceScore,
-        factsDate: affair.factsDate,
-        court: affair.court,
-        sources: datedSources.map((s) => ({
-          url: s.url,
-          title: s.title,
-          publisher: s.publisher,
-          publishedAt: s.publishedAt!,
-          sourceType: s.sourceType,
-        })),
-      });
-
-      stats.affairsCreated++;
-      stats.affairsDraft++;
-
-      if (verbose) {
-        console.log(`    [OK] Créé (DRAFT): ${affair.title} (${affair.category})`);
-      }
-    } catch (error) {
-      stats.errors++;
-      console.error(
-        `    [ERR] Erreur création pour "${affair.title}":`,
-        error instanceof Error ? error.message : error
-      );
-    }
-
-    progress.tick();
-  }
-
-  progress.finish();
-}
-
-// ============================================
-// SYNC HANDLER
-// ============================================
+import { discoverAffairs } from "../src/services/sync/discover-affairs";
 
 const handler: SyncHandler = {
-  name: "Poligraph — Découverte d'affaires (Wikidata + Wikipedia)",
-  description:
-    "Découvre les affaires judiciaires historiques via Wikidata (P1399/P1595) et Wikipedia (sections judiciaires + IA)",
+  name: "Poligraph - Découverte d’affaires (Wikidata + Wikipedia)",
+  description: "Découvre les affaires judiciaires historiques via le service partagé avec Inngest",
 
   options: [
     {
       name: "--politician",
       type: "string",
-      description: "Filtrer par nom de politicien (correspondance partielle)",
+      description: "Filtrer par nom de responsable politique (correspondance partielle)",
     },
     {
       name: "--wikidata-only",
       type: "boolean",
-      description: "Exécuter Phase 1 (Wikidata) uniquement",
+      description: "Exécuter la phase Wikidata uniquement",
     },
     {
       name: "--wikipedia-only",
       type: "boolean",
-      description: "Exécuter Phase 2 (Wikipedia) uniquement",
+      description: "Exécuter la phase Wikipedia uniquement",
     },
   ],
 
   showHelp() {
     console.log(`
-Poligraph — Découverte d'affaires judiciaires (Wikidata + Wikipedia)
+Poligraph - Découverte d’affaires judiciaires (Wikidata + Wikipedia)
 
-Découvre automatiquement les affaires judiciaires historiques pour les
-politiciens enregistrés dans la base de données.
-
-Phases :
-  1. Wikidata   — Vérifie P1399 (condamné pour) et P1595 (accusé de)
-                   pour chaque politicien avec un Q-ID Wikidata
-  2. Wikipedia  — Cherche les sections judiciaires sur la page Wikipedia
-                   et extrait les affaires via Claude (IA)
-  3. Réconciliation — Déduplique avec les affaires existantes et persiste
+Le CLI appelle le même service que le job Inngest. Le mode dry-run exécute les
+mêmes décisions sans curseur, ImportRun, proposition, resolver ou brouillon écrit.
 
 Options :
   --stats              Afficher les statistiques actuelles
   --dry-run            Prévisualiser sans sauvegarder
-  --limit=N            Limiter à N politiciens
-  --politician="Nom"   Filtrer par nom de politicien
-  --wikidata-only      Phase 1 uniquement (Wikidata)
-  --wikipedia-only     Phase 2 uniquement (Wikipedia)
-  --force              Forcer (bypass incrémental)
-  --verbose            Sortie détaillée
+  --limit=N            Limiter à N responsables politiques
+  --politician="Nom"   Filtrer par nom
+  --wikidata-only      Exécuter Wikidata uniquement
+  --wikipedia-only     Exécuter Wikipedia uniquement
+  --force              Ignorer le curseur incrémental
+  --verbose            Sortie détaillée du runner
   --help               Afficher cette aide
 
 Environnement :
-  ANTHROPIC_API_KEY    Requis pour Phase 2 (extraction IA Wikipedia)
+  ANTHROPIC_API_KEY    Requis pour l’extraction Wikipedia
     `);
   },
 
@@ -583,10 +60,7 @@ Environnement :
       await Promise.all([
         db.politician.count({ where: { publicationStatus: "PUBLISHED" } }),
         db.politician.count({
-          where: {
-            publicationStatus: "PUBLISHED",
-            affairs: { some: {} },
-          },
+          where: { publicationStatus: "PUBLISHED", affairs: { some: {} } },
         }),
         db.politician.count({
           where: {
@@ -599,161 +73,35 @@ Environnement :
         db.affair.count({ where: { publicationStatus: "DRAFT" } }),
       ]);
 
-    console.log("\n=== Statistiques Découverte d'affaires ===\n");
-    console.log(`  Politiciens publiés :            ${totalPublished}`);
-    console.log(`  Politiciens avec ≥1 affaire :    ${withAffairs}`);
-    console.log(`  Politiciens avec Q-ID Wikidata : ${withQid}`);
-    console.log(`  Total affaires :                 ${totalAffairs}`);
-    console.log(`    — Publiées :                   ${publishedAffairs}`);
-    console.log(`    — Brouillons :                 ${draftAffairs}`);
+    console.log("\n=== Statistiques Découverte d’affaires ===\n");
+    console.log(`  Responsables publiés :            ${totalPublished}`);
+    console.log(`  Responsables avec au moins une affaire : ${withAffairs}`);
+    console.log(`  Responsables avec Q-ID Wikidata : ${withQid}`);
+    console.log(`  Total affaires :                  ${totalAffairs}`);
+    console.log(`  Publiées :                        ${publishedAffairs}`);
+    console.log(`  Brouillons :                      ${draftAffairs}`);
     console.log("");
   },
 
   async sync(options): Promise<SyncResult> {
-    const startTime = Date.now();
-    const dryRun = !!options.dryRun;
-    const verbose = !!options.verbose;
-    const wikidataOnly = !!options.wikidataOnly;
-    const wikipediaOnly = !!options.wikipediaOnly;
-    const politicianFilter = options.politician as string | undefined;
-
-    const stats: DiscoveryStats = {
-      politiciansProcessed: 0,
-      politiciansWithQid: 0,
-      politiciansWithWikipedia: 0,
-      wikidataAffairsFound: 0,
-      wikipediaSectionsFound: 0,
-      wikipediaAiCalls: 0,
-      wikipediaAffairsFound: 0,
-      duplicatesSkipped: 0,
-      affairsCreated: 0,
-      affairsDraft: 0,
-      proposalsPending: 0,
-      proposalsDeduped: 0,
-      ambiguousMatches: 0,
-      insufficientSourceProvenance: 0,
-      errors: 0,
-    };
-
-    // Apply the persisted lastName cursor only on bounded runs without a name filter.
-    // Full backfills (no --limit) and targeted runs (--politician) bypass the cursor.
-    const limit = options.limit as number | undefined;
-    const cursorActive = !politicianFilter && typeof limit === "number" && limit > 0;
-    const cursorState = cursorActive ? await getDiscoverAffairsCursor() : { lastName: null };
-    const cursor = cursorState.lastName;
-
-    // Fetch politicians. Empty-string lastNames are filtered out via gt: "" when no
-    // cursor is set so we always have a meaningful sort key.
-    const politicians = await db.politician.findMany({
-      where: {
-        publicationStatus: "PUBLISHED",
-        lastName: { gt: cursor ?? "" },
-        ...(politicianFilter
-          ? { fullName: { contains: politicianFilter, mode: "insensitive" as const } }
-          : {}),
-      },
-      select: {
-        id: true,
-        fullName: true,
-        lastName: true,
-        externalIds: {
-          where: { source: "WIKIDATA" },
-          select: { externalId: true },
-        },
-      },
-      orderBy: { lastName: "asc" },
-      ...(limit ? { take: limit } : {}),
+    const startedAt = Date.now();
+    const result = await discoverAffairs({
+      limit: options.limit as number | undefined,
+      politicianFilter: options.politician as string | undefined,
+      wikidataOnly: !!options.wikidataOnly,
+      wikipediaOnly: !!options.wikipediaOnly,
+      useCursor: !options.force,
+      dryRun: !!options.dryRun,
     });
-
-    stats.politiciansProcessed = politicians.length;
-    console.log(`\n  ${politicians.length} politicien(s) trouvé(s)`);
-
-    if (cursorActive && !dryRun) {
-      if (politicians.length === 0 || (typeof limit === "number" && politicians.length < limit)) {
-        console.log(
-          `[discover-affairs] cursor: ${cursor ?? "(start)"} -> (end), processed ${politicians.length}; alphabet exhausted, cursor reset`
-        );
-        await saveDiscoverAffairsCursor(null);
-      } else {
-        const lastSeen = politicians[politicians.length - 1]!.lastName ?? null;
-        console.log(
-          `[discover-affairs] cursor: ${cursor ?? "(start)"} -> ${lastSeen ?? "(end)"}, processed ${politicians.length}`
-        );
-        await saveDiscoverAffairsCursor(lastSeen);
-      }
-    }
-
-    if (politicians.length === 0) {
-      return {
-        success: true,
-        duration: (Date.now() - startTime) / 1000,
-        stats: stats as unknown as Record<string, number>,
-        errors: [],
-      };
-    }
-
-    // Phase 1: Wikidata
-    let phase1Affairs: DiscoveredAffair[] = [];
-    if (!wikipediaOnly) {
-      phase1Affairs = await runPhase1Wikidata(politicians, stats, verbose);
-    }
-
-    // Phase 2: Wikipedia
-    let phase2Affairs: DiscoveredAffair[] = [];
-    if (!wikidataOnly) {
-      phase2Affairs = await runPhase2Wikipedia(politicians, phase1Affairs, stats, verbose);
-    }
-
-    // Phase 3: Reconciliation + Persistence
-    const allAffairs = [...phase1Affairs, ...phase2Affairs];
-
-    if (allAffairs.length > 0) {
-      if (dryRun) {
-        await runPhase3Reconciliation(allAffairs, stats, true, verbose, null);
-      } else {
-        await withImportRun(IMPORTER_DISCOVER_AFFAIRS, async ({ importRunId, setStats }) => {
-          await runPhase3Reconciliation(allAffairs, stats, false, verbose, importRunId);
-          setStats({
-            duplicatesSkipped: stats.duplicatesSkipped,
-            affairsCreated: stats.affairsCreated,
-            proposalsPending: stats.proposalsPending,
-            proposalsDeduped: stats.proposalsDeduped,
-            ambiguousMatches: stats.ambiguousMatches,
-            insufficientSourceProvenance: stats.insufficientSourceProvenance,
-          });
-        });
-      }
-    } else {
-      console.log("\n  Phase 3: Aucune affaire découverte — rien à réconcilier.");
-    }
-
-    // Summary
-    console.log("\n  === Résumé ===");
-    console.log(`  Politiciens traités :       ${stats.politiciansProcessed}`);
-    console.log(`  Politiciens avec Q-ID :     ${stats.politiciansWithQid}`);
-    console.log(`  Wikidata — affaires :       ${stats.wikidataAffairsFound}`);
-    console.log(`  Wikipedia — sections :      ${stats.wikipediaSectionsFound}`);
-    console.log(`  Wikipedia — appels IA :     ${stats.wikipediaAiCalls}`);
-    console.log(`  Wikipedia — affaires :      ${stats.wikipediaAffairsFound}`);
-    console.log(`  Doublons ignorés :          ${stats.duplicatesSkipped}`);
-    console.log(`  Affaires créées :           ${stats.affairsCreated}`);
-    console.log(`    — Brouillons (toutes) :   ${stats.affairsDraft}`);
-    console.log(`  Propositions d’événement :  ${stats.proposalsPending}`);
-    console.log(`  Rapprochements ambigus :    ${stats.ambiguousMatches}`);
-    console.log(`  Provenance insuffisante :   ${stats.insufficientSourceProvenance}`);
-    console.log(`  Erreurs :                   ${stats.errors}`);
+    const { errors, ...stats } = result;
 
     return {
-      success: stats.errors === 0,
-      duration: (Date.now() - startTime) / 1000,
-      stats: stats as unknown as Record<string, number>,
-      errors: [],
+      success: errors.length === 0,
+      duration: (Date.now() - startedAt) / 1000,
+      stats,
+      errors,
     };
   },
 };
-
-// ============================================
-// RUN
-// ============================================
 
 createCLI(handler);

--- a/scripts/proposals.ts
+++ b/scripts/proposals.ts
@@ -33,6 +33,7 @@ import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-revi
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import type { Prisma, ProposalRisk, ProposalStatus } from "@/generated/prisma";
 import { parseAffairProposalPayload } from "@/lib/security/schemas/affair-proposal";
+import { selectProposalIdsForBatch } from "@/services/affairs/proposal-batch";
 
 /** Persisted in reviewedBy and in the audit trail. Names the channel, nothing more. */
 const REVIEWED_BY = "cli";
@@ -372,7 +373,7 @@ async function group(f: BatchFilter, asJson: boolean) {
     console.log(`    affaires  : ${g.affairs.size} distincte(s)`);
     if (g.affairs.size <= 4) console.log(`                ${[...g.affairs].join(" / ")}`);
     console.log(
-      `    appliquer : npm run proposals -- --accept-ids=${g.ids.slice(0, 3).join(",")}${g.ids.length > 3 ? ",…" : ""}`
+      `    appliquer : npm run proposals -- --accept-ids=${g.ids.slice(0, 3).join(",")}${g.ids.length > 3 ? ",…" : ""}${g.fields.includes("event") ? " --include-events" : ""}`
     );
     console.log("");
   }
@@ -452,6 +453,34 @@ async function rejectBatch(ids: string[], note: string | undefined) {
   console.log(`${done}/${ids.length} rejetée(s).`);
 }
 
+async function acceptSelectedIds(
+  ids: string[],
+  note: string | undefined,
+  includeEvents: boolean
+): Promise<void> {
+  const candidates = await db.affairUpdateProposal.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, proposedPatch: true },
+  });
+  const { acceptedIds, excludedEventIds } = selectProposalIdsForBatch(
+    ids,
+    candidates,
+    includeEvents
+  );
+  if (excludedEventIds.length > 0) {
+    console.log(
+      `${excludedEventIds.length} proposition(s) d’événement exclue(s). Utilisez --include-events pour les accepter explicitement.\n`
+    );
+  }
+
+  const outcomes: Outcome[] = [];
+  for (const id of acceptedIds) outcomes.push(await accept(id, note, true));
+  console.log(
+    `${outcomes.filter((outcome) => outcome.ok).length}/${acceptedIds.length} appliquée(s).`
+  );
+  invalidateBatch(outcomes);
+}
+
 function parseRisk(raw: string | undefined): ProposalRisk[] | undefined {
   if (!raw) return undefined;
   const valid: ProposalRisk[] = ["LOW", "MEDIUM", "HIGH"];
@@ -472,11 +501,7 @@ async function main() {
   const acceptIds = arg("accept-ids");
   if (acceptIds) {
     const ids = acceptIds.split(",").filter(Boolean);
-    const outcomes: Outcome[] = [];
-    for (const id of ids) outcomes.push(await accept(id, note, true));
-    console.log(`${outcomes.filter((o) => o.ok).length}/${ids.length} appliquée(s).`);
-    invalidateBatch(outcomes);
-    return;
+    return acceptSelectedIds(ids, note, flag("include-events"));
   }
 
   const rejectIds = arg("reject-ids");

--- a/scripts/proposals.ts
+++ b/scripts/proposals.ts
@@ -33,7 +33,10 @@ import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-revi
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import type { Prisma, ProposalRisk, ProposalStatus } from "@/generated/prisma";
 import { parseAffairProposalPayload } from "@/lib/security/schemas/affair-proposal";
-import { selectProposalIdsForBatch } from "@/services/affairs/proposal-batch";
+import {
+  collectProposalCandidatesForBatch,
+  selectProposalIdsForBatch,
+} from "@/services/affairs/proposal-batch";
 
 /** Persisted in reviewedBy and in the audit trail. Names the channel, nothing more. */
 const REVIEWED_BY = "cli";
@@ -140,7 +143,13 @@ async function list(status: ProposalStatus, asJson: boolean) {
     const snap = r.affairSnapshot as { title?: string; politicianName?: string };
     const patch = r.proposedPatch as Record<string, unknown>;
     const observed = r.observedValues as Record<string, unknown>;
-    const parsed = parseAffairProposalPayload(patch);
+    let parsed: ReturnType<typeof parseAffairProposalPayload> | null = null;
+    let payloadError: string | null = null;
+    try {
+      parsed = parseAffairProposalPayload(patch);
+    } catch (error) {
+      payloadError = error instanceof Error ? error.message : "Payload invalide";
+    }
 
     console.log(`─── ${r.id}`);
     console.log(`  affaire   : ${snap?.title ?? "(supprimée)"}`);
@@ -151,7 +160,10 @@ async function list(status: ProposalStatus, asJson: boolean) {
       `  risque    : ${r.riskLevel} · confiance ${r.confidence} · ${r.importer}@${r.extractorVersion}`
     );
     console.log(`  run       : ${r.importRunId}`);
-    if (parsed.kind === "ADD_EVENT") {
+    if (!parsed) {
+      console.log("  opération  : payload invalide");
+      console.log(`  erreur     : ${payloadError}`);
+    } else if (parsed.kind === "ADD_EVENT") {
       console.log("  opération  : nouvel événement de chronologie");
       console.log(`  date       : ${fmt(parsed.event.date.toISOString())}`);
       console.log(`  type       : ${parsed.event.type}`);
@@ -165,7 +177,7 @@ async function list(status: ProposalStatus, asJson: boolean) {
       }
     }
     console.log(`  pourquoi  : ${r.rationale}`);
-    if (r.sourceUrl && parsed.kind !== "ADD_EVENT") {
+    if (r.sourceUrl && parsed?.kind !== "ADD_EVENT") {
       console.log(`  source    : ${r.source} ${r.sourceUrl}`);
     }
     if (r.conflictDetail) console.log(`  conflit   : ${JSON.stringify(r.conflictDetail)}`);
@@ -397,19 +409,19 @@ async function acceptBatch(
   limit: number,
   includeEvents: boolean
 ) {
-  const candidates = await db.affairUpdateProposal.findMany({
-    where: buildWhere(f),
-    select: { id: true, riskLevel: true, proposedPatch: true },
-    // Low risk first: the cheap wins land even if a later one fails.
-    orderBy: [{ riskLevel: "asc" }, { createdAt: "asc" }],
-    take: includeEvents ? limit : Math.max(limit, 500),
-  });
-  const excludedEvents = includeEvents
-    ? 0
-    : candidates.filter((row) => isEventProposal(row.proposedPatch)).length;
-  const rows = candidates
-    .filter((row) => includeEvents || !isEventProposal(row.proposedPatch))
-    .slice(0, limit);
+  const { rows, excludedEvents } = await collectProposalCandidatesForBatch(
+    ({ skip, take }) =>
+      db.affairUpdateProposal.findMany({
+        where: buildWhere(f),
+        select: { id: true, riskLevel: true, proposedPatch: true },
+        // Low risk first: the cheap wins land even if a later one fails.
+        orderBy: [{ riskLevel: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+        skip,
+        take,
+      }),
+    limit,
+    includeEvents
+  );
 
   if (excludedEvents > 0) {
     console.log(

--- a/scripts/proposals.ts
+++ b/scripts/proposals.ts
@@ -22,6 +22,7 @@
  *
  *   npm run proposals -- --accept-batch [--run=<id>] [--importer=<nom>]
  *                        [--risk=LOW,MEDIUM] [--limit=500] [--note="..."]
+ *                        [--include-events]
  *
  * Le traitement par lot reste séquentiel : chaque acceptation garde sa propre
  * transaction, son compare-and-set et sa détection de dérive. Un échec sur une
@@ -31,6 +32,7 @@ import { db } from "@/lib/db";
 import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-review";
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
 import type { Prisma, ProposalRisk, ProposalStatus } from "@/generated/prisma";
+import { parseAffairProposalPayload } from "@/lib/security/schemas/affair-proposal";
 
 /** Persisted in reviewedBy and in the audit trail. Names the channel, nothing more. */
 const REVIEWED_BY = "cli";
@@ -65,6 +67,14 @@ function fmt(value: unknown): string {
     return new Date(value).toLocaleDateString("fr-FR");
   }
   return String(value);
+}
+
+function isEventProposal(raw: unknown): boolean {
+  try {
+    return parseAffairProposalPayload(raw).kind === "ADD_EVENT";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -129,6 +139,7 @@ async function list(status: ProposalStatus, asJson: boolean) {
     const snap = r.affairSnapshot as { title?: string; politicianName?: string };
     const patch = r.proposedPatch as Record<string, unknown>;
     const observed = r.observedValues as Record<string, unknown>;
+    const parsed = parseAffairProposalPayload(patch);
 
     console.log(`─── ${r.id}`);
     console.log(`  affaire   : ${snap?.title ?? "(supprimée)"}`);
@@ -139,12 +150,23 @@ async function list(status: ProposalStatus, asJson: boolean) {
       `  risque    : ${r.riskLevel} · confiance ${r.confidence} · ${r.importer}@${r.extractorVersion}`
     );
     console.log(`  run       : ${r.importRunId}`);
-    for (const key of Object.keys(patch)) {
-      const label = FIELD_LABELS[key] ?? key;
-      console.log(`  ${label.padEnd(22)} ${fmt(observed[key])}  →  ${fmt(patch[key])}`);
+    if (parsed.kind === "ADD_EVENT") {
+      console.log("  opération  : nouvel événement de chronologie");
+      console.log(`  date       : ${fmt(parsed.event.date.toISOString())}`);
+      console.log(`  type       : ${parsed.event.type}`);
+      console.log(`  titre      : ${parsed.event.title}`);
+      console.log(`  source     : ${parsed.event.sourceTitle}`);
+      console.log(`  URL        : ${parsed.event.sourceUrl}`);
+    } else {
+      for (const key of Object.keys(patch)) {
+        const label = FIELD_LABELS[key] ?? key;
+        console.log(`  ${label.padEnd(22)} ${fmt(observed[key])}  →  ${fmt(patch[key])}`);
+      }
     }
     console.log(`  pourquoi  : ${r.rationale}`);
-    if (r.sourceUrl) console.log(`  source    : ${r.source} ${r.sourceUrl}`);
+    if (r.sourceUrl && parsed.kind !== "ADD_EVENT") {
+      console.log(`  source    : ${r.source} ${r.sourceUrl}`);
+    }
     if (r.conflictDetail) console.log(`  conflit   : ${JSON.stringify(r.conflictDetail)}`);
     console.log("");
   }
@@ -299,7 +321,8 @@ async function group(f: BatchFilter, asJson: boolean) {
   for (const r of rows) {
     const patch = r.proposedPatch as Record<string, unknown>;
     const observed = r.observedValues as Record<string, unknown>;
-    const fields = Object.keys(patch).sort();
+    const eventProposal = isEventProposal(patch);
+    const fields = eventProposal ? ["event"] : Object.keys(patch).sort();
     const overwrites = fields.filter(
       (k) => observed[k] !== null && observed[k] !== undefined && observed[k] !== ""
     );
@@ -367,14 +390,31 @@ async function group(f: BatchFilter, asJson: boolean) {
  * compare-and-set and drift check, and running them in parallel would only add
  * lock contention on the same affairs. A failure on one never stops the others.
  */
-async function acceptBatch(f: BatchFilter, note: string | undefined, limit: number) {
-  const rows = await db.affairUpdateProposal.findMany({
+async function acceptBatch(
+  f: BatchFilter,
+  note: string | undefined,
+  limit: number,
+  includeEvents: boolean
+) {
+  const candidates = await db.affairUpdateProposal.findMany({
     where: buildWhere(f),
-    select: { id: true, riskLevel: true },
+    select: { id: true, riskLevel: true, proposedPatch: true },
     // Low risk first: the cheap wins land even if a later one fails.
     orderBy: [{ riskLevel: "asc" }, { createdAt: "asc" }],
-    take: limit,
+    take: includeEvents ? limit : Math.max(limit, 500),
   });
+  const excludedEvents = includeEvents
+    ? 0
+    : candidates.filter((row) => isEventProposal(row.proposedPatch)).length;
+  const rows = candidates
+    .filter((row) => includeEvents || !isEventProposal(row.proposedPatch))
+    .slice(0, limit);
+
+  if (excludedEvents > 0) {
+    console.log(
+      `${excludedEvents} proposition(s) d’événement exclue(s) du lot. Utilisez --include-events pour les inclure explicitement.\n`
+    );
+  }
 
   if (rows.length === 0) {
     console.log("Aucune proposition PENDING sur ce périmètre.");
@@ -457,11 +497,11 @@ async function main() {
 
   if (flag("accept-batch")) {
     const limit = Number.parseInt(arg("limit") ?? "500", 10);
-    return acceptBatch(filter, note, limit);
+    return acceptBatch(filter, note, limit, flag("include-events"));
   }
 
   // --accept-run kept as a shorthand for the whole run.
-  if (arg("accept-run")) return acceptBatch(filter, note, 500);
+  if (arg("accept-run")) return acceptBatch(filter, note, 500, flag("include-events"));
 
   if (flag("group")) return group(filter, flag("json"));
 

--- a/src/app/admin/affaires/propositions/page.test.tsx
+++ b/src/app/admin/affaires/propositions/page.test.tsx
@@ -12,6 +12,8 @@ function listResponse() {
         importer: "press-analysis",
         extractorVersion: "v1",
         proposedPatch: { court: "Tribunal judiciaire de Paris" },
+        payloadKind: "PATCH",
+        eventPreview: null,
         observedValues: { court: null },
         affairSnapshot: {
           publicId: "PG000001",
@@ -79,5 +81,48 @@ describe("admin affair proposal ordinary sources", () => {
     expect(sourceLink).toHaveAttribute("href", PRESS_URL);
     expect(screen.getByRole("button", { name: "Accepter et appliquer" })).toBeEnabled();
     expect(screen.queryByText(/Décision officielle non vérifiée/i)).not.toBeInTheDocument();
+  });
+
+  it("présente un événement comme une opération lisible", async () => {
+    const response = listResponse();
+    Object.assign(response.rows[0] as unknown as Record<string, unknown>, {
+      proposedPatch: {
+        addEvent: {
+          date: "2026-08-27T08:00:00.000Z",
+          type: "REVELATION",
+          title: "Publication d’une nouvelle source sur l’évolution de l’affaire",
+        },
+      },
+      observedValues: {
+        addEvent: { identityVersion: "press-revelation-v1", identityKey: "a".repeat(64) },
+      },
+      payloadKind: "ADD_EVENT",
+      eventPreview: {
+        date: "2026-08-27T08:00:00.000Z",
+        type: "REVELATION",
+        title: "Publication d’une nouvelle source sur l’évolution de l’affaire",
+        description: null,
+        sourceUrl: PRESS_URL,
+        sourceTitle: "Titre original de l’article",
+        identityKey: "a".repeat(64),
+      },
+      riskLevel: "HIGH",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+
+    render(<PropositionsPage />);
+
+    expect(await screen.findByText("Nouvel événement")).toBeInTheDocument();
+    expect(screen.getByText("Ajout proposé à la chronologie")).toBeInTheDocument();
+    expect(screen.getByText("Titre original de l’article")).toBeInTheDocument();
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
   });
 });

--- a/src/app/admin/affaires/propositions/page.test.tsx
+++ b/src/app/admin/affaires/propositions/page.test.tsx
@@ -13,6 +13,8 @@ function listResponse() {
         extractorVersion: "v1",
         proposedPatch: { court: "Tribunal judiciaire de Paris" },
         payloadKind: "PATCH",
+        acceptanceEligible: true,
+        validationIssues: [],
         eventPreview: null,
         observedValues: { court: null },
         affairSnapshot: {
@@ -94,7 +96,7 @@ describe("admin affair proposal ordinary sources", () => {
         },
       },
       observedValues: {
-        addEvent: { identityVersion: "press-revelation-v1", identityKey: "a".repeat(64) },
+        addEvent: { identityVersion: "press-revelation-v2", identityKey: "a".repeat(64) },
       },
       payloadKind: "ADD_EVENT",
       eventPreview: {
@@ -105,6 +107,7 @@ describe("admin affair proposal ordinary sources", () => {
         sourceUrl: PRESS_URL,
         sourceTitle: "Titre original de l’article",
         identityKey: "a".repeat(64),
+        publisher: "Le Monde",
       },
       riskLevel: "HIGH",
     });
@@ -123,6 +126,31 @@ describe("admin affair proposal ordinary sources", () => {
     expect(await screen.findByText("Nouvel événement")).toBeInTheDocument();
     expect(screen.getByText("Ajout proposé à la chronologie")).toBeInTheDocument();
     expect(screen.getByText("Titre original de l’article")).toBeInTheDocument();
+    expect(screen.getByText("Le Monde")).toBeInTheDocument();
     expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+  });
+
+  it("désactive l’acceptation lorsque la provenance est invalide", async () => {
+    const response = listResponse();
+    Object.assign(response.rows[0] as unknown as Record<string, unknown>, {
+      payloadKind: "INVALID",
+      acceptanceEligible: false,
+      validationIssues: ["Métadonnées de provenance absentes"],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+
+    render(<PropositionsPage />);
+
+    expect(await screen.findByText("Proposition non applicable")).toBeInTheDocument();
+    expect(screen.getByText("Métadonnées de provenance absentes")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Accepter et appliquer" })).toBeDisabled();
   });
 });

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -30,6 +30,16 @@ interface ProposalRow {
   importer: string;
   extractorVersion: string;
   proposedPatch: Record<string, unknown>;
+  payloadKind: "PATCH" | "ADD_EVENT" | "INVALID";
+  eventPreview: {
+    date: string;
+    type: string;
+    title: string;
+    description: string | null;
+    sourceUrl: string;
+    sourceTitle: string;
+    identityKey: string;
+  } | null;
   observedValues: Record<string, unknown>;
   affairSnapshot: AffairSnapshot;
   source: string;
@@ -355,6 +365,9 @@ export default function PropositionsPage() {
                       <Badge variant="outline">
                         {row.importer}@{row.extractorVersion}
                       </Badge>
+                      {row.payloadKind === "ADD_EVENT" && (
+                        <Badge variant="destructive">Nouvel événement</Badge>
+                      )}
                       {evidence.required && (
                         <Badge variant={evidence.acceptable ? "outline" : "destructive"}>
                           {evidence.status
@@ -365,41 +378,63 @@ export default function PropositionsPage() {
                     </div>
                   </div>
 
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <caption className="sr-only">
-                        Valeurs actuelles et valeurs proposées pour {row.affairSnapshot.title}
-                      </caption>
-                      <thead>
-                        <tr className="text-muted-foreground text-left text-xs uppercase">
-                          <th scope="col" className="py-2 pr-4 font-medium">
-                            Champ
-                          </th>
-                          <th scope="col" className="py-2 pr-4 font-medium">
-                            Actuel
-                          </th>
-                          <th scope="col" className="py-2 font-medium">
-                            Proposé
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {fields.map((field) => (
-                          <tr key={field} className="border-border/60 border-t">
-                            <th scope="row" className="py-2 pr-4 text-left font-normal">
-                              {FIELD_LABELS[field] ?? field}
+                  {row.payloadKind === "ADD_EVENT" && row.eventPreview ? (
+                    <div className="border-border bg-muted/30 rounded-md border p-4 text-sm">
+                      <p className="font-semibold">Ajout proposé à la chronologie</p>
+                      <dl className="mt-3 grid gap-2 sm:grid-cols-[10rem_1fr]">
+                        <dt className="text-muted-foreground">Date</dt>
+                        <dd>{formatValue(row.eventPreview.date)}</dd>
+                        <dt className="text-muted-foreground">Type</dt>
+                        <dd>{row.eventPreview.type}</dd>
+                        <dt className="text-muted-foreground">Titre public</dt>
+                        <dd>{row.eventPreview.title}</dd>
+                        <dt className="text-muted-foreground">Source</dt>
+                        <dd>{row.eventPreview.sourceTitle}</dd>
+                        <dt className="text-muted-foreground">URL</dt>
+                        <dd className="break-all">{row.eventPreview.sourceUrl}</dd>
+                        <dt className="text-muted-foreground">Identité technique</dt>
+                        <dd className="font-mono text-xs break-all">
+                          {row.eventPreview.identityKey}
+                        </dd>
+                      </dl>
+                    </div>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <caption className="sr-only">
+                          Valeurs actuelles et valeurs proposées pour {row.affairSnapshot.title}
+                        </caption>
+                        <thead>
+                          <tr className="text-muted-foreground text-left text-xs uppercase">
+                            <th scope="col" className="py-2 pr-4 font-medium">
+                              Champ
                             </th>
-                            <td className="text-muted-foreground py-2 pr-4">
-                              {formatValue(row.observedValues[field])}
-                            </td>
-                            <td className="py-2 font-medium">
-                              {formatValue(row.proposedPatch[field])}
-                            </td>
+                            <th scope="col" className="py-2 pr-4 font-medium">
+                              Actuel
+                            </th>
+                            <th scope="col" className="py-2 font-medium">
+                              Proposé
+                            </th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {fields.map((field) => (
+                            <tr key={field} className="border-border/60 border-t">
+                              <th scope="row" className="py-2 pr-4 text-left font-normal">
+                                {FIELD_LABELS[field] ?? field}
+                              </th>
+                              <td className="text-muted-foreground py-2 pr-4">
+                                {formatValue(row.observedValues[field])}
+                              </td>
+                              <td className="py-2 font-medium">
+                                {formatValue(row.proposedPatch[field])}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
 
                   {row.conflictDetail && (
                     <div className="border-destructive/40 bg-destructive/10 flex gap-2 rounded-md border px-3 py-2 text-sm">

--- a/src/app/admin/affaires/propositions/page.tsx
+++ b/src/app/admin/affaires/propositions/page.tsx
@@ -31,6 +31,8 @@ interface ProposalRow {
   extractorVersion: string;
   proposedPatch: Record<string, unknown>;
   payloadKind: "PATCH" | "ADD_EVENT" | "INVALID";
+  acceptanceEligible: boolean;
+  validationIssues: string[];
   eventPreview: {
     date: string;
     type: string;
@@ -39,6 +41,7 @@ interface ProposalRow {
     sourceUrl: string;
     sourceTitle: string;
     identityKey: string;
+    publisher: string;
   } | null;
   observedValues: Record<string, unknown>;
   affairSnapshot: AffairSnapshot;
@@ -378,7 +381,11 @@ export default function PropositionsPage() {
                     </div>
                   </div>
 
-                  {row.payloadKind === "ADD_EVENT" && row.eventPreview ? (
+                  {row.payloadKind === "INVALID" ? (
+                    <p className="text-muted-foreground text-sm">
+                      Le contenu imbriqué ne peut pas être présenté de façon sûre.
+                    </p>
+                  ) : row.payloadKind === "ADD_EVENT" && row.eventPreview ? (
                     <div className="border-border bg-muted/30 rounded-md border p-4 text-sm">
                       <p className="font-semibold">Ajout proposé à la chronologie</p>
                       <dl className="mt-3 grid gap-2 sm:grid-cols-[10rem_1fr]">
@@ -390,6 +397,8 @@ export default function PropositionsPage() {
                         <dd>{row.eventPreview.title}</dd>
                         <dt className="text-muted-foreground">Source</dt>
                         <dd>{row.eventPreview.sourceTitle}</dd>
+                        <dt className="text-muted-foreground">Éditeur</dt>
+                        <dd>{row.eventPreview.publisher}</dd>
                         <dt className="text-muted-foreground">URL</dt>
                         <dd className="break-all">{row.eventPreview.sourceUrl}</dd>
                         <dt className="text-muted-foreground">Identité technique</dt>
@@ -451,6 +460,26 @@ export default function PropositionsPage() {
                               {formatConflictValue(detail.expected)}&nbsp;», trouvé «&nbsp;
                               {formatConflictValue(detail.actual)}&nbsp;»
                             </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  )}
+
+                  {row.validationIssues.length > 0 && (
+                    <div
+                      id={`validation-${row.id}`}
+                      className="border-destructive/40 bg-destructive/10 flex gap-2 rounded-md border px-3 py-2 text-sm"
+                    >
+                      <ShieldAlert
+                        className="text-destructive mt-0.5 h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <p className="font-medium">Proposition non applicable</p>
+                        <ul className="mt-1 list-disc pl-4">
+                          {row.validationIssues.map((issue) => (
+                            <li key={issue}>{issue}</li>
                           ))}
                         </ul>
                       </div>
@@ -561,13 +590,23 @@ export default function PropositionsPage() {
                           className="min-h-11"
                           onClick={() => void review(row.id, "accept")}
                           disabled={
-                            busyId === row.id || (evidence.required && !evidence.acceptable)
+                            busyId === row.id ||
+                            !row.acceptanceEligible ||
+                            (evidence.required && !evidence.acceptable)
                           }
-                          aria-describedby={evidence.required ? evidenceDescriptionId : undefined}
+                          aria-describedby={
+                            !row.acceptanceEligible
+                              ? `validation-${row.id}`
+                              : evidence.required
+                                ? evidenceDescriptionId
+                                : undefined
+                          }
                           title={
-                            evidence.required && !evidence.acceptable
-                              ? "Acceptation bloquée tant que la décision officielle n'est pas vérifiée"
-                              : undefined
+                            !row.acceptanceEligible
+                              ? "Acceptation bloquée car la proposition ou sa provenance est invalide"
+                              : evidence.required && !evidence.acceptable
+                                ? "Acceptation bloquée tant que la décision officielle n'est pas vérifiée"
+                                : undefined
                           }
                         >
                           Accepter et appliquer

--- a/src/app/api/admin/affaires/propositions/route.test.ts
+++ b/src/app/api/admin/affaires/propositions/route.test.ts
@@ -117,6 +117,7 @@ describe("GET admin affair proposals source links", () => {
     const identityKey = computeAffairEventIdentity({
       affairId: "affair-1",
       sourceUrl,
+      publishedAt: new Date(date),
       pressArticleId: "article-1",
     });
     h.db.affairUpdateProposal.findMany.mockResolvedValue([

--- a/src/app/api/admin/affaires/propositions/route.test.ts
+++ b/src/app/api/admin/affaires/propositions/route.test.ts
@@ -17,6 +17,8 @@ vi.mock("@/lib/api/with-admin-auth", () => ({
 }));
 
 import { GET } from "./route";
+import { computeAffairEventIdentity } from "@/services/affairs/proposals";
+import { AFFAIR_EVOLUTION_REVELATION_TITLE } from "@/lib/security/schemas/affair-proposal";
 
 const PRESS_URL = "https://press.example.test/politique/article-test.html";
 
@@ -107,5 +109,99 @@ describe("GET admin affair proposals source links", () => {
       sourceLink: { safeUrl: null },
       officialEvidence: { required: true, canonicalUrl: null },
     });
+  });
+
+  it("valide toute la provenance événement et expose l’éditeur", async () => {
+    const sourceUrl = "https://www.lemonde.fr/politique/article-test.html";
+    const date = "2026-08-27T08:00:00.000Z";
+    const identityKey = computeAffairEventIdentity({
+      affairId: "affair-1",
+      sourceUrl,
+      pressArticleId: "article-1",
+    });
+    h.db.affairUpdateProposal.findMany.mockResolvedValue([
+      proposalRow({
+        sourceUrl,
+        sourceExcerpt: "Extrait exact de l’article.",
+        affair: { id: "affair-1", publicationStatus: "PUBLISHED" },
+        proposedPatch: {
+          addEvent: {
+            date,
+            type: "REVELATION",
+            title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+            description: null,
+            sourceUrl,
+            sourceTitle: "Titre original",
+          },
+        },
+        observedValues: {
+          addEvent: {
+            identityVersion: "press-revelation-v2",
+            identityKey,
+            existingEventId: null,
+          },
+        },
+        metadata: {
+          eventProposal: {
+            version: 1,
+            identityVersion: "press-revelation-v2",
+            identityKey,
+            publisher: "Le Monde",
+            publishedAt: date,
+            pressArticleId: "article-1",
+            resolverDecisionId: null,
+          },
+        },
+      }),
+    ]);
+
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/affaires/propositions?status=PENDING"),
+      { params: Promise.resolve({}) }
+    );
+    const body = (await response.json()) as {
+      rows: Array<{
+        acceptanceEligible: boolean;
+        validationIssues: string[];
+        eventPreview: { publisher: string };
+      }>;
+    };
+
+    expect(body.rows[0]).toMatchObject({
+      acceptanceEligible: true,
+      validationIssues: [],
+      eventPreview: { publisher: "Le Monde" },
+    });
+  });
+
+  it("bloque la présentation événement lorsque les métadonnées sont absentes", async () => {
+    h.db.affairUpdateProposal.findMany.mockResolvedValue([
+      proposalRow({
+        affair: { id: "affair-1", publicationStatus: "PUBLISHED" },
+        proposedPatch: {
+          addEvent: {
+            date: "2026-08-27T08:00:00.000Z",
+            type: "REVELATION",
+            title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+            sourceUrl: "https://www.lemonde.fr/politique/article-test.html",
+            sourceTitle: "Titre original",
+          },
+        },
+        observedValues: {},
+        metadata: null,
+      }),
+    ]);
+
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/admin/affaires/propositions?status=PENDING"),
+      { params: Promise.resolve({}) }
+    );
+    const body = (await response.json()) as {
+      rows: Array<{ payloadKind: string; acceptanceEligible: boolean; validationIssues: string[] }>;
+    };
+
+    expect(body.rows[0]?.payloadKind).toBe("INVALID");
+    expect(body.rows[0]?.acceptanceEligible).toBe(false);
+    expect(body.rows[0]?.validationIssues.length).toBeGreaterThan(0);
   });
 });

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -6,11 +6,9 @@ import {
   summarizeProposalOfficialEvidence,
   summarizeProposalSourceLink,
 } from "@/lib/affairs/official-decision-verification";
-import type { Prisma, ProposalStatus } from "@/generated/prisma";
-import {
-  parseAffairEventObservation,
-  parseAffairProposalPayload,
-} from "@/lib/security/schemas/affair-proposal";
+import type { Prisma, ProposalStatus, SourceType } from "@/generated/prisma";
+import { parseAffairProposalPayload } from "@/lib/security/schemas/affair-proposal";
+import { parseAffairEventProposalContext } from "@/services/affairs/proposals";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
 
@@ -28,24 +26,61 @@ function parseStatus(raw: string | null): ProposalStatus {
   return VALID_STATUSES.includes(raw as ProposalStatus) ? (raw as ProposalStatus) : "PENDING";
 }
 
-function proposalPresentation(raw: unknown, observedValues: unknown) {
+function proposalPresentation(row: {
+  affair: { id: string; publicationStatus: string } | null;
+  proposedPatch: unknown;
+  observedValues: unknown;
+  metadata: unknown;
+  source: SourceType;
+  sourceUrl: string | null;
+  sourceExcerpt: string | null;
+}) {
   try {
-    const parsed = parseAffairProposalPayload(raw);
-    if (parsed.kind === "PATCH") return { payloadKind: "PATCH" as const, eventPreview: null };
+    const parsed = parseAffairProposalPayload(row.proposedPatch);
+    if (parsed.kind === "PATCH") {
+      const issues = row.affair ? [] : ["L’affaire cible a été supprimée"];
+      return {
+        payloadKind: "PATCH" as const,
+        eventPreview: null,
+        acceptanceEligible: issues.length === 0,
+        validationIssues: issues,
+      };
+    }
+    if (!row.affair) throw new Error("L’affaire cible a été supprimée");
+    if (!new Set(["DRAFT", "PUBLISHED"]).has(row.affair.publicationStatus)) {
+      throw new Error(`Le statut ${row.affair.publicationStatus} interdit l’ajout d’un événement`);
+    }
+    const context = parseAffairEventProposalContext({
+      affairId: row.affair.id,
+      proposedPatch: row.proposedPatch,
+      observedValues: row.observedValues,
+      metadata: row.metadata,
+      source: row.source,
+      sourceUrl: row.sourceUrl,
+      sourceExcerpt: row.sourceExcerpt,
+    });
     return {
       payloadKind: "ADD_EVENT" as const,
+      acceptanceEligible: true,
+      validationIssues: [],
       eventPreview: {
-        date: parsed.event.date.toISOString(),
-        type: parsed.event.type,
-        title: parsed.event.title,
-        description: parsed.event.description ?? null,
-        sourceUrl: parsed.event.sourceUrl,
-        sourceTitle: parsed.event.sourceTitle,
-        identityKey: parseAffairEventObservation(observedValues).addEvent.identityKey,
+        date: context.event.date.toISOString(),
+        type: context.event.type,
+        title: context.event.title,
+        description: context.event.description ?? null,
+        sourceUrl: context.event.sourceUrl,
+        sourceTitle: context.event.sourceTitle,
+        identityKey: context.identityKey,
+        publisher: context.metadata.eventProposal.publisher,
       },
     };
-  } catch {
-    return { payloadKind: "INVALID" as const, eventPreview: null };
+  } catch (error) {
+    return {
+      payloadKind: "INVALID" as const,
+      eventPreview: null,
+      acceptanceEligible: false,
+      validationIssues: [error instanceof Error ? error.message : "Proposition invalide"],
+    };
   }
 }
 
@@ -123,7 +158,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
 
       return {
         ...row,
-        ...proposalPresentation(row.proposedPatch, row.observedValues),
+        ...proposalPresentation({ ...row, metadata }),
         officialEvidence,
         sourceLink,
       };

--- a/src/app/api/admin/affaires/propositions/route.ts
+++ b/src/app/api/admin/affaires/propositions/route.ts
@@ -7,6 +7,10 @@ import {
   summarizeProposalSourceLink,
 } from "@/lib/affairs/official-decision-verification";
 import type { Prisma, ProposalStatus } from "@/generated/prisma";
+import {
+  parseAffairEventObservation,
+  parseAffairProposalPayload,
+} from "@/lib/security/schemas/affair-proposal";
 
 // Affaires v2, lot 1: review queue for importer-proposed affair changes.
 
@@ -22,6 +26,27 @@ const VALID_STATUSES: ProposalStatus[] = [
 
 function parseStatus(raw: string | null): ProposalStatus {
   return VALID_STATUSES.includes(raw as ProposalStatus) ? (raw as ProposalStatus) : "PENDING";
+}
+
+function proposalPresentation(raw: unknown, observedValues: unknown) {
+  try {
+    const parsed = parseAffairProposalPayload(raw);
+    if (parsed.kind === "PATCH") return { payloadKind: "PATCH" as const, eventPreview: null };
+    return {
+      payloadKind: "ADD_EVENT" as const,
+      eventPreview: {
+        date: parsed.event.date.toISOString(),
+        type: parsed.event.type,
+        title: parsed.event.title,
+        description: parsed.event.description ?? null,
+        sourceUrl: parsed.event.sourceUrl,
+        sourceTitle: parsed.event.sourceTitle,
+        identityKey: parseAffairEventObservation(observedValues).addEvent.identityKey,
+      },
+    };
+  } catch {
+    return { payloadKind: "INVALID" as const, eventPreview: null };
+  }
 }
 
 export const GET = withAdminAuth(async (request: NextRequest) => {
@@ -98,6 +123,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
 
       return {
         ...row,
+        ...proposalPresentation(row.proposedPatch, row.observedValues),
         officialEvidence,
         sourceLink,
       };

--- a/src/components/affairs/AffairTimeline.test.tsx
+++ b/src/components/affairs/AffairTimeline.test.tsx
@@ -5,6 +5,7 @@ import { AffairTimeline } from "./AffairTimeline";
 const mockEvents = [
   {
     id: "1",
+    identityKey: null,
     affairId: "affair-1",
     date: new Date("2020-01-15"),
     type: "REVELATION" as const,
@@ -16,6 +17,7 @@ const mockEvents = [
   },
   {
     id: "2",
+    identityKey: null,
     affairId: "affair-1",
     date: new Date("2020-06-20"),
     type: "MISE_EN_EXAMEN" as const,
@@ -27,6 +29,7 @@ const mockEvents = [
   },
   {
     id: "3",
+    identityKey: null,
     affairId: "affair-1",
     date: new Date("2021-03-10"),
     type: "CONDAMNATION" as const,

--- a/src/config/affair-sources.test.ts
+++ b/src/config/affair-sources.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  findVerifiedAffairPressEventSource,
+  isVerifiedAffairPressUrl,
+} from "@/config/affair-sources";
+
+describe("sources de presse des événements d’affaire", () => {
+  const completeSource = {
+    url: "https://www.lemonde.fr/politique/article/2026/08/27/suivi.html",
+    title: "Titre original de l’article",
+    publisher: "Le Monde",
+    publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+    excerpt: "Extrait vérifié dans le contenu de l’article.",
+  };
+
+  it("accepte les domaines journalistiques vérifiés et leurs sous-domaines", () => {
+    expect(isVerifiedAffairPressUrl(completeSource.url)).toBe(true);
+    expect(isVerifiedAffairPressUrl("https://politique.lefigaro.fr/article")).toBe(true);
+    expect(isVerifiedAffairPressUrl("https://lemonde.fr.example.net/article")).toBe(false);
+  });
+
+  it("exige une date de publication et un extrait explicites", () => {
+    expect(findVerifiedAffairPressEventSource([completeSource])).toEqual(completeSource);
+    expect(
+      findVerifiedAffairPressEventSource([{ ...completeSource, publishedAt: null }])
+    ).toBeNull();
+    expect(findVerifiedAffairPressEventSource([{ ...completeSource, excerpt: null }])).toBeNull();
+  });
+
+  it("ne déduit pas la date depuis une URL datée", () => {
+    const sourceWithoutMetadata = {
+      ...completeSource,
+      publishedAt: null,
+    };
+
+    expect(findVerifiedAffairPressEventSource([sourceWithoutMetadata])).toBeNull();
+  });
+});

--- a/src/config/affair-sources.ts
+++ b/src/config/affair-sources.ts
@@ -1,0 +1,48 @@
+const VERIFIED_AFFAIR_PRESS_HOSTS = new Set([
+  "lemonde.fr",
+  "mediapart.fr",
+  "afp.com",
+  "lefigaro.fr",
+  "liberation.fr",
+  "francetvinfo.fr",
+  "reuters.com",
+  "apnews.com",
+]);
+
+/** Sources journalistiques admises pour ajouter un fait judiciaire à une fiche. */
+export function isVerifiedAffairPressUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase().replace(/^www\./, "");
+    return [...VERIFIED_AFFAIR_PRESS_HOSTS].some(
+      (allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export interface AffairPressEventSource {
+  url: string;
+  title: string;
+  publisher: string;
+  publishedAt: Date | null;
+  excerpt?: string | null;
+}
+
+/** Selects only provenance complete enough for a HIGH-risk public timeline proposal. */
+export function findVerifiedAffairPressEventSource<T extends AffairPressEventSource>(
+  sources: readonly T[]
+): T | null {
+  return (
+    sources.find(
+      (source) =>
+        isVerifiedAffairPressUrl(source.url) &&
+        source.publishedAt instanceof Date &&
+        !Number.isNaN(source.publishedAt.getTime()) &&
+        source.title.trim().length > 0 &&
+        source.publisher.trim().length > 0 &&
+        Boolean(source.excerpt?.trim()) &&
+        source.excerpt!.trim().length <= 500
+    ) ?? null
+  );
+}

--- a/src/lib/affair-matching/resolver.ts
+++ b/src/lib/affair-matching/resolver.ts
@@ -68,11 +68,16 @@ export interface ResolveResult {
   decisionId: string;
 }
 
+export type ResolvePreviewResult = Omit<ResolveResult, "decisionId"> & { decisionId: null };
+
 /**
  * Full resolver entry point. Loads politicians, prefilters, scores, judges,
  * persists, and returns the decision id.
  */
-export async function resolveAffairPolitician(input: AffairScoringInput): Promise<ResolveResult> {
+async function resolveAffairPoliticianInternal(
+  input: AffairScoringInput,
+  persist: boolean
+): Promise<ResolveResult | ResolvePreviewResult> {
   if (input.text.length > 100_000) {
     throw new Error("Affair text exceeds 100KB limit");
   }
@@ -87,11 +92,15 @@ export async function resolveAffairPolitician(input: AffairScoringInput): Promis
 
   const decision = scoreAffairAgainstCandidates(input, candidates, vocabulary);
 
-  const { decisionId } = await persistDecision({
-    text: input.text,
-    metadata: input.metadata,
-    decision,
-  });
+  const decisionId = persist
+    ? (
+        await persistDecision({
+          text: input.text,
+          metadata: input.metadata,
+          decision,
+        })
+      ).decisionId
+    : null;
 
   return {
     judgment: decision.judgment,
@@ -101,4 +110,15 @@ export async function resolveAffairPolitician(input: AffairScoringInput): Promis
     topCandidates: decision.topCandidates,
     decisionId,
   };
+}
+
+export async function resolveAffairPolitician(input: AffairScoringInput): Promise<ResolveResult> {
+  return resolveAffairPoliticianInternal(input, true) as Promise<ResolveResult>;
+}
+
+/** Runs the same resolver without creating an audit row, for strict dry-runs. */
+export async function previewAffairPolitician(
+  input: AffairScoringInput
+): Promise<ResolvePreviewResult> {
+  return resolveAffairPoliticianInternal(input, false) as Promise<ResolvePreviewResult>;
 }

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { AffairStatus, Prisma } from "@/generated/prisma";
+import { AffairEventType, AffairStatus, Prisma } from "@/generated/prisma";
 import { isValidSentenceSplit, LIFE_SENTENCE_MONTHS } from "@/lib/affairs/sentence-split";
 
 // Affaires v2, lot 1: the strict gate between an importer-proposed JSON patch and
@@ -48,6 +48,115 @@ const dateLike = z
   .union([z.date(), z.string().min(1)])
   .refine((v) => !Number.isNaN(new Date(v).getTime()), { message: "Date invalide" })
   .transform((v) => new Date(v));
+
+const ISO_INSTANT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/**
+ * Event dates cross a JSON boundary before review. Accept Date objects from
+ * importers and the exact UTC representation JSON.stringify produces, but never
+ * normalize an impossible calendar date into another day.
+ */
+const strictInstantLike = z
+  .union([z.date(), z.string().regex(ISO_INSTANT_PATTERN, "Date ISO UTC invalide")])
+  .refine((value) => {
+    const date = value instanceof Date ? value : new Date(value);
+    return !Number.isNaN(date.getTime()) && (value instanceof Date || date.toISOString() === value);
+  }, "Date invalide")
+  .transform((value) => new Date(value));
+
+function normalizeHttpUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return null;
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+const httpUrl = z
+  .string()
+  .min(1)
+  .max(2048)
+  .refine((value) => normalizeHttpUrl(value) !== null, "URL HTTP(S) invalide")
+  .transform((value) => normalizeHttpUrl(value)!);
+
+/** Public copy is deterministic and never comes from an AI extraction. */
+export const AFFAIR_EVOLUTION_REVELATION_TITLE =
+  "Publication d’une nouvelle source sur l’évolution de l’affaire";
+
+export const affairEventProposalSchema = z.strictObject({
+  date: strictInstantLike,
+  // Issue #763 deliberately proposes a media event, not a dated procedural act.
+  type: z.enum(AffairEventType).refine((value) => value === "REVELATION", {
+    message: "Seul un événement REVELATION peut être proposé par un importeur",
+  }),
+  title: z.literal(AFFAIR_EVOLUTION_REVELATION_TITLE),
+  description: z.null().optional(),
+  sourceUrl: httpUrl,
+  sourceTitle: z.string().trim().min(1).max(500),
+});
+
+export const affairEventAdditionSchema = z.strictObject({
+  addEvent: affairEventProposalSchema,
+});
+
+export const affairEventObservationSchema = z.strictObject({
+  addEvent: z.strictObject({
+    identityVersion: z.literal("press-revelation-v1"),
+    identityKey: z.string().regex(/^[a-f0-9]{64}$/),
+    existingEventId: z.null(),
+  }),
+});
+
+export const affairEventProposalMetadataSchema = z.strictObject({
+  eventProposal: z.strictObject({
+    version: z.literal(1),
+    identityVersion: z.literal("press-revelation-v1"),
+    identityKey: z.string().regex(/^[a-f0-9]{64}$/),
+    publisher: z.string().trim().min(1).max(200),
+    publishedAt: strictInstantLike,
+    pressArticleId: z.string().min(1).nullable().optional(),
+    resolverDecisionId: z.string().min(1).nullable().optional(),
+  }),
+});
+
+export type AffairEventProposal = z.infer<typeof affairEventProposalSchema>;
+export type AffairEventAddition = z.infer<typeof affairEventAdditionSchema>;
+export type AffairEventObservation = z.infer<typeof affairEventObservationSchema>;
+export type AffairEventProposalMetadata = z.infer<typeof affairEventProposalMetadataSchema>;
+
+export type ParsedAffairProposal =
+  | { kind: "PATCH"; patch: AffairPatch }
+  | { kind: "ADD_EVENT"; event: AffairEventProposal };
+
+export function parseAffairProposalPayload(raw: unknown): ParsedAffairProposal {
+  const event = affairEventAdditionSchema.safeParse(raw);
+  if (event.success) return { kind: "ADD_EVENT", event: event.data.addEvent };
+
+  const patch = affairPatchSchema.safeParse(raw);
+  if (patch.success) return { kind: "PATCH", patch: patch.data };
+
+  const issues = [...event.error.issues, ...patch.error.issues].map(
+    (issue) => `${issue.path.join(".") || "payload"}: ${issue.message}`
+  );
+  throw new Error(issues.join("; "));
+}
+
+export function parseAffairEventObservation(raw: unknown): AffairEventObservation {
+  return affairEventObservationSchema.parse(raw);
+}
+
+export function parseAffairEventProposalMetadata(raw: unknown): AffairEventProposalMetadata {
+  return affairEventProposalMetadataSchema.parse(raw);
+}
+
+export function normalizeAffairEventSourceUrl(raw: string): string {
+  const normalized = normalizeHttpUrl(raw);
+  if (!normalized) throw new Error("URL HTTP(S) invalide");
+  return normalized;
+}
 
 /** 1200 months = 100 years. Guards against unit confusion (years passed as months). */
 const monthsLike = z.number().int().min(0).max(1200);

--- a/src/lib/security/schemas/affair-proposal.ts
+++ b/src/lib/security/schemas/affair-proposal.ts
@@ -69,6 +69,27 @@ function normalizeHttpUrl(raw: string): string | null {
     const url = new URL(raw);
     if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return null;
     url.hash = "";
+    for (const key of [...url.searchParams.keys()]) {
+      if (
+        /^(utm_|pk_)/i.test(key) ||
+        [
+          "fbclid",
+          "gclid",
+          "dclid",
+          "gbraid",
+          "wbraid",
+          "msclkid",
+          "mc_cid",
+          "mc_eid",
+          "at_campaign",
+          "at_medium",
+          "xtor",
+        ].includes(key.toLowerCase())
+      ) {
+        url.searchParams.delete(key);
+      }
+    }
+    url.searchParams.sort();
     return url.toString();
   } catch {
     return null;
@@ -104,7 +125,7 @@ export const affairEventAdditionSchema = z.strictObject({
 
 export const affairEventObservationSchema = z.strictObject({
   addEvent: z.strictObject({
-    identityVersion: z.literal("press-revelation-v1"),
+    identityVersion: z.literal("press-revelation-v2"),
     identityKey: z.string().regex(/^[a-f0-9]{64}$/),
     existingEventId: z.null(),
   }),
@@ -113,7 +134,7 @@ export const affairEventObservationSchema = z.strictObject({
 export const affairEventProposalMetadataSchema = z.strictObject({
   eventProposal: z.strictObject({
     version: z.literal(1),
-    identityVersion: z.literal("press-revelation-v1"),
+    identityVersion: z.literal("press-revelation-v2"),
     identityKey: z.string().regex(/^[a-f0-9]{64}$/),
     publisher: z.string().trim().min(1).max(200),
     publishedAt: strictInstantLike,

--- a/src/services/affairs/__tests__/proposal-batch.test.ts
+++ b/src/services/affairs/__tests__/proposal-batch.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AFFAIR_EVOLUTION_REVELATION_TITLE } from "@/lib/security/schemas/affair-proposal";
-import { selectProposalIdsForBatch } from "@/services/affairs/proposal-batch";
+import {
+  collectProposalCandidatesForBatch,
+  selectProposalIdsForBatch,
+} from "@/services/affairs/proposal-batch";
 
 const eventPatch = {
   addEvent: {
@@ -31,5 +34,44 @@ describe("selectProposalIdsForBatch", () => {
     expect(
       selectProposalIdsForBatch(["event-1"], [{ id: "event-1", proposedPatch: eventPatch }], true)
     ).toEqual({ acceptedIds: ["event-1"], excludedEventIds: [] });
+  });
+});
+
+describe("collectProposalCandidatesForBatch", () => {
+  it("applies the limit after excluded event proposals", async () => {
+    const candidates = [
+      ...Array.from({ length: 5 }, (_, index) => ({
+        id: `event-${index}`,
+        proposedPatch: eventPatch,
+      })),
+      { id: "patch-1", proposedPatch: { court: "TJ de Paris" } },
+      { id: "patch-2", proposedPatch: { court: "CA de Paris" } },
+    ];
+    const fetchPage = vi.fn(async ({ skip, take }: { skip: number; take: number }) =>
+      candidates.slice(skip, skip + take)
+    );
+
+    const result = await collectProposalCandidatesForBatch(fetchPage, 2, false, 3);
+
+    expect(result.rows.map((row) => row.id)).toEqual(["patch-1", "patch-2"]);
+    expect(result.excludedEvents).toBe(5);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps event proposals when explicitly included", async () => {
+    const candidates = [
+      { id: "event-1", proposedPatch: eventPatch },
+      { id: "patch-1", proposedPatch: { court: "TJ de Paris" } },
+    ];
+
+    const result = await collectProposalCandidatesForBatch(
+      async ({ skip, take }) => candidates.slice(skip, skip + take),
+      1,
+      true,
+      1
+    );
+
+    expect(result.rows.map((row) => row.id)).toEqual(["event-1"]);
+    expect(result.excludedEvents).toBe(0);
   });
 });

--- a/src/services/affairs/__tests__/proposal-batch.test.ts
+++ b/src/services/affairs/__tests__/proposal-batch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { AFFAIR_EVOLUTION_REVELATION_TITLE } from "@/lib/security/schemas/affair-proposal";
+import { selectProposalIdsForBatch } from "@/services/affairs/proposal-batch";
+
+const eventPatch = {
+  addEvent: {
+    date: "2026-08-27T08:00:00.000Z",
+    type: "REVELATION",
+    title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+    description: null,
+    sourceUrl: "https://www.lemonde.fr/politique/article-test.html",
+    sourceTitle: "Titre original",
+  },
+};
+
+describe("selectProposalIdsForBatch", () => {
+  it("exclut un événement sans opt-in explicite", () => {
+    expect(
+      selectProposalIdsForBatch(
+        ["patch-1", "event-1"],
+        [
+          { id: "patch-1", proposedPatch: { court: "Tribunal judiciaire de Paris" } },
+          { id: "event-1", proposedPatch: eventPatch },
+        ],
+        false
+      )
+    ).toEqual({ acceptedIds: ["patch-1"], excludedEventIds: ["event-1"] });
+  });
+
+  it("inclut un événement avec l’opt-in explicite", () => {
+    expect(
+      selectProposalIdsForBatch(["event-1"], [{ id: "event-1", proposedPatch: eventPatch }], true)
+    ).toEqual({ acceptedIds: ["event-1"], excludedEventIds: [] });
+  });
+});

--- a/src/services/affairs/__tests__/proposal-event-concurrency.integration.test.ts
+++ b/src/services/affairs/__tests__/proposal-event-concurrency.integration.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+let db: typeof import("@/lib/db").db;
+let acceptProposal: typeof import("@/services/affairs/proposal-review").acceptProposal;
+let proposeAffairEvent: typeof import("@/services/affairs/proposals").proposeAffairEvent;
+
+it("garde le test PostgreSQL derrière le garde de base jetable", () => {
+  expect(describeIfDisposableDb).toBeDefined();
+});
+
+describeIfDisposableDb("propositions d’événement concurrentes", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ acceptProposal } = await import("@/services/affairs/proposal-review"));
+    ({ proposeAffairEvent } = await import("@/services/affairs/proposals"));
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("crée un seul événement pour deux propositions distinctes de même identité", async () => {
+    const suffix = crypto.randomUUID();
+    const politician = await db.politician.create({
+      data: {
+        slug: `test-evolution-${suffix}`,
+        firstName: "Test",
+        lastName: "Évolution",
+        fullName: "Test Évolution",
+      },
+    });
+    const affair = await db.affair.create({
+      data: {
+        politicianId: politician.id,
+        slug: `test-affaire-evolution-${suffix}`,
+        title: "Affaire de test concurrent",
+        description: "Donnée de test jetable.",
+        status: "ENQUETE_PRELIMINAIRE",
+        category: "FAVORITISME",
+        publicationStatus: "DRAFT",
+      },
+    });
+    const importRun = await db.importRun.create({
+      data: { importer: "test-affair-evolution", status: "COMPLETED", finishedAt: new Date() },
+    });
+
+    const proposalIds: string[] = [];
+    try {
+      const base = {
+        affairId: affair.id,
+        importer: "test-affair-evolution",
+        importRunId: importRun.id,
+        sourceUrl: "https://www.lemonde.fr/politique/article/test-concurrent.html",
+        sourceTitle: "Article de test concurrent",
+        publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+        publisher: "Le Monde",
+        sourceExcerpt: "Extrait vérifié de la source de test.",
+        confidence: 55,
+        rationale: "Test de sérialisation PostgreSQL.",
+        extractorVersion: "integration-v1",
+      };
+      const first = await proposeAffairEvent({ ...base, sourceContentHash: "version-1" });
+      const second = await proposeAffairEvent({ ...base, sourceContentHash: "version-2" });
+      proposalIds.push(first.pendingProposalId!, second.pendingProposalId!);
+
+      const results = await Promise.all([
+        acceptProposal({ proposalId: proposalIds[0]!, reviewedBy: "test" }),
+        acceptProposal({ proposalId: proposalIds[1]!, reviewedBy: "test" }),
+      ]);
+
+      expect(results.filter((result) => result.ok)).toHaveLength(1);
+      expect(results.filter((result) => !result.ok && result.reason === "conflict")).toHaveLength(
+        1
+      );
+      await expect(db.affairEvent.count({ where: { affairId: affair.id } })).resolves.toBe(1);
+      const proposals = await db.affairUpdateProposal.findMany({
+        where: { id: { in: proposalIds } },
+        select: { status: true },
+      });
+      expect(proposals.map((proposal) => proposal.status).sort()).toEqual(["APPROVED", "CONFLICT"]);
+    } finally {
+      const eventIds = (
+        await db.affairEvent.findMany({ where: { affairId: affair.id }, select: { id: true } })
+      ).map((event) => event.id);
+      await db.auditLog.deleteMany({ where: { entityId: { in: [...proposalIds, ...eventIds] } } });
+      await db.affairUpdateProposal.deleteMany({ where: { id: { in: proposalIds } } });
+      await db.importRun.delete({ where: { id: importRun.id } });
+      await db.politician.delete({ where: { id: politician.id } });
+    }
+  });
+});

--- a/src/services/affairs/__tests__/proposal-event-concurrency.integration.test.ts
+++ b/src/services/affairs/__tests__/proposal-event-concurrency.integration.test.ts
@@ -45,6 +45,15 @@ describeIfDisposableDb("propositions d’événement concurrentes", () => {
     const importRun = await db.importRun.create({
       data: { importer: "test-affair-evolution", status: "COMPLETED", finishedAt: new Date() },
     });
+    const pressArticle = await db.pressArticle.create({
+      data: {
+        feedSource: "lemonde",
+        externalId: `test-concurrent-${suffix}`,
+        title: "Article de test concurrent",
+        url: `https://www.lemonde.fr/politique/article/test-concurrent-${suffix}.html`,
+        publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+      },
+    });
 
     const proposalIds: string[] = [];
     try {
@@ -52,7 +61,7 @@ describeIfDisposableDb("propositions d’événement concurrentes", () => {
         affairId: affair.id,
         importer: "test-affair-evolution",
         importRunId: importRun.id,
-        sourceUrl: "https://www.lemonde.fr/politique/article/test-concurrent.html",
+        sourceUrl: `${pressArticle.url}?utm_source=rss#suivi`,
         sourceTitle: "Article de test concurrent",
         publishedAt: new Date("2026-08-27T08:00:00.000Z"),
         publisher: "Le Monde",
@@ -60,9 +69,14 @@ describeIfDisposableDb("propositions d’événement concurrentes", () => {
         confidence: 55,
         rationale: "Test de sérialisation PostgreSQL.",
         extractorVersion: "integration-v1",
+        pressArticleId: pressArticle.id,
       };
       const first = await proposeAffairEvent({ ...base, sourceContentHash: "version-1" });
-      const second = await proposeAffairEvent({ ...base, sourceContentHash: "version-2" });
+      const second = await proposeAffairEvent({
+        ...base,
+        sourceUrl: pressArticle.url,
+        sourceContentHash: "version-2",
+      });
       proposalIds.push(first.pendingProposalId!, second.pendingProposalId!);
 
       const results = await Promise.all([
@@ -75,6 +89,8 @@ describeIfDisposableDb("propositions d’événement concurrentes", () => {
         1
       );
       await expect(db.affairEvent.count({ where: { affairId: affair.id } })).resolves.toBe(1);
+      const event = await db.affairEvent.findFirstOrThrow({ where: { affairId: affair.id } });
+      expect(event.identityKey).toMatch(/^[a-f0-9]{64}$/);
       const proposals = await db.affairUpdateProposal.findMany({
         where: { id: { in: proposalIds } },
         select: { status: true },
@@ -86,6 +102,7 @@ describeIfDisposableDb("propositions d’événement concurrentes", () => {
       ).map((event) => event.id);
       await db.auditLog.deleteMany({ where: { entityId: { in: [...proposalIds, ...eventIds] } } });
       await db.affairUpdateProposal.deleteMany({ where: { id: { in: proposalIds } } });
+      await db.pressArticle.delete({ where: { id: pressArticle.id } });
       await db.importRun.delete({ where: { id: importRun.id } });
       await db.politician.delete({ where: { id: politician.id } });
     }

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -7,9 +7,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), update: vi.fn() },
+    affairEvent: { findFirst: vi.fn(), create: vi.fn() },
+    source: { upsert: vi.fn() },
+    pressArticleAffair: { upsert: vi.fn(), update: vi.fn() },
+    affairPoliticianDecision: { findUnique: vi.fn(), updateMany: vi.fn() },
     affairUpdateProposal: { findUnique: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     moderationReview: { create: vi.fn() },
     auditLog: { create: vi.fn() },
+    $queryRaw: vi.fn(),
     $transaction: vi.fn(),
   },
   trackStatusChange: vi.fn(),
@@ -27,6 +32,8 @@ vi.mock("@/lib/affairs/official-decision-verification", async (importOriginal) =
 });
 
 import { acceptProposal, rejectProposal } from "@/services/affairs/proposal-review";
+import { computeAffairEventIdentity } from "@/services/affairs/proposals";
+import { AFFAIR_EVOLUTION_REVELATION_TITLE } from "@/lib/security/schemas/affair-proposal";
 
 const db = h.db;
 
@@ -37,6 +44,7 @@ const LIVE_AFFAIR = {
   title: "Affaire de test",
   politician: { slug: "jean-testeur", fullName: "Jean Testeur" },
   status: "APPEL_EN_COURS",
+  publicationStatus: "PUBLISHED",
   verdictDate: null,
   court: null,
   sentence: null,
@@ -86,15 +94,70 @@ function pendingProposal(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function pendingEventProposal(overrides: Record<string, unknown> = {}) {
+  const date = new Date("2026-08-27T08:00:00.000Z");
+  const sourceUrl = "https://www.lemonde.fr/politique/article-test.html";
+  const identityKey = computeAffairEventIdentity({
+    affairId: "aff_1",
+    sourceUrl,
+    publishedAt: date,
+    pressArticleId: "article_1",
+  });
+  return pendingProposal({
+    importer: "press-analysis",
+    extractorVersion: "press-evolution-v1",
+    source: "PRESSE",
+    sourceUrl,
+    sourceExcerpt: "Extrait exact.",
+    proposedPatch: {
+      addEvent: {
+        date: date.toISOString(),
+        type: "REVELATION",
+        title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+        description: null,
+        sourceUrl,
+        sourceTitle: "Titre original de l’article",
+      },
+    },
+    observedValues: {
+      addEvent: {
+        identityVersion: "press-revelation-v1",
+        identityKey,
+        existingEventId: null,
+      },
+    },
+    metadata: {
+      eventProposal: {
+        version: 1,
+        identityVersion: "press-revelation-v1",
+        identityKey,
+        publisher: "AFP",
+        publishedAt: date.toISOString(),
+        pressArticleId: "article_1",
+        resolverDecisionId: "decision_1",
+      },
+    },
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(LIVE_AFFAIR);
   db.affair.update.mockResolvedValue({});
+  db.affairEvent.findFirst.mockResolvedValue(null);
+  db.affairEvent.create.mockResolvedValue({ id: "event_1" });
+  db.source.upsert.mockResolvedValue({ id: "source_1" });
+  db.pressArticleAffair.upsert.mockResolvedValue({ id: "link_1", role: "UPDATE" });
+  db.pressArticleAffair.update.mockResolvedValue({});
+  db.affairPoliticianDecision.findUnique.mockResolvedValue({ affairId: null });
+  db.affairPoliticianDecision.updateMany.mockResolvedValue({ count: 1 });
   db.affairUpdateProposal.update.mockResolvedValue({});
   // Default: the claim succeeds (nobody else took the row).
   db.affairUpdateProposal.updateMany.mockResolvedValue({ count: 1 });
   db.moderationReview.create.mockResolvedValue({});
   db.auditLog.create.mockResolvedValue({});
+  db.$queryRaw.mockResolvedValue([{ id: "aff_1" }]);
   db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(db));
   h.trackStatusChange.mockResolvedValue(undefined);
   h.verifyProposalOfficialEvidence.mockResolvedValue(null);
@@ -289,7 +352,13 @@ describe("acceptProposal", () => {
     expect(result).toMatchObject({ ok: false, reason: "conflict" });
     expect(db.affair.update).not.toHaveBeenCalled();
     expect(db.moderationReview.create).not.toHaveBeenCalled();
-    expect(db.auditLog.create).not.toHaveBeenCalled();
+    expect(db.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          changes: expect.objectContaining({ action: "PROPOSAL_CONFLICT" }),
+        }),
+      })
+    );
 
     const conflictWrite = db.affairUpdateProposal.update.mock.calls[0]![0].data;
     expect(conflictWrite.status).toBe("CONFLICT");
@@ -370,6 +439,111 @@ describe("acceptProposal", () => {
     const result = await acceptProposal({ proposalId: "nope", reviewedBy: "admin" });
 
     expect(result).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("applique un événement et ses relations atomiquement sans modifier Affair", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: true, appliedFields: ["event"] });
+    expect(db.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          affairId: "aff_1",
+          type: "REVELATION",
+          title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+          description: null,
+        }),
+      })
+    );
+    expect(db.source.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          publisher: "AFP",
+          publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+        }),
+      })
+    );
+    expect(db.pressArticleAffair.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: { articleId: "article_1", affairId: "aff_1", role: "UPDATE" },
+      })
+    );
+    expect(db.affairPoliticianDecision.updateMany).toHaveBeenCalledWith({
+      where: { id: "decision_1", affairId: null },
+      data: { affairId: "aff_1" },
+    });
+    expect(h.trackStatusChange).not.toHaveBeenCalled();
+  });
+
+  it("passe en conflit si le même événement est apparu après le dépôt", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+    db.affairEvent.findFirst.mockResolvedValue({ id: "event_existing" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "conflict",
+      conflictDetail: { event: { expected: "absent", actual: "event_existing" } },
+    });
+    expect(db.affairEvent.create).not.toHaveBeenCalled();
+    expect(db.source.upsert).not.toHaveBeenCalled();
+    expect(db.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          changes: expect.objectContaining({ action: "PROPOSAL_CONFLICT" }),
+        }),
+      })
+    );
+  });
+
+  it("annule l’événement si la décision resolver vise déjà une autre affaire", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+    db.affairPoliticianDecision.findUnique.mockResolvedValue({ affairId: "aff_other" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "conflict" });
+    expect(db.affairEvent.create).not.toHaveBeenCalled();
+    expect(db.source.upsert).not.toHaveBeenCalled();
+  });
+
+  it("détecte une course lors du rattachement de la décision resolver", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+    db.affairPoliticianDecision.findUnique
+      .mockResolvedValueOnce({ affairId: null })
+      .mockResolvedValueOnce({ affairId: "aff_other" });
+    db.affairPoliticianDecision.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "conflict" });
+    expect(db.affairEvent.create).not.toHaveBeenCalled();
+    expect(db.source.upsert).not.toHaveBeenCalled();
+  });
+
+  it("passe en conflit si la cible est devenue archivée", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+    db.affair.findUnique.mockResolvedValue({ ...LIVE_AFFAIR, publicationStatus: "ARCHIVED" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result).toMatchObject({ ok: false, reason: "conflict" });
+    expect(db.affairEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("ne dégrade pas un lien REVELATION existant", async () => {
+    db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
+    db.pressArticleAffair.upsert.mockResolvedValue({ id: "link_1", role: "REVELATION" });
+
+    const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
+
+    expect(result.ok).toBe(true);
+    expect(db.pressArticleAffair.update).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), update: vi.fn() },
-    affairEvent: { findFirst: vi.fn(), create: vi.fn() },
+    affairEvent: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn() },
     source: { upsert: vi.fn() },
     pressArticleAffair: { upsert: vi.fn(), update: vi.fn() },
     affairPoliticianDecision: { findUnique: vi.fn(), updateMany: vi.fn() },
@@ -100,7 +100,6 @@ function pendingEventProposal(overrides: Record<string, unknown> = {}) {
   const identityKey = computeAffairEventIdentity({
     affairId: "aff_1",
     sourceUrl,
-    publishedAt: date,
     pressArticleId: "article_1",
   });
   return pendingProposal({
@@ -121,7 +120,7 @@ function pendingEventProposal(overrides: Record<string, unknown> = {}) {
     },
     observedValues: {
       addEvent: {
-        identityVersion: "press-revelation-v1",
+        identityVersion: "press-revelation-v2",
         identityKey,
         existingEventId: null,
       },
@@ -129,7 +128,7 @@ function pendingEventProposal(overrides: Record<string, unknown> = {}) {
     metadata: {
       eventProposal: {
         version: 1,
-        identityVersion: "press-revelation-v1",
+        identityVersion: "press-revelation-v2",
         identityKey,
         publisher: "AFP",
         publishedAt: date.toISOString(),
@@ -145,7 +144,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(LIVE_AFFAIR);
   db.affair.update.mockResolvedValue({});
-  db.affairEvent.findFirst.mockResolvedValue(null);
+  db.affairEvent.findUnique.mockResolvedValue(null);
+  db.affairEvent.findMany.mockResolvedValue([]);
   db.affairEvent.create.mockResolvedValue({ id: "event_1" });
   db.source.upsert.mockResolvedValue({ id: "source_1" });
   db.pressArticleAffair.upsert.mockResolvedValue({ id: "link_1", role: "UPDATE" });
@@ -453,6 +453,7 @@ describe("acceptProposal", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           affairId: "aff_1",
+          identityKey: expect.stringMatching(/^[a-f0-9]{64}$/),
           type: "REVELATION",
           title: AFFAIR_EVOLUTION_REVELATION_TITLE,
           description: null,
@@ -481,7 +482,7 @@ describe("acceptProposal", () => {
 
   it("passe en conflit si le même événement est apparu après le dépôt", async () => {
     db.affairUpdateProposal.findUnique.mockResolvedValue(pendingEventProposal());
-    db.affairEvent.findFirst.mockResolvedValue({ id: "event_existing" });
+    db.affairEvent.findUnique.mockResolvedValue({ id: "event_existing" });
 
     const result = await acceptProposal({ proposalId: "prop_1", reviewedBy: "admin" });
 

--- a/src/services/affairs/__tests__/proposal-review.test.ts
+++ b/src/services/affairs/__tests__/proposal-review.test.ts
@@ -100,6 +100,7 @@ function pendingEventProposal(overrides: Record<string, unknown> = {}) {
   const identityKey = computeAffairEventIdentity({
     affairId: "aff_1",
     sourceUrl,
+    publishedAt: date,
     pressArticleId: "article_1",
   });
   return pendingProposal({

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -442,11 +442,13 @@ describe("proposeAffairEvent", () => {
     const tracked = computeAffairEventIdentity({
       affairId: "aff_1",
       sourceUrl: "https://www.lemonde.fr/article.html?utm_source=rss#titre",
+      publishedAt: EVENT_INPUT.publishedAt,
       pressArticleId: "article_1",
     });
     const canonical = computeAffairEventIdentity({
       affairId: "aff_1",
       sourceUrl: "https://www.lemonde.fr/article.html",
+      publishedAt: EVENT_INPUT.publishedAt,
       pressArticleId: "article_1",
     });
 
@@ -457,13 +459,51 @@ describe("proposeAffairEvent", () => {
     const tracked = computeAffairEventIdentity({
       affairId: "aff_1",
       sourceUrl: "https://www.lemonde.fr/article.html?utm_source=rss&b=2&a=1#titre",
+      publishedAt: EVENT_INPUT.publishedAt,
     });
     const canonical = computeAffairEventIdentity({
       affairId: "aff_1",
       sourceUrl: "https://www.lemonde.fr/article.html?a=1&b=2",
+      publishedAt: EVENT_INPUT.publishedAt,
     });
 
     expect(tracked).toBe(canonical);
+  });
+
+  it("distingue l’affaire cible et la date réelle de publication", () => {
+    const base = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html",
+      publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+    });
+    const otherAffair = computeAffairEventIdentity({
+      affairId: "aff_2",
+      sourceUrl: "https://www.lemonde.fr/article.html",
+      publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+    });
+    const otherPublication = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html",
+      publishedAt: new Date("2026-08-28T08:00:00.000Z"),
+    });
+
+    expect(otherAffair).not.toBe(base);
+    expect(otherPublication).not.toBe(base);
+  });
+
+  it("ignore le titre et le hash de contenu dans l’identité de l’événement", async () => {
+    await proposeAffairEvent(EVENT_INPUT);
+    await proposeAffairEvent({
+      ...EVENT_INPUT,
+      sourceTitle: "Un titre éditorial modifié",
+      sourceContentHash: "un-autre-hash-de-contenu",
+    });
+
+    const identityKeys = db.affairEvent.findUnique.mock.calls.map(
+      ([query]) => query.where.affairId_identityKey.identityKey
+    );
+    expect(identityKeys).toHaveLength(2);
+    expect(identityKeys[1]).toBe(identityKeys[0]);
   });
 
   it("dépose un événement médiatique HIGH sans écrire sur l’affaire", async () => {

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
-    affairEvent: { findFirst: vi.fn() },
+    affairEvent: { findUnique: vi.fn(), findMany: vi.fn() },
     affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     auditLog: { create: vi.fn() },
     $transaction: vi.fn(),
@@ -21,12 +21,14 @@ import {
   parseAffairProposalPayload,
 } from "@/lib/security/schemas/affair-proposal";
 import {
+  computeAffairEventIdentity,
   computePayloadHash,
   deriveRiskLevel,
   detectDrift,
   EMPTY_VALUE,
   hashSourceContent,
   normalizeForCompare,
+  previewAffairEventProposal,
   proposeAffairUpdate,
   proposeAffairEvent,
   ProposalValidationError,
@@ -74,7 +76,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(EMPTY_AFFAIR);
   db.affair.findFirst.mockResolvedValue(null);
-  db.affairEvent.findFirst.mockResolvedValue(null);
+  db.affairEvent.findUnique.mockResolvedValue(null);
+  db.affairEvent.findMany.mockResolvedValue([]);
   db.affairUpdateProposal.findFirst.mockResolvedValue(null);
   db.affairUpdateProposal.create.mockImplementation(async () => ({ id: "prop_new" }));
   db.affairUpdateProposal.update.mockResolvedValue({});
@@ -435,18 +438,47 @@ describe("proposeAffairEvent", () => {
     extractorVersion: "press-evolution-v1",
   };
 
+  it("utilise uniquement PressArticle.id quand il est disponible", () => {
+    const tracked = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html?utm_source=rss#titre",
+      pressArticleId: "article_1",
+    });
+    const canonical = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html",
+      pressArticleId: "article_1",
+    });
+
+    expect(tracked).toBe(canonical);
+  });
+
+  it("canonise les paramètres de tracking quand aucun PressArticle.id n’existe", () => {
+    const tracked = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html?utm_source=rss&b=2&a=1#titre",
+    });
+    const canonical = computeAffairEventIdentity({
+      affairId: "aff_1",
+      sourceUrl: "https://www.lemonde.fr/article.html?a=1&b=2",
+    });
+
+    expect(tracked).toBe(canonical);
+  });
+
   it("dépose un événement médiatique HIGH sans écrire sur l’affaire", async () => {
     const result = await proposeAffairEvent(EVENT_INPUT);
 
     expect(result).toMatchObject({ outcome: "CREATED", pendingProposalId: "prop_new" });
     expect(db.affair.update).not.toHaveBeenCalled();
-    expect(db.affairEvent.findFirst).toHaveBeenCalledWith(
+    expect(db.affairEvent.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          affairId: "aff_1",
-          type: "REVELATION",
-          sourceUrl: "https://www.lemonde.fr/politique/article-test.html",
-        }),
+        where: {
+          affairId_identityKey: {
+            affairId: "aff_1",
+            identityKey: expect.stringMatching(/^[a-f0-9]{64}$/),
+          },
+        },
       })
     );
     const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
@@ -464,7 +496,7 @@ describe("proposeAffairEvent", () => {
   });
 
   it("ne dépose rien lorsqu’un événement identique existe déjà", async () => {
-    db.affairEvent.findFirst.mockResolvedValue({ id: "event_1" });
+    db.affairEvent.findUnique.mockResolvedValue({ id: "event_1" });
 
     const result = await proposeAffairEvent(EVENT_INPUT);
 
@@ -482,7 +514,7 @@ describe("proposeAffairEvent", () => {
     const result = await proposeAffairEvent(EVENT_INPUT);
 
     expect(result.outcome).toBe("TARGET_INELIGIBLE");
-    expect(db.affairEvent.findFirst).not.toHaveBeenCalled();
+    expect(db.affairEvent.findUnique).not.toHaveBeenCalled();
     expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
   });
 
@@ -518,5 +550,19 @@ describe("proposeAffairEvent", () => {
       existingStatus: "REJECTED",
     });
     expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("prévisualise une proposition terminale sans écriture", async () => {
+    db.affairUpdateProposal.findFirst.mockResolvedValue({ id: "prop_old", status: "REJECTED" });
+
+    const result = await previewAffairEventProposal(EVENT_INPUT);
+
+    expect(result).toMatchObject({
+      outcome: "DEDUPED_TERMINAL",
+      pendingProposalId: "prop_old",
+      existingStatus: "REJECTED",
+    });
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.update).not.toHaveBeenCalled();
   });
 });

--- a/src/services/affairs/__tests__/proposals.test.ts
+++ b/src/services/affairs/__tests__/proposals.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   db: {
     affair: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+    affairEvent: { findFirst: vi.fn() },
     affairUpdateProposal: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     auditLog: { create: vi.fn() },
     $transaction: vi.fn(),
@@ -16,6 +17,10 @@ vi.mock("@/lib/db", () => ({ db: h.db }));
 
 import { Prisma } from "@/generated/prisma";
 import {
+  AFFAIR_EVOLUTION_REVELATION_TITLE,
+  parseAffairProposalPayload,
+} from "@/lib/security/schemas/affair-proposal";
+import {
   computePayloadHash,
   deriveRiskLevel,
   detectDrift,
@@ -23,6 +28,7 @@ import {
   hashSourceContent,
   normalizeForCompare,
   proposeAffairUpdate,
+  proposeAffairEvent,
   ProposalValidationError,
   validatePatch,
 } from "@/services/affairs/proposals";
@@ -36,6 +42,7 @@ const EMPTY_AFFAIR = {
   title: "Affaire de test",
   politician: { slug: "jean-testeur", fullName: "Jean Testeur" },
   status: "INSTRUCTION",
+  publicationStatus: "PUBLISHED",
   verdictDate: null,
   court: null,
   sentence: null,
@@ -67,6 +74,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(EMPTY_AFFAIR);
   db.affair.findFirst.mockResolvedValue(null);
+  db.affairEvent.findFirst.mockResolvedValue(null);
   db.affairUpdateProposal.findFirst.mockResolvedValue(null);
   db.affairUpdateProposal.create.mockImplementation(async () => ({ id: "prop_new" }));
   db.affairUpdateProposal.update.mockResolvedValue({});
@@ -293,6 +301,51 @@ describe("validatePatch", () => {
   });
 });
 
+describe("parseAffairProposalPayload", () => {
+  const validEvent = {
+    addEvent: {
+      date: "2026-08-27T08:00:00.000Z",
+      type: "REVELATION",
+      title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+      description: null,
+      sourceUrl: "https://example.test/article",
+      sourceTitle: "Article source",
+    },
+  };
+
+  it("préserve les patchs historiques et discrimine un ajout d’événement", () => {
+    expect(parseAffairProposalPayload({ court: "TJ de Paris" }).kind).toBe("PATCH");
+    expect(parseAffairProposalPayload(validEvent).kind).toBe("ADD_EVENT");
+  });
+
+  it("refuse un payload mixte, une date impossible et une URL dangereuse", () => {
+    expect(() => parseAffairProposalPayload({ ...validEvent, court: "TJ de Paris" })).toThrow();
+    expect(() =>
+      parseAffairProposalPayload({
+        addEvent: { ...validEvent.addEvent, date: "2026-02-30T08:00:00.000Z" },
+      })
+    ).toThrow();
+    expect(() =>
+      parseAffairProposalPayload({
+        addEvent: { ...validEvent.addEvent, sourceUrl: "javascript:alert(1)" },
+      })
+    ).toThrow();
+  });
+
+  it("refuse le texte IA et les événements procéduraux dans ce lot", () => {
+    expect(() =>
+      parseAffairProposalPayload({
+        addEvent: { ...validEvent.addEvent, title: "Titre produit par le modèle" },
+      })
+    ).toThrow();
+    expect(() =>
+      parseAffairProposalPayload({
+        addEvent: { ...validEvent.addEvent, type: "MISE_EN_EXAMEN" },
+      })
+    ).toThrow();
+  });
+});
+
 describe("proposeAffairUpdate", () => {
   it("enregistre un affairSnapshot pour survivre à la suppression de l'affaire", async () => {
     await proposeAffairUpdate({ ...BASE_INPUT, patch: { verdictDate: "2026-05-13" } });
@@ -360,6 +413,110 @@ describe("proposeAffairUpdate", () => {
 
     expect(db.affair.findUnique).not.toHaveBeenCalled();
     expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("proposeAffairEvent", () => {
+  const EVENT_INPUT = {
+    affairId: "aff_1",
+    importer: "press-analysis",
+    importRunId: "run_press",
+    sourceUrl: "https://www.lemonde.fr/politique/article-test.html#section",
+    sourceTitle: "Un nouvel article documente l’affaire",
+    publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+    publisher: "AFP",
+    pressArticleId: "article_1",
+    resolverDecisionId: "decision_1",
+    sourceContentHash: "content-hash",
+    sourceExcerpt: "Extrait vérifié dans le contenu.",
+    confidence: 55,
+    rationale: "Candidat d’évolution unique.",
+    extractorVersion: "press-evolution-v1",
+  };
+
+  it("dépose un événement médiatique HIGH sans écrire sur l’affaire", async () => {
+    const result = await proposeAffairEvent(EVENT_INPUT);
+
+    expect(result).toMatchObject({ outcome: "CREATED", pendingProposalId: "prop_new" });
+    expect(db.affair.update).not.toHaveBeenCalled();
+    expect(db.affairEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          affairId: "aff_1",
+          type: "REVELATION",
+          sourceUrl: "https://www.lemonde.fr/politique/article-test.html",
+        }),
+      })
+    );
+    const created = db.affairUpdateProposal.create.mock.calls[0]![0].data;
+    expect(created.riskLevel).toBe("HIGH");
+    expect(created.proposedPatch).toEqual({
+      addEvent: {
+        date: "2026-08-27T08:00:00.000Z",
+        type: "REVELATION",
+        title: "Publication d’une nouvelle source sur l’évolution de l’affaire",
+        description: null,
+        sourceUrl: "https://www.lemonde.fr/politique/article-test.html",
+        sourceTitle: "Un nouvel article documente l’affaire",
+      },
+    });
+  });
+
+  it("ne dépose rien lorsqu’un événement identique existe déjà", async () => {
+    db.affairEvent.findFirst.mockResolvedValue({ id: "event_1" });
+
+    const result = await proposeAffairEvent(EVENT_INPUT);
+
+    expect(result).toEqual({
+      outcome: "ALREADY_APPLIED",
+      pendingProposalId: null,
+      deduped: true,
+    });
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une cible archivée", async () => {
+    db.affair.findUnique.mockResolvedValue({ ...EMPTY_AFFAIR, publicationStatus: "ARCHIVED" });
+
+    const result = await proposeAffairEvent(EVENT_INPUT);
+
+    expect(result.outcome).toBe("TARGET_INELIGIBLE");
+    expect(db.affairEvent.findFirst).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une source de presse hors de la liste vérifiée", async () => {
+    await expect(
+      proposeAffairEvent({
+        ...EVENT_INPUT,
+        sourceUrl: "https://blog.example/article-test",
+      })
+    ).rejects.toThrow(ProposalValidationError);
+
+    expect(db.affair.findUnique).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une proposition sans extrait vérifié", async () => {
+    await expect(proposeAffairEvent({ ...EVENT_INPUT, sourceExcerpt: "   " })).rejects.toThrow(
+      ProposalValidationError
+    );
+
+    expect(db.affair.findUnique).not.toHaveBeenCalled();
+    expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
+  });
+
+  it("ne ressuscite pas une proposition événement rejetée", async () => {
+    db.affairUpdateProposal.findFirst.mockResolvedValue({ id: "prop_old", status: "REJECTED" });
+
+    const result = await proposeAffairEvent(EVENT_INPUT);
+
+    expect(result).toMatchObject({
+      outcome: "DEDUPED_TERMINAL",
+      pendingProposalId: "prop_old",
+      existingStatus: "REJECTED",
+    });
     expect(db.affairUpdateProposal.create).not.toHaveBeenCalled();
   });
 });

--- a/src/services/affairs/import-run.ts
+++ b/src/services/affairs/import-run.ts
@@ -15,6 +15,7 @@ import type { Prisma } from "@/generated/prisma";
 // Business results go to `stats`.
 
 export const IMPORTER_DISCOVER_AFFAIRS = "discover-affairs";
+export const IMPORTER_PRESS_ANALYSIS = "press-analysis";
 export const IMPORTER_JUDILIBRE = "judilibre";
 /** Reserved for admin-initiated proposals, so they never end up run-less. */
 export const IMPORTER_MANUAL_ADMIN = "manual-admin";

--- a/src/services/affairs/lock.ts
+++ b/src/services/affairs/lock.ts
@@ -1,0 +1,16 @@
+import type { DbTransactionClient } from "@/lib/db";
+
+export class AffairNotFoundError extends Error {
+  constructor(affairId: string) {
+    super(`Affaire introuvable : ${affairId}`);
+    this.name = "AffairNotFoundError";
+  }
+}
+
+/** Serializes relation writes performed while accepting proposals for one affair. */
+export async function lockAffair(tx: DbTransactionClient, affairId: string): Promise<void> {
+  const rows = await tx.$queryRaw<{ id: string }[]>`
+    SELECT id FROM "Affair" WHERE id = ${affairId} FOR UPDATE
+  `;
+  if (rows.length === 0) throw new AffairNotFoundError(affairId);
+}

--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -5,11 +5,15 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/lib/db", () => ({ db: {} }));
 
 import {
+  EVOLUTION_MIN_OVERLAP_RATIO,
+  evolutionMatch,
+  isPreDecisionStatus,
   pairingRestsOnWildcard,
   pickConfidentMatch,
   sameCategoryFamily,
   significantTitleWords,
   titleContainmentMatch,
+  titleVocabularyOverlap,
   titlesShareVocabulary,
   verdictDatesConflict,
 } from "./matching";
@@ -356,5 +360,170 @@ describe("titlesShareVocabulary — issue #521", () => {
     expect(
       titlesShareVocabulary("Ordonnance de référé", "Décision rendue en refere sur le fond")
     ).toBe(true);
+  });
+});
+
+// Issue #763 — avant toute décision, une affaire n'a ni ECLI, ni numéro de pourvoi,
+// ni date de verdict : les priorités 1, 2 et 5 ne peuvent pas se déclencher. Il ne
+// reste que le titre, et la containment échoue dès qu'un article de suivi reformule
+// le titre au lieu de l'allonger. Trois brouillons Bagayoko ont ainsi été créés à
+// deux minutes d'intervalle pour une seule enquête.
+describe("isPreDecisionStatus — issue #763", () => {
+  it("reconnaît les étapes où l'affaire bouge encore", () => {
+    for (const status of [
+      "ENQUETE_PRELIMINAIRE",
+      "INSTRUCTION",
+      "MISE_EN_EXAMEN",
+      "RENVOI_TRIBUNAL",
+      "PROCES_EN_COURS",
+    ]) {
+      expect(isPreDecisionStatus(status)).toBe(true);
+    }
+  });
+
+  it("exclut les étapes postérieures à une décision, que la date de verdict discrimine", () => {
+    for (const status of [
+      "CONDAMNATION_PREMIERE_INSTANCE",
+      "APPEL_EN_COURS",
+      "POURVOI_EN_CASSATION",
+      "CONDAMNATION_DEFINITIVE",
+      "RELAXE",
+      "NON_LIEU",
+      "CLASSEMENT_SANS_SUITE",
+    ]) {
+      expect(isPreDecisionStatus(status)).toBe(false);
+    }
+  });
+
+  it("un statut absent ne permet aucune conclusion", () => {
+    expect(isPreDecisionStatus(null)).toBe(false);
+    expect(isPreDecisionStatus(undefined)).toBe(false);
+  });
+});
+
+describe("titleVocabularyOverlap — issue #763", () => {
+  it("compte les mots partagés et le ratio de Jaccard", () => {
+    // {detournement, fonds, publics, ratp} contre
+    // {detournement, fonds, publics, emploi, ratp} : 4 partagés sur 5 unis.
+    const { shared, ratio } = titleVocabularyOverlap(
+      "detournement de fonds publics a la ratp",
+      "detournement de fonds publics lie a l'emploi a la ratp"
+    );
+    expect(shared).toBe(4);
+    expect(ratio).toBeCloseTo(0.8, 2);
+  });
+
+  it("reste bas quand un libellé court est noyé dans un titre descriptif (#520)", () => {
+    // Le coefficient de recouvrement donnerait 1.0 ici : c'est exactement le faux
+    // positif que #520 a corrigé, et la raison du choix de Jaccard.
+    const { ratio } = titleVocabularyOverlap(
+      "diffamation",
+      "condamnation definitive pour diffamation envers patrick klugman"
+    );
+    expect(ratio).toBeLessThan(EVOLUTION_MIN_OVERLAP_RATIO);
+  });
+
+  it("vaut zéro sans vocabulaire commun", () => {
+    expect(titleVocabularyOverlap("fraude fiscale", "emploi fictif").shared).toBe(0);
+    expect(titleVocabularyOverlap("fraude fiscale", "emploi fictif").ratio).toBe(0);
+  });
+
+  it("ne divise pas par zéro sur des titres sans mot significatif", () => {
+    expect(titleVocabularyOverlap("vol de la clé", "")).toEqual({ shared: 0, ratio: 0 });
+  });
+});
+
+// Fixtures relevées en production sur les 189 affaires pré-décision : au-dessus du
+// seuil, chaque paire est une seule histoire éclatée entre plusieurs imports ;
+// en dessous, deux dossiers distincts ne partagent que le vocabulaire générique de
+// leur catégorie.
+describe("evolutionMatch — issue #763", () => {
+  it("rapproche deux formulations d'une même enquête (Bagayoko, 0.80)", () => {
+    const result = evolutionMatch(
+      "enquete pour detournement de fonds publics a la ratp",
+      "enquete pour detournement de fonds publics lie a l'emploi a la ratp",
+      true
+    );
+    expect(result?.matchedBy).toBe("evolution-title-overlap");
+    expect(result?.confidence).toBe("POSSIBLE");
+  });
+
+  it("rapproche la paire qui a motivé le signal, que la containment rate (Bagayoko, 0.43)", () => {
+    // Ni l'un ni l'autre n'est sous-chaîne : « et cumul d'emplois » contre
+    // « lié à l'emploi à la RATP ». C'est le cas que le matcher laissait passer.
+    const a = "enquete pour detournement de fonds publics et cumul d'emplois";
+    const b = "enquete pour detournement de fonds publics lie a l'emploi a la ratp";
+    expect(titleContainmentMatch(a, b, true)).toBeNull();
+    expect(evolutionMatch(a, b, true)).not.toBeNull();
+  });
+
+  it("rapproche malgré une catégorie repliée sur AUTRE (Mbappé, 0.83)", () => {
+    // AUTRE contre INCITATION_HAINE : le wildcard est accepté ici parce que le
+    // vocabulaire fournit le second signal réclamé par #521.
+    expect(
+      evolutionMatch(
+        "propos racistes et menaces envers kylian mbappe",
+        "enquete pour propos racistes envers kylian mbappe",
+        true
+      )
+    ).not.toBeNull();
+  });
+
+  it("rapproche deux signalements du même fait (Vinted, 0.40 — au seuil)", () => {
+    expect(
+      evolutionMatch(
+        "signalement de trafics d'enfants presumes sur vinted",
+        "soupcons de trafic d'enfants sur vinted",
+        true
+      )
+    ).not.toBeNull();
+  });
+
+  it("écarte deux détournements distincts du même élu (Ciotti, 0.30)", () => {
+    expect(
+      evolutionMatch(
+        "detournement de fonds publics visant ciotti et ses collaborateurs (mai 2024)",
+        "detournement de fonds publics lors de la campagne legislative de 2022",
+        true
+      )
+    ).toBeNull();
+  });
+
+  it("écarte deux dossiers européens distincts (Bardella, 0.25)", () => {
+    expect(
+      evolutionMatch(
+        "soupcons d'emploi fictif de jordan bardella au parlement europeen",
+        "depenses irregulieres du groupe patriots au parlement europeen",
+        true
+      )
+    ).toBeNull();
+  });
+
+  it("exige un vocabulaire commun, pas seulement une famille partagée", () => {
+    expect(evolutionMatch("fraude fiscale aggravee", "emploi fictif au senat", true)).toBeNull();
+  });
+
+  it("exige deux mots partagés : un seul ne nomme rien", () => {
+    // Ratio 1/2 = 0.50, au-dessus du seuil, mais un seul mot partagé.
+    expect(evolutionMatch("favoritisme", "favoritisme avere", true)).toBeNull();
+  });
+
+  it("ne rapproche rien hors d'une famille commune", () => {
+    expect(
+      evolutionMatch(
+        "menaces de mort contre le maire d'agen",
+        "menaces de mort contre le maire d'agen",
+        false
+      )
+    ).toBeNull();
+  });
+
+  it("reste sous le seuil de pickConfidentMatch : jamais d'enrichissement silencieux", () => {
+    const result = evolutionMatch(
+      "enquete pour detournement de fonds publics a la ratp",
+      "enquete pour detournement de fonds publics lie a l'emploi a la ratp",
+      true
+    )!;
+    expect(pickConfidentMatch([{ affairId: "a", ...result }]).kind).toBe("none");
   });
 });

--- a/src/services/affairs/matching.test.ts
+++ b/src/services/affairs/matching.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/db", () => ({ db: {} }));
 
 import {
   EVOLUTION_MIN_OVERLAP_RATIO,
+  classifyAffairMatches,
   evolutionMatch,
   isPreDecisionStatus,
   pairingRestsOnWildcard,
@@ -93,6 +94,54 @@ describe("normalizeAffairTitle", () => {
 
   it("works without politician name", () => {
     expect(normalizeAffairTitle("Fraude fiscale")).toBe("fraude fiscale");
+  });
+});
+
+describe("classifyAffairMatches", () => {
+  it("propose une évolution seulement quand la cible plausible est unique", () => {
+    expect(
+      classifyAffairMatches([
+        {
+          affairId: "aff_1",
+          confidence: "POSSIBLE",
+          score: 0.55,
+          matchedBy: "evolution-title-overlap",
+        },
+      ])
+    ).toMatchObject({ kind: "UNIQUE_EVOLUTION", match: { affairId: "aff_1" } });
+  });
+
+  it("reste ambigu si un autre signal POSSIBLE vise une autre affaire", () => {
+    expect(
+      classifyAffairMatches([
+        {
+          affairId: "aff_1",
+          confidence: "POSSIBLE",
+          score: 0.55,
+          matchedBy: "evolution-title-overlap",
+        },
+        {
+          affairId: "aff_2",
+          confidence: "POSSIBLE",
+          score: 0.5,
+          matchedBy: "title-partial",
+        },
+      ])
+    ).toMatchObject({ kind: "POSSIBLE_AMBIGUOUS" });
+  });
+
+  it("préserve les rapprochements confiants et ne choisit pas entre deux HIGH", () => {
+    expect(
+      classifyAffairMatches([
+        { affairId: "aff_1", confidence: "HIGH", score: 0.9, matchedBy: "title-exact" },
+      ])
+    ).toMatchObject({ kind: "CONFIDENT_MATCH" });
+    expect(
+      classifyAffairMatches([
+        { affairId: "aff_1", confidence: "HIGH", score: 0.9, matchedBy: "title-exact" },
+        { affairId: "aff_2", confidence: "HIGH", score: 0.9, matchedBy: "title-exact" },
+      ])
+    ).toMatchObject({ kind: "CONFIDENT_AMBIGUOUS" });
   });
 });
 

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -561,7 +561,10 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
     const normalizedCandidate = normalizeAffairTitle(candidate.title, politicianName);
 
     const samePoliticianAffairs = await db.affair.findMany({
-      where: { politicianId: candidate.politicianId },
+      where: {
+        politicianId: candidate.politicianId,
+        publicationStatus: { in: ["DRAFT", "PUBLISHED"] },
+      },
       // verdictDate discriminates repeated convictions for the same offense,
       // which titles alone cannot (issue #520). status gates the evolution
       // signal below, which only applies before a decision is handed down.
@@ -643,6 +646,7 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
         politicianId: candidate.politicianId,
         category: candidate.category,
         verdictDate: { gte: dateMin, lte: dateMax },
+        publicationStatus: { in: ["DRAFT", "PUBLISHED"] },
       },
       select: { id: true },
     });
@@ -692,4 +696,40 @@ export async function findEvolutionCandidates(candidate: MatchCandidate): Promis
 
   const matches = await findMatchingAffairs(candidate);
   return matches.filter((m) => m.matchedBy === "evolution-title-overlap");
+}
+
+export type AffairMatchRouting =
+  | { kind: "CONFIDENT_MATCH"; match: MatchResult }
+  | { kind: "CONFIDENT_AMBIGUOUS"; candidates: MatchResult[] }
+  | { kind: "UNIQUE_EVOLUTION"; match: MatchResult }
+  | { kind: "POSSIBLE_AMBIGUOUS"; candidates: MatchResult[] }
+  | { kind: "NO_MATCH"; looseMatch: MatchResult | null };
+
+/**
+ * Classifies one complete matcher result without hiding a competing signal.
+ * Importers must call the database matcher once, then route through this helper.
+ */
+export function classifyAffairMatches(matches: MatchResult[]): AffairMatchRouting {
+  const confident = pickConfidentMatch(matches);
+  if (confident.kind === "match") return { kind: "CONFIDENT_MATCH", match: confident.match };
+  if (confident.kind === "ambiguous") {
+    return { kind: "CONFIDENT_AMBIGUOUS", candidates: confident.candidates };
+  }
+
+  const possibleByAffair = new Map<string, MatchResult>();
+  for (const match of matches) {
+    if (match.confidence === "POSSIBLE" && !possibleByAffair.has(match.affairId)) {
+      possibleByAffair.set(match.affairId, match);
+    }
+  }
+  const possible = [...possibleByAffair.values()];
+  if (possible.length > 1) return { kind: "POSSIBLE_AMBIGUOUS", candidates: possible };
+  if (possible.length === 0) return { kind: "NO_MATCH", looseMatch: null };
+
+  const only = possible[0]!;
+  const evolution = matches.find(
+    (match) => match.affairId === only.affairId && match.matchedBy === "evolution-title-overlap"
+  );
+  if (evolution) return { kind: "UNIQUE_EVOLUTION", match: evolution };
+  return { kind: "NO_MATCH", looseMatch: only };
 }

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -8,7 +8,7 @@
 
 import { db } from "@/lib/db";
 import { foldJudicialReference } from "@/lib/affairs/judicial-reference";
-import type { AffairCategory, Prisma } from "@/generated/prisma";
+import type { AffairCategory, AffairStatus, Prisma } from "@/generated/prisma";
 
 export type MatchConfidence = "CERTAIN" | "HIGH" | "POSSIBLE";
 
@@ -193,6 +193,117 @@ export interface MatchResult {
 }
 
 /**
+ * Statuses where the affair is still moving and no court has ruled yet.
+ *
+ * These are the stages an investigation passes through as the press covers it, and
+ * the ones where the matcher is blind: an affair here has no ECLI, no pourvoi
+ * number and no verdictDate, so priorities 1, 2 and 5 below can never fire and
+ * title text is the only signal left (issue #763).
+ *
+ * APPEL_EN_COURS and POURVOI_EN_CASSATION are deliberately excluded: a first
+ * decision has been handed down, so they carry a verdictDate that discriminates
+ * them properly.
+ */
+const PRE_DECISION_STATUSES = new Set<string>([
+  "ENQUETE_PRELIMINAIRE",
+  "INSTRUCTION",
+  "MISE_EN_EXAMEN",
+  "RENVOI_TRIBUNAL",
+  "PROCES_EN_COURS",
+]);
+
+export function isPreDecisionStatus(status: string | null | undefined): boolean {
+  return status != null && PRE_DECISION_STATUSES.has(status);
+}
+
+/**
+ * Shared significant vocabulary between two titles, as a Jaccard ratio.
+ *
+ * Jaccard rather than the overlap coefficient (shared / smaller set) on purpose:
+ * the overlap coefficient scores 1.0 whenever the shorter title's words all appear
+ * in the longer one, which is exactly the short-offense-label false positive that
+ * issue #520 fixed ("diffamation" inside "condamnation definitive pour diffamation
+ * envers patrick klugman"). Jaccard scores that pair 0.17.
+ */
+export function titleVocabularyOverlap(a: string, b: string): { shared: number; ratio: number } {
+  const wordsA = significantTitleWords(a);
+  const wordsB = significantTitleWords(b);
+
+  let shared = 0;
+  for (const word of wordsB) {
+    if (wordsA.has(word)) shared++;
+  }
+
+  const union = wordsA.size + wordsB.size - shared;
+  return { shared, ratio: union === 0 ? 0 : shared / union };
+}
+
+/**
+ * Minimum Jaccard ratio and shared-word count for two pre-decision affairs to be
+ * reported as successive states of one investigation.
+ *
+ * Measured over the 189 pre-decision affairs in production, scoring every
+ * same-politician pair (issue #763). Ranked by ratio, the list is clean down to
+ * 0.40 — every pair at or above it is one story fragmented across imports:
+ *
+ *   1.00  "Enquête sur un emploi présumé fictif au Parlement européen en 2015"
+ *         vs "Enquête pour emploi présumé fictif au Parlement européen en 2015"
+ *   0.80  "Enquête pour détournement de fonds publics à la RATP"
+ *         vs "Enquête pour détournement de fonds publics lié à l'emploi à la RATP"
+ *   0.43  "Enquête pour détournement de fonds publics et cumul d'emplois"
+ *         vs "Enquête pour détournement de fonds publics lié à l'emploi à la RATP"
+ *   0.40  "Signalement de trafics d'enfants présumés sur Vinted"
+ *         vs "Soupçons de trafic d'enfants sur Vinted"
+ *
+ * The first genuine false positives appear just below it, where two distinct
+ * probity cases share only the generic vocabulary of their category:
+ *
+ *   0.30  "Détournement de fonds publics visant Ciotti et ses collaborateurs (mai 2024)"
+ *         vs "Détournement de fonds publics lors de la campagne législative de 2022"
+ *   0.25  "Soupçons d'emploi fictif de Jordan Bardella au Parlement européen"
+ *         vs "Dépenses irrégulières du groupe Patriots au Parlement européen"
+ *
+ * Two shared words are required on top of the ratio: with a single shared word the
+ * ratio only clears 0.40 when both titles are two words long, which is too little
+ * to name anything.
+ */
+export const EVOLUTION_MIN_OVERLAP_RATIO = 0.4;
+export const EVOLUTION_MIN_SHARED_WORDS = 2;
+
+/**
+ * Whether two pre-decision affairs look like successive states of one investigation.
+ *
+ * Reported at POSSIBLE deliberately, never HIGH. POSSIBLE is below the bar
+ * `pickConfidentMatch` uses to enrich, so this signal changes no importer's
+ * behaviour on its own: it surfaces the pair for review. Acting on it — filing an
+ * update proposal instead of creating a second draft — is the caller's decision,
+ * made explicitly through `findEvolutionCandidates`.
+ *
+ * The AUTRE wildcard is accepted here, unlike in the duplicate path guarded by
+ * `pairingRestsOnWildcard` (#521). That guard asks for a second signal before
+ * pairing on the wildcard, and the vocabulary threshold is one: measured on
+ * production, wildcard-paired hits at or above the threshold are real
+ * ("Propos racistes et menaces envers Kylian Mbappé" against "Enquête pour propos
+ * racistes envers Kylian Mbappé", 0.83, AUTRE vs INCITATION_HAINE). Importers
+ * routinely fall back to AUTRE on an early-stage story precisely because the
+ * qualification is not established yet, so excluding it would blind the signal to
+ * the cases it exists for.
+ */
+export function evolutionMatch(
+  normalizedCandidate: string,
+  normalizedExisting: string,
+  sameFamily: boolean
+): Omit<MatchResult, "affairId"> | null {
+  if (!sameFamily) return null;
+
+  const { shared, ratio } = titleVocabularyOverlap(normalizedCandidate, normalizedExisting);
+  if (shared < EVOLUTION_MIN_SHARED_WORDS) return null;
+  if (ratio < EVOLUTION_MIN_OVERLAP_RATIO) return null;
+
+  return { confidence: "POSSIBLE", score: 0.55, matchedBy: "evolution-title-overlap" };
+}
+
+/**
  * Re-exported so callers keep importing the match vocabulary from the matcher, next
  * to the code that produces the signals. The definitions live in a database-free
  * module because the merge planner that consumes them is pure (#557).
@@ -322,6 +433,14 @@ export interface MatchCandidate {
   category?: AffairCategory;
   verdictDate?: Date | null;
   /**
+   * Procedural stage of the candidate, when known.
+   *
+   * Only consulted by the evolution signal (priority 6), which needs both sides to
+   * be pre-decision. Absent, that signal stays silent and matching behaves exactly
+   * as before.
+   */
+  status?: AffairStatus;
+  /**
    * Set when the candidate IS an existing row, so it cannot match itself.
    *
    * Importers leave this empty: they match a candidate that has no row yet.
@@ -444,8 +563,9 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
     const samePoliticianAffairs = await db.affair.findMany({
       where: { politicianId: candidate.politicianId },
       // verdictDate discriminates repeated convictions for the same offense,
-      // which titles alone cannot (issue #520).
-      select: { id: true, title: true, category: true, verdictDate: true },
+      // which titles alone cannot (issue #520). status gates the evolution
+      // signal below, which only applies before a decision is handed down.
+      select: { id: true, title: true, category: true, verdictDate: true, status: true },
     });
 
     for (const existing of samePoliticianAffairs) {
@@ -484,6 +604,29 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
       );
       if (containment) {
         matches.push({ affairId: existing.id, ...containment });
+        continue;
+      }
+
+      // Priority 6: successive states of one pre-decision investigation.
+      //
+      // Only reached when containment found nothing, which is the blind spot: a
+      // follow-up article rephrases the headline, so neither title contains the
+      // other, and with no ECLI, pourvoi or verdict date yet nothing else fires
+      // either (issue #763). Requires both sides to be pre-decision — once a court
+      // has ruled, the verdict date discriminates and this heuristic would only
+      // conflate repeated convictions for the same offense.
+      const bothPreDecision =
+        isPreDecisionStatus(candidate.status) && isPreDecisionStatus(existing.status);
+
+      if (bothPreDecision && !datesRuleOutSameAffair) {
+        const evolution = evolutionMatch(
+          normalizedCandidate,
+          normalizedExisting,
+          Boolean(candidate.category) && sameCategoryFamily(candidate.category!, existing.category)
+        );
+        if (evolution) {
+          matches.push({ affairId: existing.id, ...evolution });
+        }
       }
     }
   }
@@ -528,4 +671,25 @@ export async function findMatchingAffairs(candidate: MatchCandidate): Promise<Ma
 export async function isDuplicate(candidate: MatchCandidate): Promise<boolean> {
   const matches = await findMatchingAffairs(candidate);
   return matches.some((m) => m.confidence === "CERTAIN" || m.confidence === "HIGH");
+}
+
+/**
+ * Existing affairs the candidate looks like a later development of.
+ *
+ * Separate from `findMatchingAffairs` on purpose. That function answers "is this
+ * the same affair?", and its CERTAIN/HIGH tiers authorise an importer to write to
+ * an existing row. This one answers a different question — "is this the same story,
+ * further along?" — whose answer must never authorise a silent write: the caller is
+ * expected to file an `AffairUpdateProposal` for a human, not to enrich in place.
+ *
+ * Ordered by score, best first. Ambiguity is not collapsed here the way
+ * `pickConfidentMatch` collapses it: several candidates on one story is normal
+ * once a story has already fragmented, and the reviewer needs to see the whole
+ * cluster to pick the survivor.
+ */
+export async function findEvolutionCandidates(candidate: MatchCandidate): Promise<MatchResult[]> {
+  if (!isPreDecisionStatus(candidate.status)) return [];
+
+  const matches = await findMatchingAffairs(candidate);
+  return matches.filter((m) => m.matchedBy === "evolution-title-overlap");
 }

--- a/src/services/affairs/proposal-batch.ts
+++ b/src/services/affairs/proposal-batch.ts
@@ -5,6 +5,54 @@ export interface ProposalBatchCandidate {
   proposedPatch: unknown;
 }
 
+export interface ProposalBatchPage {
+  skip: number;
+  take: number;
+}
+
+/**
+ * Reads through the whole filtered queue until the requested number of eligible
+ * proposals has been collected. The database limit therefore cannot be consumed
+ * entirely by event proposals that the operator did not opt into.
+ */
+export async function collectProposalCandidatesForBatch<T extends ProposalBatchCandidate>(
+  fetchPage: (page: ProposalBatchPage) => Promise<T[]>,
+  limit: number,
+  includeEvents: boolean,
+  pageSize = 500
+): Promise<{ rows: T[]; excludedEvents: number }> {
+  const rows: T[] = [];
+  let excludedEvents = 0;
+  let skip = 0;
+
+  while (rows.length < limit) {
+    const page = await fetchPage({ skip, take: pageSize });
+    if (page.length === 0) break;
+    skip += page.length;
+
+    for (const candidate of page) {
+      if (!includeEvents && isEventProposal(candidate.proposedPatch)) {
+        excludedEvents++;
+        continue;
+      }
+      rows.push(candidate);
+      if (rows.length === limit) break;
+    }
+
+    if (page.length < pageSize) break;
+  }
+
+  return { rows, excludedEvents };
+}
+
+function isEventProposal(raw: unknown): boolean {
+  try {
+    return parseAffairProposalPayload(raw).kind === "ADD_EVENT";
+  } catch {
+    return false;
+  }
+}
+
 /** Keeps HIGH-risk event additions out of every generic multi-ID acceptance. */
 export function selectProposalIdsForBatch(
   requestedIds: readonly string[],

--- a/src/services/affairs/proposal-batch.ts
+++ b/src/services/affairs/proposal-batch.ts
@@ -1,0 +1,31 @@
+import { parseAffairProposalPayload } from "@/lib/security/schemas/affair-proposal";
+
+export interface ProposalBatchCandidate {
+  id: string;
+  proposedPatch: unknown;
+}
+
+/** Keeps HIGH-risk event additions out of every generic multi-ID acceptance. */
+export function selectProposalIdsForBatch(
+  requestedIds: readonly string[],
+  candidates: readonly ProposalBatchCandidate[],
+  includeEvents: boolean
+): { acceptedIds: string[]; excludedEventIds: string[] } {
+  const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  const excludedEventIds = includeEvents
+    ? []
+    : requestedIds.filter((id) => {
+        const candidate = byId.get(id);
+        if (!candidate) return false;
+        try {
+          return parseAffairProposalPayload(candidate.proposedPatch).kind === "ADD_EVENT";
+        } catch {
+          return false;
+        }
+      });
+  const excluded = new Set(excludedEventIds);
+  return {
+    acceptedIds: requestedIds.filter((id) => !excluded.has(id)),
+    excludedEventIds,
+  };
+}

--- a/src/services/affairs/proposal-review.ts
+++ b/src/services/affairs/proposal-review.ts
@@ -1,4 +1,4 @@
-import { db } from "@/lib/db";
+import { db, type DbTransactionClient } from "@/lib/db";
 import type { AffairStatus, ProposalStatus } from "@/generated/prisma";
 import { isValidSentenceSplit } from "@/lib/affairs/sentence-split";
 import { trackStatusChange } from "@/services/affairs/status-tracking";
@@ -10,11 +10,23 @@ import {
 import {
   AFFAIR_PROPOSABLE_SELECT,
   buildPrismaData,
+  computeAffairEventIdentity,
   detectDrift,
   ProposalValidationError,
-  validatePatch,
   type ConflictDetail,
 } from "@/services/affairs/proposals";
+import {
+  normalizeAffairEventSourceUrl,
+  parseAffairEventObservation,
+  parseAffairEventProposalMetadata,
+  parseAffairProposalPayload,
+  type AffairEventObservation,
+  type AffairEventProposal,
+  type AffairEventProposalMetadata,
+  type ParsedAffairProposal,
+} from "@/lib/security/schemas/affair-proposal";
+import { AffairNotFoundError, lockAffair } from "@/services/affairs/lock";
+import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
 
 // Affaires v2, lot 1: human review of importer proposals.
 //
@@ -71,6 +83,18 @@ class RollbackSignal extends Error {
   }
 }
 
+interface EventReviewContext {
+  event: AffairEventProposal;
+  observation: AffairEventObservation;
+  metadata: AffairEventProposalMetadata;
+}
+
+function validationIssues(error: unknown): string[] {
+  if (error instanceof ProposalValidationError) return error.issues;
+  if (error instanceof Error) return [error.message];
+  return ["Payload invalide"];
+}
+
 /**
  * Checks the firm/suspended pairs against what the row actually holds (#576).
  *
@@ -104,6 +128,36 @@ async function currentStatus(proposalId: string): Promise<ProposalStatus | null>
   return row?.status ?? null;
 }
 
+async function markConflict(
+  tx: DbTransactionClient,
+  proposal: { id: string; affairId: string | null; importer: string; extractorVersion: string },
+  input: ReviewInput,
+  drift: ConflictDetail
+): Promise<{ kind: "conflict"; drift: ConflictDetail }> {
+  await tx.affairUpdateProposal.update({
+    where: { id: proposal.id },
+    data: { status: "CONFLICT", conflictDetail: drift, appliedAt: null },
+  });
+  await tx.auditLog.create({
+    data: {
+      action: "UPDATE",
+      entityType: "AffairUpdateProposal",
+      entityId: proposal.id,
+      userId: input.reviewedBy,
+      ipAddress: input.requestMeta?.ip ?? null,
+      userAgent: input.requestMeta?.userAgent ?? null,
+      changes: {
+        action: "PROPOSAL_CONFLICT",
+        affairId: proposal.affairId,
+        importer: proposal.importer,
+        extractorVersion: proposal.extractorVersion,
+        conflictDetail: drift,
+      },
+    },
+  });
+  return { kind: "conflict", drift };
+}
+
 /**
  * Applies a pending proposal.
  *
@@ -127,6 +181,7 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       rationale: true,
       source: true,
       sourceUrl: true,
+      sourceExcerpt: true,
       officialId: true,
       metadata: true,
       affair: {
@@ -134,6 +189,7 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
           id: true,
           slug: true,
           status: true,
+          publicationStatus: true,
           politician: { select: { slug: true } },
         },
       },
@@ -150,14 +206,50 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
     return { ok: false, reason: "orphaned" };
   }
 
-  let patch;
+  let parsed: ParsedAffairProposal;
+  let eventContext: EventReviewContext | null = null;
   try {
-    patch = validatePatch(proposal.proposedPatch);
-  } catch (error) {
-    if (error instanceof ProposalValidationError) {
-      return { ok: false, reason: "invalid_patch", issues: error.issues };
+    parsed = parseAffairProposalPayload(proposal.proposedPatch);
+    if (parsed.kind === "ADD_EVENT") {
+      const observation = parseAffairEventObservation(proposal.observedValues);
+      const metadata = parseAffairEventProposalMetadata(proposal.metadata);
+      const normalizedProposalUrl = proposal.sourceUrl
+        ? normalizeAffairEventSourceUrl(proposal.sourceUrl)
+        : null;
+      if (proposal.source !== "PRESSE" || !normalizedProposalUrl) {
+        throw new Error("Un événement importé exige une source de presse HTTP(S)");
+      }
+      if (!isVerifiedAffairPressUrl(normalizedProposalUrl)) {
+        throw new Error("La source journalistique de l’événement n’est pas vérifiée");
+      }
+      if (!proposal.sourceExcerpt?.trim() || proposal.sourceExcerpt.trim().length > 500) {
+        throw new Error("Un extrait vérifié est obligatoire pour cet événement");
+      }
+      if (parsed.event.sourceUrl !== normalizedProposalUrl) {
+        throw new Error("L’URL de l’événement diffère de celle de la proposition");
+      }
+      if (metadata.eventProposal.publishedAt.getTime() !== parsed.event.date.getTime()) {
+        throw new Error("La date de provenance diffère de celle de l’événement");
+      }
+      if (
+        observation.addEvent.identityKey !== metadata.eventProposal.identityKey ||
+        observation.addEvent.identityVersion !== metadata.eventProposal.identityVersion
+      ) {
+        throw new Error("L’identité observée de l’événement est incohérente");
+      }
+      const expectedIdentity = computeAffairEventIdentity({
+        affairId: proposal.affairId,
+        sourceUrl: parsed.event.sourceUrl,
+        publishedAt: parsed.event.date,
+        pressArticleId: metadata.eventProposal.pressArticleId,
+      });
+      if (metadata.eventProposal.identityKey !== expectedIdentity) {
+        throw new Error("L’identité de l’événement ne correspond pas à son contenu");
+      }
+      eventContext = { event: parsed.event, observation, metadata };
     }
-    throw error;
+  } catch (error) {
+    return { ok: false, reason: "invalid_patch", issues: validationIssues(error) };
   }
 
   const officialEvidence = await verifyProposalOfficialEvidence({
@@ -179,11 +271,17 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
 
   const affairId = proposal.affairId;
   const observedValues = (proposal.observedValues ?? {}) as Record<string, unknown>;
-  const fields = Object.keys(observedValues);
-  const previousStatus = proposal.affair.status;
+  const fields = parsed.kind === "ADD_EVENT" ? ["event"] : Object.keys(observedValues);
   const now = new Date();
 
-  let outcome: { kind: "applied" } | { kind: "conflict"; drift: ConflictDetail };
+  let outcome:
+    | {
+        kind: "applied";
+        affairSlug: string;
+        politicianSlug: string;
+        previousStatus: AffairStatus;
+      }
+    | { kind: "conflict"; drift: ConflictDetail };
   try {
     outcome = await db.$transaction(async (tx) => {
       // Compare-and-set: this is the concurrency gate. A second acceptance
@@ -200,31 +298,126 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       });
       if (claim.count === 0) throw new RollbackSignal("lost_race");
 
+      await lockAffair(tx, affairId);
       const live = await tx.affair.findUnique({
         where: { id: affairId },
         select: AFFAIR_PROPOSABLE_SELECT,
       });
       if (!live) throw new RollbackSignal("affair_gone");
 
-      const drift = detectDrift(observedValues, live as unknown as Record<string, unknown>);
-      if (drift) {
-        await tx.affairUpdateProposal.update({
-          where: { id: proposal.id },
-          data: { status: "CONFLICT", conflictDetail: drift, appliedAt: null },
+      let eventId: string | null = null;
+      if (parsed.kind === "PATCH") {
+        const drift = detectDrift(observedValues, live as unknown as Record<string, unknown>);
+        if (drift) return markConflict(tx, proposal, input, drift);
+
+        const issues = splitIssues(
+          live as unknown as Record<string, unknown>,
+          parsed.patch as unknown as Record<string, unknown>
+        );
+        if (issues.length > 0) throw new RollbackSignal("invalid_split", issues);
+
+        await tx.affair.update({
+          where: { id: affairId },
+          data: buildPrismaData(parsed.patch),
         });
-        return { kind: "conflict" as const, drift };
+      } else {
+        const context = eventContext!;
+        if (!new Set(["DRAFT", "PUBLISHED"]).has(live.publicationStatus)) {
+          return markConflict(tx, proposal, input, {
+            publicationStatus: {
+              expected: "DRAFT|PUBLISHED",
+              actual: live.publicationStatus,
+            },
+          });
+        }
+
+        const existingEvent = await tx.affairEvent.findFirst({
+          where: {
+            affairId,
+            type: context.event.type,
+            date: context.event.date,
+            sourceUrl: context.event.sourceUrl,
+          },
+          select: { id: true },
+        });
+        if (existingEvent) {
+          return markConflict(tx, proposal, input, {
+            event: { expected: "absent", actual: existingEvent.id },
+          });
+        }
+
+        const decisionId = context.metadata.eventProposal.resolverDecisionId ?? null;
+        if (decisionId) {
+          const decision = await tx.affairPoliticianDecision.findUnique({
+            where: { id: decisionId },
+            select: { affairId: true },
+          });
+          if (!decision || (decision.affairId !== null && decision.affairId !== affairId)) {
+            return markConflict(tx, proposal, input, {
+              resolverDecision: {
+                expected: `absent|${affairId}`,
+                actual: decision?.affairId ?? "introuvable",
+              },
+            });
+          }
+          if (decision.affairId === null) {
+            const attached = await tx.affairPoliticianDecision.updateMany({
+              where: { id: decisionId, affairId: null },
+              data: { affairId },
+            });
+            if (attached.count === 0) {
+              const racedDecision = await tx.affairPoliticianDecision.findUnique({
+                where: { id: decisionId },
+                select: { affairId: true },
+              });
+              if (racedDecision?.affairId !== affairId) {
+                return markConflict(tx, proposal, input, {
+                  resolverDecision: {
+                    expected: `absent|${affairId}`,
+                    actual: racedDecision?.affairId ?? "introuvable",
+                  },
+                });
+              }
+            }
+          }
+        }
+
+        const createdEvent = await tx.affairEvent.create({
+          data: { affairId, ...context.event },
+          select: { id: true },
+        });
+        eventId = createdEvent.id;
+
+        await tx.source.upsert({
+          where: { affairId_url: { affairId, url: context.event.sourceUrl } },
+          update: {},
+          create: {
+            affairId,
+            url: context.event.sourceUrl,
+            title: context.event.sourceTitle,
+            publisher: context.metadata.eventProposal.publisher,
+            publishedAt: context.metadata.eventProposal.publishedAt,
+            sourceType: "PRESSE",
+            excerpt: proposal.sourceExcerpt ?? null,
+          },
+        });
+
+        const pressArticleId = context.metadata.eventProposal.pressArticleId ?? null;
+        if (pressArticleId) {
+          const link = await tx.pressArticleAffair.upsert({
+            where: { articleId_affairId: { articleId: pressArticleId, affairId } },
+            update: {},
+            create: { articleId: pressArticleId, affairId, role: "UPDATE" },
+            select: { id: true, role: true },
+          });
+          if (link.role === "MENTION") {
+            await tx.pressArticleAffair.update({
+              where: { id: link.id },
+              data: { role: "UPDATE" },
+            });
+          }
+        }
       }
-
-      const issues = splitIssues(
-        live as unknown as Record<string, unknown>,
-        patch as unknown as Record<string, unknown>
-      );
-      if (issues.length > 0) throw new RollbackSignal("invalid_split", issues);
-
-      await tx.affair.update({
-        where: { id: affairId },
-        data: buildPrismaData(patch),
-      });
 
       await tx.moderationReview.create({
         data: {
@@ -244,8 +437,8 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       await tx.auditLog.create({
         data: {
           action: "UPDATE",
-          entityType: "Affair",
-          entityId: affairId,
+          entityType: eventId ? "AffairEvent" : "Affair",
+          entityId: eventId ?? affairId,
           userId: input.reviewedBy,
           ipAddress: input.requestMeta?.ip ?? null,
           userAgent: input.requestMeta?.userAgent ?? null,
@@ -260,7 +453,12 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
         },
       });
 
-      return { kind: "applied" as const };
+      return {
+        kind: "applied" as const,
+        affairSlug: live.slug,
+        politicianSlug: live.politician.slug,
+        previousStatus: live.status,
+      };
     });
   } catch (error) {
     if (error instanceof RollbackSignal) {
@@ -273,6 +471,7 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
       const status = await currentStatus(proposal.id);
       return { ok: false, reason: "not_pending", status: status ?? "APPROVED" };
     }
+    if (error instanceof AffairNotFoundError) return { ok: false, reason: "orphaned" };
     throw error;
   }
 
@@ -282,10 +481,11 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
 
   // Timeline event, outside the transaction. It is display-only: the audit trail
   // already committed, so a failure here must not fail the acceptance.
-  const newStatus = patch.status as AffairStatus | null | undefined;
-  if (newStatus && newStatus !== previousStatus) {
+  const newStatus =
+    parsed.kind === "PATCH" ? (parsed.patch.status as AffairStatus | null | undefined) : null;
+  if (newStatus && newStatus !== outcome.previousStatus) {
     try {
-      await trackStatusChange(affairId, previousStatus, newStatus, {
+      await trackStatusChange(affairId, outcome.previousStatus, newStatus, {
         type: proposal.source,
         url: proposal.sourceUrl ?? undefined,
         title: `Proposition ${proposal.importer} acceptée`,
@@ -301,8 +501,8 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
   return {
     ok: true,
     affairId,
-    affairSlug: proposal.affair.slug,
-    politicianSlug: proposal.affair.politician.slug,
+    affairSlug: outcome.affairSlug,
+    politicianSlug: outcome.politicianSlug,
     appliedFields: fields,
   };
 }

--- a/src/services/affairs/proposal-review.ts
+++ b/src/services/affairs/proposal-review.ts
@@ -10,23 +10,18 @@ import {
 import {
   AFFAIR_PROPOSABLE_SELECT,
   buildPrismaData,
-  computeAffairEventIdentity,
   detectDrift,
+  parseAffairEventProposalContext,
   ProposalValidationError,
+  type AffairEventProposalContext,
   type ConflictDetail,
 } from "@/services/affairs/proposals";
 import {
   normalizeAffairEventSourceUrl,
-  parseAffairEventObservation,
-  parseAffairEventProposalMetadata,
   parseAffairProposalPayload,
-  type AffairEventObservation,
-  type AffairEventProposal,
-  type AffairEventProposalMetadata,
   type ParsedAffairProposal,
 } from "@/lib/security/schemas/affair-proposal";
 import { AffairNotFoundError, lockAffair } from "@/services/affairs/lock";
-import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
 
 // Affaires v2, lot 1: human review of importer proposals.
 //
@@ -81,12 +76,6 @@ class RollbackSignal extends Error {
     super(`proposal review rollback: ${reason}`);
     this.name = "RollbackSignal";
   }
-}
-
-interface EventReviewContext {
-  event: AffairEventProposal;
-  observation: AffairEventObservation;
-  metadata: AffairEventProposalMetadata;
 }
 
 function validationIssues(error: unknown): string[] {
@@ -207,46 +196,19 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
   }
 
   let parsed: ParsedAffairProposal;
-  let eventContext: EventReviewContext | null = null;
+  let eventContext: AffairEventProposalContext | null = null;
   try {
     parsed = parseAffairProposalPayload(proposal.proposedPatch);
     if (parsed.kind === "ADD_EVENT") {
-      const observation = parseAffairEventObservation(proposal.observedValues);
-      const metadata = parseAffairEventProposalMetadata(proposal.metadata);
-      const normalizedProposalUrl = proposal.sourceUrl
-        ? normalizeAffairEventSourceUrl(proposal.sourceUrl)
-        : null;
-      if (proposal.source !== "PRESSE" || !normalizedProposalUrl) {
-        throw new Error("Un événement importé exige une source de presse HTTP(S)");
-      }
-      if (!isVerifiedAffairPressUrl(normalizedProposalUrl)) {
-        throw new Error("La source journalistique de l’événement n’est pas vérifiée");
-      }
-      if (!proposal.sourceExcerpt?.trim() || proposal.sourceExcerpt.trim().length > 500) {
-        throw new Error("Un extrait vérifié est obligatoire pour cet événement");
-      }
-      if (parsed.event.sourceUrl !== normalizedProposalUrl) {
-        throw new Error("L’URL de l’événement diffère de celle de la proposition");
-      }
-      if (metadata.eventProposal.publishedAt.getTime() !== parsed.event.date.getTime()) {
-        throw new Error("La date de provenance diffère de celle de l’événement");
-      }
-      if (
-        observation.addEvent.identityKey !== metadata.eventProposal.identityKey ||
-        observation.addEvent.identityVersion !== metadata.eventProposal.identityVersion
-      ) {
-        throw new Error("L’identité observée de l’événement est incohérente");
-      }
-      const expectedIdentity = computeAffairEventIdentity({
+      eventContext = parseAffairEventProposalContext({
         affairId: proposal.affairId,
-        sourceUrl: parsed.event.sourceUrl,
-        publishedAt: parsed.event.date,
-        pressArticleId: metadata.eventProposal.pressArticleId,
+        proposedPatch: proposal.proposedPatch,
+        observedValues: proposal.observedValues,
+        metadata: proposal.metadata,
+        source: proposal.source,
+        sourceUrl: proposal.sourceUrl,
+        sourceExcerpt: proposal.sourceExcerpt,
       });
-      if (metadata.eventProposal.identityKey !== expectedIdentity) {
-        throw new Error("L’identité de l’événement ne correspond pas à son contenu");
-      }
-      eventContext = { event: parsed.event, observation, metadata };
     }
   } catch (error) {
     return { ok: false, reason: "invalid_patch", issues: validationIssues(error) };
@@ -331,15 +293,28 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
           });
         }
 
-        const existingEvent = await tx.affairEvent.findFirst({
+        let existingEvent = await tx.affairEvent.findUnique({
           where: {
-            affairId,
-            type: context.event.type,
-            date: context.event.date,
-            sourceUrl: context.event.sourceUrl,
+            affairId_identityKey: { affairId, identityKey: context.identityKey },
           },
           select: { id: true },
         });
+        if (!existingEvent) {
+          const legacyEvents = await tx.affairEvent.findMany({
+            where: {
+              affairId,
+              type: context.event.type,
+              date: context.event.date,
+            },
+            select: { id: true, sourceUrl: true },
+          });
+          existingEvent =
+            legacyEvents.find(
+              (event) =>
+                event.sourceUrl !== null &&
+                normalizeAffairEventSourceUrl(event.sourceUrl) === context.normalizedSourceUrl
+            ) ?? null;
+        }
         if (existingEvent) {
           return markConflict(tx, proposal, input, {
             event: { expected: "absent", actual: existingEvent.id },
@@ -383,7 +358,7 @@ export async function acceptProposal(input: ReviewInput): Promise<AcceptResult> 
         }
 
         const createdEvent = await tx.affairEvent.create({
-          data: { affairId, ...context.event },
+          data: { affairId, identityKey: context.identityKey, ...context.event },
           select: { id: true },
         });
         eventId = createdEvent.id;

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -2,15 +2,22 @@ import { createHash } from "node:crypto";
 import { canonicalJson, hashSourceContent } from "@/lib/hash/canonical";
 import { db, type DbTransactionClient } from "@/lib/db";
 import { Prisma } from "@/generated/prisma";
-import type { ProposalRisk, SourceType } from "@/generated/prisma";
+import type { ProposalRisk, ProposalStatus, SourceType } from "@/generated/prisma";
 import { safeJsonParseOrThrow } from "@/lib/api/safe-json";
 import {
+  AFFAIR_EVOLUTION_REVELATION_TITLE,
+  affairEventAdditionSchema,
+  affairEventProposalMetadataSchema,
   affairPatchSchema,
+  normalizeAffairEventSourceUrl,
   PROPOSABLE_FIELDS,
+  type AffairEventAddition,
+  type AffairEventProposalMetadata,
   type AffairPatch,
   type ProposableField,
 } from "@/lib/security/schemas/affair-proposal";
 import { verifyAndAnnotateProposalOfficialEvidence } from "@/lib/affairs/official-decision-verification";
+import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
 
 // Affaires v2, lot 1.
 //
@@ -63,6 +70,7 @@ export const AFFAIR_PROPOSABLE_SELECT = {
   publicId: true,
   title: true,
   politician: { select: { slug: true, fullName: true } },
+  publicationStatus: true,
   status: true,
   verdictDate: true,
   court: true,
@@ -280,6 +288,8 @@ export type LiveAffair = Record<string, unknown> & {
   politician?: { slug: string; fullName: string } | null;
 };
 
+const EVENT_TARGET_PUBLICATION_STATUSES = new Set(["DRAFT", "PUBLISHED"]);
+
 /**
  * Entry point for importers. Splits the patch into what may be auto-applied and
  * what needs review, then records both halves as proposals so every automated
@@ -335,6 +345,168 @@ export async function proposeAffairUpdate(
   return result;
 }
 
+export interface ProposeAffairEventInput {
+  affairId: string;
+  importer: string;
+  importRunId: string;
+  sourceUrl: string;
+  sourceTitle: string;
+  publishedAt: Date;
+  publisher: string;
+  pressArticleId?: string | null;
+  resolverDecisionId?: string | null;
+  sourceContentHash?: string | null;
+  sourceExcerpt: string;
+  confidence: number;
+  rationale: string;
+  extractorVersion?: string;
+}
+
+export type ProposeAffairEventOutcome =
+  | "CREATED"
+  | "DEDUPED_PENDING"
+  | "DEDUPED_TERMINAL"
+  | "ALREADY_APPLIED"
+  | "TARGET_INELIGIBLE";
+
+export interface ProposeAffairEventResult extends ProposeAffairUpdateResult {
+  outcome: ProposeAffairEventOutcome;
+  existingStatus?: ProposalStatus;
+}
+
+export function computeAffairEventIdentity(input: {
+  affairId: string;
+  sourceUrl: string;
+  publishedAt: Date;
+  pressArticleId?: string | null;
+}): string {
+  return createHash("sha256")
+    .update(
+      canonicalJson({
+        version: "press-revelation-v1",
+        affairId: input.affairId,
+        pressArticleId: input.pressArticleId ?? null,
+        sourceUrl: normalizeAffairEventSourceUrl(input.sourceUrl),
+        publishedAt: input.publishedAt.toISOString(),
+        type: "REVELATION",
+      })
+    )
+    .digest("hex");
+}
+
+/**
+ * Files a human-reviewed proposal for a media timeline entry.
+ *
+ * The source article is the event: its publication date is known, while the date
+ * of any procedural act mentioned by the article is not. Nothing related to the
+ * target affair is written before a reviewer accepts the proposal.
+ */
+export async function proposeAffairEvent(
+  input: ProposeAffairEventInput
+): Promise<ProposeAffairEventResult> {
+  const sourceUrl = normalizeAffairEventSourceUrl(input.sourceUrl);
+  if (!isVerifiedAffairPressUrl(sourceUrl)) {
+    throw new ProposalValidationError(["sourceUrl: source journalistique non vérifiée"]);
+  }
+  const sourceExcerpt = input.sourceExcerpt.trim();
+  if (!sourceExcerpt || sourceExcerpt.length > 500) {
+    throw new ProposalValidationError([
+      "sourceExcerpt: un extrait vérifié de 1 à 500 caractères est obligatoire",
+    ]);
+  }
+  const eventPayload = affairEventAdditionSchema.parse({
+    addEvent: {
+      date: input.publishedAt,
+      type: "REVELATION",
+      title: AFFAIR_EVOLUTION_REVELATION_TITLE,
+      description: null,
+      sourceUrl,
+      sourceTitle: input.sourceTitle,
+    },
+  }) as AffairEventAddition;
+
+  const affair = await db.affair.findUnique({
+    where: { id: input.affairId },
+    select: AFFAIR_PROPOSABLE_SELECT,
+  });
+  if (!affair) throw new Error(`Affaire introuvable : ${input.affairId}`);
+  if (!EVENT_TARGET_PUBLICATION_STATUSES.has(affair.publicationStatus)) {
+    return { outcome: "TARGET_INELIGIBLE", pendingProposalId: null, deduped: false };
+  }
+
+  const existingEvent = await db.affairEvent.findFirst({
+    where: {
+      affairId: input.affairId,
+      type: "REVELATION",
+      date: eventPayload.addEvent.date,
+      sourceUrl,
+    },
+    select: { id: true },
+  });
+  if (existingEvent) {
+    return { outcome: "ALREADY_APPLIED", pendingProposalId: null, deduped: true };
+  }
+
+  const identityKey = computeAffairEventIdentity({
+    affairId: input.affairId,
+    sourceUrl,
+    publishedAt: eventPayload.addEvent.date,
+    pressArticleId: input.pressArticleId,
+  });
+  const metadata = affairEventProposalMetadataSchema.parse({
+    eventProposal: {
+      version: 1,
+      identityVersion: "press-revelation-v1",
+      identityKey,
+      publisher: input.publisher,
+      publishedAt: eventPayload.addEvent.date,
+      pressArticleId: input.pressArticleId ?? null,
+      resolverDecisionId: input.resolverDecisionId ?? null,
+    },
+  }) as AffairEventProposalMetadata;
+  const observedValues = {
+    addEvent: {
+      identityVersion: "press-revelation-v1" as const,
+      identityKey,
+      existingEventId: null,
+    },
+  };
+  const normalizedInput: ProposeAffairUpdateInput = {
+    affairId: input.affairId,
+    importer: input.importer,
+    importRunId: input.importRunId,
+    patch: eventPayload,
+    source: "PRESSE",
+    sourceUrl,
+    sourceContentHash: input.sourceContentHash ?? null,
+    sourceExcerpt,
+    metadata: toJson(metadata),
+    confidence: input.confidence,
+    rationale: input.rationale,
+    extractorVersion: input.extractorVersion,
+  };
+
+  const recorded = await recordPendingProposal(
+    normalizedInput,
+    input.extractorVersion ?? "v1",
+    eventPayload,
+    affair as unknown as LiveAffair,
+    { observedValues, riskLevel: "HIGH" }
+  );
+  const outcome = recorded.deduped
+    ? recorded.status === "PENDING"
+      ? "DEDUPED_PENDING"
+      : "DEDUPED_TERMINAL"
+    : "CREATED";
+
+  return {
+    outcome,
+    pendingProposalId: recorded.proposalId,
+    deduped: recorded.deduped,
+    existingStatus: recorded.deduped ? recorded.status : undefined,
+  };
+}
+
 function pickObserved(
   patch: Record<string, unknown>,
   live: Record<string, unknown>
@@ -351,6 +523,7 @@ interface ProposalRowArgs {
   observedValues: Record<string, unknown>;
   snapshot: AffairSnapshot;
   payloadHash: string;
+  riskLevel?: ProposalRisk;
 }
 
 /**
@@ -376,7 +549,7 @@ function buildProposalData(
     sourceExcerpt: args.input.sourceExcerpt ?? null,
     metadata: args.input.metadata ?? undefined,
     confidence: clampConfidence(args.input.confidence),
-    riskLevel: deriveRiskLevel(Object.keys(args.patch), args.observedValues),
+    riskLevel: args.riskLevel ?? deriveRiskLevel(Object.keys(args.patch), args.observedValues),
     rationale: args.input.rationale,
     extractorVersion: args.extractorVersion,
     payloadHash: args.payloadHash,
@@ -394,7 +567,7 @@ async function findExisting(
   affairId: string,
   importer: string,
   payloadHash: string
-): Promise<{ id: string; status: string } | null> {
+): Promise<{ id: string; status: ProposalStatus } | null> {
   return db.affairUpdateProposal.findFirst({
     where: { affairId, importer, payloadHash },
     select: { id: true, status: true },
@@ -412,8 +585,10 @@ export function buildPendingProposalPayload(args: {
   extractorVersion: string;
   patch: Record<string, unknown>;
   live: LiveAffair;
+  observedValues?: Record<string, unknown>;
+  riskLevel?: ProposalRisk;
 }): { payloadHash: string; data: Prisma.AffairUpdateProposalUncheckedCreateInput } {
-  const observedValues = pickObserved(args.patch, args.live);
+  const observedValues = args.observedValues ?? pickObserved(args.patch, args.live);
   const payloadHash = computePayloadHash({
     importer: args.input.importer,
     extractorVersion: args.extractorVersion,
@@ -435,6 +610,7 @@ export function buildPendingProposalPayload(args: {
         observedValues,
         snapshot: buildAffairSnapshot(args.live),
         payloadHash,
+        riskLevel: args.riskLevel,
       },
       "PENDING"
     ),
@@ -483,13 +659,16 @@ async function recordPendingProposal(
   input: ProposeAffairUpdateInput,
   extractorVersion: string,
   patch: Record<string, unknown>,
-  live: LiveAffair
-): Promise<{ proposalId: string; deduped: boolean }> {
+  live: LiveAffair,
+  options: { observedValues?: Record<string, unknown>; riskLevel?: ProposalRisk } = {}
+): Promise<{ proposalId: string; deduped: boolean; status: ProposalStatus }> {
   const { payloadHash, data } = buildPendingProposalPayload({
     input,
     extractorVersion,
     patch,
     live,
+    observedValues: options.observedValues,
+    riskLevel: options.riskLevel,
   });
 
   const existing = await findExisting(input.affairId, input.importer, payloadHash);
@@ -502,11 +681,20 @@ async function recordPendingProposal(
         data: { updatedAt: new Date() },
       });
     }
-    return { proposalId: existing.id, deduped: true };
+    return { proposalId: existing.id, deduped: true, status: existing.status };
   }
 
-  const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
-  return { proposalId: created.id, deduped: false };
+  try {
+    const created = await db.affairUpdateProposal.create({ data, select: { id: true } });
+    return { proposalId: created.id, deduped: false, status: "PENDING" };
+  } catch (error) {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+      throw error;
+    }
+    const winner = await findExisting(input.affairId, input.importer, payloadHash);
+    if (!winner) throw error;
+    return { proposalId: winner.id, deduped: true, status: winner.status };
+  }
 }
 
 function clampConfidence(value: number): number {

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -10,8 +10,13 @@ import {
   affairEventProposalMetadataSchema,
   affairPatchSchema,
   normalizeAffairEventSourceUrl,
+  parseAffairEventObservation,
+  parseAffairEventProposalMetadata,
+  parseAffairProposalPayload,
   PROPOSABLE_FIELDS,
   type AffairEventAddition,
+  type AffairEventObservation,
+  type AffairEventProposal,
   type AffairEventProposalMetadata,
   type AffairPatch,
   type ProposableField,
@@ -374,36 +379,149 @@ export interface ProposeAffairEventResult extends ProposeAffairUpdateResult {
   existingStatus?: ProposalStatus;
 }
 
+export type PreviewAffairEventProposalOutcome =
+  | "WOULD_CREATE"
+  | Exclude<ProposeAffairEventOutcome, "CREATED">;
+
+export interface PreviewAffairEventProposalResult extends ProposeAffairUpdateResult {
+  outcome: PreviewAffairEventProposalOutcome;
+  existingStatus?: ProposalStatus;
+}
+
+export type PreviewAffairEventProposalInput = Omit<ProposeAffairEventInput, "importRunId"> & {
+  importRunId?: string;
+};
+
 export function computeAffairEventIdentity(input: {
   affairId: string;
   sourceUrl: string;
-  publishedAt: Date;
   pressArticleId?: string | null;
 }): string {
+  const sourceIdentity = input.pressArticleId
+    ? { pressArticleId: input.pressArticleId }
+    : { sourceUrl: normalizeAffairEventSourceUrl(input.sourceUrl) };
   return createHash("sha256")
     .update(
       canonicalJson({
-        version: "press-revelation-v1",
-        affairId: input.affairId,
-        pressArticleId: input.pressArticleId ?? null,
-        sourceUrl: normalizeAffairEventSourceUrl(input.sourceUrl),
-        publishedAt: input.publishedAt.toISOString(),
+        version: "press-revelation-v2",
         type: "REVELATION",
+        sourceIdentity,
       })
     )
     .digest("hex");
 }
 
-/**
- * Files a human-reviewed proposal for a media timeline entry.
- *
- * The source article is the event: its publication date is known, while the date
- * of any procedural act mentioned by the article is not. Nothing related to the
- * target affair is written before a reviewer accepts the proposal.
- */
-export async function proposeAffairEvent(
-  input: ProposeAffairEventInput
-): Promise<ProposeAffairEventResult> {
+export interface AffairEventProposalContext {
+  event: AffairEventProposal;
+  observation: AffairEventObservation;
+  metadata: AffairEventProposalMetadata;
+  normalizedSourceUrl: string;
+  identityKey: string;
+}
+
+/** Single strict parser shared by the review UI and the acceptance service. */
+export function parseAffairEventProposalContext(input: {
+  affairId: string;
+  proposedPatch: unknown;
+  observedValues: unknown;
+  metadata: unknown;
+  source: SourceType;
+  sourceUrl: string | null;
+  sourceExcerpt: string | null;
+}): AffairEventProposalContext {
+  const parsed = parseAffairProposalPayload(input.proposedPatch);
+  if (parsed.kind !== "ADD_EVENT") throw new Error("La proposition n’ajoute pas un événement");
+  const observation = parseAffairEventObservation(input.observedValues);
+  const metadata = parseAffairEventProposalMetadata(input.metadata);
+  const normalizedSourceUrl = input.sourceUrl
+    ? normalizeAffairEventSourceUrl(input.sourceUrl)
+    : null;
+  if (input.source !== "PRESSE" || !normalizedSourceUrl) {
+    throw new Error("Un événement importé exige une source de presse HTTP(S)");
+  }
+  if (!isVerifiedAffairPressUrl(normalizedSourceUrl)) {
+    throw new Error("La source journalistique de l’événement n’est pas vérifiée");
+  }
+  if (!input.sourceExcerpt?.trim() || input.sourceExcerpt.trim().length > 500) {
+    throw new Error("Un extrait vérifié est obligatoire pour cet événement");
+  }
+  if (parsed.event.sourceUrl !== normalizedSourceUrl) {
+    throw new Error("L’URL de l’événement diffère de celle de la proposition");
+  }
+  if (metadata.eventProposal.publishedAt.getTime() !== parsed.event.date.getTime()) {
+    throw new Error("La date de provenance diffère de celle de l’événement");
+  }
+  if (
+    observation.addEvent.identityKey !== metadata.eventProposal.identityKey ||
+    observation.addEvent.identityVersion !== metadata.eventProposal.identityVersion
+  ) {
+    throw new Error("L’identité observée de l’événement est incohérente");
+  }
+  const identityKey = computeAffairEventIdentity({
+    affairId: input.affairId,
+    sourceUrl: parsed.event.sourceUrl,
+    pressArticleId: metadata.eventProposal.pressArticleId,
+  });
+  if (metadata.eventProposal.identityKey !== identityKey) {
+    throw new Error("L’identité de l’événement ne correspond pas à son contenu");
+  }
+  return {
+    event: parsed.event,
+    observation,
+    metadata,
+    normalizedSourceUrl,
+    identityKey,
+  };
+}
+
+interface PreparedAffairEventProposal {
+  affair: LiveAffair;
+  eventPayload: AffairEventAddition;
+  normalizedInput: ProposeAffairUpdateInput;
+  observedValues: AffairEventObservation;
+  identityKey: string;
+}
+
+type AffairEventAssessment =
+  | { outcome: "WOULD_CREATE"; prepared: PreparedAffairEventProposal }
+  | {
+      outcome: Exclude<PreviewAffairEventProposalOutcome, "WOULD_CREATE">;
+      pendingProposalId: string | null;
+      deduped: boolean;
+      existingStatus?: ProposalStatus;
+    };
+
+async function findAppliedAffairEvent(input: {
+  affairId: string;
+  identityKey: string;
+  date: Date;
+  sourceUrl: string;
+}): Promise<{ id: string } | null> {
+  const identified = await db.affairEvent.findUnique({
+    where: {
+      affairId_identityKey: { affairId: input.affairId, identityKey: input.identityKey },
+    },
+    select: { id: true },
+  });
+  if (identified) return identified;
+
+  const legacyEvents = await db.affairEvent.findMany({
+    where: { affairId: input.affairId, type: "REVELATION", date: input.date },
+    select: { id: true, sourceUrl: true },
+  });
+  const canonicalSourceUrl = normalizeAffairEventSourceUrl(input.sourceUrl);
+  return (
+    legacyEvents.find(
+      (event) =>
+        event.sourceUrl !== null &&
+        normalizeAffairEventSourceUrl(event.sourceUrl) === canonicalSourceUrl
+    ) ?? null
+  );
+}
+
+async function assessAffairEventProposal(
+  input: PreviewAffairEventProposalInput
+): Promise<AffairEventAssessment> {
   const sourceUrl = normalizeAffairEventSourceUrl(input.sourceUrl);
   if (!isVerifiedAffairPressUrl(sourceUrl)) {
     throw new ProposalValidationError(["sourceUrl: source journalistique non vérifiée"]);
@@ -434,29 +552,25 @@ export async function proposeAffairEvent(
     return { outcome: "TARGET_INELIGIBLE", pendingProposalId: null, deduped: false };
   }
 
-  const existingEvent = await db.affairEvent.findFirst({
-    where: {
-      affairId: input.affairId,
-      type: "REVELATION",
-      date: eventPayload.addEvent.date,
-      sourceUrl,
-    },
-    select: { id: true },
+  const identityKey = computeAffairEventIdentity({
+    affairId: input.affairId,
+    sourceUrl,
+    pressArticleId: input.pressArticleId,
+  });
+  const existingEvent = await findAppliedAffairEvent({
+    affairId: input.affairId,
+    identityKey,
+    date: eventPayload.addEvent.date,
+    sourceUrl,
   });
   if (existingEvent) {
     return { outcome: "ALREADY_APPLIED", pendingProposalId: null, deduped: true };
   }
 
-  const identityKey = computeAffairEventIdentity({
-    affairId: input.affairId,
-    sourceUrl,
-    publishedAt: eventPayload.addEvent.date,
-    pressArticleId: input.pressArticleId,
-  });
   const metadata = affairEventProposalMetadataSchema.parse({
     eventProposal: {
       version: 1,
-      identityVersion: "press-revelation-v1",
+      identityVersion: "press-revelation-v2",
       identityKey,
       publisher: input.publisher,
       publishedAt: eventPayload.addEvent.date,
@@ -464,9 +578,9 @@ export async function proposeAffairEvent(
       resolverDecisionId: input.resolverDecisionId ?? null,
     },
   }) as AffairEventProposalMetadata;
-  const observedValues = {
+  const observedValues: AffairEventObservation = {
     addEvent: {
-      identityVersion: "press-revelation-v1" as const,
+      identityVersion: "press-revelation-v2",
       identityKey,
       existingEventId: null,
     },
@@ -474,7 +588,7 @@ export async function proposeAffairEvent(
   const normalizedInput: ProposeAffairUpdateInput = {
     affairId: input.affairId,
     importer: input.importer,
-    importRunId: input.importRunId,
+    importRunId: input.importRunId ?? "dry-run",
     patch: eventPayload,
     source: "PRESSE",
     sourceUrl,
@@ -485,13 +599,65 @@ export async function proposeAffairEvent(
     rationale: input.rationale,
     extractorVersion: input.extractorVersion,
   };
+  const prepared: PreparedAffairEventProposal = {
+    affair: affair as unknown as LiveAffair,
+    eventPayload,
+    normalizedInput,
+    observedValues,
+    identityKey,
+  };
+  const { payloadHash } = buildPendingProposalPayload({
+    input: normalizedInput,
+    extractorVersion: input.extractorVersion ?? "v1",
+    patch: eventPayload,
+    live: prepared.affair,
+    observedValues,
+    riskLevel: "HIGH",
+  });
+  const existing = await findExisting(input.affairId, input.importer, payloadHash);
+  if (existing) {
+    return {
+      outcome: existing.status === "PENDING" ? "DEDUPED_PENDING" : "DEDUPED_TERMINAL",
+      pendingProposalId: existing.id,
+      deduped: true,
+      existingStatus: existing.status,
+    };
+  }
+
+  return { outcome: "WOULD_CREATE", prepared };
+}
+
+/** Performs every validation and deduplication lookup without writing anything. */
+export async function previewAffairEventProposal(
+  input: PreviewAffairEventProposalInput
+): Promise<PreviewAffairEventProposalResult> {
+  const assessment = await assessAffairEventProposal(input);
+  if (assessment.outcome === "WOULD_CREATE") {
+    return { outcome: "WOULD_CREATE", pendingProposalId: null, deduped: false };
+  }
+  return assessment;
+}
+
+/**
+ * Files a human-reviewed proposal for a media timeline entry.
+ *
+ * The source article is the event: its publication date is known, while the date
+ * of any procedural act mentioned by the article is not. Nothing related to the
+ * target affair is written before a reviewer accepts the proposal.
+ */
+export async function proposeAffairEvent(
+  input: ProposeAffairEventInput
+): Promise<ProposeAffairEventResult> {
+  const assessment = await assessAffairEventProposal(input);
+  if (assessment.outcome !== "WOULD_CREATE") return assessment;
+  const { prepared } = assessment;
 
   const recorded = await recordPendingProposal(
-    normalizedInput,
+    prepared.normalizedInput,
     input.extractorVersion ?? "v1",
-    eventPayload,
-    affair as unknown as LiveAffair,
-    { observedValues, riskLevel: "HIGH" }
+    prepared.eventPayload,
+    prepared.affair,
+    { observedValues: prepared.observedValues, riskLevel: "HIGH" }
   );
   const outcome = recorded.deduped
     ? recorded.status === "PENDING"

--- a/src/services/affairs/proposals.ts
+++ b/src/services/affairs/proposals.ts
@@ -395,6 +395,7 @@ export type PreviewAffairEventProposalInput = Omit<ProposeAffairEventInput, "imp
 export function computeAffairEventIdentity(input: {
   affairId: string;
   sourceUrl: string;
+  publishedAt: Date;
   pressArticleId?: string | null;
 }): string {
   const sourceIdentity = input.pressArticleId
@@ -404,6 +405,8 @@ export function computeAffairEventIdentity(input: {
     .update(
       canonicalJson({
         version: "press-revelation-v2",
+        affairId: input.affairId,
+        publishedAt: input.publishedAt.toISOString(),
         type: "REVELATION",
         sourceIdentity,
       })
@@ -460,6 +463,7 @@ export function parseAffairEventProposalContext(input: {
   const identityKey = computeAffairEventIdentity({
     affairId: input.affairId,
     sourceUrl: parsed.event.sourceUrl,
+    publishedAt: metadata.eventProposal.publishedAt,
     pressArticleId: metadata.eventProposal.pressArticleId,
   });
   if (metadata.eventProposal.identityKey !== identityKey) {
@@ -555,6 +559,7 @@ async function assessAffairEventProposal(
   const identityKey = computeAffairEventIdentity({
     affairId: input.affairId,
     sourceUrl,
+    publishedAt: eventPayload.addEvent.date,
     pressArticleId: input.pressArticleId,
   });
   const existingEvent = await findAppliedAffairEvent({

--- a/src/services/affairs/reconciliation.ts
+++ b/src/services/affairs/reconciliation.ts
@@ -581,9 +581,13 @@ export async function mergeAffairsInTransaction(
         description: true,
         sourceUrl: true,
         sourceTitle: true,
+        identityKey: true,
       },
     });
     const existingEventKeys = new Set(existingEvents.map(eventKey));
+    const existingEventIdentities = new Set(
+      existingEvents.flatMap((event) => (event.identityKey ? [event.identityKey] : []))
+    );
 
     const eventsToTransfer = await tx.affairEvent.findMany({
       where: { affairId: removeId },
@@ -595,14 +599,21 @@ export async function mergeAffairsInTransaction(
         description: true,
         sourceUrl: true,
         sourceTitle: true,
+        identityKey: true,
       },
     });
     let eventsMoved = 0;
     for (const event of eventsToTransfer) {
       const key = eventKey(event);
-      if (existingEventKeys.has(key)) continue;
+      if (
+        existingEventKeys.has(key) ||
+        (event.identityKey !== null && existingEventIdentities.has(event.identityKey))
+      ) {
+        continue;
+      }
       await tx.affairEvent.update({ where: { id: event.id }, data: { affairId: keepId } });
       existingEventKeys.add(key);
+      if (event.identityKey) existingEventIdentities.add(event.identityKey);
       eventsMoved++;
     }
 

--- a/src/services/press-analysis.ts
+++ b/src/services/press-analysis.ts
@@ -47,7 +47,11 @@ export interface DetectedAffair {
   politicianName: string;
   involvement: "DIRECT" | "INDIRECT" | "MENTIONED_ONLY" | "VICTIM" | "PLAINTIFF";
   category: string;
+  /** False when an unknown model value was replaced by the conservative fallback. */
+  categoryValidated?: boolean;
   status: string;
+  /** Required for evolution routing, where a fallback would create a false match. */
+  statusValidated?: boolean;
   title: string;
   description: string;
   factsDate: string | null;
@@ -203,6 +207,8 @@ export async function analyzeArticle(input: ArticleAnalysisInput): Promise<Artic
   // Validate and sanitize the result
   const affairs: DetectedAffair[] = ((result.affairs as Record<string, unknown>[]) || []).map(
     (a: Record<string, unknown>) => {
+      const categoryValidated = isEnumValue(a.category as string, AFFAIR_CATEGORIES);
+      const statusValidated = isEnumValue(a.status as string, AFFAIR_STATUSES);
       const category = validateEnum(a.category as string, AFFAIR_CATEGORIES, "AUTRE");
       const status = validateEnum(a.status as string, AFFAIR_STATUSES, "ENQUETE_PRELIMINAIRE");
       const involvement = validateEnum(
@@ -215,7 +221,9 @@ export async function analyzeArticle(input: ArticleAnalysisInput): Promise<Artic
         politicianName: String(a.politician_name || ""),
         involvement,
         category,
+        categoryValidated,
         status,
+        statusValidated,
         title: String(a.title || ""),
         description: String(a.description || ""),
         factsDate: a.facts_date ? String(a.facts_date) : null,
@@ -261,4 +269,8 @@ function validateEnum<T extends string>(value: string, validValues: readonly T[]
     return value as T;
   }
   return fallback;
+}
+
+function isEnumValue<T extends string>(value: string, validValues: readonly T[]): value is T {
+  return (validValues as readonly string[]).includes(value);
 }

--- a/src/services/sync/discover-affairs-builders.ts
+++ b/src/services/sync/discover-affairs-builders.ts
@@ -58,6 +58,7 @@ export interface DiscoveredAffair {
     publisher: string;
     sourceType: "WIKIDATA" | "WIKIPEDIA" | "PRESSE";
     publishedAt: Date | null;
+    excerpt?: string | null;
   }>;
   phase: "wikidata" | "wikipedia";
 }

--- a/src/services/sync/discover-affairs-cursor.test.ts
+++ b/src/services/sync/discover-affairs-cursor.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({
   db: {
+    politician: {
+      findMany: vi.fn(),
+    },
     syncMetadata: {
       findUnique: vi.fn(),
       upsert: vi.fn(),
@@ -12,6 +15,7 @@ vi.mock("@/lib/db", () => ({
 import { db } from "@/lib/db";
 import {
   DISCOVER_AFFAIRS_CURSOR_KEY,
+  discoverAffairs,
   getDiscoverAffairsCursor,
   saveDiscoverAffairsCursor,
 } from "./discover-affairs";
@@ -83,5 +87,14 @@ describe("discover-affairs cursor", () => {
     const callArgs = vi.mocked(db.syncMetadata.upsert).mock.calls[0]![0];
     expect(callArgs.update.lastSyncAt).toBeInstanceOf(Date);
     expect((callArgs.update.lastSyncAt as Date).getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("ne déplace jamais le curseur en dry-run", async () => {
+    vi.mocked(db.syncMetadata.findUnique).mockResolvedValueOnce({ cursor: "Martin" } as never);
+    vi.mocked(db.politician.findMany).mockResolvedValueOnce([] as never);
+
+    await discoverAffairs({ limit: 10, dryRun: true });
+
+    expect(db.syncMetadata.upsert).not.toHaveBeenCalled();
   });
 });

--- a/src/services/sync/discover-affairs.test.ts
+++ b/src/services/sync/discover-affairs.test.ts
@@ -68,6 +68,23 @@ describe("extractPenaltyData", () => {
     expect(result.verdictDate).toEqual(new Date("2022-02-18"));
   });
 
+  it.each([
+    ["une année", "+2024-00-00T00:00:00Z", 9],
+    ["un mois", "+2024-05-00T00:00:00Z", 10],
+    ["un jour impossible", "+2024-02-30T00:00:00Z", 11],
+  ])("n’invente pas de date exacte à partir de %s", (_label, time, precision) => {
+    const claim: WikidataClaim = {
+      mainsnak: {
+        datavalue: { value: { id: "Q852973" }, type: "wikibase-entityid" },
+      },
+      qualifiers: {
+        P585: [{ datavalue: { value: { time, precision } } }],
+      },
+    };
+
+    expect(extractPenaltyData(claim).verdictDate).toBeUndefined();
+  });
+
   it("extracts court from P4884 qualifier", () => {
     const claim: WikidataClaim = {
       mainsnak: {

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -24,17 +24,22 @@ export type { ExtractedPenaltyData };
 import { wikipediaService } from "@/lib/api/wikipedia";
 import type { WikidataClaim } from "@/lib/api/wikidata";
 import { extractAffairsFromWikipedia } from "@/services/wikipedia-affair-extraction";
-import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matching";
+import { classifyAffairMatches, findMatchingAffairs } from "@/services/affairs/matching";
 import { clampConfidenceScore } from "@/services/affairs/confidence";
-import { extractDateFromUrl } from "@/lib/extract-date-from-url";
 import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
 import { loadCandidatePool, loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
 import type { SurnameVocabulary } from "@/lib/affair-matching/surname-ambiguity";
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
-import { hashSourceContent, proposeAffairUpdate } from "@/services/affairs/proposals";
+import {
+  hashSourceContent,
+  proposeAffairEvent,
+  proposeAffairUpdate,
+} from "@/services/affairs/proposals";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { IMPORTER_DISCOVER_AFFAIRS, withImportRun } from "@/services/affairs/import-run";
+import { previewAffairPolitician } from "@/lib/affair-matching/resolver";
+import { findVerifiedAffairPressEventSource } from "@/config/affair-sources";
 
 export const DISCOVER_AFFAIRS_CURSOR_KEY = "discover-affairs:cursor:lastName";
 
@@ -92,6 +97,7 @@ export interface DiscoverAffairsResult {
   proposalsDeduped: number;
   /** Several affairs tied at HIGH: no enrichment, a draft is created instead. */
   ambiguousMatches: number;
+  insufficientSourceProvenance: number;
   errors: string[];
 }
 
@@ -214,6 +220,7 @@ export async function discoverAffairs(options?: {
   wikidataOnly?: boolean;
   wikipediaOnly?: boolean;
   useCursor?: boolean;
+  dryRun?: boolean;
 }): Promise<DiscoverAffairsResult> {
   const {
     limit,
@@ -221,6 +228,7 @@ export async function discoverAffairs(options?: {
     wikidataOnly = false,
     wikipediaOnly = false,
     useCursor = true,
+    dryRun = false,
   } = options ?? {};
 
   const stats: DiscoverAffairsResult = {
@@ -232,6 +240,7 @@ export async function discoverAffairs(options?: {
     proposalsPending: 0,
     proposalsDeduped: 0,
     ambiguousMatches: 0,
+    insufficientSourceProvenance: 0,
     errors: [],
   };
 
@@ -274,7 +283,7 @@ export async function discoverAffairs(options?: {
   stats.politiciansProcessed = politicians.length;
   console.log(`${politicians.length} politician(s) found`);
 
-  if (cursorActive) {
+  if (cursorActive && !dryRun) {
     if (politicians.length === 0 || (typeof limit === "number" && politicians.length < limit)) {
       console.log(
         `[discover-affairs] cursor: ${cursor ?? "(start)"} -> (end), processed ${politicians.length}; alphabet exhausted, cursor reset`
@@ -296,7 +305,7 @@ export async function discoverAffairs(options?: {
   // Phase 1: Wikidata
   let phase1Affairs: DiscoveredAffair[] = [];
   if (!wikipediaOnly) {
-    phase1Affairs = await runPhase1Wikidata(politicians, stats);
+    phase1Affairs = await runPhase1Wikidata(politicians, stats, dryRun);
   }
 
   // Phase 2: Wikipedia
@@ -321,18 +330,21 @@ export async function discoverAffairs(options?: {
   // Phase 3: Reconciliation
   const allAffairs = [...phase1Affairs, ...phase2Affairs];
 
-  if (allAffairs.length > 0) {
+  if (allAffairs.length > 0 && dryRun) {
+    await runPhase3Reconciliation(allAffairs, stats, null, true);
+  } else if (allAffairs.length > 0) {
     // Reconciliation is the only phase that touches existing affairs, so it is
     // the only one that needs an ImportRun to anchor its proposals.
     // withImportRun guarantees the run leaves RUNNING whatever happens.
     await withImportRun(IMPORTER_DISCOVER_AFFAIRS, async ({ importRunId, setStats }) => {
-      await runPhase3Reconciliation(allAffairs, stats, importRunId);
+      await runPhase3Reconciliation(allAffairs, stats, importRunId, false);
       setStats({
         duplicatesSkipped: stats.duplicatesSkipped,
         affairsCreated: stats.affairsCreated,
         proposalsPending: stats.proposalsPending,
         proposalsDeduped: stats.proposalsDeduped,
         ambiguousMatches: stats.ambiguousMatches,
+        insufficientSourceProvenance: stats.insufficientSourceProvenance,
       });
     });
   }
@@ -346,7 +358,8 @@ async function runPhase1Wikidata(
     fullName: string;
     externalIds: Array<{ externalId: string }>;
   }>,
-  stats: DiscoverAffairsResult
+  stats: DiscoverAffairsResult,
+  dryRun: boolean
 ): Promise<DiscoveredAffair[]> {
   const discovered: DiscoveredAffair[] = [];
   const wikidataService = new WikidataService();
@@ -388,7 +401,7 @@ async function runPhase1Wikidata(
           // future liaison d\u00e9cision\u2192affaire, jamais pour publier.
           let decisionId: string | null = null;
           try {
-            const resolveResult = await resolveAffairPolitician({
+            const resolverInput = {
               text: `${politician.fullName}: ${label}`,
               metadata: {
                 source: "WIKIDATA" as SourceType,
@@ -396,7 +409,10 @@ async function runPhase1Wikidata(
                 factsDate: penaltyData.verdictDate ?? null,
                 externalIds: { wikidataQId: qid },
               },
-            });
+            };
+            const resolveResult = dryRun
+              ? await previewAffairPolitician(resolverInput)
+              : await resolveAffairPolitician(resolverInput);
             decisionId = resolveResult.decisionId;
           } catch (resolveErr) {
             console.warn(
@@ -536,7 +552,9 @@ async function runPhase2Wikipedia(
               title: extracted.title,
               publisher: extractPublisherFromUrl(sourceUrl),
               sourceType: "PRESSE",
-              publishedAt: extractDateFromUrl(sourceUrl),
+              // The URL may contain a date, but that does not prove the article's
+              // publication date. Keep it unknown until a verified source supplies it.
+              publishedAt: null,
             });
           }
 
@@ -703,7 +721,8 @@ function extractQidFromUrl(url: string | undefined): string | null {
 async function runPhase3Reconciliation(
   allAffairs: DiscoveredAffair[],
   stats: DiscoverAffairsResult,
-  importRunId: string
+  importRunId: string | null,
+  dryRun: boolean
 ): Promise<void> {
   console.log(`Phase 3: Reconciliation - ${allAffairs.length} affairs`);
 
@@ -713,36 +732,89 @@ async function runPhase3Reconciliation(
         politicianId: affair.politicianId,
         title: affair.title,
         category: affair.category,
+        status: affair.status,
         // Without it, two convictions for the same offense are indistinguishable:
         // the Wikidata title is the bare offense label (issue #520).
         verdictDate: affair.verdictDate,
       });
 
-      const picked = pickConfidentMatch(matches);
-      if (picked.kind === "ambiguous") {
-        // Several affairs tie: enriching one of them would be a coin flip. Fall
-        // through to creation and let the merge tooling decide (issue #520).
+      const routing = classifyAffairMatches(matches);
+      let insufficientEvolutionProvenance = false;
+      if (routing.kind === "CONFIDENT_AMBIGUOUS" || routing.kind === "POSSIBLE_AMBIGUOUS") {
         stats.ambiguousMatches++;
       }
-      const highMatch = picked.kind === "match" ? picked.match : null;
 
-      if (highMatch) {
+      if (routing.kind === "CONFIDENT_MATCH") {
         // Affaires v2, lot 1: an importer never writes to an existing affair.
         // Penalty data, dates and jurisdiction go through the proposal queue.
-        if (affair.phase === "wikidata") {
-          await proposePenaltyEnrichment(affair, highMatch.affairId, stats, importRunId);
+        if (!dryRun && affair.phase === "wikidata") {
+          if (!importRunId) throw new Error("ImportRun discover-affairs absent");
+          await proposePenaltyEnrichment(affair, routing.match.affairId, stats, importRunId);
         }
 
         // Même en cas de doublon enrichi, la décision resolver est rattachée
         // à l'affaire existante pour la piste d'audit du rattachement.
-        if (affair.decisionId) {
+        if (!dryRun && affair.decisionId) {
           await db.affairPoliticianDecision.update({
             where: { id: affair.decisionId },
-            data: { affairId: highMatch.affairId },
+            data: { affairId: routing.match.affairId },
           });
         }
 
         stats.duplicatesSkipped++;
+        continue;
+      }
+
+      if (routing.kind === "UNIQUE_EVOLUTION") {
+        const pressSource = findVerifiedAffairPressEventSource(
+          affair.sources.filter((source) => source.sourceType === "PRESSE")
+        );
+        if (pressSource?.publishedAt) {
+          if (dryRun) {
+            stats.proposalsPending++;
+            continue;
+          }
+          if (!importRunId) throw new Error("ImportRun discover-affairs absent");
+          const proposal = await proposeAffairEvent({
+            affairId: routing.match.affairId,
+            importer: IMPORTER_DISCOVER_AFFAIRS,
+            importRunId,
+            sourceUrl: pressSource.url,
+            sourceTitle: pressSource.title,
+            publishedAt: pressSource.publishedAt,
+            publisher: pressSource.publisher,
+            sourceExcerpt: pressSource.excerpt!,
+            resolverDecisionId: affair.decisionId,
+            sourceContentHash: hashSourceContent({
+              sourceUrl: pressSource.url,
+              publishedAt: pressSource.publishedAt,
+              title: affair.title,
+              status: affair.status,
+            }),
+            confidence: Math.round(routing.match.score * 100),
+            rationale:
+              `Candidat d’évolution unique (${routing.match.matchedBy}) avec une source de presse ` +
+              `datée. La publication est proposée comme événement médiatique, sans déduire la ` +
+              `date d’un acte judiciaire.`,
+            extractorVersion: "discover-evolution-v1",
+          });
+          if (proposal.outcome === "CREATED") stats.proposalsPending++;
+          if (proposal.deduped) stats.proposalsDeduped++;
+          if (proposal.outcome !== "TARGET_INELIGIBLE") continue;
+        } else {
+          insufficientEvolutionProvenance = true;
+        }
+      }
+
+      if (insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
+
+      const datedSources = affair.sources.filter((source) => source.publishedAt !== null);
+      if (datedSources.length === 0) {
+        if (!insufficientEvolutionProvenance) stats.insufficientSourceProvenance++;
+        continue;
+      }
+      if (dryRun) {
+        stats.affairsCreated++;
         continue;
       }
 
@@ -768,11 +840,11 @@ async function runPhase3Reconciliation(
         communityService: affair.communityService,
         otherSentence: affair.otherSentence,
         sentence: buildSentenceSummary(affair),
-        sources: affair.sources.map((s) => ({
+        sources: datedSources.map((s) => ({
           url: s.url,
           title: s.title,
           publisher: s.publisher,
-          publishedAt: s.publishedAt ?? affair.factsDate ?? affair.verdictDate ?? new Date(),
+          publishedAt: s.publishedAt!,
           sourceType: s.sourceType,
         })),
       });

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -33,8 +33,11 @@ import type { SurnameVocabulary } from "@/lib/affair-matching/surname-ambiguity"
 import type { AffairCandidateRecord } from "@/lib/affair-matching";
 import {
   hashSourceContent,
+  previewAffairEventProposal,
   proposeAffairEvent,
   proposeAffairUpdate,
+  type PreviewAffairEventProposalOutcome,
+  type ProposeAffairEventOutcome,
 } from "@/services/affairs/proposals";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { IMPORTER_DISCOVER_AFFAIRS, withImportRun } from "@/services/affairs/import-run";
@@ -95,6 +98,10 @@ export interface DiscoverAffairsResult {
   /** Affaires v2, lot 1: enrichment of existing affairs is now proposal-based. */
   proposalsPending: number;
   proposalsDeduped: number;
+  proposalsWouldCreate: number;
+  proposalsDedupedPending: number;
+  proposalsDedupedTerminal: number;
+  eventsAlreadyApplied: number;
   /** Several affairs tied at HIGH: no enrichment, a draft is created instead. */
   ambiguousMatches: number;
   insufficientSourceProvenance: number;
@@ -113,14 +120,20 @@ export function extractPenaltyData(claim: WikidataClaim): ExtractedPenaltyData {
   const timeClaims = claim.qualifiers[WD_PROPS.POINT_IN_TIME];
   if (timeClaims?.[0]?.datavalue?.value) {
     const tv = timeClaims[0].datavalue.value;
-    if (typeof tv === "object" && "time" in tv) {
+    if (typeof tv === "object" && "time" in tv && "precision" in tv && tv.precision >= 11) {
       const match = tv.time.match(/^\+?(\d{4})-(\d{2})-(\d{2})/);
-      if (match) {
-        // Wikidata uses 00 for unknown month/day (year-only or month-only precision)
-        const safeMonth = match[2] === "00" ? "01" : match[2];
-        const safeDay = match[3] === "00" ? "01" : match[3];
-        const date = new Date(`${match[1]}-${safeMonth}-${safeDay}`);
-        if (!isNaN(date.getTime())) result.verdictDate = date;
+      if (match && match[2] !== "00" && match[3] !== "00") {
+        const year = Number(match[1]);
+        const month = Number(match[2]);
+        const day = Number(match[3]);
+        const date = new Date(Date.UTC(year, month - 1, day));
+        if (
+          date.getUTCFullYear() === year &&
+          date.getUTCMonth() === month - 1 &&
+          date.getUTCDate() === day
+        ) {
+          result.verdictDate = date;
+        }
       }
     }
   }
@@ -239,6 +252,10 @@ export async function discoverAffairs(options?: {
     affairsCreated: 0,
     proposalsPending: 0,
     proposalsDeduped: 0,
+    proposalsWouldCreate: 0,
+    proposalsDedupedPending: 0,
+    proposalsDedupedTerminal: 0,
+    eventsAlreadyApplied: 0,
     ambiguousMatches: 0,
     insufficientSourceProvenance: 0,
     errors: [],
@@ -343,6 +360,10 @@ export async function discoverAffairs(options?: {
         affairsCreated: stats.affairsCreated,
         proposalsPending: stats.proposalsPending,
         proposalsDeduped: stats.proposalsDeduped,
+        proposalsWouldCreate: stats.proposalsWouldCreate,
+        proposalsDedupedPending: stats.proposalsDedupedPending,
+        proposalsDedupedTerminal: stats.proposalsDedupedTerminal,
+        eventsAlreadyApplied: stats.eventsAlreadyApplied,
         ambiguousMatches: stats.ambiguousMatches,
         insufficientSourceProvenance: stats.insufficientSourceProvenance,
       });
@@ -770,15 +791,9 @@ async function runPhase3Reconciliation(
           affair.sources.filter((source) => source.sourceType === "PRESSE")
         );
         if (pressSource?.publishedAt) {
-          if (dryRun) {
-            stats.proposalsPending++;
-            continue;
-          }
-          if (!importRunId) throw new Error("ImportRun discover-affairs absent");
-          const proposal = await proposeAffairEvent({
+          const eventInput = {
             affairId: routing.match.affairId,
             importer: IMPORTER_DISCOVER_AFFAIRS,
-            importRunId,
             sourceUrl: pressSource.url,
             sourceTitle: pressSource.title,
             publishedAt: pressSource.publishedAt,
@@ -797,9 +812,15 @@ async function runPhase3Reconciliation(
               `datée. La publication est proposée comme événement médiatique, sans déduire la ` +
               `date d’un acte judiciaire.`,
             extractorVersion: "discover-evolution-v1",
-          });
-          if (proposal.outcome === "CREATED") stats.proposalsPending++;
-          if (proposal.deduped) stats.proposalsDeduped++;
+          };
+          let proposal;
+          if (dryRun) {
+            proposal = await previewAffairEventProposal(eventInput);
+          } else {
+            if (!importRunId) throw new Error("ImportRun discover-affairs absent");
+            proposal = await proposeAffairEvent({ ...eventInput, importRunId });
+          }
+          recordEventProposalOutcome(stats, proposal.outcome);
           if (proposal.outcome !== "TARGET_INELIGIBLE") continue;
         } else {
           insufficientEvolutionProvenance = true;
@@ -865,4 +886,21 @@ async function runPhase3Reconciliation(
       );
     }
   }
+}
+
+function recordEventProposalOutcome(
+  stats: DiscoverAffairsResult,
+  outcome: ProposeAffairEventOutcome | PreviewAffairEventProposalOutcome
+): void {
+  if (outcome === "CREATED") stats.proposalsPending++;
+  if (outcome === "WOULD_CREATE") stats.proposalsWouldCreate++;
+  if (outcome === "DEDUPED_PENDING") {
+    stats.proposalsDeduped++;
+    stats.proposalsDedupedPending++;
+  }
+  if (outcome === "DEDUPED_TERMINAL") {
+    stats.proposalsDeduped++;
+    stats.proposalsDedupedTerminal++;
+  }
+  if (outcome === "ALREADY_APPLIED") stats.eventsAlreadyApplied++;
 }

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -5,8 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // these tests of their meaning.
 const mocks = vi.hoisted(() => ({
   resolveAffairPolitician: vi.fn(),
+  previewAffairPolitician: vi.fn(),
   findMatchingAffairs: vi.fn(),
   createDraftAffairFromDiscovery: vi.fn(),
+  proposeAffairEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -29,6 +31,10 @@ vi.mock("@/lib/affair-matching", async (importOriginal) => ({
   resolveAffairPolitician: mocks.resolveAffairPolitician,
 }));
 
+vi.mock("@/lib/affair-matching/resolver", () => ({
+  previewAffairPolitician: mocks.previewAffairPolitician,
+}));
+
 // pickConfidentMatch is pure and stays real; only the DB lookup is replaced.
 vi.mock("@/services/affairs/matching", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/affairs/matching")>()),
@@ -37,6 +43,11 @@ vi.mock("@/services/affairs/matching", async (importOriginal) => ({
 
 vi.mock("@/services/affairs/create-draft", () => ({
   createDraftAffairFromDiscovery: mocks.createDraftAffairFromDiscovery,
+}));
+
+vi.mock("@/services/affairs/proposals", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/affairs/proposals")>()),
+  proposeAffairEvent: mocks.proposeAffairEvent,
 }));
 
 import { isPressAnalysisSuccessful, processAnalyzedArticle } from "./press-analysis";
@@ -48,8 +59,18 @@ beforeEach(() => {
     topCandidateId: null,
     decisionId: null,
   });
+  mocks.previewAffairPolitician.mockResolvedValue({
+    judgment: "NO_MATCH",
+    topCandidateId: null,
+    decisionId: null,
+  });
   mocks.findMatchingAffairs.mockResolvedValue([]);
   mocks.createDraftAffairFromDiscovery.mockResolvedValue({ id: "aff-1", slug: "aff-1" });
+  mocks.proposeAffairEvent.mockResolvedValue({
+    outcome: "CREATED",
+    pendingProposalId: "proposal-1",
+    deduped: false,
+  });
 });
 
 function zeroStats() {
@@ -60,6 +81,9 @@ function zeroStats() {
     affairsEnriched: 0,
     affairsCreated: 0,
     affairsRejected: 0,
+    proposalsPending: 0,
+    proposalsDeduped: 0,
+    ambiguousMatches: 0,
     scrapeErrors: 0,
     analysisErrors: 0,
     sensitiveWarnings: 0,
@@ -275,5 +299,145 @@ describe("createAffairFromPress : involvement", () => {
     expect(mocks.createDraftAffairFromDiscovery).toHaveBeenCalledWith(
       expect.objectContaining({ involvement: "DIRECT" })
     );
+  });
+});
+
+describe("processAnalyzedArticle : proposition d’évolution", () => {
+  const article = {
+    id: "article-evolution",
+    url: "https://www.lemonde.fr/politique/article/2026/08/27/suivi-affaire.html",
+    title: "Un nouvel article sur l’enquête",
+    feedSource: "lemonde",
+    publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+  };
+  const excerpt = "Jeanne Martin fait toujours l’objet d’une enquête préliminaire.";
+  const detected = {
+    politicianName: "Jeanne Martin",
+    involvement: "DIRECT" as const,
+    category: "DETOURNEMENT_FONDS_PUBLICS",
+    categoryValidated: true,
+    status: "ENQUETE_PRELIMINAIRE",
+    statusValidated: true,
+    title: "Enquête sur des marchés publics contestés",
+    description: "Résumé produit par le modèle, non publiable.",
+    factsDate: null,
+    court: null,
+    charges: [],
+    excerpts: [excerpt],
+    isNewRevelation: true,
+    confidenceScore: 95,
+    mentionedNames: ["Jeanne Martin"],
+  };
+
+  beforeEach(() => {
+    mocks.resolveAffairPolitician.mockResolvedValue({
+      judgment: "SAME",
+      topCandidateId: "pol-1",
+      decisionId: "decision-1",
+    });
+    mocks.findMatchingAffairs.mockResolvedValue([
+      {
+        affairId: "aff-existing",
+        confidence: "POSSIBLE",
+        score: 0.55,
+        matchedBy: "evolution-title-overlap",
+      },
+    ]);
+  });
+
+  it("dépose une proposition unique sans créer de brouillon ni relation", async () => {
+    const stats = zeroStats();
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt} Suite de l’article.`,
+      { isAffairRelated: true, summary: "résumé", affairs: [detected] },
+      stats,
+      { dryRun: false, verbose: false, importRunId: "run-press" }
+    );
+
+    expect(mocks.proposeAffairEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        affairId: "aff-existing",
+        importRunId: "run-press",
+        pressArticleId: "article-evolution",
+        resolverDecisionId: "decision-1",
+        sourceExcerpt: excerpt,
+        confidence: 55,
+      })
+    );
+    expect(mocks.createDraftAffairFromDiscovery).not.toHaveBeenCalled();
+    expect(stats.proposalsPending).toBe(1);
+  });
+
+  it("ne choisit rien lorsqu’un autre candidat POSSIBLE existe", async () => {
+    mocks.findMatchingAffairs.mockResolvedValue([
+      {
+        affairId: "aff-existing",
+        confidence: "POSSIBLE",
+        score: 0.55,
+        matchedBy: "evolution-title-overlap",
+      },
+      {
+        affairId: "aff-other",
+        confidence: "POSSIBLE",
+        score: 0.5,
+        matchedBy: "title-partial",
+      },
+    ]);
+    const stats = zeroStats();
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt}`,
+      { isAffairRelated: true, summary: "résumé", affairs: [detected] },
+      stats,
+      { dryRun: false, verbose: false, importRunId: "run-press" }
+    );
+
+    expect(mocks.proposeAffairEvent).not.toHaveBeenCalled();
+    expect(mocks.createDraftAffairFromDiscovery).toHaveBeenCalledTimes(1);
+    expect(stats.ambiguousMatches).toBe(1);
+  });
+
+  it("utilise le resolver sans persistance en dry-run", async () => {
+    mocks.previewAffairPolitician.mockResolvedValue({
+      judgment: "SAME",
+      topCandidateId: "pol-1",
+      decisionId: null,
+    });
+    const stats = zeroStats();
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt}`,
+      { isAffairRelated: true, summary: "résumé", affairs: [detected] },
+      stats,
+      { dryRun: true, verbose: false }
+    );
+
+    expect(mocks.previewAffairPolitician).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveAffairPolitician).not.toHaveBeenCalled();
+    expect(mocks.proposeAffairEvent).not.toHaveBeenCalled();
+    expect(stats.proposalsPending).toBe(1);
+  });
+
+  it("ne route pas un statut remplacé par le fallback de l’analyse", async () => {
+    const stats = zeroStats();
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt}`,
+      {
+        isAffairRelated: true,
+        summary: "résumé",
+        affairs: [{ ...detected, statusValidated: false }],
+      },
+      stats,
+      { dryRun: false, verbose: false, importRunId: "run-press" }
+    );
+
+    expect(mocks.proposeAffairEvent).not.toHaveBeenCalled();
+    expect(mocks.createDraftAffairFromDiscovery).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   findMatchingAffairs: vi.fn(),
   createDraftAffairFromDiscovery: vi.fn(),
   proposeAffairEvent: vi.fn(),
+  previewAffairEventProposal: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -48,6 +49,7 @@ vi.mock("@/services/affairs/create-draft", () => ({
 vi.mock("@/services/affairs/proposals", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/affairs/proposals")>()),
   proposeAffairEvent: mocks.proposeAffairEvent,
+  previewAffairEventProposal: mocks.previewAffairEventProposal,
 }));
 
 import { isPressAnalysisSuccessful, processAnalyzedArticle } from "./press-analysis";
@@ -71,6 +73,11 @@ beforeEach(() => {
     pendingProposalId: "proposal-1",
     deduped: false,
   });
+  mocks.previewAffairEventProposal.mockResolvedValue({
+    outcome: "WOULD_CREATE",
+    pendingProposalId: null,
+    deduped: false,
+  });
 });
 
 function zeroStats() {
@@ -83,7 +90,12 @@ function zeroStats() {
     affairsRejected: 0,
     proposalsPending: 0,
     proposalsDeduped: 0,
+    proposalsWouldCreate: 0,
+    proposalsDedupedPending: 0,
+    proposalsDedupedTerminal: 0,
+    eventsAlreadyApplied: 0,
     ambiguousMatches: 0,
+    insufficientSourceProvenance: 0,
     scrapeErrors: 0,
     analysisErrors: 0,
     sensitiveWarnings: 0,
@@ -419,7 +431,39 @@ describe("processAnalyzedArticle : proposition d’évolution", () => {
     expect(mocks.previewAffairPolitician).toHaveBeenCalledTimes(1);
     expect(mocks.resolveAffairPolitician).not.toHaveBeenCalled();
     expect(mocks.proposeAffairEvent).not.toHaveBeenCalled();
-    expect(stats.proposalsPending).toBe(1);
+    expect(mocks.previewAffairEventProposal).toHaveBeenCalledTimes(1);
+    expect(stats.proposalsPending).toBe(0);
+    expect(stats.proposalsWouldCreate).toBe(1);
+  });
+
+  it.each([
+    ["DEDUPED_PENDING", "proposalsDedupedPending"],
+    ["DEDUPED_TERMINAL", "proposalsDedupedTerminal"],
+    ["ALREADY_APPLIED", "eventsAlreadyApplied"],
+  ] as const)("distingue l’issue %s en dry-run", async (outcome, counter) => {
+    mocks.previewAffairPolitician.mockResolvedValue({
+      judgment: "SAME",
+      topCandidateId: "pol-1",
+      decisionId: null,
+    });
+    mocks.previewAffairEventProposal.mockResolvedValue({
+      outcome,
+      pendingProposalId: outcome.startsWith("DEDUPED") ? "proposal-1" : null,
+      deduped: true,
+    });
+    const stats = zeroStats();
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt}`,
+      { isAffairRelated: true, summary: "résumé", affairs: [detected] },
+      stats,
+      { dryRun: true, verbose: false }
+    );
+
+    expect(stats[counter]).toBe(1);
+    expect(stats.proposalsWouldCreate).toBe(0);
+    expect(mocks.createDraftAffairFromDiscovery).not.toHaveBeenCalled();
   });
 
   it("ne route pas un statut remplacé par le fallback de l’analyse", async () => {

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -23,7 +23,7 @@ import {
   type DetectedAffair,
   type ArticleAnalysisResult,
 } from "@/services/press-analysis";
-import { findMatchingAffairs, pickConfidentMatch } from "@/services/affairs/matching";
+import { classifyAffairMatches, findMatchingAffairs } from "@/services/affairs/matching";
 import { syncMetadata } from "@/lib/sync";
 import { classifyArticleTier, type ArticleTier } from "@/config/press-keywords";
 import { MIN_CONFIDENCE_THRESHOLD } from "@/config/press-analysis";
@@ -32,8 +32,12 @@ import {
   assessPressAttribution,
   assessProcedureEvidence,
 } from "@/lib/affair-matching";
+import { previewAffairPolitician } from "@/lib/affair-matching/resolver";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { safeJsonParseOrThrow } from "@/lib/api/safe-json";
+import { hashSourceContent, proposeAffairEvent } from "@/services/affairs/proposals";
+import { IMPORTER_PRESS_ANALYSIS, withImportRun } from "@/services/affairs/import-run";
+import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
 
 // ============================================
 // TYPES
@@ -56,6 +60,9 @@ export interface PressAnalysisStats {
   affairsEnriched: number;
   affairsCreated: number;
   affairsRejected: number;
+  proposalsPending: number;
+  proposalsDeduped: number;
+  ambiguousMatches: number;
   scrapeErrors: number;
   analysisErrors: number;
   sensitiveWarnings: number;
@@ -117,6 +124,9 @@ export async function syncPressAnalysis(
     affairsEnriched: 0,
     affairsCreated: 0,
     affairsRejected: 0,
+    proposalsPending: 0,
+    proposalsDeduped: 0,
+    ambiguousMatches: 0,
     scrapeErrors: 0,
     analysisErrors: 0,
     sensitiveWarnings: 0,
@@ -164,101 +174,117 @@ export async function syncPressAnalysis(
   console.log(`  Tier 1 (Sonnet, mots-clés judiciaires): ${tier1Count}`);
   console.log(`  Tier 2 (Haiku, couverture large): ${classifiedArticles.length - tier1Count}\n`);
 
-  const scraper = getArticleScraper();
+  const execute = async (importRunId: string | null): Promise<PressAnalysisStats> => {
+    const scraper = getArticleScraper();
 
-  for (const article of classifiedArticles) {
-    stats.articlesProcessed++;
+    for (const article of classifiedArticles) {
+      stats.articlesProcessed++;
 
-    if (verbose) {
-      console.log(
-        `\n[${stats.articlesProcessed}/${classifiedArticles.length}] [${article.tier}] ${article.feedSource}: ${article.title.slice(0, 80)}...`
-      );
-    }
+      if (verbose) {
+        console.log(
+          `\n[${stats.articlesProcessed}/${classifiedArticles.length}] [${article.tier}] ${article.feedSource}: ${article.title.slice(0, 80)}...`
+        );
+      }
 
-    // Step 1: Get article content — scrape or fallback to RSS
-    let analysisContent: string;
+      // Step 1: Get article content, scrape or fallback to RSS
+      let analysisContent: string;
 
-    if (scraper.canScrape(article.feedSource)) {
-      const content = await scraper.extractArticle(article.url, article.feedSource);
+      if (scraper.canScrape(article.feedSource)) {
+        const content = await scraper.extractArticle(article.url, article.feedSource);
 
-      if (!content) {
-        stats.scrapeErrors++;
-        // Fallback to RSS title+description even for scrapable sources
-        analysisContent = buildRSSFallbackContent(article);
-        if (verbose) {
-          console.log("  ⚠ Scrape échoué, fallback RSS");
+        if (!content) {
+          stats.scrapeErrors++;
+          // Fallback to RSS title+description even for scrapable sources
+          analysisContent = buildRSSFallbackContent(article);
+          if (verbose) {
+            console.log("  ⚠ Scrape échoué, fallback RSS");
+          }
+        } else {
+          analysisContent = content.textContent;
+          if (verbose) {
+            console.log(`  Contenu extrait: ${content.length} chars`);
+          }
         }
       } else {
-        analysisContent = content.textContent;
+        // Paywalled source (lemonde, lefigaro): use RSS title+description
+        analysisContent = buildRSSFallbackContent(article);
         if (verbose) {
-          console.log(`  Contenu extrait: ${content.length} chars`);
+          console.log("  Source payante, analyse sur titre+description RSS");
         }
       }
-    } else {
-      // Paywalled source (lemonde, lefigaro) — use RSS title+description
-      analysisContent = buildRSSFallbackContent(article);
-      if (verbose) {
-        console.log("  Source payante, analyse sur titre+description RSS");
-      }
-    }
 
-    // Step 2: AI Analysis
-    try {
-      // Get pre-detected politician mentions from the article
-      const mentionedNames = article.mentions.map((m) => m.politician.fullName);
+      // Step 2: AI Analysis
+      try {
+        // Get pre-detected politician mentions from the article
+        const mentionedNames = article.mentions.map((m) => m.politician.fullName);
 
-      const result = await analyzeArticle({
-        title: article.title,
-        content: analysisContent,
-        feedSource: article.feedSource,
-        publishedAt: article.publishedAt,
-        mentionedPoliticians: mentionedNames,
-        tier: article.tier,
-      });
-
-      await processAnalyzedArticle(article, analysisContent, result, stats, {
-        dryRun,
-        verbose,
-      });
-    } catch (error) {
-      stats.analysisErrors++;
-      const errorMsg = error instanceof Error ? error.message : String(error);
-
-      // Detect quota/rate limit errors to avoid marking articles and to stop early
-      const isQuotaError = /usage.limits|quota|rate.limit|429|402/i.test(errorMsg);
-
-      if (!dryRun) {
-        await db.pressArticle.update({
-          where: { id: article.id },
-          data: {
-            // Don't mark as analyzed on quota errors so they can be retried
-            ...(isQuotaError ? {} : { aiAnalyzedAt: new Date() }),
-            aiAnalysisError: errorMsg.slice(0, 500),
-          },
+        const result = await analyzeArticle({
+          title: article.title,
+          content: analysisContent,
+          feedSource: article.feedSource,
+          publishedAt: article.publishedAt,
+          mentionedPoliticians: mentionedNames,
+          tier: article.tier,
         });
+
+        await processAnalyzedArticle(article, analysisContent, result, stats, {
+          dryRun,
+          verbose,
+          importRunId,
+        });
+      } catch (error) {
+        stats.analysisErrors++;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+
+        // Detect quota/rate limit errors to avoid marking articles and to stop early
+        const isQuotaError = /usage.limits|quota|rate.limit|429|402/i.test(errorMsg);
+
+        if (!dryRun) {
+          await db.pressArticle.update({
+            where: { id: article.id },
+            data: {
+              // Don't mark as analyzed on quota errors so they can be retried
+              ...(isQuotaError ? {} : { aiAnalyzedAt: new Date() }),
+              aiAnalysisError: errorMsg.slice(0, 500),
+            },
+          });
+        }
+
+        if (isQuotaError) {
+          stats.quotaStopped = true;
+          console.error(`\n✗ API quota/rate limit error, stopping early: ${errorMsg}`);
+          break;
+        }
+
+        console.error(`  ✗ Analyse IA échouée: ${errorMsg}`);
       }
 
-      if (isQuotaError) {
-        stats.quotaStopped = true;
-        console.error(`\n✗ API quota/rate limit error, stopping early: ${errorMsg}`);
-        break;
-      }
-
-      console.error(`  ✗ Analyse IA échouée: ${errorMsg}`);
+      // Rate limit between AI calls
+      await sleep(getAIRateLimitMs());
     }
 
-    // Rate limit between AI calls
-    await sleep(getAIRateLimitMs());
-  }
+    // Update sync metadata
+    if (!dryRun) {
+      await syncMetadata.markCompleted(SYNC_SOURCE_KEY, {
+        itemCount: stats.articlesAnalyzed,
+      });
+    }
 
-  // Update sync metadata
-  if (!dryRun) {
-    await syncMetadata.markCompleted(SYNC_SOURCE_KEY, {
-      itemCount: stats.articlesAnalyzed,
+    return stats;
+  };
+
+  if (dryRun) return execute(null);
+
+  return withImportRun(IMPORTER_PRESS_ANALYSIS, async ({ importRunId, setStats }) => {
+    const result = await execute(importRunId);
+    setStats({
+      proposalsPending: result.proposalsPending,
+      proposalsDeduped: result.proposalsDeduped,
+      ambiguousMatches: result.ambiguousMatches,
+      affairsCreated: result.affairsCreated,
     });
-  }
-
-  return stats;
+    return result;
+  });
 }
 
 /** Article fields needed to persist an analysis result. */
@@ -268,6 +294,23 @@ export interface AnalyzedArticleRef {
   title: string;
   feedSource: string;
   publishedAt: Date;
+}
+
+function normalizeExcerpt(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Keeps only a model-proposed excerpt that is actually present in the source text. */
+export function findVerifiedPressExcerpt(
+  excerpts: string[],
+  analysisContent: string
+): string | null {
+  const normalizedContent = normalizeExcerpt(analysisContent);
+  for (const excerpt of excerpts) {
+    const normalized = normalizeExcerpt(excerpt);
+    if (normalized && normalizedContent.includes(normalized)) return excerpt.trim().slice(0, 500);
+  }
+  return null;
 }
 
 /**
@@ -284,9 +327,9 @@ export async function processAnalyzedArticle(
   analysisContent: string,
   result: ArticleAnalysisResult,
   stats: PressAnalysisStats,
-  options: { dryRun: boolean; verbose: boolean }
+  options: { dryRun: boolean; verbose: boolean; importRunId?: string | null }
 ): Promise<void> {
-  const { dryRun, verbose } = options;
+  const { dryRun, verbose, importRunId = null } = options;
 
   stats.articlesAnalyzed++;
 
@@ -347,7 +390,7 @@ export async function processAnalyzedArticle(
     }
 
     // Resolve politician via the deterministic resolver (full DB, no context window)
-    const resolveResult = await resolveAffairPolitician({
+    const resolverInput = {
       text: analysisContent,
       candidateNames: detected.mentionedNames,
       metadata: {
@@ -356,7 +399,10 @@ export async function processAnalyzedArticle(
         factsDate: detected.factsDate ? new Date(detected.factsDate) : null,
         court: detected.court ?? null,
       },
-    });
+    };
+    const resolveResult = dryRun
+      ? await previewAffairPolitician(resolverInput)
+      : await resolveAffairPolitician(resolverInput);
 
     if (resolveResult.judgment !== "SAME" || !resolveResult.topCandidateId) {
       if (verbose) {
@@ -408,21 +454,14 @@ export async function processAnalyzedArticle(
       politicianId,
       title: detected.title,
       category: detected.category as AffairCategory,
+      status: detected.status as AffairStatus,
     });
+    const routing = classifyAffairMatches(matches);
 
-    // Enrichment requires an unambiguous match: several affairs tied at HIGH means
-    // the evidence does not identify one (issue #520).
-    const picked = pickConfidentMatch(matches);
-    const bestMatch = picked.kind === "match" ? picked.match : null;
-
-    // Weaker signal, kept for the MENTION link only. Associating an article with
-    // an affair is additive and reversible, unlike writing judicial fields.
-    const looseMatch = matches[0] ?? null;
-
-    if (bestMatch) {
+    if (routing.kind === "CONFIDENT_MATCH") {
       // Enrich existing affair
       const enriched = await enrichAffairFromPress(
-        bestMatch.affairId,
+        routing.match.affairId,
         article.id,
         article.url,
         article.title,
@@ -434,20 +473,76 @@ export async function processAnalyzedArticle(
       );
       if (enriched) {
         stats.affairsEnriched++;
-        if (!dryRun) {
+        if (!dryRun && resolveResult.decisionId) {
           await db.affairPoliticianDecision.update({
             where: { id: resolveResult.decisionId },
-            data: { affairId: bestMatch.affairId },
+            data: { affairId: routing.match.affairId },
           });
         }
       }
-    } else if (detected.isNewRevelation) {
+      continue;
+    }
+
+    if (routing.kind === "CONFIDENT_AMBIGUOUS" || routing.kind === "POSSIBLE_AMBIGUOUS") {
+      stats.ambiguousMatches++;
+    }
+
+    if (detected.isNewRevelation) {
       // Reject low-confidence detections before creating
       if (detected.confidenceScore < MIN_CONFIDENCE_THRESHOLD) {
         await rejectLowConfidenceAffair(article.id, politicianId, detected, dryRun, verbose);
         stats.affairsRejected++;
         continue;
       }
+
+      if (
+        routing.kind === "UNIQUE_EVOLUTION" &&
+        detected.statusValidated === true &&
+        detected.categoryValidated === true
+      ) {
+        const sourceExcerpt = findVerifiedPressExcerpt(detected.excerpts, analysisContent);
+        if (sourceExcerpt && isVerifiedAffairPressUrl(article.url)) {
+          if (dryRun) {
+            stats.proposalsPending++;
+            if (verbose) {
+              console.log(`  [DRY-RUN] Proposerait un événement sur ${routing.match.affairId}`);
+            }
+            continue;
+          }
+          if (!importRunId) throw new Error("ImportRun presse absent pour la proposition");
+
+          const proposal = await proposeAffairEvent({
+            affairId: routing.match.affairId,
+            importer: IMPORTER_PRESS_ANALYSIS,
+            importRunId,
+            sourceUrl: article.url,
+            sourceTitle: article.title,
+            publishedAt: article.publishedAt,
+            publisher: feedSourceToPublisher(article.feedSource),
+            pressArticleId: article.id,
+            resolverDecisionId: resolveResult.decisionId,
+            sourceContentHash: hashSourceContent({
+              articleId: article.id,
+              sourceUrl: article.url,
+              publishedAt: article.publishedAt,
+              analysisContent,
+            }),
+            sourceExcerpt,
+            confidence: Math.round(routing.match.score * 100),
+            rationale:
+              `Candidat d’évolution unique (${routing.match.matchedBy}) pour une affaire ` +
+              `pré-décision du même politique. L’article est proposé comme nouvelle source ` +
+              `médiatique, sans modification automatique de l’état judiciaire.`,
+            extractorVersion: "press-evolution-v1",
+          });
+          if (proposal.outcome === "CREATED") stats.proposalsPending++;
+          if (proposal.deduped) stats.proposalsDeduped++;
+          if (proposal.outcome !== "TARGET_INELIGIBLE") continue;
+        } else if (verbose) {
+          console.log("  - Source ou extrait insuffisant, conservation du brouillon de revue");
+        }
+      }
+
       // New revelation — create affair as DRAFT (no title prefix)
       const created = await createAffairFromPress(
         politicianId,
@@ -462,13 +557,13 @@ export async function processAnalyzedArticle(
         verbose
       );
       if (created) stats.affairsCreated++;
-    } else if (looseMatch) {
+    } else if (routing.kind === "NO_MATCH" && routing.looseMatch) {
       // Weaker match — link the article as a MENTION, without touching the affair
       if (!dryRun) {
-        await linkArticleToAffair(article.id, looseMatch.affairId, "MENTION");
+        await linkArticleToAffair(article.id, routing.looseMatch.affairId, "MENTION");
       }
       if (verbose) {
-        console.log(`  → Lien MENTION créé: article ↔ affaire ${looseMatch.affairId}`);
+        console.log(`  → Lien MENTION créé: article ↔ affaire ${routing.looseMatch.affairId}`);
       }
     }
   }

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -35,7 +35,13 @@ import {
 import { previewAffairPolitician } from "@/lib/affair-matching/resolver";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { safeJsonParseOrThrow } from "@/lib/api/safe-json";
-import { hashSourceContent, proposeAffairEvent } from "@/services/affairs/proposals";
+import {
+  hashSourceContent,
+  previewAffairEventProposal,
+  proposeAffairEvent,
+  type PreviewAffairEventProposalOutcome,
+  type ProposeAffairEventOutcome,
+} from "@/services/affairs/proposals";
 import { IMPORTER_PRESS_ANALYSIS, withImportRun } from "@/services/affairs/import-run";
 import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
 
@@ -62,7 +68,12 @@ export interface PressAnalysisStats {
   affairsRejected: number;
   proposalsPending: number;
   proposalsDeduped: number;
+  proposalsWouldCreate: number;
+  proposalsDedupedPending: number;
+  proposalsDedupedTerminal: number;
+  eventsAlreadyApplied: number;
   ambiguousMatches: number;
+  insufficientSourceProvenance: number;
   scrapeErrors: number;
   analysisErrors: number;
   sensitiveWarnings: number;
@@ -126,7 +137,12 @@ export async function syncPressAnalysis(
     affairsRejected: 0,
     proposalsPending: 0,
     proposalsDeduped: 0,
+    proposalsWouldCreate: 0,
+    proposalsDedupedPending: 0,
+    proposalsDedupedTerminal: 0,
+    eventsAlreadyApplied: 0,
     ambiguousMatches: 0,
+    insufficientSourceProvenance: 0,
     scrapeErrors: 0,
     analysisErrors: 0,
     sensitiveWarnings: 0,
@@ -280,7 +296,12 @@ export async function syncPressAnalysis(
     setStats({
       proposalsPending: result.proposalsPending,
       proposalsDeduped: result.proposalsDeduped,
+      proposalsWouldCreate: result.proposalsWouldCreate,
+      proposalsDedupedPending: result.proposalsDedupedPending,
+      proposalsDedupedTerminal: result.proposalsDedupedTerminal,
+      eventsAlreadyApplied: result.eventsAlreadyApplied,
       ambiguousMatches: result.ambiguousMatches,
+      insufficientSourceProvenance: result.insufficientSourceProvenance,
       affairsCreated: result.affairsCreated,
     });
     return result;
@@ -502,19 +523,9 @@ export async function processAnalyzedArticle(
       ) {
         const sourceExcerpt = findVerifiedPressExcerpt(detected.excerpts, analysisContent);
         if (sourceExcerpt && isVerifiedAffairPressUrl(article.url)) {
-          if (dryRun) {
-            stats.proposalsPending++;
-            if (verbose) {
-              console.log(`  [DRY-RUN] Proposerait un événement sur ${routing.match.affairId}`);
-            }
-            continue;
-          }
-          if (!importRunId) throw new Error("ImportRun presse absent pour la proposition");
-
-          const proposal = await proposeAffairEvent({
+          const eventInput = {
             affairId: routing.match.affairId,
             importer: IMPORTER_PRESS_ANALYSIS,
-            importRunId,
             sourceUrl: article.url,
             sourceTitle: article.title,
             publishedAt: article.publishedAt,
@@ -534,12 +545,24 @@ export async function processAnalyzedArticle(
               `pré-décision du même politique. L’article est proposé comme nouvelle source ` +
               `médiatique, sans modification automatique de l’état judiciaire.`,
             extractorVersion: "press-evolution-v1",
-          });
-          if (proposal.outcome === "CREATED") stats.proposalsPending++;
-          if (proposal.deduped) stats.proposalsDeduped++;
+          };
+          let proposal;
+          if (dryRun) {
+            proposal = await previewAffairEventProposal(eventInput);
+          } else {
+            if (!importRunId) throw new Error("ImportRun presse absent pour la proposition");
+            proposal = await proposeAffairEvent({ ...eventInput, importRunId });
+          }
+          recordEventProposalOutcome(stats, proposal.outcome);
+          if (verbose && dryRun) {
+            console.log(`  [DRY-RUN] Proposition événement : ${proposal.outcome}`);
+          }
           if (proposal.outcome !== "TARGET_INELIGIBLE") continue;
         } else if (verbose) {
           console.log("  - Source ou extrait insuffisant, conservation du brouillon de revue");
+        }
+        if (!sourceExcerpt || !isVerifiedAffairPressUrl(article.url)) {
+          stats.insufficientSourceProvenance++;
         }
       }
 
@@ -567,6 +590,23 @@ export async function processAnalyzedArticle(
       }
     }
   }
+}
+
+function recordEventProposalOutcome(
+  stats: PressAnalysisStats,
+  outcome: ProposeAffairEventOutcome | PreviewAffairEventProposalOutcome
+): void {
+  if (outcome === "CREATED") stats.proposalsPending++;
+  if (outcome === "WOULD_CREATE") stats.proposalsWouldCreate++;
+  if (outcome === "DEDUPED_PENDING") {
+    stats.proposalsDeduped++;
+    stats.proposalsDedupedPending++;
+  }
+  if (outcome === "DEDUPED_TERMINAL") {
+    stats.proposalsDeduped++;
+    stats.proposalsDedupedTerminal++;
+  }
+  if (outcome === "ALREADY_APPLIED") stats.eventsAlreadyApplied++;
 }
 
 // ============================================


### PR DESCRIPTION
## Résumé

- détecte les évolutions plausibles sans résoudre automatiquement les ambiguïtés
- crée des propositions humaines HIGH pour des événements médiatiques REVELATION
- applique les événements de manière atomique avec verrou PostgreSQL et identité persistée
- aligne la presse, discover-affairs, Inngest, la CLI et les dry-runs
- ajoute la revue admin et protège les acceptations par lot

## Sûreté éditoriale

- aucune relation ni événement avant acceptation humaine
- aucun texte IA ni date inventée publié
- sources journalistiques vérifiées uniquement
- importeurs limités aux affaires DRAFT

## Validation

- revue adversariale du diff: READY_FOR_VERIFIER_REVIEW
- typecheck, lint, tests ciblés et build examinés pendant la revue
- test PostgreSQL concurrent exécuté lors de la revue précédente

Refs #763