### PR TITLE
API: exposer le suivi public de la présidentielle 2027

### DIFF
--- a/docs/api/PRESIDENTIAL_CAMPAIGN_API_V1.md
+++ b/docs/api/PRESIDENTIAL_CAMPAIGN_API_V1.md
@@ -1,0 +1,163 @@
+# API publique de campagne présidentielle, contrat v1
+
+Ce contrat additif expose le suivi public des candidatures et les mesures présidentielles
+publiées. Il ne remplace pas `GET /api/elections/{slug}`, qui reste le contrat générique des
+résultats électoraux.
+
+## Principes
+
+- Le suivi décrit des annonces et des hypothèses publiques sourcées. Il ne constitue pas une liste
+  officielle de candidatures.
+- Chaque candidature exposée possède un statut, une URL de source, un libellé de source et une fiche
+  politique publiée.
+- Les mesures cumulent le verrou de publication de la mesure, celui de sa révision publiée et celui
+  de l'extension présidentielle de la candidature.
+- Le contrat ne produit aucun score, classement, comparaison normative ou recommandation.
+- Les réponses ne contiennent aucun champ de modération ou d'administration.
+
+## GET `/api/elections/{slug}/candidacies`
+
+### Paramètres
+
+| Paramètre              | Valeurs                                      | Défaut |
+| ---------------------- | -------------------------------------------- | ------ |
+| `status`               | `DECLARE`, `PRESSENTI`, `ENVISAGE`, `RETIRE` | tous   |
+| `hasPublishedMeasures` | `true` ou `false`                            | tous   |
+| `page`                 | entier supérieur ou égal à 1                 | `1`    |
+| `limit`                | entier entre 1 et 100                        | `20`   |
+
+`page` et `limit` doivent être des entiers complets dans ces bornes. Une valeur malformée ou hors
+bornes renvoie `400`.
+
+### Statuts de suivi
+
+| Code        | Libellé                 |
+| ----------- | ----------------------- |
+| `DECLARE`   | Candidature annoncée    |
+| `PRESSENTI` | Personnalité pressentie |
+| `ENVISAGE`  | Personnalité évoquée    |
+| `RETIRE`    | Candidature retirée     |
+
+Le champ `meta.statusScope` vaut toujours
+`PUBLIC_TRACKING_NOT_OFFICIAL_CANDIDATE_LIST`.
+
+### États de programme
+
+| Code                                       | Signification                                                                                        |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `NO_PROGRAM_IDENTIFIED`                    | Aucun programme propre à la candidature n'est publié et aucune mesure accessible n'est exposée.      |
+| `PROGRAM_IDENTIFIED_NO_PUBLISHED_MEASURES` | Un programme propre à la candidature est publié, mais aucune mesure accessible n'est encore exposée. |
+| `PUBLISHED_MEASURES`                       | Une ou plusieurs mesures accessibles sont publiées.                                                  |
+
+Une édition publiée par un parti n'est jamais attribuée automatiquement à une candidature. Seule
+une édition explicitement rattachée à la candidature peut produire le deuxième état.
+
+### Forme de réponse
+
+```json
+{
+  "election": {
+    "id": "...",
+    "slug": "presidentielle-2027",
+    "title": "Élection présidentielle 2027",
+    "type": "PRESIDENTIELLE"
+  },
+  "data": [
+    {
+      "candidacyId": "...",
+      "candidateName": "...",
+      "politicianSlug": "...",
+      "trackingStatus": {
+        "code": "DECLARE",
+        "label": "Candidature annoncée",
+        "source": { "label": "...", "url": "https://..." }
+      },
+      "party": { "label": "...", "shortName": "..." },
+      "programmeState": {
+        "code": "PUBLISHED_MEASURES",
+        "label": "Mesures publiées"
+      },
+      "publishedMeasureCount": 1,
+      "themesCoveredCount": 1,
+      "publicUrl": "/elections/presidentielle-2027/candidats/..."
+    }
+  ],
+  "pagination": { "page": 1, "limit": 20, "total": 1, "totalPages": 1 },
+  "meta": { "statusScope": "PUBLIC_TRACKING_NOT_OFFICIAL_CANDIDATE_LIST" }
+}
+```
+
+## GET `/api/elections/{slug}/measures`
+
+### Paramètres
+
+| Paramètre          | Valeurs                                              | Défaut  |
+| ------------------ | ---------------------------------------------------- | ------- |
+| `candidateSlug`    | slug exact d'une candidature présidentielle publique | tous    |
+| `theme`            | slug canonique d'un des treize thèmes                | tous    |
+| `includeWithdrawn` | `true` ou `false`                                    | `false` |
+| `page`             | entier supérieur ou égal à 1                         | `1`     |
+| `limit`            | entier entre 1 et 100                                | `20`    |
+
+Une élection inconnue ou une candidature qui n'appartient pas au champ public sourcé renvoie `404`.
+Une candidature connue dont l'extension présidentielle n'est pas publiée renvoie `200` avec
+`data: []`. Un thème, un booléen, une pagination ou un type d'élection invalide renvoie `400`. Le
+filtre `candidateSlug` est limité à 200 caractères. Une page sans résultat renvoie `200` avec une
+pagination cohérente.
+
+### Publication et sources
+
+Une mesure est exposée seulement si toutes les conditions suivantes sont vraies :
+
+1. elle appartient à l'élection demandée ;
+2. elle est rattachée à une candidature ;
+3. la candidature possède un statut public non nul, une URL de source non nulle, un libellé de
+   source non nul et un identifiant de personnalité non nul ;
+4. la personnalité associée franchit la porte de publication publique ;
+5. l'extension présidentielle existe et possède le statut `PUBLISHED` ;
+6. la mesure possède le statut de publication `PUBLISHED` et désigne une révision publiée ;
+7. la révision désignée est relue, publiée, non supplantée, non écartée, non rejetée et associée à
+   au moins une source.
+
+Chaque entrée est un DTO en liste blanche. Il contient le texte et la précision de la révision
+publiée, le thème, l'attribution, l'identité publique de la candidature, les sources de la révision
+et l'état de retrait. Aucun objet Prisma brut n'est sérialisé.
+
+Les sources d'une mesure sont ordonnées par date de publication croissante, puis par identifiant
+interne croissant lorsque plusieurs sources partagent la même date. Cet identifiant stabilise
+l'ordre sans être nécessairement exposé dans le DTO public.
+
+Les URLs de fiche candidat et de page sujet sont incluses lorsqu'elles existent. Aucune URL de
+détail de mesure n'est inventée.
+
+### Retraits
+
+Par défaut, une liste répond à la question des mesures actuellement défendues et exclut donc les
+mesures retirées. `includeWithdrawn=true` les rend consultables pour l'historique. Une mesure active
+porte exactement la forme suivante :
+
+```json
+{
+  "withdrawal": null
+}
+```
+
+Une mesure retirée porte exactement la forme suivante :
+
+```json
+{
+  "withdrawal": {
+    "withdrawnAt": "2026-08-01T10:00:00.000Z",
+    "sourceUrl": "https://source.example/retrait",
+    "sourceLabel": null
+  }
+}
+```
+
+`sourceUrl` et `sourceLabel` sont indépendamment nullables. L'absence de l'un ne permet pas
+d'inventer l'autre. Une mesure retirée ne doit pas être présentée comme actuellement défendue.
+
+## Évolution du contrat
+
+Ce document couvre uniquement les deux endpoints présidentiels. L'issue `#737` reste le chantier
+du contrat OpenAPI global et n'est pas traitée ici.

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -91,6 +91,7 @@ else
     src/lib/data/__tests__/latest-review-date.integration.test.ts \
     src/lib/data/__tests__/measures.integration.test.ts \
     src/lib/data/__tests__/pending-review-and-review-date.integration.test.ts \
+    src/lib/data/__tests__/presidential-public-api.integration.test.ts \
     src/lib/data/__tests__/presidential-candidates-public.integration.test.ts \
     src/lib/data/__tests__/priorites.integration.test.ts \
     src/lib/data/__tests__/subject-page.integration.test.ts \

