### PR TITLE
feat(presidentielle): améliorer le hub, les fiches et la comparaison

### DIFF
--- a/docs/design/comparaison-presidentielle-2027.md
+++ b/docs/design/comparaison-presidentielle-2027.md
@@ -1,0 +1,115 @@
+# Comparaison factuelle des candidatures à la présidentielle 2027
+
+## Objectif
+
+Permettre de placer côte à côte les mesures publiées de deux ou trois personnalités, par thème et
+par sous-thème, sans score, recommandation, résumé libre ni jugement de faisabilité.
+
+La comparaison porte sur le corpus Poligraph, pas sur une prétendue exhaustivité des programmes.
+Une cellule vide doit donc dire « Poligraph n'a pas encore trouvé ou traité de mesure sur ce
+sujet », jamais « cette personnalité ne propose rien ».
+
+## Parcours retenu
+
+Route : `/elections/presidentielle-2027/comparer`.
+
+État partageable dans l'URL :
+
+- `candidat=slug-a&candidat=slug-b`, deux personnes au minimum, trois au maximum ;
+- `theme=logement-urbanisme`, obligatoire pour afficher la comparaison ;
+- `sous-theme=logement-social`, facultatif.
+
+Entrées vers ce parcours :
+
+1. une action « Comparer » sur les fiches candidates et les pages thématiques ;
+2. la sélection d'une deuxième personnalité dans un panneau dédié ;
+3. un lien partageable qui conserve les personnes et le sujet choisis.
+
+Sur mobile, les personnalités sont présentées l'une après l'autre. On évite un tableau horizontal
+illisible. Sur écran large, deux ou trois colonnes sont affichées côte à côte. L'ordre des
+personnalités reste alphabétique. Le filtre par sous-thème viendra ensuite, après mesure de la
+couverture des affectations validées.
+
+Chaque personnalité dispose de sa propre pagination, conservée dans l'URL. Cette indépendance évite
+qu'un programme très long impose plusieurs écrans vides à une personnalité qui ne porte qu'une
+mesure sur le thème. Six mesures sont affichées par page et aucun extrait n'est présenté comme un
+échantillon éditorial.
+
+Les liens de pagination utilisent la navigation Next.js avec `scroll={false}` lorsque JavaScript
+est disponible : la colonne mise à jour reste dans le champ de lecture et son compteur est annoncé
+par une région `aria-live`. Les mêmes liens sont des URL ordinaires sans JavaScript, ce qui garantit
+un rechargement complet fonctionnel et partageable sans maintenir une seconde API.
+
+## Module de données
+
+Créer un module profond dans `src/lib/data/presidential-comparison.ts` avec une seule interface :
+
+```ts
+getPresidentialComparison({
+  electionSlug,
+  candidateSlugs,
+  theme,
+  subtopicSlug,
+}): Promise<PresidentialComparison | null>
+```
+
+Son implémentation réutilise les autorités publiques existantes : mesures publiées, fiche de
+candidature ouverte, sources et affectations de sous-thèmes `APPROVED`. Le module prend aussi en
+charge l'ordre, les limites, les retraits et les libellés de couverture. Les pages ne construisent
+aucun filtre Prisma.
+
+L'analyse par IA reste en amont : elle peut suggérer les sous-thèmes pendant l'import, mais seule
+une affectation validée par l'équipe éditoriale structure la comparaison publique. Aucun appel à un
+modèle n'est déclenché à la consultation.
+
+## Présentation
+
+Chaque mesure conserve :
+
+- sa formulation publiée sans reformulation comparative ;
+- le lien vers sa page canonique ;
+- sa source primaire ou secondaire ;
+- son statut de retrait éventuel ;
+- les qualifications éditoriales déjà validées.
+
+Le haut de page affiche le périmètre : nombre de mesures traitées, date de dernière revue et rappel
+que les volumes reflètent le corpus Poligraph. Aucun total n'est transformé en score.
+
+## Synthèse factuelle par thème
+
+La fiche d'une candidature peut afficher une courte synthèse avant les mesures d'un thème lorsque
+celui-ci contient au moins trois mesures. Cette synthèse décrit les orientations communes présentes
+dans le corpus, sans en déduire une intention, une faisabilité ou une priorité politique.
+
+Le texte doit être stocké et daté, citer les identifiants des mesures qui l'étayent, puis être
+invalidé dès qu'une de ces mesures change ou qu'une nouvelle mesure est publiée dans le thème. Le
+modèle peut proposer le texte en amont, mais aucune génération n'a lieu pendant la consultation et
+la publication reste soumise à une validation éditoriale.
+
+Dans l'interface :
+
+- 40 à 60 mots au maximum, directement sous le titre du thème ;
+- un libellé visible « Synthèse des mesures publiées » ;
+- un accès aux mesures utilisées comme références ;
+- aucun résumé pour un thème ne contenant qu'une ou deux mesures, où le texte serait redondant ;
+- sur la comparaison, la synthèse précède les mesures de chaque personnalité sans remplacer les
+  formulations originales.
+
+## SEO et accessibilité
+
+La page de comparaison est `noindex,follow` : ses combinaisons de paramètres sont nombreuses et
+dupliquent des contenus canoniques. Les pages mesure, candidat et thème restent les surfaces à
+indexer.
+
+Les sélecteurs utilisent des libellés visibles, des groupes de cases à cocher et une annonce
+`aria-live` lors de la mise à jour. Les intitulés de personne et de sous-thème restent associés à
+chaque mesure sur mobile, sans dépendre de la couleur ou de la position d'une colonne.
+
+## Découpage de livraison
+
+1. Module de données et tests d'invariants éditoriaux.
+2. Sélecteur de deux ou trois personnalités et URL partageable.
+3. Vue par thème, responsive et accessible.
+4. Entrées depuis les fiches candidates, les thèmes et les pages mesure.
+5. Ajout facultatif du filtre par sous-thème après validation de la couverture réelle des
+   affectations `APPROVED`.

--- a/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
+++ b/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
@@ -1,0 +1,179 @@
+# Enrichissement des pages de mesure présidentielle 2027
+
+## Objectif
+
+Faire de chaque page mesure une fiche de référence utile même lorsqu'elle est consultée directement,
+sans ajouter de texte pour atteindre une longueur arbitraire. Google recommande un contenu fiable,
+original et pensé pour répondre au besoin du lecteur, plutôt qu'un volume de texte produit pour le
+référencement. La page doit donc aider à comprendre la formulation, retrouver son contexte exact et
+la comparer à des propositions proches.
+
+Référence : [Creating helpful, reliable, people-first content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content).
+
+## État actuel
+
+La page possède déjà :
+
+- une URL stable et descriptive ;
+- un titre et une description SEO propres à la mesure ;
+- le thème, le niveau de précision et la date de revue ;
+- l'édition du programme dont elle provient ;
+- le candidat ou la candidate qui la porte ;
+- la source primaire avec son emplacement dans le document ;
+- des mesures d'autres candidats sur le même thème ;
+- les votes parlementaires lorsqu'un rapprochement a été validé ;
+- un fil d'Ariane, un canonical et des données structurées.
+
+Dans la base locale auditée le 29 août 2026, les 1 402 mesures publiées sont rattachées à une édition
+de programme. Les champs `details`, qualifications, sous-thèmes approuvés et liens de vote sont
+encore vides. Le premier enjeu n'est donc pas d'ajouter de nouveaux blocs, mais d'alimenter les
+structures éditoriales déjà prévues.
+
+## Contenu cible d'une fiche
+
+### 1. Ce que prévoit la mesure
+
+Utiliser `MeasureRevision.details`, déjà versionné et lié à la formulation publiée. Ce texte doit
+apporter uniquement des précisions présentes dans la source : mécanisme annoncé, population ou
+territoire concernés, calendrier, seuils, exceptions et articulation avec une mesure voisine du
+même programme.
+
+Règles proposées :
+
+- 80 à 250 mots lorsque la source contient réellement ces informations ;
+- aucune reformulation sur la faisabilité, l'intention ou les effets supposés ;
+- chaque élément doit être vérifiable dans une source attachée à la révision ;
+- génération par IA autorisée comme proposition de brouillon, jamais comme publication automatique ;
+- validation humaine et date de revue obligatoires.
+
+Lorsque la source ne dit rien de plus que le titre, le bloc reste absent. Un texte redondant ferait
+baisser la valeur de la page au lieu de l'améliorer.
+
+### 2. Repères structurés
+
+Afficher les informations validées sous forme de liste courte :
+
+- attribution personnelle ou reprise du programme du parti ;
+- sous-thèmes approuvés ;
+- calendrier précisé ;
+- financement non précisé ;
+- périmètre incertain ;
+- mesure déjà tentée, avec sa source.
+
+Ces éléments existent déjà dans `MeasureRevisionSubtopic` et `MeasureQualification`. Les libellés
+publics doivent expliquer le constat sans suggérer une note ou un jugement.
+
+### 3. Contexte dans le programme
+
+Conserver le bloc désormais présent, puis l'enrichir avec :
+
+- l'emplacement exact dans le document ;
+- le chapitre ou l'axe du programme ;
+- un lien vers les autres mesures publiées du même chapitre ;
+- une courte citation seulement lorsqu'elle apporte un contexte distinct et respecte les limites de
+  reproduction de la source.
+
+L'emplacement est aujourd'hui stocké dans `MeasureSource.page`. Si le chapitre doit devenir un outil
+de navigation, il faudra le modéliser dans l'édition du programme plutôt que le déduire à chaque
+affichage depuis une chaîne libre.
+
+### 4. Comparaisons réellement proches
+
+Les cartes actuelles utilisent le thème général faute de sous-thèmes approuvés. Une fois la
+classification relue :
+
+- proposer en priorité les mesures partageant un sous-thème ;
+- afficher le sous-thème commun ;
+- garantir au maximum une mesure par candidat ;
+- conserver l'ordre alphabétique ;
+- proposer ensuite la comparaison complète du thème.
+
+Le classement sémantique peut suggérer des rapprochements en administration, mais il ne doit pas
+ordonner seul les candidats sur la page publique.
+
+### 5. Votes et historique
+
+Lorsqu'un rapprochement manuel existe, expliquer factuellement la relation avec le scrutin et son
+périmètre. Lorsqu'une mesure reprend une proposition d'une campagne précédente, utiliser les liens
+`precedingMeasure` et `followingMeasures` pour présenter une chronologie sourcée.
+
+Ne jamais afficher un bloc vide ou une mention générique indiquant que le travail reste à faire.
+
+## Maillage interne
+
+Chaque fiche doit conduire vers :
+
+- la fiche du candidat ;
+- l'édition complète du programme ;
+- la page du thème et, plus tard, du sous-thème ;
+- les mesures proches d'autres candidats ;
+- les autres mesures du même candidat sur ce sous-thème ;
+- le scrutin lié lorsqu'il existe.
+
+Le maillage doit aussi fonctionner dans l'autre sens : programme, candidat, thème, sous-thème et
+comparateur doivent tous pouvoir mener à l'URL canonique de la mesure.
+
+## Doctrine d'indexation
+
+Ne pas supposer que les 1 402 pages méritent toutes le même verdict. Avant d'ajouter une règle,
+mesurer sur la production la répartition des signaux suivants :
+
+- source primaire et emplacement précis ;
+- détails relus suffisamment distincts du titre ;
+- au moins un sous-thème approuvé ;
+- qualification sourcée ;
+- vote ou filiation validé ;
+- plusieurs liens entrants contextuels.
+
+Construire ensuite un prédicat pur dans `src/lib/seo/measure-robots.ts`, partagé par les métadonnées
+et le sitemap, puis le couvrir dans `indexation-doctrine.test.ts`. Aucun seuil ne doit être choisi
+avant ce comptage : un signal devenu universel ne distingue plus une fiche riche d'une fiche mince.
+
+Dans l'intervalle, conserver les pages publiées indexables. Les masquer toutes avant d'avoir des
+données Search Console et une mesure du contenu réel détruirait le bénéfice des URL déjà diffusées.
+
+## Données structurées et confiance
+
+Auditer l'usage actuel de `ArticleJsonLd` : une fiche mesure n'est pas nécessairement un article.
+Privilégier un `WebPage` avec fil d'Ariane, entité `about`, dates de publication et de modification si
+ce modèle décrit plus honnêtement le contenu. Les données structurées doivent refléter ce que le
+lecteur voit, pas viser artificiellement un résultat enrichi.
+
+Ajouter près de la date une mention courte de la revue par Poligraph, avec un lien vers la méthode.
+La page doit rendre immédiatement visibles la source, la date et la manière dont le contenu a été
+produit ou vérifié.
+
+## Administration et chaîne éditoriale
+
+Ajouter à l'administration d'une révision publiée :
+
+1. édition des `details` avec aperçu public ;
+2. propositions de sous-thèmes, puis approbation ou rejet humain ;
+3. qualifications avec justification et source ;
+4. contrôle de complétude avant publication ;
+5. filtre « fiche publique à enrichir » ;
+6. traitement par lots assisté par Mistral, sans publication automatique.
+
+Le contrôle de complétude signale les champs manquants, mais ne bloque pas une mesure dont la source
+ne permet honnêtement aucun enrichissement.
+
+## Ordre de livraison
+
+1. Mesurer la couverture réelle des signaux et définir le tableau de bord d'enrichissement.
+2. Alimenter et publier `details` sur un échantillon de 30 mesures couvrant plusieurs candidats et
+   thèmes.
+3. Valider les sous-thèmes et améliorer les mesures connexes.
+4. Publier les qualifications sourcées déjà prévues par le modèle.
+5. Ajouter la navigation par chapitre de programme si les imports fournissent une structure fiable.
+6. Calibrer le prédicat d'indexation avec les données de production et Search Console.
+7. Étendre progressivement le traitement, avec audit éditorial par lots.
+
+## Critères de réussite
+
+- un lecteur comprend ce qui est annoncé sans ouvrir immédiatement le PDF ;
+- chaque précision reste traçable à une source ;
+- aucune page ne contient un résumé redondant ou une appréciation de faisabilité ;
+- les mesures proches sont réellement comparables ;
+- le taux de retour vers les pages candidat, thème et programme augmente ;
+- Search Console montre une progression des pages découvertes et utiles, sans hausse des pages
+  explorées mais non indexées pour contenu insuffisant.

--- a/docs/design/recherche-naturelle-presidentielle-2027.md
+++ b/docs/design/recherche-naturelle-presidentielle-2027.md
@@ -1,0 +1,154 @@
+# Recherche en langage naturel dans le corpus présidentiel 2027
+
+## Décision
+
+Faire évoluer la recherche existante vers une recherche hybride, pas vers un chatbot qui invente
+une réponse. Le premier résultat doit rester une liste structurée de thèmes, candidats et mesures
+publiées, avec un lien direct vers chaque source. Une réponse rédigée pourra être ajoutée ensuite,
+uniquement à partir des résultats retrouvés et avec des références visibles.
+
+Cette approche conserve trois propriétés éditoriales : une absence reste qualifiée comme une
+absence dans le corpus Poligraph, les mêmes règles s'appliquent à tous les candidats et aucun modèle
+ne juge la pertinence ou la faisabilité d'une mesure.
+
+## État actuel à conserver
+
+- `SearchDocument` est l'index public central. Il contient déjà les candidatures et les mesures,
+  leur périmètre électoral, leur visibilité et leur URL canonique.
+- `searchPublicPage()` fournit une recherche lexicale rapide, accentuée et déterministe. Elle reste
+  le premier passage et le repli en cas d'indisponibilité d'un service d'IA.
+- les transitions éditoriales synchronisent l'index et `search:reindex` permet une reconstruction
+  bornée par élection et type d'entité ;
+- l'autocomplétion et la page de résultats hydratent les identifiants par les autorités publiques,
+  ce qui empêche un index obsolète d'exposer un brouillon ;
+- `ChatEmbedding` ne doit pas être réutilisé pour ce chantier : il ne connaît pas les mesures,
+  stocke des vecteurs JSON et calcule les similarités dans Node.js. Il appartient au RAG historique
+  du chatbot général, pas à l'index électoral public.
+
+## Parcours de recherche
+
+### 1. Pendant la saisie
+
+À partir de deux caractères, conserver l'autocomplétion lexicale actuelle. Elle répond aux noms,
+titres et préfixes sans appeler un modèle à chaque frappe. Le délai de 150 ms et l'annulation des
+requêtes précédentes restent adaptés. Le panneau annonce le chargement, les erreurs et le nombre de
+résultats dans une région accessible.
+
+Une phrase complète peut être envoyée avec Entrée, par exemple : « Que proposent les candidats pour
+réduire le coût du logement ? ». Aucun appel sémantique ne part pendant la frappe.
+
+### 2. À la soumission
+
+Exécuter en parallèle :
+
+1. la recherche lexicale actuelle ;
+2. un embedding de la requête puis une recherche vectorielle dans les seuls documents publics de
+   `presidentielle-2027` ;
+3. la détection déterministe des noms de candidats et des thèmes connus.
+
+Fusionner les deux listes avec un classement réciproque, sans score politique. Un résultat trouvé
+exactement par son nom ou son titre reste prioritaire. La recherche sémantique récupère les
+formulations proches, par exemple « faire baisser les loyers » face à une mesure parlant
+« d'encadrement locatif ».
+
+Le reranking externe n'est déclenché que si la fusion produit plus de douze résultats plausibles et
+peu discriminés. Cette condition évite un second appel payant sur les requêtes simples.
+
+### 3. Format des résultats
+
+La page conserve des groupes explicites :
+
+- thèmes correspondants ;
+- candidats mentionnés ou retrouvés ;
+- mesures, regroupées par thème puis par candidat, avec la formulation publiée et la source ;
+- raccourci vers le comparateur lorsque la requête concerne au moins deux candidats ou un thème
+  comparable.
+
+Une synthèse générée n'est pas nécessaire à la première version. Dans une seconde version, un bouton
+« Résumer ces résultats » pourra produire 80 à 120 mots à partir d'un maximum de huit mesures. Chaque
+phrase factuelle devra référencer au moins une mesure affichée. Sans références suffisantes, le
+service retourne les résultats sans synthèse.
+
+## Index sémantique
+
+Ajouter à `SearchDocument` les informations de version et le vecteur sémantique, ou une table
+`SearchEmbedding` strictement liée à son couple `(entityType, entityId)`. Le stockage doit utiliser
+`pgvector`, avec un index de voisinage et un filtre préalable sur `visibility = PUBLIC` et
+`electionId`. Il ne faut pas charger tous les vecteurs JSON dans une fonction Vercel.
+
+Le texte embarqué pour une mesure est composé uniquement de données publiées : candidat, parti,
+thème, sous-thèmes validés, formulation, détails relus et titre du programme. Pour une candidature :
+nom, parti et statut public. Le modèle d'embedding et la révision source sont enregistrés afin de
+détecter les lignes périmées.
+
+La synchronisation suit les mêmes événements que l'index lexical : publication, nouvelle révision,
+retrait, dépublication et changement de candidature. Une écriture éditoriale ne doit pas attendre
+le fournisseur d'embeddings : elle marque le vecteur comme à reconstruire, puis une tâche asynchrone
+le calcule. La recherche lexicale couvre cet intervalle.
+
+Le CLI existant devient :
+
+```bash
+npm run search:reindex -- --election=presidentielle-2027 --entity-type=MEASURE
+npm run search:embed -- --election=presidentielle-2027 --entity-type=MEASURE --stale-only
+```
+
+L'administration expose les deux opérations avec progression, reprise sur curseur et audit du
+nombre de documents publics sans embedding. Aucun bouton ne lance une reconstruction synchrone dans
+une requête HTTP.
+
+## Modèles et maîtrise des coûts
+
+La première version utilise un modèle d'embedding multilingue Mistral. L'interprétation facultative
+d'une requête complexe et la synthèse de résultats utilisent un petit modèle Mistral avec sortie
+JSON validée. Les identifiants de modèles et leurs tarifs doivent être vérifiés au moment de
+l'implémentation, puis consignés dans la configuration, jamais écrits dans le composant.
+
+Garde-fous de coût :
+
+- zéro LLM pendant l'autocomplétion ;
+- un embedding au maximum par recherche soumise, mis en cache sur le hash de la requête normalisée ;
+- texte limité à 500 caractères, résultats candidats limités avant reranking ;
+- synthèse uniquement sur action explicite dans la deuxième version ;
+- mesure des tokens renvoyés par le SDK, coût estimé, latence et fournisseur pour chaque appel ;
+- plafonds journalier et mensuel avec coupure automatique de la partie IA ;
+- repli immédiat vers la recherche lexicale en cas de quota, délai dépassé ou erreur fournisseur ;
+- réindexation différentielle par révision, avec traitement par lots et concurrence bornée.
+
+Cloudflare Workers n'est pas nécessaire au premier déploiement. Vercel, PostgreSQL et le rate limit
+existant suffisent pour exécuter le parcours. Cloudflare pourra servir plus tard de cache de requêtes
+ou de protection supplémentaire, mais ne doit pas devenir un second backend tant qu'une limite
+mesurée ne le justifie pas.
+
+## Accessibilité et interface
+
+- conserver un vrai formulaire GET et une page de résultats utilisable sans JavaScript ;
+- afficher un libellé visible et des exemples de questions, sans faux historique de conversation ;
+- annoncer « Recherche sémantique en cours » puis le nombre de résultats via `aria-live` ;
+- déplacer le focus vers le titre des résultats seulement après une soumission volontaire, jamais
+  pendant l'autocomplétion ;
+- rendre chaque résultat comme un lien autonome avec candidat, thème et source lisibles hors
+  contexte ;
+- éviter l'animation de texte tapé et respecter `prefers-reduced-motion` ;
+- conserver la page et toutes ses variantes en `noindex,follow` avec un canonical sans requête.
+
+## Évaluation avant ouverture
+
+Constituer un jeu de 50 à 100 requêtes françaises validées manuellement : mots exacts, synonymes,
+fautes, questions complètes, candidat plus thème, requêtes sans réponse et formulations pouvant
+produire des faux positifs. Exemples : « loge », « encadrer les loyers », « que propose X pour les
+déserts médicaux ? », « retraite » contre « retrait ».
+
+Mesurer séparément recherche lexicale, vectorielle et hybride : rappel dans les cinq premiers
+résultats, précision, taux de zéro résultat, faux positifs éditoriaux, latence p50/p95 et coût par
+requête. Le lancement exige une amélioration mesurable sur les synonymes et les phrases, sans
+régression sur les noms propres et les recherches exactes.
+
+## Découpage proposé
+
+1. Jeu d'évaluation et instrumentation de la recherche actuelle.
+2. Migration `pgvector`, index sémantique des mesures et CLI de reconstruction différentielle.
+3. Recherche hybride côté serveur, sans génération de texte.
+4. Nouvelle page de résultats et autocomplétion conservée, tests clavier et lecteur d'écran.
+5. Commande d'administration, budgets, métriques et coupe-circuit.
+6. Expérimentation séparée de la synthèse Mistral sourcée, après validation de la recherche hybride.

