### PR TITLE
fix(presidentielle): valider la couverture des synthèses

### DIFF
--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -3,6 +3,7 @@ import {
   buildCandidateSynthesisPrompt,
   buildSynthesisSystemPrompt,
   isSynthesisContradictedByMeasures,
+  screenCandidateSynthesis,
   screenSynthesis,
   synthesisFloor,
   synthesisMaterial,
@@ -62,6 +63,7 @@ describe("buildCandidateSynthesisPrompt", () => {
     expect(prompt).toContain(
       "Représente au moins une mesure de chacun de ces thèmes : Santé, Transports."
     );
+    expect(prompt).toContain("[M1] Rouvrir des maternités de proximité.");
   });
 
   it("asks a large programme to cover its eight most represented themes", () => {
@@ -139,6 +141,82 @@ describe("buildCandidateSynthesisPrompt", () => {
       measures: [{ theme: "SANTE", text: "a".repeat(1000) }],
     });
     expect(prompt).not.toContain("a".repeat(300));
+  });
+});
+
+describe("screenCandidateSynthesis", () => {
+  const career = words(30);
+
+  it("derives coverage from inline measure references and removes the internal markup", () => {
+    const raw = `<synthese>${career}.\n\nSon programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
+
+    const result = screenCandidateSynthesis(raw, BASE);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).not.toContain("<engagement");
+    expect(result.ok && result.text).not.toContain("<synthese>");
+  });
+
+  it("refuses valid-length prose that omits an expected theme", () => {
+    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "couverture_theme",
+    });
+  });
+
+  it("refuses more than two evidenced engagements from one theme", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [...BASE.measures, { theme: "SANTE", text: "Créer des centres de santé publics." }],
+    };
+    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>, de <engagement ref="M2">rembourser à 100 % les soins prescrits</engagement>, de <engagement ref="M4">créer des centres de santé publics</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, input)).toMatchObject({
+      ok: false,
+      reason: "concentration_theme",
+    });
+  });
+
+  it("does not trust a reference whose annotated prose does not reflect its measure", () => {
+    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">réduire les taxes sur les entreprises</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "preuve_non_refletee",
+    });
+  });
+
+  it("refuses a theme declaration that is not tied to a known measure", () => {
+    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M99">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "preuve_inconnue",
+    });
+  });
+
+  it("refuses substantive programme prose left outside evidence spans", () => {
+    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>. Il baisse aussi les impôts.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "engagement_non_reference",
+    });
+  });
+
+  it("accepts short and numeric measures when their distinctive terms are evidenced", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [
+        { theme: "ECONOMIE_BUDGET", text: "Abolir la TVA." },
+        { theme: "SOCIAL_TRAVAIL", text: "Fixer la retraite à 60 ans." },
+      ],
+    };
+    const raw = `<synthese>${career}.\n\nLe programme propose d'<engagement ref="M1">abolir la TVA</engagement> et de <engagement ref="M2">fixer la retraite à 60 ans</engagement>.</synthese>`;
+
+    expect(screenCandidateSynthesis(raw, input)).toMatchObject({ ok: true });
   });
 });
 

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -48,7 +48,12 @@ function words(n: number): string {
 
 /** Most pure-screen tests use one generated segment as the complete text. */
 function screenSynthesis(raw: string, material?: SynthesisMaterial) {
-  return screenSynthesisSegments({ text: raw, generatedText: raw, sourceText: "", material });
+  return screenSynthesisSegments({
+    text: raw,
+    generatedText: raw,
+    exemptSourceTexts: [],
+    material,
+  });
 }
 
 describe("buildCandidateSynthesisPrompt", () => {
@@ -279,6 +284,25 @@ describe("screenCandidateSynthesis", () => {
     expect(result).toMatchObject({ ok: true });
     expect(result.ok && result.text).toContain("source219.");
   });
+
+  it("charges an optional second source from the same theme against the maximum", () => {
+    const longOptional = Array.from(
+      { length: SYNTHESIS_MAX_WORDS + 20 },
+      (_, i) => `option${i}`
+    ).join(" ");
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [
+        { theme: "SANTE", text: "Rouvrir des maternités de proximité." },
+        { theme: "SANTE", text: `${longOptional}.` },
+      ],
+    };
+
+    expect(screenCandidateSynthesis(structured(["M2", "M1"]), input)).toMatchObject({
+      ok: false,
+      reason: "trop_long",
+    });
+  });
 });
 
 describe("buildSynthesisSystemPrompt", () => {
@@ -366,7 +390,7 @@ describe("screenSynthesis", () => {
       screenSynthesisSegments({
         text: good,
         generatedText: good,
-        sourceText: "formulation canonique absente",
+        exemptSourceTexts: ["formulation canonique absente"],
       })
     ).toMatchObject({ ok: false, reason: "source_absente" });
   });

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -48,7 +48,7 @@ function words(n: number): string {
 
 /** Most pure-screen tests use one generated segment as the complete text. */
 function screenSynthesis(raw: string, material?: SynthesisMaterial) {
-  return screenSynthesisSegments({ text: raw, generatedText: raw, material });
+  return screenSynthesisSegments({ text: raw, generatedText: raw, sourceText: "", material });
 }
 
 describe("buildCandidateSynthesisPrompt", () => {
@@ -254,6 +254,31 @@ describe("screenCandidateSynthesis", () => {
       reason: "judiciaire",
     });
   });
+
+  it("rejects an empty career even when canonical measures satisfy the overall floor", () => {
+    const raw = `<synthese><parcours></parcours><programme><engagement ref="M1" /><engagement ref="M3" /></programme></synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "parcours_vide",
+    });
+  });
+
+  it("does not charge required canonical measure wording against the flexible maximum", () => {
+    const longMeasure = Array.from(
+      { length: SYNTHESIS_MAX_WORDS + 20 },
+      (_, i) => `source${i}`
+    ).join(" ");
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [{ theme: "SANTE", text: `${longMeasure}.` }],
+    };
+
+    const result = screenCandidateSynthesis(structured(["M1"]), input);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain("source219.");
+  });
 });
 
 describe("buildSynthesisSystemPrompt", () => {
@@ -334,6 +359,16 @@ describe("screenSynthesis", () => {
   it("accepts a text of the right length", () => {
     const result = screenSynthesis(good);
     expect(result.ok).toBe(true);
+  });
+
+  it("cannot exclude source words that are absent from the final text", () => {
+    expect(
+      screenSynthesisSegments({
+        text: good,
+        generatedText: good,
+        sourceText: "formulation canonique absente",
+      })
+    ).toMatchObject({ ok: false, reason: "source_absente" });
   });
 
   it("trims before measuring", () => {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -4,7 +4,7 @@ import {
   buildSynthesisSystemPrompt,
   isSynthesisContradictedByMeasures,
   screenCandidateSynthesis,
-  screenSynthesis,
+  screenSynthesis as screenSynthesisSegments,
   synthesisFloor,
   synthesisMaterial,
   synthesisTargetRange,
@@ -44,6 +44,11 @@ const BASE: CandidateSynthesisInput = {
 
 function words(n: number): string {
   return Array.from({ length: n }, (_, i) => `mot${i}`).join(" ");
+}
+
+/** Most pure-screen tests use one generated segment as the complete text. */
+function screenSynthesis(raw: string, material?: SynthesisMaterial) {
+  return screenSynthesisSegments({ text: raw, generatedText: raw, material });
 }
 
 describe("buildCandidateSynthesisPrompt", () => {
@@ -231,6 +236,22 @@ describe("screenCandidateSynthesis", () => {
     expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
       ok: false,
       reason: "format_programme",
+    });
+  });
+
+  it("accepts judicial vocabulary from a canonical measure but not from the generated career", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [{ theme: "SECURITE_JUSTICE", text: "Créer un tribunal spécialisé." }],
+    };
+    const sourced = screenCandidateSynthesis(structured(["M1"]), input);
+    const generated = `<synthese><parcours>${career}. Il a comparu devant un tribunal.</parcours><programme><engagement ref="M1" /></programme></synthese>`;
+
+    expect(sourced).toMatchObject({ ok: true });
+    expect(sourced.ok && sourced.text).toContain("Créer un tribunal spécialisé.");
+    expect(screenCandidateSynthesis(generated, input)).toMatchObject({
+      ok: false,
+      reason: "judiciaire",
     });
   });
 });

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -146,21 +146,22 @@ describe("buildCandidateSynthesisPrompt", () => {
 
 describe("screenCandidateSynthesis", () => {
   const career = words(30);
+  const structured = (refs: string[]) =>
+    `<synthese><parcours>${career}.</parcours><programme>${refs
+      .map((ref) => `<engagement ref="${ref}" />`)
+      .join("")}</programme></synthese>`;
 
-  it("derives coverage from inline measure references and removes the internal markup", () => {
-    const raw = `<synthese>${career}.\n\nSon programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
-
-    const result = screenCandidateSynthesis(raw, BASE);
+  it("derives coverage from references and builds the public text from source measures", () => {
+    const result = screenCandidateSynthesis(structured(["M1", "M3"]), BASE);
 
     expect(result).toMatchObject({ ok: true });
-    expect(result.ok && result.text).not.toContain("<engagement");
-    expect(result.ok && result.text).not.toContain("<synthese>");
+    expect(result.ok && result.text).toContain("Rouvrir des maternités de proximité.");
+    expect(result.ok && result.text).toContain("Rétablir des trains de nuit sur six lignes.");
+    expect(result.ok && result.text).not.toMatch(/<engagement|<synthese>/);
   });
 
   it("refuses valid-length prose that omits an expected theme", () => {
-    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
-
-    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+    expect(screenCandidateSynthesis(structured(["M1"]), BASE)).toMatchObject({
       ok: false,
       reason: "couverture_theme",
     });
@@ -171,52 +172,66 @@ describe("screenCandidateSynthesis", () => {
       ...BASE,
       measures: [...BASE.measures, { theme: "SANTE", text: "Créer des centres de santé publics." }],
     };
-    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>, de <engagement ref="M2">rembourser à 100 % les soins prescrits</engagement>, de <engagement ref="M4">créer des centres de santé publics</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
 
-    expect(screenCandidateSynthesis(raw, input)).toMatchObject({
+    expect(screenCandidateSynthesis(structured(["M1", "M2", "M4", "M3"]), input)).toMatchObject({
       ok: false,
       reason: "concentration_theme",
     });
   });
 
-  it("does not trust a reference whose annotated prose does not reflect its measure", () => {
-    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">réduire les taxes sur les entreprises</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
+  it("cannot persist an action reversed by generated prose", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [{ theme: "ECONOMIE_BUDGET", text: "Augmenter les impôts des entreprises." }],
+    };
+    const reversed = `<synthese><parcours>${career}.</parcours><programme><engagement ref="M1">Supprimer les impôts des entreprises.</engagement></programme></synthese>`;
 
-    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+    expect(screenCandidateSynthesis(reversed, input)).toMatchObject({
       ok: false,
-      reason: "preuve_non_refletee",
+      reason: "format_structure",
     });
+    const accepted = screenCandidateSynthesis(structured(["M1"]), input);
+    expect(accepted.ok && accepted.text).toContain("Augmenter les impôts des entreprises.");
+    expect(accepted.ok && accepted.text).not.toContain("Supprimer");
   });
 
   it("refuses a theme declaration that is not tied to a known measure", () => {
-    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M99">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>.</synthese>`;
-
-    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+    expect(screenCandidateSynthesis(structured(["M99", "M3"]), BASE)).toMatchObject({
       ok: false,
       reason: "preuve_inconnue",
     });
   });
 
-  it("refuses substantive programme prose left outside evidence spans", () => {
-    const raw = `<synthese>${career}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M3">rétablir des trains de nuit</engagement>. Il baisse aussi les impôts.</synthese>`;
+  it("refuses any free programme prose alongside references", () => {
+    const raw = `<synthese><parcours>${career}.</parcours><programme><engagement ref="M1" /><engagement ref="M3" />Il baisse aussi les impôts.</programme></synthese>`;
 
     expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
       ok: false,
-      reason: "engagement_non_reference",
+      reason: "format_structure",
     });
   });
 
-  it("accepts short and numeric measures when their distinctive terms are evidenced", () => {
-    const input: CandidateSynthesisInput = {
+  it("handles an empty programme with one bounded canonical sentence", () => {
+    const empty: CandidateSynthesisInput = {
       ...BASE,
-      measures: [
-        { theme: "ECONOMIE_BUDGET", text: "Abolir la TVA." },
-        { theme: "SOCIAL_TRAVAIL", text: "Fixer la retraite à 60 ans." },
-      ],
+      measures: [],
     };
-    const raw = `<synthese>${career}.\n\nLe programme propose d'<engagement ref="M1">abolir la TVA</engagement> et de <engagement ref="M2">fixer la retraite à 60 ans</engagement>.</synthese>`;
+    const raw = `<synthese><parcours>${career}.</parcours><programme-vide /></synthese>`;
+    const result = screenCandidateSynthesis(raw, empty);
 
-    expect(screenCandidateSynthesis(raw, input)).toMatchObject({ ok: true });
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain(
+      "Aucune mesure n'est publiée dans le cadre de son programme."
+    );
+  });
+
+  it("does not relax the empty marker for a non-empty programme", () => {
+    const raw = `<synthese><parcours>${career}.</parcours><programme-vide /></synthese>`;
+
+    expect(screenCandidateSynthesis(raw, BASE)).toMatchObject({
+      ok: false,
+      reason: "format_programme",
+    });
   });
 });
 

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -139,6 +139,17 @@ export type CandidateSynthesisInput = {
   measures: Array<{ theme: ThemeCategory; text: string }>;
 };
 
+type ProgrammeReference = {
+  ref: string;
+  theme: ThemeCategory;
+  text: string;
+};
+
+type ProgrammePlan = {
+  references: ProgrammeReference[];
+  expectedThemes: ThemeCategory[];
+};
+
 /**
  * Neutralises a database value before it reaches the prompt.
  *
@@ -202,7 +213,37 @@ Forme :
 - Pas de phrase de conclusion générale du type « une candidature qui entend peser ». Termine sur un fait.
 - Si le parcours ou le programme est vide, dis-le en une phrase simple plutôt que de meubler.
 
-Réponds uniquement par le texte de la synthèse, sans titre ni préambule.`;
+Format interne obligatoire :
+- Place tout le texte dans une unique balise <synthese>...</synthese>, sans titre ni préambule.
+- Dans le paragraphe du programme, entoure chaque engagement cité avec <engagement ref="M1">...</engagement>, en remplaçant M1 par la référence fournie devant la mesure correspondante.
+- Le passage à l'intérieur de la balise engagement doit reprendre assez de mots de la mesure source pour que la référence soit vérifiable.
+- Dans le paragraphe du programme, ne laisse hors de ces balises que la ponctuation, les articles et les mots de liaison. Toute information de fond doit appartenir à un engagement référencé.
+- Ces balises sont retirées après contrôle et ne seront jamais montrées au lecteur.`;
+}
+
+function buildProgrammePlan(input: CandidateSynthesisInput): ProgrammePlan {
+  const references = input.measures.map((measure, index) => ({
+    ref: `M${index + 1}`,
+    theme: measure.theme,
+    text: safe(measure.text),
+  }));
+  const counts = new Map<ThemeCategory, number>();
+  for (const reference of references) {
+    counts.set(reference.theme, (counts.get(reference.theme) ?? 0) + 1);
+  }
+  const themes = [...counts.entries()].sort(
+    ([themeA, countA], [themeB, countB]) =>
+      countB - countA ||
+      THEME_CATEGORY_LABELS[themeA].localeCompare(THEME_CATEGORY_LABELS[themeB], "fr")
+  );
+  // Theme frequency is context, not an editorial ranking. It gives a stable, candidate-agnostic
+  // answer to “principal themes” while the explicit cap prevents the largest family swallowing the
+  // paragraph. Eight short examples fit the large 250-word format; five fit the standard one.
+  const coverageLimit = input.measures.length >= LARGE_PROGRAMME_MEASURES ? 8 : 5;
+  return {
+    references,
+    expectedThemes: themes.slice(0, coverageLimit).map(([theme]) => theme),
+  };
 }
 
 export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): string {
@@ -211,31 +252,26 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
       ? input.mandates.map(formatMandate).join("\n")
       : "Aucun mandat enregistré sur le site.";
 
-  const byTheme = new Map<ThemeCategory, string[]>();
-  for (const measure of input.measures) {
-    if (!byTheme.has(measure.theme)) byTheme.set(measure.theme, []);
-    byTheme.get(measure.theme)!.push(safe(measure.text));
+  const programmePlan = buildProgrammePlan(input);
+  const byTheme = new Map<ThemeCategory, ProgrammeReference[]>();
+  for (const reference of programmePlan.references) {
+    if (!byTheme.has(reference.theme)) byTheme.set(reference.theme, []);
+    byTheme.get(reference.theme)!.push(reference);
   }
   const themes = [...byTheme.entries()].sort(
-    ([themeA, textsA], [themeB, textsB]) =>
-      textsB.length - textsA.length ||
+    ([themeA, referencesA], [themeB, referencesB]) =>
+      referencesB.length - referencesA.length ||
       THEME_CATEGORY_LABELS[themeA].localeCompare(THEME_CATEGORY_LABELS[themeB], "fr")
   );
-  // Theme frequency is context, not an editorial ranking. It gives a stable, candidate-agnostic
-  // answer to “principal themes” while the explicit cap prevents the largest family swallowing the
-  // paragraph. Eight short examples fit the large 250-word format; five fit the standard one.
-  const coverageLimit = input.measures.length >= LARGE_PROGRAMME_MEASURES ? 8 : 5;
-  const expectedThemes = themes
-    .slice(0, coverageLimit)
-    .map(([theme]) => THEME_CATEGORY_LABELS[theme]);
+  const expectedThemes = programmePlan.expectedThemes.map((theme) => THEME_CATEGORY_LABELS[theme]);
   const measures =
     themes.length > 0
       ? themes
           .map(
-            ([theme, texts]) =>
-              `${THEME_CATEGORY_LABELS[theme]} (${texts.length} mesure${texts.length > 1 ? "s" : ""}) :\n${texts
-                .sort((a, b) => a.localeCompare(b, "fr"))
-                .map((t) => `  - ${t}`)
+            ([theme, references]) =>
+              `${THEME_CATEGORY_LABELS[theme]} (${references.length} mesure${references.length > 1 ? "s" : ""}) :\n${references
+                .sort((a, b) => a.text.localeCompare(b.text, "fr"))
+                .map((reference) => `  - [${reference.ref}] ${reference.text}`)
                 .join("\n")}`
           )
           .join("\n")
@@ -244,8 +280,8 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
     themes.length > 0
       ? themes
           .map(
-            ([theme, texts]) =>
-              `- ${THEME_CATEGORY_LABELS[theme]} : ${texts.length} mesure${texts.length > 1 ? "s" : ""}`
+            ([theme, references]) =>
+              `- ${THEME_CATEGORY_LABELS[theme]} : ${references.length} mesure${references.length > 1 ? "s" : ""}`
           )
           .join("\n")
       : "Aucun thème représenté.";
@@ -287,6 +323,211 @@ Rédige la synthèse.`;
 export type SynthesisScreen =
   | { ok: true; text: string }
   | { ok: false; reason: string; detail: string };
+
+const EVIDENCE_STOP_WORDS = new Set([
+  "afin",
+  "ainsi",
+  "au",
+  "aux",
+  "avec",
+  "ce",
+  "ces",
+  "cet",
+  "cette",
+  "ceux",
+  "dans",
+  "de",
+  "des",
+  "depuis",
+  "defend",
+  "dont",
+  "du",
+  "elle",
+  "en",
+  "entre",
+  "est",
+  "et",
+  "il",
+  "ils",
+  "la",
+  "le",
+  "les",
+  "leur",
+  "leurs",
+  "lui",
+  "mais",
+  "mesure",
+  "ne",
+  "notamment",
+  "nous",
+  "on",
+  "ou",
+  "par",
+  "pas",
+  "pour",
+  "programme",
+  "propose",
+  "prevoit",
+  "que",
+  "qui",
+  "sans",
+  "se",
+  "sera",
+  "ses",
+  "son",
+  "sont",
+  "sous",
+  "sur",
+  "tous",
+  "tout",
+  "toute",
+  "toutes",
+  "un",
+  "une",
+  "vers",
+  "vos",
+  "votre",
+]);
+
+function evidenceTerms(value: string): Set<string> {
+  const words = value
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase("fr")
+    .match(/[a-z]{2,}|[0-9]+(?:[.,][0-9]+)?%?/g);
+  return new Set(
+    (words ?? [])
+      .filter((word) => !EVIDENCE_STOP_WORDS.has(word))
+      .map((word) => (word.length > 6 ? word.slice(0, 6) : word))
+  );
+}
+
+function engagementMatchesMeasure(engagement: string, measure: string): boolean {
+  const sourceTerms = evidenceTerms(measure);
+  const engagementTerms = evidenceTerms(engagement);
+  const shared = [...sourceTerms].filter((term) => engagementTerms.has(term)).length;
+  return sourceTerms.size > 0 && shared >= Math.min(2, sourceTerms.size);
+}
+
+/**
+ * Validates the internal evidence markup and returns only the reader-facing prose.
+ *
+ * Theme names reported beside the prose would be unverifiable declarations by the same model that
+ * wrote it. Instead, each cited engagement carries a measure reference in the exact span rendered
+ * as prose. The screen resolves that reference itself, checks that the span shares source wording,
+ * derives its theme from the database input, and only then applies coverage and concentration.
+ */
+export function screenCandidateSynthesis(
+  raw: string,
+  input: CandidateSynthesisInput
+): SynthesisScreen {
+  const wrapper = /^<synthese>\s*([\s\S]*?)\s*<\/synthese>$/u.exec(raw.trim());
+  if (!wrapper) {
+    return {
+      ok: false,
+      reason: "format_structure",
+      detail: "la réponse doit être contenue dans une unique balise <synthese>",
+    };
+  }
+
+  const inner = wrapper[1]!;
+  const paragraphBreak = inner.search(/\n\s*\n/u);
+  if (paragraphBreak < 0) {
+    return {
+      ok: false,
+      reason: "format_paragraphes",
+      detail: "le parcours et le programme doivent former deux paragraphes",
+    };
+  }
+  const careerParagraph = inner.slice(0, paragraphBreak);
+  if (careerParagraph.includes("<engagement")) {
+    return {
+      ok: false,
+      reason: "preuve_hors_programme",
+      detail: "une référence de mesure figure dans le paragraphe du parcours",
+    };
+  }
+
+  const plan = buildProgrammePlan(input);
+  const references = new Map(plan.references.map((reference) => [reference.ref, reference]));
+  const themeCounts = new Map<ThemeCategory, number>();
+  const usedReferences = new Set<string>();
+  const engagementPattern = /<engagement ref="(M[1-9][0-9]*)">([^<>]+)<\/engagement>/gu;
+  let failure: SynthesisScreen | null = null;
+  const text = inner.replace(engagementPattern, (_match, ref: string, engagement: string) => {
+    if (failure) return engagement;
+    const source = references.get(ref);
+    if (!source) {
+      failure = {
+        ok: false,
+        reason: "preuve_inconnue",
+        detail: `la référence ${ref} ne correspond à aucune mesure fournie`,
+      };
+      return engagement;
+    }
+    if (usedReferences.has(ref)) {
+      failure = {
+        ok: false,
+        reason: "preuve_repetee",
+        detail: `la référence ${ref} est utilisée plusieurs fois`,
+      };
+      return engagement;
+    }
+    if (!engagementMatchesMeasure(engagement, source.text)) {
+      failure = {
+        ok: false,
+        reason: "preuve_non_refletee",
+        detail: `le passage associé à ${ref} ne reprend pas assez précisément la mesure source`,
+      };
+      return engagement;
+    }
+    usedReferences.add(ref);
+    themeCounts.set(source.theme, (themeCounts.get(source.theme) ?? 0) + 1);
+    return engagement;
+  });
+  if (failure) return failure;
+  if (/[<>]/u.test(text)) {
+    return {
+      ok: false,
+      reason: "format_structure",
+      detail: "une balise interne est absente, inconnue ou mal formée",
+    };
+  }
+  const unreferencedProgramme = inner
+    .slice(paragraphBreak)
+    .replace(/<engagement ref="M[1-9][0-9]*">[^<>]+<\/engagement>/gu, " ");
+  const unreferencedTerms = evidenceTerms(unreferencedProgramme);
+  if (unreferencedTerms.size > 0) {
+    return {
+      ok: false,
+      reason: "engagement_non_reference",
+      detail: `le programme contient du texte de fond sans référence : ${[...unreferencedTerms]
+        .slice(0, 3)
+        .join(", ")}`,
+    };
+  }
+
+  for (const theme of plan.expectedThemes) {
+    if (!themeCounts.has(theme)) {
+      return {
+        ok: false,
+        reason: "couverture_theme",
+        detail: `aucun engagement vérifiable ne représente le thème ${THEME_CATEGORY_LABELS[theme]}`,
+      };
+    }
+  }
+  for (const [theme, count] of themeCounts) {
+    if (count > 2) {
+      return {
+        ok: false,
+        reason: "concentration_theme",
+        detail: `${count} engagements représentent le thème ${THEME_CATEGORY_LABELS[theme]}, maximum 2`,
+      };
+    }
+  }
+
+  return screenSynthesis(text, synthesisMaterial(input));
+}
 
 /**
  * Screens a generated synthesis before anything stores or displays it.

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -360,6 +360,13 @@ export function screenCandidateSynthesis(
 
   const career = wrapper[1]!.trim();
   const programmeOutput = wrapper[2]!.trim();
+  if (!/\p{L}{2,}/u.test(career) || !/[.!?]$/u.test(career)) {
+    return {
+      ok: false,
+      reason: "parcours_vide",
+      detail: "le parcours doit contenir une phrase non vide",
+    };
+  }
   if (/[<>]/u.test(career)) {
     return {
       ok: false,
@@ -380,6 +387,7 @@ export function screenCandidateSynthesis(
     return screenSynthesis({
       text: `${career}\n\n${EMPTY_PROGRAMME_SENTENCE}`,
       generatedText: career,
+      sourceText: "",
       material: synthesisMaterial(input),
     });
   }
@@ -455,6 +463,7 @@ export function screenCandidateSynthesis(
   return screenSynthesis({
     text: `${career}\n\n${programmeText}`,
     generatedText: career,
+    sourceText: selectedReferences.map((reference) => asSentence(reference.text)).join(" "),
     material: synthesisMaterial(input),
   });
 }
@@ -470,6 +479,7 @@ export function screenCandidateSynthesis(
 export function screenSynthesis({
   text: raw,
   generatedText,
+  sourceText,
   material = {
     mandateCount: SUBSTANTIAL_MANDATES,
     voteCount: SUBSTANTIAL_VOTES,
@@ -480,6 +490,8 @@ export function screenSynthesis({
   text: string;
   /** Provider-authored segment only. Judicial vocabulary is forbidden here, not in sources. */
   generatedText: string;
+  /** Canonical source wording inserted by the server and excluded from the flexible maximum. */
+  sourceText: string;
   /** Omitted, the strictest ordinary floor applies. */
   material?: SynthesisMaterial;
 }): SynthesisScreen {
@@ -520,11 +532,20 @@ export function screenSynthesis({
     };
   }
   const maxWords = synthesisTargetRange(material).max;
-  if (words > maxWords) {
+  if (sourceText !== "" && !text.includes(sourceText)) {
+    return {
+      ok: false,
+      reason: "source_absente",
+      detail: "le texte exclu du plafond ne figure pas dans la synthèse finale",
+    };
+  }
+  const sourceWords = sourceText.trim() === "" ? 0 : sourceText.trim().split(/\s+/).length;
+  const cappedWords = Math.max(0, words - sourceWords);
+  if (cappedWords > maxWords) {
     return {
       ok: false,
       reason: "trop_long",
-      detail: `${words} mots, maximum ${maxWords}`,
+      detail: `${cappedWords} mots non sourcés, maximum ${maxWords}`,
     };
   }
 

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -336,6 +336,10 @@ function asSentence(value: string): string {
   return /[.!?]$/u.test(value) ? value : `${value}.`;
 }
 
+function wordCount(value: string): number {
+  return value.trim() === "" ? 0 : value.trim().split(/\s+/).length;
+}
+
 /**
  * Validates the internal evidence markup and returns only the reader-facing prose.
  *
@@ -387,7 +391,7 @@ export function screenCandidateSynthesis(
     return screenSynthesis({
       text: `${career}\n\n${EMPTY_PROGRAMME_SENTENCE}`,
       generatedText: career,
-      sourceText: "",
+      exemptSourceTexts: [],
       material: synthesisMaterial(input),
     });
   }
@@ -460,10 +464,20 @@ export function screenCandidateSynthesis(
   const programmeText = `Son programme comprend notamment les engagements suivants. ${selectedReferences
     .map((reference) => asSentence(reference.text))
     .join(" ")}`;
+  // Coverage needs one measure per expected theme, never every measure the provider selected. When
+  // it chose two, exempt the shorter one: the second is optional and remains inside the cap. Text
+  // from a non-required theme is optional too and is never deducted.
+  const exemptSourceTexts = plan.expectedThemes.map(
+    (theme) =>
+      selectedReferences
+        .filter((reference) => reference.theme === theme)
+        .map((reference) => asSentence(reference.text))
+        .sort((a, b) => wordCount(a) - wordCount(b))[0]!
+  );
   return screenSynthesis({
     text: `${career}\n\n${programmeText}`,
     generatedText: career,
-    sourceText: selectedReferences.map((reference) => asSentence(reference.text)).join(" "),
+    exemptSourceTexts,
     material: synthesisMaterial(input),
   });
 }
@@ -479,7 +493,7 @@ export function screenCandidateSynthesis(
 export function screenSynthesis({
   text: raw,
   generatedText,
-  sourceText,
+  exemptSourceTexts,
   material = {
     mandateCount: SUBSTANTIAL_MANDATES,
     voteCount: SUBSTANTIAL_VOTES,
@@ -490,8 +504,8 @@ export function screenSynthesis({
   text: string;
   /** Provider-authored segment only. Judicial vocabulary is forbidden here, not in sources. */
   generatedText: string;
-  /** Canonical source wording inserted by the server and excluded from the flexible maximum. */
-  sourceText: string;
+  /** One canonical source formulation per mandatory theme, excluded from the flexible maximum. */
+  exemptSourceTexts: string[];
   /** Omitted, the strictest ordinary floor applies. */
   material?: SynthesisMaterial;
 }): SynthesisScreen {
@@ -523,7 +537,7 @@ export function screenSynthesis({
     return { ok: false, reason: "judiciaire", detail: `mention « ${judicial[0]} »` };
   }
 
-  const words = text.split(/\s+/).filter(Boolean).length;
+  const words = wordCount(text);
   if (words < minWords) {
     return {
       ok: false,
@@ -532,14 +546,18 @@ export function screenSynthesis({
     };
   }
   const maxWords = synthesisTargetRange(material).max;
-  if (sourceText !== "" && !text.includes(sourceText)) {
+  const absentSource = exemptSourceTexts.find((sourceText) => !text.includes(sourceText));
+  if (absentSource) {
     return {
       ok: false,
       reason: "source_absente",
       detail: "le texte exclu du plafond ne figure pas dans la synthèse finale",
     };
   }
-  const sourceWords = sourceText.trim() === "" ? 0 : sourceText.trim().split(/\s+/).length;
+  const sourceWords = exemptSourceTexts.reduce(
+    (total, sourceText) => total + wordCount(sourceText),
+    0
+  );
   const cappedWords = Math.max(0, words - sourceWords);
   if (cappedWords > maxWords) {
     return {

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -377,7 +377,11 @@ export function screenCandidateSynthesis(
         detail: "une candidature sans mesure doit utiliser uniquement <programme-vide />",
       };
     }
-    return screenSynthesis(`${career}\n\n${EMPTY_PROGRAMME_SENTENCE}`, synthesisMaterial(input));
+    return screenSynthesis({
+      text: `${career}\n\n${EMPTY_PROGRAMME_SENTENCE}`,
+      generatedText: career,
+      material: synthesisMaterial(input),
+    });
   }
 
   const programme = /^<programme>\s*([\s\S]*?)\s*<\/programme>$/u.exec(programmeOutput);
@@ -448,7 +452,11 @@ export function screenCandidateSynthesis(
   const programmeText = `Son programme comprend notamment les engagements suivants. ${selectedReferences
     .map((reference) => asSentence(reference.text))
     .join(" ")}`;
-  return screenSynthesis(`${career}\n\n${programmeText}`, synthesisMaterial(input));
+  return screenSynthesis({
+    text: `${career}\n\n${programmeText}`,
+    generatedText: career,
+    material: synthesisMaterial(input),
+  });
 }
 
 /**
@@ -459,18 +467,22 @@ export function screenCandidateSynthesis(
  * reach a length, a model that reaches for the em dash it was told not to use.
  * A rejection is not a fallback to a degraded text: the caller stores nothing.
  */
-export function screenSynthesis(
-  raw: string,
-  /**
-   * The material the text was written from. Omitted, it defaults to the richest case, which is the
-   * strictest floor: a caller that forgets to say gets the demanding answer rather than a free pass.
-   */
-  material: SynthesisMaterial = {
+export function screenSynthesis({
+  text: raw,
+  generatedText,
+  material = {
     mandateCount: SUBSTANTIAL_MANDATES,
     voteCount: SUBSTANTIAL_VOTES,
     measureCount: SUBSTANTIAL_MEASURES,
-  }
-): SynthesisScreen {
+  },
+}: {
+  /** Complete reader-facing text, including canonical source wording. */
+  text: string;
+  /** Provider-authored segment only. Judicial vocabulary is forbidden here, not in sources. */
+  generatedText: string;
+  /** Omitted, the strictest ordinary floor applies. */
+  material?: SynthesisMaterial;
+}): SynthesisScreen {
   const minWords = synthesisFloor(material);
   const text = raw.trim();
   if (text === "") return { ok: false, reason: "vide", detail: "le modèle n'a rien renvoyé" };
@@ -482,9 +494,9 @@ export function screenSynthesis(
     return { ok: false, reason: "tiret_long", detail: `caractère « ${dash[0]} » interdit` };
   }
 
-  // Judicial vocabulary. A synthesis that mentions a case is not edited down, it is
-  // thrown away: the model was told plainly, and a text that ignored that rule cannot
-  // be trusted on the rest either.
+  // Judicial vocabulary is screened only in provider-authored prose. Canonical programme measures
+  // may legitimately propose a tribunal or a parquet and are inserted after generation from a
+  // reviewed source. Passing both segments explicitly makes that trust boundary hard to erase.
   //
   // Unicode lookarounds rather than `\b`, and that is not a style choice: `\b` sits
   // between a word character and a non-word one, and JavaScript counts `é` as a
@@ -493,7 +505,7 @@ export function screenSynthesis(
   // followed by one, so the whole family was affected.
   const judicial =
     /(?<!\p{L})(mises? en examen|condamn(?:é|ée|és|ées|ation|ations)|procès|enquête judiciaire|garde à vue|instruction judiciaire|tribunal|cour d'appel|parquet|inéligibilité)(?!\p{L})/iu.exec(
-      text
+      generatedText
     );
   if (judicial) {
     return { ok: false, reason: "judiciaire", detail: `mention « ${judicial[0]} »` };

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -177,6 +177,11 @@ function safe(value: string): string {
   );
 }
 
+/** Reader-facing measure wording, changed only where the house style already requires it. */
+function canonicalMeasureText(value: string): string {
+  return value.replace(/[—–]/g, "-").replace(/\s+/g, " ").trim();
+}
+
 function formatMandate(mandate: SynthesisMandate): string {
   const where = mandate.institution ? ` (${safe(mandate.institution)})` : "";
   const from = mandate.startYear ?? "?";
@@ -211,13 +216,13 @@ Forme :
 - Entre ${synthesisTargetRange(material).min} et ${synthesisTargetRange(material).max} mots au total.
 - Aucun tiret cadratin ni demi-cadratin. Utilise virgules, parenthèses ou deux-points.
 - Pas de phrase de conclusion générale du type « une candidature qui entend peser ». Termine sur un fait.
-- Si le parcours ou le programme est vide, dis-le en une phrase simple plutôt que de meubler.
+- Si le parcours est vide, dis-le en une phrase simple plutôt que de meubler. Le programme vide suit le marqueur imposé ci-dessous et sa phrase est ajoutée par le serveur.
 
 Format interne obligatoire :
-- Place tout le texte dans une unique balise <synthese>...</synthese>, sans titre ni préambule.
-- Dans le paragraphe du programme, entoure chaque engagement cité avec <engagement ref="M1">...</engagement>, en remplaçant M1 par la référence fournie devant la mesure correspondante.
-- Le passage à l'intérieur de la balise engagement doit reprendre assez de mots de la mesure source pour que la référence soit vérifiable.
-- Dans le paragraphe du programme, ne laisse hors de ces balises que la ponctuation, les articles et les mots de liaison. Toute information de fond doit appartenir à un engagement référencé.
+- Place le premier paragraphe dans <parcours>...</parcours>, lui-même dans une unique balise <synthese>...</synthese>.
+- Si des mesures sont fournies, ajoute ensuite <programme> avec uniquement des balises vides <engagement ref="M1" />. Choisis les références qui couvrent les thèmes attendus, sans aucun texte libre dans <programme>.
+- Si aucune mesure n'est fournie, ajoute uniquement <programme-vide /> après le parcours.
+- Le serveur compose lui-même le paragraphe public du programme à partir des formulations exactes référencées. N'écris et ne paraphrase aucun engagement.
 - Ces balises sont retirées après contrôle et ne seront jamais montrées au lecteur.`;
 }
 
@@ -225,7 +230,7 @@ function buildProgrammePlan(input: CandidateSynthesisInput): ProgrammePlan {
   const references = input.measures.map((measure, index) => ({
     ref: `M${index + 1}`,
     theme: measure.theme,
-    text: safe(measure.text),
+    text: canonicalMeasureText(measure.text),
   }));
   const counts = new Map<ThemeCategory, number>();
   for (const reference of references) {
@@ -271,7 +276,7 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
             ([theme, references]) =>
               `${THEME_CATEGORY_LABELS[theme]} (${references.length} mesure${references.length > 1 ? "s" : ""}) :\n${references
                 .sort((a, b) => a.text.localeCompare(b.text, "fr"))
-                .map((reference) => `  - [${reference.ref}] ${reference.text}`)
+                .map((reference) => `  - [${reference.ref}] ${safe(reference.text)}`)
                 .join("\n")}`
           )
           .join("\n")
@@ -324,138 +329,72 @@ export type SynthesisScreen =
   | { ok: true; text: string }
   | { ok: false; reason: string; detail: string };
 
-const EVIDENCE_STOP_WORDS = new Set([
-  "afin",
-  "ainsi",
-  "au",
-  "aux",
-  "avec",
-  "ce",
-  "ces",
-  "cet",
-  "cette",
-  "ceux",
-  "dans",
-  "de",
-  "des",
-  "depuis",
-  "defend",
-  "dont",
-  "du",
-  "elle",
-  "en",
-  "entre",
-  "est",
-  "et",
-  "il",
-  "ils",
-  "la",
-  "le",
-  "les",
-  "leur",
-  "leurs",
-  "lui",
-  "mais",
-  "mesure",
-  "ne",
-  "notamment",
-  "nous",
-  "on",
-  "ou",
-  "par",
-  "pas",
-  "pour",
-  "programme",
-  "propose",
-  "prevoit",
-  "que",
-  "qui",
-  "sans",
-  "se",
-  "sera",
-  "ses",
-  "son",
-  "sont",
-  "sous",
-  "sur",
-  "tous",
-  "tout",
-  "toute",
-  "toutes",
-  "un",
-  "une",
-  "vers",
-  "vos",
-  "votre",
-]);
+export const EMPTY_PROGRAMME_SENTENCE =
+  "Aucune mesure n'est publiée dans le cadre de son programme.";
 
-function evidenceTerms(value: string): Set<string> {
-  const words = value
-    .normalize("NFD")
-    .replace(/\p{M}/gu, "")
-    .toLocaleLowerCase("fr")
-    .match(/[a-z]{2,}|[0-9]+(?:[.,][0-9]+)?%?/g);
-  return new Set(
-    (words ?? [])
-      .filter((word) => !EVIDENCE_STOP_WORDS.has(word))
-      .map((word) => (word.length > 6 ? word.slice(0, 6) : word))
-  );
-}
-
-function engagementMatchesMeasure(engagement: string, measure: string): boolean {
-  const sourceTerms = evidenceTerms(measure);
-  const engagementTerms = evidenceTerms(engagement);
-  const shared = [...sourceTerms].filter((term) => engagementTerms.has(term)).length;
-  return sourceTerms.size > 0 && shared >= Math.min(2, sourceTerms.size);
+function asSentence(value: string): string {
+  return /[.!?]$/u.test(value) ? value : `${value}.`;
 }
 
 /**
  * Validates the internal evidence markup and returns only the reader-facing prose.
  *
- * Theme names reported beside the prose would be unverifiable declarations by the same model that
- * wrote it. Instead, each cited engagement carries a measure reference in the exact span rendered
- * as prose. The screen resolves that reference itself, checks that the span shares source wording,
- * derives its theme from the database input, and only then applies coverage and concentration.
+ * Theme names or paraphrases reported beside the prose would be unverifiable declarations by the
+ * same model that wrote it. The provider therefore returns references only. The screen resolves
+ * them against the input, derives their themes, and constructs the public paragraph from the
+ * canonical source wording. No generated verb can reverse or soften a published action.
  */
 export function screenCandidateSynthesis(
   raw: string,
   input: CandidateSynthesisInput
 ): SynthesisScreen {
-  const wrapper = /^<synthese>\s*([\s\S]*?)\s*<\/synthese>$/u.exec(raw.trim());
+  const wrapper =
+    /^<synthese>\s*<parcours>([\s\S]*?)<\/parcours>\s*([\s\S]*?)\s*<\/synthese>$/u.exec(raw.trim());
   if (!wrapper) {
     return {
       ok: false,
       reason: "format_structure",
-      detail: "la réponse doit être contenue dans une unique balise <synthese>",
+      detail: "la réponse doit contenir un parcours structuré dans une unique balise <synthese>",
     };
   }
 
-  const inner = wrapper[1]!;
-  const paragraphBreak = inner.search(/\n\s*\n/u);
-  if (paragraphBreak < 0) {
+  const career = wrapper[1]!.trim();
+  const programmeOutput = wrapper[2]!.trim();
+  if (/[<>]/u.test(career)) {
     return {
       ok: false,
-      reason: "format_paragraphes",
-      detail: "le parcours et le programme doivent former deux paragraphes",
-    };
-  }
-  const careerParagraph = inner.slice(0, paragraphBreak);
-  if (careerParagraph.includes("<engagement")) {
-    return {
-      ok: false,
-      reason: "preuve_hors_programme",
-      detail: "une référence de mesure figure dans le paragraphe du parcours",
+      reason: "format_structure",
+      detail: "le parcours contient une balise interne interdite",
     };
   }
 
   const plan = buildProgrammePlan(input);
+  if (plan.references.length === 0) {
+    if (!/^<programme-vide\s*\/>$/u.test(programmeOutput)) {
+      return {
+        ok: false,
+        reason: "programme_vide_invalide",
+        detail: "une candidature sans mesure doit utiliser uniquement <programme-vide />",
+      };
+    }
+    return screenSynthesis(`${career}\n\n${EMPTY_PROGRAMME_SENTENCE}`, synthesisMaterial(input));
+  }
+
+  const programme = /^<programme>\s*([\s\S]*?)\s*<\/programme>$/u.exec(programmeOutput);
+  if (!programme) {
+    return {
+      ok: false,
+      reason: "format_programme",
+      detail: "les références doivent être contenues dans une unique balise <programme>",
+    };
+  }
   const references = new Map(plan.references.map((reference) => [reference.ref, reference]));
   const themeCounts = new Map<ThemeCategory, number>();
   const usedReferences = new Set<string>();
-  const engagementPattern = /<engagement ref="(M[1-9][0-9]*)">([^<>]+)<\/engagement>/gu;
-  let failure: SynthesisScreen | null = null;
-  const text = inner.replace(engagementPattern, (_match, ref: string, engagement: string) => {
-    if (failure) return engagement;
+  const selectedReferences: ProgrammeReference[] = [];
+  const engagementPattern = /<engagement ref="(M[1-9][0-9]*)"\s*\/>/gu;
+  let failure: Extract<SynthesisScreen, { ok: false }> | null = null;
+  const remainder = programme[1]!.replace(engagementPattern, (_match, ref: string) => {
     const source = references.get(ref);
     if (!source) {
       failure = {
@@ -463,7 +402,7 @@ export function screenCandidateSynthesis(
         reason: "preuve_inconnue",
         detail: `la référence ${ref} ne correspond à aucune mesure fournie`,
       };
-      return engagement;
+      return "";
     }
     if (usedReferences.has(ref)) {
       failure = {
@@ -471,39 +410,19 @@ export function screenCandidateSynthesis(
         reason: "preuve_repetee",
         detail: `la référence ${ref} est utilisée plusieurs fois`,
       };
-      return engagement;
-    }
-    if (!engagementMatchesMeasure(engagement, source.text)) {
-      failure = {
-        ok: false,
-        reason: "preuve_non_refletee",
-        detail: `le passage associé à ${ref} ne reprend pas assez précisément la mesure source`,
-      };
-      return engagement;
+      return "";
     }
     usedReferences.add(ref);
+    selectedReferences.push(source);
     themeCounts.set(source.theme, (themeCounts.get(source.theme) ?? 0) + 1);
-    return engagement;
+    return "";
   });
   if (failure) return failure;
-  if (/[<>]/u.test(text)) {
+  if (remainder.trim() !== "") {
     return {
       ok: false,
       reason: "format_structure",
-      detail: "une balise interne est absente, inconnue ou mal formée",
-    };
-  }
-  const unreferencedProgramme = inner
-    .slice(paragraphBreak)
-    .replace(/<engagement ref="M[1-9][0-9]*">[^<>]+<\/engagement>/gu, " ");
-  const unreferencedTerms = evidenceTerms(unreferencedProgramme);
-  if (unreferencedTerms.size > 0) {
-    return {
-      ok: false,
-      reason: "engagement_non_reference",
-      detail: `le programme contient du texte de fond sans référence : ${[...unreferencedTerms]
-        .slice(0, 3)
-        .join(", ")}`,
+      detail: "le programme doit contenir uniquement des références de mesures sans texte libre",
     };
   }
 
@@ -526,7 +445,10 @@ export function screenCandidateSynthesis(
     }
   }
 
-  return screenSynthesis(text, synthesisMaterial(input));
+  const programmeText = `Son programme comprend notamment les engagements suivants. ${selectedReferences
+    .map((reference) => asSentence(reference.text))
+    .join(" ")}`;
+  return screenSynthesis(`${career}\n\n${programmeText}`, synthesisMaterial(input));
 }
 
 /**

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -30,8 +30,10 @@ vi.mock("@/lib/api/mistral", () => ({
   extractMistralText: (response: { text: string }) => response.text,
 }));
 
-/** A text that clears every rule of `screenSynthesis`: no long dash, no judicial term, 90+ words. */
-const ACCEPTED = `${Array.from({ length: 120 }, (_, i) => `mot${i}`).join(" ")}.`;
+const CAREER = Array.from({ length: 40 }, (_, i) => `parcours${i}`).join(" ");
+/** Internal provider output and the reader-facing text obtained after evidence screening. */
+const ACCEPTED = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
+const STORED = `${CAREER}.\n\nLe programme prévoit de rouvrir des maternités de proximité.`;
 
 function anthropicText(text: string) {
   return { content: [{ type: "text", text }] };
@@ -74,7 +76,7 @@ describe("generateCandidateSynthesis", () => {
     expect(result).toMatchObject({ ok: true, provider: "anthropic", measureCount: 1 });
     const write = dbMock.candidacyPresidential.update.mock.calls[0]![0];
     expect(write.where).toEqual({ id: "pres-1" });
-    expect(write.data.synthesis).toBe(ACCEPTED);
+    expect(write.data.synthesis).toBe(STORED);
     expect(write.data.synthesisGeneratedAt).toBeInstanceOf(Date);
     expect(dbMock.auditLog.create).toHaveBeenCalled();
   });
@@ -118,11 +120,13 @@ describe("generateCandidateSynthesis", () => {
     dbMock.measure.findMany.mockResolvedValue(
       Array.from({ length: 5 }, (_, i) => ({
         theme: "SANTE",
-        publishedRevision: { text: `Mesure ${i}.` },
+        publishedRevision: { text: `Rouvrir des maternités de proximité ${i}.` },
       }))
     );
     callAnthropicMock.mockResolvedValue(
-      anthropicText(`${Array.from({ length: 81 }, (_, i) => `mot${i}`).join(" ")}.`)
+      anthropicText(
+        `<synthese>${Array.from({ length: 30 }, (_, i) => `parcours${i}`).join(" ")}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`
+      )
     );
     const { generateCandidateSynthesis } = await service();
 
@@ -163,7 +167,11 @@ describe("generateCandidateSynthesis", () => {
 
   it("réessaie une fois en nommant la règle enfreinte, puis stocke", async () => {
     callAnthropicMock
-      .mockResolvedValueOnce(anthropicText(`Un tiret cadratin — interdit. ${ACCEPTED}`))
+      .mockResolvedValueOnce(
+        anthropicText(
+          `<synthese>Un tiret cadratin — interdit. ${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`
+        )
+      )
       .mockResolvedValueOnce(anthropicText(ACCEPTED));
     const { generateCandidateSynthesis } = await service();
 
@@ -182,6 +190,47 @@ describe("generateCandidateSynthesis", () => {
     const result = await generateCandidateSynthesis("cand-1", { persist: true });
 
     expect(result).toMatchObject({ ok: false, reason: "refuse" });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
+
+  it("réessaie une prose équilibrée en longueur mais incomplète en thèmes", async () => {
+    dbMock.measure.findMany.mockResolvedValue([
+      { theme: "SANTE", publishedRevision: { text: "Rouvrir des maternités de proximité." } },
+      {
+        theme: "TRANSPORTS",
+        publishedRevision: { text: "Rétablir des trains de nuit sur six lignes." },
+      },
+    ]);
+    const incomplete = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
+    const complete = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M2">rétablir des trains de nuit sur six lignes</engagement>.</synthese>`;
+    callAnthropicMock
+      .mockResolvedValueOnce(anthropicText(incomplete))
+      .mockResolvedValueOnce(anthropicText(complete));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    const retryPrompt = callAnthropicMock.mock.calls[1]![0][0].content as string;
+    expect(retryPrompt).toContain("aucun engagement vérifiable ne représente le thème Transports");
+    expect(dbMock.candidacyPresidential.update).toHaveBeenCalledOnce();
+  });
+
+  it("ne persiste pas deux réponses qui dépassent le plafond par thème", async () => {
+    dbMock.measure.findMany.mockResolvedValue([
+      { theme: "SANTE", publishedRevision: { text: "Rouvrir des maternités de proximité." } },
+      { theme: "SANTE", publishedRevision: { text: "Rembourser les soins prescrits." } },
+      { theme: "SANTE", publishedRevision: { text: "Créer des centres de santé publics." } },
+    ]);
+    const concentrated = `<synthese>${CAREER}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>, de <engagement ref="M2">rembourser les soins prescrits</engagement> et de <engagement ref="M3">créer des centres de santé publics</engagement>.</synthese>`;
+    callAnthropicMock.mockResolvedValue(anthropicText(concentrated));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "refuse" });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
     expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
   });
 });

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -307,4 +307,35 @@ describe("generateCandidateSynthesis", () => {
       "Créer un tribunal spécialisé."
     );
   });
+
+  it("réessaie un parcours vide avant de persister", async () => {
+    const emptyCareer = `<synthese><parcours></parcours><programme><engagement ref="M1" /></programme></synthese>`;
+    callAnthropicMock
+      .mockResolvedValueOnce(anthropicText(emptyCareer))
+      .mockResolvedValueOnce(anthropicText(providerOutput(["M1"])));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    expect(dbMock.candidacyPresidential.update).toHaveBeenCalledOnce();
+  });
+
+  it("persiste une mesure canonique qui dépasse à elle seule le plafond fixe", async () => {
+    const longMeasure = Array.from({ length: 220 }, (_, i) => `source${i}`).join(" ");
+    dbMock.measure.findMany.mockResolvedValue([
+      { theme: "SANTE", publishedRevision: { text: `${longMeasure}.` } },
+    ]);
+    callAnthropicMock.mockResolvedValue(anthropicText(providerOutput(["M1"])));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(1);
+    expect(dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis).toContain(
+      "source219."
+    );
+  });
 });

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -283,4 +283,28 @@ describe("generateCandidateSynthesis", () => {
       "Aucune mesure n'est publiée dans le cadre de son programme."
     );
   });
+
+  it("réessaie un tribunal généré dans le parcours puis stocke le tribunal sourcé", async () => {
+    dbMock.measure.findMany.mockResolvedValue([
+      {
+        theme: "SECURITE_JUSTICE",
+        publishedRevision: { text: "Créer un tribunal spécialisé." },
+      },
+    ]);
+    const unsafeCareer = `<synthese><parcours>${CAREER}. Il a comparu devant un tribunal.</parcours><programme><engagement ref="M1" /></programme></synthese>`;
+    callAnthropicMock
+      .mockResolvedValueOnce(anthropicText(unsafeCareer))
+      .mockResolvedValueOnce(anthropicText(providerOutput(["M1"])));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    const retryPrompt = callAnthropicMock.mock.calls[1]![0][0].content as string;
+    expect(retryPrompt).toContain("mention « tribunal »");
+    expect(dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis).toContain(
+      "Créer un tribunal spécialisé."
+    );
+  });
 });

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -338,4 +338,20 @@ describe("generateCandidateSynthesis", () => {
       "source219."
     );
   });
+
+  it("ne persiste pas une seconde formulation optionnelle qui dépasse le plafond", async () => {
+    const longOptional = Array.from({ length: 220 }, (_, i) => `option${i}`).join(" ");
+    dbMock.measure.findMany.mockResolvedValue([
+      { theme: "SANTE", publishedRevision: { text: "Rouvrir des maternités de proximité." } },
+      { theme: "SANTE", publishedRevision: { text: `${longOptional}.` } },
+    ]);
+    callAnthropicMock.mockResolvedValue(anthropicText(providerOutput(["M2", "M1"])));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: false, reason: "refuse" });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -31,9 +31,13 @@ vi.mock("@/lib/api/mistral", () => ({
 }));
 
 const CAREER = Array.from({ length: 40 }, (_, i) => `parcours${i}`).join(" ");
+const providerOutput = (refs: string[], career = CAREER) =>
+  `<synthese><parcours>${career}.</parcours><programme>${refs
+    .map((ref) => `<engagement ref="${ref}" />`)
+    .join("")}</programme></synthese>`;
 /** Internal provider output and the reader-facing text obtained after evidence screening. */
-const ACCEPTED = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
-const STORED = `${CAREER}.\n\nLe programme prévoit de rouvrir des maternités de proximité.`;
+const ACCEPTED = providerOutput(["M1"]);
+const STORED = `${CAREER}.\n\nSon programme comprend notamment les engagements suivants. Rouvrir des maternités de proximité.`;
 
 function anthropicText(text: string) {
   return { content: [{ type: "text", text }] };
@@ -125,7 +129,7 @@ describe("generateCandidateSynthesis", () => {
     );
     callAnthropicMock.mockResolvedValue(
       anthropicText(
-        `<synthese>${Array.from({ length: 30 }, (_, i) => `parcours${i}`).join(" ")}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`
+        providerOutput(["M1"], Array.from({ length: 30 }, (_, i) => `parcours${i}`).join(" "))
       )
     );
     const { generateCandidateSynthesis } = await service();
@@ -169,7 +173,7 @@ describe("generateCandidateSynthesis", () => {
     callAnthropicMock
       .mockResolvedValueOnce(
         anthropicText(
-          `<synthese>Un tiret cadratin — interdit. ${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`
+          `<synthese><parcours>Un tiret cadratin — interdit. ${CAREER}.</parcours><programme><engagement ref="M1" /></programme></synthese>`
         )
       )
       .mockResolvedValueOnce(anthropicText(ACCEPTED));
@@ -201,8 +205,8 @@ describe("generateCandidateSynthesis", () => {
         publishedRevision: { text: "Rétablir des trains de nuit sur six lignes." },
       },
     ]);
-    const incomplete = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement>.</synthese>`;
-    const complete = `<synthese>${CAREER}.\n\nLe programme prévoit de <engagement ref="M1">rouvrir des maternités de proximité</engagement> et de <engagement ref="M2">rétablir des trains de nuit sur six lignes</engagement>.</synthese>`;
+    const incomplete = providerOutput(["M1"]);
+    const complete = providerOutput(["M1", "M2"]);
     callAnthropicMock
       .mockResolvedValueOnce(anthropicText(incomplete))
       .mockResolvedValueOnce(anthropicText(complete));
@@ -223,7 +227,7 @@ describe("generateCandidateSynthesis", () => {
       { theme: "SANTE", publishedRevision: { text: "Rembourser les soins prescrits." } },
       { theme: "SANTE", publishedRevision: { text: "Créer des centres de santé publics." } },
     ]);
-    const concentrated = `<synthese>${CAREER}.\n\nLe programme propose de <engagement ref="M1">rouvrir des maternités de proximité</engagement>, de <engagement ref="M2">rembourser les soins prescrits</engagement> et de <engagement ref="M3">créer des centres de santé publics</engagement>.</synthese>`;
+    const concentrated = providerOutput(["M1", "M2", "M3"]);
     callAnthropicMock.mockResolvedValue(anthropicText(concentrated));
     const { generateCandidateSynthesis } = await service();
 
@@ -232,5 +236,51 @@ describe("generateCandidateSynthesis", () => {
     expect(result).toMatchObject({ ok: false, reason: "refuse" });
     expect(callAnthropicMock).toHaveBeenCalledTimes(2);
     expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+  });
+
+  it("réessaie une action inversée puis persiste uniquement la formulation source", async () => {
+    dbMock.measure.findMany.mockResolvedValue([
+      {
+        theme: "ECONOMIE_BUDGET",
+        publishedRevision: { text: "Augmenter les impôts des entreprises." },
+      },
+    ]);
+    const reversed = `<synthese><parcours>${CAREER}.</parcours><programme><engagement ref="M1">Supprimer les impôts des entreprises.</engagement></programme></synthese>`;
+    callAnthropicMock
+      .mockResolvedValueOnce(anthropicText(reversed))
+      .mockResolvedValueOnce(anthropicText(providerOutput(["M1"])));
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    const stored = dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis as string;
+    expect(stored).toContain("Augmenter les impôts des entreprises.");
+    expect(stored).not.toContain("Supprimer");
+  });
+
+  it("réessaie puis persiste la phrase canonique d'absence pour une candidature sans mesure", async () => {
+    dbMock.measure.findMany.mockResolvedValue([]);
+    callAnthropicMock
+      .mockResolvedValueOnce(
+        anthropicText(
+          `<synthese><parcours>${CAREER}.</parcours><programme>Aucune mesure n'est publiée dans le cadre de son programme.</programme></synthese>`
+        )
+      )
+      .mockResolvedValueOnce(
+        anthropicText(`<synthese><parcours>${CAREER}.</parcours><programme-vide /></synthese>`)
+      );
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true, measureCount: 0 });
+    expect(callAnthropicMock).toHaveBeenCalledTimes(2);
+    const retryPrompt = callAnthropicMock.mock.calls[1]![0][0].content as string;
+    expect(retryPrompt).toContain("une candidature sans mesure doit utiliser uniquement");
+    expect(dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis).toContain(
+      "Aucune mesure n'est publiée dans le cadre de son programme."
+    );
   });
 });

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -19,7 +19,7 @@ import { db } from "@/lib/db";
 import {
   buildCandidateSynthesisPrompt,
   buildSynthesisSystemPrompt,
-  screenSynthesis,
+  screenCandidateSynthesis,
   synthesisMaterial,
   type CandidateSynthesisInput,
 } from "@/lib/presidentielle/candidate-synthesis";
