### PR TITLE
fix(mesures): auditer les dépublications

### DIFF
--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -417,6 +417,7 @@ export async function depublishMeasureAction(input: {
     await depublishMeasure({
       measureId: input.measureId,
       reason: input.reason,
+      depublishedBy: ACTOR,
       expectedUpdatedAt: parseDate(input.expectedUpdatedAt, "La version attendue"),
     });
     revalidate(input.measureId);

--- a/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
+++ b/src/lib/measures/__tests__/depublish-withdraw.integration.test.ts
@@ -45,7 +45,11 @@ describeIfDisposableDb("depublishMeasure", () => {
   it("leaves a trace of why", async () => {
     const { measureId } = await publishSeededMeasure();
 
-    await depublishMeasure({ measureId, reason: "Erreur factuelle signalée." });
+    await depublishMeasure({
+      measureId,
+      reason: "Erreur factuelle signalée.",
+      depublishedBy: "admin",
+    });
 
     const measure = await db.measure.findUniqueOrThrow({ where: { id: measureId } });
     // Without these two fields, a depublished measure is indistinguishable from one that
@@ -59,6 +63,16 @@ describeIfDisposableDb("depublishMeasure", () => {
       where: { id: measure.publishedRevisionId! },
     });
     expect(revision.supersededAt).toBeNull();
+    await expect(
+      db.auditLog.findFirst({
+        where: {
+          action: "DEPUBLISH_MEASURE",
+          entityType: "Measure",
+          entityId: measureId,
+          userId: "admin",
+        },
+      })
+    ).resolves.not.toBeNull();
   });
 
   it("rolls back the depublication when indexing fails", async () => {

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -695,6 +695,8 @@ export async function publishMeasureRevision(input: {
 export async function depublishMeasure(input: {
   measureId: string;
   reason: string;
+  /** Set by authenticated editorial entrypoints so the removal itself is auditable. */
+  depublishedBy?: string;
   /**
    * The `Measure.updatedAt` the caller last saw. Without it, an old page depublishes a correction
    * that was published in the meantime, with a reason written about the previous formulation.
@@ -703,6 +705,9 @@ export async function depublishMeasure(input: {
 }): Promise<void> {
   if (input.reason.trim() === "") {
     throw new MeasureValidationError("Une dépublication exige un motif");
+  }
+  if (input.depublishedBy !== undefined && input.depublishedBy.trim() === "") {
+    throw new MeasureValidationError("Le responsable de la dépublication doit être identifié");
   }
 
   const { electionId } = await db.$transaction(async (tx) => {
@@ -723,6 +728,18 @@ export async function depublishMeasure(input: {
         depublicationReason: input.reason,
       },
     });
+
+    if (input.depublishedBy) {
+      await tx.auditLog.create({
+        data: {
+          action: "DEPUBLISH_MEASURE",
+          entityType: "Measure",
+          entityId: input.measureId,
+          changes: { reason: input.reason.trim() },
+          userId: input.depublishedBy,
+        },
+      });
+    }
 
     // Re-derives rather than just flipping visibility. With a draft in flight, the
     // reference revision becomes latestRevisionId, so the document must carry the draft


### PR DESCRIPTION
## Résumé

- transmet l'acteur authentifié au service de dépublication
- écrit un AuditLog atomiquement avec le changement de statut
- couvre la trace d'audit dans le test d'intégration

## Vérifications

- `npx eslint src/app/admin/mesures/actions.ts src/lib/measures/transitions.ts src/lib/measures/__tests__/depublish-withdraw.integration.test.ts`
- test Vitest ciblé découvert, mais ignoré faute de base jetable configurée : 1 fichier et 6 tests ignorés

Aucune modification de schéma ni de données de production.