### PR TITLE
fix(presidentielle): fiabiliser les lots et le statut candidat

### DIFF
--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -11,6 +11,7 @@ import type { CandidacyMeasureReadiness } from "@/lib/data/measures";
 import {
   regenerateCandidateSynthesisAction,
   setCandidacyPublicationAction,
+  setCandidacyStatusAction,
   setProgramEditionPublicationAction,
 } from "./actions";
 
@@ -180,6 +181,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
           <tbody>
             {rows.map((row) => {
               const publicationKey = `publication:${row.candidacyId}`;
+              const statusKey = `statut:${row.candidacyId}`;
               const synthesisKey = `synthese:${row.candidacyId}`;
               const published = row.publicationStatus === "PUBLISHED";
               const locked = busy !== null || pending;
@@ -214,7 +216,31 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">{row.partyLabel ?? "Sans parti"}</td>
                   <td className="px-3 py-2 whitespace-nowrap">
-                    {STATUS_LABELS[row.status ?? ""] ?? "Statut non renseigné"}
+                    <label className="sr-only" htmlFor={statusKey}>
+                      Statut de {row.candidateName}
+                    </label>
+                    <select
+                      id={statusKey}
+                      value={row.status ?? ""}
+                      onChange={(event) => {
+                        const status = event.target.value as CandidacyStatus;
+                        if (status) {
+                          runAction(statusKey, () =>
+                            setCandidacyStatusAction({ candidacyId: row.candidacyId, status })
+                          );
+                        }
+                      }}
+                      disabled={locked}
+                      className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
+                      aria-label={`Statut de ${row.candidateName}`}
+                    >
+                      {!row.status && <option value="">Statut non renseigné</option>}
+                      {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">
                     {row.readiness.measureCount === 0 ? (

--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -54,6 +54,8 @@ export type CandidateRowView = {
   politicianSlug: string | null;
   partyLabel: string | null;
   status: CandidacyStatus | null;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
   /** Status, source URL and source label all present: the condition the public fiche imposes. */
   sourced: boolean;
   /** Null when the candidacy carries no `CandidacyPresidential` row yet. */
@@ -77,6 +79,18 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [statusDrafts, setStatusDrafts] = useState(() =>
+    Object.fromEntries(
+      rows.map((row) => [
+        row.candidacyId,
+        {
+          status: row.status ?? "",
+          sourceUrl: row.sourceUrl ?? "",
+          sourceLabel: row.sourceLabel ?? "",
+        },
+      ])
+    )
+  );
 
   const held = rows.filter(isHoldingBackMeasures);
   const heldMeasureCount = held.reduce((total, row) => total + row.readiness.measureCount, 0);
@@ -185,6 +199,16 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
               const synthesisKey = `synthese:${row.candidacyId}`;
               const published = row.publicationStatus === "PUBLISHED";
               const locked = busy !== null || pending;
+              const statusDraft = statusDrafts[row.candidacyId] ?? {
+                status: row.status ?? "",
+                sourceUrl: row.sourceUrl ?? "",
+                sourceLabel: row.sourceLabel ?? "",
+              };
+              const updateStatusDraft = (patch: Partial<typeof statusDraft>) =>
+                setStatusDrafts((current) => ({
+                  ...current,
+                  [row.candidacyId]: { ...statusDraft, ...patch },
+                }));
               return (
                 <tr key={row.candidacyId} className="border-t align-top">
                   <td className="px-3 py-2 w-12">
@@ -219,28 +243,63 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                     <label className="sr-only" htmlFor={statusKey}>
                       Statut de {row.candidateName}
                     </label>
-                    <select
-                      id={statusKey}
-                      value={row.status ?? ""}
-                      onChange={(event) => {
-                        const status = event.target.value as CandidacyStatus;
-                        if (status) {
+                    <div className="flex min-w-64 flex-col gap-2">
+                      <select
+                        id={statusKey}
+                        value={statusDraft.status}
+                        onChange={(event) => updateStatusDraft({ status: event.target.value })}
+                        disabled={locked}
+                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
+                        aria-label={`Statut de ${row.candidateName}`}
+                      >
+                        {!row.status && <option value="">Statut non renseigné</option>}
+                        {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                          <option key={value} value={value}>
+                            {label}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        type="url"
+                        value={statusDraft.sourceUrl}
+                        onChange={(event) => updateStatusDraft({ sourceUrl: event.target.value })}
+                        disabled={locked}
+                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
+                        aria-label={`URL source du statut de ${row.candidateName}`}
+                        placeholder="https://site-officiel.fr/annonce"
+                      />
+                      <input
+                        type="text"
+                        value={statusDraft.sourceLabel}
+                        onChange={(event) => updateStatusDraft({ sourceLabel: event.target.value })}
+                        disabled={locked}
+                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
+                        aria-label={`Libellé source du statut de ${row.candidateName}`}
+                        placeholder="Annonce officielle, date"
+                      />
+                      <button
+                        type="button"
+                        onClick={() =>
                           runAction(statusKey, () =>
-                            setCandidacyStatusAction({ candidacyId: row.candidacyId, status })
-                          );
+                            setCandidacyStatusAction({
+                              candidacyId: row.candidacyId,
+                              status: statusDraft.status as CandidacyStatus,
+                              sourceUrl: statusDraft.sourceUrl.trim(),
+                              sourceLabel: statusDraft.sourceLabel.trim(),
+                            })
+                          )
                         }
-                      }}
-                      disabled={locked}
-                      className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
-                      aria-label={`Statut de ${row.candidateName}`}
-                    >
-                      {!row.status && <option value="">Statut non renseigné</option>}
-                      {Object.entries(STATUS_LABELS).map(([value, label]) => (
-                        <option key={value} value={value}>
-                          {label}
-                        </option>
-                      ))}
-                    </select>
+                        disabled={
+                          locked ||
+                          !statusDraft.status ||
+                          !statusDraft.sourceUrl.trim() ||
+                          !statusDraft.sourceLabel.trim()
+                        }
+                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
+                      >
+                        {busy === statusKey ? "Enregistrement..." : "Enregistrer le statut"}
+                      </button>
+                    </div>
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">
                     {row.readiness.measureCount === 0 ? (

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -14,10 +14,14 @@ const setProgramEditionPublicationMock = vi.fn<(input: unknown) => Promise<Actio
 const regenerateCandidateSynthesisMock = vi.fn<(input: unknown) => Promise<ActionResult>>(
   async () => ({ ok: true })
 );
+const setCandidacyStatusMock = vi.fn<(input: unknown) => Promise<ActionResult>>(async () => ({
+  ok: true,
+}));
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 vi.mock("../actions", () => ({
   setCandidacyPublicationAction: (input: unknown) => setCandidacyPublicationMock(input),
+  setCandidacyStatusAction: (input: unknown) => setCandidacyStatusMock(input),
   setProgramEditionPublicationAction: (input: unknown) => setProgramEditionPublicationMock(input),
   regenerateCandidateSynthesisAction: (input: unknown) => regenerateCandidateSynthesisMock(input),
 }));
@@ -81,6 +85,21 @@ describe("CandidatesListClient", () => {
     expect(setCandidacyPublicationMock).toHaveBeenCalledWith({
       candidacyId: "cand-1",
       status: "PUBLISHED",
+    });
+  });
+
+  it("modifie le statut politique depuis la liste", async () => {
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row({ status: "PRESSENTI" })]} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Statut de Alix Démonstration" }),
+      "DECLARE"
+    );
+
+    expect(setCandidacyStatusMock).toHaveBeenCalledWith({
+      candidacyId: "cand-1",
+      status: "DECLARE",
     });
   });
 

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -33,6 +33,8 @@ function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
     politicianSlug: "alix-demonstration",
     partyLabel: "PD",
     status: "DECLARE",
+    sourceUrl: "https://example.org/annonce",
+    sourceLabel: "Annonce officielle",
     sourced: true,
     presidentialId: "pres-1",
     publicationStatus: "DRAFT",
@@ -96,10 +98,27 @@ describe("CandidatesListClient", () => {
       screen.getByRole("combobox", { name: "Statut de Alix Démonstration" }),
       "DECLARE"
     );
+    await user.clear(
+      screen.getByRole("textbox", { name: "URL source du statut de Alix Démonstration" })
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "URL source du statut de Alix Démonstration" }),
+      "https://example.org/declaration"
+    );
+    await user.clear(
+      screen.getByRole("textbox", { name: "Libellé source du statut de Alix Démonstration" })
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Libellé source du statut de Alix Démonstration" }),
+      "Déclaration officielle"
+    );
+    await user.click(screen.getByRole("button", { name: "Enregistrer le statut" }));
 
     expect(setCandidacyStatusMock).toHaveBeenCalledWith({
       candidacyId: "cand-1",
       status: "DECLARE",
+      sourceUrl: "https://example.org/declaration",
+      sourceLabel: "Déclaration officielle",
     });
   });
 

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -23,6 +23,13 @@ const dbMock = {
 
 vi.mock("@/lib/auth", () => ({ isAuthenticated: () => isAuthenticatedMock() }));
 vi.mock("next/cache", () => ({ revalidatePath: (path: string) => revalidatePathMock(path) }));
+vi.mock("next/headers", () => ({
+  headers: async () =>
+    new Headers({
+      "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      "user-agent": "Poligraph test",
+    }),
+}));
 vi.mock("@/lib/cache", () => ({
   invalidateEntity: (...args: unknown[]) => invalidateEntityMock(...args),
 }));
@@ -226,19 +233,35 @@ describe("statut politique d'une candidature", () => {
     dbMock.candidacy.findUnique.mockResolvedValue({ ...SOURCED_CANDIDACY, status: "PRESSENTI" });
     const a = await actions();
 
-    expect(await a.setCandidacyStatusAction({ candidacyId: "cand-1", status: "DECLARE" })).toEqual({
-      ok: true,
-    });
+    expect(
+      await a.setCandidacyStatusAction({
+        candidacyId: "cand-1",
+        status: "DECLARE",
+        sourceUrl: "https://example.org/declaration",
+        sourceLabel: "Déclaration officielle",
+      })
+    ).toEqual({ ok: true });
     expect(dbMock.candidacy.update).toHaveBeenCalledWith({
       where: { id: "cand-1" },
-      data: { status: "DECLARE" },
+      data: {
+        status: "DECLARE",
+        sourceUrl: "https://example.org/declaration",
+        sourceLabel: "Déclaration officielle",
+      },
     });
     expect(dbMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           entityType: "Candidacy",
           entityId: "cand-1",
-          changes: { status: "DECLARE", previousStatus: "PRESSENTI" },
+          changes: expect.objectContaining({
+            status: "DECLARE",
+            sourceUrl: "https://example.org/declaration",
+            sourceLabel: "Déclaration officielle",
+            previousStatus: "PRESSENTI",
+          }),
+          ipAddress: "203.0.113.10",
+          userAgent: "Poligraph test",
         }),
       })
     );

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -15,7 +15,7 @@ const invalidateCandidacyTagsMock = vi.fn();
 
 const dbMock = {
   $transaction: vi.fn(),
-  candidacy: { findUnique: vi.fn() },
+  candidacy: { findUnique: vi.fn(), update: vi.fn() },
   candidacyPresidential: { upsert: vi.fn() },
   programEdition: { findUnique: vi.fn(), update: vi.fn() },
   auditLog: { create: vi.fn() },
@@ -58,6 +58,7 @@ beforeEach(() => {
   isAuthenticatedMock.mockResolvedValue(true);
   dbMock.candidacy.findUnique.mockResolvedValue(SOURCED_CANDIDACY);
   dbMock.candidacyPresidential.upsert.mockResolvedValue({ id: "pres-1" });
+  dbMock.candidacy.update.mockResolvedValue({ id: "cand-1" });
   dbMock.programEdition.findUnique.mockResolvedValue({
     id: "ed-1",
     electionId: "elec-1",
@@ -217,6 +218,30 @@ describe("actions de publication des candidatures", () => {
 
     expect(result).toEqual({ ok: false, message: "Requête invalide." });
     expect(dbMock.programEdition.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("statut politique d'une candidature", () => {
+  it("met à jour le statut sourcé et écrit l'audit", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue({ ...SOURCED_CANDIDACY, status: "PRESSENTI" });
+    const a = await actions();
+
+    expect(await a.setCandidacyStatusAction({ candidacyId: "cand-1", status: "DECLARE" })).toEqual({
+      ok: true,
+    });
+    expect(dbMock.candidacy.update).toHaveBeenCalledWith({
+      where: { id: "cand-1" },
+      data: { status: "DECLARE" },
+    });
+    expect(dbMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entityType: "Candidacy",
+          entityId: "cand-1",
+          changes: { status: "DECLARE", previousStatus: "PRESSENTI" },
+        }),
+      })
+    );
   });
 });
 

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -111,6 +111,10 @@ describe("actions de publication des candidatures", () => {
     });
 
     expect(result).toEqual({ ok: true });
+    expect(dbMock.$queryRaw).toHaveBeenCalledOnce();
+    expect(dbMock.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      dbMock.candidacy.findUnique.mock.invocationCallOrder[0]!
+    );
     expect(dbMock.candidacyPresidential.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { candidacyId: "cand-1" },

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -235,22 +235,24 @@ describe("actions de publication des candidatures", () => {
 });
 
 describe("statut politique d'une candidature", () => {
-  it.each(["mailto:redaction@example.org", "ftp://example.org/source", "data:text/plain,test"])(
-    "refuse une source non HTTP(S): %s",
-    async (sourceUrl) => {
-      const a = await actions();
+  it.each([
+    "not a url",
+    "mailto:redaction@example.org",
+    "ftp://example.org/source",
+    "data:text/plain,test",
+  ])("refuse une source non HTTP(S): %s", async (sourceUrl) => {
+    const a = await actions();
 
-      expect(
-        await a.setCandidacyStatusAction({
-          candidacyId: "cand-1",
-          status: "DECLARE",
-          sourceUrl,
-          sourceLabel: "Déclaration officielle",
-        })
-      ).toEqual({ ok: false, message: "Requête invalide." });
-      expect(dbMock.$transaction).not.toHaveBeenCalled();
-    }
-  );
+    expect(
+      await a.setCandidacyStatusAction({
+        candidacyId: "cand-1",
+        status: "DECLARE",
+        sourceUrl,
+        sourceLabel: "Déclaration officielle",
+      })
+    ).toEqual({ ok: false, message: "Requête invalide." });
+    expect(dbMock.$transaction).not.toHaveBeenCalled();
+  });
 
   it("met à jour le statut sourcé et écrit l'audit", async () => {
     dbMock.candidacy.findUnique.mockResolvedValue({ ...SOURCED_CANDIDACY, status: "PRESSENTI" });

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -235,6 +235,23 @@ describe("actions de publication des candidatures", () => {
 });
 
 describe("statut politique d'une candidature", () => {
+  it.each(["mailto:redaction@example.org", "ftp://example.org/source", "data:text/plain,test"])(
+    "refuse une source non HTTP(S): %s",
+    async (sourceUrl) => {
+      const a = await actions();
+
+      expect(
+        await a.setCandidacyStatusAction({
+          candidacyId: "cand-1",
+          status: "DECLARE",
+          sourceUrl,
+          sourceLabel: "Déclaration officielle",
+        })
+      ).toEqual({ ok: false, message: "Requête invalide." });
+      expect(dbMock.$transaction).not.toHaveBeenCalled();
+    }
+  );
+
   it("met à jour le statut sourcé et écrit l'audit", async () => {
     dbMock.candidacy.findUnique.mockResolvedValue({ ...SOURCED_CANDIDACY, status: "PRESSENTI" });
     const a = await actions();

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -15,6 +15,7 @@ const invalidateCandidacyTagsMock = vi.fn();
 
 const dbMock = {
   $transaction: vi.fn(),
+  $queryRaw: vi.fn(),
   candidacy: { findUnique: vi.fn(), update: vi.fn() },
   candidacyPresidential: { upsert: vi.fn() },
   programEdition: { findUnique: vi.fn(), update: vi.fn() },
@@ -62,6 +63,7 @@ async function actions() {
 beforeEach(() => {
   vi.clearAllMocks();
   dbMock.$transaction.mockImplementation(async (callback) => callback(dbMock));
+  dbMock.$queryRaw.mockResolvedValue([{ id: "cand-1" }]);
   isAuthenticatedMock.mockResolvedValue(true);
   dbMock.candidacy.findUnique.mockResolvedValue(SOURCED_CANDIDACY);
   dbMock.candidacyPresidential.upsert.mockResolvedValue({ id: "pres-1" });

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -17,7 +17,7 @@ const dbMock = {
   $transaction: vi.fn(),
   $queryRaw: vi.fn(),
   candidacy: { findUnique: vi.fn(), update: vi.fn() },
-  candidacyPresidential: { upsert: vi.fn() },
+  candidacyPresidential: { upsert: vi.fn(), updateMany: vi.fn() },
   programEdition: { findUnique: vi.fn(), update: vi.fn() },
   auditLog: { create: vi.fn() },
 };
@@ -67,6 +67,7 @@ beforeEach(() => {
   isAuthenticatedMock.mockResolvedValue(true);
   dbMock.candidacy.findUnique.mockResolvedValue(SOURCED_CANDIDACY);
   dbMock.candidacyPresidential.upsert.mockResolvedValue({ id: "pres-1" });
+  dbMock.candidacyPresidential.updateMany.mockResolvedValue({ count: 1 });
   dbMock.candidacy.update.mockResolvedValue({ id: "cand-1" });
   dbMock.programEdition.findUnique.mockResolvedValue({
     id: "ed-1",
@@ -235,6 +236,34 @@ describe("actions de publication des candidatures", () => {
 });
 
 describe("statut politique d'une candidature", () => {
+  it("efface la synthèse en quittant le statut déclaré", async () => {
+    dbMock.candidacy.findUnique.mockResolvedValue({
+      ...SOURCED_CANDIDACY,
+      presidentialData: { ...SOURCED_CANDIDACY.presidentialData, synthesis: "Synthèse existante" },
+    });
+    const a = await actions();
+
+    expect(
+      await a.setCandidacyStatusAction({
+        candidacyId: "cand-1",
+        status: "PRESSENTI",
+        sourceUrl: "https://example.org/nouveau-statut",
+        sourceLabel: "Annonce officielle",
+      })
+    ).toEqual({ ok: true });
+    expect(dbMock.candidacyPresidential.updateMany).toHaveBeenCalledWith({
+      where: { candidacyId: "cand-1" },
+      data: { synthesis: null, synthesisGeneratedAt: null },
+    });
+    expect(dbMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          changes: expect.objectContaining({ synthesisCleared: true }),
+        }),
+      })
+    );
+  });
+
   it.each([
     "not a url",
     "mailto:redaction@example.org",

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -9,6 +9,7 @@ import { invalidateEntity } from "@/lib/cache";
 import { db } from "@/lib/db";
 import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 import { syncPresidentialSearchDocumentsForCandidacy } from "@/lib/presidentielle/search-sync";
+import { lockMeasureCandidacy } from "@/lib/measures/lock";
 import { generateCandidateSynthesis } from "@/services/candidate-synthesis";
 
 /**
@@ -76,6 +77,7 @@ export async function setCandidacyStatusAction(input: {
   const userAgent = requestHeaders.get("user-agent") || "unknown";
 
   const outcome = await db.$transaction(async (tx) => {
+    await lockMeasureCandidacy(tx, candidacyId);
     const candidacy = await tx.candidacy.findUnique({
       where: { id: candidacyId },
       select: { id: true, electionId: true, status: true, sourceUrl: true, sourceLabel: true },

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -83,13 +83,23 @@ export async function setCandidacyStatusAction(input: {
     await lockMeasureCandidacy(tx, candidacyId);
     const candidacy = await tx.candidacy.findUnique({
       where: { id: candidacyId },
-      select: { id: true, electionId: true, status: true, sourceUrl: true, sourceLabel: true },
+      select: {
+        id: true,
+        electionId: true,
+        status: true,
+        sourceUrl: true,
+        sourceLabel: true,
+        presidentialData: { select: { synthesis: true } },
+      },
     });
     if (!candidacy) return { ok: false as const, message: "Candidature introuvable." };
+    const mustClearSynthesis =
+      status !== "DECLARE" && candidacy.presidentialData?.synthesis != null;
     if (
       candidacy.status === status &&
       candidacy.sourceUrl === sourceUrl &&
-      candidacy.sourceLabel === sourceLabel
+      candidacy.sourceLabel === sourceLabel &&
+      !mustClearSynthesis
     ) {
       return { ok: true as const, electionId: candidacy.electionId };
     }
@@ -98,6 +108,12 @@ export async function setCandidacyStatusAction(input: {
       where: { id: candidacyId },
       data: { status, sourceUrl, sourceLabel },
     });
+    if (mustClearSynthesis) {
+      await tx.candidacyPresidential.updateMany({
+        where: { candidacyId },
+        data: { synthesis: null, synthesisGeneratedAt: null },
+      });
+    }
     await tx.auditLog.create({
       data: {
         action: "UPDATE",
@@ -110,6 +126,7 @@ export async function setCandidacyStatusAction(input: {
           previousStatus: candidacy.status,
           previousSourceUrl: candidacy.sourceUrl,
           previousSourceLabel: candidacy.sourceLabel,
+          synthesisCleared: mustClearSynthesis,
         },
         ipAddress,
         userAgent,

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -39,7 +39,10 @@ const candidacyStatusSchema = z
   .object({
     candidacyId: z.string().min(1),
     status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]),
-    sourceUrl: z.string().url(),
+    sourceUrl: z
+      .string()
+      .url()
+      .refine((value) => ["http:", "https:"].includes(new URL(value).protocol)),
     sourceLabel: z.string().trim().min(1),
   })
   .strict();

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -39,10 +39,10 @@ const candidacyStatusSchema = z
   .object({
     candidacyId: z.string().min(1),
     status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]),
-    sourceUrl: z
-      .string()
-      .url()
-      .refine((value) => ["http:", "https:"].includes(new URL(value).protocol)),
+    sourceUrl: z.string().refine((value) => {
+      if (!URL.canParse(value)) return false;
+      return ["http:", "https:"].includes(new URL(value).protocol);
+    }),
     sourceLabel: z.string().trim().min(1),
   })
   .strict();

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
 import { z } from "zod";
 import type { CandidacyStatus, PublicationStatus } from "@/generated/prisma";
 import { isAuthenticated } from "@/lib/auth";
@@ -37,6 +38,8 @@ const candidacyStatusSchema = z
   .object({
     candidacyId: z.string().min(1),
     status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]),
+    sourceUrl: z.string().url(),
+    sourceLabel: z.string().trim().min(1),
   })
   .strict();
 
@@ -58,12 +61,19 @@ function revalidate(): void {
 export async function setCandidacyStatusAction(input: {
   candidacyId: string;
   status: CandidacyStatus;
+  sourceUrl: string;
+  sourceLabel: string;
 }): Promise<CandidacyActionResult> {
   await assertAuthenticated();
 
   const parsed = candidacyStatusSchema.safeParse(input);
   if (!parsed.success) return { ok: false, message: "Requête invalide." };
-  const { candidacyId, status } = parsed.data;
+  const { candidacyId, status, sourceUrl, sourceLabel } = parsed.data;
+  const requestHeaders = await headers();
+  const forwarded = requestHeaders.get("x-forwarded-for");
+  const ipAddress =
+    forwarded?.split(",")[0]?.trim() || requestHeaders.get("x-real-ip") || "unknown";
+  const userAgent = requestHeaders.get("user-agent") || "unknown";
 
   const outcome = await db.$transaction(async (tx) => {
     const candidacy = await tx.candidacy.findUnique({
@@ -71,21 +81,33 @@ export async function setCandidacyStatusAction(input: {
       select: { id: true, electionId: true, status: true, sourceUrl: true, sourceLabel: true },
     });
     if (!candidacy) return { ok: false as const, message: "Candidature introuvable." };
-    if (!candidacy.sourceUrl || !candidacy.sourceLabel) {
-      return {
-        ok: false as const,
-        message: "Une source et son libellé sont requis avant de modifier le statut.",
-      };
+    if (
+      candidacy.status === status &&
+      candidacy.sourceUrl === sourceUrl &&
+      candidacy.sourceLabel === sourceLabel
+    ) {
+      return { ok: true as const, electionId: candidacy.electionId };
     }
-    if (candidacy.status === status) return { ok: true as const, electionId: candidacy.electionId };
 
-    await tx.candidacy.update({ where: { id: candidacyId }, data: { status } });
+    await tx.candidacy.update({
+      where: { id: candidacyId },
+      data: { status, sourceUrl, sourceLabel },
+    });
     await tx.auditLog.create({
       data: {
         action: "UPDATE",
         entityType: "Candidacy",
         entityId: candidacyId,
-        changes: { status, previousStatus: candidacy.status },
+        changes: {
+          status,
+          sourceUrl,
+          sourceLabel,
+          previousStatus: candidacy.status,
+          previousSourceUrl: candidacy.sourceUrl,
+          previousSourceLabel: candidacy.sourceLabel,
+        },
+        ipAddress,
+        userAgent,
       },
     });
     await syncPresidentialSearchDocumentsForCandidacy(tx, candidacyId);

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -149,6 +149,7 @@ export async function setCandidacyPublicationAction(input: {
   const { candidacyId, status } = parsed.data;
 
   const outcome = await db.$transaction(async (tx) => {
+    await lockMeasureCandidacy(tx, candidacyId);
     const candidacy = await tx.candidacy.findUnique({
       where: { id: candidacyId },
       select: {

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import type { PublicationStatus } from "@/generated/prisma";
+import type { CandidacyStatus, PublicationStatus } from "@/generated/prisma";
 import { isAuthenticated } from "@/lib/auth";
 import { invalidateEntity } from "@/lib/cache";
 import { db } from "@/lib/db";
@@ -33,6 +33,13 @@ const candidacyPublicationSchema = z
   .object({ candidacyId: z.string().min(1), status: publicationStatusSchema })
   .strict();
 
+const candidacyStatusSchema = z
+  .object({
+    candidacyId: z.string().min(1),
+    status: z.enum(["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"]),
+  })
+  .strict();
+
 const programEditionPublicationSchema = z
   .object({ programEditionId: z.string().min(1), status: publicationStatusSchema })
   .strict();
@@ -45,6 +52,51 @@ async function assertAuthenticated(): Promise<void> {
 
 function revalidate(): void {
   revalidatePath("/admin/candidats");
+}
+
+/** Updates the sourced political status carried by the core candidacy row. */
+export async function setCandidacyStatusAction(input: {
+  candidacyId: string;
+  status: CandidacyStatus;
+}): Promise<CandidacyActionResult> {
+  await assertAuthenticated();
+
+  const parsed = candidacyStatusSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: "Requête invalide." };
+  const { candidacyId, status } = parsed.data;
+
+  const outcome = await db.$transaction(async (tx) => {
+    const candidacy = await tx.candidacy.findUnique({
+      where: { id: candidacyId },
+      select: { id: true, electionId: true, status: true, sourceUrl: true, sourceLabel: true },
+    });
+    if (!candidacy) return { ok: false as const, message: "Candidature introuvable." };
+    if (!candidacy.sourceUrl || !candidacy.sourceLabel) {
+      return {
+        ok: false as const,
+        message: "Une source et son libellé sont requis avant de modifier le statut.",
+      };
+    }
+    if (candidacy.status === status) return { ok: true as const, electionId: candidacy.electionId };
+
+    await tx.candidacy.update({ where: { id: candidacyId }, data: { status } });
+    await tx.auditLog.create({
+      data: {
+        action: "UPDATE",
+        entityType: "Candidacy",
+        entityId: candidacyId,
+        changes: { status, previousStatus: candidacy.status },
+      },
+    });
+    await syncPresidentialSearchDocumentsForCandidacy(tx, candidacyId);
+    return { ok: true as const, electionId: candidacy.electionId };
+  });
+
+  if (!outcome.ok) return outcome;
+  invalidateEntity("election");
+  invalidatePresidentialCandidacyTags(outcome.electionId);
+  revalidate();
+  return { ok: true };
 }
 
 /**

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -39,6 +39,8 @@ export default async function AdminCandidatsPage() {
       politicianSlug: candidacy.politician?.slug ?? null,
       partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
       status: candidacy.status,
+      sourceUrl: candidacy.sourceUrl,
+      sourceLabel: candidacy.sourceLabel,
       sourced: Boolean(candidacy.status && candidacy.sourceUrl && candidacy.sourceLabel),
       presidentialId: candidacy.presidentialData?.id ?? null,
       publicationStatus: candidacy.presidentialData?.publicationStatus ?? null,

--- a/src/app/admin/syncs/page.tsx
+++ b/src/app/admin/syncs/page.tsx
@@ -120,6 +120,11 @@ const SCRIPT_CATALOG: ScriptCategory[] = [
     scripts: [
       { id: "classify-themes", label: "Classification", description: "Thèmes des dossiers" },
       { id: "index-embeddings", label: "Embeddings", description: "Index vectoriel RAG" },
+      {
+        id: "reindex-measures-search",
+        label: "Recherche des mesures 2027",
+        description: "Reconstruit l'index lexical des mesures de la présidentielle",
+      },
     ],
   },
   {

--- a/src/app/api/admin/candidats/[id]/route.ts
+++ b/src/app/api/admin/candidats/[id]/route.ts
@@ -7,6 +7,7 @@ import { getRequestMeta } from "@/lib/security/audit";
 import { invalidateEntity } from "@/lib/cache";
 import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 import { syncPresidentialSearchDocumentsForCandidacy } from "@/lib/presidentielle/search-sync";
+import { lockMeasureCandidacy } from "@/lib/measures/lock";
 
 export const PATCH = withAdminAuth(
   withValidation(updateCandidatePresidentialSchema, async (request, context, body) => {
@@ -23,6 +24,13 @@ export const PATCH = withAdminAuth(
     };
     const { ip, userAgent } = getRequestMeta(request);
     const outcome = await db.$transaction(async (tx) => {
+      const target = await tx.candidacyPresidential.findUnique({
+        where: { id },
+        select: { candidacyId: true },
+      });
+      if (!target) return null;
+      await lockMeasureCandidacy(tx, target.candidacyId);
+
       const existing = await tx.candidacyPresidential.findUnique({
         where: { id },
         select: {
@@ -88,6 +96,13 @@ export const DELETE = withAdminAuth(async (request, context) => {
   const { id } = await context.params;
   const { ip, userAgent } = getRequestMeta(request);
   const outcome = await db.$transaction(async (tx) => {
+    const target = await tx.candidacyPresidential.findUnique({
+      where: { id },
+      select: { candidacyId: true },
+    });
+    if (!target) return null;
+    await lockMeasureCandidacy(tx, target.candidacyId);
+
     const existing = await tx.candidacyPresidential.findUnique({
       where: { id },
       select: { id: true, candidacyId: true, candidacy: { select: { electionId: true } } },

--- a/src/app/api/admin/partis/[id]/route.ts
+++ b/src/app/api/admin/partis/[id]/route.ts
@@ -4,6 +4,7 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
 import { updatePartySchema } from "@/lib/security/schemas/party";
 import { invalidateEntity } from "@/lib/cache";
+import { lockMeasureCandidacy } from "@/lib/measures/lock";
 import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 import { syncCandidacySearchDocumentsForParty } from "@/lib/presidentielle/search-sync";
 import type { z } from "zod/v4";
@@ -87,6 +88,15 @@ export const PUT = withAdminAuth(
     }
 
     const { updatedParty, presidentialElectionIds } = await db.$transaction(async (tx) => {
+      const candidacies = await tx.candidacy.findMany({
+        where: { partyId: id, election: { type: "PRESIDENTIELLE" } },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      });
+      for (const candidacy of candidacies) {
+        await lockMeasureCandidacy(tx, candidacy.id);
+      }
+
       const updatedParty = await tx.party.update({
         where: { id },
         data: {

--- a/src/app/api/admin/politiques/[id]/route.ts
+++ b/src/app/api/admin/politiques/[id]/route.ts
@@ -7,6 +7,7 @@ import { generateSlug } from "@/lib/utils";
 import { invalidateEntity } from "@/lib/cache";
 import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
 import { syncPresidentialSearchDocumentsForCandidacy } from "@/lib/presidentielle/search-sync";
+import { lockMeasureCandidacy } from "@/lib/measures/lock";
 import type { DataSource, PublicationStatus } from "@/generated/prisma";
 import type { z } from "zod/v4";
 
@@ -65,6 +66,15 @@ export const PUT = withAdminAuth(
 
     // Update politician
     const { politician, presidentialElectionIds } = await db.$transaction(async (tx) => {
+      const candidacies = await tx.candidacy.findMany({
+        where: { politicianId: id, election: { type: "PRESIDENTIELLE" } },
+        select: { id: true, electionId: true },
+        orderBy: { id: "asc" },
+      });
+      for (const candidacy of candidacies) {
+        await lockMeasureCandidacy(tx, candidacy.id);
+      }
+
       const politician = await tx.politician.update({
         where: { id },
         data: {
@@ -83,10 +93,6 @@ export const PUT = withAdminAuth(
           publicationStatus:
             (body.publicationStatus as PublicationStatus) || existing.publicationStatus,
         },
-      });
-      const candidacies = await tx.candidacy.findMany({
-        where: { politicianId: id, election: { type: "PRESIDENTIELLE" } },
-        select: { id: true, electionId: true },
       });
       for (const candidacy of candidacies) {
         // Slug/name changes rewrite canonical result URLs; a publication loss closes candidate and

--- a/src/app/api/admin/syncs/route.test.ts
+++ b/src/app/api/admin/syncs/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  createJob: vi.fn(),
+  createAudit: vi.fn(),
+  transaction: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    syncJob: {
+      findFirst: h.findFirst,
+      update: vi.fn(),
+    },
+    $transaction: h.transaction,
+  },
+}));
+vi.mock("@/lib/api/with-admin-auth", () => ({
+  withAdminAuth: (handler: unknown) => handler,
+}));
+vi.mock("@/lib/security/validate", () => ({
+  withValidation:
+    (_schema: unknown, handler: (request: Request, context: unknown, body: unknown) => unknown) =>
+    async (request: Request, context: unknown) =>
+      handler(request, context, await request.json()),
+}));
+vi.mock("@/inngest/client", () => ({ inngest: { send: h.send } }));
+
+import { POST } from "./route";
+
+describe("POST /api/admin/syncs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.findFirst.mockResolvedValue(null);
+    h.createJob.mockResolvedValue({ id: "job-1", script: "reindex-measures-search" });
+    h.createAudit.mockResolvedValue({ id: "audit-1" });
+    h.transaction.mockImplementation((callback) =>
+      callback({
+        syncJob: { create: h.createJob },
+        auditLog: { create: h.createAudit },
+      })
+    );
+    h.send.mockResolvedValue(undefined);
+  });
+
+  it("crée le job et sa trace d'audit dans la même transaction", async () => {
+    const request = new Request("https://poligraph.fr/api/admin/syncs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "vitest",
+        "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+      },
+      body: JSON.stringify({ script: "reindex-measures-search" }),
+    });
+
+    const response = await POST(request as never, { params: Promise.resolve({}) });
+
+    expect(response.status).toBe(201);
+    expect(h.transaction).toHaveBeenCalledTimes(1);
+    expect(h.createAudit).toHaveBeenCalledWith({
+      data: {
+        action: "CREATE",
+        entityType: "SyncJob",
+        entityId: "job-1",
+        changes: { script: "reindex-measures-search", status: "PENDING" },
+        ipAddress: "203.0.113.10",
+        userAgent: "vitest",
+      },
+    });
+    expect(h.send).toHaveBeenCalledWith({
+      name: "sync/reindex-measures-search",
+      data: { jobId: "job-1" },
+    });
+  });
+});

--- a/src/app/api/admin/syncs/route.ts
+++ b/src/app/api/admin/syncs/route.ts
@@ -45,7 +45,7 @@ export const GET = withAdminAuth(async (request) => {
 });
 
 export const POST = withAdminAuth(
-  withValidation(createSyncSchema, async (_request, _context, { script }) => {
+  withValidation(createSyncSchema, async (request, _context, { script }) => {
     // Check if this script is already running
     const existing = await db.syncJob.findFirst({
       where: { script, status: { in: ["PENDING", "RUNNING"] } },
@@ -57,8 +57,24 @@ export const POST = withAdminAuth(
       );
     }
 
-    const job = await db.syncJob.create({
-      data: { script, status: "PENDING" },
+    const forwarded = request.headers.get("x-forwarded-for");
+    const ipAddress = forwarded?.split(",")[0]?.trim() || request.headers.get("x-real-ip") || null;
+    const userAgent = request.headers.get("user-agent");
+    const job = await db.$transaction(async (tx) => {
+      const created = await tx.syncJob.create({
+        data: { script, status: "PENDING" },
+      });
+      await tx.auditLog.create({
+        data: {
+          action: "CREATE",
+          entityType: "SyncJob",
+          entityId: created.id,
+          changes: { script, status: "PENDING" },
+          ipAddress,
+          userAgent,
+        },
+      });
+      return created;
     });
 
     // Trigger via Inngest

--- a/src/app/api/elections/presidentielle-2027/recherche/route.test.ts
+++ b/src/app/api/elections/presidentielle-2027/recherche/route.test.ts
@@ -22,16 +22,17 @@ describe("GET recherche présidentielle", () => {
       state: "too_short",
       query: "a",
       total: 0,
-      groups: { candidacies: [], measures: [] },
+      groups: { subjects: [], candidacies: [], measures: [] },
     });
     expect(search).not.toHaveBeenCalled();
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
-  it("renvoie seulement les groupes Personnalités puis Mesures du corpus scopé", async () => {
+  it("renvoie les sujets avant les personnalités et mesures du corpus scopé", async () => {
     search.mockResolvedValue({
       query: "logement",
-      total: 2,
+      total: 3,
+      subjects: [{ theme: "LOGEMENT_URBANISME", type: "subject" }],
       candidacies: [{ id: "c1", type: "candidacy" }],
       measures: [{ id: "m1", type: "measure" }],
     });
@@ -43,13 +44,19 @@ describe("GET recherche présidentielle", () => {
     );
     const body = await response.json();
     expect(search).toHaveBeenCalledWith("presidentielle-2027", "logement", 8);
-    expect(Object.keys(body.groups)).toEqual(["candidacies", "measures"]);
-    expect(body).not.toHaveProperty("subjects");
+    expect(Object.keys(body.groups)).toEqual(["subjects", "candidacies", "measures"]);
+    expect(body.groups.subjects).toHaveLength(1);
     expect(body.state).toBe("results");
   });
 
   it("renvoie un état vide prudent sans transformer l'absence en fait politique", async () => {
-    search.mockResolvedValue({ query: "inconnu", total: 0, candidacies: [], measures: [] });
+    search.mockResolvedValue({
+      query: "inconnu",
+      total: 0,
+      subjects: [],
+      candidacies: [],
+      measures: [],
+    });
     const response = await GET(
       new NextRequest("https://poligraph.fr/api/elections/presidentielle-2027/recherche?q=inconnu"),
       context

--- a/src/app/api/elections/presidentielle-2027/recherche/route.ts
+++ b/src/app/api/elections/presidentielle-2027/recherche/route.ts
@@ -22,7 +22,7 @@ export const GET = withPublicRoute(async (request) => {
         state: "too_short" as const,
         query,
         total: 0,
-        groups: { candidacies: [], measures: [] },
+        groups: { subjects: [], candidacies: [], measures: [] },
       }),
       "none"
     );
@@ -43,6 +43,7 @@ export const GET = withPublicRoute(async (request) => {
       query: result.query,
       total: result.total,
       groups: {
+        subjects: result.subjects,
         candidacies: result.candidacies,
         measures: result.measures,
       },

--- a/src/app/elections/presidentielle-2027/_components/PresidentialCorpusSearch.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PresidentialCorpusSearch.tsx
@@ -12,6 +12,7 @@ import {
 import type {
   PresidentialCandidacySearchResult,
   PresidentialMeasureSearchResult,
+  PresidentialSubjectSearchResult,
 } from "@/lib/presidentielle/corpus-search";
 import { cn } from "@/lib/utils";
 
@@ -23,12 +24,14 @@ type ApiResponse = {
   query: string;
   total: number;
   groups: {
+    subjects: PresidentialSubjectSearchResult[];
     candidacies: PresidentialCandidacySearchResult[];
     measures: PresidentialMeasureSearchResult[];
   };
 };
 
 type Option =
+  | { kind: "subject"; value: PresidentialSubjectSearchResult }
   | { kind: "candidacy"; value: PresidentialCandidacySearchResult }
   | { kind: "measure"; value: PresidentialMeasureSearchResult };
 
@@ -47,6 +50,10 @@ export function PresidentialCorpusSearch() {
   const [hydrated, setHydrated] = useState(false);
   const options = useMemo<Option[]>(
     () => [
+      ...(response?.groups.subjects.map((value) => ({
+        kind: "subject" as const,
+        value,
+      })) ?? []),
       ...(response?.groups.candidacies.map((value) => ({
         kind: "candidacy" as const,
         value,
@@ -173,14 +180,15 @@ export function PresidentialCorpusSearch() {
           }}
         >
           <label htmlFor="presidential-corpus-query" className="mb-2 block font-bold">
-            Rechercher une mesure ou une personnalité suivie
+            Rechercher un sujet, une mesure ou une personnalité suivie
           </label>
           <div className="flex min-h-14 items-center rounded-2xl border border-border bg-card shadow-sm focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2">
             <Search aria-hidden="true" className="ml-4 h-5 w-5 shrink-0 text-muted-foreground" />
             <input
               ref={inputRef}
               id="presidential-corpus-query"
-              type="search"
+              type="text"
+              inputMode="search"
               disabled={!hydrated}
               value={query}
               placeholder="logement, retraites, une personnalité…"
@@ -256,11 +264,50 @@ export function PresidentialCorpusSearch() {
             )}
             {status === "idle" && response && options.length > 0 && (
               <>
+                {response.groups.subjects.length > 0 && (
+                  <div role="group" aria-labelledby={listboxId + "-subjects"}>
+                    <h3
+                      id={listboxId + "-subjects"}
+                      className="px-4 pb-1 pt-4 text-xs font-bold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Sujets
+                    </h3>
+                    {response.groups.subjects.map((result) => {
+                      const currentIndex = optionIndex++;
+                      return (
+                        <button
+                          key={result.theme}
+                          id={listboxId + "-option-" + currentIndex}
+                          type="button"
+                          role="option"
+                          aria-selected={selectedIndex === currentIndex}
+                          className={cn(
+                            "min-h-14 w-full px-4 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-primary",
+                            selectedIndex === currentIndex ? "bg-accent" : "hover:bg-accent/60"
+                          )}
+                          onMouseEnter={() => {
+                            selectedIndexRef.current = currentIndex;
+                            setSelectedIndex(currentIndex);
+                          }}
+                          onClick={() => navigate(result.url)}
+                        >
+                          <span className="block font-bold">{result.label}</span>
+                          <span className="mt-1 block text-sm text-muted-foreground">
+                            Sujet du corpus 2027
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
                 {response.groups.candidacies.length > 0 && (
                   <div role="group" aria-labelledby={listboxId + "-candidacies"}>
                     <h3
                       id={listboxId + "-candidacies"}
-                      className="px-4 pb-1 pt-4 text-xs font-bold uppercase tracking-wide text-muted-foreground"
+                      className={cn(
+                        "px-4 pb-1 pt-4 text-xs font-bold uppercase tracking-wide text-muted-foreground",
+                        response.groups.subjects.length > 0 && "border-t border-border"
+                      )}
                     >
                       Personnalités suivies
                     </h3>
@@ -362,8 +409,8 @@ export function PresidentialCorpusSearch() {
         )}
       </div>
       <p className="mt-3 text-sm text-muted-foreground">
-        Recherche limitée aux contenus publics de l{"'"}élection présidentielle 2027. Une absence de
-        résultat ne prouve pas qu{"'"}une proposition n{"'"}existe pas.
+        Recherche limitée aux sujets et contenus publics de l{"'"}élection présidentielle 2027. Une
+        absence de résultat ne prouve pas qu{"'"}une proposition n{"'"}existe pas.
       </p>
       <div className="sr-only" aria-live="polite" aria-atomic="true">
         {liveMessage}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialCorpusSearch.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialCorpusSearch.test.tsx
@@ -13,6 +13,12 @@ function response() {
     query: "logement",
     total: 2,
     groups: {
+      subjects: [] as Array<{
+        type: "subject";
+        theme: "LOGEMENT_URBANISME";
+        label: string;
+        url: string;
+      }>,
       candidacies: [
         {
           type: "candidacy",
@@ -72,20 +78,31 @@ describe("PresidentialCorpusSearch", () => {
     expect(screen.getByRole("combobox")).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("affiche les groupes dans l'ordre sans ajouter les sujets", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => response() }));
+  it("affiche les sujets avant les personnalités et les mesures", async () => {
+    const result = response();
+    result.total = 3;
+    result.groups.subjects = [
+      {
+        type: "subject",
+        theme: "LOGEMENT_URBANISME",
+        label: "Logement & Urbanisme",
+        url: "/elections/presidentielle-2027/sujets/logement-urbanisme",
+      },
+    ];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => result }));
     render(<PresidentialCorpusSearch />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "logement" } });
     await runDebounce();
 
     const listbox = screen.getByRole("listbox");
-    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+    expect(within(listbox).getAllByRole("option")).toHaveLength(3);
     const headings = within(listbox).getAllByRole("heading");
     expect(headings.map((heading) => heading.textContent)).toEqual([
+      "Sujets",
       "Personnalités suivies",
       "Mesures",
     ]);
-    expect(within(listbox).queryByRole("heading", { name: /sujets/i })).not.toBeInTheDocument();
+    expect(within(listbox).getByText("Logement & Urbanisme")).toBeInTheDocument();
   });
 
   it("distingue le chargement, l'état vide et l'erreur technique", async () => {
@@ -97,7 +114,7 @@ describe("PresidentialCorpusSearch", () => {
           state: "empty",
           query: "introuvable",
           total: 0,
-          groups: { candidacies: [], measures: [] },
+          groups: { subjects: [], candidacies: [], measures: [] },
         }),
       })
       .mockResolvedValueOnce({ ok: false });
@@ -178,6 +195,14 @@ describe("PresidentialCorpusSearch", () => {
     fireEvent.click(screen.getByRole("button", { name: "Effacer la recherche" }));
     expect(input).toHaveValue("");
     expect(input).toHaveFocus();
+  });
+
+  it("n'affiche qu'un seul bouton d'effacement", () => {
+    render(<PresidentialCorpusSearch />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "logement" } });
+    expect(input).toHaveAttribute("type", "text");
+    expect(screen.getAllByRole("button", { name: "Effacer la recherche" })).toHaveLength(1);
   });
 
   it("envoie la page complète avec une requête partageable", () => {

--- a/src/app/elections/presidentielle-2027/recherche/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.test.tsx
@@ -6,7 +6,7 @@ vi.mock("@/lib/presidentielle/corpus-search", () => ({
   searchPresidentialCorpus: (...args: unknown[]) => search(...args),
 }));
 
-import Page, { metadata } from "./page";
+import PresidentialSearchPage, { metadata } from "./page";
 
 describe("page complète de recherche présidentielle", () => {
   beforeEach(() => {
@@ -14,6 +14,7 @@ describe("page complète de recherche présidentielle", () => {
     search.mockResolvedValue({
       query: "logement",
       total: 1,
+      subjects: [],
       candidacies: [],
       measures: [
         {
@@ -36,7 +37,7 @@ describe("page complète de recherche présidentielle", () => {
   });
 
   it("affiche le texte complet et le lien canonique de la mesure", async () => {
-    render(await Page({ searchParams: Promise.resolve({ q: "logement" }) }));
+    render(await PresidentialSearchPage({ searchParams: Promise.resolve({ q: "logement" }) }));
     const link = screen.getByRole("link", {
       name: /Construire davantage de logements accessibles sur tout le territoire/,
     });
@@ -44,22 +45,46 @@ describe("page complète de recherche présidentielle", () => {
     expect(search).toHaveBeenCalledWith("presidentielle-2027", "logement", 50);
   });
 
-  it("rend utile une correspondance claire avec un sujet sans l'ajouter au panneau", async () => {
-    render(await Page({ searchParams: Promise.resolve({ q: "Santé" }) }));
-    expect(screen.getByRole("link", { name: "Comparer le sujet Santé" })).toHaveAttribute(
-      "href",
-      "/elections/presidentielle-2027/sujets/sante"
+  it("présente un sujet comme un résultat sans message vide ni promesse de comparabilité", async () => {
+    search.mockResolvedValue({
+      query: "Logement",
+      total: 1,
+      subjects: [
+        {
+          type: "subject",
+          theme: "LOGEMENT_URBANISME",
+          label: "Logement & Urbanisme",
+          url: "/elections/presidentielle-2027/sujets/logement-urbanisme",
+        },
+      ],
+      candidacies: [],
+      measures: [],
+    });
+
+    render(
+      await PresidentialSearchPage({
+        searchParams: Promise.resolve({ q: "Logement" }),
+      })
     );
+
+    expect(screen.getByRole("heading", { level: 2, name: "Sujets" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Logement & Urbanisme/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/sujets/logement-urbanisme"
+    );
+    expect(screen.queryByText(/Aucun résultat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/sujet comparable/)).not.toBeInTheDocument();
   });
 
   it("reprend l'état vide prudent du handoff", async () => {
     search.mockResolvedValue({
       query: "inconnu",
       total: 0,
+      subjects: [],
       candidacies: [],
       measures: [],
     });
-    render(await Page({ searchParams: Promise.resolve({ q: "inconnu" }) }));
+    render(await PresidentialSearchPage({ searchParams: Promise.resolve({ q: "inconnu" }) }));
     expect(
       screen.getByRole("heading", { name: "Aucun résultat pour « inconnu »" })
     ).toBeInTheDocument();

--- a/src/app/elections/presidentielle-2027/recherche/page.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.tsx
@@ -9,11 +9,7 @@ import {
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
 import { searchPresidentialCorpus } from "@/lib/presidentielle/corpus-search";
-import {
-  PRESIDENTIELLE_2027_SLUG,
-  THEMES_IN_ORDER,
-  themeToSlug,
-} from "@/lib/presidentielle/themes";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
 
 const PAGE_PATH = "/elections/presidentielle-2027/recherche";
 
@@ -24,30 +20,6 @@ export const metadata: Metadata = {
   alternates: { canonical: PAGE_PATH },
 };
 
-function normalize(value: string): string {
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLocaleLowerCase("fr")
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
-}
-
-function matchingTheme(query: string) {
-  const normalized = normalize(query);
-  const exact = THEMES_IN_ORDER.find(
-    (theme) =>
-      normalize(THEME_CATEGORY_LABELS[theme]) === normalized ||
-      normalize(themeToSlug(theme)) === normalized
-  );
-  if (exact || normalized.length < 3) return exact;
-
-  const tokenMatches = THEMES_IN_ORDER.filter((theme) =>
-    normalize(THEME_CATEGORY_LABELS[theme]).split(" ").includes(normalized)
-  );
-  return tokenMatches.length === 1 ? tokenMatches[0] : undefined;
-}
-
 export default async function PresidentialSearchPage({
   searchParams,
 }: {
@@ -57,7 +29,6 @@ export default async function PresidentialSearchPage({
   const raw = Array.isArray(params.q) ? params.q[0] : params.q;
   const query = raw?.trim().slice(0, 200) ?? "";
   const result = await searchPresidentialCorpus(PRESIDENTIELLE_2027_SLUG, query, 50);
-  const theme = matchingTheme(query);
   const hasResults = result !== null && result.total > 0;
 
   return (
@@ -101,19 +72,6 @@ export default async function PresidentialSearchPage({
           </button>
         </form>
 
-        {theme && (
-          <aside className="mt-6 rounded-2xl border border-primary/30 bg-primary/5 p-5">
-            <p className="font-bold">Cette recherche correspond à un sujet comparable.</p>
-            <Link
-              href={"/elections/presidentielle-2027/sujets/" + themeToSlug(theme)}
-              className="mt-2 inline-flex min-h-11 items-center gap-2 rounded-lg font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
-            >
-              Comparer le sujet {THEME_CATEGORY_LABELS[theme]}
-              <ArrowRight aria-hidden="true" className="h-4 w-4" />
-            </Link>
-          </aside>
-        )}
-
         {query.length < 2 ? (
           <p className="mt-10 text-muted-foreground">
             Saisissez au moins deux caractères pour rechercher dans le corpus public.
@@ -134,6 +92,35 @@ export default async function PresidentialSearchPage({
             <p className="text-sm text-muted-foreground">
               {result.total} résultat{result.total > 1 ? "s" : ""} dans le corpus public
             </p>
+            {result.subjects.length > 0 && (
+              <section aria-labelledby="full-subjects-title">
+                <h2
+                  id="full-subjects-title"
+                  className="font-display text-2xl font-extrabold tracking-tight"
+                >
+                  Sujets
+                </h2>
+                <ul className="mt-4 space-y-3">
+                  {result.subjects.map((subject) => (
+                    <li key={subject.theme}>
+                      <Link
+                        href={subject.url}
+                        prefetch={false}
+                        className="flex min-h-16 items-center justify-between gap-4 rounded-2xl border border-border bg-card p-5 hover:border-primary/50 hover:bg-accent/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      >
+                        <span>
+                          <span className="block text-lg font-bold">{subject.label}</span>
+                          <span className="mt-1 block text-sm text-muted-foreground">
+                            Sujet du corpus 2027
+                          </span>
+                        </span>
+                        <ArrowRight aria-hidden="true" className="h-5 w-5 shrink-0" />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
             {result.candidacies.length > 0 && (
               <section aria-labelledby="full-candidacies-title">
                 <h2
@@ -147,6 +134,7 @@ export default async function PresidentialSearchPage({
                     <li key={candidacy.id}>
                       <Link
                         href={candidacy.url}
+                        prefetch={false}
                         className="flex min-h-20 items-center gap-4 rounded-2xl border border-border bg-card p-4 hover:border-primary/50 hover:bg-accent/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                       >
                         <PoliticianAvatar
@@ -185,6 +173,7 @@ export default async function PresidentialSearchPage({
                       <li key={measure.id}>
                         <Link
                           href={measure.url}
+                          prefetch={false}
                           className="block rounded-2xl border border-border bg-card p-5 hover:border-primary/50 hover:bg-accent/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                         >
                           <p className="text-lg font-bold leading-relaxed">{measure.text}</p>

--- a/src/inngest/index.ts
+++ b/src/inngest/index.ts
@@ -93,6 +93,20 @@ const migratedFunctions = [
     const limit = (data.limit as number) || 30;
     return classifyThemes({ limit });
   }),
+  createSyncFunction("reindex-measures-search", async (data) => {
+    const { reindexPresidentialMeasureSearch } =
+      await import("@/services/sync/reindex-measures-search");
+    const result = await reindexPresidentialMeasureSearch();
+    const jobId = typeof data.jobId === "string" ? data.jobId : null;
+    if (jobId) {
+      const { db } = await import("@/lib/db");
+      await db.syncJob.update({
+        where: { id: jobId },
+        data: { total: result.total, processed: result.processed, progress: 90 },
+      });
+    }
+    return result;
+  }),
 ];
 
 // Phase 2a: Migrated — services already exist, just wire them up

--- a/src/lib/measures/__tests__/audit.integration.test.ts
+++ b/src/lib/measures/__tests__/audit.integration.test.ts
@@ -246,6 +246,16 @@ describeIfDisposableDb("auditMeasures", () => {
     expect(await violationsFor(measureId)).toContain("search_document_stale");
   });
 
+  it("detects a search document outside its measure's election scope", async () => {
+    const { measureId } = await publishSeededMeasure();
+    await db.searchDocument.update({
+      where: { entityType_entityId: { entityType: "MEASURE", entityId: measureId } },
+      data: { electionId: null },
+    });
+
+    expect(await violationsFor(measureId)).toContain("search_document_election_mismatch");
+  });
+
   // The last three rules carry no measureId, so they are checked on the whole result.
 
   it("detects an EQUIVALENT_FOUND assessment with no match", async () => {

--- a/src/lib/measures/__tests__/evidence-snapshot.test.ts
+++ b/src/lib/measures/__tests__/evidence-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createV6CorrectionFingerprint,
   EvidenceSnapshotV3Schema,
   readEvidenceSnapshot,
   validateRevisionEvidence,
@@ -103,5 +104,28 @@ describe("EvidenceSnapshotV3 persistant", () => {
       { raw: "2", normalized: "2", role: "STRUCTURAL" },
       { raw: "67 millions", normalized: "67000000", role: "CONTENT" },
     ]);
+  });
+});
+
+describe("createV6CorrectionFingerprint", () => {
+  it("produit une clé stable propre au texte corrigé et à sa révision source", () => {
+    const first = createV6CorrectionFingerprint({
+      previousRevisionId: "revision-source",
+      text: "  Encadrer les loyers.  ",
+    });
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(
+      createV6CorrectionFingerprint({
+        previousRevisionId: "revision-source",
+        text: "Encadrer les loyers.",
+      })
+    ).toBe(first);
+    expect(
+      createV6CorrectionFingerprint({
+        previousRevisionId: "revision-source",
+        text: "Plafonner les loyers.",
+      })
+    ).not.toBe(first);
   });
 });

--- a/src/lib/measures/audit.ts
+++ b/src/lib/measures/audit.ts
@@ -10,7 +10,7 @@ export type AuditViolation = {
 /**
  * The invariants Prisma cannot express, checked in the database.
  *
- * Twenty-two rules. Two rules of an earlier draft are deliberately absent: "orphan
+ * Twenty-three rules. Two rules of an earlier draft are deliberately absent: "orphan
  * qualification" and "orphan assessment" queried `revision: { is: null }` on a required
  * relation with cascade delete. The orphan is structurally impossible and the query is
  * meaningless.
@@ -61,7 +61,7 @@ export async function auditMeasures(): Promise<AuditViolation[]> {
 
   const documents = await db.searchDocument.findMany({
     where: { entityType: "MEASURE" },
-    select: { entityId: true, visibility: true, sourceRevisionId: true },
+    select: { entityId: true, electionId: true, visibility: true, sourceRevisionId: true },
   });
   const byEntity = new Map(documents.map((d) => [d.entityId, d]));
   const publicMeasureIds = new Set(
@@ -218,6 +218,13 @@ export async function auditMeasures(): Promise<AuditViolation[]> {
         rule: "search_document_visibility_mismatch",
         measureId: m.id,
         detail: doc.visibility,
+      });
+    }
+    if (doc && doc.electionId !== m.electionId) {
+      violations.push({
+        rule: "search_document_election_mismatch",
+        measureId: m.id,
+        detail: `${doc.electionId ?? "null"} != ${m.electionId}`,
       });
     }
     if (doc) {

--- a/src/lib/measures/evidence-snapshot.ts
+++ b/src/lib/measures/evidence-snapshot.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Prisma } from "@/generated/prisma";
 import {
   evidenceSnapshotV3Schema,
@@ -24,6 +25,22 @@ export type EvidenceSnapshotReadResult =
   | { status: "ABSENT" }
   | { status: "VALID"; snapshot: EvidenceSnapshot }
   | { status: "INVALID"; reason: string };
+
+/** Gives an editorial correction of a V6 import its own stable idempotency key. */
+export function createV6CorrectionFingerprint(input: {
+  previousRevisionId: string;
+  text: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        kind: "V6_CORRECTION",
+        previousRevisionId: input.previousRevisionId,
+        text: input.text.trim(),
+      })
+    )
+    .digest("hex");
+}
 
 function toPrismaJson(snapshot: EvidenceSnapshot): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(snapshot)) as Prisma.InputJsonValue;

--- a/src/lib/measures/lock.ts
+++ b/src/lib/measures/lock.ts
@@ -24,3 +24,13 @@ export async function lockMeasure(tx: DbTransactionClient, measureId: string): P
   `;
   if (rows.length === 0) throw new MeasureNotFoundError(measureId);
 }
+
+/** Serializes visibility decisions shared by every measure of one candidacy. */
+export async function lockMeasureCandidacy(
+  tx: DbTransactionClient,
+  candidacyId: string
+): Promise<void> {
+  await tx.$queryRaw<{ id: string }[]>`
+    SELECT id FROM "Candidacy" WHERE id = ${candidacyId} FOR UPDATE
+  `;
+}

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -248,8 +248,15 @@ export async function draftMeasureRevision(
 
     const measure = await tx.measure.findUniqueOrThrow({
       where: { id: input.measureId },
-      select: { latestRevisionId: true, publishedRevisionId: true, updatedAt: true },
+      select: {
+        latestRevisionId: true,
+        publishedRevisionId: true,
+        candidacyId: true,
+        updatedAt: true,
+      },
     });
+
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
 
     assertVersionMatches(input.measureId, input.expectedUpdatedAt, measure.updatedAt);
 
@@ -462,8 +469,9 @@ export async function discardMeasureRevision(input: {
 
     const measure = await tx.measure.findUniqueOrThrow({
       where: { id: input.measureId },
-      select: { latestRevisionId: true, publishedRevisionId: true },
+      select: { latestRevisionId: true, publishedRevisionId: true, candidacyId: true },
     });
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
     if (input.revisionId === measure.publishedRevisionId) {
       throw new MeasureValidationError(
         "Une révision publiée ne s'abandonne pas, elle se dépublie ou se remplace"
@@ -505,8 +513,9 @@ export async function rejectMeasureRevision(input: {
     await lockMeasure(tx, input.measureId);
     const measure = await tx.measure.findUniqueOrThrow({
       where: { id: input.measureId },
-      select: { latestRevisionId: true, publishedRevisionId: true },
+      select: { latestRevisionId: true, publishedRevisionId: true, candidacyId: true },
     });
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
     if (input.revisionId === measure.publishedRevisionId) {
       throw new MeasureValidationError("Une révision publiée ne peut pas être rejetée");
     }

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -694,12 +694,19 @@ export async function publishMeasureRevision(input: {
       });
     }
 
+    const ficheIsPublic = measure.candidacyId
+      ? (await tx.candidacy.findFirst({
+          where: { id: measure.candidacyId, ...PUBLIC_PRESIDENTIAL_FICHE_WHERE },
+          select: { id: true },
+        })) !== null
+      : false;
+
     // In the same transaction: the database must never expose a new revision while the
     // index still holds the previous text. Called last, so it reads the pointers this
     // transaction has just written.
-    if (measure.candidacyId && !ficheWasPublic) {
-      // Publishing can open the carrier fiche (first primary-sourced measure), which changes the
-      // visibility of every already-published measure of that candidacy.
+    if (measure.candidacyId && ficheWasPublic !== ficheIsPublic) {
+      // Opening or closing the carrier fiche changes the visibility of every measure attached to
+      // the candidacy. A stable fiche only requires the edited measure to be refreshed.
       await syncPresidentialSearchDocumentsForCandidacy(tx, measure.candidacyId);
     } else {
       await syncSearchDocument(tx, input.measureId);

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -748,6 +748,8 @@ export async function depublishMeasure(input: {
       select: { electionId: true, candidacyId: true, updatedAt: true },
     });
 
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
+
     assertVersionMatches(input.measureId, input.expectedUpdatedAt, measure.updatedAt);
 
     await tx.measure.update({
@@ -812,6 +814,8 @@ export async function withdrawMeasure(input: {
       where: { id: input.measureId },
       select: { electionId: true, candidacyId: true, updatedAt: true },
     });
+
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
 
     assertVersionMatches(input.measureId, input.expectedUpdatedAt, measure.updatedAt);
 

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -17,7 +17,7 @@ import {
   type MeasureImportEngine,
 } from "./evidence-snapshot";
 import { MeasureConcurrencyError, MeasureValidationError } from "./errors";
-import { lockMeasure } from "./lock";
+import { lockMeasure, lockMeasureCandidacy } from "./lock";
 import { syncSearchDocument } from "./search-sync";
 import { PUBLIC_PRESIDENTIAL_FICHE_WHERE } from "@/lib/presidentielle/publication";
 import { syncPresidentialSearchDocumentsForCandidacy } from "@/lib/presidentielle/search-sync";
@@ -594,6 +594,8 @@ export async function publishMeasureRevision(input: {
         updatedAt: true,
       },
     });
+
+    if (measure.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
 
     assertVersionMatches(input.measureId, input.expectedUpdatedAt, measure.updatedAt);
 

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -11,10 +11,15 @@ import type {
 } from "@/generated/prisma";
 import { db, type DbTransactionClient } from "@/lib/db";
 import { invalidateMeasureTags } from "./cache";
-import { validateRevisionEvidence, type MeasureImportEngine } from "./evidence-snapshot";
+import {
+  createV6CorrectionFingerprint,
+  validateRevisionEvidence,
+  type MeasureImportEngine,
+} from "./evidence-snapshot";
 import { MeasureConcurrencyError, MeasureValidationError } from "./errors";
 import { lockMeasure } from "./lock";
 import { syncSearchDocument } from "./search-sync";
+import { PUBLIC_PRESIDENTIAL_FICHE_WHERE } from "@/lib/presidentielle/publication";
 import { syncPresidentialSearchDocumentsForCandidacy } from "@/lib/presidentielle/search-sync";
 
 export type MeasureSourceInput = {
@@ -283,7 +288,13 @@ export async function draftMeasureRevision(
         evidenceSnapshot: previous.evidenceSnapshot,
         reviewReadiness: previous.reviewReadiness,
         reviewWarnings: previous.reviewWarnings,
-        importFingerprint: null,
+        importFingerprint:
+          input.revision.extractionMethod === "AI_ASSISTED"
+            ? createV6CorrectionFingerprint({
+                previousRevisionId: input.preserveEvidenceFromRevisionId,
+                text: input.revision.text,
+              })
+            : null,
       };
       revisionSources = previous.sources;
     }
@@ -586,6 +597,13 @@ export async function publishMeasureRevision(input: {
 
     assertVersionMatches(input.measureId, input.expectedUpdatedAt, measure.updatedAt);
 
+    const ficheWasPublic = measure.candidacyId
+      ? (await tx.candidacy.findFirst({
+          where: { id: measure.candidacyId, ...PUBLIC_PRESIDENTIAL_FICHE_WHERE },
+          select: { id: true },
+        })) !== null
+      : false;
+
     const revision = await tx.measureRevision.findUnique({
       where: { id: input.revisionId },
       select: {
@@ -679,7 +697,7 @@ export async function publishMeasureRevision(input: {
     // In the same transaction: the database must never expose a new revision while the
     // index still holds the previous text. Called last, so it reads the pointers this
     // transaction has just written.
-    if (measure.candidacyId) {
+    if (measure.candidacyId && !ficheWasPublic) {
       // Publishing can open the carrier fiche (first primary-sourced measure), which changes the
       // visibility of every already-published measure of that candidacy.
       await syncPresidentialSearchDocumentsForCandidacy(tx, measure.candidacyId);

--- a/src/lib/presidentielle/__tests__/corpus-search.test.ts
+++ b/src/lib/presidentielle/__tests__/corpus-search.test.ts
@@ -79,17 +79,25 @@ describe("searchPresidentialCorpus", () => {
       text: "Construire des logements publics",
       url: "/elections/presidentielle-test/mesures/measure-public",
     });
+    expect(result?.subjects).toEqual([
+      {
+        type: "subject",
+        theme: "LOGEMENT_URBANISME",
+        label: "Logement & Urbanisme",
+        url: "/elections/presidentielle-test/sujets/logement-urbanisme",
+      },
+    ]);
   });
 
   it("écarte défensivement un document devenu privé sans exposer son total", async () => {
     const result = await searchPresidentialCorpus("presidentielle-test", "logement", 8);
     expect(result?.measures.map((measure) => measure.id)).not.toContain("measure-stale");
-    expect(result?.total).toBe(2);
+    expect(result?.total).toBe(3);
   });
 
   it("ne consulte pas l'index pour une requête trop courte", async () => {
     const result = await searchPresidentialCorpus("presidentielle-test", "a", 8);
-    expect(result).toMatchObject({ total: 0, candidacies: [], measures: [] });
+    expect(result).toMatchObject({ total: 0, subjects: [], candidacies: [], measures: [] });
     expect(searchPublicPage).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/presidentielle/__tests__/themes.test.ts
+++ b/src/lib/presidentielle/__tests__/themes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { themeToSlug, parseThemeSlug, THEMES_IN_ORDER, PRESIDENTIELLE_2027_SLUG } from "../themes";
+import {
+  findMatchingThemes,
+  themeToSlug,
+  parseThemeSlug,
+  THEMES_IN_ORDER,
+  PRESIDENTIELLE_2027_SLUG,
+} from "../themes";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
 import type { ThemeCategory } from "@/generated/prisma";
 
@@ -22,5 +28,12 @@ describe("theme route helpers", () => {
   });
   it("pins the slug", () => {
     expect(PRESIDENTIELLE_2027_SLUG).toBe("presidentielle-2027");
+  });
+  it("retrouve un sujet par un mot de son libellé, accents neutralisés", () => {
+    expect(findMatchingThemes("Logement")).toEqual(["LOGEMENT_URBANISME"]);
+    expect(findMatchingThemes("santé")).toEqual(["SANTE"]);
+  });
+  it("ne transforme pas un mot étranger à la taxonomie en sujet", () => {
+    expect(findMatchingThemes("introuvable")).toEqual([]);
   });
 });

--- a/src/lib/presidentielle/corpus-search.ts
+++ b/src/lib/presidentielle/corpus-search.ts
@@ -12,6 +12,8 @@ import {
   PUBLIC_HUB_CANDIDACY_WHERE,
   PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
 } from "@/lib/presidentielle/publication";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { findMatchingThemes, themeToSlug } from "@/lib/presidentielle/themes";
 
 const MAX_RESULTS = 50;
 
@@ -37,9 +39,17 @@ export type PresidentialMeasureSearchResult = {
   sourceLabel: MeasureSourceKind | null;
 };
 
+export type PresidentialSubjectSearchResult = {
+  type: "subject";
+  theme: ThemeCategory;
+  label: string;
+  url: string;
+};
+
 export type PresidentialCorpusSearchResult = {
   query: string;
   total: number;
+  subjects: PresidentialSubjectSearchResult[];
   candidacies: PresidentialCandidacySearchResult[];
   measures: PresidentialMeasureSearchResult[];
 };
@@ -66,8 +76,15 @@ export async function searchPresidentialCorpus(
   });
   if (election === null) return null;
   if (query.length < 2) {
-    return { query, total: 0, candidacies: [], measures: [] };
+    return { query, total: 0, subjects: [], candidacies: [], measures: [] };
   }
+
+  const subjects: PresidentialSubjectSearchResult[] = findMatchingThemes(query).map((theme) => ({
+    type: "subject",
+    theme,
+    label: THEME_CATEGORY_LABELS[theme],
+    url: `/elections/${election.slug}/sujets/${themeToSlug(theme)}`,
+  }));
 
   const page = await searchPublicPage(query, {
     electionId: election.id,
@@ -178,7 +195,8 @@ export async function searchPresidentialCorpus(
   const discardedFromPage = page.hits.length - candidacies.length - measures.length;
   return {
     query,
-    total: Math.max(0, page.total - discardedFromPage),
+    total: subjects.length + Math.max(0, page.total - discardedFromPage),
+    subjects,
     candidacies,
     measures,
   };

--- a/src/lib/presidentielle/themes.ts
+++ b/src/lib/presidentielle/themes.ts
@@ -1,4 +1,6 @@
 import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { themeToSlug } from "@/lib/theme-utils";
 
 export { themeToSlug, themeFromSlug as parseThemeSlug } from "@/lib/theme-utils";
 
@@ -20,3 +22,27 @@ export const THEMES_IN_ORDER: ThemeCategory[] = [
   "AFFAIRES_ETRANGERES_DEFENSE",
   "INSTITUTIONS",
 ];
+
+function normalizeThemeSearch(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("fr")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Search the controlled subject taxonomy without duplicating it in the full-text index. */
+export function findMatchingThemes(query: string): ThemeCategory[] {
+  const normalized = normalizeThemeSearch(query);
+  if (normalized.length < 2) return [];
+
+  const queryTerms = normalized.split(" ");
+  return THEMES_IN_ORDER.filter((theme) => {
+    const searchable = normalizeThemeSearch(
+      `${THEME_CATEGORY_LABELS[theme]} ${themeToSlug(theme)}`
+    );
+    const subjectTerms = new Set(searchable.split(" "));
+    return queryTerms.every((term) => subjectTerms.has(term));
+  });
+}

--- a/src/lib/search/maintenance.ts
+++ b/src/lib/search/maintenance.ts
@@ -1,5 +1,6 @@
 import type { SearchEntityType } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { lockMeasure, lockMeasureCandidacy } from "@/lib/measures/lock";
 import { syncSearchDocument } from "@/lib/measures/search-sync";
 import { syncCandidacySearchDocument } from "@/lib/presidentielle/search-sync";
 
@@ -58,7 +59,10 @@ const INDEXABLE: Record<ReindexableSearchEntityType, Indexable> = {
       return rows.map((row) => row.id);
     },
     sync: async (entityId) => {
-      await db.$transaction((tx) => syncCandidacySearchDocument(tx, entityId));
+      await db.$transaction(async (tx) => {
+        await lockMeasureCandidacy(tx, entityId);
+        await syncCandidacySearchDocument(tx, entityId);
+      });
     },
   },
   MEASURE: {
@@ -80,7 +84,17 @@ const INDEXABLE: Record<ReindexableSearchEntityType, Indexable> = {
       return rows.map((row) => row.id);
     },
     sync: async (entityId) => {
-      await db.$transaction((tx) => syncSearchDocument(tx, entityId));
+      await db.$transaction(async (tx) => {
+        // Match the transition lock order so a maintenance rebuild cannot overwrite a publication
+        // document derived from a newer measure or candidacy state.
+        await lockMeasure(tx, entityId);
+        const measure = await tx.measure.findUnique({
+          where: { id: entityId },
+          select: { candidacyId: true },
+        });
+        if (measure?.candidacyId) await lockMeasureCandidacy(tx, measure.candidacyId);
+        await syncSearchDocument(tx, entityId);
+      });
     },
   },
 };

--- a/src/services/sync/reindex-measures-search.test.ts
+++ b/src/services/sync/reindex-measures-search.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  count: vi.fn(),
+  reindexMeasures: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: { measure: { count: h.count } } }));
+vi.mock("@/lib/search/maintenance", () => ({ reindexMeasures: h.reindexMeasures }));
+
+import { reindexPresidentialMeasureSearch } from "./reindex-measures-search";
+
+describe("reindexPresidentialMeasureSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.count.mockResolvedValue(605);
+    h.reindexMeasures.mockResolvedValue({
+      entityType: "MEASURE",
+      processed: 605,
+      batches: 7,
+      lastId: "measure-605",
+    });
+  });
+
+  it("borne la reconstruction à la présidentielle 2027", async () => {
+    await expect(reindexPresidentialMeasureSearch()).resolves.toEqual({
+      electionSlug: "presidentielle-2027",
+      total: 605,
+      processed: 605,
+      batches: 7,
+      lastId: "measure-605",
+    });
+    expect(h.count).toHaveBeenCalledWith({
+      where: { election: { slug: "presidentielle-2027" } },
+    });
+    expect(h.reindexMeasures).toHaveBeenCalledWith({
+      electionSlug: "presidentielle-2027",
+      batchSize: 100,
+    });
+  });
+});

--- a/src/services/sync/reindex-measures-search.ts
+++ b/src/services/sync/reindex-measures-search.ts
@@ -1,0 +1,30 @@
+import { db } from "@/lib/db";
+import { reindexMeasures } from "@/lib/search/maintenance";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+
+export type ReindexMeasuresSearchResult = {
+  electionSlug: string;
+  total: number;
+  processed: number;
+  batches: number;
+  lastId: string | null;
+};
+
+/** Rebuild every measure search document for the bounded 2027 presidential corpus. */
+export async function reindexPresidentialMeasureSearch(): Promise<ReindexMeasuresSearchResult> {
+  const total = await db.measure.count({
+    where: { election: { slug: PRESIDENTIELLE_2027_SLUG } },
+  });
+  const result = await reindexMeasures({
+    electionSlug: PRESIDENTIELLE_2027_SLUG,
+    batchSize: 100,
+  });
+
+  return {
+    electionSlug: PRESIDENTIELLE_2027_SLUG,
+    total,
+    processed: result.processed,
+    batches: result.batches,
+    lastId: result.lastId,
+  };
+}


### PR DESCRIPTION
## Résultat

- évite de reconstruire les documents de recherche de toute une candidature à chaque publication lorsque sa fiche est déjà publique
- permet de modifier un statut de candidature sourcé depuis la liste admin, avec audit et resynchronisation
- conserve une clé d’idempotence V6 valide lors d’une correction éditoriale

## Vérifications

- typecheck
- lint, 0 erreur
- 5 138 tests passants
- build Next.js 16 avec Webpack
- publication réelle de 31 mesures Ruffin validée après l’optimisation