@@ -223,7 +223,7 @@ export async function generateCandidateSynthesis(
       message: error instanceof Error ? error.message : String(error),
     };
   }
-  let screened = screenSynthesis(attempt.text, material);
+  let screened = screenCandidateSynthesis(attempt.text, input);
 
   // One retry, naming the rule that was broken. Measured on a first full run: the model obeys the
   // rules it is reminded of and slips on the ones it is only told once, the long dash above all.
@@ -242,7 +242,7 @@ export async function generateCandidateSynthesis(
         message: error instanceof Error ? error.message : String(error),
       };
     }
-    screened = screenSynthesis(attempt.text, material);
+    screened = screenCandidateSynthesis(attempt.text, input);
   }
 
   if (!screened.ok) {


### PR DESCRIPTION
## Correctif P1

Corrige le commentaire inline de la PR #774 : les consignes de couverture thématique sont désormais contrôlées avant toute persistance.

## Garanties

- chaque engagement porte une référence interne vers une mesure fournie
- le thème est dérivé côté serveur depuis cette référence
- le passage doit reprendre des termes vérifiables de la mesure
- couverture obligatoire des thèmes attendus
- maximum de deux engagements par thème
- contenu programmatique non référencé refusé
- balises internes retirées avant stockage et affichage
- retry existant déclenché avec la cause précise

## Vérifications

- 62 tests ciblés Vitest
- ESLint et Prettier ciblés
- git diff --check ciblé

Le typecheck global est actuellement perturbé par des modifications locales non incluses dans cette PR. La CI exécute le contrôle sur la branche propre.

Fixes review comment https://github.com/ironlam/poligraph/pull/774#discussion_r3881608052