--- a/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
+++ b/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
@@ -64,6 +64,8 @@ const PARTY_SURFACES = [
   "src/app/api/compare/suggestions/route.ts",
   "src/app/api/deputies/by-commune/route.ts",
   "src/app/api/deputies/by-department/route.ts",
+  "src/app/api/elections/[slug]/candidacies/route.ts",
+  "src/app/api/elections/[slug]/measures/route.ts",
   "src/app/api/elections/[slug]/route.ts",
   "src/app/api/export/affaires/route.ts",
   "src/app/api/export/factchecks/route.ts",

--- a/src/app/api/elections/[slug]/candidacies/route.ts
+++ b/src/app/api/elections/[slug]/candidacies/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import type { CandidacyStatus } from "@/generated/prisma";
+import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
+import { buildPaginationMeta, parseStrictPagination } from "@/lib/api/pagination";
+import { withPublicRoute } from "@/lib/api/with-public-route";
+import { withCache } from "@/lib/cache";
+import { getPublicPresidentialCandidacyField } from "@/lib/data/presidential-candidacy-field";
+
+const CANDIDACY_STATUSES = ["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"] as const;
+
+const PROGRAMME_STATES = {
+  aucun_programme: {
+    code: "NO_PROGRAM_IDENTIFIED",
+    label: "Aucun programme identifié",
+  },
+  non_depouille: {
+    code: "PROGRAM_IDENTIFIED_NO_PUBLISHED_MEASURES",
+    label: "Programme identifié, aucune mesure publiée",
+  },
+  published: {
+    code: "PUBLISHED_MEASURES",
+    label: "Mesures publiées",
+  },
+} as const;
+
+function parseOptionalBoolean(value: string | null): boolean | null | undefined {
+  if (value === null) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+export const GET = withPublicRoute(async (request, context) => {
+  const { slug } = await context.params;
+  if (!slug) {
+    return NextResponse.json({ error: "Slug d'élection invalide" }, { status: 400 });
+  }
+  const searchParams = request.nextUrl.searchParams;
+  const statusParam = searchParams.get("status");
+  const hasPublishedMeasures = parseOptionalBoolean(searchParams.get("hasPublishedMeasures"));
+
+  if (
+    statusParam !== null &&
+    !CANDIDACY_STATUSES.includes(statusParam as (typeof CANDIDACY_STATUSES)[number])
+  ) {
+    return NextResponse.json({ error: "Statut de candidature invalide" }, { status: 400 });
+  }
+  if (hasPublishedMeasures === null) {
+    return NextResponse.json({ error: "Filtre hasPublishedMeasures invalide" }, { status: 400 });
+  }
+
+  const pagination = parseStrictPagination(searchParams, { defaultLimit: 20, maxLimit: 100 });
+  if (pagination === null) {
+    return NextResponse.json({ error: "Pagination invalide" }, { status: 400 });
+  }
+
+  const field = await getPublicPresidentialCandidacyField(slug);
+  if (field === null) {
+    return NextResponse.json({ error: "Élection non trouvée" }, { status: 404 });
+  }
+  if (field.election.type !== "PRESIDENTIELLE") {
+    return NextResponse.json(
+      { error: "Ce contrat est réservé aux élections présidentielles" },
+      { status: 400 }
+    );
+  }
+
+  const { page, limit } = pagination;
+  const status = statusParam as CandidacyStatus | null;
+  const filtered = field.candidacies.filter((candidacy) => {
+    if (status !== null && candidacy.status !== status) return false;
+    if (hasPublishedMeasures !== undefined && candidacy.measureCount > 0 !== hasPublishedMeasures) {
+      return false;
+    }
+    return true;
+  });
+  const data = filtered.slice((page - 1) * limit, page * limit).map((candidacy) => {
+    const programmeState = candidacy.programmeAbsence
+      ? PROGRAMME_STATES[candidacy.programmeAbsence]
+      : PROGRAMME_STATES.published;
+    return {
+      candidacyId: candidacy.id,
+      candidateName: candidacy.candidateName,
+      politicianSlug: candidacy.politicianSlug,
+      trackingStatus: {
+        code: candidacy.status,
+        label: CANDIDACY_STATUS_LABELS[candidacy.status],
+        source: {
+          label: candidacy.sourceLabel,
+          url: candidacy.sourceUrl,
+        },
+      },
+      party: candidacy.partyLabel
+        ? { label: candidacy.partyLabel, shortName: candidacy.partyShortName }
+        : null,
+      programmeState,
+      publishedMeasureCount: candidacy.measureCount,
+      themesCoveredCount: candidacy.themesCoveredCount,
+      publicUrl: `/elections/${field.election.slug}/candidats/${candidacy.politicianSlug}`,
+    };
+  });
+
+  return withCache(
+    NextResponse.json({
+      election: field.election,
+      data,
+      pagination: buildPaginationMeta(page, limit, filtered.length),
+      meta: {
+        statusScope: "PUBLIC_TRACKING_NOT_OFFICIAL_CANDIDATE_LIST",
+      },
+    }),
+    "daily"
+  );
+});

--- a/src/app/api/elections/[slug]/measures/route.ts
+++ b/src/app/api/elections/[slug]/measures/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { buildPaginationMeta, parseStrictPagination } from "@/lib/api/pagination";
+import { withPublicRoute } from "@/lib/api/with-public-route";
+import { withCache } from "@/lib/cache";
+import {
+  getPublicElectionIdentity,
+  hasPublicTrackedPresidentialCandidacy,
+} from "@/lib/data/presidential-candidacy-field";
+import { listPublicPresidentialMeasures } from "@/lib/data/measures";
+import { themeFromSlug } from "@/lib/theme-utils";
+
+function parseOptionalBoolean(value: string | null): boolean | null | undefined {
+  if (value === null) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+const MAX_CANDIDATE_SLUG_LENGTH = 200;
+
+export const GET = withPublicRoute(async (request, context) => {
+  const { slug } = await context.params;
+  if (!slug) {
+    return NextResponse.json({ error: "Slug d'élection invalide" }, { status: 400 });
+  }
+  const searchParams = request.nextUrl.searchParams;
+  const candidateSlugParam = searchParams.get("candidateSlug");
+  const themeParam = searchParams.get("theme");
+  const includeWithdrawn = parseOptionalBoolean(searchParams.get("includeWithdrawn"));
+
+  if (
+    candidateSlugParam !== null &&
+    (candidateSlugParam.trim() === "" ||
+      candidateSlugParam !== candidateSlugParam.trim() ||
+      candidateSlugParam.length > MAX_CANDIDATE_SLUG_LENGTH)
+  ) {
+    return NextResponse.json({ error: "Candidature invalide" }, { status: 400 });
+  }
+  const theme = themeParam === null ? undefined : themeFromSlug(themeParam);
+  if (themeParam !== null && theme === null) {
+    return NextResponse.json({ error: "Thème invalide" }, { status: 400 });
+  }
+  if (includeWithdrawn === null) {
+    return NextResponse.json({ error: "Filtre includeWithdrawn invalide" }, { status: 400 });
+  }
+  const pagination = parseStrictPagination(searchParams, { defaultLimit: 20, maxLimit: 100 });
+  if (pagination === null) {
+    return NextResponse.json({ error: "Pagination invalide" }, { status: 400 });
+  }
+
+  const election = await getPublicElectionIdentity(slug);
+  if (election === null) {
+    return NextResponse.json({ error: "Élection non trouvée" }, { status: 404 });
+  }
+  if (election.type !== "PRESIDENTIELLE") {
+    return NextResponse.json(
+      { error: "Ce contrat est réservé aux élections présidentielles" },
+      { status: 400 }
+    );
+  }
+
+  const candidateSlug = candidateSlugParam ?? undefined;
+  if (
+    candidateSlug !== undefined &&
+    !(await hasPublicTrackedPresidentialCandidacy(election.id, candidateSlug))
+  ) {
+    return NextResponse.json({ error: "Candidature non trouvée" }, { status: 404 });
+  }
+
+  const { page, limit } = pagination;
+  const result = await listPublicPresidentialMeasures({
+    electionId: election.id,
+    electionSlug: election.slug,
+    candidateSlug,
+    theme: theme ?? undefined,
+    includeWithdrawn: includeWithdrawn ?? false,
+    page,
+    limit,
+  });
+
+  return withCache(
+    NextResponse.json({
+      election,
+      data: result.data,
+      pagination: buildPaginationMeta(page, limit, result.total),
+      meta: { includeWithdrawn: includeWithdrawn ?? false },
+    }),
+    "daily"
+  );
+});

--- a/src/app/api/elections/[slug]/presidential-routes.test.ts
+++ b/src/app/api/elections/[slug]/presidential-routes.test.ts
@@ -1,0 +1,401 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPublicPresidentialCandidacyField: vi.fn(),
+  getPublicElectionIdentity: vi.fn(),
+  hasPublicTrackedPresidentialCandidacy: vi.fn(),
+  listPublicPresidentialMeasures: vi.fn(),
+}));
+
+vi.mock("@/lib/api/with-public-route", () => ({
+  withPublicRoute: <T extends (...args: never[]) => unknown>(handler: T) => handler,
+}));
+vi.mock("@/lib/cache", () => ({
+  withCache: (response: Response) => response,
+}));
+vi.mock("@/lib/data/presidential-candidacy-field", () => ({
+  getPublicPresidentialCandidacyField: mocks.getPublicPresidentialCandidacyField,
+  getPublicElectionIdentity: mocks.getPublicElectionIdentity,
+  hasPublicTrackedPresidentialCandidacy: mocks.hasPublicTrackedPresidentialCandidacy,
+}));
+vi.mock("@/lib/data/measures", () => ({
+  listPublicPresidentialMeasures: mocks.listPublicPresidentialMeasures,
+}));
+
+import { GET as getCandidacies } from "./candidacies/route";
+import { GET as getMeasures } from "./measures/route";
+
+const context = { params: Promise.resolve({ slug: "presidentielle-2027" }) };
+const election = {
+  id: "election-1",
+  slug: "presidentielle-2027",
+  title: "Élection présidentielle 2027",
+  type: "PRESIDENTIELLE",
+};
+
+function candidacy(
+  id: string,
+  status: "DECLARE" | "PRESSENTI" | "ENVISAGE" | "RETIRE",
+  programmeAbsence: "aucun_programme" | "non_depouille" | null,
+  measureCount: number
+) {
+  return {
+    id,
+    candidateName: `Candidate ${id}`,
+    politicianSlug: `candidate-${id}`,
+    photoUrl: null,
+    blobPhotoUrl: null,
+    status,
+    sourceUrl: `https://example.org/source-${id}`,
+    sourceLabel: `Source ${id}`,
+    partyLabel: `Parti ${id}`,
+    partyColor: null,
+    partyShortName: `P${id}`,
+    partyLogoUrl: null,
+    measureCount,
+    themesCoveredCount: measureCount > 0 ? 1 : 0,
+    programmeAbsence,
+  };
+}
+
+describe("GET /api/elections/[slug]/candidacies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPublicPresidentialCandidacyField.mockResolvedValue({
+      election,
+      candidacies: [
+        candidacy("1", "DECLARE", null, 2),
+        candidacy("2", "PRESSENTI", "non_depouille", 0),
+        candidacy("3", "ENVISAGE", "aucun_programme", 0),
+        candidacy("4", "RETIRE", "aucun_programme", 0),
+      ],
+    });
+  });
+
+  it("retourne le suivi sourcé, les libellés et les trois états sans statut officiel", async () => {
+    const response = await getCandidacies(
+      new NextRequest("https://poligraph.fr/api/elections/presidentielle-2027/candidacies"),
+      context
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(
+      body.data.map((item: { trackingStatus: { label: string } }) => item.trackingStatus.label)
+    ).toEqual([
+      "Candidature annoncée",
+      "Personnalité pressentie",
+      "Personnalité évoquée",
+      "Candidature retirée",
+    ]);
+    expect(
+      body.data.map((item: { programmeState: { code: string } }) => item.programmeState.code)
+    ).toEqual([
+      "PUBLISHED_MEASURES",
+      "PROGRAM_IDENTIFIED_NO_PUBLISHED_MEASURES",
+      "NO_PROGRAM_IDENTIFIED",
+      "NO_PROGRAM_IDENTIFIED",
+    ]);
+    expect(body.meta.statusScope).toBe("PUBLIC_TRACKING_NOT_OFFICIAL_CANDIDATE_LIST");
+    expect(body.data[0].trackingStatus.source).toEqual({
+      label: "Source 1",
+      url: "https://example.org/source-1",
+    });
+    expect(body.data[0]).not.toHaveProperty("statusSource");
+    expect(JSON.stringify(body)).not.toMatch(/admin|moderation|secret|officialCandidate/i);
+  });
+
+  it("filtre le statut et la présence de mesures avec une pagination bornée", async () => {
+    const response = await getCandidacies(
+      new NextRequest(
+        "https://poligraph.fr/api/elections/presidentielle-2027/candidacies?status=DECLARE&hasPublishedMeasures=true&page=1&limit=100"
+      ),
+      context
+    );
+    const body = await response.json();
+
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].trackingStatus.code).toBe("DECLARE");
+    expect(body.pagination).toEqual({ page: 1, limit: 100, total: 1, totalPages: 1 });
+  });
+
+  it("isole les candidatures sans mesure publiée", async () => {
+    const response = await getCandidacies(
+      new NextRequest(
+        "https://poligraph.fr/api/elections/presidentielle-2027/candidacies?hasPublishedMeasures=false"
+      ),
+      context
+    );
+    const body = await response.json();
+
+    expect(body.data.map((item: { candidacyId: string }) => item.candidacyId)).toEqual([
+      "2",
+      "3",
+      "4",
+    ]);
+  });
+
+  it.each([
+    ["?status=OFFICIEL", "Statut de candidature invalide"],
+    ["?hasPublishedMeasures=oui", "Filtre hasPublishedMeasures invalide"],
+    ["?page=0", "Pagination invalide"],
+    ["?page=1.5", "Pagination invalide"],
+    ["?page=abc", "Pagination invalide"],
+    ["?limit=101", "Pagination invalide"],
+  ])("retourne 400 pour des paramètres invalides (%s)", async (query, error) => {
+    const response = await getCandidacies(
+      new NextRequest(`https://poligraph.fr/api/elections/presidentielle-2027/candidacies${query}`),
+      context
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error });
+    expect(mocks.getPublicPresidentialCandidacyField).not.toHaveBeenCalled();
+  });
+
+  it("distingue l'élection absente du type non supporté", async () => {
+    mocks.getPublicPresidentialCandidacyField.mockResolvedValueOnce(null);
+    const missing = await getCandidacies(
+      new NextRequest("https://poligraph.fr/api/elections/inconnue/candidacies"),
+      { params: Promise.resolve({ slug: "inconnue" }) }
+    );
+    expect(missing.status).toBe(404);
+
+    mocks.getPublicPresidentialCandidacyField.mockResolvedValueOnce({
+      election: { ...election, type: "MUNICIPALES" },
+      candidacies: [],
+    });
+    const unsupported = await getCandidacies(
+      new NextRequest("https://poligraph.fr/api/elections/municipales-2026/candidacies"),
+      { params: Promise.resolve({ slug: "municipales-2026" }) }
+    );
+    expect(unsupported.status).toBe(400);
+    expect(await unsupported.json()).toEqual({
+      error: "Ce contrat est réservé aux élections présidentielles",
+    });
+  });
+});
+
+describe("GET /api/elections/[slug]/measures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPublicElectionIdentity.mockResolvedValue(election);
+    mocks.hasPublicTrackedPresidentialCandidacy.mockResolvedValue(true);
+    mocks.listPublicPresidentialMeasures.mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          measureId: "measure-1",
+          publishedRevisionId: "revision-1",
+          text: "Mesure publiée et sourcée.",
+          precision: { code: "OBJECTIF_SANS_CHIFFRE", label: "Objectif sans chiffre" },
+          theme: {
+            code: "SANTE",
+            label: "Santé",
+            slug: "sante",
+            publicUrl: "/elections/presidentielle-2027/sujets/sante",
+          },
+          attribution: { code: "PERSONAL", label: "Formulée personnellement" },
+          candidacy: {
+            candidacyId: "candidacy-1",
+            candidateName: "Candidate test",
+            politicianSlug: "candidate-test",
+            publicUrl: "/elections/presidentielle-2027/candidats/candidate-test",
+          },
+          sources: [
+            {
+              sourceKind: "DISCOURS_CAMPAGNE",
+              tier: "PRIMARY",
+              url: "https://example.org/source",
+              page: null,
+              publishedAt: new Date("2027-01-01T00:00:00Z"),
+            },
+          ],
+          withdrawal: null,
+        },
+      ],
+    });
+  });
+
+  it("retourne le DTO nominal et transmet les filtres avec une pagination bornée", async () => {
+    const request = new NextRequest(
+      "https://poligraph.fr/api/elections/presidentielle-2027/measures?candidateSlug=candidate-test&theme=sante&includeWithdrawn=true&page=2&limit=100"
+    );
+    const response = await getMeasures(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.hasPublicTrackedPresidentialCandidacy).toHaveBeenCalledWith(
+      "election-1",
+      "candidate-test"
+    );
+    expect(mocks.listPublicPresidentialMeasures).toHaveBeenCalledWith({
+      electionId: "election-1",
+      electionSlug: "presidentielle-2027",
+      candidateSlug: "candidate-test",
+      theme: "SANTE",
+      includeWithdrawn: true,
+      page: 2,
+      limit: 100,
+    });
+    expect(body.pagination).toEqual({ page: 2, limit: 100, total: 1, totalPages: 1 });
+    expect(Object.keys(body.data[0]).sort()).toEqual([
+      "attribution",
+      "candidacy",
+      "measureId",
+      "precision",
+      "publishedRevisionId",
+      "sources",
+      "text",
+      "theme",
+      "withdrawal",
+    ]);
+    expect(body.data[0].withdrawal).toBeNull();
+    expect(body.data[0]).not.toHaveProperty("withdrawn");
+    expect(JSON.stringify(body)).not.toMatch(/admin|reviewedBy|secret|publicationStatus/i);
+  });
+
+  it("sérialise un retrait avec trois champs directs et sans ancienne forme", async () => {
+    mocks.listPublicPresidentialMeasures.mockResolvedValueOnce({
+      total: 1,
+      data: [
+        {
+          measureId: "measure-withdrawn",
+          publishedRevisionId: "revision-withdrawn",
+          text: "Mesure retirée et sourcée.",
+          precision: { code: "OBJECTIF_SANS_CHIFFRE", label: "Objectif sans chiffre" },
+          theme: {
+            code: "SANTE",
+            label: "Santé",
+            slug: "sante",
+            publicUrl: "/elections/presidentielle-2027/sujets/sante",
+          },
+          attribution: { code: "PERSONAL", label: "Formulée personnellement" },
+          candidacy: {
+            candidacyId: "candidacy-1",
+            candidateName: "Candidate test",
+            politicianSlug: "candidate-test",
+            publicUrl: "/elections/presidentielle-2027/candidats/candidate-test",
+          },
+          sources: [],
+          withdrawal: {
+            withdrawnAt: new Date("2027-03-01T00:00:00.000Z"),
+            sourceUrl: "https://example.org/retrait",
+            sourceLabel: null,
+          },
+        },
+      ],
+    });
+
+    const response = await getMeasures(
+      new NextRequest(
+        "https://poligraph.fr/api/elections/presidentielle-2027/measures?includeWithdrawn=true"
+      ),
+      context
+    );
+    const body = await response.json();
+    const item = body.data[0];
+
+    expect(response.status).toBe(200);
+    expect(item.withdrawal.withdrawnAt).toBe("2027-03-01T00:00:00.000Z");
+    expect(item.withdrawal.sourceUrl).toBe("https://example.org/retrait");
+    expect(item.withdrawal.sourceLabel).toBeNull();
+    expect(item.withdrawal).not.toHaveProperty("withdrawn");
+    expect(item.withdrawal).not.toHaveProperty("source");
+  });
+
+  it.each([
+    ["?theme=inconnu", "Thème invalide"],
+    ["?includeWithdrawn=oui", "Filtre includeWithdrawn invalide"],
+    ["?candidateSlug=", "Candidature invalide"],
+    [`?candidateSlug=${"a".repeat(201)}`, "Candidature invalide"],
+    ["?page=0", "Pagination invalide"],
+    ["?page=1.5", "Pagination invalide"],
+    ["?limit=101", "Pagination invalide"],
+  ])("retourne 400 avant toute lecture pour un filtre invalide (%s)", async (query, error) => {
+    const response = await getMeasures(
+      new NextRequest(`https://poligraph.fr/api/elections/presidentielle-2027/measures${query}`),
+      context
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error });
+    expect(mocks.getPublicElectionIdentity).not.toHaveBeenCalled();
+    expect(mocks.listPublicPresidentialMeasures).not.toHaveBeenCalled();
+  });
+
+  it("retourne 404 pour une élection ou une candidature absente", async () => {
+    mocks.getPublicElectionIdentity.mockResolvedValueOnce(null);
+    const missingElection = await getMeasures(
+      new NextRequest("https://poligraph.fr/api/elections/inconnue/measures"),
+      { params: Promise.resolve({ slug: "inconnue" }) }
+    );
+    expect(missingElection.status).toBe(404);
+
+    mocks.hasPublicTrackedPresidentialCandidacy.mockResolvedValueOnce(false);
+    const missingCandidate = await getMeasures(
+      new NextRequest(
+        "https://poligraph.fr/api/elections/presidentielle-2027/measures?candidateSlug=inconnue"
+      ),
+      context
+    );
+    expect(missingCandidate.status).toBe(404);
+    expect(mocks.listPublicPresidentialMeasures).not.toHaveBeenCalled();
+  });
+
+  it("retourne 200 vide pour une candidature suivie dont la fiche n'est pas publiée", async () => {
+    mocks.listPublicPresidentialMeasures.mockResolvedValueOnce({ total: 0, data: [] });
+    const response = await getMeasures(
+      new NextRequest(
+        "https://poligraph.fr/api/elections/presidentielle-2027/measures?candidateSlug=charlie-fixture"
+      ),
+      context
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.hasPublicTrackedPresidentialCandidacy).toHaveBeenCalledWith(
+      "election-1",
+      "charlie-fixture"
+    );
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        data: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      })
+    );
+  });
+
+  it("rejette explicitement une élection non présidentielle", async () => {
+    mocks.getPublicElectionIdentity.mockResolvedValueOnce({
+      ...election,
+      type: "MUNICIPALES",
+    });
+    const response = await getMeasures(
+      new NextRequest("https://poligraph.fr/api/elections/municipales-2026/measures"),
+      { params: Promise.resolve({ slug: "municipales-2026" }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Ce contrat est réservé aux élections présidentielles",
+    });
+    expect(mocks.listPublicPresidentialMeasures).not.toHaveBeenCalled();
+  });
+
+  it("retourne une liste vide avec une pagination cohérente", async () => {
+    mocks.listPublicPresidentialMeasures.mockResolvedValueOnce({ total: 0, data: [] });
+    const response = await getMeasures(
+      new NextRequest("https://poligraph.fr/api/elections/presidentielle-2027/measures"),
+      context
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        data: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      })
+    );
+  });
+});

