### PR TITLE
fix(factchecks): republier les vérifications bloquées depuis avril 2026

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
     "audit:careers:export": "tsx scripts/audit-careers.ts --export",
     "audit:bio-quality": "tsx scripts/audit-bio-quality.ts",
     "audit:sync-health": "tsx scripts/audit-sync-health.ts",
+    "backfill:factcheck-sources": "dotenv -e .env -- tsx scripts/backfill-factcheck-sources.ts",
+    "backfill:factcheck-sources:apply": "dotenv -e .env -- tsx scripts/backfill-factcheck-sources.ts --apply --confirm-production",
     "backfill:citizen-impact-reader-role": "dotenv -e .env -- tsx scripts/backfill-citizen-impact-reader-role.ts",
     "backfill:citizen-impact-reader-role:apply": "dotenv -e .env -- tsx scripts/backfill-citizen-impact-reader-role.ts --apply --confirm-production",
     "perf:check": "dotenv -e .env -- tsx scripts/perf-check-vote-denorm.ts",

--- a/scripts/__tests__/backfill-factcheck-sources.test.ts
+++ b/scripts/__tests__/backfill-factcheck-sources.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs, planRepair, type FactCheckRow } from "../backfill-factcheck-sources";
+
+function row(overrides: Partial<FactCheckRow> = {}): FactCheckRow {
+  return {
+    id: "fc-1",
+    slug: "2026-06-13-vrai-ou-faux",
+    source: "franceinfo",
+    publicationStatus: "DRAFT",
+    publishedAt: new Date("2026-06-13T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+const NONE = new Set<string>();
+
+describe("parseArgs", () => {
+  it("defaults to report-only", () => {
+    expect(parseArgs([]).apply).toBe(false);
+  });
+
+  it("requires --confirm-production alongside --apply", () => {
+    expect(() => parseArgs(["--apply"])).toThrow(/confirm-production/);
+    expect(parseArgs(["--apply", "--confirm-production"]).apply).toBe(true);
+  });
+
+  it("parses --batch and --show-rows", () => {
+    expect(parseArgs(["--batch=50", "--show-rows=3"])).toMatchObject({ batch: 50, showRows: 3 });
+  });
+
+  it("rejects a non-positive batch", () => {
+    expect(() => parseArgs(["--batch=0"])).toThrow(/--batch/);
+  });
+});
+
+describe("planRepair", () => {
+  it("renames a variant spelling and publishes it", () => {
+    const plan = planRepair(row(), NONE);
+    expect(plan).toMatchObject({
+      source: { from: "franceinfo", to: "Franceinfo" },
+      publicationStatus: "PUBLISHED",
+      publish: true,
+    });
+  });
+
+  it("leaves a row whose source is already canonical alone", () => {
+    expect(planRepair(row({ source: "Franceinfo" }), NONE)).toBeNull();
+    expect(planRepair(row({ source: "Snopes" }), NONE)).toBeNull();
+  });
+
+  it("renames an already published row without touching its status", () => {
+    const plan = planRepair(row({ source: "De Facto", publicationStatus: "PUBLISHED" }), NONE);
+    expect(plan).toMatchObject({
+      source: { to: "DE FACTO" },
+      publicationStatus: "PUBLISHED",
+      publish: false,
+    });
+  });
+
+  it("respects a moderator who unpublished the row", () => {
+    const plan = planRepair(row(), new Set(["fc-1"]));
+    expect(plan).toMatchObject({
+      source: { to: "Franceinfo" },
+      publicationStatus: "DRAFT",
+      publish: false,
+    });
+  });
+
+  it("renames towards a non-allow-listed label without publishing it", () => {
+    // Whitespace tidying alone can change the stored string; that is a rename,
+    // not a licence to publish an outlet the allow-list never accepted.
+    const plan = planRepair(row({ source: "  Snopes  " }), NONE);
+    expect(plan).toMatchObject({
+      source: { from: "  Snopes  ", to: "Snopes" },
+      publicationStatus: "DRAFT",
+      publish: false,
+    });
+  });
+
+  it("folds the reversed AFP spelling onto the French desk", () => {
+    const plan = planRepair(row({ source: "Factuel AFP" }), NONE);
+    expect(plan).toMatchObject({
+      source: { to: "AFP Factuel" },
+      publicationStatus: "PUBLISHED",
+      publish: true,
+    });
+  });
+
+  it("does not publish AFP's English desk", () => {
+    expect(planRepair(row({ source: "AFP Fact Check" }), NONE)).toBeNull();
+  });
+});

--- a/scripts/backfill-factcheck-sources.ts
+++ b/scripts/backfill-factcheck-sources.ts
@@ -1,0 +1,239 @@
+/**
+ * Repairs fact-checks stored under a variant spelling of an allow-listed
+ * publisher.
+ *
+ * The Google Fact Check Tools API returns a publisher's name as that publisher
+ * spells it in its own ClaimReview markup, and the spelling drifts: Franceinfo
+ * became "franceinfo", DE FACTO became "De Facto", AFP Factuel became
+ * "Factuel AFP". `getPublicationStatusForSource` compared the raw string with
+ * FACTCHECK_ALLOWED_SOURCES, so those reviews were stored as DRAFT, and the
+ * public listing — which also matches the exact string — never showed them.
+ * The sync is fixed (sources are canonicalised on the way in); this repairs
+ * the rows imported before the fix.
+ *
+ * Two writes per row, both narrow:
+ *   - `source` is rewritten to the canonical label, so the source facet keeps
+ *     one entry per outlet instead of one per spelling.
+ *   - DRAFT is lifted to PUBLISHED only when the canonical label is on the
+ *     allow-list AND no moderator ever set that row's publicationStatus. A
+ *     moderation decision recorded in AuditLog outranks the allow-list: the
+ *     one such decision in production unpublished an English-language AFP
+ *     review, and this must not undo it.
+ *
+ * Rows already PUBLISHED are only renamed, never touched otherwise.
+ *
+ * User-accord-gated: report-only by default, `--apply` performs real writes
+ * against the production database (see CLAUDE.local.md — .env and .env.prod
+ * point at the same Supabase instance). Do NOT run in CI.
+ *
+ * Usage:
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-factcheck-sources.ts
+ *   npx dotenv -e .env -- npx tsx scripts/backfill-factcheck-sources.ts --apply --confirm-production
+ */
+import { canonicalizeFactCheckSource, FACTCHECK_ALLOWED_SOURCES } from "@/config/labels";
+
+/** Type-only, so importing this module (e.g. from the unit test) never builds a
+ *  Prisma client and never needs DATABASE_URL. `db` is imported dynamically in
+ *  `main`, following the convention of the other backfill scripts. */
+type Db = (typeof import("@/lib/db"))["db"];
+
+export interface BackfillSourcesArgs {
+  apply: boolean;
+  batch: number;
+  showRows: number;
+}
+
+export function parseArgs(argv: string[]): BackfillSourcesArgs {
+  const has = (f: string) => argv.includes(f);
+  const num = (f: string) => {
+    const hit = argv.find((a) => a.startsWith(`${f}=`));
+    return hit ? Number(hit.split("=")[1]) : undefined;
+  };
+
+  const apply = has("--apply");
+  if (apply && !has("--confirm-production")) {
+    throw new Error("--apply requires --confirm-production (this DB is production)");
+  }
+
+  const batch = num("--batch") ?? 500;
+  if (!Number.isFinite(batch) || batch < 1) {
+    throw new Error(`--batch must be a positive number, got: ${batch}`);
+  }
+  const showRows = num("--show-rows") ?? 20;
+  if (!Number.isFinite(showRows) || showRows < 0) {
+    throw new Error(`--show-rows must be zero or a positive number, got: ${showRows}`);
+  }
+
+  return { apply, batch, showRows };
+}
+
+export interface FactCheckRow {
+  id: string;
+  slug: string | null;
+  source: string;
+  publicationStatus: "PUBLISHED" | "DRAFT";
+  publishedAt: Date;
+}
+
+export interface RepairPlan {
+  id: string;
+  slug: string | null;
+  publishedAt: Date;
+  source: { from: string; to: string };
+  /** Status to store — the row's own unless the canonical label unlocks it. */
+  publicationStatus: "PUBLISHED" | "DRAFT";
+  /** True when that status differs from what the row carries today. */
+  publish: boolean;
+}
+
+/**
+ * Plans the repair for one row. Returns null when the stored source is already
+ * canonical: a rename that changes nothing must not produce a no-op write, and
+ * a row left in DRAFT under a name that was always correct was not a victim of
+ * this bug.
+ */
+export function planRepair(row: FactCheckRow, moderated: ReadonlySet<string>): RepairPlan | null {
+  const canonical = canonicalizeFactCheckSource(row.source);
+  if (canonical === row.source) return null;
+
+  // Same rule as the sync's getPublicationStatusForSource, applied to the
+  // canonical label — but only over a DRAFT row nobody moderated. A row a
+  // moderator touched, or one already published, keeps the status it has.
+  const unlocked =
+    row.publicationStatus === "DRAFT" &&
+    !moderated.has(row.id) &&
+    FACTCHECK_ALLOWED_SOURCES.includes(canonical);
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    publishedAt: row.publishedAt,
+    source: { from: row.source, to: canonical },
+    publicationStatus: unlocked ? "PUBLISHED" : row.publicationStatus,
+    publish: unlocked,
+  };
+}
+
+/** Ids whose publicationStatus a moderator set by hand, from the audit trail. */
+async function loadModeratedIds(db: Db): Promise<Set<string>> {
+  // jsonb_exists() rather than Prisma's JSON path filters: the question is
+  // whether the key is present at all, which `path` + `not` cannot express.
+  const rows = await db.$queryRaw<Array<{ entityId: string | null }>>`
+    SELECT DISTINCT "entityId"
+    FROM "AuditLog"
+    WHERE "entityType" = 'FactCheck'
+      AND jsonb_exists(changes::jsonb, 'publicationStatus')
+  `;
+  return new Set(rows.map((r) => r.entityId).filter((id): id is string => Boolean(id)));
+}
+
+/** Pages through the table so a large corpus never lands in memory at once. */
+async function* iterateFactChecks(db: Db, batch: number): AsyncGenerator<FactCheckRow> {
+  let cursor: string | undefined;
+
+  for (;;) {
+    // Explicit `id > cursor` rather than Prisma's cursor/skip: the rows are
+    // rewritten as we go, and skip:1 would step over an unprocessed row.
+    const rows = await db.factCheck.findMany({
+      where: cursor ? { id: { gt: cursor } } : {},
+      select: {
+        id: true,
+        slug: true,
+        source: true,
+        publicationStatus: true,
+        publishedAt: true,
+      },
+      orderBy: { id: "asc" },
+      take: batch,
+    });
+
+    if (rows.length === 0) return;
+
+    for (const row of rows) {
+      yield {
+        id: row.id,
+        slug: row.slug,
+        source: row.source,
+        publicationStatus: row.publicationStatus as "PUBLISHED" | "DRAFT",
+        publishedAt: row.publishedAt,
+      };
+    }
+
+    cursor = rows[rows.length - 1]!.id;
+    if (rows.length < batch) return;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { db } = await import("@/lib/db");
+  const { revalidateRemoteCache } = await import("./lib/revalidate-cache");
+
+  console.log(
+    `[factcheck-sources] source canonicalisation backfill  apply=${args.apply}  batch=${args.batch}`
+  );
+
+  const moderated = await loadModeratedIds(db);
+  console.log(`[factcheck-sources] rows with a moderation decision on record: ${moderated.size}`);
+
+  let scanned = 0;
+  let renamed = 0;
+  let published = 0;
+  const shown: RepairPlan[] = [];
+
+  for await (const row of iterateFactChecks(db, args.batch)) {
+    scanned++;
+    const plan = planRepair(row, moderated);
+    if (!plan) continue;
+
+    renamed++;
+    if (plan.publish) published++;
+    if (shown.length < args.showRows) shown.push(plan);
+
+    if (args.apply) {
+      await db.factCheck.update({
+        where: { id: plan.id },
+        data: { source: plan.source.to, publicationStatus: plan.publicationStatus },
+      });
+    }
+  }
+
+  console.log(`[factcheck-sources] fact-checks scanned: ${scanned}`);
+  console.log(`[factcheck-sources] stored under a variant spelling: ${renamed}`);
+  console.log(`[factcheck-sources] of those, becoming publicly visible: ${published}`);
+
+  for (const plan of shown) {
+    const date = plan.publishedAt.toISOString().split("T")[0];
+    const flag = plan.publish ? "DRAFT → PUBLISHED" : "rename only";
+    console.log(
+      `  [${date}] "${plan.source.from}" → "${plan.source.to}"  ${flag}  ${plan.slug ?? plan.id}`
+    );
+  }
+  if (renamed > shown.length) {
+    console.log(`  ... and ${renamed - shown.length} more (raise --show-rows to see them)`);
+  }
+
+  if (args.apply) {
+    console.log(`\n[factcheck-sources] updated ${renamed} row(s)`);
+    if (renamed > 0) {
+      // Non-fatal: the writes are already committed, and a failed purge only
+      // means the listing carries its old page for up to the 24h cache window.
+      await revalidateRemoteCache(["factchecks"]).catch((err) => {
+        console.warn(`[factcheck-sources] cache purge failed (${err}); purge "factchecks" by hand`);
+      });
+    }
+  } else {
+    console.log(`\n[factcheck-sources] report only — re-run with --apply --confirm-production`);
+  }
+
+  await db.$disconnect();
+}
+
+// Guarded so importing this module never touches the database: main() only
+// runs when this file is the process entry point, not on import.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -151,14 +151,17 @@ const steps: SyncStep[] = [
         {
           // Scoped tags only — never use { all: true }. See Phase 4 of
           // docs/superpowers/plans/2026-04-07-supabase-perf-improvements.md.
-          // The three tags below match the remaining data domains touched by
+          // The four tags below match the remaining data domains touched by
           // the daily sync. Votes are invalidated immediately after both vote
           // syncs, before the longer steps below can time out the workflow.
-          // Adding "elections" or "factchecks" here would purge
-          // caches that the daily sync did NOT update.
+          // Adding "elections" here would purge caches that the daily sync did
+          // NOT update. "factchecks" is not one of those: the Google API step
+          // above imports fact-checks on every run, and the listing that shows
+          // them holds its cache for 24h, so leaving the tag out kept a new
+          // fact-check off the site for a day after it was stored.
           name: "Cache revalidation",
-          command: "POST /api/cron/revalidate (dossiers, stats, politicians)",
-          run: () => revalidateRemoteCache(["dossiers", "stats", "politicians"]),
+          command: "POST /api/cron/revalidate (dossiers, stats, politicians, factchecks)",
+          run: () => revalidateRemoteCache(["dossiers", "stats", "politicians", "factchecks"]),
         },
       ]
     : []),

--- a/scripts/sync-factchecks.ts
+++ b/scripts/sync-factchecks.ts
@@ -154,6 +154,8 @@ Environment:
       duration: 0,
       stats: {
         politiciansSearched: stats.politiciansSearched,
+        searchPoolSize: stats.searchPoolSize,
+        rotationOffset: stats.rotationOffset,
         claimsFound: stats.claimsFound,
         factChecksCreated: stats.factChecksCreated,
         factChecksSkipped: stats.factChecksSkipped,

--- a/src/__tests__/architecture/vote-cache-invalidation.test.ts
+++ b/src/__tests__/architecture/vote-cache-invalidation.test.ts
@@ -86,7 +86,12 @@ describe("architecture d'invalidation du cache des votes", () => {
       'revalidateRemoteCache(["votes"])',
       'name: "Législation (active, 3j)"',
     ]);
-    expect(dailyScript).toContain('revalidateRemoteCache(["dossiers", "stats", "politicians"])');
+    // "factchecks" belongs in the final purge because the Daily runs the Google
+    // Fact Check step; without it a freshly imported fact-check waited out the
+    // listing's 24h cache window before appearing.
+    expect(dailyScript).toContain(
+      'revalidateRemoteCache(["dossiers", "stats", "politicians", "factchecks"])'
+    );
     expect(dailyScript).toContain("...(!DRY_RUN");
   });
 