--- a/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
+++ b/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
@@ -112,6 +112,7 @@ const PARTY_SURFACES = [
   "src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.tsx",
   "src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx",
   "src/app/elections/presidentielle-2027/candidats/page.tsx",
+  "src/app/elections/presidentielle-2027/comparer/page.tsx",
   "src/app/elections/presidentielle-2027/mesures/[id]/page.tsx",
   "src/app/elections/presidentielle-2027/page.tsx",
   "src/app/elections/presidentielle-2027/priorites/page.tsx",

--- a/src/app/admin/mesures/_components/MeasureActionPanel.tsx
+++ b/src/app/admin/mesures/_components/MeasureActionPanel.tsx
@@ -4,10 +4,16 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import {
   MEASURE_REJECTION_REASON_LABELS,
+  MEASURE_PRECISION_LABELS,
   MEASURE_SOURCE_KIND_LABELS,
   SOURCE_TIER_LABELS,
 } from "@/config/labels";
-import type { MeasureRejectionReason, MeasureSourceKind, SourceTier } from "@/generated/prisma";
+import type {
+  MeasurePrecision,
+  MeasureRejectionReason,
+  MeasureSourceKind,
+  SourceTier,
+} from "@/generated/prisma";
 import type { AvailableAction } from "../_data/available-actions";
 import {
   depublishMeasureAction,
@@ -46,6 +52,7 @@ const LABEL = "text-xs font-semibold uppercase tracking-wide text-muted-foregrou
 const SOURCE_KINDS = Object.keys(MEASURE_SOURCE_KIND_LABELS) as MeasureSourceKind[];
 const TIERS = Object.keys(SOURCE_TIER_LABELS) as SourceTier[];
 const REJECTION_REASONS = Object.keys(MEASURE_REJECTION_REASON_LABELS) as MeasureRejectionReason[];
+const PRECISIONS = Object.keys(MEASURE_PRECISION_LABELS) as MeasurePrecision[];
 
 function excerpt(text: string | undefined): string {
   if (text === undefined) return "révision inconnue";
@@ -451,8 +458,11 @@ export function MeasureActionPanel({
                   </label>
                   <select id="draft-precision" name="precision" className={FIELD}>
                     <option value="">Non qualifiée</option>
-                    <option value="CHIFFREE">Chiffrée</option>
-                    <option value="OBJECTIF_SANS_CHIFFRE">Objectif sans chiffre</option>
+                    {PRECISIONS.map((precision) => (
+                      <option key={precision} value={precision}>
+                        {MEASURE_PRECISION_LABELS[precision]}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>

--- a/src/app/admin/mesures/_components/NewMeasureForm.tsx
+++ b/src/app/admin/mesures/_components/NewMeasureForm.tsx
@@ -4,12 +4,14 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import {
   MEASURE_ATTRIBUTION_LABELS,
+  MEASURE_PRECISION_LABELS,
   MEASURE_SOURCE_KIND_LABELS,
   SOURCE_TIER_LABELS,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
 import type {
   MeasureAttribution,
+  MeasurePrecision,
   MeasureSourceKind,
   SourceTier,
   ThemeCategory,
@@ -38,6 +40,7 @@ const THEMES: readonly ThemeCategory[] = THEMES_IN_ORDER;
 const ATTRIBUTIONS = Object.keys(MEASURE_ATTRIBUTION_LABELS) as MeasureAttribution[];
 const SOURCE_KINDS = Object.keys(MEASURE_SOURCE_KIND_LABELS) as MeasureSourceKind[];
 const TIERS = Object.keys(SOURCE_TIER_LABELS) as SourceTier[];
+const PRECISIONS = Object.keys(MEASURE_PRECISION_LABELS) as MeasurePrecision[];
 
 export function NewMeasureForm({ candidacies }: { candidacies: CandidacyOption[] }) {
   const router = useRouter();
@@ -188,8 +191,11 @@ export function NewMeasureForm({ candidacies }: { candidacies: CandidacyOption[]
           </label>
           <select id="new-precision" name="precision" className={FIELD}>
             <option value="">Non qualifiée</option>
-            <option value="CHIFFREE">Chiffrée</option>
-            <option value="OBJECTIF_SANS_CHIFFRE">Objectif sans chiffre</option>
+            {PRECISIONS.map((precision) => (
+              <option key={precision} value={precision}>
+                {MEASURE_PRECISION_LABELS[precision]}
+              </option>
+            ))}
           </select>
         </div>
       </div>

--- a/src/app/api/elections/[slug]/candidacies/route.ts
+++ b/src/app/api/elections/[slug]/candidacies/route.ts
@@ -11,11 +11,11 @@ const CANDIDACY_STATUSES = ["DECLARE", "PRESSENTI", "ENVISAGE", "RETIRE"] as con
 const PROGRAMME_STATES = {
   aucun_programme: {
     code: "NO_PROGRAM_IDENTIFIED",
-    label: "Aucun programme identifié",
+    label: "Programme non trouvé ou pas encore traité par Poligraph",
   },
   non_depouille: {
     code: "PROGRAM_IDENTIFIED_NO_PUBLISHED_MEASURES",
-    label: "Programme identifié, aucune mesure publiée",
+    label: "Programme repéré, traitement éditorial en cours",
   },
   published: {
     code: "PUBLISHED_MEASURES",

--- a/src/app/elections/presidentielle-2027/_components/CandidacyDirectoryLink.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyDirectoryLink.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
+import type { HubCandidacy } from "@/lib/data/hub";
+import { CandidacyStatusBadge } from "./CandidacyStatusBadge";
+import { PartyLogo } from "./PartyLogo";
+
+function publishedContentLabel(candidacy: HubCandidacy): string {
+  if (candidacy.measureCount > 0) {
+    const measures = `${candidacy.measureCount} ${
+      candidacy.measureCount === 1 ? "mesure" : "mesures"
+    }`;
+    const themes = `${candidacy.themesCoveredCount} ${
+      candidacy.themesCoveredCount === 1 ? "thème" : "thèmes"
+    }`;
+    return `${measures} · ${themes}`;
+  }
+  return candidacy.programmeAbsence === "non_depouille"
+    ? "Programme repéré, traitement en cours"
+    : "Programme non trouvé ou pas encore traité";
+}
+
+export function CandidacyDirectoryLink({
+  candidacy,
+  onNavigate,
+}: {
+  candidacy: HubCandidacy;
+  onNavigate?: () => void;
+}) {
+  return (
+    <Link
+      href={`/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`}
+      prefetch={false}
+      onClick={onNavigate}
+      className="group grid h-full min-h-24 grid-cols-[3.5rem_minmax(0,1fr)_1.25rem] items-center gap-3 rounded-2xl border border-border bg-card p-3 transition-colors hover:border-primary hover:bg-muted/40 active:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none"
+    >
+      <span aria-hidden="true" className="shrink-0">
+        <PoliticianAvatar
+          photoUrl={candidacy.photoUrl}
+          blobPhotoUrl={candidacy.blobPhotoUrl}
+          fullName={candidacy.candidateName}
+          size="md"
+          className="h-14 w-14"
+        />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block break-words font-display text-base font-extrabold leading-tight">
+          {candidacy.candidateName}
+        </span>
+        {candidacy.partyLabel && (
+          <span className="mt-1 grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-1.5 text-sm font-semibold leading-snug text-foreground">
+            <PartyLogo
+              logoUrl={candidacy.partyLogoUrl}
+              label={candidacy.partyLabel}
+              shortName={candidacy.partyShortName}
+              color={candidacy.partyColor}
+            />
+            <span>{candidacy.partyLabel}</span>
+          </span>
+        )}
+        <span className="mt-2 flex flex-wrap items-center gap-1.5">
+          <CandidacyStatusBadge status={candidacy.status} />
+          <span className="text-xs leading-snug text-muted-foreground-strong">
+            {publishedContentLabel(candidacy)}
+          </span>
+        </span>
+      </span>
+      <ChevronRight
+        aria-hidden="true"
+        className="h-5 w-5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none"
+      />
+    </Link>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
+++ b/src/app/elections/presidentielle-2027/_components/CandidacyFieldBrowser.tsx
@@ -1,12 +1,8 @@
 "use client";
 
-import Image from "next/image";
-import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { ArrowRight, Search } from "lucide-react";
-import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
-import { getAccessibleTextColor } from "@/lib/contrast";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Search, X } from "lucide-react";
 import type { HubCandidacy } from "@/lib/data/hub";
 import {
   CANDIDACY_FILTERS,
@@ -17,75 +13,7 @@ import {
   parseCandidacyFilter,
   type CandidacyFilter,
 } from "@/lib/presidentielle/candidacy-filters";
-import { CandidacyStatusBadge } from "./CandidacyStatusBadge";
-
-function initials(value: string): string {
-  return value
-    .split(/\s+/)
-    .map((part) => part[0] ?? "")
-    .join("")
-    .slice(0, 3)
-    .toUpperCase();
-}
-
-function PartyIdentity({ candidacy }: { candidacy: HubCandidacy }) {
-  const label = candidacy.partyLabel ?? "Sans rattachement renseigné";
-  return (
-    <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground-strong">
-      {candidacy.partyLogoUrl ? (
-        <span className="relative h-8 w-8 shrink-0 overflow-hidden rounded-lg border bg-white">
-          <Image
-            src={candidacy.partyLogoUrl}
-            alt=""
-            fill
-            sizes="32px"
-            className="object-contain p-1"
-          />
-        </span>
-      ) : (
-        <span
-          aria-hidden="true"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-bold"
-          style={
-            candidacy.partyColor
-              ? {
-                  backgroundColor: candidacy.partyColor,
-                  color: getAccessibleTextColor(candidacy.partyColor),
-                }
-              : undefined
-          }
-        >
-          {candidacy.partyShortName?.slice(0, 3).toUpperCase() ?? initials(label)}
-        </span>
-      )}
-      <span className="min-w-0 break-words">{label}</span>
-    </div>
-  );
-}
-
-function PublishedContent({ candidacy }: { candidacy: HubCandidacy }) {
-  if (candidacy.measureCount > 0) {
-    return (
-      <p className="text-sm font-medium text-foreground">
-        {candidacy.themesCoveredCount === 1
-          ? "Des propositions sont disponibles sur 1 thème"
-          : `Des propositions sont disponibles sur ${candidacy.themesCoveredCount} thématiques`}
-      </p>
-    );
-  }
-  if (candidacy.programmeAbsence === "non_depouille") {
-    return (
-      <p className="text-sm text-muted-foreground-strong">
-        Programme identifié, aucune proposition encore publiée sur Poligraph
-      </p>
-    );
-  }
-  return (
-    <p className="text-sm text-muted-foreground-strong">
-      Poligraph n&apos;a identifié aucun programme publié à ce jour
-    </p>
-  );
-}
+import { CandidacyDirectoryLink } from "./CandidacyDirectoryLink";
 
 export function CandidacyCard({
   candidacy,
@@ -94,67 +22,34 @@ export function CandidacyCard({
   candidacy: HubCandidacy;
   onNavigate?: () => void;
 }) {
-  return (
-    <li className="flex min-w-0 flex-col rounded-2xl border border-border bg-card p-4 shadow-sm">
-      <div className="flex items-start gap-4">
-        <div aria-hidden="true">
-          <PoliticianAvatar
-            photoUrl={candidacy.photoUrl}
-            blobPhotoUrl={candidacy.blobPhotoUrl}
-            fullName={candidacy.candidateName}
-            size="lg"
-            className="h-20 w-20 sm:h-24 sm:w-24"
-          />
-        </div>
-        <div className="min-w-0 flex-1 space-y-2">
-          <h2 className="break-words font-display text-xl font-extrabold leading-tight tracking-tight">
-            {candidacy.candidateName}
-          </h2>
-          <PartyIdentity candidacy={candidacy} />
-        </div>
-      </div>
-      <div className="mt-4 space-y-3 border-t border-border pt-4">
-        <CandidacyStatusBadge status={candidacy.status} />
-        <PublishedContent candidacy={candidacy} />
-      </div>
-      <div className="mt-auto pt-5">
-        <Link
-          href={`/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`}
-          prefetch={false}
-          onClick={onNavigate}
-          className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:brightness-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-        >
-          Voir le suivi 2027
-          <ArrowRight aria-hidden="true" className="h-4 w-4" />
-          <span className="sr-only"> de {candidacy.candidateName}</span>
-        </Link>
-      </div>
-    </li>
-  );
+  return <CandidacyDirectoryLink candidacy={candidacy} onNavigate={onNavigate} />;
 }
 
 export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandidacy[] }) {
-  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const status = parseCandidacyFilter(searchParams.get("statut"));
   const urlQuery = searchParams.get("q") ?? "";
+  const urlStatus = parseCandidacyFilter(searchParams.get("statut"));
+  const urlPublishedOnly = searchParams.get("propositions") === "publiees";
   const [query, setQuery] = useState(urlQuery);
-  const submittedQuery = useRef<string | null>(null);
-  const previousUrlQuery = useRef(urlQuery);
+  const [status, setStatus] = useState<CandidacyFilter>(urlStatus);
+  const [publishedOnly, setPublishedOnly] = useState(urlPublishedOnly);
   const pendingQuerySync = useRef<number | null>(null);
-  const publishedOnly = searchParams.get("propositions") === "publiees";
+  const lastWrittenQuery = useRef<string | null>(null);
+
   const counts = Object.fromEntries(
     CANDIDACY_FILTERS.map((key) => [
       key,
-      candidacies.filter((c) => matchesCandidacyFilter(c, key)).length,
+      candidacies.filter((candidacy) => matchesCandidacyFilter(candidacy, key)).length,
     ])
   ) as Record<CandidacyFilter, number>;
   const visible = candidacies.filter(
-    (c) =>
-      matchesCandidacyFilter(c, status) &&
-      matchesPublishedProposals(c, publishedOnly) &&
-      matchesCandidacyQuery(c, query)
+    (candidacy) =>
+      matchesCandidacyFilter(candidacy, status) &&
+      matchesPublishedProposals(candidacy, publishedOnly) &&
+      matchesCandidacyQuery(candidacy, query)
   );
+  const hasActiveFilters = status !== "toutes" || publishedOnly || query.trim() !== "";
 
   const cancelPendingQuerySync = useCallback(() => {
     if (pendingQuerySync.current === null) return;
@@ -162,122 +57,155 @@ export function CandidacyFieldBrowser({ candidacies }: { candidacies: HubCandida
     pendingQuerySync.current = null;
   }, []);
 
-  const update = useCallback(
-    function update(next: { statut?: CandidacyFilter; q?: string; publishedOnly?: boolean }) {
-      cancelPendingQuerySync();
+  const writeUrl = useCallback(
+    (next: { statut: CandidacyFilter; q: string; publishedOnly: boolean }) => {
+      lastWrittenQuery.current = next.q.trim();
       const params = new URLSearchParams(searchParams.toString());
-      if (next.statut !== undefined) {
-        if (next.statut === "toutes") params.delete("statut");
-        else params.set("statut", next.statut);
-      }
-      if (next.q !== undefined) {
-        submittedQuery.current = next.q;
-        if (next.q === "") params.delete("q");
-        else params.set("q", next.q);
-      }
-      if (next.publishedOnly !== undefined) {
-        if (next.publishedOnly) params.set("propositions", "publiees");
-        else params.delete("propositions");
-      }
+      if (next.statut === "toutes") params.delete("statut");
+      else params.set("statut", next.statut);
+      if (next.q.trim() === "") params.delete("q");
+      else params.set("q", next.q.trim());
+      if (next.publishedOnly) params.set("propositions", "publiees");
+      else params.delete("propositions");
       const value = params.toString();
-      router.replace(value === "" ? "?" : `?${value}`, { scroll: false });
+      window.history.replaceState(null, "", value === "" ? pathname : `${pathname}?${value}`);
     },
-    [cancelPendingQuerySync, router, searchParams]
+    [pathname, searchParams]
   );
 
   useEffect(() => {
-    if (previousUrlQuery.current === urlQuery) return;
-    previousUrlQuery.current = urlQuery;
-
-    if (submittedQuery.current === urlQuery) {
-      submittedQuery.current = null;
-      return;
-    }
-    const frame = window.requestAnimationFrame(() => setQuery(urlQuery));
-    return () => window.cancelAnimationFrame(frame);
-  }, [urlQuery]);
-
-  useEffect(() => {
-    if (query === urlQuery || submittedQuery.current === query) return;
+    if (query === urlQuery || query.trim() === lastWrittenQuery.current) return;
     const timeout = window.setTimeout(() => {
       pendingQuerySync.current = null;
-      update({ q: query });
+      writeUrl({ statut: status, q: query, publishedOnly });
     }, 250);
     pendingQuerySync.current = timeout;
     return () => {
       window.clearTimeout(timeout);
       if (pendingQuerySync.current === timeout) pendingQuerySync.current = null;
     };
-  }, [query, update, urlQuery]);
+  }, [publishedOnly, query, status, urlQuery, writeUrl]);
+
+  function selectStatus(nextStatus: CandidacyFilter) {
+    cancelPendingQuerySync();
+    setStatus(nextStatus);
+    writeUrl({ statut: nextStatus, q: query, publishedOnly });
+  }
+
+  function selectPublishedOnly(nextPublishedOnly: boolean) {
+    cancelPendingQuerySync();
+    setPublishedOnly(nextPublishedOnly);
+    writeUrl({ statut: status, q: query, publishedOnly: nextPublishedOnly });
+  }
+
+  function resetFilters() {
+    cancelPendingQuerySync();
+    setQuery("");
+    setStatus("toutes");
+    setPublishedOnly(false);
+    writeUrl({ statut: "toutes", q: "", publishedOnly: false });
+  }
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-5 rounded-2xl border border-border bg-card p-4 md:p-5">
-        <label className="block max-w-lg text-sm font-semibold">
-          Rechercher une personne ou un parti
-          <span className="mt-2 flex min-h-11 items-center gap-2 rounded-lg border border-border px-3 font-normal focus-within:ring-2 focus-within:ring-primary">
-            <Search aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+    <div className="space-y-5">
+      <div className="space-y-4 rounded-2xl border border-border bg-card p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <label className="block w-full max-w-xl text-sm font-semibold">
+            Rechercher une personne ou un parti
+            <span className="mt-2 flex min-h-11 items-center gap-2 rounded-xl border border-border bg-background px-3 font-normal focus-within:ring-2 focus-within:ring-primary">
+              <Search aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                className="min-w-0 flex-1 bg-transparent outline-none"
+              />
+              {query !== "" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    cancelPendingQuerySync();
+                    setQuery("");
+                    writeUrl({ statut: status, q: "", publishedOnly });
+                  }}
+                  aria-label="Effacer la recherche"
+                  title="Effacer la recherche"
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <X aria-hidden="true" className="h-4 w-4" />
+                </button>
+              )}
+            </span>
+          </label>
+
+          <label className="flex min-h-11 cursor-pointer items-center gap-3 text-sm font-medium">
             <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              className="min-w-0 flex-1 bg-transparent outline-none"
+              type="checkbox"
+              checked={publishedOnly}
+              onChange={(event) => selectPublishedOnly(event.target.checked)}
+              className="h-5 w-5 rounded border-border accent-primary"
             />
-          </span>
-        </label>
+            Avec des propositions publiées
+          </label>
+        </div>
+
         <fieldset className="space-y-2">
           <legend className="text-sm font-semibold">Statut public</legend>
-          <div className="flex flex-wrap gap-2">
-            {CANDIDACY_FILTERS.map((key) => (
-              <button
-                key={key}
-                type="button"
-                aria-pressed={key === status}
-                onClick={() => update({ statut: key, q: query })}
-                className={`min-h-11 rounded-full border px-4 text-sm ${
-                  key === status
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-card hover:bg-muted"
-                }`}
-              >
-                {CANDIDACY_FILTER_LABELS[key]} ({counts[key]})
-              </button>
-            ))}
+          <div className="-mx-4 overflow-x-auto px-4 pb-1">
+            <div className="flex min-w-max gap-2">
+              {CANDIDACY_FILTERS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={key === status}
+                  onClick={() => selectStatus(key)}
+                  className={`min-h-11 rounded-full border px-4 text-sm font-medium ${
+                    key === status
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background hover:border-primary hover:text-primary"
+                  }`}
+                >
+                  {CANDIDACY_FILTER_LABELS[key]} ({counts[key]})
+                </button>
+              ))}
+            </div>
           </div>
         </fieldset>
-        <label className="flex min-h-11 cursor-pointer items-center gap-3 text-sm font-medium">
-          <input
-            type="checkbox"
-            checked={publishedOnly}
-            onChange={(event) => update({ q: query, publishedOnly: event.target.checked })}
-            className="h-5 w-5 rounded border-border accent-primary"
-          />
-          Afficher uniquement les personnes avec des propositions publiées
-        </label>
+      </div>
+
+      <div className="flex min-h-11 flex-wrap items-center justify-between gap-3">
+        <p aria-live="polite" className="text-sm font-medium text-muted-foreground-strong">
+          {visible.length}{" "}
+          {visible.length === 1 ? "personnalité affichée" : "personnalités affichées"}
+        </p>
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={resetFilters}
+            className="inline-flex min-h-11 items-center rounded-lg text-sm font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            Réinitialiser les filtres
+          </button>
+        )}
       </div>
 
       {visible.length === 0 ? (
         <div className="rounded-2xl border border-dashed p-8 text-center text-sm text-muted-foreground">
-          Aucune personne ne correspond à ces critères.
+          <p>Aucune personne ne correspond à ces critères.</p>
           <button
             type="button"
-            onClick={() => {
-              setQuery("");
-              update({ statut: "toutes", q: "", publishedOnly: false });
-            }}
-            className="ml-2 min-h-11 font-semibold text-primary underline"
+            onClick={resetFilters}
+            className="mt-2 inline-flex min-h-11 items-center font-semibold text-primary underline"
           >
             Réinitialiser
           </button>
         </div>
       ) : (
-        <ul className="grid min-w-0 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <ul className="grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {visible.map((candidacy) => (
-            <CandidacyCard
-              key={candidacy.id}
-              candidacy={candidacy}
-              onNavigate={cancelPendingQuerySync}
-            />
+            <li key={candidacy.id}>
+              <CandidacyCard candidacy={candidacy} onNavigate={cancelPendingQuerySync} />
+            </li>
           ))}
         </ul>
       )}

--- a/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubCandidacyField.tsx
@@ -10,11 +10,7 @@ import { CandidacyFieldBrowser } from "./CandidacyFieldBrowser";
  */
 export function HubCandidacyField({ candidacies }: { candidacies: HubCandidacy[] }) {
   return (
-    <div className="space-y-3">
-      <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
-        Retrouvez les annonces de candidature et les propositions actuellement publiées sur
-        Poligraph. L&apos;ordre est alphabétique.
-      </p>
+    <div>
       <Suspense
         fallback={<div className="h-96 rounded-xl border border-border bg-card" aria-hidden />}
       >

--- a/src/app/elections/presidentielle-2027/_components/HubCandidacyOverview.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubCandidacyOverview.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import type { HubCandidacy } from "@/lib/data/hub";
 import {
   CANDIDACY_FILTERS,
@@ -8,18 +7,7 @@ import {
   matchesCandidacyFilter,
   matchesPublishedProposals,
 } from "@/lib/presidentielle/candidacy-filters";
-import { CandidacyStatusBadge } from "./CandidacyStatusBadge";
-
-function publishedContentLabel(candidacy: HubCandidacy): string {
-  if (candidacy.measureCount > 0) {
-    return `${candidacy.measureCount} ${
-      candidacy.measureCount === 1 ? "mesure publiée" : "mesures publiées"
-    }`;
-  }
-  return candidacy.programmeAbsence === "non_depouille"
-    ? "Programme non dépouillé"
-    : "Aucun programme identifié";
-}
+import { CandidacyDirectoryLink } from "./CandidacyDirectoryLink";
 
 /**
  * The people followed by Poligraph, directly on the hub rather than reduced to four counters.
@@ -27,6 +15,10 @@ function publishedContentLabel(candidacy: HubCandidacy): string {
  */
 export function HubCandidacyOverview({ candidacies }: { candidacies: HubCandidacy[] }) {
   const total = candidacies.length;
+  const candidaciesWithPublishedProposals = candidacies.filter((candidacy) =>
+    matchesPublishedProposals(candidacy, true)
+  );
+  const publishedTotal = candidaciesWithPublishedProposals.length;
   const filters = [
     ...CANDIDACY_FILTERS.filter((key) => key !== "toutes").map((key) => ({
       key,
@@ -50,11 +42,13 @@ export function HubCandidacyOverview({ candidacies }: { candidacies: HubCandidac
             id="hub-candidatures"
             className="font-display text-xl font-bold tracking-tight md:text-2xl"
           >
-            {total} {total === 1 ? "personnalité suivie" : "personnalités suivies"}
+            {publishedTotal} {publishedTotal === 1 ? "personnalité a" : "personnalités ont"} déjà
+            des propositions publiées
           </h2>
           <p className="max-w-3xl text-sm text-muted-foreground">
-            Poligraph documente des candidatures, ce n&apos;est pas la liste officielle des
-            candidats. L&apos;ordre est alphabétique, sans classement.
+            L&apos;accueil montre les personnalités pour lesquelles des mesures sont déjà
+            documentées. L&apos;annuaire rassemble les {total} personnalités suivies, y compris
+            celles dont les propositions restent à documenter.
           </p>
         </div>
         {total > 0 && (
@@ -63,59 +57,29 @@ export function HubCandidacyOverview({ candidacies }: { candidacies: HubCandidac
             prefetch={false}
             className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            {total === 1 ? "La fiche" : `Les ${total} fiches`}
+            Explorer {total === 1 ? "la personnalité suivie" : `les ${total} personnalités`}
             <ArrowRight aria-hidden="true" className="h-4 w-4" />
           </Link>
         )}
       </div>
 
-      {total === 0 ? (
+      {publishedTotal === 0 ? (
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Aucune candidature sourcée à ce jour.
+          Aucune proposition publiée à ce jour.
         </p>
       ) : (
         <>
           <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-            {candidacies.map((candidacy) => (
+            {candidaciesWithPublishedProposals.map((candidacy) => (
               <li key={candidacy.id}>
-                <Link
-                  href={`/elections/presidentielle-2027/candidats/${candidacy.politicianSlug}`}
-                  prefetch={false}
-                  className="flex h-full min-h-11 items-center gap-2.5 rounded-2xl border border-border bg-card px-3 py-2.5 transition-colors hover:border-primary hover:bg-muted/40 active:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none"
-                >
-                  <span aria-hidden="true" className="shrink-0">
-                    <PoliticianAvatar
-                      photoUrl={candidacy.photoUrl}
-                      blobPhotoUrl={candidacy.blobPhotoUrl}
-                      fullName={candidacy.candidateName}
-                      size="sm"
-                      className="h-9 w-9"
-                    />
-                  </span>
-                  <span className="min-w-0 flex-1 space-y-1">
-                    <span className="block break-words text-sm font-bold leading-tight">
-                      {candidacy.candidateName}
-                    </span>
-                    {candidacy.partyLabel && (
-                      <span className="block text-sm font-medium leading-snug text-foreground">
-                        {candidacy.partyLabel}
-                      </span>
-                    )}
-                    <span className="flex flex-wrap items-center gap-1.5">
-                      <CandidacyStatusBadge status={candidacy.status} />
-                      <span className="text-xs leading-snug text-muted-foreground-strong">
-                        {publishedContentLabel(candidacy)}
-                      </span>
-                    </span>
-                  </span>
-                </Link>
+                <CandidacyDirectoryLink candidacy={candidacy} />
               </li>
             ))}
           </ul>
 
-          <nav aria-label="Filtrer les personnalités suivies" className="flex flex-wrap gap-2">
+          <nav aria-label="Explorer l'annuaire des personnalités" className="flex flex-wrap gap-2">
             <span className="self-center text-xs text-muted-foreground-strong">
-              Filtrer la liste :
+              Explorer l&apos;annuaire :
             </span>
             {filters
               .filter((filter) => filter.count > 0)

--- a/src/app/elections/presidentielle-2027/_components/HubComparisonLauncher.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubComparisonLauncher.tsx
@@ -1,0 +1,90 @@
+import { ArrowRight } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import type { HubCandidacy, HubTheme } from "@/lib/data/hub";
+import { cn } from "@/lib/utils";
+
+const COMPARISON_PATH = "/elections/presidentielle-2027/comparer";
+
+export function HubComparisonLauncher({
+  candidacies,
+  themes,
+}: {
+  candidacies: HubCandidacy[];
+  themes: HubTheme[];
+}) {
+  const candidateOptions = candidacies.filter((candidacy) => candidacy.measureCount > 0);
+  const themeOptions = themes.filter((theme) => theme.publishable);
+
+  if (candidateOptions.length < 2 || themeOptions.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="hub-comparison-title"
+      className="rounded-2xl border border-border bg-card p-5 md:p-6"
+    >
+      <div className="max-w-3xl">
+        <h2 id="hub-comparison-title" className="font-display text-xl font-bold md:text-2xl">
+          Comparer deux candidats
+        </h2>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          Choisissez deux candidats et un thème pour placer leurs mesures publiées côte à côte.
+        </p>
+      </div>
+      <form
+        action={COMPARISON_PATH}
+        method="get"
+        className="mt-5 grid items-end gap-4 md:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_auto]"
+      >
+        {[0, 1].map((index) => (
+          <div key={index}>
+            <label htmlFor={`hub-candidate-${index}`} className="mb-1.5 block text-sm font-bold">
+              Candidat {index + 1}
+            </label>
+            <Select
+              id={`hub-candidate-${index}`}
+              name="candidat"
+              required
+              defaultValue=""
+              className="min-h-11"
+            >
+              <option value="">Choisir</option>
+              {candidateOptions.map((candidate) => (
+                <option key={candidate.id} value={candidate.politicianSlug}>
+                  {candidate.candidateName}
+                  {candidate.partyLabel ? `, ${candidate.partyLabel}` : ""}
+                </option>
+              ))}
+            </Select>
+          </div>
+        ))}
+        <div>
+          <label htmlFor="hub-comparison-theme" className="mb-1.5 block text-sm font-bold">
+            Thème
+          </label>
+          <Select
+            id="hub-comparison-theme"
+            name="theme"
+            required
+            defaultValue=""
+            className="min-h-11"
+          >
+            <option value="">Choisir</option>
+            {themeOptions.map((theme) => (
+              <option key={theme.theme} value={theme.slug}>
+                {theme.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <button
+          type="submit"
+          className={cn(buttonVariants({ variant: "default" }), "min-h-11 w-full lg:w-auto")}
+        >
+          Comparer
+          <ArrowRight aria-hidden="true" />
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/PartyLogo.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PartyLogo.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { getAccessibleTextColor } from "@/lib/contrast";
+import { cn } from "@/lib/utils";
+
+const SIZE_CLASSES = {
+  sm: "h-6 w-6 rounded-md text-[9px]",
+  md: "h-12 w-12 rounded-xl text-xs",
+  lg: "h-16 w-16 rounded-2xl text-sm sm:h-24 sm:w-24",
+} as const;
+
+export function PartyLogo({
+  logoUrl,
+  label,
+  shortName,
+  color,
+  size = "sm",
+  className,
+}: {
+  logoUrl: string | null;
+  label: string;
+  shortName?: string | null;
+  color?: string | null;
+  size?: keyof typeof SIZE_CLASSES;
+  className?: string;
+}) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  const sizeClass = SIZE_CLASSES[size];
+
+  if (logoUrl && !logoFailed) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "relative inline-flex shrink-0 overflow-hidden border border-border bg-white",
+          sizeClass,
+          className
+        )}
+      >
+        <Image
+          src={logoUrl}
+          alt=""
+          fill
+          unoptimized
+          sizes={size === "lg" ? "96px" : size === "md" ? "48px" : "24px"}
+          onError={() => setLogoFailed(true)}
+          className="object-contain p-1"
+        />
+      </span>
+    );
+  }
+
+  const initials = shortName
+    ? shortName.slice(0, 3).toLocaleUpperCase("fr")
+    : label
+        .split(/\s+/u)
+        .filter(Boolean)
+        .slice(0, 3)
+        .map((word) => word[0])
+        .join("")
+        .toLocaleUpperCase("fr");
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center border border-border bg-muted font-bold",
+        sizeClass,
+        className
+      )}
+      style={color ? { backgroundColor: color, color: getAccessibleTextColor(color) } : undefined}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/PresidentialHubNav.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PresidentialHubNav.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+
+const HUB_LINKS = [
+  {
+    key: "overview",
+    label: "Vue d’ensemble",
+    mobileLabel: "Aperçu",
+    href: "/elections/presidentielle-2027",
+  },
+  {
+    key: "themes",
+    label: "Thématiques",
+    mobileLabel: "Thèmes",
+    href: "/elections/presidentielle-2027/themes",
+  },
+  {
+    key: "candidates",
+    label: "Candidatures",
+    mobileLabel: "Candidats",
+    href: "/elections/presidentielle-2027/candidats",
+  },
+  {
+    key: "compare",
+    label: "Comparer",
+    mobileLabel: "Comparer",
+    href: "/elections/presidentielle-2027/comparer",
+  },
+] as const;
+
+export type PresidentialHubSection = (typeof HUB_LINKS)[number]["key"];
+
+export function PresidentialHubNav({ active }: { active: PresidentialHubSection }) {
+  return (
+    <nav aria-label="Explorer la présidentielle 2027">
+      <ul className="grid w-full grid-cols-4 border-b border-border sm:flex sm:gap-1">
+        {HUB_LINKS.map((item) => {
+          const isActive = item.key === active;
+          return (
+            <li key={item.key}>
+              <Link
+                href={item.href}
+                prefetch={false}
+                aria-label={item.label}
+                aria-current={isActive ? "page" : undefined}
+                className={`inline-flex min-h-11 w-full items-center justify-center whitespace-nowrap border-b-2 px-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset motion-reduce:transition-none sm:w-auto sm:px-3 sm:text-sm ${
+                  isActive
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground-strong hover:border-border hover:text-foreground"
+                }`}
+              >
+                <span className="sm:hidden">{item.mobileLabel}</span>
+                <span className="hidden sm:inline">{item.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyField.test.tsx
@@ -4,19 +4,12 @@ import type { HubCandidacy } from "@/lib/data/hub";
 import { CandidacyCard, CandidacyFieldBrowser } from "../CandidacyFieldBrowser";
 
 const navigation = vi.hoisted(() => ({
-  replace: vi.fn(),
   searchParams: new URLSearchParams(),
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: navigation.replace,
-    prefetch: vi.fn(),
-    back: vi.fn(),
-  }),
   useSearchParams: () => navigation.searchParams,
-  usePathname: () => "/elections/presidentielle-2027",
+  usePathname: () => "/elections/presidentielle-2027/candidats",
 }));
 
 function candidacy(over: Partial<HubCandidacy> = {}): HubCandidacy {
@@ -42,12 +35,13 @@ function candidacy(over: Partial<HubCandidacy> = {}): HubCandidacy {
 
 describe("annuaire présidentiel", () => {
   beforeEach(() => {
-    navigation.replace.mockReset();
     navigation.searchParams = new URLSearchParams();
+    window.history.replaceState(null, "", "/elections/presidentielle-2027/candidats");
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("donne à chaque carte une destination interne unique et aucune action externe", () => {
@@ -58,11 +52,11 @@ describe("annuaire présidentiel", () => {
       "href",
       "/elections/presidentielle-2027/candidats/alix-dupont"
     );
-    expect(links[0]).toHaveTextContent("Voir le suivi 2027");
+    expect(links[0]).toHaveTextContent("Alix Dupont");
   });
 
-  it("rend portrait et logo quand ils existent", () => {
-    render(
+  it("rend le portrait et donne de l'importance au parti", () => {
+    const { container } = render(
       <CandidacyCard
         candidacy={candidacy({
           photoUrl: "https://upload.wikimedia.org/photo.jpg",
@@ -70,18 +64,29 @@ describe("annuaire présidentiel", () => {
         })}
       />
     );
-    expect(screen.getByRole("img", { hidden: true, name: "Alix Dupont" })).toBeInTheDocument();
-    expect(
-      document.querySelector('img[src="https://upload.wikimedia.org/logo.svg"]')
-    ).not.toBeNull();
+    expect(screen.getByAltText("Alix Dupont").parentElement?.parentElement).toHaveAttribute(
+      "aria-hidden",
+      "true"
+    );
+    expect(screen.getByText("Parti Test")).toBeInTheDocument();
+    expect(container.querySelector('img[alt=""]')).not.toBeNull();
+  });
+
+  it("rend le fallback du portrait", () => {
+    const { container } = render(<CandidacyCard candidacy={candidacy()} />);
+    expect(container).toHaveTextContent("AD");
     expect(screen.getByText("Parti Test")).toBeInTheDocument();
   });
 
-  it("rend les fallbacks portrait et logo", () => {
-    const { container } = render(<CandidacyCard candidacy={candidacy()} />);
-    expect(container).toHaveTextContent("AD");
-    expect(container).toHaveTextContent("PT");
-    expect(screen.getByText("Parti Test")).toBeInTheDocument();
+  it("remplace un logo de parti inaccessible par ses initiales", () => {
+    const { container } = render(
+      <CandidacyCard
+        candidacy={candidacy({ partyLogoUrl: "https://example.org/logo-inaccessible.svg" })}
+      />
+    );
+
+    fireEvent.error(container.querySelector('img[alt=""]')!);
+    expect(screen.getByText("PT")).toBeInTheDocument();
   });
 
   it("distingue zéro proposition, programme identifié et propositions publiées", () => {
@@ -106,15 +111,9 @@ describe("annuaire présidentiel", () => {
         />
       </ul>
     );
-    expect(
-      screen.getByText("Poligraph n'a identifié aucun programme publié à ce jour")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Programme identifié, aucune proposition encore publiée sur Poligraph")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Des propositions sont disponibles sur 3 thématiques")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Programme non trouvé ou pas encore traité")).toBeInTheDocument();
+    expect(screen.getByText("Programme repéré, traitement en cours")).toBeInTheDocument();
+    expect(screen.getByText("8 mesures · 3 thèmes")).toBeInTheDocument();
   });
 
   it("sépare visuellement statut public et contenu disponible", () => {
@@ -129,7 +128,7 @@ describe("annuaire présidentiel", () => {
     expect(screen.getByRole("group", { name: "Statut public" })).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", {
-        name: "Afficher uniquement les personnes avec des propositions publiées",
+        name: "Avec des propositions publiées",
       })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Candidatures annoncées (1)" })).toBeInTheDocument();
@@ -164,68 +163,97 @@ describe("annuaire présidentiel", () => {
         })}
       />
     );
-    const heading = screen.getByRole("heading");
-    expect(heading.className).toContain("break-words");
+    expect(
+      screen.getByText("Anne-Charlotte de la Très Longue Circonscription").className
+    ).toContain("break-words");
     expect(container).toHaveTextContent("Rassemblement démocratique écologique et social");
   });
 
   it("annule la synchronisation différée quand un statut est sélectionné", () => {
     vi.useFakeTimers();
+    const replaceState = vi.spyOn(window.history, "replaceState");
     render(<CandidacyFieldBrowser candidacies={[candidacy()]} />);
 
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Alix" } });
     fireEvent.click(screen.getByRole("button", { name: "Personnalités pressenties (1)" }));
     act(() => vi.advanceTimersByTime(250));
 
-    expect(navigation.replace).toHaveBeenCalledTimes(1);
-    expect(navigation.replace).toHaveBeenCalledWith("?statut=pressenties&q=Alix", {
-      scroll: false,
-    });
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "/elections/presidentielle-2027/candidats?statut=pressenties&q=Alix"
+    );
   });
 
   it("synchronise la dernière saisie après le délai", () => {
     vi.useFakeTimers();
+    const replaceState = vi.spyOn(window.history, "replaceState");
     render(<CandidacyFieldBrowser candidacies={[candidacy()]} />);
 
     const searchbox = screen.getByRole("searchbox");
     fireEvent.change(searchbox, { target: { value: "Ali" } });
     fireEvent.change(searchbox, { target: { value: "Alix" } });
     act(() => vi.advanceTimersByTime(249));
-    expect(navigation.replace).not.toHaveBeenCalled();
+    expect(replaceState).not.toHaveBeenCalled();
 
     act(() => vi.advanceTimersByTime(1));
-    expect(navigation.replace).toHaveBeenCalledTimes(1);
-    expect(navigation.replace).toHaveBeenCalledWith("?q=Alix", { scroll: false });
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "/elections/presidentielle-2027/candidats?q=Alix"
+    );
   });
 
   it("annule la synchronisation différée quand le filtre de propositions change", () => {
     vi.useFakeTimers();
+    const replaceState = vi.spyOn(window.history, "replaceState");
     render(<CandidacyFieldBrowser candidacies={[candidacy()]} />);
 
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Alix" } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: "Afficher uniquement les personnes avec des propositions publiées",
+        name: "Avec des propositions publiées",
       })
     );
     act(() => vi.advanceTimersByTime(250));
 
-    expect(navigation.replace).toHaveBeenCalledTimes(1);
-    expect(navigation.replace).toHaveBeenCalledWith("?q=Alix&propositions=publiees", {
-      scroll: false,
-    });
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "/elections/presidentielle-2027/candidats?q=Alix&propositions=publiees"
+    );
   });
 
   it("annule la synchronisation différée avant d'ouvrir une fiche candidate", () => {
     vi.useFakeTimers();
+    const replaceState = vi.spyOn(window.history, "replaceState");
     render(<CandidacyFieldBrowser candidacies={[candidacy()]} />);
 
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Alix" } });
-    const link = screen.getByRole("link", { name: /Voir le suivi 2027/ });
+    const link = screen.getByRole("link", { name: /Alix Dupont/ });
     link.addEventListener("click", (event) => event.preventDefault());
     fireEvent.click(link);
     act(() => vi.advanceTimersByTime(250));
 
-    expect(navigation.replace).not.toHaveBeenCalled();
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+
+  it("annonce le nombre de résultats et permet de réinitialiser les filtres", () => {
+    render(
+      <CandidacyFieldBrowser
+        candidacies={[
+          candidacy({ id: "a", candidateName: "Alix Dupont" }),
+          candidacy({ id: "b", candidateName: "Béatrice Martin" }),
+        ]}
+      />
+    );
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Béatrice" } });
+    expect(screen.getByText("1 personnalité affichée")).toHaveAttribute("aria-live", "polite");
+    fireEvent.click(screen.getByRole("button", { name: "Réinitialiser les filtres" }));
+    expect(screen.getByText("2 personnalités affichées")).toBeInTheDocument();
   });
 });

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyOverview.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubCandidacyOverview.test.tsx
@@ -32,10 +32,11 @@ const field = [
 ];
 
 describe("HubCandidacyOverview", () => {
-  it("montre chaque personnalité et compte les filtres avec les mêmes prédicats que la liste", () => {
+  it("montre seulement les personnalités ayant des propositions et compte tous les filtres", () => {
     render(<HubCandidacyOverview candidacies={field} />);
 
-    expect(screen.getAllByRole("link", { name: /Alix Dupont/ })).toHaveLength(4);
+    expect(screen.getAllByRole("link", { name: /Alix Dupont/ })).toHaveLength(1);
+    expect(screen.getByText(/1 personnalité a déjà des propositions publiées/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Candidatures annoncées · 2/ })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats?statut=annoncees"
@@ -64,30 +65,26 @@ describe("HubCandidacyOverview", () => {
   it("mène au champ complet, avec son effectif dans le libellé du lien", () => {
     render(<HubCandidacyOverview candidacies={field} />);
 
-    expect(screen.getByRole("link", { name: /Les 4 fiches/ })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Explorer les 4 personnalités/ })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats"
     );
   });
 
-  it("qualifie l'état du programme sans inventer de mesure", () => {
+  it("qualifie les propositions publiées sans inventer de thème", () => {
     render(
       <HubCandidacyOverview
-        candidacies={[
-          candidacy({ programmeAbsence: "non_depouille" }),
-          candidacy({ id: "c2", measureCount: 1, programmeAbsence: null }),
-        ]}
+        candidacies={[candidacy({ id: "c2", measureCount: 1, programmeAbsence: null })]}
       />
     );
 
-    expect(screen.getByText("Programme non dépouillé")).toBeInTheDocument();
-    expect(screen.getByText("1 mesure publiée")).toBeInTheDocument();
+    expect(screen.getByText("1 mesure · 0 thèmes")).toBeInTheDocument();
   });
 
   it("reste lisible sur un champ vide, sans compteurs à zéro", () => {
     render(<HubCandidacyOverview candidacies={[]} />);
 
-    expect(screen.getByText("Aucune candidature sourcée à ce jour.")).toBeInTheDocument();
+    expect(screen.getByText("Aucune proposition publiée à ce jour.")).toBeInTheDocument();
     expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
   });
 });

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubComparisonLauncher.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubComparisonLauncher.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { HubCandidacy, HubTheme } from "@/lib/data/hub";
+import { HubComparisonLauncher } from "../HubComparisonLauncher";
+
+function candidacy(id: string, name: string, measureCount: number): HubCandidacy {
+  return {
+    id,
+    candidateName: name,
+    politicianSlug: name.toLocaleLowerCase("fr").replace(" ", "-"),
+    photoUrl: null,
+    blobPhotoUrl: null,
+    status: "DECLARE",
+    sourceUrl: "https://example.org/source",
+    sourceLabel: "Source",
+    partyLabel: null,
+    partyColor: null,
+    partyShortName: null,
+    partyLogoUrl: null,
+    measureCount,
+    themesCoveredCount: measureCount > 0 ? 1 : 0,
+    programmeAbsence: measureCount > 0 ? null : "aucun_programme",
+  };
+}
+
+const themes: HubTheme[] = [
+  { theme: "SANTE", label: "Santé", slug: "sante", publishable: true },
+  {
+    theme: "LOGEMENT_URBANISME",
+    label: "Logement et urbanisme",
+    slug: "logement-urbanisme",
+    publishable: false,
+  },
+];
+
+describe("HubComparisonLauncher", () => {
+  it("prépare une comparaison avec deux candidats documentés et un thème ouvert", () => {
+    render(
+      <HubComparisonLauncher
+        candidacies={[
+          candidacy("c1", "Alice Martin", 3),
+          candidacy("c2", "Bruno Zola", 2),
+          candidacy("c3", "Camille Durand", 0),
+        ]}
+        themes={themes}
+      />
+    );
+
+    const form = screen.getByRole("button", { name: "Comparer" }).closest("form");
+    expect(form).toHaveAttribute("action", "/elections/presidentielle-2027/comparer");
+    expect(screen.getAllByRole("combobox")).toHaveLength(3);
+    expect(screen.getAllByRole("option", { name: "Alice Martin" })).toHaveLength(2);
+    expect(screen.queryByRole("option", { name: "Camille Durand" })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Santé" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Logement et urbanisme" })).not.toBeInTheDocument();
+  });
+
+  it("ne rend pas un formulaire inutilisable sans deux candidats", () => {
+    const { container } = render(
+      <HubComparisonLauncher candidacies={[candidacy("c1", "Alice Martin", 3)]} themes={themes} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialHubNav.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialHubNav.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PresidentialHubNav } from "../PresidentialHubNav";
+
+describe("PresidentialHubNav", () => {
+  it("relie les trois entrées utiles du hub et expose la page courante", () => {
+    render(<PresidentialHubNav active="candidates" />);
+
+    expect(
+      screen.getByRole("navigation", { name: "Explorer la présidentielle 2027" })
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: "Vue d’ensemble" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+    expect(screen.getByRole("link", { name: "Thématiques" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/themes"
+    );
+    expect(screen.getByRole("link", { name: "Candidatures" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { CandidateFicheDetail } from "@/lib/data/politician-candidacy";
-import { CandidateThemes } from "../_components/CandidateFicheBlocks";
+import { CandidateThemes, CandidateTransparency } from "../_components/CandidateFicheBlocks";
 
 type Theme = CandidateFicheDetail["themes"][number];
 
@@ -108,6 +108,23 @@ describe("CandidateThemes", () => {
     );
   });
 
+  it("ouvre directement la mesure quand un thème d'un grand programme n'en contient qu'une", () => {
+    render(
+      <CandidateThemes
+        themes={[theme()]}
+        electionSlug="presidentielle-2027"
+        candidateSlug="camille-riviere"
+        measureCount={16}
+        lastReviewedAt={null}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Voir cette mesure" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/mesures/rouvrir-des-maternites"
+    );
+  });
+
   it("ne perd aucune mesure au regroupement, sur plusieurs sujets", () => {
     render(
       <CandidateThemes
@@ -203,5 +220,28 @@ describe("CandidateThemes", () => {
       />
     );
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("CandidateTransparency", () => {
+  it("ne présente pas toutes les procédures comme un compteur à charge", () => {
+    render(
+      <CandidateTransparency
+        declarationCount={2}
+        probityConvictionCount={1}
+        probityNonDefinitiveConvictionCount={1}
+        politicianSlug="camille-riviere"
+      />
+    );
+
+    expect(screen.getByText("1 condamnation documentée")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Transparence et probité" })).toBeInTheDocument();
+    expect(screen.getByText(/au moins en première instance/)).toBeInTheDocument();
+    expect(screen.getByText(/Présomption d'innocence/)).toBeInTheDocument();
+    expect(screen.queryByText(/procédures documentées/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Voir le détail sur sa fiche" })).toHaveAttribute(
+      "href",
+      "/politiques/camille-riviere"
+    );
   });
 });

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/page.test.ts
@@ -33,6 +33,7 @@ const candidacy = (overrides: Record<string, unknown> = {}) => ({
   sourceLabel: "Le Monde, 14 janvier 2026",
   partyLabel: "Parti Test",
   partyLogoUrl: null,
+  partyColor: "#123456",
   programmeIdentified: false,
   declaredAt: null,
   withdrewAt: null,
@@ -61,7 +62,13 @@ describe("page présidentielle d'une personne", () => {
       declarations: [],
       affairs: [],
     });
-    mockGetDetail.mockResolvedValue({ themes: [], recentVotes: [], mandateCount: 0 });
+    mockGetDetail.mockResolvedValue({
+      themes: [],
+      recentVotes: [],
+      mandateCount: 0,
+      probityConvictionCount: 0,
+      probityNonDefinitiveConvictionCount: 0,
+    });
   });
 
   it("rend en 200 une page minimale avec zéro proposition publiée", async () => {
@@ -70,7 +77,9 @@ describe("page présidentielle d'une personne", () => {
     render(await Page({ params: Promise.resolve({ slug: "camille-riviere" }) }));
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Camille Rivière");
     expect(
-      screen.getByText("Poligraph n’a identifié aucun programme publié à ce jour.")
+      screen.getByText(
+        "Poligraph n’a pas encore trouvé ou traité de programme pour cette candidature."
+      )
     ).toBeInTheDocument();
     expect(mockRedirect).not.toHaveBeenCalled();
     expect(mockGetDetail).not.toHaveBeenCalled();
@@ -81,7 +90,7 @@ describe("page présidentielle d'une personne", () => {
     const { default: Page } = await import("../page");
     render(await Page({ params: Promise.resolve({ slug: "camille-riviere" }) }));
     expect(
-      screen.getByText("Programme identifié, aucune proposition encore publiée sur Poligraph.")
+      screen.getByText("Poligraph a repéré un programme. Son traitement éditorial est en cours.")
     ).toBeInTheDocument();
   });
 
@@ -129,9 +138,7 @@ describe("page présidentielle d'une personne", () => {
     mockGetCandidacy.mockResolvedValue(candidacy());
     const { default: Page } = await import("../page");
     render(await Page({ params: Promise.resolve({ slug: "camille-riviere" }) }));
-    expect(
-      screen.getByRole("heading", { name: "Source du statut de candidature" })
-    ).toBeInTheDocument();
+    expect(screen.getByText("Vérifier le statut de candidature")).toBeInTheDocument();
     const source = screen.getByRole("link", { name: /source originale, lien externe/ });
     expect(source).toHaveAttribute("href", "https://example.org/source");
     expect(source).toHaveAttribute("rel", "nofollow noopener noreferrer");

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -183,6 +183,10 @@ export function CandidateThemes({
 
       <ul className="divide-y divide-border">
         {themes.map((t) => {
+          const singleMeasureUrl =
+            t.measureCount === 1 && t.measures[0]
+              ? `/elections/${electionSlug}/mesures/${t.measures[0].slug}`
+              : null;
           return (
             <li key={t.theme} className="py-5 first:pt-0 last:pb-0">
               <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
@@ -228,7 +232,7 @@ export function CandidateThemes({
                     </ul>
                   )}
                   <Link
-                    href={`${programmeUrl}?theme=${t.slug}`}
+                    href={singleMeasureUrl ?? `${programmeUrl}?theme=${t.slug}`}
                     prefetch={false}
                     className={cn(
                       buttonVariants({ variant: "outline" }),
@@ -246,18 +250,28 @@ export function CandidateThemes({
       </ul>
 
       <div className="border-t border-border pt-4 text-sm">
-        <Link
-          href={programmeUrl}
-          prefetch={false}
-          className={cn(
-            buttonVariants({ variant: showAllMeasures ? "link" : "default" }),
-            "min-h-11 whitespace-normal px-0 text-left font-bold",
-            !showAllMeasures && "w-full px-4 sm:w-auto"
-          )}
-        >
-          Explorer {measureCount === 1 ? "la mesure" : `les ${measureCount} mesures`}
-          <ArrowRight aria-hidden="true" />
-        </Link>
+        <div className="flex flex-wrap items-center gap-x-5">
+          <Link
+            href={programmeUrl}
+            prefetch={false}
+            className={cn(
+              buttonVariants({ variant: showAllMeasures ? "link" : "default" }),
+              "min-h-11 whitespace-normal px-0 text-left font-bold",
+              !showAllMeasures && "w-full px-4 sm:w-auto"
+            )}
+          >
+            Explorer {measureCount === 1 ? "la mesure" : `les ${measureCount} mesures`}
+            <ArrowRight aria-hidden="true" />
+          </Link>
+          <Link
+            href={`/elections/${electionSlug}/comparer?candidat=${candidateSlug}`}
+            prefetch={false}
+            className={MEASURE_ACTION_CLASS_NAME}
+          >
+            Comparer avec une autre candidature
+            <ArrowRight aria-hidden="true" />
+          </Link>
+        </div>
         {lastReviewedAt !== null && (
           <span className="text-muted-foreground">
             {" "}
@@ -361,19 +375,24 @@ export function CandidateRecentVotes({
  * The caveat is required, not editorial politeness: an ongoing procedure is not a conviction, and
  * a bare number next to a candidate's name invites exactly that reading.
  */
-export function CandidateIntegrity({
+export function CandidateTransparency({
   declarationCount,
-  affairCount,
+  probityConvictionCount,
+  probityNonDefinitiveConvictionCount,
   politicianSlug,
 }: {
   declarationCount: number;
-  affairCount: number;
+  probityConvictionCount: number;
+  probityNonDefinitiveConvictionCount: number;
   politicianSlug: string;
 }) {
   return (
-    <section aria-labelledby="integrite" className="space-y-3 rounded-xl border bg-card p-4 md:p-6">
-      <h2 id="integrite" className="font-display text-xl font-bold tracking-tight">
-        Intégrité
+    <section
+      aria-labelledby="transparence-probite"
+      className="space-y-3 rounded-xl border bg-card p-4 md:p-6"
+    >
+      <h2 id="transparence-probite" className="font-display text-xl font-bold tracking-tight">
+        Transparence et probité
       </h2>
       <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div className="rounded-lg border border-border px-4 py-3">
@@ -385,18 +404,27 @@ export function CandidateIntegrity({
           </dd>
         </div>
         <div className="rounded-lg border border-border px-4 py-3">
-          <dt className="text-xs text-muted-foreground">Procédures judiciaires</dt>
+          <dt className="text-xs text-muted-foreground">Atteintes à la probité</dt>
           <dd className="text-sm font-bold">
-            {affairCount === 0
-              ? "Aucune procédure documentée"
-              : `${affairCount} ${affairCount === 1 ? "procédure documentée" : "procédures documentées"}`}
+            {probityConvictionCount === 0
+              ? "Aucune condamnation documentée"
+              : `${probityConvictionCount} ${probityConvictionCount === 1 ? "condamnation documentée" : "condamnations documentées"}`}
           </dd>
         </div>
       </dl>
       <p className="text-xs text-muted-foreground">
-        Quand une procédure existe, son statut exact figure sur sa fiche. Une mise en cause ne vaut
-        pas condamnation.
+        Ce compteur ne retient que les condamnations prononcées au moins en première instance pour
+        atteinte à la probité. Les autres procédures et leur statut exact figurent sur la fiche.
       </p>
+      {probityNonDefinitiveConvictionCount > 0 && (
+        <p className="text-xs text-muted-foreground-strong">
+          Présomption d{"'"}innocence :{" "}
+          {probityNonDefinitiveConvictionCount === 1
+            ? "une condamnation comptée n'est pas définitive"
+            : `${probityNonDefinitiveConvictionCount} condamnations comptées ne sont pas définitives`}
+          .
+        </p>
+      )}
       <Link
         href={`/politiques/${politicianSlug}`}
         prefetch={false}

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.test.tsx
@@ -182,7 +182,7 @@ describe("page des mesures d'une candidature", () => {
     );
   });
 
-  it("garde le thème historique Social et travail lisible pendant la transition", async () => {
+  it("garde l'ancienne URL lisible sans proposer le thème historique dans le filtre", async () => {
     const { default: Page } = await import("./page");
 
     render(
@@ -194,6 +194,8 @@ describe("page des mesures d'une candidature", () => {
     expect(mocks.listMeasures).toHaveBeenCalledWith(
       expect.objectContaining({ theme: "SOCIAL_TRAVAIL" })
     );
-    expect(screen.getByRole("option", { name: /ancienne classification/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /ancienne classification/ })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.tsx
@@ -1,7 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { ArrowLeft, ArrowRight, ExternalLink, Search } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronDown,
+  ExternalLink,
+  Search,
+  SlidersHorizontal,
+} from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,7 +30,7 @@ const ELECTION_SLUG = "presidentielle-2027";
 const PAGE_SIZE = 20;
 const MAX_PAGE = 10_000;
 const MAX_QUERY_LENGTH = 120;
-const THEME_ENTRIES = [...THEMES_IN_ORDER, "SOCIAL_TRAVAIL" as const].map(
+const THEME_ENTRIES = THEMES_IN_ORDER.map(
   (theme) => [theme, THEME_CATEGORY_LABELS[theme]] as const
 );
 
@@ -173,14 +180,24 @@ export default async function CandidateMeasuresPage({ params, searchParams }: Pa
           </p>
         </header>
 
-        <section aria-labelledby="filters-title" className="rounded-2xl border bg-card p-4 sm:p-6">
-          <h2 id="filters-title" className="font-display text-lg font-bold">
-            Rechercher dans ce programme
-          </h2>
+        <details className="group rounded-2xl border bg-card">
+          <summary className="flex min-h-14 cursor-pointer list-none items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden sm:px-5">
+            <SlidersHorizontal aria-hidden="true" className="h-5 w-5 shrink-0 text-primary" />
+            <span className="font-display text-base font-bold">Filtrer et rechercher</span>
+            {activeFilterCount > 0 && (
+              <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground-strong">
+                {activeFilterCount} {activeFilterCount === 1 ? "filtre actif" : "filtres actifs"}
+              </span>
+            )}
+            <ChevronDown
+              aria-hidden="true"
+              className="ml-auto h-5 w-5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+            />
+          </summary>
           <form
             action={basePath}
             method="get"
-            className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-[1fr_14rem_14rem_auto]"
+            className="grid gap-4 border-t border-border px-4 py-4 md:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_12rem_12rem_auto] sm:px-5"
           >
             <div>
               <label htmlFor="measure-query" className="mb-1.5 block text-sm font-bold">
@@ -214,7 +231,7 @@ export default async function CandidateMeasuresPage({ params, searchParams }: Pa
                 <option value="">Toutes les thématiques</option>
                 {THEME_ENTRIES.map(([code, label]) => (
                   <option key={code} value={themeToSlug(code)}>
-                    {code === "SOCIAL_TRAVAIL" ? `${label} (ancienne classification)` : label}
+                    {label}
                   </option>
                 ))}
               </Select>
@@ -246,22 +263,19 @@ export default async function CandidateMeasuresPage({ params, searchParams }: Pa
             >
               Filtrer
             </button>
+            {activeFilterCount > 0 && (
+              <div className="flex items-center md:col-span-2 lg:col-span-4">
+                <Link
+                  href={basePath}
+                  prefetch={false}
+                  className={cn(buttonVariants({ variant: "link" }), "min-h-11 px-0")}
+                >
+                  Effacer les filtres
+                </Link>
+              </div>
+            )}
           </form>
-          {activeFilterCount > 0 && (
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t pt-4">
-              <p role="status" className="text-sm text-muted-foreground-strong">
-                {result.total} {result.total === 1 ? "mesure trouvée" : "mesures trouvées"}
-              </p>
-              <Link
-                href={basePath}
-                prefetch={false}
-                className={cn(buttonVariants({ variant: "outline" }), "min-h-11")}
-              >
-                Effacer les filtres
-              </Link>
-            </div>
-          )}
-        </section>
+        </details>
 
         <section aria-labelledby="results-title">
           <div className="flex flex-wrap items-end justify-between gap-2 border-b pb-4">

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { ExternalLink, UserRound } from "lucide-react";
+import { ChevronDown, ExternalLink, UserRound } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { ShareBar } from "@/components/ui/ShareBar";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
@@ -17,9 +17,10 @@ import {
   getPoliticianPresidentialCandidacy,
 } from "@/lib/data/politician-candidacy";
 import { CandidacyStatusBadge } from "../../_components/CandidacyStatusBadge";
+import { PartyLogo } from "../../_components/PartyLogo";
 import { CandidacyBackBar } from "./_components/CandidacyBackBar";
 import {
-  CandidateIntegrity,
+  CandidateTransparency,
   CandidateRecentVotes,
   CandidateStats,
   CandidateSynthesis,
@@ -160,7 +161,7 @@ export default async function CandidateFichePage({ params }: PageProps) {
           ]}
         />
 
-        <header className="flex flex-col gap-5 sm:flex-row sm:items-start">
+        <header className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-5 gap-y-3 sm:grid-cols-[auto_minmax(0,1fr)_6rem]">
           <div aria-hidden="true">
             <PoliticianAvatar
               photoUrl={politician.photoUrl ?? null}
@@ -187,30 +188,24 @@ export default async function CandidateFichePage({ params }: PageProps) {
               <p className="text-base font-semibold text-foreground">{candidacy.partyLabel}</p>
             )}
           </div>
+          {candidacy.partyLabel && (
+            <PartyLogo
+              logoUrl={candidacy.partyLogoUrl}
+              label={candidacy.partyLabel}
+              color={candidacy.partyColor}
+              size="lg"
+              className="col-start-2 justify-self-start sm:col-start-3 sm:row-start-1 sm:justify-self-end"
+            />
+          )}
         </header>
-
-        <section className="space-y-2 rounded-xl border bg-card p-4 md:p-6">
-          <h2 className="font-display text-base font-bold">Source du statut de candidature</h2>
-          <p className="text-sm text-muted-foreground">{candidacy.sourceLabel}</p>
-          <a
-            href={candidacy.sourceUrl}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-            aria-label="Consulter l’annonce ou la source originale, lien externe"
-            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-primary underline hover:no-underline"
-          >
-            Consulter l&apos;annonce ou la source originale
-            <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          </a>
-        </section>
 
         {!publishable && (
           <section className="rounded-xl border border-dashed bg-muted/30 p-5 md:p-7">
             <h2 className="font-display text-xl font-bold">Contenu disponible sur Poligraph</h2>
             <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground-strong">
               {candidacy.programmeIdentified
-                ? "Programme identifié, aucune proposition encore publiée sur Poligraph."
-                : "Poligraph n’a identifié aucun programme publié à ce jour."}
+                ? "Poligraph a repéré un programme. Son traitement éditorial est en cours."
+                : "Poligraph n’a pas encore trouvé ou traité de programme pour cette candidature."}
             </p>
           </section>
         )}
@@ -247,33 +242,42 @@ export default async function CandidateFichePage({ params }: PageProps) {
 
             <CandidateRecentVotes votes={detail.recentVotes} politicianSlug={slug} />
 
-            <CandidateIntegrity
+            <CandidateTransparency
               declarationCount={politician.declarations.length}
-              affairCount={politician.affairs.length}
+              probityConvictionCount={detail.probityConvictionCount}
+              probityNonDefinitiveConvictionCount={detail.probityNonDefinitiveConvictionCount}
               politicianSlug={slug}
             />
           </>
         )}
 
-        <section className="space-y-2 rounded-xl border bg-card p-4 text-sm text-muted-foreground md:p-6">
-          <h2 className="font-display text-base font-bold tracking-tight text-foreground">
-            D&apos;où viennent ces données
-          </h2>
-          <p>
-            Chaque mesure est extraite d&apos;un document daté, relue, et publiée avec sa source. Le
-            statut de la candidature vient de la source citée ci-dessus, à sa date. Aucun
-            classement, aucun score de proximité : l&apos;ordre des candidatures est alphabétique
-            partout sur le site.
-          </p>
-          {/* Named rather than hidden: a reader who sees the gap stated can tell "not built yet"
-              from "nothing to say". Neither block has a date, and promising one would be worse. */}
-          <p>
-            Deux volets manquent encore. Le rapprochement entre chaque mesure et les scrutins
-            portant sur le même objet, qui demande un rattachement que la base ne porte pas encore.
-            Et le bilan des fonctions exercées, objectifs annoncés face aux chiffres constatés, qui
-            demande un suivi post-électoral à construire.
-          </p>
-        </section>
+        <details className="group rounded-xl border bg-card">
+          <summary className="flex min-h-14 cursor-pointer list-none items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden md:px-6">
+            <span className="font-display text-sm font-bold">
+              Vérifier le statut de candidature
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+              {candidacy.sourceLabel}
+            </span>
+            <ChevronDown
+              aria-hidden="true"
+              className="h-5 w-5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+            />
+          </summary>
+          <div className="border-t border-border px-4 pb-4 pt-3 md:px-6 md:pb-5">
+            <p className="text-sm leading-relaxed text-muted-foreground">{candidacy.sourceLabel}</p>
+            <a
+              href={candidacy.sourceUrl}
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+              aria-label="Consulter l’annonce ou la source originale, lien externe"
+              className="mt-2 inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-primary underline hover:no-underline"
+            >
+              Consulter l&apos;annonce ou la source originale
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
+        </details>
 
         {/* The one filled-weight control of the page, and it is an outline: the fiche is about the
             candidacy, so what lies outside it gets a single named exit rather than a navy block

--- a/src/app/elections/presidentielle-2027/candidats/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/page.test.tsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/data/hub", () => ({ getHubCandidacyField: vi.fn() }));
+
+import { getHubCandidacyField } from "@/lib/data/hub";
+import { generateMetadata } from "./page";
+
+const mockGetCandidacies = vi.mocked(getHubCandidacyField);
+
+beforeEach(() => {
+  mockGetCandidacies.mockReset();
+  mockGetCandidacies.mockResolvedValue([
+    {
+      id: "c1",
+      candidateName: "Alix Dupont",
+      politicianSlug: "alix-dupont",
+      photoUrl: null,
+      blobPhotoUrl: null,
+      status: "DECLARE",
+      sourceUrl: "https://example.org/source",
+      sourceLabel: "Le Monde",
+      partyLabel: "Parti Test",
+      partyColor: null,
+      partyShortName: null,
+      partyLogoUrl: null,
+      measureCount: 1,
+      themesCoveredCount: 1,
+      programmeAbsence: null,
+    },
+  ]);
+});
+
+describe("metadata de l'annuaire présidentiel", () => {
+  it("indexe la liste nue avec son canonical", async () => {
+    const metadata = await generateMetadata({ searchParams: Promise.resolve({}) });
+
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe("/elections/presidentielle-2027/candidats");
+    expect(String(metadata.title)).toContain("Présidentielle 2027");
+  });
+
+  it("passe les variantes filtrées en noindex,follow", async () => {
+    const metadata = await generateMetadata({
+      searchParams: Promise.resolve({ statut: "annoncees" }),
+    });
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+    expect(metadata.alternates?.canonical).toBe("/elections/presidentielle-2027/candidats");
+  });
+
+  it("n'indexe pas un annuaire vide", async () => {
+    mockGetCandidacies.mockResolvedValue([]);
+    const metadata = await generateMetadata({ searchParams: Promise.resolve({}) });
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+});

--- a/src/app/elections/presidentielle-2027/candidats/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/page.tsx
@@ -1,23 +1,66 @@
 import type { Metadata } from "next";
+import { cache } from "react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { BreadcrumbJsonLd, ItemListJsonLd } from "@/components/seo/JsonLd";
+import { SITE_URL } from "@/config/site";
 import { getHubCandidacyField } from "@/lib/data/hub";
-import { formatCandidacyFieldSummary } from "@/lib/presidentielle/candidacy-filters";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { PRESIDENTIAL_CANDIDATES_FILTER_KEYS } from "@/lib/seo/listing-filters";
+import { hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import { HubCandidacyField } from "../_components/HubCandidacyField";
+import { PresidentialHubNav } from "../_components/PresidentialHubNav";
 
 export const revalidate = 86400;
 
-export const metadata: Metadata = {
-  title: "Candidatures et personnalités suivies, présidentielle 2027 | Poligraph",
-  description:
-    "Les candidatures annoncées et les personnalités suivies pour la présidentielle 2027, avec leur statut sourcé et les propositions publiées sur Poligraph.",
-  alternates: { canonical: "/elections/presidentielle-2027/candidats" },
+const PAGE_PATH = "/elections/presidentielle-2027/candidats";
+const getCandidacies = cache(() => getHubCandidacyField(PRESIDENTIELLE_2027_SLUG));
+
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const [params, candidacies] = await Promise.all([searchParams, getCandidacies()]);
+  // Filtered and searched variants are useful navigation surfaces, but duplicate the same finite
+  // directory. Keep discovery through their links without asking search engines to index them.
+  const normalizedParams = Object.fromEntries(
+    Object.entries(params).map(([key, value]) => [key, Array.isArray(value) ? value[0] : value])
+  );
+  const hasUtilityParams = hasActiveListingFilter(
+    normalizedParams,
+    PRESIDENTIAL_CANDIDATES_FILTER_KEYS
+  );
+
+  return {
+    title: "Présidentielle 2027 : candidatures et programmes | Poligraph",
+    description:
+      "Les candidatures annoncées et les personnalités suivies pour la présidentielle 2027, avec leur statut sourcé et les propositions publiées sur Poligraph.",
+    robots:
+      hasUtilityParams || candidacies.length === 0 ? { index: false, follow: true } : undefined,
+    alternates: { canonical: PAGE_PATH },
+  };
+}
+
 export default async function PresidentialCandidatesPage() {
-  const candidacies = await getHubCandidacyField(PRESIDENTIELLE_2027_SLUG);
+  const candidacies = await getCandidacies();
   return (
-    <div className="container mx-auto space-y-8 px-4 pb-10 pt-4">
+    <main className="container mx-auto space-y-8 px-4 pb-10 pt-4">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Présidentielle 2027", url: `${SITE_URL}/elections/presidentielle-2027` },
+          { name: "Candidatures", url: `${SITE_URL}${PAGE_PATH}` },
+        ]}
+      />
+      <ItemListJsonLd
+        name="Candidatures et personnalités suivies pour la présidentielle 2027"
+        description="Liste alphabétique des candidatures sourcées et des personnalités suivies par Poligraph."
+        url={`${SITE_URL}${PAGE_PATH}`}
+        items={candidacies.map((candidacy) => ({
+          name: candidacy.candidateName,
+          url: `${SITE_URL}${PAGE_PATH}/${candidacy.politicianSlug}`,
+          image: candidacy.blobPhotoUrl ?? candidacy.photoUrl ?? undefined,
+        }))}
+      />
       <Breadcrumb
         items={[
           { label: "Élections", href: "/elections" },
@@ -25,18 +68,20 @@ export default async function PresidentialCandidatesPage() {
           { label: "Candidatures" },
         ]}
       />
+      <PresidentialHubNav active="candidates" />
       <header className="max-w-4xl space-y-3">
         <p className="text-xs font-bold uppercase tracking-widest text-brand">
           Présidentielle 2027
         </p>
         <h1 className="font-display text-3xl font-extrabold tracking-tight md:text-5xl">
-          Candidatures et personnalités suivies
+          Candidatures à la présidentielle 2027
         </h1>
-        <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
-          {formatCandidacyFieldSummary(candidacies)}
+        <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          Cette liste n&apos;est pas la liste officielle des candidats. Chaque statut est sourcé et
+          l&apos;ordre reste alphabétique, sans classement.
         </p>
       </header>
       <HubCandidacyField candidacies={candidacies} />
-    </div>
+    </main>
   );
 }

--- a/src/app/elections/presidentielle-2027/comparer/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/comparer/page.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const getComparison = vi.fn();
+vi.mock("@/lib/data/presidential-comparison", () => ({
+  getPresidentialComparison: (...args: unknown[]) => getComparison(...args),
+}));
+
+describe("comparaison présidentielle", () => {
+  it("présente les mesures côte à côte et qualifie une absence", async () => {
+    getComparison.mockResolvedValue({
+      candidateOptions: [
+        { candidacyId: "c1", name: "Alice Martin", slug: "alice-martin", partyLabel: "A" },
+        { candidacyId: "c2", name: "Bruno Zola", slug: "bruno-zola", partyLabel: "B" },
+      ],
+      themes: [{ code: "SANTE", slug: "sante", label: "Santé" }],
+      selectedTheme: { code: "SANTE", slug: "sante", label: "Santé" },
+      selectedCandidates: [
+        {
+          candidacyId: "c1",
+          name: "Alice Martin",
+          slug: "alice-martin",
+          partyLabel: "A",
+          accentColor: null,
+          totalMeasures: 1,
+          page: 1,
+          totalPages: 1,
+          measures: [
+            {
+              id: "m1",
+              slug: "ouvrir-un-centre",
+              text: "Ouvrir un centre de santé.",
+              sourceUrl: "https://example.org/source",
+              subtopics: [],
+              precision: null,
+              qualifications: [],
+              withdrawal: null,
+            },
+          ],
+        },
+        {
+          candidacyId: "c2",
+          name: "Bruno Zola",
+          slug: "bruno-zola",
+          partyLabel: "B",
+          accentColor: null,
+          totalMeasures: 0,
+          page: 1,
+          totalPages: 1,
+          measures: [],
+        },
+      ],
+      lastReviewedAt: new Date("2026-08-29T00:00:00Z"),
+    });
+
+    const { default: Page } = await import("./page");
+    render(
+      await Page({
+        searchParams: Promise.resolve({ candidat: ["alice-martin", "bruno-zola"], theme: "sante" }),
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: "Santé", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("Ouvrir un centre de santé.")).toBeInTheDocument();
+    expect(screen.getByText(/Poligraph n'a pas encore trouvé ou traité/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Voir la mesure" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/mesures/ouvrir-un-centre"
+    );
+  });
+
+  it("reste noindex pour éviter les combinaisons dupliquées", async () => {
+    const { metadata } = await import("./page");
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+    expect(metadata.alternates?.canonical).toBe("/elections/presidentielle-2027/comparer");
+  });
+});

--- a/src/app/elections/presidentielle-2027/comparer/page.tsx
+++ b/src/app/elections/presidentielle-2027/comparer/page.tsx
@@ -1,0 +1,387 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight, ChevronDown, ExternalLink, SlidersHorizontal } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { MeasureBadge } from "@/components/measures/MeasureBadge";
+import { MeasurePrecisionBadge } from "@/components/measures/MeasurePrecisionBadge";
+import { buttonVariants } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { getPresidentialComparison } from "@/lib/data/presidential-comparison";
+import { cn, formatDate } from "@/lib/utils";
+import { PresidentialHubNav } from "../_components/PresidentialHubNav";
+
+const ELECTION_SLUG = "presidentielle-2027";
+const COMPARISON_PATH = `/elections/${ELECTION_SLUG}/comparer`;
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: "Comparer les programmes, présidentielle 2027 | Poligraph",
+  description:
+    "Comparer côte à côte les mesures publiées des candidats à la présidentielle 2027, par thème et avec leurs sources.",
+  alternates: { canonical: COMPARISON_PATH },
+  robots: { index: false, follow: true },
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function paramsAsArray(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function comparisonUrl({
+  candidateSlugs,
+  themeSlug,
+  pages,
+}: {
+  candidateSlugs: string[];
+  themeSlug: string;
+  pages: Record<string, number>;
+}): string {
+  const params = new URLSearchParams();
+  candidateSlugs.forEach((slug) => params.append("candidat", slug));
+  params.set("theme", themeSlug);
+  for (const [slug, page] of Object.entries(pages)) {
+    if (page > 1 && candidateSlugs.includes(slug)) params.set(`page-${slug}`, String(page));
+  }
+  return `${COMPARISON_PATH}?${params.toString()}`;
+}
+
+export default async function PresidentialComparisonPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const rawParams = await searchParams;
+  const candidatePages = Object.fromEntries(
+    Object.entries(rawParams)
+      .filter(([key]) => key.startsWith("page-"))
+      .map(([key, value]) => [key.slice(5), Number.parseInt(firstParam(value) ?? "1", 10)])
+  );
+  const comparison = await getPresidentialComparison({
+    electionSlug: ELECTION_SLUG,
+    candidateSlugs: paramsAsArray(rawParams.candidat),
+    themeSlug: firstParam(rawParams.theme),
+    candidatePages,
+  });
+  if (comparison === null) notFound();
+
+  const selectedSlugs = comparison.selectedCandidates.map((candidate) => candidate.slug);
+  const selectedTheme = comparison.selectedTheme;
+
+  return (
+    <main className="container mx-auto px-4 pb-16 pt-4">
+      <Breadcrumb
+        items={[
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: `/elections/${ELECTION_SLUG}` },
+          { label: "Comparer" },
+        ]}
+      />
+      <PresidentialHubNav active="compare" />
+
+      <div className="mt-8 space-y-8">
+        <header className="max-w-3xl">
+          <p className="text-sm font-bold uppercase tracking-widest text-brand">
+            Présidentielle 2027
+          </p>
+          <h1 className="mt-2 font-display text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            Comparer les mesures des candidats
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground-strong">
+            Choisissez deux ou trois candidats et une thématique. Poligraph place leurs mesures
+            publiées côte à côte, sans note ni classement.
+          </p>
+        </header>
+
+        <details
+          open={selectedSlugs.length < 2 || selectedTheme === null}
+          className="group rounded-2xl border bg-card"
+        >
+          <summary className="flex min-h-14 cursor-pointer list-none items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden md:px-6">
+            <SlidersHorizontal aria-hidden="true" className="h-5 w-5 shrink-0 text-primary" />
+            <span className="font-display text-base font-bold">
+              {selectedSlugs.length >= 2 && selectedTheme
+                ? "Modifier la comparaison"
+                : "Préparer la comparaison"}
+            </span>
+            {selectedSlugs.length >= 2 && selectedTheme && (
+              <span className="hidden min-w-0 flex-1 truncate text-sm text-muted-foreground md:block">
+                {comparison.selectedCandidates.map((candidate) => candidate.name).join(", ")},{" "}
+                {selectedTheme.label}
+              </span>
+            )}
+            <ChevronDown
+              aria-hidden="true"
+              className="ml-auto h-5 w-5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+            />
+          </summary>
+          <form
+            action={COMPARISON_PATH}
+            method="get"
+            className="grid gap-4 border-t border-border p-4 lg:grid-cols-4 md:p-6"
+          >
+            {[0, 1, 2].map((index) => (
+              <div key={index}>
+                <label htmlFor={`candidate-${index}`} className="mb-1.5 block text-sm font-bold">
+                  {index === 2 ? "Troisième candidat (facultatif)" : `Candidat ${index + 1}`}
+                </label>
+                <Select
+                  id={`candidate-${index}`}
+                  name="candidat"
+                  defaultValue={selectedSlugs[index] ?? ""}
+                  required={index < 2}
+                  className="min-h-11"
+                >
+                  <option value="">Choisir</option>
+                  {comparison.candidateOptions.map((candidate) => (
+                    <option key={candidate.candidacyId} value={candidate.slug}>
+                      {candidate.name}
+                      {candidate.partyLabel ? `, ${candidate.partyLabel}` : ""}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            ))}
+            <div>
+              <label htmlFor="comparison-theme" className="mb-1.5 block text-sm font-bold">
+                Thématique
+              </label>
+              <Select
+                id="comparison-theme"
+                name="theme"
+                defaultValue={selectedTheme?.slug ?? ""}
+                required
+                className="min-h-11"
+              >
+                <option value="">Choisir</option>
+                {comparison.themes.map((theme) => (
+                  <option key={theme.code} value={theme.slug}>
+                    {theme.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="lg:col-span-4">
+              <button
+                type="submit"
+                className={cn(buttonVariants({ variant: "default" }), "min-h-11 w-full sm:w-auto")}
+              >
+                Comparer
+                <ArrowRight aria-hidden="true" />
+              </button>
+            </div>
+          </form>
+        </details>
+
+        {selectedSlugs.length < 2 || selectedTheme === null ? (
+          <section className="rounded-2xl border border-dashed bg-muted/30 p-6 md:p-8">
+            <h2 className="font-display text-xl font-bold">Préparer la comparaison</h2>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground-strong">
+              Sélectionnez deux candidats différents et une thématique. Un troisième candidat peut
+              être ajouté pour élargir la lecture.
+            </p>
+          </section>
+        ) : (
+          <section aria-labelledby="comparison-results" className="space-y-5">
+            <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
+              <div>
+                <p className="text-sm font-bold uppercase tracking-wide text-brand">Thématique</p>
+                <h2 id="comparison-results" className="font-display text-3xl font-extrabold">
+                  {selectedTheme.label}
+                </h2>
+              </div>
+              {comparison.lastReviewedAt && (
+                <p className="text-xs text-muted-foreground">
+                  Dernière revue du corpus le {formatDate(comparison.lastReviewedAt)}
+                </p>
+              )}
+            </div>
+
+            <div
+              className={cn(
+                "grid items-start gap-4",
+                comparison.selectedCandidates.length === 2
+                  ? "lg:grid-cols-2"
+                  : "lg:grid-cols-2 xl:grid-cols-3"
+              )}
+            >
+              {comparison.selectedCandidates.map((candidate) => (
+                <article
+                  key={candidate.candidacyId}
+                  className="overflow-hidden rounded-2xl border bg-card"
+                >
+                  <div className="border-b border-border p-4 md:p-5">
+                    <div className="flex items-start gap-3">
+                      <span
+                        aria-hidden="true"
+                        className="mt-1 h-10 w-1.5 shrink-0 rounded-full bg-primary"
+                        style={
+                          candidate.accentColor
+                            ? { backgroundColor: candidate.accentColor }
+                            : undefined
+                        }
+                      />
+                      <div>
+                        <h3 className="font-display text-xl font-extrabold">{candidate.name}</h3>
+                        {candidate.partyLabel && (
+                          <p className="text-sm text-muted-foreground-strong">
+                            {candidate.partyLabel}
+                          </p>
+                        )}
+                        <p aria-live="polite" className="mt-1 text-xs text-muted-foreground">
+                          {candidate.totalMeasures}{" "}
+                          {candidate.totalMeasures === 1 ? "mesure" : "mesures"}
+                          {candidate.totalPages > 1
+                            ? `, page ${candidate.page} sur ${candidate.totalPages}`
+                            : ""}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {candidate.measures.length === 0 ? (
+                    <p className="p-4 text-sm leading-relaxed text-muted-foreground-strong md:p-5">
+                      Poligraph n&apos;a pas encore trouvé ou traité de mesure publiée sur cette
+                      thématique pour cette candidature.
+                    </p>
+                  ) : (
+                    <>
+                      <ol className="divide-y divide-border">
+                        {candidate.measures.map((measure) => (
+                          <li key={measure.id} className="p-4 md:p-5">
+                            <p className="text-sm leading-relaxed">{measure.text}</p>
+                            {(measure.precision !== null || measure.qualifications.length > 0) && (
+                              <div className="mt-3 flex flex-wrap gap-1.5">
+                                {measure.precision !== null && (
+                                  <MeasurePrecisionBadge precision={measure.precision} />
+                                )}
+                                {measure.qualifications.map((qualification) => (
+                                  <MeasureBadge key={qualification.id} tier="qualification">
+                                    {qualification.label}
+                                  </MeasureBadge>
+                                ))}
+                              </div>
+                            )}
+                            {measure.subtopics.length > 0 && (
+                              <ul aria-label="Sous-thèmes" className="mt-3 flex flex-wrap gap-1.5">
+                                {measure.subtopics.map((subtopic) => (
+                                  <li
+                                    key={subtopic.slug}
+                                    className="rounded-full border bg-muted/40 px-2.5 py-1 text-xs"
+                                  >
+                                    {subtopic.label}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                            {measure.withdrawal !== null && (
+                              <p className="mt-3 text-xs text-muted-foreground-strong">
+                                Mesure retirée le {formatDate(measure.withdrawal.withdrawnAt)}
+                                {measure.withdrawal.sourceUrl !== null && (
+                                  <>
+                                    {" · "}
+                                    <a
+                                      href={measure.withdrawal.sourceUrl}
+                                      target="_blank"
+                                      rel="nofollow noopener noreferrer"
+                                      aria-label={`Consulter la source du retrait de la mesure de ${candidate.name}, lien externe`}
+                                      className="font-bold text-primary underline"
+                                    >
+                                      {measure.withdrawal.sourceLabel ?? "Source du retrait"}
+                                    </a>
+                                  </>
+                                )}
+                              </p>
+                            )}
+                            <div className="mt-3 flex flex-wrap gap-x-4">
+                              <Link
+                                href={`/elections/${ELECTION_SLUG}/mesures/${measure.slug}`}
+                                prefetch={false}
+                                className="inline-flex min-h-11 items-center gap-1.5 text-sm font-bold text-primary hover:underline"
+                              >
+                                Voir la mesure
+                                <ArrowRight aria-hidden="true" className="h-4 w-4" />
+                              </Link>
+                              {measure.sourceUrl && (
+                                <a
+                                  href={measure.sourceUrl}
+                                  target="_blank"
+                                  rel="nofollow noopener noreferrer"
+                                  aria-label={`Consulter la source de la mesure de ${candidate.name}, lien externe`}
+                                  className="inline-flex min-h-11 items-center gap-1.5 text-sm font-bold text-primary hover:underline"
+                                >
+                                  Source
+                                  <ExternalLink aria-hidden="true" className="h-4 w-4" />
+                                </a>
+                              )}
+                            </div>
+                          </li>
+                        ))}
+                      </ol>
+                      {candidate.totalPages > 1 && (
+                        <nav
+                          aria-label={`Pagination des mesures de ${candidate.name}`}
+                          className="flex items-center justify-between gap-3 border-t border-border p-4"
+                        >
+                          {candidate.page > 1 ? (
+                            <Link
+                              href={comparisonUrl({
+                                candidateSlugs: selectedSlugs,
+                                themeSlug: selectedTheme.slug,
+                                pages: {
+                                  ...candidatePages,
+                                  [candidate.slug]: candidate.page - 1,
+                                },
+                              })}
+                              prefetch={false}
+                              scroll={false}
+                              className="inline-flex min-h-11 items-center text-sm font-bold text-primary hover:underline"
+                            >
+                              Précédentes
+                            </Link>
+                          ) : (
+                            <span />
+                          )}
+                          {candidate.page < candidate.totalPages && (
+                            <Link
+                              href={comparisonUrl({
+                                candidateSlugs: selectedSlugs,
+                                themeSlug: selectedTheme.slug,
+                                pages: {
+                                  ...candidatePages,
+                                  [candidate.slug]: candidate.page + 1,
+                                },
+                              })}
+                              prefetch={false}
+                              scroll={false}
+                              className="inline-flex min-h-11 items-center text-sm font-bold text-primary hover:underline"
+                            >
+                              Suivantes
+                            </Link>
+                          )}
+                        </nav>
+                      )}
+                    </>
+                  )}
+                </article>
+              ))}
+            </div>
+
+            <p className="max-w-3xl text-xs leading-relaxed text-muted-foreground">
+              Cette vue compare le corpus publié par Poligraph. Une absence indique que nous
+              n&apos;avons pas encore trouvé ou traité de mesure correspondante, pas que la
+              candidature ne propose rien.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -19,8 +19,14 @@ const detail = {
   text: "Construire davantage de logements accessibles",
   details: "La source précise les **territoires concernés** et le calendrier annoncé.",
   precision: "CHIFFREE",
+  attribution: "PERSONAL",
   reviewedAt: new Date("2026-08-20T00:00:00Z"),
   publishedAt: new Date("2026-08-21T00:00:00Z"),
+  programEdition: {
+    label: "Programme pour 2027",
+    publishedAt: new Date("2026-08-10T00:00:00Z"),
+    documentUrl: "https://example.org/programme-complet",
+  },
   candidate: {
     name: "Camille Rivière",
     slug: "camille-riviere",
@@ -39,6 +45,7 @@ const detail = {
     },
   ],
   votes: [],
+  relatedMeasures: [],
 };
 
 describe("page publique d'une mesure présidentielle", () => {
@@ -55,10 +62,16 @@ describe("page publique d'une mesure présidentielle", () => {
       </TooltipProvider>
     );
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(detail.text);
-    expect(screen.getByText("Chiffrée")).toBeInTheDocument();
+    expect(screen.getByText("Objectif quantifié")).toBeInTheDocument();
     expect(screen.getByText("Source primaire")).toBeInTheDocument();
     expect(screen.getByText("Programme de candidature")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Ce que prévoit la mesure" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Dans le programme" })).toBeInTheDocument();
+    expect(screen.getByText("Formulée personnellement")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Consulter le programme/ })).toHaveAttribute(
+      "href",
+      "https://example.org/programme-complet"
+    );
     expect(screen.getByText("territoires concernés")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Camille Rivière/ })).toHaveAttribute(
       "href",
@@ -68,6 +81,37 @@ describe("page publique d'une mesure présidentielle", () => {
       "href",
       "/elections/presidentielle-2027/themes/logement-urbanisme"
     );
+  });
+
+  it("propose des mesures factuelles d'autres personnalités quand elles existent", async () => {
+    getDetail.mockResolvedValue({
+      ...detail,
+      relatedMeasures: [
+        {
+          slug: "alex-martin-encadrer-les-loyers",
+          text: "Encadrer les loyers dans les zones tendues",
+          candidateName: "Alex Martin",
+          candidateSlug: "alex-martin",
+          party: "Parti Test",
+          sharedSubtopics: ["Encadrement des loyers"],
+        },
+      ],
+    });
+    const { default: Page } = await import("./page");
+    render(
+      <TooltipProvider>
+        {await Page({ params: Promise.resolve({ id: "measure-1" }) })}
+      </TooltipProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Ce que proposent d'autres candidates et candidats" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Alex Martin/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/mesures/alex-martin-encadrer-les-loyers"
+    );
+    expect(screen.getByText("Encadrement des loyers")).toBeInTheDocument();
   });
 
   it("n'invente aucun vote quand aucun lien public n'existe", async () => {

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -77,9 +77,13 @@ describe("page publique d'une mesure présidentielle", () => {
       "href",
       "/elections/presidentielle-2027/candidats/camille-riviere"
     );
-    expect(screen.getByRole("link", { name: /Comparer les mesures/ })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", {
+        name: "Comparer cette mesure avec celles d'un autre candidat",
+      })
+    ).toHaveAttribute(
       "href",
-      "/elections/presidentielle-2027/themes/logement-urbanisme"
+      "/elections/presidentielle-2027/comparer?candidat=camille-riviere&theme=logement-urbanisme"
     );
   });
 

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -11,6 +11,7 @@ import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import {
   CHAMBER_LABELS,
   MEASURE_SOURCE_KIND_LABELS,
+  MEASURE_ATTRIBUTION_LABELS,
   SOURCE_TIER_LABELS,
   THEME_CATEGORY_LABELS,
 } from "@/config/labels";
@@ -56,6 +57,13 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
   const canonical = "/elections/" + ELECTION_SLUG + "/mesures/" + measure.slug;
   const themeUrl = "/elections/" + ELECTION_SLUG + "/themes/" + themeToSlug(measure.theme);
   const candidateUrl = "/elections/" + ELECTION_SLUG + "/candidats/" + measure.candidate.slug;
+  const comparisonUrl =
+    "/elections/" +
+    ELECTION_SLUG +
+    "/comparer?candidat=" +
+    encodeURIComponent(measure.candidate.slug) +
+    "&theme=" +
+    encodeURIComponent(themeToSlug(measure.theme));
   const themeLabel = THEME_CATEGORY_LABELS[measure.theme];
   const seoDescription = buildMeasureSeoDescription({
     candidateName: measure.candidate.name,
@@ -95,7 +103,12 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
       />
       <article className="container mx-auto max-w-5xl px-4">
         <header className="border-b border-border pb-8 pt-3">
-          <p className="text-sm font-bold text-primary">Mesure publiée · {themeLabel}</p>
+          <Link
+            href={themeUrl}
+            className="inline-flex min-h-11 items-center text-sm font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            {themeLabel}
+          </Link>
           <h1
             className={`mt-3 max-w-[28ch] font-display font-extrabold leading-[1.08] tracking-tight ${titleClass}`}
           >
@@ -108,15 +121,18 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
                 <InfoTooltip
                   text={
                     measure.precision === "CHIFFREE"
-                      ? "La formulation comporte un objectif numérique explicite. Cela ne signifie pas que son coût ou sa faisabilité ont été évalués."
-                      : "La formulation fixe un objectif, sans valeur numérique explicite."
+                      ? "La formulation comporte une quantité, écrite en chiffres ou en toutes lettres. Cela ne signifie pas que son coût ou sa faisabilité ont été évalués."
+                      : "La formulation fixe un objectif sans quantité explicite."
                   }
                   className="-my-3 min-h-11 min-w-11"
                 />
               </span>
             )}
             <span className="text-sm text-muted-foreground">
-              Dernière revue éditoriale le {formatDate(measure.reviewedAt)}
+              Revue par Poligraph le {formatDate(measure.reviewedAt)}.{" "}
+              <Link href="/methodologie" className="font-bold text-primary underline">
+                Voir la méthode
+              </Link>
             </span>
           </div>
         </header>
@@ -129,6 +145,33 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
               {measure.details}
             </MarkdownText>
+          </section>
+        )}
+
+        {measure.programEdition !== null && (
+          <section aria-labelledby="programme-title" className="border-b border-border py-8">
+            <h2 id="programme-title" className="font-display text-2xl font-extrabold">
+              Dans le programme
+            </h2>
+            <div className="mt-4 rounded-2xl border border-border bg-card p-5">
+              <p className="text-sm font-bold text-muted-foreground">
+                {MEASURE_ATTRIBUTION_LABELS[measure.attribution]}
+              </p>
+              <p className="mt-1 text-lg font-bold">{measure.programEdition.label}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Document publié le {formatDate(measure.programEdition.publishedAt)}
+              </p>
+              <a
+                href={measure.programEdition.documentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Consulter le programme ${measure.programEdition.label}, lien externe`}
+                className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-lg font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+              >
+                Consulter le programme complet
+                <ExternalLink aria-hidden="true" className="h-4 w-4" />
+              </a>
+            </div>
           </section>
         )}
 
@@ -157,13 +200,63 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <ArrowRight aria-hidden="true" className="h-5 w-5 shrink-0 text-primary" />
           </Link>
           <Link
-            href={themeUrl}
+            href={comparisonUrl}
             className="mt-4 inline-flex min-h-11 items-center gap-2 rounded-lg font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
           >
-            Comparer les mesures sur {themeLabel}
+            Comparer cette mesure avec celles d&apos;un autre candidat
             <ArrowRight aria-hidden="true" className="h-4 w-4" />
           </Link>
         </section>
+
+        {measure.relatedMeasures.length > 0 && (
+          <section aria-labelledby="related-title" className="border-t border-border py-8">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <h2 id="related-title" className="font-display text-2xl font-extrabold">
+                  Ce que proposent d&apos;autres candidates et candidats
+                </h2>
+                <p className="mt-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground">
+                  Mesures publiées sur {themeLabel.toLocaleLowerCase("fr")}
+                  {measure.relatedMeasures.some((related) => related.sharedSubtopics.length > 0)
+                    ? ", rapprochées par sous-thème quand cette information a été validée."
+                    : "."}{" "}
+                  Aucun classement ni jugement de faisabilité n&apos;est appliqué.
+                </p>
+              </div>
+              <Link
+                href={themeUrl}
+                className="inline-flex min-h-11 items-center gap-2 font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                Voir toute la comparaison
+                <ArrowRight aria-hidden="true" className="h-4 w-4" />
+              </Link>
+            </div>
+            <ul className="mt-5 grid gap-3 md:grid-cols-2">
+              {measure.relatedMeasures.map((related) => (
+                <li key={related.slug}>
+                  <Link
+                    href={`/elections/${ELECTION_SLUG}/mesures/${related.slug}`}
+                    prefetch={false}
+                    className="group flex h-full min-h-32 flex-col rounded-2xl border border-border bg-card p-5 hover:border-primary/60 hover:bg-accent/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  >
+                    <span className="text-sm font-bold text-primary">
+                      {related.candidateName}
+                      {related.party ? ` · ${related.party}` : ""}
+                    </span>
+                    <span className="mt-2 line-clamp-3 leading-relaxed text-foreground group-hover:underline">
+                      {related.text}
+                    </span>
+                    {related.sharedSubtopics.length > 0 && (
+                      <span className="mt-3 text-xs text-muted-foreground">
+                        {related.sharedSubtopics.join(" · ")}
+                      </span>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <section aria-labelledby="sources-title" className="border-t border-border py-8">
           <h2 id="sources-title" className="font-display text-2xl font-extrabold">

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Mail } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { AddToCalendar } from "@/components/elections/AddToCalendar";
 import { CollectionPageJsonLd, EventJsonLd } from "@/components/seo/JsonLd";
@@ -10,7 +11,9 @@ import { SITE_URL } from "@/config/site";
 import { HubCandidacyOverview } from "./_components/HubCandidacyOverview";
 import { HubClosedState } from "./_components/HubClosedState";
 import { HubCorpusState } from "./_components/HubCorpusState";
+import { HubComparisonLauncher } from "./_components/HubComparisonLauncher";
 import { HubSubjects } from "./_components/HubSubjects";
+import { PresidentialHubNav } from "./_components/PresidentialHubNav";
 import { PresidentialCorpusSearch } from "./_components/PresidentialCorpusSearch";
 
 // ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
@@ -25,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Présidentielle 2027 : programmes, mesures et candidatures",
     description:
-      "Les candidatures à la présidentielle 2027, leurs mesures sourcées et relues par thème et les votes qui les éclairent.",
+      "Les candidatures à la présidentielle 2027, leurs mesures sourcées et relues par thème, et les votes parlementaires disponibles dans Poligraph.",
     robots: publishable ? undefined : { index: false, follow: true },
     alternates: { canonical: "/elections/presidentielle-2027" },
   };
@@ -67,7 +70,7 @@ export default async function PresidentialHubPage() {
       )}
       <CollectionPageJsonLd
         name="Présidentielle 2027 : programmes et mesures des candidatures"
-        description="Comparer les candidatures à l'élection présidentielle 2027, leurs mesures sourcées et leurs votes parlementaires par sujet."
+        description="Comparer les candidatures à l'élection présidentielle 2027, leurs mesures sourcées et les votes parlementaires disponibles par sujet."
         url={`${SITE_URL}/elections/${PRESIDENTIELLE_2027_SLUG}`}
         numberOfItems={context.verifiedMeasureCount}
       />
@@ -75,6 +78,8 @@ export default async function PresidentialHubPage() {
         <Breadcrumb
           items={[{ label: "Élections", href: "/elections" }, { label: "Présidentielle 2027" }]}
         />
+
+        <PresidentialHubNav active="overview" />
 
         <header className="max-w-3xl space-y-3">
           <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
@@ -84,8 +89,8 @@ export default async function PresidentialHubPage() {
             Présidentielle 2027 : comparer les programmes et les mesures
           </h1>
           <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-lg">
-            Pour chaque thème : ce que les personnalités suivies proposent, ce qu&apos;elles ont
-            voté, et ce qu&apos;elles ont fait quand elles étaient au pouvoir.
+            Pour chaque thème : les mesures publiées par les personnalités suivies et,
+            lorsqu&apos;ils existent, les votes parlementaires documentés sur le même objet.
           </p>
           {context.round1Date && (
             <p className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground-strong">
@@ -115,6 +120,30 @@ export default async function PresidentialHubPage() {
         <HubSubjects themes={context.themes} />
 
         <HubCandidacyOverview candidacies={field} />
+
+        <HubComparisonLauncher candidacies={field} themes={context.themes} />
+
+        <section
+          aria-labelledby="campaign-contact-title"
+          className="flex flex-col gap-3 rounded-2xl border border-border bg-card p-5 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h2 id="campaign-contact-title" className="font-display text-lg font-bold">
+              Vous représentez une équipe de campagne ?
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+              Envoyez-nous le programme officiel, une correction ou une source. Chaque ajout reste
+              soumis à la même vérification éditoriale.
+            </p>
+          </div>
+          <a
+            href="mailto:contact@poligraph.fr?subject=Présidentielle%202027%20-%20programme%20ou%20correction"
+            className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-xl border border-primary px-4 font-display text-sm font-bold text-primary hover:bg-primary hover:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <Mail aria-hidden="true" className="h-4 w-4" />
+            Contacter Poligraph
+          </a>
+        </section>
 
         <HubCorpusState
           electionTitle={context.electionTitle}

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from "lucide-react";
+import { ArrowRight, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import {
   CHAMBER_SHORT_LABELS,
@@ -15,6 +15,7 @@ import type { ThemeCategory } from "@/generated/prisma";
 import type { PublicMeasure } from "@/lib/data/measures";
 import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
+import { themeToSlug } from "@/lib/presidentielle/themes";
 import { formatDate } from "@/lib/utils";
 import { SubjectGate } from "./SubjectGate";
 import { SubjectSidebar } from "./SubjectSidebar";
@@ -362,6 +363,16 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
             thème, réparties entre {documented} {documented === 1 ? "candidature" : "candidatures"}.
             Classées par nom de famille.
           </p>
+          {data.publishable && (
+            <Link
+              href={`/elections/${data.electionSlug}/comparer?theme=${themeToSlug(data.theme)}`}
+              prefetch={false}
+              className="inline-flex min-h-11 items-center gap-2 font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              Choisir deux candidats à comparer
+              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+          )}
         </header>
 
         {!data.publishable ? (

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -620,7 +620,7 @@ describe("SubjectComparison", () => {
     );
 
     // Une pastille chiffrée pour la première, une absence qualifiée pour la seconde, pas l'inverse.
-    expect(screen.getAllByText("Chiffrée")).toHaveLength(2);
+    expect(screen.getAllByText("Objectif quantifié")).toHaveLength(2);
     expect(screen.getAllByText("Précision non renseignée")).toHaveLength(2);
     // Et deux états de vote différents sur la même ligne. Portée sur la ligne du tableau : le
     // paragraphe de méthode cite les mêmes libellés en bas de page.

--- a/src/app/elections/presidentielle-2027/themes/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/themes/__tests__/page.test.ts
@@ -21,9 +21,7 @@ describe("generateMetadata de l'index des thématiques", () => {
       publishableSubjectPageCount: 1,
     });
     const meta = await generateMetadata();
-    expect(String(meta.title)).toMatch(
-      /Couverture du corpus par thématique, présidentielle 2027 \| Poligraph/
-    );
+    expect(String(meta.title)).toBe("Programmes par thème, présidentielle 2027 | Poligraph");
   });
 
   it("noindex quand aucune page thème n'est publiable", async () => {

--- a/src/app/elections/presidentielle-2027/themes/_components/ThemesIndexList.tsx
+++ b/src/app/elections/presidentielle-2027/themes/_components/ThemesIndexList.tsx
@@ -41,6 +41,10 @@ function SubjectLink({
 }
 
 export function ThemesIndexList({ data }: ThemesIndexListProps) {
+  const hasWithdrawnMeasures = data.themes.some(
+    (entry) => entry.documentedMeasureCount > entry.currentlyDefendedMeasureCount
+  );
+
   return (
     <>
       <ul className="space-y-3 md:hidden">
@@ -49,26 +53,27 @@ export function ThemesIndexList({ data }: ThemesIndexListProps) {
             <SubjectLink slug={entry.slug} theme={entry.theme} label={entry.label} />
             <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 border-t border-border pt-3 text-sm">
               <div>
-                <dt className="text-xs text-muted-foreground">Candidatures documentées</dt>
+                <dt className="text-xs text-muted-foreground">Candidats avec des mesures</dt>
                 <dd className="mt-0.5 font-display text-xl font-bold tabular-nums">
                   {entry.documentedCandidacyCount}
                 </dd>
               </div>
               <div>
-                <dt className="text-xs text-muted-foreground">Mesures documentées</dt>
+                <dt className="text-xs text-muted-foreground">Mesures publiées</dt>
                 <dd className="mt-0.5">
                   <span className="block font-display text-xl font-bold tabular-nums">
-                    {entry.documentedMeasureCount}
+                    {entry.currentlyDefendedMeasureCount}
                   </span>
-                  <span className="block text-xs text-muted-foreground">Retraits inclus</span>
                 </dd>
               </div>
-              <div>
-                <dt className="text-xs text-muted-foreground">Actuellement défendues</dt>
-                <dd className="mt-0.5 font-display text-xl font-bold tabular-nums">
-                  {entry.currentlyDefendedMeasureCount}
-                </dd>
-              </div>
+              {hasWithdrawnMeasures && (
+                <div>
+                  <dt className="text-xs text-muted-foreground">Mesures retirées</dt>
+                  <dd className="mt-0.5 font-display text-xl font-bold tabular-nums">
+                    {entry.documentedMeasureCount - entry.currentlyDefendedMeasureCount}
+                  </dd>
+                </div>
+              )}
               <div>
                 <dt className="text-xs text-muted-foreground">Dernière revue éditoriale</dt>
                 <dd className="mt-1 text-xs">
@@ -83,7 +88,7 @@ export function ThemesIndexList({ data }: ThemesIndexListProps) {
       <div className="hidden overflow-x-auto md:block">
         <table className="w-full border-collapse text-sm">
           <caption className="sr-only">
-            Couverture du corpus Poligraph par thématique de la présidentielle 2027
+            Mesures publiées par thème pour la présidentielle 2027
           </caption>
           <thead>
             <tr className="border-b border-border text-xs uppercase tracking-wider text-muted-foreground-strong">
@@ -91,17 +96,16 @@ export function ThemesIndexList({ data }: ThemesIndexListProps) {
                 Thème
               </th>
               <th scope="col" className="px-3 py-2 text-right font-bold">
-                Candidatures documentées
+                Candidats avec des mesures
               </th>
               <th scope="col" className="px-3 py-2 text-right font-bold">
-                Mesures documentées
-                <span className="block text-[11px] font-normal normal-case tracking-normal">
-                  Retraits inclus
-                </span>
+                Mesures publiées
               </th>
-              <th scope="col" className="px-3 py-2 text-right font-bold">
-                Actuellement défendues
-              </th>
+              {hasWithdrawnMeasures && (
+                <th scope="col" className="px-3 py-2 text-right font-bold">
+                  Mesures retirées
+                </th>
+              )}
               <th scope="col" className="py-2 pl-3 text-left font-bold">
                 Dernière revue
               </th>
@@ -117,11 +121,13 @@ export function ThemesIndexList({ data }: ThemesIndexListProps) {
                   {entry.documentedCandidacyCount}
                 </td>
                 <td className="px-3 py-3 text-right tabular-nums">
-                  {entry.documentedMeasureCount}
-                </td>
-                <td className="px-3 py-3 text-right tabular-nums">
                   {entry.currentlyDefendedMeasureCount}
                 </td>
+                {hasWithdrawnMeasures && (
+                  <td className="px-3 py-3 text-right tabular-nums">
+                    {entry.documentedMeasureCount - entry.currentlyDefendedMeasureCount}
+                  </td>
+                )}
                 <td className="py-3 pl-3 text-muted-foreground">
                   <ReviewDate value={entry.lastReviewedAt} />
                 </td>

--- a/src/app/elections/presidentielle-2027/themes/_components/__tests__/ThemesIndexList.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/_components/__tests__/ThemesIndexList.test.tsx
@@ -47,10 +47,22 @@ describe("ThemesIndexList", () => {
         "/elections/presidentielle-2027/themes/logement-urbanisme"
       );
     }
-    expect(screen.getAllByText("Candidatures documentées").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Mesures documentées").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Actuellement défendues").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Candidats avec des mesures").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mesures publiées").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Mesures retirées")).not.toBeInTheDocument();
     expect(screen.getAllByText(/21 août 2026/).length).toBeGreaterThan(0);
+  });
+
+  it("n'ajoute le compteur des mesures retirées que lorsqu'il est utile", () => {
+    const withWithdrawal = data();
+    withWithdrawal.themes[0] = {
+      ...withWithdrawal.themes[0]!,
+      documentedMeasureCount: 4,
+      currentlyDefendedMeasureCount: 3,
+    };
+    render(<ThemesIndexList data={withWithdrawal} />);
+
+    expect(screen.getAllByText("Mesures retirées").length).toBeGreaterThan(0);
   });
 
   it("garde un thème à zéro mesure dans la liste, pour la navigation", () => {

--- a/src/app/elections/presidentielle-2027/themes/page.tsx
+++ b/src/app/elections/presidentielle-2027/themes/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { getThemesIndex } from "@/lib/data/themes-index";
 import { isHubPublishable, PUBLICATION_GATES } from "@/config/publication-gates";
 import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { PresidentialHubNav } from "../_components/PresidentialHubNav";
 import { ThemesIndexList } from "./_components/ThemesIndexList";
 
 // ISR: 24h backstop. Real changes propagate on demand: a measure write busts election-measures:<id>.
@@ -18,9 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
   const publishable = data !== null && isHubPublishable(data.publishableSubjectPageCount);
 
   return {
-    title: "Couverture du corpus par thématique, présidentielle 2027 | Poligraph",
+    title: "Programmes par thème, présidentielle 2027 | Poligraph",
     description:
-      "Candidatures documentées, mesures publiées et dernière revue éditoriale du corpus Poligraph pour chaque thématique de la présidentielle 2027.",
+      "Comparez les mesures publiées des candidats à la présidentielle 2027 sur le logement, la santé, l'économie, l'écologie et les autres thèmes.",
     robots: publishable ? undefined : { index: false, follow: true },
     alternates: { canonical: "/elections/presidentielle-2027/themes" },
   };
@@ -41,21 +41,17 @@ export default async function ThemesIndexPage() {
         ]}
       />
 
-      <div className="space-y-6">
+      <PresidentialHubNav active="themes" />
+
+      <div className="mt-8 space-y-6">
         <header className="max-w-3xl space-y-2">
-          <Link
-            href="/elections/presidentielle-2027"
-            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-            Retour au hub
-          </Link>
           <h1 className="font-display text-3xl font-extrabold tracking-tight md:text-4xl">
-            Où en est le corpus, thématique par thématique ?
+            Comparer les programmes par thème
           </h1>
           <p className="text-muted-foreground">
-            Une thématique s&apos;ouvre à la comparaison à partir de {required} candidatures portant
-            une mesure sourcée et relue.
+            Choisissez un thème pour consulter côte à côte les mesures publiées des candidats. La
+            comparaison devient disponible dès que {required} candidats ont au moins une mesure
+            sourcée et relue sur ce thème.
           </p>
         </header>
 
@@ -63,9 +59,9 @@ export default async function ThemesIndexPage() {
 
         <div className="flex flex-wrap items-center justify-between gap-4 border-t border-border pt-4">
           <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">
-            Ces compteurs décrivent le corpus Poligraph, pas la totalité de la campagne. Une mesure
-            documentée reste comptée dans l&apos;historique après son retrait, mais plus parmi les
-            mesures actuellement défendues.
+            Ces chiffres décrivent les contenus publiés par Poligraph, pas la totalité de la
+            campagne. Une mesure retirée reste visible dans l&apos;historique, mais elle est
+            distinguée des propositions toujours portées.
           </p>
           <Link
             href="/methodologie"

--- a/src/components/measures/MeasurePrecisionBadge.tsx
+++ b/src/components/measures/MeasurePrecisionBadge.tsx
@@ -6,9 +6,9 @@ import { MeasureBadge } from "./MeasureBadge";
  * The two precision states of a published measure, on the `qualification` tier of `MeasureBadge`.
  *
  * Both states take the SAME form and differ by their word. They used to differ by their form too,
- * a dark solid fill against a bare outline, which read as a scale: "Chiffrée" looked like a better
- * grade than "Objectif sans chiffre", and its fill was heavier than the vote position pills that
- * carry an actual verdict. Precision is descriptive, not a rank, so it gets one shape.
+ * a dark solid fill against a bare outline, which read as a scale: "Objectif quantifié" looked like
+ * a better grade than "Objectif non quantifié", and its fill was heavier than the vote position
+ * pills that carry an actual verdict. Precision is descriptive, not a rank, so it gets one shape.
  *
  * `precision` is nullable on the revision, and a null is NOT a state this badge renders: the caller
  * decides what an unqualified measure looks like, because "we have not qualified it" is a statement

--- a/src/components/politicians/__tests__/CandidacyNotice.test.tsx
+++ b/src/components/politicians/__tests__/CandidacyNotice.test.tsx
@@ -17,6 +17,7 @@ const base: PoliticianCandidacy = {
   sourceLabel: "Le Monde, 14 janvier 2026",
   partyLabel: null,
   partyLogoUrl: null,
+  partyColor: null,
   programmeIdentified: false,
   declaredAt: new Date("2026-01-14T00:00:00.000Z"),
   withdrewAt: null,

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1577,8 +1577,8 @@ export const MEASURE_ATTRIBUTION_LABELS: Record<MeasureAttribution, string> = {
 };
 
 export const MEASURE_PRECISION_LABELS: Record<MeasurePrecision, string> = {
-  CHIFFREE: "Chiffrée",
-  OBJECTIF_SANS_CHIFFRE: "Objectif sans chiffre",
+  CHIFFREE: "Objectif quantifié",
+  OBJECTIF_SANS_CHIFFRE: "Objectif non quantifié",
 };
 
 // Deliberately NOT a green/amber pair. A traffic light reads as a verdict, and a measure carrying a

--- a/src/lib/data/__tests__/presidential-comparison.test.ts
+++ b/src/lib/data/__tests__/presidential-comparison.test.ts
@@ -92,6 +92,7 @@ describe("getPresidentialComparison", () => {
         { candidate: bruno, measures: [] },
       ],
       siblingThemes: [{ theme: "SANTE", slug: "sante", label: "Santé", publishable: true }],
+      publishable: true,
       lastReviewedAt: new Date("2026-08-29T00:00:00Z"),
     });
 
@@ -139,6 +140,7 @@ describe("getPresidentialComparison", () => {
         { candidate: bruno, measures: [] },
       ],
       siblingThemes: [{ theme: "SANTE", slug: "sante", label: "Santé", publishable: true }],
+      publishable: true,
       lastReviewedAt: null,
     });
 
@@ -163,5 +165,23 @@ describe("getPresidentialComparison", () => {
       "mesure-11",
       "mesure-12",
     ]);
+  });
+
+  it("ne compare pas un thème qui ne franchit pas le seuil de publication", async () => {
+    mocks.getSubject.mockResolvedValue({
+      candidates: [],
+      siblingThemes: [],
+      publishable: false,
+      lastReviewedAt: null,
+    });
+
+    const { getPresidentialComparison } = await import("../presidential-comparison");
+    const result = await getPresidentialComparison({
+      electionSlug: "presidentielle-2027",
+      candidateSlugs: ["alice-martin", "bruno-zola"],
+      themeSlug: "sante",
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/data/__tests__/presidential-comparison.test.ts
+++ b/src/lib/data/__tests__/presidential-comparison.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCandidates: vi.fn(),
+  getSubject: vi.fn(),
+  getThemes: vi.fn(),
+}));
+
+vi.mock("../presidential-candidates-public", () => ({
+  getPublicPresidentialCandidates: mocks.getCandidates,
+}));
+vi.mock("../subject-page", () => ({ getSubjectPageData: mocks.getSubject }));
+vi.mock("../themes-index", () => ({ getThemesIndex: mocks.getThemes }));
+
+const alice = {
+  id: "c1",
+  candidateName: "Alice Martin",
+  politicianSlug: "alice-martin",
+  partyLabel: "Parti A",
+  accentColor: "#111111",
+};
+const bruno = {
+  id: "c2",
+  candidateName: "Bruno Zola",
+  politicianSlug: "bruno-zola",
+  partyLabel: "Parti B",
+  accentColor: "#222222",
+};
+
+describe("getPresidentialComparison", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getCandidates.mockResolvedValue([alice, bruno]);
+    mocks.getThemes.mockResolvedValue({
+      themes: [
+        { theme: "SANTE", slug: "sante", label: "Santé", publishable: true },
+        { theme: "TRANSPORTS", slug: "transports", label: "Transports", publishable: false },
+      ],
+    });
+  });
+
+  it("normalise la sélection sans changer l'ordre éditorial", async () => {
+    const { getPresidentialComparison } = await import("../presidential-comparison");
+    const result = await getPresidentialComparison({
+      electionSlug: "presidentielle-2027",
+      candidateSlugs: ["bruno-zola", "alice-martin", "bruno-zola"],
+    });
+
+    expect(result?.selectedCandidates.map((candidate) => candidate.slug)).toEqual([
+      "alice-martin",
+      "bruno-zola",
+    ]);
+    expect(result?.themes).toEqual([{ code: "SANTE", slug: "sante", label: "Santé" }]);
+  });
+
+  it("conserve une colonne vide et qualifie une mesure retirée", async () => {
+    mocks.getSubject.mockResolvedValue({
+      candidates: [
+        {
+          candidate: alice,
+          measures: [
+            {
+              measure: {
+                id: "m1",
+                slug: "mesure-active",
+                text: "Ouvrir un centre de santé.",
+                withdrawal: null,
+                precision: "CHIFFREE",
+                qualifications: [{ id: "q1", label: "Financement précisé" }],
+                sources: [{ url: "https://example.org/source" }],
+                subtopics: [{ slug: "soins", label: "Accès aux soins" }],
+              },
+            },
+            {
+              measure: {
+                id: "m2",
+                slug: "mesure-retiree",
+                text: "Ancienne mesure.",
+                withdrawal: {
+                  withdrawnAt: new Date("2026-08-20T00:00:00Z"),
+                  sourceUrl: null,
+                  sourceLabel: null,
+                },
+                precision: null,
+                qualifications: [],
+                sources: [],
+                subtopics: [],
+              },
+            },
+          ],
+        },
+        { candidate: bruno, measures: [] },
+      ],
+      siblingThemes: [{ theme: "SANTE", slug: "sante", label: "Santé", publishable: true }],
+      lastReviewedAt: new Date("2026-08-29T00:00:00Z"),
+    });
+
+    const { getPresidentialComparison } = await import("../presidential-comparison");
+    const result = await getPresidentialComparison({
+      electionSlug: "presidentielle-2027",
+      candidateSlugs: ["alice-martin", "bruno-zola"],
+      themeSlug: "sante",
+    });
+
+    expect(result?.selectedCandidates).toHaveLength(2);
+    expect(result?.selectedCandidates[0]?.measures.map((measure) => measure.slug)).toEqual([
+      "mesure-active",
+      "mesure-retiree",
+    ]);
+    expect(result?.selectedCandidates[0]?.measures[0]).toMatchObject({
+      precision: "CHIFFREE",
+      qualifications: [{ label: "Financement précisé" }],
+    });
+    expect(result?.selectedCandidates[0]?.measures[1]?.withdrawal).not.toBeNull();
+    expect(result?.selectedCandidates[1]?.measures).toEqual([]);
+    expect(result?.selectedCandidates[0]).toMatchObject({
+      totalMeasures: 2,
+      page: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("pagine chaque personnalité indépendamment", async () => {
+    const measures = Array.from({ length: 13 }, (_, index) => ({
+      measure: {
+        id: `m${index + 1}`,
+        slug: `mesure-${index + 1}`,
+        text: `Mesure ${index + 1}`,
+        withdrawal: null,
+        precision: null,
+        qualifications: [],
+        sources: [],
+        subtopics: [],
+      },
+    }));
+    mocks.getSubject.mockResolvedValue({
+      candidates: [
+        { candidate: alice, measures },
+        { candidate: bruno, measures: [] },
+      ],
+      siblingThemes: [{ theme: "SANTE", slug: "sante", label: "Santé", publishable: true }],
+      lastReviewedAt: null,
+    });
+
+    const { getPresidentialComparison } = await import("../presidential-comparison");
+    const result = await getPresidentialComparison({
+      electionSlug: "presidentielle-2027",
+      candidateSlugs: ["alice-martin", "bruno-zola"],
+      themeSlug: "sante",
+      candidatePages: { "alice-martin": 2 },
+    });
+
+    expect(result?.selectedCandidates[0]).toMatchObject({
+      totalMeasures: 13,
+      page: 2,
+      totalPages: 3,
+    });
+    expect(result?.selectedCandidates[0]?.measures.map((measure) => measure.slug)).toEqual([
+      "mesure-7",
+      "mesure-8",
+      "mesure-9",
+      "mesure-10",
+      "mesure-11",
+      "mesure-12",
+    ]);
+  });
+});

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -346,7 +346,8 @@ async function getPoliticianPresidentialCandidacyCached(
 /**
  * Cached companion of the read above, same tags for the same reason: the themes and their quotes
  * move on a measure publication, and the candidacy's visibility on an extension transition. The
- * `votes` tag as well, since the last-votes block is invalidated by a scrutin import.
+ * `votes` tag as well, since the last-votes block is invalidated by a scrutin import. The probity
+ * counters make `affairs` another direct dependency of this read.
  */
 export async function getCandidateFicheDetail(
   candidacyId: string,
@@ -377,6 +378,7 @@ async function getCandidateFicheDetailCached(
   cacheTag(`election-measures:${electionId}`);
   cacheTag(`election-candidacies:${electionId}`);
   cacheTag("votes");
+  cacheTag("affairs");
   cacheLife("synced");
   return loadCandidateFicheDetail(candidacyId, politicianId);
 }

--- a/src/lib/data/politician-candidacy.ts
+++ b/src/lib/data/politician-candidacy.ts
@@ -1,7 +1,9 @@
 import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import type { CandidacyStatus, ThemeCategory, VotePosition } from "@/generated/prisma";
+import { getCategoriesForSuper } from "@/config/labels";
 import { db } from "@/lib/db";
+import { getConvictionOnlyWhere } from "@/lib/affairs/public-filters";
 import { isSynthesisContradictedByMeasures } from "@/lib/presidentielle/candidate-synthesis";
 import { pickMeasureSourceUrl } from "@/lib/presidentielle/measure-source";
 import { PRESIDENTIELLE_2027_SLUG, themeToSlug } from "@/lib/presidentielle/themes";
@@ -41,6 +43,7 @@ export type PoliticianCandidacy = {
   sourceLabel: string;
   partyLabel: string | null;
   partyLogoUrl: string | null;
+  partyColor: string | null;
   programmeIdentified: boolean;
   declaredAt: Date | null;
   withdrewAt: Date | null;
@@ -84,7 +87,7 @@ export async function loadPoliticianPresidentialCandidacy(
       sourceUrl: true,
       sourceLabel: true,
       partyLabel: true,
-      party: { select: { name: true, shortName: true, logoUrl: true } },
+      party: { select: { name: true, shortName: true, logoUrl: true, color: true } },
       round1Pct: true,
       round2Pct: true,
       isElected: true,
@@ -138,6 +141,7 @@ export async function loadPoliticianPresidentialCandidacy(
     sourceLabel: row.sourceLabel,
     partyLabel: row.partyLabel ?? row.party?.shortName ?? row.party?.name ?? null,
     partyLogoUrl: row.party?.logoUrl ?? null,
+    partyColor: row.party?.color ?? null,
     programmeIdentified: programme !== null,
     declaredAt: row.presidentialData?.declaredAt ?? null,
     withdrewAt: row.presidentialData?.withdrewAt ?? null,
@@ -192,6 +196,10 @@ export type CandidateFicheDetail = {
   recentVotes: CandidateRecentVote[];
   /** Every mandate ever held, for the header count. */
   mandateCount: number;
+  /** Convictions for probity offences, pronounced at least at first instance. */
+  probityConvictionCount: number;
+  /** Probity convictions that can still be challenged on appeal or cassation. */
+  probityNonDefinitiveConvictionCount: number;
 };
 
 /**
@@ -206,23 +214,45 @@ export async function loadCandidateFicheDetail(
   candidacyId: string,
   politicianId: string
 ): Promise<CandidateFicheDetail> {
-  const [measures, votes, mandateCount] = await Promise.all([
-    getPublicMeasuresByCandidacy(candidacyId),
-    // Cheap and index-backed: `votingDate` is denormalized onto Vote precisely so a
-    // "votes for politician" sort needs no join.
-    db.vote.findMany({
-      where: { politicianId },
-      orderBy: { votingDate: "desc" },
-      take: 5,
-      select: {
-        id: true,
-        position: true,
-        votingDate: true,
-        scrutin: { select: { id: true, title: true } },
-      },
-    }),
-    db.mandate.count({ where: { politicianId } }),
-  ]);
+  const [measures, mandates, probityConvictionCount, probityNonDefinitiveConvictionCount] =
+    await Promise.all([
+      getPublicMeasuresByCandidacy(candidacyId),
+      db.mandate.findMany({ where: { politicianId }, select: { type: true } }),
+      db.affair.count({
+        where: {
+          politicianId,
+          ...getConvictionOnlyWhere(),
+          category: { in: getCategoriesForSuper("PROBITE") },
+        },
+      }),
+      db.affair.count({
+        where: {
+          politicianId,
+          ...getConvictionOnlyWhere(),
+          category: { in: getCategoriesForSuper("PROBITE") },
+          status: {
+            in: ["CONDAMNATION_PREMIERE_INSTANCE", "APPEL_EN_COURS", "POURVOI_EN_CASSATION"],
+          },
+        },
+      }),
+    ]);
+
+  const hasDeputyMandate = mandates.some((mandate) => mandate.type === "DEPUTE");
+  // Votes on the presidential fiche describe work at the Assemblée nationale. A person who has
+  // never been a député does not get a generic "votes" block assembled from another institution.
+  const votes = hasDeputyMandate
+    ? await db.vote.findMany({
+        where: { politicianId, scrutin: { chamber: "AN" } },
+        orderBy: { votingDate: "desc" },
+        take: 5,
+        select: {
+          id: true,
+          position: true,
+          votingDate: true,
+          scrutin: { select: { id: true, title: true } },
+        },
+      })
+    : [];
 
   const byTheme = new Map<ThemeCategory, PublicMeasure[]>();
   for (const measure of measures) {
@@ -272,7 +302,9 @@ export async function loadCandidateFicheDetail(
       scrutinTitle: v.scrutin.title,
       scrutinId: v.scrutin.id,
     })),
-    mandateCount,
+    mandateCount: mandates.length,
+    probityConvictionCount,
+    probityNonDefinitiveConvictionCount,
   };
 }
 
@@ -324,7 +356,15 @@ export async function getCandidateFicheDetail(
     where: { slug: PRESIDENTIELLE_2027_SLUG },
     select: { id: true },
   });
-  if (election === null) return { themes: [], recentVotes: [], mandateCount: 0 };
+  if (election === null) {
+    return {
+      themes: [],
+      recentVotes: [],
+      mandateCount: 0,
+      probityConvictionCount: 0,
+      probityNonDefinitiveConvictionCount: 0,
+    };
+  }
   return getCandidateFicheDetailCached(candidacyId, politicianId, election.id);
 }
 

--- a/src/lib/data/presidential-comparison.ts
+++ b/src/lib/data/presidential-comparison.ts
@@ -91,7 +91,7 @@ export async function getPresidentialComparison({
 
   if (theme !== null) {
     const subject = await getSubjectPageData(electionSlug, theme);
-    if (subject === null) return null;
+    if (subject === null || !subject.publishable) return null;
 
     const candidateOptions = subject.candidates
       .map(({ candidate }) => toOption(candidate))

--- a/src/lib/data/presidential-comparison.ts
+++ b/src/lib/data/presidential-comparison.ts
@@ -1,0 +1,169 @@
+import "server-only";
+import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { pickMeasureSourceUrl } from "@/lib/presidentielle/measure-source";
+import { parseThemeSlug } from "@/lib/presidentielle/themes";
+import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
+import { getSubjectPageData } from "./subject-page";
+import type { PublicMeasure } from "./measures";
+import { getThemesIndex } from "./themes-index";
+
+const MAX_CANDIDATES = 3;
+const MEASURES_PER_CANDIDATE = 6;
+
+export type PresidentialComparisonOption = {
+  candidacyId: string;
+  name: string;
+  slug: string;
+  partyLabel: string | null;
+  accentColor: string | null;
+};
+
+export type PresidentialComparisonMeasure = {
+  id: string;
+  slug: string;
+  text: string;
+  sourceUrl: string | null;
+  subtopics: Array<{ slug: string; label: string }>;
+  precision: PublicMeasure["precision"];
+  qualifications: PublicMeasure["qualifications"];
+  withdrawal: PublicMeasure["withdrawal"];
+};
+
+export type PresidentialComparisonCandidate = PresidentialComparisonOption & {
+  measures: PresidentialComparisonMeasure[];
+  totalMeasures: number;
+  page: number;
+  totalPages: number;
+};
+
+export type PresidentialComparison = {
+  candidateOptions: PresidentialComparisonOption[];
+  themes: Array<{ code: ThemeCategory; slug: string; label: string }>;
+  selectedTheme: { code: ThemeCategory; slug: string; label: string } | null;
+  selectedCandidates: PresidentialComparisonCandidate[];
+  lastReviewedAt: Date | null;
+};
+
+function toOption(candidate: {
+  id: string;
+  candidateName: string;
+  politicianSlug: string | null;
+  partyLabel: string | null;
+  accentColor: string | null;
+}): PresidentialComparisonOption | null {
+  if (candidate.politicianSlug === null) return null;
+  return {
+    candidacyId: candidate.id,
+    name: candidate.candidateName,
+    slug: candidate.politicianSlug,
+    partyLabel: candidate.partyLabel,
+    accentColor: candidate.accentColor,
+  };
+}
+
+function normalizeCandidateSlugs(slugs: string[]): string[] {
+  return [...new Set(slugs.map((slug) => slug.trim()).filter(Boolean))].slice(0, MAX_CANDIDATES);
+}
+
+function normalizePage(value: number | undefined, totalPages: number): number {
+  if (!Number.isSafeInteger(value) || !value || value < 1) return 1;
+  return Math.min(value, totalPages);
+}
+
+/**
+ * One public comparison read. Callers provide URL-shaped values and receive only validated,
+ * published content in the repository's alphabetical candidacy order.
+ */
+export async function getPresidentialComparison({
+  electionSlug,
+  candidateSlugs,
+  themeSlug,
+  candidatePages = {},
+}: {
+  electionSlug: string;
+  candidateSlugs: string[];
+  themeSlug?: string;
+  candidatePages?: Record<string, number>;
+}): Promise<PresidentialComparison | null> {
+  const theme = themeSlug ? parseThemeSlug(themeSlug) : null;
+  const normalizedSlugs = normalizeCandidateSlugs(candidateSlugs);
+
+  if (theme !== null) {
+    const subject = await getSubjectPageData(electionSlug, theme);
+    if (subject === null) return null;
+
+    const candidateOptions = subject.candidates
+      .map(({ candidate }) => toOption(candidate))
+      .filter((candidate): candidate is PresidentialComparisonOption => candidate !== null);
+    const selected = new Set(normalizedSlugs);
+    const selectedCandidates = subject.candidates.flatMap(({ candidate, measures }) => {
+      const option = toOption(candidate);
+      if (option === null || !selected.has(option.slug)) return [];
+      const currentMeasures = measures.map(({ measure }) => ({
+        id: measure.id,
+        slug: measure.slug,
+        text: measure.text,
+        sourceUrl: pickMeasureSourceUrl(measure.sources),
+        subtopics: measure.subtopics,
+        precision: measure.precision,
+        qualifications: measure.qualifications,
+        withdrawal: measure.withdrawal,
+      }));
+      const totalPages = Math.max(1, Math.ceil(currentMeasures.length / MEASURES_PER_CANDIDATE));
+      const page = normalizePage(candidatePages[option.slug], totalPages);
+      const offset = (page - 1) * MEASURES_PER_CANDIDATE;
+      return [
+        {
+          ...option,
+          measures: currentMeasures.slice(offset, offset + MEASURES_PER_CANDIDATE),
+          totalMeasures: currentMeasures.length,
+          page,
+          totalPages,
+        },
+      ];
+    });
+
+    return {
+      candidateOptions,
+      themes: subject.siblingThemes
+        .filter((item) => item.publishable)
+        .map((item) => ({ code: item.theme, slug: item.slug, label: item.label })),
+      selectedTheme: {
+        code: theme,
+        slug: themeSlug!,
+        label: THEME_CATEGORY_LABELS[theme],
+      },
+      selectedCandidates,
+      lastReviewedAt: subject.lastReviewedAt,
+    };
+  }
+
+  const [candidates, themesIndex] = await Promise.all([
+    getPublicPresidentialCandidates(electionSlug),
+    getThemesIndex(electionSlug),
+  ]);
+  if (themesIndex === null) return null;
+  const candidateOptions = candidates
+    .map(toOption)
+    .filter((candidate): candidate is PresidentialComparisonOption => candidate !== null);
+  const selected = new Set(normalizedSlugs);
+
+  return {
+    candidateOptions,
+    themes: themesIndex.themes
+      .filter((item) => item.publishable)
+      .map((item) => ({ code: item.theme, slug: item.slug, label: item.label })),
+    selectedTheme: null,
+    selectedCandidates: candidateOptions
+      .filter((candidate) => selected.has(candidate.slug))
+      .map((candidate) => ({
+        ...candidate,
+        measures: [],
+        totalMeasures: 0,
+        page: 1,
+        totalPages: 1,
+      })),
+    lastReviewedAt: null,
+  };
+}

--- a/src/lib/data/presidential-measure-detail.ts
+++ b/src/lib/data/presidential-measure-detail.ts
@@ -3,13 +3,17 @@ import "server-only";
 import { cache } from "react";
 import type {
   Chamber,
+  MeasureAttribution,
   MeasurePrecision,
   MeasureSourceKind,
   SourceTier,
   ThemeCategory,
 } from "@/generated/prisma";
 import { db } from "@/lib/db";
-import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
+import {
+  PUBLIC_MEASURE_REVISION_WHERE,
+  PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+} from "@/lib/presidentielle/publication";
 import { deriveVoteRelation, type VoteRelation } from "@/lib/measures/vote-relation";
 
 export type PublicPresidentialMeasureDetail = {
@@ -20,8 +24,14 @@ export type PublicPresidentialMeasureDetail = {
   text: string;
   details: string | null;
   precision: MeasurePrecision | null;
+  attribution: MeasureAttribution;
   reviewedAt: Date;
   publishedAt: Date;
+  programEdition: {
+    label: string;
+    publishedAt: Date;
+    documentUrl: string;
+  } | null;
   candidate: {
     name: string;
     slug: string;
@@ -51,6 +61,14 @@ export type PublicPresidentialMeasureDetail = {
       sourceUrl: string | null;
     } | null;
   }>;
+  relatedMeasures: Array<{
+    slug: string;
+    text: string;
+    candidateName: string;
+    candidateSlug: string;
+    party: string | null;
+    sharedSubtopics: string[];
+  }>;
 };
 
 async function loadPublicPresidentialMeasureDetail(electionSlug: string, measureSlug: string) {
@@ -64,7 +82,16 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
       id: true,
       slug: true,
       theme: true,
-      election: { select: { slug: true } },
+      attribution: true,
+      election: { select: { id: true, slug: true } },
+      programEdition: {
+        select: {
+          label: true,
+          publishedAt: true,
+          documentUrl: true,
+          publicationStatus: true,
+        },
+      },
       publishedRevisionId: true,
       publishedRevision: {
         select: {
@@ -84,10 +111,16 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
               publishedAt: true,
             },
           },
+          subtopics: {
+            where: { status: "APPROVED", subtopic: { active: true } },
+            select: { subtopic: { select: { slug: true, label: true, sortOrder: true } } },
+            orderBy: { subtopic: { sortOrder: "asc" } },
+          },
         },
       },
       candidacy: {
         select: {
+          id: true,
           candidateName: true,
           party: { select: { name: true, shortName: true } },
           politician: {
@@ -135,6 +168,81 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
     return null;
   }
   const publishedRevisionId = row.publishedRevisionId;
+  const currentSubtopics = revision.subtopics.map(({ subtopic }) => subtopic);
+  const currentSubtopicSlugs = new Set(currentSubtopics.map((subtopic) => subtopic.slug));
+
+  const relatedRows = await db.measure.findMany({
+    where: {
+      id: { not: row.id },
+      electionId: row.election.id,
+      theme: row.theme,
+      ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+      ...(currentSubtopics.length > 0
+        ? {
+            publishedRevision: {
+              is: {
+                ...PUBLIC_MEASURE_REVISION_WHERE,
+                subtopics: {
+                  some: {
+                    status: "APPROVED" as const,
+                    subtopic: {
+                      active: true,
+                      slug: { in: currentSubtopics.map((subtopic) => subtopic.slug) },
+                    },
+                  },
+                },
+              },
+            },
+          }
+        : {}),
+    },
+    select: {
+      slug: true,
+      publishedRevision: {
+        select: {
+          text: true,
+          subtopics: {
+            where: { status: "APPROVED", subtopic: { active: true } },
+            select: { subtopic: { select: { slug: true, label: true } } },
+          },
+        },
+      },
+      candidacy: {
+        select: {
+          candidateName: true,
+          party: { select: { name: true, shortName: true } },
+          politician: { select: { slug: true } },
+        },
+      },
+    },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    take: 100,
+  });
+
+  // One proposal per other personality keeps this a navigation aid rather than another long list.
+  // Alphabetical sorting is explicit and carries no editorial ranking.
+  const relatedMeasures = relatedRows
+    .flatMap((related) => {
+      if (!related.publishedRevision || !related.candidacy?.politician) return [];
+      return [
+        {
+          slug: related.slug,
+          text: related.publishedRevision.text,
+          candidateName: related.candidacy.candidateName,
+          candidateSlug: related.candidacy.politician.slug,
+          party: related.candidacy.party?.shortName ?? related.candidacy.party?.name ?? null,
+          sharedSubtopics: related.publishedRevision.subtopics
+            .filter(({ subtopic }) => currentSubtopicSlugs.has(subtopic.slug))
+            .map(({ subtopic }) => subtopic.label),
+        },
+      ];
+    })
+    .sort((a, b) => a.candidateName.localeCompare(b.candidateName, "fr"))
+    .filter(
+      (related, index, all) =>
+        all.findIndex((candidate) => candidate.candidateSlug === related.candidateSlug) === index
+    )
+    .slice(0, 6);
 
   return {
     id: row.id,
@@ -144,8 +252,17 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
     text: revision.text,
     details: revision.details,
     precision: revision.precision,
+    attribution: row.attribution,
     reviewedAt: revision.reviewedAt,
     publishedAt: revision.publishedAt,
+    programEdition:
+      row.programEdition?.publicationStatus === "PUBLISHED"
+        ? {
+            label: row.programEdition.label,
+            publishedAt: row.programEdition.publishedAt,
+            documentUrl: row.programEdition.documentUrl,
+          }
+        : null,
     candidate: {
       name: candidate.candidateName,
       slug: candidate.politician.slug,
@@ -170,6 +287,7 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
       institutionScope: link.institutionScope,
       scrutin: link.scrutin,
     })),
+    relatedMeasures,
   };
 }
 

--- a/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
+++ b/src/lib/politicians/__tests__/candidacy-notice-state.test.ts
@@ -16,6 +16,7 @@ const base: PoliticianCandidacy = {
   sourceLabel: "Le Monde, 14 janvier 2026",
   partyLabel: null,
   partyLogoUrl: null,
+  partyColor: null,
   programmeIdentified: false,
   declaredAt: new Date("2026-01-14T00:00:00.000Z"),
   withdrewAt: null,

--- a/src/lib/security-headers.test.ts
+++ b/src/lib/security-headers.test.ts
@@ -25,6 +25,10 @@ describe("security headers", () => {
     expect(buildContentSecurityPolicy(true)).toContain("'unsafe-eval'");
     expect(buildContentSecurityPolicy(false)).not.toContain("'unsafe-eval'");
   });
+  it("limite les workers aux ressources du site", () => {
+    expect(buildContentSecurityPolicy(false)).toMatch(/worker-src 'self'(;|$)/);
+    expect(buildContentSecurityPolicy(false)).not.toMatch(/worker-src[^;]*blob:/);
+  });
   it("Permissions-Policy délègue payment à HelloAsso", () => {
     const pp = buildSecurityHeaders(false).find((h) => h.key === "Permissions-Policy");
     expect(pp!.value).toContain('payment=(self "https://www.helloasso.com")');

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -18,6 +18,7 @@ import {
   POLITIQUES_LISTING_FILTER_KEYS,
   VOTES_LISTING_FILTER_KEYS,
   DOSSIERS_LISTING_FILTER_KEYS,
+  PRESIDENTIAL_CANDIDATES_FILTER_KEYS,
 } from "../listing-filters";
 
 // votes/page.tsx renders <ScrutinsListing>, whose data-layer import chain
@@ -28,6 +29,7 @@ import {
 vi.mock("@/lib/db", () => ({ db: {} }));
 
 import { generateMetadata as votesGenerateMetadata } from "@/app/parlement/votes/page";
+import { metadata as presidentialComparisonMetadata } from "@/app/elections/presidentielle-2027/comparer/page";
 
 // Living map of the index-bloat doctrine. If any representative surface flips, this
 // file fails: a strong page must never become noindex, a thin one must never become
@@ -133,6 +135,22 @@ describe("doctrine — thin/duplicate surfaces stay out of the index", () => {
   it("filtered /parlement/dossiers (?status)", () => {
     expect(listingRobots({ status: "ADOPTED" }, DOSSIERS_LISTING_FILTER_KEYS)).toEqual(
       NOINDEX_FOLLOW
+    );
+  });
+  it("filtered presidential candidates directory (?statut)", () => {
+    expect(listingRobots({ statut: "annoncees" }, PRESIDENTIAL_CANDIDATES_FILTER_KEYS)).toEqual(
+      NOINDEX_FOLLOW
+    );
+  });
+  it("searched presidential candidates directory (?q)", () => {
+    expect(listingRobots({ q: "dupont" }, PRESIDENTIAL_CANDIDATES_FILTER_KEYS)).toEqual(
+      NOINDEX_FOLLOW
+    );
+  });
+  it("presidential comparison combinations stay noindex,follow", () => {
+    expect(presidentialComparisonMetadata.robots).toEqual({ index: false, follow: true });
+    expect(presidentialComparisonMetadata.alternates?.canonical).toBe(
+      "/elections/presidentielle-2027/comparer"
     );
   });
   it("paginated listing (page=2)", () => {

--- a/src/lib/seo/listing-filters.ts
+++ b/src/lib/seo/listing-filters.ts
@@ -32,3 +32,5 @@ export const VOTES_LISTING_FILTER_KEYS = [
 ] as const;
 
 export const DOSSIERS_LISTING_FILTER_KEYS = ["status", "theme", "sort"] as const;
+
+export const PRESIDENTIAL_CANDIDATES_FILTER_KEYS = ["q", "statut", "propositions"] as const;


### PR DESCRIPTION
## Résumé

- améliore la navigation du hub et l’annuaire des candidats, avec logos de partis et libellés plus neutres
- enrichit les fiches candidats, les pages mesure et les pages thématiques, y compris sur mobile et pour l’accessibilité
- ajoute un comparateur factuel de deux ou trois candidats par thème, sans score ni classement
- conserve les retraits, les qualifications éditoriales et les sources dans la comparaison
- ajoute les plans de recherche en langage naturel et d’enrichissement SEO des fiches mesure

## Vérifications

- `npm run typecheck`
- 31 tests ciblés passés
- lint ciblé passé
- build de production passé sous Node 22
- vérification navigateur desktop et mobile des principaux parcours

## Notes

Les cinq modifications locales liées à l’import des programmes ont été volontairement exclues de cette PR.