--- a/src/lib/api/__tests__/pagination.test.ts
+++ b/src/lib/api/__tests__/pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parsePagination } from "../pagination";
+import { parsePagination, parseStrictPagination } from "../pagination";
 
 describe("parsePagination", () => {
   it("uses defaults when no params", () => {
@@ -40,5 +40,34 @@ describe("parsePagination", () => {
   it("handles NaN gracefully", () => {
     const params = new URLSearchParams({ page: "abc", limit: "xyz" });
     expect(parsePagination(params)).toEqual({ page: 1, limit: 50, skip: 0 });
+  });
+});
+
+describe("parseStrictPagination", () => {
+  it("applique les valeurs par défaut et calcule le décalage", () => {
+    expect(parseStrictPagination(new URLSearchParams(), { defaultLimit: 20 })).toEqual({
+      page: 1,
+      limit: 20,
+      skip: 0,
+    });
+    expect(
+      parseStrictPagination(new URLSearchParams({ page: "3", limit: "20" }), {
+        defaultLimit: 20,
+      })
+    ).toEqual({ page: 3, limit: 20, skip: 40 });
+  });
+
+  it.each([
+    "page=0",
+    "page=1.5",
+    "page=abc",
+    "page=9007199254740992",
+    "limit=0",
+    "limit=1.5",
+    "limit=101",
+  ])("refuse une pagination malformée ou hors bornes : %s", (query) => {
+    expect(
+      parseStrictPagination(new URLSearchParams(query), { defaultLimit: 20, maxLimit: 100 })
+    ).toBeNull();
   });
 });

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -34,6 +34,31 @@ export function parsePagination(
 }
 
 /**
+ * Parse pagination without correcting malformed client input.
+ *
+ * Public contracts that promise bounded integers use this variant so `1.5`, `0`, an unsafe
+ * integer or an out-of-range limit is rejected instead of being silently truncated or clamped.
+ */
+export function parseStrictPagination(
+  searchParams: URLSearchParams,
+  options?: PaginationOptions
+): PaginationResult | null {
+  const { defaultLimit = 50, maxLimit = 100 } = options ?? {};
+  const rawPage = searchParams.get("page");
+  const rawLimit = searchParams.get("limit");
+  const isPositiveInteger = (value: string): boolean => /^[1-9][0-9]*$/.test(value);
+
+  if (rawPage !== null && !isPositiveInteger(rawPage)) return null;
+  if (rawLimit !== null && !isPositiveInteger(rawLimit)) return null;
+
+  const page = rawPage === null ? 1 : Number(rawPage);
+  const limit = rawLimit === null ? defaultLimit : Number(rawLimit);
+  if (!Number.isSafeInteger(page) || !Number.isSafeInteger(limit) || limit > maxLimit) return null;
+
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+/**
  * Build a pagination metadata object for API responses.
  */
 export function buildPaginationMeta(page: number, limit: number, total: number): PaginationMeta {

--- a/src/lib/data/__tests__/presidential-public-api.integration.test.ts
+++ b/src/lib/data/__tests__/presidential-public-api.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
 
 let db: typeof import("@/lib/db").db;

--- a/src/lib/data/__tests__/presidential-public-api.integration.test.ts
+++ b/src/lib/data/__tests__/presidential-public-api.integration.test.ts
@@ -1,0 +1,461 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+let db: typeof import("@/lib/db").db;
+let getPublicPresidentialCandidacyField: typeof import("../presidential-candidacy-field").getPublicPresidentialCandidacyField;
+let hasPublicTrackedPresidentialCandidacy: typeof import("../presidential-candidacy-field").hasPublicTrackedPresidentialCandidacy;
+let listPublicPresidentialMeasures: typeof import("../measures").listPublicPresidentialMeasures;
+let transitions: typeof import("@/lib/measures/transitions");
+
+const SLUG = "presidential-public-api-test";
+
+describeIfDisposableDb("autorités publiques de campagne présidentielle", () => {
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getPublicPresidentialCandidacyField, hasPublicTrackedPresidentialCandidacy } =
+      await import("../presidential-candidacy-field"));
+    ({ listPublicPresidentialMeasures } = await import("../measures"));
+    transitions = await import("@/lib/measures/transitions");
+    const { seedHubFixture } = await import("./hub-fixture");
+    electionId = await seedHubFixture(db, { electionSlug: SLUG });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.election.deleteMany({ where: { slug: SLUG } });
+    await db.party.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.$disconnect();
+  });
+
+  it("expose le champ sourcé sans exiger une extension présidentielle publiée", async () => {
+    const field = await getPublicPresidentialCandidacyField(SLUG);
+
+    expect(field?.election).toEqual(
+      expect.objectContaining({ slug: SLUG, type: "PRESIDENTIELLE" })
+    );
+    expect(field?.candidacies.map((candidate) => candidate.candidateName)).toEqual([
+      "Alpha Fixture",
+      "Bravo Fixture",
+      "Charlie Fixture",
+    ]);
+    expect(
+      field?.candidacies.some((candidate) => candidate.candidateName === "Delta Fixture")
+    ).toBe(false);
+    expect(field?.candidacies.some((candidate) => candidate.candidateName === "Echo Fixture")).toBe(
+      false
+    );
+
+    const charlie = field?.candidacies.find(
+      (candidate) => candidate.candidateName === "Charlie Fixture"
+    );
+    expect(charlie).toEqual(
+      expect.objectContaining({
+        status: "ENVISAGE",
+        sourceUrl: "https://example.org/rumeur",
+        sourceLabel: "Presse",
+        measureCount: 0,
+        themesCoveredCount: 0,
+        programmeAbsence: "aucun_programme",
+      })
+    );
+
+    expect(await hasPublicTrackedPresidentialCandidacy(electionId, `${SLUG}-charlie`)).toBe(true);
+    const charlieMeasures = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      candidateSlug: `${SLUG}-charlie`,
+      page: 1,
+      limit: 20,
+    });
+    expect(charlieMeasures).toEqual({ total: 0, data: [] });
+  });
+
+  it("distingue les trois états de programme sans attribuer l'édition du parti", async () => {
+    const initial = await getPublicPresidentialCandidacyField(SLUG);
+    expect(
+      initial?.candidacies.find((candidate) => candidate.candidateName === "Alpha Fixture")
+        ?.programmeAbsence
+    ).toBeNull();
+    expect(
+      initial?.candidacies.find((candidate) => candidate.candidateName === "Charlie Fixture")
+        ?.programmeAbsence
+    ).toBe("aucun_programme");
+
+    const charlie = await db.candidacy.findFirstOrThrow({
+      where: { electionId, candidateName: "Charlie Fixture" },
+      select: { id: true },
+    });
+    const edition = await db.programEdition.create({
+      data: {
+        electionId,
+        ownerType: "CANDIDACY",
+        candidacyId: charlie.id,
+        label: "Programme propre à Charlie",
+        version: 1,
+        publishedAt: new Date("2027-02-01T00:00:00Z"),
+        documentUrl: "https://example.org/programme-charlie",
+        publicationStatus: "PUBLISHED",
+      },
+    });
+
+    try {
+      const updated = await getPublicPresidentialCandidacyField(SLUG);
+      expect(
+        updated?.candidacies.find((candidate) => candidate.candidateName === "Charlie Fixture")
+          ?.programmeAbsence
+      ).toBe("non_depouille");
+    } finally {
+      await db.programEdition.delete({ where: { id: edition.id } });
+    }
+  });
+
+  it("cumule les verrous mesure, révision, source et extension présidentielle", async () => {
+    const alpha = await db.candidacy.findFirstOrThrow({
+      where: { electionId, candidateName: "Alpha Fixture" },
+      select: { id: true, politicianId: true },
+    });
+    expect(alpha.politicianId).not.toBeNull();
+
+    async function invalidMeasure(
+      text: string,
+      invalidation: "UNREVIEWED" | "NO_SOURCE" | "SUPERSEDED" | "DISCARDED" | "REJECTED"
+    ) {
+      const seeded = await transitions.createMeasure({
+        politicianId: alpha.politicianId!,
+        electionId,
+        candidacyId: alpha.id,
+        programEditionId: null,
+        attribution: "PERSONAL",
+        theme: "SANTE",
+        precedingMeasureId: null,
+        revision: {
+          text,
+          precision: "OBJECTIF_SANS_CHIFFRE",
+          validFrom: new Date("2027-02-01T00:00:00Z"),
+          extractionMethod: "MANUAL",
+          extractionConfidence: null,
+          extractorVersion: null,
+        },
+        sources: [
+          {
+            sourceKind: "DISCOURS_CAMPAGNE",
+            tier: "PRIMARY",
+            url: "https://example.org/source-invalide",
+            page: null,
+            publishedAt: new Date("2027-02-01T00:00:00Z"),
+          },
+        ],
+      });
+
+      const commonRevision = {
+        reviewedAt: new Date("2027-02-02T00:00:00Z"),
+        reviewedBy: "fixture",
+        publishedAt: new Date("2027-02-02T00:00:00Z"),
+      };
+      if (invalidation !== "UNREVIEWED") {
+        await db.measureRevision.update({
+          where: { id: seeded.revisionId },
+          data: {
+            ...commonRevision,
+            ...(invalidation === "SUPERSEDED" ? { supersededAt: new Date() } : {}),
+            ...(invalidation === "DISCARDED" ? { discardedAt: new Date() } : {}),
+            ...(invalidation === "REJECTED"
+              ? { rejectedAt: new Date(), rejectedBy: "fixture", rejectionReason: "OTHER" }
+              : {}),
+          },
+        });
+      }
+      if (invalidation === "NO_SOURCE") {
+        await db.measureSource.deleteMany({ where: { measureRevisionId: seeded.revisionId } });
+      }
+      await db.measure.update({
+        where: { id: seeded.measureId },
+        data: { publicationStatus: "PUBLISHED", publishedRevisionId: seeded.revisionId },
+      });
+      return seeded.measureId;
+    }
+
+    const invalidIds = await Promise.all([
+      invalidMeasure("Révision non relue.", "UNREVIEWED"),
+      invalidMeasure("Révision sans source.", "NO_SOURCE"),
+      invalidMeasure("Révision supplantée.", "SUPERSEDED"),
+      invalidMeasure("Révision écartée.", "DISCARDED"),
+      invalidMeasure("Révision rejetée.", "REJECTED"),
+    ]);
+    const result = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      page: 1,
+      limit: 100,
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.data.map((measure) => measure.measureId)).not.toEqual(
+      expect.arrayContaining(invalidIds)
+    );
+    expect(result.data.map((measure) => measure.text)).not.toContain(
+      "Mesure logement rattachée à une candidature non publiée."
+    );
+  });
+
+  it("exclut une personnalité DRAFT même si son extension présidentielle est publiée", async () => {
+    const echo = await db.candidacy.findFirstOrThrow({
+      where: { electionId, candidateName: "Echo Fixture" },
+      select: { id: true, politicianId: true },
+    });
+    expect(echo.politicianId).not.toBeNull();
+    await db.candidacyPresidential.create({
+      data: { candidacyId: echo.id, publicationStatus: "PUBLISHED" },
+    });
+    const seeded = await transitions.createMeasure({
+      politicianId: echo.politicianId!,
+      electionId,
+      candidacyId: echo.id,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: "SANTE",
+      precedingMeasureId: null,
+      revision: {
+        text: "Mesure d'une personnalité non publiée.",
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-02-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/source-echo",
+          page: null,
+          publishedAt: new Date("2027-02-01T00:00:00Z"),
+        },
+      ],
+    });
+    await transitions.reviewMeasureRevision({ ...seeded, reviewedBy: "fixture" });
+    await transitions.publishMeasureRevision(seeded);
+
+    const result = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      page: 1,
+      limit: 100,
+    });
+    expect(result.data.map((measure) => measure.measureId)).not.toContain(seeded.measureId);
+  });
+
+  it("pagine en base, filtre par candidature et thème, et ne sérialise qu'un DTO public", async () => {
+    const page = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      theme: "LOGEMENT_URBANISME",
+      page: 1,
+      limit: 1,
+    });
+    expect(page.total).toBe(2);
+    expect(page.data).toHaveLength(1);
+
+    const candidateSlug = page.data[0]?.candidacy.politicianSlug;
+    expect(candidateSlug).toBeTruthy();
+    const candidatePage = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      candidateSlug: candidateSlug!,
+      page: 1,
+      limit: 100,
+    });
+    expect(candidatePage.total).toBe(1);
+    expect(candidatePage.data[0]?.candidacy.politicianSlug).toBe(candidateSlug);
+
+    expect(Object.keys(page.data[0] ?? {}).sort()).toEqual([
+      "attribution",
+      "candidacy",
+      "measureId",
+      "precision",
+      "publishedRevisionId",
+      "sources",
+      "text",
+      "theme",
+      "withdrawal",
+    ]);
+    expect(page.data[0]?.withdrawal).toBeNull();
+    expect(page.data[0]).not.toHaveProperty("withdrawn");
+    expect(JSON.stringify(page.data)).not.toMatch(
+      /reviewedBy|evidenceSnapshot|publicationStatus|depublicationReason|notes|moderation/i
+    );
+
+    const revisionId = page.data[0]!.publishedRevisionId;
+    const existingSource = await db.measureSource.findFirstOrThrow({
+      where: { measureRevisionId: revisionId },
+      select: { url: true, publishedAt: true },
+    });
+    await db.measureSource.createMany({
+      data: [
+        {
+          id: `0-${SLUG}`,
+          measureRevisionId: revisionId,
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/source-ordre-a",
+          publishedAt: existingSource.publishedAt,
+        },
+        {
+          id: `z-${SLUG}`,
+          measureRevisionId: revisionId,
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/source-ordre-z",
+          publishedAt: existingSource.publishedAt,
+        },
+      ],
+    });
+    const ordered = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      theme: "LOGEMENT_URBANISME",
+      page: 1,
+      limit: 1,
+    });
+    expect(ordered.data[0]?.sources.map((source) => source.url)).toEqual([
+      "https://example.org/source-ordre-a",
+      existingSource.url,
+      "https://example.org/source-ordre-z",
+    ]);
+  });
+
+  it("exclut les retraits par défaut et conserve chaque forme de provenance partielle", async () => {
+    const urlOnlyMeasure = await db.measure.findFirstOrThrow({
+      where: { electionId, candidacy: { candidateName: "Alpha Fixture" } },
+      select: { id: true },
+    });
+    const labelOnlyMeasure = await db.measure.findFirstOrThrow({
+      where: { electionId, candidacy: { candidateName: "Bravo Fixture" } },
+      select: { id: true },
+    });
+    const alpha = await db.candidacy.findFirstOrThrow({
+      where: { electionId, candidateName: "Alpha Fixture" },
+      select: { id: true, politicianId: true },
+    });
+    expect(alpha.politicianId).not.toBeNull();
+
+    const noSourceMeasure = await transitions.createMeasure({
+      politicianId: alpha.politicianId!,
+      electionId,
+      candidacyId: alpha.id,
+      programEditionId: null,
+      attribution: "PERSONAL",
+      theme: "SANTE",
+      precedingMeasureId: null,
+      revision: {
+        text: "Mesure retirée sans provenance historique disponible.",
+        precision: "OBJECTIF_SANS_CHIFFRE",
+        validFrom: new Date("2027-02-01T00:00:00Z"),
+        extractionMethod: "MANUAL",
+        extractionConfidence: null,
+        extractorVersion: null,
+      },
+      sources: [
+        {
+          sourceKind: "DISCOURS_CAMPAGNE",
+          tier: "PRIMARY",
+          url: "https://example.org/source-retrait-sans-provenance",
+          page: null,
+          publishedAt: new Date("2027-02-01T00:00:00Z"),
+        },
+      ],
+    });
+    await transitions.reviewMeasureRevision({ ...noSourceMeasure, reviewedBy: "fixture" });
+    await transitions.publishMeasureRevision(noSourceMeasure);
+
+    const active = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      page: 1,
+      limit: 100,
+    });
+    expect(active.data.find((item) => item.measureId === urlOnlyMeasure.id)?.withdrawal).toBeNull();
+    expect(active.data.find((item) => item.measureId === urlOnlyMeasure.id)).not.toHaveProperty(
+      "withdrawn"
+    );
+
+    await transitions.withdrawMeasure({
+      measureId: urlOnlyMeasure.id,
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait-alpha",
+      sourceLabel: "Source du retrait",
+    });
+    await transitions.withdrawMeasure({
+      measureId: labelOnlyMeasure.id,
+      withdrawnAt: new Date("2027-03-02T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait-bravo",
+      sourceLabel: "Source du retrait Bravo",
+    });
+    await transitions.withdrawMeasure({
+      measureId: noSourceMeasure.measureId,
+      withdrawnAt: new Date("2027-03-03T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait-sans-provenance",
+      sourceLabel: "Source temporaire",
+    });
+    await db.measure.update({
+      where: { id: urlOnlyMeasure.id },
+      data: { withdrawnSourceLabel: null },
+    });
+    await db.measure.update({
+      where: { id: labelOnlyMeasure.id },
+      data: { withdrawnSourceUrl: null },
+    });
+    await db.measure.update({
+      where: { id: noSourceMeasure.measureId },
+      data: { withdrawnSourceUrl: null, withdrawnSourceLabel: null },
+    });
+
+    const current = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      page: 1,
+      limit: 100,
+    });
+    expect(current.data.map((item) => item.measureId)).not.toEqual(
+      expect.arrayContaining([urlOnlyMeasure.id, labelOnlyMeasure.id, noSourceMeasure.measureId])
+    );
+
+    const history = await listPublicPresidentialMeasures({
+      electionId,
+      electionSlug: SLUG,
+      includeWithdrawn: true,
+      page: 1,
+      limit: 100,
+    });
+    const urlOnly = history.data.find((item) => item.measureId === urlOnlyMeasure.id);
+    expect(urlOnly?.withdrawal).toEqual({
+      withdrawnAt: new Date("2027-03-01T00:00:00Z"),
+      sourceUrl: "https://example.org/retrait-alpha",
+      sourceLabel: null,
+    });
+    expect(urlOnly).not.toHaveProperty("withdrawn");
+    expect(urlOnly?.withdrawal).not.toHaveProperty("source");
+
+    const labelOnly = history.data.find((item) => item.measureId === labelOnlyMeasure.id);
+    expect(labelOnly?.withdrawal).toEqual({
+      withdrawnAt: new Date("2027-03-02T00:00:00Z"),
+      sourceUrl: null,
+      sourceLabel: "Source du retrait Bravo",
+    });
+    expect(labelOnly).not.toHaveProperty("withdrawn");
+    expect(labelOnly?.withdrawal).not.toHaveProperty("source");
+
+    const noSource = history.data.find((item) => item.measureId === noSourceMeasure.measureId);
+    expect(noSource?.withdrawal).toEqual({
+      withdrawnAt: new Date("2027-03-03T00:00:00Z"),
+      sourceUrl: null,
+      sourceLabel: null,
+    });
+    expect(noSource).not.toHaveProperty("withdrawn");
+    expect(noSource?.withdrawal).not.toHaveProperty("source");
+  });
+});

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -1,18 +1,14 @@
 import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