--- a/src/__tests__/services/sync/factchecks.test.ts
+++ b/src/__tests__/services/sync/factchecks.test.ts
@@ -11,7 +11,11 @@ vi.mock("@/lib/identity/mention-blocklist", () => ({
 }));
 
 import { FACTCHECK_ALLOWED_SOURCES } from "@/config/labels";
-import { getPublicationStatusForSource } from "@/services/sync/factchecks";
+import {
+  getPublicationStatusForSource,
+  rotateWindow,
+  FACTCHECK_SEARCH_POOL_SIZE,
+} from "@/services/sync/factchecks";
 
 describe("getPublicationStatusForSource", () => {
   it("returns PUBLISHED for allowed sources", () => {
@@ -20,9 +24,67 @@ describe("getPublicationStatusForSource", () => {
     }
   });
 
+  it("returns PUBLISHED for the spelling variants of an allowed source", () => {
+    // The names Google actually returned for these outlets in 2026; matching
+    // them literally kept the reviews in DRAFT and off every public listing.
+    expect(getPublicationStatusForSource("franceinfo")).toBe("PUBLISHED");
+    expect(getPublicationStatusForSource("De Facto")).toBe("PUBLISHED");
+    expect(getPublicationStatusForSource("Factuel AFP")).toBe("PUBLISHED");
+  });
+
   it("returns DRAFT for unknown sources", () => {
     expect(getPublicationStatusForSource("dpa-factchecking")).toBe("DRAFT");
     expect(getPublicationStatusForSource("Snopes")).toBe("DRAFT");
     expect(getPublicationStatusForSource("PolitiFact")).toBe("DRAFT");
+  });
+
+  it("keeps AFP's English desk out of the publishable set", () => {
+    expect(getPublicationStatusForSource("AFP Fact Check")).toBe("DRAFT");
+  });
+});
+
+describe("rotateWindow", () => {
+  const pool = ["a", "b", "c", "d", "e"];
+
+  it("takes the head at offset 0", () => {
+    expect(rotateWindow(pool, 0, 2)).toEqual(["a", "b"]);
+  });
+
+  it("resumes where the previous window stopped", () => {
+    expect(rotateWindow(pool, 2, 2)).toEqual(["c", "d"]);
+  });
+
+  it("wraps past the end instead of returning a short window", () => {
+    expect(rotateWindow(pool, 4, 3)).toEqual(["e", "a", "b"]);
+  });
+
+  it("normalizes an offset beyond the pool", () => {
+    expect(rotateWindow(pool, 7, 2)).toEqual(rotateWindow(pool, 2, 2));
+  });
+
+  it("never returns more than the pool holds", () => {
+    expect(rotateWindow(pool, 1, 99)).toHaveLength(pool.length);
+  });
+
+  it("handles an empty pool", () => {
+    expect(rotateWindow([], 3, 5)).toEqual([]);
+  });
+
+  it("covers the whole pool over successive windows", () => {
+    const size = 2;
+    const seen = new Set<string>();
+    let offset = 0;
+    for (let run = 0; run < Math.ceil(pool.length / size); run++) {
+      for (const item of rotateWindow(pool, offset, size)) seen.add(item);
+      offset = (offset + size) % pool.length;
+    }
+    expect(seen.size).toBe(pool.length);
+  });
+});
+
+describe("FACTCHECK_SEARCH_POOL_SIZE", () => {
+  it("lets the cron walk the whole pool inside a fortnight", () => {
+    const perDay = 50 * 3; // --limit=50, three daily-sync runs a day
+    expect(FACTCHECK_SEARCH_POOL_SIZE / perDay).toBeLessThan(14);
   });
 });

--- a/src/config/labels.test.ts
+++ b/src/config/labels.test.ts
@@ -14,6 +14,8 @@ import {
   DOSSIER_STATUS_DESCRIPTIONS,
   DOSSIER_STATUS_SITUATIONS,
   CANDIDACY_STATUS_LABELS,
+  FACTCHECK_ALLOWED_SOURCES,
+  canonicalizeFactCheckSource,
 } from "./labels";
 
 describe("AFFAIR_STATUS_LABELS", () => {
@@ -248,5 +250,38 @@ describe("CANDIDACY_STATUS_LABELS", () => {
   it("should not describe an unannounced candidacy as declared", () => {
     expect(CANDIDACY_STATUS_LABELS.PRESSENTI).not.toMatch(/déclar/i);
     expect(CANDIDACY_STATUS_LABELS.ENVISAGE).not.toMatch(/déclar/i);
+  });
+});
+
+describe("canonicalizeFactCheckSource", () => {
+  it("leaves a canonical label untouched", () => {
+    for (const label of FACTCHECK_ALLOWED_SOURCES) {
+      expect(canonicalizeFactCheckSource(label)).toBe(label);
+    }
+  });
+
+  it("folds the case variants Google returns for allowed outlets", () => {
+    expect(canonicalizeFactCheckSource("franceinfo")).toBe("Franceinfo");
+    expect(canonicalizeFactCheckSource("FRANCEINFO")).toBe("Franceinfo");
+    expect(canonicalizeFactCheckSource("De Facto")).toBe("DE FACTO");
+  });
+
+  it("folds accent and spacing variants", () => {
+    expect(canonicalizeFactCheckSource("Liberation")).toBe("Libération");
+    expect(canonicalizeFactCheckSource("  Le   Monde ")).toBe("Le Monde");
+  });
+
+  it("folds the reversed AFP spelling", () => {
+    expect(canonicalizeFactCheckSource("Factuel AFP")).toBe("AFP Factuel");
+  });
+
+  it("keeps AFP's English desk distinct from its French one", () => {
+    expect(canonicalizeFactCheckSource("AFP Fact Check")).toBe("AFP Fact Check");
+    expect(FACTCHECK_ALLOWED_SOURCES).not.toContain("AFP Fact Check");
+  });
+
+  it("returns an unknown publisher unchanged", () => {
+    expect(canonicalizeFactCheckSource("Snopes")).toBe("Snopes");
+    expect(canonicalizeFactCheckSource("dpa-factchecking")).toBe("dpa-factchecking");
   });
 });

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1276,7 +1276,10 @@ export const FACTCHECK_RATING_DESCRIPTIONS: Record<FactCheckRating, string> = {
  * Whitelist of francophone fact-checking sources.
  * Non-francophone sources (Snopes, PolitiFact, Full Fact, Indian outlets, etc.)
  * are kept in DB but excluded from display queries.
- * Includes known name variants from the Google Fact Check API.
+ *
+ * One canonical label per outlet: the spelling variants the Google Fact Check
+ * API returns are folded onto these labels by canonicalizeFactCheckSource()
+ * before anything is stored or compared.
  */
 export const FACTCHECK_ALLOWED_SOURCES = [
   "TF1 Info",
@@ -1292,6 +1295,53 @@ export const FACTCHECK_ALLOWED_SOURCES = [
   "RTBF",
   "Fasocheck",
 ];
+
+/**
+ * Google returns a publisher's name as that publisher spells it in its own
+ * ClaimReview markup, and the spelling drifts over time: the same outlet
+ * arrives as "Franceinfo" then "franceinfo", "DE FACTO" then "De Facto",
+ * "AFP Factuel" then "Factuel AFP". Comparing the raw string against
+ * FACTCHECK_ALLOWED_SOURCES sent those reviews to DRAFT and kept them out of
+ * every public listing, which is what froze the public fact-check feed on its
+ * April 2026 entry while the sync kept importing.
+ *
+ * Case and accents are folded, so only spellings that differ by more than that
+ * need an entry here.
+ */
+const FACTCHECK_SOURCE_ALIASES: Record<string, string> = {
+  // AFP's French desk (factuel.afp.com), whose two words Google returns in
+  // either order. Its English desk publishes under "AFP Fact Check" and is
+  // deliberately absent: those reviews are in English, and the one moderation
+  // decision recorded on a fact-check unpublished exactly such a review.
+  "Factuel AFP": "AFP Factuel",
+};
+
+/** Case-, accent- and punctuation-insensitive key for one publisher name. */
+function factCheckSourceKey(source: string): string {
+  return source
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+const CANONICAL_FACTCHECK_SOURCES = new Map<string, string>([
+  ...FACTCHECK_ALLOWED_SOURCES.map((label) => [factCheckSourceKey(label), label] as const),
+  ...Object.entries(FACTCHECK_SOURCE_ALIASES).map(
+    ([variant, label]) => [factCheckSourceKey(variant), label] as const
+  ),
+]);
+
+/**
+ * Fold a publisher name onto its canonical label. Unknown publishers are
+ * returned as they came (whitespace-tidied only): the allow-list, not this
+ * function, decides what is publishable.
+ */
+export function canonicalizeFactCheckSource(source: string): string {
+  const tidied = source.trim().replace(/\s+/g, " ");
+  return CANONICAL_FACTCHECK_SOURCES.get(factCheckSourceKey(tidied)) ?? tidied;
+}
 
 /**
  * Detect if a fact-check claimant is a specific person (politician)

--- a/src/services/sync/factchecks.ts
+++ b/src/services/sync/factchecks.ts
@@ -15,12 +15,57 @@ import {
   findMentions,
   type PoliticianName,
 } from "@/lib/name-matching";
-import { isDirectPoliticianClaim, FACTCHECK_ALLOWED_SOURCES } from "@/config/labels";
+import {
+  isDirectPoliticianClaim,
+  canonicalizeFactCheckSource,
+  FACTCHECK_ALLOWED_SOURCES,
+} from "@/config/labels";
 import { generateDateSlug, generateUniqueSlug, sleep } from "@/lib/utils";
 import { loadMentionBlocklist, type MentionBlocklist } from "@/lib/identity/mention-blocklist";
+import { syncMetadata } from "@/lib/sync";
 
+/**
+ * Publishable when the publisher is on the allow-list, compared on the
+ * canonical label so a case or word-order variant of an allowed outlet is not
+ * mistaken for an unknown one.
+ */
 export function getPublicationStatusForSource(source: string): "PUBLISHED" | "DRAFT" {
-  return FACTCHECK_ALLOWED_SOURCES.includes(source) ? "PUBLISHED" : "DRAFT";
+  return FACTCHECK_ALLOWED_SOURCES.includes(canonicalizeFactCheckSource(source))
+    ? "PUBLISHED"
+    : "DRAFT";
+}
+
+/**
+ * How many politicians the default (cron) target list draws from, ranked by
+ * prominence. 22 000+ hold a current mandate, nearly all of them local
+ * councillors no fact-checker writes about, and the daily cron searches 50 per
+ * run; walking the whole set would take five months per pass. Capping the pool
+ * at the most prominent 1 200 keeps a full pass under ten days at the current
+ * cadence (3 runs/day x --limit=50), which is the latency a new fact-check
+ * about a rank-1000 politician waits before it is picked up.
+ */
+export const FACTCHECK_SEARCH_POOL_SIZE = 1200;
+
+/** SyncMetadata row holding where the last run stopped in that pool. */
+const FACTCHECK_ROTATION_KEY = "factchecks:search-rotation";
+
+/**
+ * `count` items starting at `offset`, wrapping past the end of the list. The
+ * rotation is what makes the pool reachable: without it every run searched the
+ * same slice and the rest of the pool was never queried at all.
+ */
+export function rotateWindow<T>(items: T[], offset: number, count: number): T[] {
+  if (items.length === 0) return [];
+  const size = Math.min(count, items.length);
+  const start = ((offset % items.length) + items.length) % items.length;
+  return Array.from({ length: size }, (_, i) => items[(start + i) % items.length]!);
+}
+
+/** Stored offset, or 0 when absent or unreadable. */
+async function readRotationOffset(): Promise<number> {
+  const state = await syncMetadata.get(FACTCHECK_ROTATION_KEY);
+  const stored = Number(state?.cursor);
+  return Number.isInteger(stored) && stored >= 0 ? stored : 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -37,6 +82,10 @@ export interface FactcheckSyncOptions {
 
 export interface FactcheckSyncStats {
   politiciansSearched: number;
+  /** Size of the pool the searched politicians were drawn from. */
+  searchPoolSize: number;
+  /** Offset the run started at inside that pool (0 when not rotating). */
+  rotationOffset: number;
   claimsFound: number;
   factChecksCreated: number;
   factChecksSkipped: number;
@@ -92,6 +141,8 @@ export async function syncFactchecks(
 
   const stats: FactcheckSyncStats = {
     politiciansSearched: 0,
+    searchPoolSize: 0,
+    rotationOffset: 0,
     claimsFound: 0,
     factChecksCreated: 0,
     factChecksSkipped: 0,
@@ -107,6 +158,9 @@ export async function syncFactchecks(
 
   // Determine which politicians to search
   let searchTargets: Array<{ id: string; fullName: string }>;
+  /** Only the default (cron) target list walks the pool across runs. */
+  let rotates = false;
+  let nextRotationOffset: number | null = null;
 
   if (politicianFilter) {
     const normalized = normalizeText(politicianFilter);
@@ -121,18 +175,44 @@ export async function syncFactchecks(
       return stats;
     }
   } else if (all) {
-    searchTargets = allPoliticians.map((p) => ({ id: p.id, fullName: p.fullName }));
+    // Same population as buildPoliticianIndex (published politicians), but
+    // prominence-ranked so that a --limit here takes the politicians most
+    // likely to be fact-checked rather than an arbitrary slice of 37 000 rows.
+    const everyone = await db.politician.findMany({
+      where: { publicationStatus: "PUBLISHED" },
+      select: { id: true, fullName: true },
+      orderBy: [{ prominenceScore: "desc" }, { id: "asc" }],
+    });
+    searchTargets = everyone;
   } else {
-    // Default: only politicians with current mandates
-    const activePoliticians = await db.politician.findMany({
+    // Default: politicians holding a current mandate, most prominent first,
+    // capped at FACTCHECK_SEARCH_POOL_SIZE. The order is the whole of the
+    // coverage decision — this query used to have none, so the cron's 50 came
+    // out in whatever physical order the table happened to be in, and
+    // recalculate-prominence rewrites every row three times a day, which
+    // reshuffles it. Coverage was 0.2% of the corpus, re-drawn at random.
+    const pool = await db.politician.findMany({
       where: { mandates: { some: { isCurrent: true } } },
       select: { id: true, fullName: true },
+      orderBy: [{ prominenceScore: "desc" }, { id: "asc" }],
+      take: FACTCHECK_SEARCH_POOL_SIZE,
     });
-    searchTargets = activePoliticians;
+    searchTargets = pool;
+    rotates = true;
   }
 
+  stats.searchPoolSize = searchTargets.length;
+
   if (limit) {
-    searchTargets = searchTargets.slice(0, limit);
+    if (rotates) {
+      // Resume where the previous run stopped so successive runs walk the pool
+      // instead of re-querying its head forever.
+      stats.rotationOffset = (await readRotationOffset()) % Math.max(searchTargets.length, 1);
+      nextRotationOffset = (stats.rotationOffset + limit) % Math.max(searchTargets.length, 1);
+      searchTargets = rotateWindow(searchTargets, stats.rotationOffset, limit);
+    } else {
+      searchTargets = searchTargets.slice(0, limit);
+    }
   }
 
   for (const target of searchTargets) {
@@ -179,6 +259,11 @@ export async function syncFactchecks(
 
           const verdictRating = mapTextualRating(review.textualRating);
           const reviewDate = review.reviewDate ? new Date(review.reviewDate) : new Date();
+          // Fold the publisher name onto its canonical label before it is
+          // stored: the public listing and the source facet both match on the
+          // exact string, so a variant spelling would be invisible on one and
+          // a duplicate entry on the other.
+          const source = canonicalizeFactCheckSource(review.publisher.name);
 
           // Fetch full title from source page when Google API truncates it
           let title = review.title;
@@ -234,7 +319,7 @@ export async function syncFactchecks(
                     title,
                     verdict: review.textualRating,
                     verdictRating,
-                    source: review.publisher.name,
+                    source,
                     publishedAt: reviewDate,
                     claimDate: claim.claimDate ? new Date(claim.claimDate) : null,
                     languageCode: review.languageCode || null,
@@ -254,12 +339,12 @@ export async function syncFactchecks(
                     title,
                     verdict: review.textualRating,
                     verdictRating,
-                    source: review.publisher.name,
+                    source,
                     sourceUrl: review.url,
                     publishedAt: reviewDate,
                     claimDate: claim.claimDate ? new Date(claim.claimDate) : null,
                     languageCode: review.languageCode || null,
-                    publicationStatus: getPublicationStatusForSource(review.publisher.name),
+                    publicationStatus: getPublicationStatusForSource(source),
                     mentions: {
                       create: mentions.map((m) => ({
                         politicianId: m.politicianId,
@@ -278,12 +363,12 @@ export async function syncFactchecks(
                     title,
                     verdict: review.textualRating,
                     verdictRating,
-                    source: review.publisher.name,
+                    source,
                     sourceUrl: review.url,
                     publishedAt: reviewDate,
                     claimDate: claim.claimDate ? new Date(claim.claimDate) : null,
                     languageCode: review.languageCode || null,
-                    publicationStatus: getPublicationStatusForSource(review.publisher.name),
+                    publicationStatus: getPublicationStatusForSource(source),
                     mentions: {
                       create: mentions.map((m) => ({
                         politicianId: m.politicianId,
@@ -314,6 +399,13 @@ export async function syncFactchecks(
 
     // Rate limiting between politician searches
     await sleep(FACTCHECK_RATE_LIMIT_MS);
+  }
+
+  // Advance the cursor even when some searches errored: the slice was spent,
+  // and replaying it would stall the rotation on whichever politician the API
+  // is currently unhappy about. The next pass comes back round in a few days.
+  if (nextRotationOffset !== null && !dryRun) {
+    await syncMetadata.set(FACTCHECK_ROTATION_KEY, { cursor: String(nextRotationOffset) });
   }
 
   return stats;


### PR DESCRIPTION
## Description

Le dernier fact-check visible sur le site datait du **20 avril 2026**. La synchronisation Google n'était pourtant pas en panne : elle a créé 14 lignes rien qu'en août. Deux causes distinctes, indépendantes l'une de l'autre.

### 1. Le nom de l'éditeur était comparé littéralement

`getPublicationStatusForSource` comparait `review.publisher.name` à `FACTCHECK_ALLOWED_SOURCES` caractère pour caractère. Google renvoie ce nom tel que l'éditeur l'écrit dans son propre balisage ClaimReview, et cette graphie dérive avec le temps :

| stocké en base | libellé attendu | conséquence |
| --- | --- | --- |
| `franceinfo` | `Franceinfo` | DRAFT |
| `De Facto` | `DE FACTO` | DRAFT |
| `Factuel AFP` | `AFP Factuel` | DRAFT |

Les quatre vérifications les plus récentes de la base (13 juin, 2 juin, 21 mai, 22 avril) sont exactement dans ce cas. La liste publique filtre elle aussi sur la chaîne exacte, donc elles étaient invisibles des deux côtés à la fois.

`canonicalizeFactCheckSource()` replie casse, accents et ponctuation, avec une table d'alias pour ce qui diffère davantage. Le libellé canonique est **stocké**, pas la variante : la facette « source » de la liste publique garde ainsi une entrée par média au lieu d'une par graphie.

Le bureau anglophone de l'AFP (`AFP Fact Check`, factcheck.afp.com, `languageCode: en`) en est volontairement absent : la seule décision de modération jamais enregistrée sur un fact-check a précisément dépublié un article de ce bureau. La replier sur `AFP Factuel` aurait défait cette décision.

### 2. La sélection des politiques interrogés n'avait aucun tri

22 645 personnes ont un mandat en cours, le cron en interroge 50, et `findMany` les rendait dans l'ordre physique de la table — que `recalculate-prominence`, qui réécrit les 37 685 lignes trois fois par jour, remélange en permanence. La couverture réelle était donc de **0,2 % du corpus, retiré au hasard à chaque passage**.

Le vivier est maintenant trié par prominence et plafonné aux 1 200 premiers (les élus dont un fact-checkeur parle effectivement), et chaque exécution reprend là où la précédente s'est arrêtée via un curseur `SyncMetadata` : une passe complète en moins de dix jours au lieu de jamais.

### 3. Tag de cache manquant

`factchecks` rejoint la revalidation du sync quotidien. Le commentaire en place affirmait que le Daily ne touchait pas aux fact-checks, alors que l'étape Google y tourne à chaque passage ; sans ce tag, une vérification fraîchement importée attendait la fenêtre de cache de 24 h avant d'apparaître.

### Rattrapage des lignes déjà en base

`scripts/backfill-factcheck-sources.ts`, rapport seul par défaut. Son plan a été simulé en SQL sur la production : **10 lignes concernées**, toutes en DRAFT sous une graphie variante, aucune modérée. Il renomme vers le libellé canonique et ne relève en `PUBLISHED` que ce que la liste blanche autorise **et** qu'aucun modérateur n'a touché (l'`AuditLog` fait foi sur la liste blanche).

```
npm run backfill:factcheck-sources          # rapport
npm run backfill:factcheck-sources:apply    # écriture
```

> À noter : après le backfill, le fact-check le plus récent visible sera celui du **13 juin**, pas d'août — rien de plus récent n'existe en base aujourd'hui. C'est la rotation du point 2 qui doit combler l'écart aux prochains passages du cron.

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Autre : \_\_\_

## Issue liée

Aucune issue ouverte sur le sujet.

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [x] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [x] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

### État des vérifications

CI verte sur `3be6438` — 9 jobs sur 9, plus Code Quality Guards : ESLint, TypeScript, Prettier, Unit Tests, Build, Header responsive et les trois contrats SEC.

Nouveaux tests : `canonicalizeFactCheckSource`, `rotateWindow`, `getPublicationStatusForSource` sur les graphies variantes, et le planificateur du backfill. L'assertion de `vote-cache-invalidation.test.ts` qui figeait la liste des tags de revalidation a été mise à jour.
