### PR TITLE
fix(presidentielle): retirer la redondance "mesures" sur les boutons de sujet

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
@@ -79,7 +79,7 @@ describe("CandidateThemes", () => {
     );
 
     expect(screen.queryByText("Mesure 1.")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Voir les 16 mesures" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Voir ces mesures" })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats/camille-riviere/mesures?theme=sante"
     );

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -231,7 +231,7 @@ export function CandidateThemes({
                       "min-h-11 w-full justify-between whitespace-normal px-4 text-left sm:w-auto"
                     )}
                   >
-                    Voir les {t.measureCount} {t.measureCount === 1 ? "mesure" : "mesures"}
+                    Voir {t.measureCount === 1 ? "cette mesure" : "ces mesures"}
                     <ArrowRight aria-hidden="true" />
                   </Link>
                 </div>


### PR DESCRIPTION
Chaque sujet affichait déjà "X mesures" dans son en-tête, puis répétait
"Voir les X mesures" dans le bouton. Le bouton dit maintenant "Voir cette
mesure" / "Voir ces mesures", ce qui règle au passage l'accord du pluriel.