-import type { CandidacyStatus, ThemeCategory } from "@/generated/prisma";
-import { PUBLIC_POLITICIAN_WHERE } from "@/lib/api/public-contract";
+import type { ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isHubPublishable } from "@/config/publication-gates";
-import { resolveCandidateAccentColor } from "@/lib/presidentielle/candidate-accent";
-import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
 import {
-  resolveProgrammeAbsence,
-  rollupMeasuresByCandidacy,
-} from "@/lib/presidentielle/candidacy-rollup";
-import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
+  getPublicPresidentialCandidacyField,
+  type PublicPresidentialCandidacyFieldEntry,
+} from "./presidential-candidacy-field";
 import { loadThemesIndex } from "./themes-index";
-import { getLatestPresidentialReviewDate, getPublicMeasuresByElection } from "./measures";
+import { getLatestPresidentialReviewDate } from "./measures";
 
 /**
  * The two read authorities for the presidential hub page.
@@ -34,39 +30,7 @@ import { getLatestPresidentialReviewDate, getPublicMeasuresByElection } from "./
  * wrapper.
  */
 
-export type HubCandidacy = {
-  id: string;
-  candidateName: string;
-  politicianSlug: string;
-  photoUrl: string | null;
-  blobPhotoUrl: string | null;
-  status: CandidacyStatus | null;
-  sourceUrl: string | null;
-  sourceLabel: string | null;
-  partyLabel: string | null;
-  /**
-   * The visual identity. The colour follows the same resolver as the subject pages, while the short
-   * name and logo still require a linked party entity.
-   */
-  partyColor: string | null;
-  partyShortName: string | null;
-  partyLogoUrl: string | null;
-  /** Currently defended public measures, withdrawals excluded. */
-  measureCount: number;
-  /** Distinct themes those measures cover, out of the thirteen. */
-  themesCoveredCount: number;
-  /**
-   * Why the measure count is zero, and never a bare zero.
-   *
-   * `aucun_programme` documents the CANDIDACY: nothing has been published for this election.
-   * `non_depouille` documents US: a programme exists and we have not extracted it yet. Presenting
-   * our own backlog as a candidate's silence would be a false claim about a person, so the two are
-   * distinct values and the display renders different sentences for them.
-   *
-   * Null when `measureCount > 0`, since there is then no absence to qualify.
-   */
-  programmeAbsence: "aucun_programme" | "non_depouille" | null;
-};
+export type HubCandidacy = PublicPresidentialCandidacyFieldEntry;
 
 /**
  * One subject, as the hub home names it: enough to link to its page and to say whether it is open
@@ -105,115 +69,8 @@ export type HubMeasureContext = {
  * that calls it is only as fresh as its ISR backstop.
  */
 export async function getHubCandidacyField(electionSlug: string): Promise<HubCandidacy[]> {
-  const election = await db.election.findFirst({
-    where: { slug: electionSlug },
-    select: { id: true },
-  });
-  if (election === null) return [];
-
-  const [rows, measures, publicCandidates, editions] = await Promise.all([
-    db.candidacy.findMany({
-      // The field is the race, not the published fiches: sourced candidacies (status + both
-      // source fields non-null), no extension required. Alphabetical order.
-      where: {
-        electionId: election.id,
-        status: { not: null },
-        sourceUrl: { not: null },
-        sourceLabel: { not: null },
-        politicianId: { not: null },
-        politician: PUBLIC_POLITICIAN_WHERE,
-      },
-      select: {
-        id: true,
-        candidateName: true,
-        status: true,
-        sourceUrl: true,
-        sourceLabel: true,
-        partyLabel: true,
-        presidentialData: { select: { accentColor: true, publicationStatus: true } },
-        politician: {
-          select: {
-            slug: true,
-            lastName: true,
-            photoUrl: true,
-            blobPhotoUrl: true,
-            currentParty: { select: { color: true, name: true, shortName: true } },
-          },
-        },
-        party: { select: { color: true, name: true, shortName: true, logoUrl: true } },
-      },
-    }),
-    // Defended measures only: `getPublicMeasuresByElection` drops withdrawals unless asked, and a
-    // proposal a candidate has dropped is not one they still carry.
-    getPublicMeasuresByElection(election.id),
-    // The subject-page population, used to intersect those measures. Same read and same reason as
-    // `loadThemesIndex`: a measure on a DRAFT-extension candidacy is rendered nowhere, so counting
-    // it on this row would advertise work the reader cannot reach (invariant I7).
-    getPublicPresidentialCandidates(electionSlug),
-    // A party platform is not a candidate programme without an explicit editorial attribution.
-    // Only editions directly owned by the candidacy can qualify this candidate-level state.
-    db.programEdition.findMany({
-      where: {
-        electionId: election.id,
-        publicationStatus: "PUBLISHED",
-        candidacyId: { not: null },
-      },
-      select: { candidacyId: true },
-    }),
-  ]);
-
-  const byCandidacy = rollupMeasuresByCandidacy(
-    measures.map((m) => ({
-      candidacyId: m.candidacyId,
-      theme: m.theme,
-      hasPrimarySource: m.sources.some((s) => s.tier === "PRIMARY"),
-    })),
-    new Set(publicCandidates.map((c) => c.id))
-  );
-
-  const editionCandidacyIds = new Set(
-    editions.map((e) => e.candidacyId).filter((id): id is string => id !== null)
-  );
-  return sortPresidentialCandidatesBySurname(rows).flatMap((c) => {
-    if (c.politician === null) return [];
-    const rollup = byCandidacy.get(c.id);
-    const measureCount = rollup?.measureCount ?? 0;
-    const hasProgramme = editionCandidacyIds.has(c.id);
-
-    return [
-      {
-        id: c.id,
-        candidateName: c.candidateName,
-        politicianSlug: c.politician.slug,
-        photoUrl: c.politician.photoUrl,
-        blobPhotoUrl: c.politician.blobPhotoUrl,
-        status: c.status,
-        sourceUrl: c.sourceUrl,
-        sourceLabel: c.sourceLabel,
-        partyLabel: c.partyLabel ?? c.party?.shortName ?? c.party?.name ?? null,
-        partyColor: resolveCandidateAccentColor({
-          // The hub includes candidacies without a published presidential extension. Use an editorial
-          // accent only after that extension clears its publication gate, otherwise fall back to the
-          // candidacy's public party data.
-          accentColor:
-            c.presidentialData?.publicationStatus === "PUBLISHED"
-              ? c.presidentialData.accentColor
-              : null,
-          candidacyParty: c.party,
-          partyLabel: c.partyLabel,
-          currentParty: c.politician?.currentParty ?? null,
-        }),
-        partyShortName: c.party?.shortName ?? null,
-        partyLogoUrl: c.party?.logoUrl ?? null,
-        measureCount,
-        themesCoveredCount: rollup?.themesCoveredCount ?? 0,
-        programmeAbsence: resolveProgrammeAbsence(measureCount, hasProgramme),
-        // Evaluated with the gate the fiche itself uses, not re-derived from `measureCount`.
-        // The row is what decides which link to offer, so a disagreement between the two
-        // would send the reader to a page that redirects them somewhere else without a word.
-      },
-    ];
-  });
+  const field = await getPublicPresidentialCandidacyField(electionSlug);
+  return field?.candidacies ?? [];
 }
 
 /**

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -1,14 +1,20 @@
 import type { Prisma, ThemeCategory } from "@/generated/prisma";
+import {
+  MEASURE_ATTRIBUTION_LABELS,
+  MEASURE_PRECISION_LABELS,
+  THEME_CATEGORY_LABELS,
+} from "@/config/labels";
 import { db } from "@/lib/db";
+import { themeToSlug } from "@/lib/theme-utils";
+import { getPublicTrackedPresidentialCandidacyWhere } from "./presidential-candidacy-policy";
 import { PUBLIC_CANDIDACY_WHERE } from "./presidential-candidates-public";
 
 /**
- * The two cumulative publication conditions, as a reusable predicate.
+ * The cumulative public measure predicate.
  *
- * publicationStatus alone is not enough, and that is the whole point: the second condition
- * is about the state of the revision the pointer designates. A measure can be PUBLISHED
- * while pointing at a revision that was never reviewed, never published, has been
- * superseded, or carries no source, and each of those must stay invisible.
+ * publicationStatus alone is not enough. The designated revision must have reviewedAt and
+ * publishedAt set, supersededAt, discardedAt and rejectedAt unset, and at least one source.
+ * Every condition is required, so a measure pointing at an ineligible revision stays invisible.
  */
 const PUBLIC_MEASURE_WHERE = {
   publicationStatus: "PUBLISHED",
@@ -18,6 +24,7 @@ const PUBLIC_MEASURE_WHERE = {
     publishedAt: { not: null },
     supersededAt: null,
     discardedAt: null,
+    rejectedAt: null,
     sources: { some: {} },
   },
 } satisfies Prisma.MeasureWhereInput;
@@ -35,17 +42,8 @@ type MeasureRow = Prisma.MeasureGetPayload<{ include: typeof PUBLIC_MEASURE_INCL
 type PublishedRevision = NonNullable<MeasureRow["publishedRevision"]>;
 
 /**
- * The withdrawal state, as one object rather than three loose fields.
- *
- * Its PRESENCE is the fact that the candidate dropped the proposal, and that fact must
- * never be hidden: a page showing a withdrawn measure as if it were still defended is a
- * factual error, which is worse than a missing source label.
- *
- * That is why the two source fields are nullable inside a non-null object, which is the one
- * deviation from the shape asked for in review. withdrawMeasure() writes the three fields
- * together or none, so a partial state can only come from a direct database write, and the
- * audit reports it. Requiring both sources here would mean returning `withdrawal: null` on
- * such a row, which hides a real withdrawal to protect a type.
+ * The canonical withdrawal state. Its presence records that the candidate dropped the proposal.
+ * Historical source fields remain independently nullable so partial provenance is never hidden.
  */
 export type MeasureWithdrawal = {
   withdrawnAt: Date;
@@ -119,6 +117,165 @@ export type MeasureListOptions = { includeWithdrawn?: boolean };
 
 function withdrawalFilter(options?: MeasureListOptions): Prisma.MeasureWhereInput {
   return options?.includeWithdrawn ? {} : { withdrawnAt: null };
+}
+
+const PUBLIC_PRESIDENTIAL_MEASURE_SELECT = {
+  id: true,
+  publishedRevisionId: true,
+  theme: true,
+  attribution: true,
+  withdrawnAt: true,
+  withdrawnSourceUrl: true,
+  withdrawnSourceLabel: true,
+  publishedRevision: {
+    select: {
+      id: true,
+      text: true,
+      precision: true,
+      sources: {
+        select: {
+          sourceKind: true,
+          tier: true,
+          url: true,
+          page: true,
+          publishedAt: true,
+        },
+        orderBy: [{ publishedAt: "asc" }, { id: "asc" }],
+      },
+    },
+  },
+  candidacy: {
+    select: {
+      id: true,
+      candidateName: true,
+      politician: { select: { slug: true } },
+    },
+  },
+} satisfies Prisma.MeasureSelect;
+
+type PublicPresidentialMeasureRow = Prisma.MeasureGetPayload<{
+  select: typeof PUBLIC_PRESIDENTIAL_MEASURE_SELECT;
+}>;
+
+export type PublicPresidentialMeasure = {
+  measureId: string;
+  publishedRevisionId: string;
+  text: string;
+  precision: {
+    code: NonNullable<PublicPresidentialMeasureRow["publishedRevision"]>["precision"];
+    label: string | null;
+  };
+  theme: { code: ThemeCategory; label: string; slug: string; publicUrl: string };
+  attribution: { code: PublicPresidentialMeasureRow["attribution"]; label: string };
+  candidacy: {
+    candidacyId: string;
+    candidateName: string;
+    politicianSlug: string | null;
+    publicUrl: string | null;
+  };
+  sources: NonNullable<PublicPresidentialMeasureRow["publishedRevision"]>["sources"];
+  withdrawal: MeasureWithdrawal | null;
+};
+
+export type ListPublicPresidentialMeasuresOptions = {
+  electionId: string;
+  electionSlug: string;
+  candidateSlug?: string;
+  theme?: ThemeCategory;
+  includeWithdrawn?: boolean;
+  page: number;
+  limit: number;
+};
+
+export type PublicPresidentialMeasurePage = {
+  data: PublicPresidentialMeasure[];
+  total: number;
+};
+
+function toPublicPresidentialMeasure(
+  row: PublicPresidentialMeasureRow,
+  electionSlug: string
+): PublicPresidentialMeasure | null {
+  const revision = row.publishedRevision;
+  const candidacy = row.candidacy;
+  if (revision === null || row.publishedRevisionId === null || candidacy === null) return null;
+
+  const politicianSlug = candidacy.politician?.slug ?? null;
+  const themeSlug = themeToSlug(row.theme);
+  return {
+    measureId: row.id,
+    publishedRevisionId: row.publishedRevisionId,
+    text: revision.text,
+    precision: {
+      code: revision.precision,
+      label: revision.precision ? MEASURE_PRECISION_LABELS[revision.precision] : null,
+    },
+    theme: {
+      code: row.theme,
+      label: THEME_CATEGORY_LABELS[row.theme],
+      slug: themeSlug,
+      publicUrl: `/elections/${electionSlug}/sujets/${themeSlug}`,
+    },
+    attribution: {
+      code: row.attribution,
+      label: MEASURE_ATTRIBUTION_LABELS[row.attribution],
+    },
+    candidacy: {
+      candidacyId: candidacy.id,
+      candidateName: candidacy.candidateName,
+      politicianSlug,
+      publicUrl: politicianSlug ? `/elections/${electionSlug}/candidats/${politicianSlug}` : null,
+    },
+    sources: revision.sources,
+    withdrawal:
+      row.withdrawnAt !== null
+        ? {
+            withdrawnAt: row.withdrawnAt,
+            sourceUrl: row.withdrawnSourceUrl,
+            sourceLabel: row.withdrawnSourceLabel,
+          }
+        : null,
+  };
+}
+
+/**
+ * Database-paginated public read for presidential measures.
+ *
+ * The measure/revision gate and the published presidential-candidacy gate are cumulative. Neither
+ * a PUBLISHED measure alone nor a PUBLISHED candidacy extension alone can surface a row.
+ */
+export async function listPublicPresidentialMeasures(
+  options: ListPublicPresidentialMeasuresOptions
+): Promise<PublicPresidentialMeasurePage> {
+  const candidacyWhere: Prisma.CandidacyWhereInput = {
+    ...getPublicTrackedPresidentialCandidacyWhere(options.candidateSlug),
+    ...PUBLIC_CANDIDACY_WHERE,
+  };
+  const where: Prisma.MeasureWhereInput = {
+    electionId: options.electionId,
+    ...(options.theme ? { theme: options.theme } : {}),
+    ...PUBLIC_MEASURE_WHERE,
+    ...withdrawalFilter(options),
+    candidacy: { is: candidacyWhere },
+  };
+
+  const [total, rows] = await Promise.all([
+    db.measure.count({ where }),
+    db.measure.findMany({
+      where,
+      select: PUBLIC_PRESIDENTIAL_MEASURE_SELECT,
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      skip: (options.page - 1) * options.limit,
+      take: options.limit,
+    }),
+  ]);
+
+  return {
+    total,
+    data: rows
+      .map((row) => toPublicPresidentialMeasure(row, options.electionSlug))
+      .filter((measure): measure is PublicPresidentialMeasure => measure !== null),
+  };
 }
 
 /**

--- a/src/lib/data/presidential-candidacy-field.ts
+++ b/src/lib/data/presidential-candidacy-field.ts
@@ -1,0 +1,189 @@
+import "server-only";
+import type { CandidacyStatus, ElectionType } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import { resolveCandidateAccentColor } from "@/lib/presidentielle/candidate-accent";
+import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
+import {
+  resolveProgrammeAbsence,
+  rollupMeasuresByCandidacy,
+} from "@/lib/presidentielle/candidacy-rollup";
+import { getPublicMeasuresByElection } from "./measures";
+import {
+  getPublicTrackedPresidentialCandidacyWhere,
+  PUBLIC_TRACKED_PRESIDENTIAL_CANDIDACY_WHERE,
+} from "./presidential-candidacy-policy";
+import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
+
+export type PublicPresidentialElection = {
+  id: string;
+  slug: string;
+  title: string;
+  type: ElectionType;
+};
+
+export type PublicPresidentialCandidacyFieldEntry = {
+  id: string;
+  candidateName: string;
+  politicianSlug: string;
+  photoUrl: string | null;
+  blobPhotoUrl: string | null;
+  status: CandidacyStatus;
+  sourceUrl: string;
+  sourceLabel: string;
+  partyLabel: string | null;
+  partyColor: string | null;
+  partyShortName: string | null;
+  partyLogoUrl: string | null;
+  /** Currently defended public measures, withdrawals excluded. */
+  measureCount: number;
+  themesCoveredCount: number;
+  programmeAbsence: "aucun_programme" | "non_depouille" | null;
+};
+
+export type PublicPresidentialCandidacyField = {
+  election: PublicPresidentialElection;
+  candidacies: PublicPresidentialCandidacyFieldEntry[];
+};
+
+export async function getPublicElectionIdentity(
+  electionSlug: string
+): Promise<PublicPresidentialElection | null> {
+  return db.election.findUnique({
+    where: { slug: electionSlug },
+    select: { id: true, slug: true, title: true, type: true },
+  });
+}
+
+export async function hasPublicTrackedPresidentialCandidacy(
+  electionId: string,
+  politicianSlug: string
+): Promise<boolean> {
+  const candidacy = await db.candidacy.findFirst({
+    where: {
+      electionId,
+      ...getPublicTrackedPresidentialCandidacyWhere(politicianSlug),
+    },
+    select: { id: true },
+  });
+  return candidacy !== null;
+}
+
+/**
+ * Public authority for the sourced presidential tracking field.
+ *
+ * This population is deliberately wider than the published candidate pages: a sourced status on a
+ * public politician is enough to appear, even when the presidential editorial extension is absent
+ * or still DRAFT. Measure counters stay narrower and only count measures reachable from the public
+ * presidential surfaces.
+ */
+export async function getPublicPresidentialCandidacyField(
+  electionSlug: string
+): Promise<PublicPresidentialCandidacyField | null> {
+  const election = await getPublicElectionIdentity(electionSlug);
+  if (election === null) return null;
+
+  // The authority is presidential only. Returning the election still lets an HTTP adapter
+  // distinguish an unknown slug from a known but unsupported election without reading candidacies.
+  if (election.type !== "PRESIDENTIELLE") {
+    return { election, candidacies: [] };
+  }
+
+  const [rows, measures, publicCandidates, editions] = await Promise.all([
+    db.candidacy.findMany({
+      where: {
+        electionId: election.id,
+        ...PUBLIC_TRACKED_PRESIDENTIAL_CANDIDACY_WHERE,
+      },
+      select: {
+        id: true,
+        candidateName: true,
+        status: true,
+        sourceUrl: true,
+        sourceLabel: true,
+        partyLabel: true,
+        presidentialData: { select: { accentColor: true, publicationStatus: true } },
+        politician: {
+          select: {
+            slug: true,
+            lastName: true,
+            photoUrl: true,
+            blobPhotoUrl: true,
+            currentParty: { select: { color: true, name: true, shortName: true } },
+          },
+        },
+        party: { select: { color: true, name: true, shortName: true, logoUrl: true } },
+      },
+    }),
+    getPublicMeasuresByElection(election.id),
+    getPublicPresidentialCandidates(electionSlug),
+    // A party edition is not a candidate programme without an explicit candidacy owner.
+    db.programEdition.findMany({
+      where: {
+        electionId: election.id,
+        publicationStatus: "PUBLISHED",
+        candidacyId: { not: null },
+      },
+      select: { candidacyId: true },
+    }),
+  ]);
+
+  const byCandidacy = rollupMeasuresByCandidacy(
+    measures.map((measure) => ({
+      candidacyId: measure.candidacyId,
+      theme: measure.theme,
+      hasPrimarySource: measure.sources.some((source) => source.tier === "PRIMARY"),
+    })),
+    new Set(publicCandidates.map((candidate) => candidate.id))
+  );
+  const editionCandidacyIds = new Set(
+    editions.map((edition) => edition.candidacyId).filter((id): id is string => id !== null)
+  );
+
+  const candidacies = sortPresidentialCandidatesBySurname(rows).flatMap((candidacy) => {
+    if (
+      candidacy.politician === null ||
+      candidacy.status === null ||
+      candidacy.sourceUrl === null ||
+      candidacy.sourceLabel === null
+    ) {
+      return [];
+    }
+
+    const rollup = byCandidacy.get(candidacy.id);
+    const measureCount = rollup?.measureCount ?? 0;
+
+    return [
+      {
+        id: candidacy.id,
+        candidateName: candidacy.candidateName,
+        politicianSlug: candidacy.politician.slug,
+        photoUrl: candidacy.politician.photoUrl,
+        blobPhotoUrl: candidacy.politician.blobPhotoUrl,
+        status: candidacy.status,
+        sourceUrl: candidacy.sourceUrl,
+        sourceLabel: candidacy.sourceLabel,
+        partyLabel:
+          candidacy.partyLabel ?? candidacy.party?.shortName ?? candidacy.party?.name ?? null,
+        partyColor: resolveCandidateAccentColor({
+          accentColor:
+            candidacy.presidentialData?.publicationStatus === "PUBLISHED"
+              ? candidacy.presidentialData.accentColor
+              : null,
+          candidacyParty: candidacy.party,
+          partyLabel: candidacy.partyLabel,
+          currentParty: candidacy.politician.currentParty,
+        }),
+        partyShortName: candidacy.party?.shortName ?? null,
+        partyLogoUrl: candidacy.party?.logoUrl ?? null,
+        measureCount,
+        themesCoveredCount: rollup?.themesCoveredCount ?? 0,
+        programmeAbsence: resolveProgrammeAbsence(
+          measureCount,
+          editionCandidacyIds.has(candidacy.id)
+        ),
+      },
+    ];
+  });
+
+  return { election, candidacies };
+}

--- a/src/lib/data/presidential-candidacy-policy.ts
+++ b/src/lib/data/presidential-candidacy-policy.ts
@@ -1,0 +1,27 @@
+import type { Prisma } from "@/generated/prisma";
+import { PUBLIC_POLITICIAN_WHERE } from "@/lib/api/public-contract";
+
+/**
+ * Public tracking population, independent from publication of the richer presidential fiche.
+ */
+export const PUBLIC_TRACKED_PRESIDENTIAL_CANDIDACY_WHERE = {
+  status: { not: null },
+  sourceUrl: { not: null },
+  sourceLabel: { not: null },
+  politicianId: { not: null },
+  politician: { is: PUBLIC_POLITICIAN_WHERE },
+} satisfies Prisma.CandidacyWhereInput;
+
+export function getPublicTrackedPresidentialCandidacyWhere(
+  politicianSlug?: string
+): Prisma.CandidacyWhereInput {
+  return {
+    ...PUBLIC_TRACKED_PRESIDENTIAL_CANDIDACY_WHERE,
+    politician: {
+      is: {
+        ...PUBLIC_POLITICIAN_WHERE,
+        ...(politicianSlug !== undefined ? { slug: politicianSlug } : {}),
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Résumé

- ajoute GET /api/elections/[slug]/candidacies
- ajoute GET /api/elections/[slug]/measures
- réutilise les autorités publiques présidentielles et les portes cumulatives de publication
- documente le contrat V1, les retraits et la provenance

## Garanties éditoriales

- suivi public distinct d’une liste officielle de candidatures
- mesures publiées et sourcées uniquement
- retraits exclus par défaut et exposés explicitement pour l’historique
- aucun score, classement ou recommandation

## Validation

- typecheck réussi
- format check réussi
- 23 tests de route réussis
- 6 tests PostgreSQL réussis
- build Next.js réussi

## Périmètre

- route générique /api/elections/[slug] inchangée
- schéma Prisma et migrations inchangés
- dépendances inchangées
- serveur MCP et dossier marketplace inchangés
- le chantier OpenAPI global #737 reste hors périmètre