### PR TITLE
Améliorer le hub présidentiel, la recherche et les statistiques

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,10 @@ const nextConfig: NextConfig = {
     ],
   },
   experimental: {
+    // Next 16.3 enables its TypeScript CLI subprocess by default. Its output capture is empty on
+    // Node 24, which makes `next build` fail while the compiler itself is healthy. The installed
+    // TypeScript 5 compiler API supports the same checks without that subprocess.
+    useTypeScriptCli: false,
     useCache: true,
     webpackMemoryOptimizations: true,
     webpackBuildWorker: true,

--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -23,6 +23,7 @@ const EMPTY_RESULT: MeasureQueueResult = {
   counts: { EMPTY: 0, DRAFT: 0, REVIEWED: 0, PUBLISHED: 0, DEPUBLISHED: 0 },
   anomalyCount: 0,
   withdrawnCount: 0,
+  enrichmentCounts: { SUBTOPICS_PENDING: 0, SUBTOPICS_APPROVED: 0, DETAILS_MISSING: 0 },
   scanCapped: false,
 };
 

--- a/src/app/admin/mesures/_components/QueueFilters.tsx
+++ b/src/app/admin/mesures/_components/QueueFilters.tsx
@@ -3,7 +3,11 @@ import { PUBLICATION_STATE_LABELS, THEME_CATEGORY_LABELS } from "@/config/labels
 import type { ThemeCategory } from "@/generated/prisma";
 import type { PublicationState } from "@/lib/measures/moderation-state";
 import { THEMES_IN_ORDER } from "@/lib/presidentielle/themes";
-import type { MeasureQueueCandidateOption, MeasureQueueResult } from "../_data/queue-query";
+import type {
+  EnrichmentState,
+  MeasureQueueCandidateOption,
+  MeasureQueueResult,
+} from "../_data/queue-query";
 
 /**
  * Filters as plain links, server-rendered.
@@ -18,6 +22,7 @@ export type QueueFilterState = {
   theme: ThemeCategory[];
   candidacyId: string | undefined;
   anomaliesOnly: boolean;
+  enrichment: EnrichmentState | undefined;
   withdrawn: "only" | "exclude" | undefined;
   q: string | undefined;
 };
@@ -45,6 +50,7 @@ function hrefWith(current: QueueFilterState, patch: Partial<QueueFilterState>): 
   for (const theme of next.theme) params.append("theme", theme);
   if (next.candidacyId) params.set("candidat", next.candidacyId);
   if (next.anomaliesOnly) params.set("anomalies", "1");
+  if (next.enrichment) params.set("enrichissement", next.enrichment);
   if (next.withdrawn) params.set("retrait", next.withdrawn);
   if (next.q) params.set("q", next.q);
 
@@ -129,6 +135,45 @@ export function QueueFilters({
 
       <fieldset>
         <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Enrichissement éditorial
+        </legend>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Ces boutons filtrent la file. Les actions de traitement apparaissent ensuite dans le
+          tableau.
+        </p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Link
+            href={hrefWith(current, { enrichment: undefined })}
+            prefetch={false}
+            className={`${TAB} ${current.enrichment === undefined ? TAB_ACTIVE : ""}`}
+          >
+            Toutes
+          </Link>
+          {(
+            [
+              ["SUBTOPICS_PENDING", "Sous-thèmes à valider"],
+              ["SUBTOPICS_APPROVED", "Sous-thèmes validés"],
+              ["DETAILS_MISSING", "Contexte à compléter"],
+            ] as const
+          ).map(([state, label]) => (
+            <Link
+              key={state}
+              href={hrefWith(current, {
+                enrichment: current.enrichment === state ? undefined : state,
+              })}
+              prefetch={false}
+              className={`${TAB} ${current.enrichment === state ? TAB_ACTIVE : ""}`}
+              aria-current={current.enrichment === state ? "true" : undefined}
+            >
+              {label}
+              <span className="ml-1.5 text-muted-foreground">{result.enrichmentCounts[state]}</span>
+            </Link>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Signalements
         </legend>
         <div className="mt-2 flex flex-wrap gap-2">
@@ -195,6 +240,9 @@ export function QueueFilters({
         ))}
         {current.candidacyId && <input type="hidden" name="candidat" value={current.candidacyId} />}
         {current.anomaliesOnly && <input type="hidden" name="anomalies" value="1" />}
+        {current.enrichment && (
+          <input type="hidden" name="enrichissement" value={current.enrichment} />
+        )}
         {current.withdrawn && <input type="hidden" name="retrait" value={current.withdrawn} />}
 
         <div className="flex-1">

--- a/src/app/admin/mesures/_components/QueueTable.tsx
+++ b/src/app/admin/mesures/_components/QueueTable.tsx
@@ -1,7 +1,15 @@
 import Link from "next/link";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
-import type { MeasureQueueRow } from "../_data/queue-query";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { EnrichmentState, MeasureQueueRow } from "../_data/queue-query";
 import { ModerationStateBadge } from "./ModerationStateBadge";
+
+const ENRICHMENT_ACTIONS: Record<EnrichmentState, { label: string; hash: string }> = {
+  SUBTOPICS_PENDING: { label: "Valider les sous-thèmes", hash: "#subtopics-heading" },
+  SUBTOPICS_APPROVED: { label: "Consulter les sous-thèmes", hash: "#subtopics-heading" },
+  DETAILS_MISSING: { label: "Compléter le contexte", hash: "#actions-heading" },
+};
 
 /**
  * The queue itself.
@@ -10,8 +18,15 @@ import { ModerationStateBadge } from "./ModerationStateBadge";
  * table destroys the tabular semantics screen readers rely on. Wide content scrolls inside its
  * own container so the page never scrolls horizontally.
  */
-export function QueueTable({ rows }: { rows: MeasureQueueRow[] }) {
+export function QueueTable({
+  rows,
+  activeEnrichment,
+}: {
+  rows: MeasureQueueRow[];
+  activeEnrichment?: EnrichmentState;
+}) {
   const formatter = new Intl.DateTimeFormat("fr-FR", { dateStyle: "short" });
+  const activeAction = activeEnrichment ? ENRICHMENT_ACTIONS[activeEnrichment] : null;
 
   if (rows.length === 0) {
     return (
@@ -56,7 +71,7 @@ export function QueueTable({ rows }: { rows: MeasureQueueRow[] }) {
               Saisie
             </th>
             <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground">
-              <span className="sr-only">Ouvrir la fiche de modération</span>
+              Action
             </th>
           </tr>
         </thead>
@@ -77,17 +92,29 @@ export function QueueTable({ rows }: { rows: MeasureQueueRow[] }) {
               </td>
               <td className="px-3 py-3 align-top">
                 <ModerationStateBadge state={row.state} />
+                <div className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
+                  {row.suggestedSubtopicCount > 0 && (
+                    <span>{row.suggestedSubtopicCount} sous-thème(s) à valider</span>
+                  )}
+                  {row.approvedSubtopicCount > 0 && (
+                    <span>{row.approvedSubtopicCount} sous-thème(s) validé(s)</span>
+                  )}
+                  {!row.hasDetails && <span>Contexte à compléter</span>}
+                </div>
               </td>
               <td className="px-3 py-3 align-top whitespace-nowrap text-muted-foreground">
                 {formatter.format(row.createdAt)}
               </td>
               <td className="px-3 py-3 align-top">
                 <Link
-                  href={`/admin/mesures/${row.id}`}
+                  href={`/admin/mesures/${row.id}${activeAction?.hash ?? ""}`}
                   prefetch={false}
-                  className="inline-flex min-h-11 items-center text-primary underline"
+                  className={cn(
+                    buttonVariants({ variant: activeAction ? "default" : "outline" }),
+                    "min-h-11 whitespace-normal text-center"
+                  )}
                 >
-                  Examiner
+                  {activeAction?.label ?? "Examiner"}
                 </Link>
               </td>
             </tr>

--- a/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
@@ -9,6 +9,7 @@ const RESULT: MeasureQueueResult = {
   counts: { EMPTY: 0, DRAFT: 0, REVIEWED: 0, PUBLISHED: 0, DEPUBLISHED: 0 },
   anomalyCount: 0,
   withdrawnCount: 0,
+  enrichmentCounts: { SUBTOPICS_PENDING: 12, SUBTOPICS_APPROVED: 3, DETAILS_MISSING: 8 },
   scanCapped: false,
 };
 
@@ -17,6 +18,7 @@ const CURRENT: QueueFilterState = {
   theme: ["SANTE"],
   candidacyId: undefined,
   anomaliesOnly: false,
+  enrichment: "SUBTOPICS_PENDING",
   withdrawn: "exclude",
   q: "hôpital",
 };
@@ -46,6 +48,7 @@ describe("QueueFilters", () => {
     expect(href).toContain("etat=REVIEWED");
     expect(href).toContain("theme=SANTE");
     expect(href).toContain("retrait=exclude");
+    expect(href).toContain("enrichissement=SUBTOPICS_PENDING");
     expect(href).toContain("q=h%C3%B4pital");
   });
 
@@ -59,9 +62,22 @@ describe("QueueFilters", () => {
     );
 
     expect(container.querySelector('input[name="candidat"]')).toHaveValue("candidature-1");
+    expect(container.querySelector('input[name="enrichissement"]')).toHaveValue(
+      "SUBTOPICS_PENDING"
+    );
     expect(screen.getByRole("link", { name: "Alix Démonstration" })).toHaveAttribute(
       "aria-current",
       "true"
     );
+  });
+
+  it("présente les files d’enrichissement avec leurs compteurs", () => {
+    render(<QueueFilters current={CURRENT} result={RESULT} candidates={CANDIDATES} />);
+
+    expect(screen.getByRole("link", { name: "Sous-thèmes à valider 12" })).toHaveAttribute(
+      "aria-current",
+      "true"
+    );
+    expect(screen.getByRole("link", { name: "Contexte à compléter 8" })).toBeInTheDocument();
   });
 });

--- a/src/app/admin/mesures/_components/__tests__/QueueTable.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/QueueTable.test.tsx
@@ -12,6 +12,9 @@ function row(over: Partial<MeasureQueueRow> = {}): MeasureQueueRow {
     electionTitle: "Élection de démonstration 2027",
     createdAt: new Date("2027-01-15T00:00:00Z"),
     referenceText: "Encadrer les loyers dans les zones tendues.",
+    hasDetails: true,
+    suggestedSubtopicCount: 0,
+    approvedSubtopicCount: 0,
     state: {
       publication: "PUBLISHED",
       declaredStatus: "PUBLISHED",
@@ -78,5 +81,28 @@ describe("QueueTable", () => {
 
     expect(screen.getByText("Aucune mesure ne correspond à ces filtres.")).toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("propose l’action correspondant au filtre d’enrichissement", () => {
+    render(
+      <QueueTable
+        rows={[row({ suggestedSubtopicCount: 2 })]}
+        activeEnrichment="SUBTOPICS_PENDING"
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Valider les sous-thèmes" })).toHaveAttribute(
+      "href",
+      "/admin/mesures/m-1#subtopics-heading"
+    );
+  });
+
+  it("conduit directement aux actions de révision pour compléter le contexte", () => {
+    render(<QueueTable rows={[row({ hasDetails: false })]} activeEnrichment="DETAILS_MISSING" />);
+
+    expect(screen.getByRole("link", { name: "Compléter le contexte" })).toHaveAttribute(
+      "href",
+      "/admin/mesures/m-1#actions-heading"
+    );
   });
 });

--- a/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/queue-query.integration.test.ts
@@ -50,6 +50,13 @@ describeIfDisposableDb("queryMeasureQueue", () => {
     expect(result.withdrawnCount).toBe(2);
   });
 
+  it("isole les fiches dont le contexte éditorial reste à compléter", async () => {
+    const result = await scoped({ enrichment: "DETAILS_MISSING" });
+
+    expect(result.total).toBe(result.enrichmentCounts.DETAILS_MISSING);
+    expect(result.rows.every((row) => !row.hasDetails)).toBe(true);
+  });
+
   it("borne la page sans jamais produire un LIMIT invalide", async () => {
     // take: 0 and take: -5 must not reach the database as such. A negative LIMIT fails with
     // P2010, and a zero one silently returns an empty page that reads like "no measures".

--- a/src/app/admin/mesures/_data/queue-query.ts
+++ b/src/app/admin/mesures/_data/queue-query.ts
@@ -30,6 +30,8 @@ const MAX_TAKE = 100;
  */
 export const QUEUE_SCAN_CAP = 500;
 
+export type EnrichmentState = "SUBTOPICS_PENDING" | "SUBTOPICS_APPROVED" | "DETAILS_MISSING";
+
 export type MeasureQueueFilters = {
   publication?: PublicationState[];
   theme?: ThemeCategory[];
@@ -38,6 +40,7 @@ export type MeasureQueueFilters = {
   politicianId?: string;
   withdrawn?: "only" | "exclude";
   anomaliesOnly?: boolean;
+  enrichment?: EnrichmentState;
   q?: string;
   take?: number;
   skip?: number;
@@ -53,7 +56,13 @@ const QUEUE_SELECT = {
   // Extends the shared selection rather than replacing it: the derivation reads the same
   // fields either way, and the queue needs the text and the date on top.
   revisions: {
-    select: { ...MODERATION_MEASURE_SELECT.revisions.select, text: true, validFrom: true },
+    select: {
+      ...MODERATION_MEASURE_SELECT.revisions.select,
+      text: true,
+      details: true,
+      validFrom: true,
+      subtopics: { select: { status: true } },
+    },
     orderBy: MODERATION_MEASURE_SELECT.revisions.orderBy,
   },
 } satisfies Prisma.MeasureSelect;
@@ -72,6 +81,9 @@ export type MeasureQueueRow = {
    * Null only when the measure has no revision at all, which the EMPTY stage names.
    */
   referenceText: string | null;
+  hasDetails: boolean;
+  suggestedSubtopicCount: number;
+  approvedSubtopicCount: number;
   state: ModerationState;
 };
 
@@ -82,6 +94,7 @@ export type MeasureQueueResult = {
   counts: Record<PublicationState, number>;
   anomalyCount: number;
   withdrawnCount: number;
+  enrichmentCounts: Record<EnrichmentState, number>;
   scanCapped: boolean;
 };
 
@@ -149,6 +162,9 @@ function referenceTextOf(row: QueueDbRow): string | null {
 }
 
 function toQueueRow(row: QueueDbRow): MeasureQueueRow {
+  const referenceId = row.publishedRevisionId ?? row.latestRevisionId;
+  const referenceRevision = row.revisions.find((revision) => revision.id === referenceId);
+
   return {
     id: row.id,
     theme: row.theme,
@@ -157,6 +173,11 @@ function toQueueRow(row: QueueDbRow): MeasureQueueRow {
     electionTitle: row.election.title,
     createdAt: row.createdAt,
     referenceText: referenceTextOf(row),
+    hasDetails: Boolean(referenceRevision?.details?.trim()),
+    suggestedSubtopicCount:
+      referenceRevision?.subtopics.filter((item) => item.status === "SUGGESTED").length ?? 0,
+    approvedSubtopicCount:
+      referenceRevision?.subtopics.filter((item) => item.status === "APPROVED").length ?? 0,
     state: deriveModerationState(toModerationMeasureRow(row)),
   };
 }
@@ -166,6 +187,9 @@ function matchesDerivedFilters(row: MeasureQueueRow, filters: MeasureQueueFilter
     if (!filters.publication.includes(row.state.publication)) return false;
   }
   if (filters.anomaliesOnly && row.state.anomalies.length === 0) return false;
+  if (filters.enrichment === "SUBTOPICS_PENDING" && row.suggestedSubtopicCount === 0) return false;
+  if (filters.enrichment === "SUBTOPICS_APPROVED" && row.approvedSubtopicCount === 0) return false;
+  if (filters.enrichment === "DETAILS_MISSING" && row.hasDetails) return false;
   return true;
 }
 
@@ -196,10 +220,18 @@ export async function queryMeasureQueue(
   const counts = emptyCounts();
   let anomalyCount = 0;
   let withdrawnCount = 0;
+  const enrichmentCounts: Record<EnrichmentState, number> = {
+    SUBTOPICS_PENDING: 0,
+    SUBTOPICS_APPROVED: 0,
+    DETAILS_MISSING: 0,
+  };
   for (const row of rows) {
     counts[row.state.publication] += 1;
     if (row.state.anomalies.length > 0) anomalyCount += 1;
     if (row.state.withdrawal !== null) withdrawnCount += 1;
+    if (row.suggestedSubtopicCount > 0) enrichmentCounts.SUBTOPICS_PENDING += 1;
+    if (row.approvedSubtopicCount > 0) enrichmentCounts.SUBTOPICS_APPROVED += 1;
+    if (!row.hasDetails) enrichmentCounts.DETAILS_MISSING += 1;
   }
 
   const matching = rows.filter((row) => matchesDerivedFilters(row, filters));
@@ -210,6 +242,7 @@ export async function queryMeasureQueue(
     counts,
     anomalyCount,
     withdrawnCount,
+    enrichmentCounts,
     scanCapped,
   };
 }

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -9,9 +9,15 @@ import { BatchPublishPanel } from "./_components/BatchPublishPanel";
 import { BatchReviewPanel } from "./_components/BatchReviewPanel";
 import { QueueFilters, type QueueFilterState } from "./_components/QueueFilters";
 import { QueueTable } from "./_components/QueueTable";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { queryBatchPublishGroups } from "./_data/batch-publish-query";
 import { queryBatchReviewGroups } from "./_data/batch-review-query";
-import { listMeasureQueueCandidates, queryMeasureQueue } from "./_data/queue-query";
+import {
+  listMeasureQueueCandidates,
+  queryMeasureQueue,
+  type EnrichmentState,
+} from "./_data/queue-query";
 
 export const metadata = {
   title: "Mesures : relecture (admin) | Poligraph",
@@ -22,6 +28,11 @@ const PAGE_SIZE = 25;
 
 const PUBLICATION_KEYS = Object.keys(PUBLICATION_STATE_LABELS) as PublicationState[];
 const THEME_KEYS: readonly ThemeCategory[] = THEMES_IN_ORDER;
+const ENRICHMENT_KEYS: readonly EnrichmentState[] = [
+  "SUBTOPICS_PENDING",
+  "SUBTOPICS_APPROVED",
+  "DETAILS_MISSING",
+];
 
 interface PageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -55,6 +66,10 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
   const retrait = asString(params.retrait);
   const withdrawn = retrait === "only" || retrait === "exclude" ? retrait : undefined;
   const anomaliesOnly = asString(params.anomalies) === "1";
+  const enrichmentParam = asString(params.enrichissement);
+  const enrichment = ENRICHMENT_KEYS.includes(enrichmentParam as EnrichmentState)
+    ? (enrichmentParam as EnrichmentState)
+    : undefined;
   const candidacyId = asString(params.candidat);
   const q = asString(params.q);
 
@@ -68,6 +83,7 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
       candidacyId,
       withdrawn,
       anomaliesOnly,
+      enrichment,
       q,
       take: PAGE_SIZE,
       skip: (page - 1) * PAGE_SIZE,
@@ -82,10 +98,38 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
     theme,
     candidacyId,
     anomaliesOnly,
+    enrichment,
     withdrawn,
     q,
   };
   const totalPages = Math.max(1, Math.ceil(result.total / PAGE_SIZE));
+  const firstMeasure = result.rows[0];
+  const enrichmentWorkflow =
+    enrichment === "SUBTOPICS_PENDING"
+      ? {
+          title: "Sous-thèmes à valider",
+          description:
+            "Examinez les propositions une mesure après l’autre. Rien ne devient public sans validation humaine.",
+          action: "Valider les sous-thèmes de la première mesure",
+          hash: "#subtopics-heading",
+        }
+      : enrichment === "DETAILS_MISSING"
+        ? {
+            title: "Contextes à compléter",
+            description:
+              "Ajoutez uniquement les éléments factuels présents dans les sources de la mesure.",
+            action: "Compléter le contexte de la première mesure",
+            hash: "#actions-heading",
+          }
+        : enrichment === "SUBTOPICS_APPROVED"
+          ? {
+              title: "Sous-thèmes validés",
+              description:
+                "Consultez les rattachements déjà validés et leur révision de référence.",
+              action: "Consulter la première mesure",
+              hash: "#subtopics-heading",
+            }
+          : null;
 
   return (
     <div className="space-y-6">
@@ -121,11 +165,37 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
 
       <QueueFilters current={current} result={result} candidates={candidates} />
 
+      {enrichmentWorkflow !== null && firstMeasure !== undefined ? (
+        <section
+          aria-labelledby="enrichment-workflow-title"
+          className="flex flex-col gap-4 rounded-lg border border-primary/30 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h2 id="enrichment-workflow-title" className="font-display text-lg font-bold">
+              {enrichmentWorkflow.title}
+            </h2>
+            <p className="mt-1 max-w-3xl text-sm leading-relaxed text-muted-foreground-strong">
+              {enrichmentWorkflow.description}
+            </p>
+          </div>
+          <Link
+            href={`/admin/mesures/${firstMeasure.id}${enrichmentWorkflow.hash}`}
+            prefetch={false}
+            className={cn(
+              buttonVariants({ variant: "default" }),
+              "min-h-11 shrink-0 whitespace-normal text-center"
+            )}
+          >
+            {enrichmentWorkflow.action}
+          </Link>
+        </section>
+      ) : null}
+
       <BatchReviewPanel groups={batchReviewGroups} />
 
       <BatchPublishPanel groups={batchPublishGroups} />
 
-      <QueueTable rows={result.rows} />
+      <QueueTable rows={result.rows} activeEnrichment={enrichment} />
 
       {totalPages > 1 && (
         <nav className="flex flex-wrap justify-center gap-2" aria-label="Pagination">
@@ -135,6 +205,7 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
             for (const key of theme) query.append("theme", key);
             if (candidacyId) query.set("candidat", candidacyId);
             if (anomaliesOnly) query.set("anomalies", "1");
+            if (enrichment) query.set("enrichissement", enrichment);
             if (withdrawn) query.set("retrait", withdrawn);
             if (q) query.set("q", q);
             query.set("page", String(number));

--- a/src/app/api/chat/route.public-contract.test.ts
+++ b/src/app/api/chat/route.public-contract.test.ts
@@ -23,7 +23,9 @@ vi.mock("@/services/chat/keywords", () => ({
 import { POST } from "@/app/api/chat/route";
 
 function rawSqlText(call: unknown[]): string {
-  const strings = call[0] as readonly string[];
+  const query = call[0] as { sql?: string } | readonly string[];
+  if (!Array.isArray(query)) return query.sql ?? "";
+  const strings = query;
   const values = call.slice(1);
   return strings
     .map((part, index) => {

--- a/src/app/api/chat/route.public-contract.test.ts
+++ b/src/app/api/chat/route.public-contract.test.ts
@@ -24,7 +24,7 @@ import { POST } from "@/app/api/chat/route";
 
 function rawSqlText(call: unknown[]): string {
   const query = call[0] as { sql?: string } | readonly string[];
-  if (!Array.isArray(query)) return query.sql ?? "";
+  if (!Array.isArray(query)) return (query as { sql?: string }).sql ?? "";
   const strings = query;
   const values = call.slice(1);
   return strings

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,6 +3,7 @@ import { streamText } from "ai";
 import { headers } from "next/headers";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import { Prisma } from "@/generated/prisma";
 import { searchSimilar, rerankResults, type SearchResult } from "@/services/embeddings";
 import { db } from "@/lib/db";
 import { getSystemPrompt } from "@/services/chat/systemPrompt";
@@ -91,7 +92,7 @@ async function getGlobalStats(): Promise<{
         total_ministers: bigint;
       },
     ]
-  >`
+  >(Prisma.sql`
     SELECT
       (SELECT COUNT(*) FROM "Affair" a
         WHERE ${getPublishedAffairSqlWhere()}
@@ -127,7 +128,7 @@ async function getGlobalStats(): Promise<{
         WHERE m."isCurrent" = true
           AND m."type" IN ('MINISTRE', 'MINISTRE_DELEGUE', 'SECRETAIRE_ETAT', 'PREMIER_MINISTRE')
           AND p."publicationStatus" = ${PUBLIC_POLITICIAN_PUBLICATION_STATUS}) AS total_ministers
-  `;
+  `);
 
   const r = rows[0];
   return {

--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -110,7 +110,7 @@ export const GET = withPublicRoute(async (request) => {
       `,
 
       // Parties: accent-insensitive on name/shortName; public member count only.
-      db.$queryRaw<RawParty[]>`
+      db.$queryRaw<RawParty[]>(Prisma.sql`
         SELECT p."slug", p."name", p."shortName", p."color",
                (SELECT COUNT(*) FROM "Politician" pol
                 WHERE pol."currentPartyId" = p."id"
@@ -121,7 +121,7 @@ export const GET = withPublicRoute(async (request) => {
             OR unaccent(p."shortName") ILIKE unaccent(${Prisma.sql`${query}`}))
         ORDER BY p."name" ASC
         LIMIT ${limit}
-      `,
+      `),
 
       // Affairs: public affairs tied to public politicians only.
       db.$queryRaw<RawAffair[]>`
@@ -148,7 +148,7 @@ export const GET = withPublicRoute(async (request) => {
 
       // Fact-checks: preserve accent-insensitive search while composing the
       // canonical public publication + allow-list predicate.
-      db.$queryRaw<RawFactCheck[]>`
+      db.$queryRaw<RawFactCheck[]>(Prisma.sql`
         SELECT fc."slug", fc."title", fc."source", fc."verdictRating", fc."publishedAt",
                (SELECT p."fullName"
                 FROM "FactCheckMention" m
@@ -161,7 +161,7 @@ export const GET = withPublicRoute(async (request) => {
           AND unaccent(fc."title") ILIKE unaccent(${pattern})
         ORDER BY fc."publishedAt" DESC
         LIMIT ${limit}
-      `,
+      `),
 
       // Legislative dossiers: accent-insensitive on title/shortTitle
       db.$queryRaw<RawDossier[]>`

--- a/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
+++ b/src/app/elections/presidentielle-2027/_components/DataProvenance.tsx
@@ -18,7 +18,7 @@ export function DataProvenance() {
       </ul>
       <p className="mt-3 text-sm">
         <Link
-          href="/methodologie"
+          href="/methodologie/mesures-presidentielle-2027"
           className="inline-flex min-h-11 items-center underline hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           Méthode et sources

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -34,6 +34,13 @@ const detail = {
     blobPhotoUrl: null,
     party: null,
   },
+  subtopics: [
+    {
+      slug: "logement-social",
+      label: "Logement social",
+      description: "Construction, attribution et financement du logement social.",
+    },
+  ],
   sources: [
     {
       id: "source-1",
@@ -73,9 +80,18 @@ describe("page publique d'une mesure présidentielle", () => {
       "https://example.org/programme-complet"
     );
     expect(screen.getByText("territoires concernés")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Notions abordées" })).toBeInTheDocument();
+    expect(screen.getByText("Logement social")).toBeInTheDocument();
+    expect(
+      screen.getByText("Construction, attribution et financement du logement social.")
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Camille Rivière/ })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027/candidats/camille-riviere"
+    );
+    expect(screen.getByRole("link", { name: "Voir la méthode" })).toHaveAttribute(
+      "href",
+      "/methodologie/mesures-presidentielle-2027"
     );
     expect(
       screen.getByRole("link", {

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -130,7 +130,10 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             )}
             <span className="text-sm text-muted-foreground">
               Revue par Poligraph le {formatDate(measure.reviewedAt)}.{" "}
-              <Link href="/methodologie" className="font-bold text-primary underline">
+              <Link
+                href="/methodologie/mesures-presidentielle-2027"
+                className="font-bold text-primary underline"
+              >
                 Voir la méthode
               </Link>
             </span>
@@ -145,6 +148,28 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
               {measure.details}
             </MarkdownText>
+          </section>
+        )}
+
+        {measure.subtopics.length > 0 && (
+          <section aria-labelledby="concepts-title" className="border-b border-border py-8">
+            <h2 id="concepts-title" className="font-display text-2xl font-extrabold">
+              Notions abordées
+            </h2>
+            <p className="mt-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground">
+              Ces repères décrivent les sujets auxquels la mesure a été rattachée après validation
+              éditoriale. Ils n&apos;évaluent ni son coût, ni sa faisabilité.
+            </p>
+            <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+              {measure.subtopics.map((subtopic) => (
+                <div key={subtopic.slug} className="rounded-xl border border-border bg-card p-4">
+                  <dt className="font-display text-lg font-bold">{subtopic.label}</dt>
+                  <dd className="mt-1 text-sm leading-relaxed text-muted-foreground-strong">
+                    {subtopic.description}
+                  </dd>
+                </div>
+              ))}
+            </dl>
           </section>
         )}
 

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
@@ -600,7 +600,7 @@ function MethodCard() {
         travail de notre part.
       </p>
       <Link
-        href="/methodologie"
+        href="/methodologie/mesures-presidentielle-2027"
         className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-lg bg-primary px-5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
       >
         Voir la méthode

--- a/src/app/elections/presidentielle-2027/themes/page.tsx
+++ b/src/app/elections/presidentielle-2027/themes/page.tsx
@@ -64,7 +64,7 @@ export default async function ThemesIndexPage() {
             distinguée des propositions toujours portées.
           </p>
           <Link
-            href="/methodologie"
+            href="/methodologie/mesures-presidentielle-2027"
             className="inline-flex min-h-11 items-center text-sm font-medium underline hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             Méthode et sources

--- a/src/app/methodologie/mesures-presidentielle-2027/page.tsx
+++ b/src/app/methodologie/mesures-presidentielle-2027/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+
+const PAGE_PATH = "/methodologie/mesures-presidentielle-2027";
+
+export const metadata: Metadata = {
+  title: "Méthode des mesures de la présidentielle 2027 | Poligraph",
+  description:
+    "Comment Poligraph sélectionne, source, relit, classe et compare les mesures des candidates et candidats à l'élection présidentielle de 2027.",
+  alternates: { canonical: PAGE_PATH },
+};
+
+export default function PresidentialMeasuresMethodologyPage() {
+  return (
+    <main className="container mx-auto max-w-3xl px-4 pb-12 pt-4">
+      <Breadcrumb
+        items={[
+          { label: "Méthodologie", href: "/methodologie" },
+          { label: "Mesures de la présidentielle 2027" },
+        ]}
+      />
+
+      <header className="mb-10">
+        <p className="text-sm font-bold uppercase tracking-widest text-brand">
+          Élection présidentielle 2027
+        </p>
+        <h1 className="mt-2 font-display text-3xl font-extrabold tracking-tight sm:text-4xl">
+          Comment les mesures sont documentées
+        </h1>
+        <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+          Cette page décrit ce qui entre dans le corpus, les contrôles effectués avant publication
+          et les limites à garder en tête pour lire les comparaisons.
+        </p>
+      </header>
+
+      <div className="space-y-12">
+        <section aria-labelledby="definition-title">
+          <h2 id="definition-title" className="font-display text-2xl font-bold">
+            Ce que Poligraph appelle une mesure
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Une mesure est une proposition d&apos;action ou un objectif vérifiable, attribuable à
+              une candidature et rattaché à une source. Une valeur, un diagnostic ou une déclaration
+              d&apos;intention générale ne suffit pas.
+            </p>
+            <p>
+              Le texte publié reste aussi proche que possible de la formulation source. Poligraph ne
+              complète pas une proposition avec une intention supposée et ne se prononce ni sur son
+              opportunité, ni sur sa faisabilité.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="sources-title">
+          <h2 id="sources-title" className="font-display text-2xl font-bold">
+            Sources et rattachement
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              La source de référence est prioritairement un programme officiel, un discours, un
+              débat ou une interview de la candidate ou du candidat. Une source secondaire peut être
+              utilisée lorsqu&apos;elle rapporte la proposition de façon vérifiable, avec son niveau
+              indiqué sur la fiche.
+            </p>
+            <p>
+              Chaque mesure est rattachée à une candidature déclarée et sourcée. Lorsqu&apos;une
+              édition de programme existe, la fiche indique le document, sa date et
+              l&apos;emplacement connu de la mesure.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="review-title">
+          <h2 id="review-title" className="font-display text-2xl font-bold">
+            Extraction, relecture et publication
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Une mesure peut être saisie manuellement, importée ou proposée avec une assistance
+              automatique. Elle reste un brouillon tant qu&apos;une personne ne l&apos;a pas relue
+              avec sa source et validée pour publication.
+            </p>
+            <p>
+              L&apos;intelligence artificielle peut aider à extraire ou classer un contenu. Elle ne
+              publie pas une mesure, ne lui prête pas une intention et ne décide pas seule des
+              rapprochements présentés au public.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="classification-title">
+          <h2 id="classification-title" className="font-display text-2xl font-bold">
+            Thèmes, sous-thèmes et niveau de précision
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Chaque mesure appartient à l&apos;un des seize thèmes communs au corpus. Des
+              sous-thèmes issus d&apos;une taxonomie fermée peuvent être proposés automatiquement,
+              mais ils ne deviennent publics qu&apos;après validation humaine.
+            </p>
+            <p>
+              Le niveau « Objectif quantifié » indique que la formulation comporte une quantité,
+              écrite en chiffres ou en toutes lettres. Il ne signifie pas que Poligraph a évalué le
+              coût, l&apos;efficacité ou la faisabilité de la proposition.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="history-title">
+          <h2 id="history-title" className="font-display text-2xl font-bold">
+            Corrections, évolutions et retraits
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Une reformulation crée une nouvelle révision. La version déjà publique reste visible
+              jusqu&apos;à la relecture et à la publication de la correction.
+            </p>
+            <p>
+              Lorsqu&apos;une candidature abandonne une proposition, la mesure n&apos;est pas
+              effacée. Son retrait est daté et sourcé afin de conserver l&apos;historique de la
+              campagne.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="comparison-title">
+          <h2 id="comparison-title" className="font-display text-2xl font-bold">
+            Comparaisons et votes parlementaires
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Les pages de comparaison placent côte à côte les formulations publiées, sans score de
+              proximité et sans classement politique. Les candidatures suivent un ordre
+              alphabétique.
+            </p>
+            <p>
+              Une mesure n&apos;est rapprochée d&apos;un scrutin de l&apos;Assemblée nationale ou du
+              Sénat qu&apos;après examen de leur objet. Une position parlementaire ne peut être
+              affichée que pour une personne qui siégeait au moment du vote. L&apos;absence de
+              position ne permet donc pas de déduire une opinion.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="limits-title" className="rounded-2xl border border-border p-5">
+          <h2 id="limits-title" className="font-display text-2xl font-bold">
+            Ce que couvre le corpus
+          </h2>
+          <p className="mt-4 leading-relaxed text-muted-foreground">
+            Poligraph publie progressivement les contenus trouvés, sourcés et relus. Une absence
+            signifie qu&apos;aucune mesure correspondante n&apos;est publiée dans le corpus à cette
+            date. Elle ne prouve pas qu&apos;une proposition n&apos;existe pas.
+          </p>
+        </section>
+      </div>
+
+      <nav aria-label="Liens complémentaires" className="mt-10 flex flex-wrap gap-4 border-t pt-6">
+        <Link href="/elections/presidentielle-2027" className="font-bold text-primary underline">
+          Consulter le dossier présidentielle 2027
+        </Link>
+        <Link href="/sources" className="font-bold text-primary underline">
+          Voir les sources et principes éditoriaux
+        </Link>
+        <Link href="/methodologie" className="font-bold text-primary underline">
+          Toutes les méthodes de Poligraph
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/src/app/methodologie/methodologie.test.tsx
+++ b/src/app/methodologie/methodologie.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MethodologiePage, { metadata as indexMetadata } from "./page";
+import PresidentialMeasuresMethodologyPage, {
+  metadata as measuresMetadata,
+} from "./mesures-presidentielle-2027/page";
+
+describe("pages de méthodologie", () => {
+  it("présente la méthodologie générale comme une entrée par domaine", () => {
+    const { container } = render(<MethodologiePage />);
+
+    expect(indexMetadata.title).toBe("Méthodologie de Poligraph");
+    expect(screen.getByRole("link", { name: /Mesures de la présidentielle 2027/ })).toHaveAttribute(
+      "href",
+      "/methodologie/mesures-presidentielle-2027"
+    );
+    expect(container.querySelector("#comment-nous-comptons")).toBeInTheDocument();
+  });
+
+  it("explique la chaîne éditoriale des mesures sur une URL canonique dédiée", () => {
+    render(<PresidentialMeasuresMethodologyPage />);
+
+    expect(measuresMetadata.alternates?.canonical).toBe(
+      "/methodologie/mesures-presidentielle-2027"
+    );
+    expect(
+      screen.getByRole("heading", { name: "Comment les mesures sont documentées" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Extraction, relecture et publication" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Elle ne prouve pas qu'une proposition n'existe pas/)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/methodologie/page.tsx
+++ b/src/app/methodologie/page.tsx
@@ -10,9 +10,9 @@ import { AFFAIR_SUPER_CATEGORY_LABELS, type AffairSuperCategory } from "@/config
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 
 export const metadata: Metadata = {
-  title: "Méthodologie - Classification des affaires judiciaires",
+  title: "Méthodologie de Poligraph",
   description:
-    "Comment Poligraph classe et présente les affaires judiciaires des responsables politiques français",
+    "Découvrez comment Poligraph sélectionne, source, vérifie et présente ses données politiques.",
   alternates: { canonical: "/methodologie" },
 };
 
@@ -76,233 +76,271 @@ export default function MethodologiePage() {
     <main className="container mx-auto max-w-3xl px-4 pt-4 pb-12">
       <Breadcrumb items={[{ label: "Sources", href: "/sources" }, { label: "Méthodologie" }]} />
       <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">Méthodologie</h1>
-      <p className="text-muted-foreground mb-10">
-        Comment Poligraph classe et présente les affaires judiciaires
+      <p className="text-muted-foreground mb-6">
+        Comment Poligraph sélectionne, vérifie et présente les informations publiées sur le site.
       </p>
 
-      {/* Section 1: Certainty levels */}
-      <section className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">Niveaux de certitude judiciaire</h2>
-        <p className="text-muted-foreground mb-6">
-          Chaque affaire est classée selon l{"'"}avancement de la procédure judiciaire. Ce
-          classement reflète le degré de certitude juridique, pas la gravité de l{"'"}infraction.
-        </p>
-        <div className="space-y-4">
-          {CERTAINTY_ORDER.map((level) => (
-            <div key={level} className="rounded-lg border p-4">
-              <div className="flex items-center gap-3 mb-2">
-                <span
-                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${CERTAINTY_COLORS[level]}`}
-                >
-                  {CERTAINTY_LABELS[level]}
-                </span>
-              </div>
-              <p className="text-sm text-muted-foreground mb-2">{CERTAINTY_DESCRIPTIONS[level]}</p>
-              <ul className="text-sm text-muted-foreground list-disc list-inside">
-                {CERTAINTY_STATUSES[level].map((s) => (
-                  <li key={s}>{s}</li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      </section>
+      <nav aria-label="Méthodes par domaine" className="mb-12 grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/methodologie/mesures-presidentielle-2027"
+          className="rounded-xl border border-border p-4 hover:border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          <span className="block font-bold">Mesures de la présidentielle 2027</span>
+          <span className="mt-1 block text-sm text-muted-foreground">
+            Sélection, sources, relecture, classement et comparaison.
+          </span>
+        </Link>
+        <Link
+          href="#affaires-judiciaires"
+          className="rounded-xl border border-border p-4 hover:border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          <span className="block font-bold">Affaires judiciaires</span>
+          <span className="mt-1 block text-sm text-muted-foreground">
+            Niveaux de certitude, catégories et règles de comptage.
+          </span>
+        </Link>
+      </nav>
 
-      {/* Section 2: Super-categories */}
-      <section className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">Types d{"'"}infractions</h2>
-        <p className="text-muted-foreground mb-6">
-          Les affaires sont regroupées en cinq grandes catégories, inspirées du cadre de la{" "}
-          <Link
-            href="https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528"
-            className="text-primary hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            loi Sapin II
-          </Link>{" "}
-          pour la distinction entre infractions liées à la probité et infractions de droit commun.
-        </p>
-        <div className="space-y-3">
-          {SUPER_CATEGORIES.map(({ key, description }) => (
-            <div key={key} className="rounded-lg border p-4">
-              <h3 className="font-medium mb-1">{AFFAIR_SUPER_CATEGORY_LABELS[key]}</h3>
-              <p className="text-sm text-muted-foreground">{description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Section 3: Counting rules / Maturity model */}
-      <section id="comment-nous-comptons" className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">Comment nous comptons</h2>
-        <p className="text-muted-foreground mb-6">
-          Les compteurs agrégés (page d{"'"}accueil, pages de partis, badges sur les profils)
-          utilisent un seuil de maturité judiciaire pour ne mettre en avant que les affaires
-          validées par un juge.
-        </p>
-        <div className="space-y-3 text-sm text-muted-foreground">
-          <div className="rounded-lg border border-red-200 dark:border-red-800 p-4">
-            <h3 className="font-medium text-foreground mb-1">Condamnations (comptabilisées)</h3>
-            <p>
-              Condamnation définitive, condamnation en première instance ou appel en cours. Ce sont
-              les affaires où un tribunal a prononcé une peine. Elles forment le chiffre principal
-              affiché dans les compteurs.
-            </p>
-          </div>
-          <div className="rounded-lg border border-amber-200 dark:border-amber-800 p-4">
-            <h3 className="font-medium text-foreground mb-1">
-              Procédures validées par un juge (comptabilisées)
-            </h3>
-            <p>
-              Mise en examen, instruction, renvoi devant le tribunal, procès en cours. Un juge a
-              estimé qu{"'"}il existait des indices graves ou concordants justifiant des poursuites.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">
-              Enquêtes préliminaires (non comptabilisées)
-            </h3>
-            <p>
-              Les enquêtes préliminaires ne sont <strong>pas</strong> comptabilisées dans les totaux
-              agrégés. N{"'"}importe qui peut porter plainte : une enquête préliminaire ne signifie
-              pas qu{"'"}un juge a validé les accusations. Ces affaires restent visibles sur la
-              fiche détaillée du politicien.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">
-              Procédures closes sans condamnation
-            </h3>
-            <p>
-              Relaxe, acquittement, non-lieu et classement sans suite : la procédure s{"'"}est
-              terminée sans condamnation. Ces issues favorables sont affichées séparément des
-              condamnations et ne sont jamais présentées comme une mise en cause active.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">
-              Action publique éteinte par prescription
-            </h3>
-            <p>
-              La prescription clôt la procédure sans condamnation, mais à la différence d{"'"}une
-              relaxe ou d{"'"}un non-lieu, elle ne constitue pas une décision sur le fond. Elle est
-              donc signalée distinctement, et non assimilée à une issue favorable au fond.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">Implication directe et indirecte</h3>
-            <p>
-              Seules les affaires où le politicien est directement ou indirectement impliqué (mis en
-              cause, poursuivi ou condamné) sont comptabilisées dans les agrégats à charge. Les
-              simples mentions dans une affaire tierce ou les cas où le politicien est
-              victime/plaignant ne sont pas inclus dans ces compteurs.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">Décompte par politicien</h3>
-            <p>
-              Les statistiques globales ({'"'}élus condamnés{'"'}, {'"'}élus mis en cause{'"'})
-              comptent le nombre de politiciens uniques concernés, pas le nombre total d{"'"}
-              affaires.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Section 3b: Per-role counters on the politician page */}
-      <section className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">
-          Compteurs d{"'"}affaires sur la fiche d{"'"}un politicien
+      <section id="affaires-judiciaires" aria-labelledby="affaires-judiciaires-title">
+        <h2
+          id="affaires-judiciaires-title"
+          className="mb-2 font-display text-2xl font-extrabold tracking-tight"
+        >
+          Affaires judiciaires
         </h2>
-        <p className="text-muted-foreground mb-6">
-          La fiche d{"'"}un politicien expose plusieurs compteurs, qui ne mesurent pas la même
-          chose. Ils sont volontairement distincts pour ne pas mélanger une mise en cause, une
-          simple mention et une situation de victime.
+        <p className="mb-10 text-muted-foreground">
+          Comment Poligraph classe, présente et comptabilise les procédures judiciaires.
         </p>
-        <div className="space-y-3 text-sm text-muted-foreground">
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">
-              Total des affaires publiées (tous rôles confondus)
-            </h3>
-            <p>
-              Le compteur général recense toutes les affaires publiées impliquant la personne, quel
-              que soit son rôle : mise en cause, simplement mentionnée, victime ou plaignante. Ce
-              chiffre ne dit donc rien, à lui seul, du degré de mise en cause.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">À charge (procédures validées)</h3>
-            <p>
-              Affaires où la personne est mise en cause (directement ou indirectement) et où un juge
-              a validé la procédure : condamnations et procédures validées par un juge. Les enquêtes
-              préliminaires en sont exclues.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">Issues favorables</h3>
-            <p>
-              Affaires où la personne était mise en cause et dont la procédure s{"'"}est terminée
-              sans condamnation : relaxe, acquittement, non-lieu, classement sans suite et
-              prescription.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">Simple mention</h3>
-            <p>Affaires où la personne est citée sans être mise en cause ni poursuivie.</p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h3 className="font-medium text-foreground mb-1">Victime ou plaignant</h3>
-            <p>
-              Affaires où la personne est victime ou a porté plainte. Ces affaires ne sont jamais
-              comptées comme une mise en cause.
-            </p>
-          </div>
-          <p className="text-xs">
-            Ces compteurs ne se cumulent pas pour reconstituer le total : une enquête préliminaire
-            visant directement la personne, par exemple, n{"'"}entre ni dans les affaires à charge
-            (faute de validation par un juge), ni dans les issues favorables.
+
+        {/* Section 1: Certainty levels */}
+        <section className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">
+            Niveaux de certitude judiciaire
+          </h3>
+          <p className="text-muted-foreground mb-6">
+            Chaque affaire est classée selon l{"'"}avancement de la procédure judiciaire. Ce
+            classement reflète le degré de certitude juridique, pas la gravité de l{"'"}infraction.
           </p>
-        </div>
-      </section>
+          <div className="space-y-4">
+            {CERTAINTY_ORDER.map((level) => (
+              <div key={level} className="rounded-lg border p-4">
+                <div className="flex items-center gap-3 mb-2">
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${CERTAINTY_COLORS[level]}`}
+                  >
+                    {CERTAINTY_LABELS[level]}
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground mb-2">
+                  {CERTAINTY_DESCRIPTIONS[level]}
+                </p>
+                <ul className="text-sm text-muted-foreground list-disc list-inside">
+                  {CERTAINTY_STATUSES[level].map((s) => (
+                    <li key={s}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
 
-      {/* Section 4: Presumption of innocence */}
-      <section className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">Présomption d{"'"}innocence</h2>
-        <p className="text-muted-foreground text-sm">
-          Conformément à l{"'"}article 9-1 du Code civil, toute personne mise en cause dans une
-          procédure judiciaire est présumée innocente jusqu{"'"}à ce qu{"'"}elle ait été déclarée
-          coupable par une décision de justice définitive. Cette mention apparaît systématiquement
-          sur les fiches de politiciens concernés par des procédures en cours ou des condamnations
-          non définitives. Le référencement d{"'"}une affaire sur Poligraph ne constitue en aucun
-          cas un jugement de valeur.
-        </p>
-      </section>
+        {/* Section 2: Super-categories */}
+        <section className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">Types d{"'"}infractions</h3>
+          <p className="text-muted-foreground mb-6">
+            Les affaires sont regroupées en cinq grandes catégories, inspirées du cadre de la{" "}
+            <Link
+              href="https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528"
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              loi Sapin II
+            </Link>{" "}
+            pour la distinction entre infractions liées à la probité et infractions de droit commun.
+          </p>
+          <div className="space-y-3">
+            {SUPER_CATEGORIES.map(({ key, description }) => (
+              <div key={key} className="rounded-lg border p-4">
+                <h4 className="font-medium mb-1">{AFFAIR_SUPER_CATEGORY_LABELS[key]}</h4>
+                <p className="text-sm text-muted-foreground">{description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-      {/* Section 5: Victims/plaintiffs */}
-      <section className="mb-12">
-        <h2 className="text-xl font-display font-semibold mb-4">Victimes et plaignants</h2>
-        <p className="text-muted-foreground text-sm">
-          Lorsqu{"'"}un politicien est victime ou plaignant dans une affaire (violences, menaces,
-          harcèlement), cette information est traitée séparément des affaires où il est mis en
-          cause. Ces affaires ne sont jamais comptabilisées dans les indicateurs d{"'"}intégrité et
-          apparaissent dans une section distincte sur le profil.
-        </p>
-      </section>
+        {/* Section 3: Counting rules / Maturity model */}
+        <section id="comment-nous-comptons" className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">Comment nous comptons</h3>
+          <p className="text-muted-foreground mb-6">
+            Les compteurs agrégés (page d{"'"}accueil, pages de partis, badges sur les profils)
+            utilisent un seuil de maturité judiciaire pour ne mettre en avant que les affaires
+            validées par un juge.
+          </p>
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <div className="rounded-lg border border-red-200 dark:border-red-800 p-4">
+              <h4 className="font-medium text-foreground mb-1">Condamnations (comptabilisées)</h4>
+              <p>
+                Condamnation définitive, condamnation en première instance ou appel en cours. Ce
+                sont les affaires où un tribunal a prononcé une peine. Elles forment le chiffre
+                principal affiché dans les compteurs.
+              </p>
+            </div>
+            <div className="rounded-lg border border-amber-200 dark:border-amber-800 p-4">
+              <h4 className="font-medium text-foreground mb-1">
+                Procédures validées par un juge (comptabilisées)
+              </h4>
+              <p>
+                Mise en examen, instruction, renvoi devant le tribunal, procès en cours. Un juge a
+                estimé qu{"'"}il existait des indices graves ou concordants justifiant des
+                poursuites.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">
+                Enquêtes préliminaires (non comptabilisées)
+              </h4>
+              <p>
+                Les enquêtes préliminaires ne sont <strong>pas</strong> comptabilisées dans les
+                totaux agrégés. N{"'"}importe qui peut porter plainte : une enquête préliminaire ne
+                signifie pas qu{"'"}un juge a validé les accusations. Ces affaires restent visibles
+                sur la fiche détaillée du politicien.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">
+                Procédures closes sans condamnation
+              </h4>
+              <p>
+                Relaxe, acquittement, non-lieu et classement sans suite : la procédure s{"'"}est
+                terminée sans condamnation. Ces issues favorables sont affichées séparément des
+                condamnations et ne sont jamais présentées comme une mise en cause active.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">
+                Action publique éteinte par prescription
+              </h4>
+              <p>
+                La prescription clôt la procédure sans condamnation, mais à la différence d{"'"}une
+                relaxe ou d{"'"}un non-lieu, elle ne constitue pas une décision sur le fond. Elle
+                est donc signalée distinctement, et non assimilée à une issue favorable au fond.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">Implication directe et indirecte</h4>
+              <p>
+                Seules les affaires où le politicien est directement ou indirectement impliqué (mis
+                en cause, poursuivi ou condamné) sont comptabilisées dans les agrégats à charge. Les
+                simples mentions dans une affaire tierce ou les cas où le politicien est
+                victime/plaignant ne sont pas inclus dans ces compteurs.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">Décompte par politicien</h4>
+              <p>
+                Les statistiques globales ({'"'}élus condamnés{'"'}, {'"'}élus mis en cause{'"'})
+                comptent le nombre de politiciens uniques concernés, pas le nombre total d{"'"}
+                affaires.
+              </p>
+            </div>
+          </div>
+        </section>
 
-      {/* Section 6: Sources */}
-      <section className="mb-8">
-        <h2 className="text-xl font-display font-semibold mb-4">Sources</h2>
-        <p className="text-muted-foreground text-sm">
-          Chaque affaire judiciaire référencée sur Poligraph est documentée par au moins une source
-          journalistique vérifiable (Le Monde, Mediapart, AFP, etc.). Les données officielles
-          (Assemblée nationale, Sénat, gouvernement) prévalent sur les sources tierces. Pour plus de
-          détails sur nos sources de données, consultez la page{" "}
-          <Link href="/sources" className="text-primary hover:underline">
-            Sources et principes éditoriaux
-          </Link>
-          .
-        </p>
+        {/* Section 3b: Per-role counters on the politician page */}
+        <section className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">
+            Compteurs d{"'"}affaires sur la fiche d{"'"}un politicien
+          </h3>
+          <p className="text-muted-foreground mb-6">
+            La fiche d{"'"}un politicien expose plusieurs compteurs, qui ne mesurent pas la même
+            chose. Ils sont volontairement distincts pour ne pas mélanger une mise en cause, une
+            simple mention et une situation de victime.
+          </p>
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">
+                Total des affaires publiées (tous rôles confondus)
+              </h4>
+              <p>
+                Le compteur général recense toutes les affaires publiées impliquant la personne,
+                quel que soit son rôle : mise en cause, simplement mentionnée, victime ou
+                plaignante. Ce chiffre ne dit donc rien, à lui seul, du degré de mise en cause.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">À charge (procédures validées)</h4>
+              <p>
+                Affaires où la personne est mise en cause (directement ou indirectement) et où un
+                juge a validé la procédure : condamnations et procédures validées par un juge. Les
+                enquêtes préliminaires en sont exclues.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">Issues favorables</h4>
+              <p>
+                Affaires où la personne était mise en cause et dont la procédure s{"'"}est terminée
+                sans condamnation : relaxe, acquittement, non-lieu, classement sans suite et
+                prescription.
+              </p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">Simple mention</h4>
+              <p>Affaires où la personne est citée sans être mise en cause ni poursuivie.</p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <h4 className="font-medium text-foreground mb-1">Victime ou plaignant</h4>
+              <p>
+                Affaires où la personne est victime ou a porté plainte. Ces affaires ne sont jamais
+                comptées comme une mise en cause.
+              </p>
+            </div>
+            <p className="text-xs">
+              Ces compteurs ne se cumulent pas pour reconstituer le total : une enquête préliminaire
+              visant directement la personne, par exemple, n{"'"}entre ni dans les affaires à charge
+              (faute de validation par un juge), ni dans les issues favorables.
+            </p>
+          </div>
+        </section>
+
+        {/* Section 4: Presumption of innocence */}
+        <section className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">Présomption d{"'"}innocence</h3>
+          <p className="text-muted-foreground text-sm">
+            Conformément à l{"'"}article 9-1 du Code civil, toute personne mise en cause dans une
+            procédure judiciaire est présumée innocente jusqu{"'"}à ce qu{"'"}elle ait été déclarée
+            coupable par une décision de justice définitive. Cette mention apparaît systématiquement
+            sur les fiches de politiciens concernés par des procédures en cours ou des condamnations
+            non définitives. Le référencement d{"'"}une affaire sur Poligraph ne constitue en aucun
+            cas un jugement de valeur.
+          </p>
+        </section>
+
+        {/* Section 5: Victims/plaintiffs */}
+        <section className="mb-12">
+          <h3 className="text-xl font-display font-semibold mb-4">Victimes et plaignants</h3>
+          <p className="text-muted-foreground text-sm">
+            Lorsqu{"'"}un politicien est victime ou plaignant dans une affaire (violences, menaces,
+            harcèlement), cette information est traitée séparément des affaires où il est mis en
+            cause. Ces affaires ne sont jamais comptabilisées dans les indicateurs d{"'"}intégrité
+            et apparaissent dans une section distincte sur le profil.
+          </p>
+        </section>
+
+        {/* Section 6: Sources */}
+        <section className="mb-8">
+          <h3 className="text-xl font-display font-semibold mb-4">Sources</h3>
+          <p className="text-muted-foreground text-sm">
+            Chaque affaire judiciaire référencée sur Poligraph est documentée par au moins une
+            source journalistique vérifiable (Le Monde, Mediapart, AFP, etc.). Les données
+            officielles (Assemblée nationale, Sénat, gouvernement) prévalent sur les sources
+            tierces. Pour plus de détails sur nos sources de données, consultez la page{" "}
+            <Link href="/sources" className="text-primary hover:underline">
+              Sources et principes éditoriaux
+            </Link>
+            .
+          </p>
+        </section>
       </section>
     </main>
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -213,6 +213,8 @@ async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap
       changeFrequency: "monthly",
       priority: 0.8,
     },
+    // Rich, self-canonical methodology supporting every presidential measure page. It is stable
+    // public content, not a utility view, so it belongs in the index and in the sitemap together.
     {
       url: `${SITE_URL}/methodologie/mesures-presidentielle-2027`,
       lastModified: new Date(),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -214,6 +214,12 @@ async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/methodologie/mesures-presidentielle-2027`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/soutenir`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/src/app/statistiques/page.tsx
+++ b/src/app/statistiques/page.tsx
@@ -15,9 +15,12 @@ import { LegislativeSection } from "@/components/stats/LegislativeSection";
 import { JudicialSection } from "@/components/stats/JudicialSection";
 import { FactCheckSection } from "@/components/stats/FactCheckSection";
 import { ParticipationSection } from "@/components/stats/ParticipationSection";
+import { PresidentialEntry } from "@/components/stats/PresidentialEntry";
 import { getHemicycleData } from "@/lib/data/hemicycle";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { getPresidentialOverviewStats } from "@/lib/data/presidential-stats";
+import { SITE_URL } from "@/config/site";
 
 export const revalidate = 300;
 
@@ -51,6 +54,7 @@ export default async function StatistiquesPage({ searchParams }: PageProps) {
     groupDynamicsData,
     hemicycleData,
     victimStats,
+    presidentialStats,
   ] = await Promise.all([
     getLegislativeData(),
     getJudicialData(),
@@ -59,6 +63,7 @@ export default async function StatistiquesPage({ searchParams }: PageProps) {
     getGroupDynamicsData(),
     getHemicycleData(),
     getVictimStats(),
+    getPresidentialOverviewStats("presidentielle-2027"),
   ]);
 
   return (
@@ -66,7 +71,7 @@ export default async function StatistiquesPage({ searchParams }: PageProps) {
       <CollectionPageJsonLd
         name="Statistiques politiques de la France"
         description="Statistiques sur la vie politique française : travail législatif, transparence judiciaire, fact-checking."
-        url="https://poligraph.fr/statistiques"
+        url={`${SITE_URL}/statistiques`}
       />
       <div className="container mx-auto px-4 pt-4 pb-8">
         <Breadcrumb items={[{ label: "Statistiques" }]} />
@@ -114,6 +119,7 @@ export default async function StatistiquesPage({ searchParams }: PageProps) {
             />
           }
         />
+        {presidentialStats !== null ? <PresidentialEntry stats={presidentialStats} /> : null}
       </div>
     </>
   );

--- a/src/components/stats/JudicialSection.tsx
+++ b/src/components/stats/JudicialSection.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   AFFAIR_SUPER_CATEGORY_LABELS,
   AFFAIR_STATUS_LABELS,
@@ -93,22 +96,33 @@ export function JudicialSection({
 
   return (
     <section aria-labelledby="judicial-heading" className="py-8 overflow-x-hidden">
-      <div className="flex flex-wrap gap-3 mb-6 text-sm">
+      <nav
+        aria-label="Approfondir les statistiques judiciaires"
+        className="mb-6 grid gap-3 sm:grid-cols-2"
+      >
         <Link
           href="/affaires/condamnations?view=stats"
-          className="inline-flex items-center gap-1 text-primary hover:underline"
+          className={cn(
+            buttonVariants({ variant: "default" }),
+            "min-h-12 justify-between whitespace-normal px-4 text-left"
+          )}
           prefetch={false}
         >
-          Voir le taux de condamnation par parti →
+          Taux de condamnation par parti
+          <ArrowRight aria-hidden="true" className="h-4 w-4" />
         </Link>
         <Link
           href="/affaires/condamnations?certainty=etabli"
-          className="inline-flex items-center gap-1 text-primary hover:underline"
+          className={cn(
+            buttonVariants({ variant: "outline" }),
+            "min-h-12 justify-between whitespace-normal px-4 text-left"
+          )}
           prefetch={false}
         >
-          Liste complète des condamnés définitifs →
+          Condamnations définitives documentées
+          <ArrowRight aria-hidden="true" className="h-4 w-4" />
         </Link>
-      </div>
+      </nav>
 
       {/* Hemicycle visualization */}
       {hemicycleGroups.length > 0 && (

--- a/src/components/stats/PresidentialEntry.test.tsx
+++ b/src/components/stats/PresidentialEntry.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PresidentialEntry } from "./PresidentialEntry";
+
+describe("PresidentialEntry", () => {
+  it("relie les statistiques au dossier présidentiel et au comparateur", () => {
+    render(
+      <PresidentialEntry
+        stats={{
+          trackedCandidacyCount: 27,
+          documentedCandidacyCount: 14,
+          verifiedMeasureCount: 1_208,
+          comparableThemeCount: 16,
+          probityCandidateCount: 3,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Candidatures et mesures documentées" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Voir le dossier/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+    expect(
+      screen.getByRole("link", { name: "Comparer les mesures des candidats" })
+    ).toHaveAttribute("href", "/elections/presidentielle-2027/comparer");
+    expect(
+      screen.getByText((content) => content.replace(/\s/g, "") === "1208")
+    ).toBeInTheDocument();
+    expect(screen.getByText("mesures publiées")).toBeInTheDocument();
+    expect(screen.getByText(/3 personnalités suivies/)).toBeInTheDocument();
+  });
+});

--- a/src/components/stats/PresidentialEntry.tsx
+++ b/src/components/stats/PresidentialEntry.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { PresidentialOverviewStats } from "@/lib/data/presidential-stats";
+
+const HUB_PATH = "/elections/presidentielle-2027";
+
+export function PresidentialEntry({ stats }: { stats: PresidentialOverviewStats }) {
+  const figures = [
+    {
+      value: stats.trackedCandidacyCount,
+      label: "personnalités suivies",
+    },
+    {
+      value: stats.documentedCandidacyCount,
+      label: "avec des mesures publiées",
+    },
+    {
+      value: stats.verifiedMeasureCount,
+      label: "mesures publiées",
+    },
+    {
+      value: stats.comparableThemeCount,
+      label: "thèmes comparables",
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="presidential-entry-title"
+      className="mt-12 border-t border-border pt-8"
+    >
+      <div className="rounded-2xl border border-border bg-card p-5 md:p-7">
+        <p className="text-sm font-bold uppercase tracking-widest text-brand">
+          Élection présidentielle 2027
+        </p>
+        <h2
+          id="presidential-entry-title"
+          className="mt-2 font-display text-2xl font-extrabold tracking-tight md:text-3xl"
+        >
+          Candidatures et mesures documentées
+        </h2>
+        <p className="mt-3 max-w-3xl leading-relaxed text-muted-foreground-strong">
+          Consultez les candidatures suivies par Poligraph, explorez les mesures publiées par thème
+          et placez les propositions de deux ou trois candidats côte à côte.
+        </p>
+        <dl className="mt-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {figures.map((figure) => (
+            <div
+              key={figure.label}
+              className="flex flex-col rounded-xl border border-border bg-background p-4"
+            >
+              <dt className="order-2 mt-1 text-sm leading-snug text-muted-foreground-strong">
+                {figure.label}
+              </dt>
+              <dd className="order-1 font-display text-3xl font-extrabold tabular-nums text-primary">
+                {figure.value.toLocaleString("fr-FR")}
+              </dd>
+            </div>
+          ))}
+        </dl>
+        <div className="mt-4 rounded-xl bg-muted px-4 py-3 text-sm leading-relaxed">
+          <p>
+            <strong>
+              {stats.probityCandidateCount === 0
+                ? "Aucune personnalité suivie"
+                : `${stats.probityCandidateCount} ${stats.probityCandidateCount === 1 ? "personnalité suivie" : "personnalités suivies"}`}
+            </strong>{" "}
+            {stats.probityCandidateCount === 0
+              ? "n’a"
+              : stats.probityCandidateCount === 1
+                ? "a"
+                : "ont"}{" "}
+            au moins une condamnation documentée pour atteinte à la probité, prononcée au minimum en
+            première instance.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Ce nombre porte sur les personnes, pas sur le nombre d’affaires. Le statut précis de
+            chaque procédure figure sur sa fiche.
+          </p>
+        </div>
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <Link
+            href={HUB_PATH}
+            className={cn(buttonVariants({ variant: "default" }), "min-h-11 justify-center")}
+          >
+            Voir le dossier présidentielle 2027
+            <ArrowRight aria-hidden="true" className="h-4 w-4" />
+          </Link>
+          <Link
+            href={`${HUB_PATH}/comparer`}
+            className={cn(buttonVariants({ variant: "outline" }), "min-h-11 justify-center")}
+          >
+            Comparer les mesures des candidats
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/data/__tests__/presidential-stats.test.ts
+++ b/src/lib/data/__tests__/presidential-stats.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getField: vi.fn(),
+  getContext: vi.fn(),
+  groupBy: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+
+vi.mock("@/lib/data/hub", () => ({
+  getHubCandidacyField: (...args: unknown[]) => mocks.getField(...args),
+  getHubMeasureContext: (...args: unknown[]) => mocks.getContext(...args),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { affair: { groupBy: mocks.groupBy } },
+}));
+
+import { getPresidentialOverviewStats } from "../presidential-stats";
+
+describe("getPresidentialOverviewStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getField.mockResolvedValue([
+      { id: "c1", measureCount: 12 },
+      { id: "c2", measureCount: 0 },
+      { id: "c3", measureCount: 2 },
+    ]);
+    mocks.getContext.mockResolvedValue({
+      verifiedMeasureCount: 14,
+      publishableSubjectPageCount: 5,
+    });
+    mocks.groupBy.mockResolvedValue([{ politicianId: "p1" }, { politicianId: "p3" }]);
+  });
+
+  it("compte les personnalités, les programmes documentés et les thèmes comparables", async () => {
+    await expect(getPresidentialOverviewStats("presidentielle-2027")).resolves.toEqual({
+      trackedCandidacyCount: 3,
+      documentedCandidacyCount: 2,
+      verifiedMeasureCount: 14,
+      comparableThemeCount: 5,
+      probityCandidateCount: 2,
+    });
+    expect(mocks.cacheTag).toHaveBeenCalledWith("statistics", "affairs", "elections");
+    expect(mocks.cacheLife).toHaveBeenCalledWith("minutes");
+  });
+
+  it("limite la probité aux condamnations publiées des personnalités suivies", async () => {
+    await getPresidentialOverviewStats("presidentielle-2027");
+
+    expect(mocks.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        by: ["politicianId"],
+        where: expect.objectContaining({
+          publicationStatus: "PUBLISHED",
+          involvement: { in: ["DIRECT", "INDIRECT"] },
+          status: { in: expect.any(Array) },
+          category: { in: expect.any(Array) },
+        }),
+      })
+    );
+  });
+
+  it("ne publie aucune statistique pour une élection inconnue", async () => {
+    mocks.getContext.mockResolvedValue(null);
+
+    await expect(getPresidentialOverviewStats("inconnue")).resolves.toBeNull();
+  });
+});

--- a/src/lib/data/__tests__/recap.test.ts
+++ b/src/lib/data/__tests__/recap.test.ts
@@ -28,7 +28,7 @@ import { getISOWeekString, getWeeklyRecap, parseISOWeekString } from "../recap";
 
 function rawSqlText(call: unknown[]): string {
   const query = call[0] as { sql?: string } | readonly string[];
-  if (!Array.isArray(query)) return query.sql ?? "";
+  if (!Array.isArray(query)) return (query as { sql?: string }).sql ?? "";
   const strings = query;
   const values = call.slice(1);
   return strings

--- a/src/lib/data/__tests__/recap.test.ts
+++ b/src/lib/data/__tests__/recap.test.ts
@@ -27,7 +27,9 @@ vi.mock("@/lib/db", () => ({
 import { getISOWeekString, getWeeklyRecap, parseISOWeekString } from "../recap";
 
 function rawSqlText(call: unknown[]): string {
-  const strings = call[0] as readonly string[];
+  const query = call[0] as { sql?: string } | readonly string[];
+  if (!Array.isArray(query)) return query.sql ?? "";
+  const strings = query;
   const values = call.slice(1);
   return strings
     .map((part, index) => {

--- a/src/lib/data/condamnations.ts
+++ b/src/lib/data/condamnations.ts
@@ -187,7 +187,7 @@ export async function getCondamnationsStatsByParty(
       nCondamnesDefinitifs: bigint;
       nCondamnesPrononces: bigint;
     }>
-  >`
+  >(Prisma.sql`
     SELECT
       pt.id AS "partyId",
       pt.slug AS "partySlug",
@@ -211,7 +211,7 @@ export async function getCondamnationsStatsByParty(
     HAVING COUNT(DISTINCT p.id) >= 3
         OR COUNT(DISTINCT CASE WHEN a.status = 'CONDAMNATION_DEFINITIVE' THEN a."politicianId" END) >= 1
     ORDER BY "nCondamnesDefinitifs" DESC, "nSuivis" DESC
-  `;
+  `);
 
   return rows.map((r) => ({
     partyId: r.partyId,

--- a/src/lib/data/partis.ts
+++ b/src/lib/data/partis.ts
@@ -1,6 +1,6 @@
 import { cache } from "react";
 import { cacheTag, cacheLife } from "next/cache";
-import type { Prisma } from "@/generated/prisma";
+import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { CONVICTION_BADGE_WHERE } from "@/config/labels";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
@@ -285,7 +285,7 @@ export async function getPartiesStats() {
 
   const [counts] = await db.$queryRaw<
     [{ actifs: bigint; gauche: bigint; centre: bigint; droite: bigint; affaires: bigint }]
-  >`
+  >(Prisma.sql`
     SELECT
       COUNT(*) FILTER (
         WHERE p."dissolvedDate" IS NULL
@@ -322,7 +322,7 @@ export async function getPartiesStats() {
     FROM "Party" p
     WHERE p.slug IS NOT NULL
       AND ${getPublicPartySqlWhere()}
-  `;
+  `);
 
   return {
     actifs: Number(counts.actifs),

--- a/src/lib/data/presidential-measure-detail.ts
+++ b/src/lib/data/presidential-measure-detail.ts
@@ -39,6 +39,11 @@ export type PublicPresidentialMeasureDetail = {
     blobPhotoUrl: string | null;
     party: string | null;
   };
+  subtopics: Array<{
+    slug: string;
+    label: string;
+    description: string;
+  }>;
   sources: Array<{
     id: string;
     sourceKind: MeasureSourceKind;
@@ -113,7 +118,9 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
           },
           subtopics: {
             where: { status: "APPROVED", subtopic: { active: true } },
-            select: { subtopic: { select: { slug: true, label: true, sortOrder: true } } },
+            select: {
+              subtopic: { select: { slug: true, label: true, description: true, sortOrder: true } },
+            },
             orderBy: { subtopic: { sortOrder: "asc" } },
           },
         },
@@ -270,6 +277,11 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
       blobPhotoUrl: candidate.politician.blobPhotoUrl,
       party: candidate.party?.shortName ?? candidate.party?.name ?? null,
     },
+    subtopics: currentSubtopics.map(({ slug, label, description }) => ({
+      slug,
+      label,
+      description,
+    })),
     sources: revision.sources,
     votes: row.voteLinks.map((link) => ({
       id: link.id,

--- a/src/lib/data/presidential-stats.ts
+++ b/src/lib/data/presidential-stats.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+import { getCategoriesForSuper } from "@/config/labels";
+import { getConvictionOnlyWhere } from "@/lib/affairs/public-filters";
+import { db } from "@/lib/db";
+import { PUBLIC_HUB_CANDIDACY_WHERE } from "@/lib/presidentielle/publication";
+import { getHubCandidacyField, getHubMeasureContext } from "./hub";
+
+export type PresidentialOverviewStats = {
+  trackedCandidacyCount: number;
+  documentedCandidacyCount: number;
+  verifiedMeasureCount: number;
+  comparableThemeCount: number;
+  probityCandidateCount: number;
+};
+
+/**
+ * Public presidential figures shown on the general statistics page.
+ *
+ * The judicial number counts people, not cases. It uses the same conviction-only and probity
+ * predicates as candidate fiches, so an investigation or a favourable outcome can never enter it.
+ */
+export async function getPresidentialOverviewStats(
+  electionSlug: string
+): Promise<PresidentialOverviewStats | null> {
+  "use cache";
+  cacheTag("statistics", "affairs", "elections");
+  // The overview joins several independently cached authorities and a judicial aggregation.
+  // Cache the assembled result so every page view does not repeat that expensive cross-domain read.
+  cacheLife("minutes");
+
+  const [field, context, probityCandidates] = await Promise.all([
+    getHubCandidacyField(electionSlug),
+    getHubMeasureContext(electionSlug),
+    db.affair.groupBy({
+      by: ["politicianId"],
+      where: {
+        ...getConvictionOnlyWhere(),
+        category: { in: getCategoriesForSuper("PROBITE") },
+        politician: {
+          is: {
+            candidacies: {
+              some: {
+                election: { slug: electionSlug },
+                ...PUBLIC_HUB_CANDIDACY_WHERE,
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  if (context === null) return null;
+
+  return {
+    trackedCandidacyCount: field.length,
+    documentedCandidacyCount: field.filter((candidacy) => candidacy.measureCount > 0).length,
+    verifiedMeasureCount: context.verifiedMeasureCount,
+    comparableThemeCount: context.publishableSubjectPageCount,
+    probityCandidateCount: probityCandidates.length,
+  };
+}

--- a/src/lib/data/recap.ts
+++ b/src/lib/data/recap.ts
@@ -1,6 +1,6 @@
 import { cacheTag, cacheLife } from "next/cache";
 import { db } from "@/lib/db";
-import type { PlatformUpdateType } from "@/generated/prisma";
+import { Prisma, type PlatformUpdateType } from "@/generated/prisma";
 import { getCertaintyLevel } from "@/config/certainty";
 import {
   getPublicFactCheckSqlWhere,
@@ -396,7 +396,7 @@ async function queryWeeklyRecap(weekStart: Date, weekEnd: Date): Promise<WeeklyR
           politicianName: string;
           politicianSlug: string;
         }>
-      >`
+      >(Prisma.sql`
       SELECT
         a.slug,
         a.title,
@@ -436,7 +436,7 @@ async function queryWeeklyRecap(weekStart: Date, weekEnd: Date): Promise<WeeklyR
         ELSE 4
       END ASC
       LIMIT 10
-    `,
+    `),
 
       // 4. Fact-checks this week
       Promise.all([
@@ -457,7 +457,7 @@ async function queryWeeklyRecap(weekStart: Date, weekEnd: Date): Promise<WeeklyR
             partyColor: string | null;
             count: bigint;
           }>
-        >`
+        >(Prisma.sql`
         SELECT
           p.slug,
           p."fullName" as "fullName",
@@ -477,7 +477,7 @@ async function queryWeeklyRecap(weekStart: Date, weekEnd: Date): Promise<WeeklyR
         GROUP BY p.id, p.slug, p."fullName", p."photoUrl", par."shortName", par.color
         ORDER BY count DESC
         LIMIT 5
-      `,
+      `),
       ]),
 
       // 5. Press mentions this week (only articles with at least one mention)

--- a/src/lib/measures/__tests__/search-sync.test.ts
+++ b/src/lib/measures/__tests__/search-sync.test.ts
@@ -11,18 +11,25 @@ const measure = {
   slug: "camille-riviere-construire-des-logements-publics",
   electionId: "election-1",
   election: { slug: "election-reelle" },
+  theme: "LOGEMENT_URBANISME" as const,
+  candidacy: {
+    candidateName: "Camille Rivière",
+    party: { name: "Parti du logement", shortName: "PL" },
+  },
   publicationStatus: "PUBLISHED" as const,
   publishedRevisionId: "revision-pub",
   publishedRevision: {
     id: "revision-pub",
     text: "Construire des logements publics.",
     details: "Dans les zones tendues.",
+    subtopics: [{ subtopic: { label: "Logement social", aliases: ["HLM", "habitat social"] } }],
     updatedAt: new Date("2026-08-27T12:00:00Z"),
   },
   latestRevision: {
     id: "revision-pub",
     text: "Construire des logements publics.",
     details: "Dans les zones tendues.",
+    subtopics: [{ subtopic: { label: "Logement social", aliases: ["HLM", "habitat social"] } }],
     updatedAt: new Date("2026-08-27T12:00:00Z"),
   },
 };
@@ -50,7 +57,7 @@ describe("synchronisation recherche des mesures", () => {
       expect.objectContaining({
         electionId: "election-1",
         url: "/elections/election-reelle/mesures/camille-riviere-construire-des-logements-publics",
-        body: "Construire des logements publics.\n\nDans les zones tendues.",
+        body: "Construire des logements publics.\n\nDans les zones tendues.\n\nCamille Rivière\n\nPL\n\nLogement et urbanisme\n\nLogement social\n\nHLM\n\nhabitat social",
         visibility: "PUBLIC",
       })
     );

--- a/src/lib/measures/__tests__/search-sync.test.ts
+++ b/src/lib/measures/__tests__/search-sync.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const upsertSearchDocumentMock = vi.fn(async (_tx: unknown, _input: unknown) => undefined);
+const upsertSearchDocumentsMock = vi.fn(async (_tx: unknown, _inputs: unknown) => undefined);
+const deleteSearchDocumentsMock = vi.fn(
+  async (_tx: unknown, _type: unknown, _ids: unknown) => undefined
+);
 
 vi.mock("@/lib/search/documents", () => ({
   upsertSearchDocument: (tx: unknown, input: unknown) => upsertSearchDocumentMock(tx, input),
+  upsertSearchDocuments: (tx: unknown, inputs: unknown) => upsertSearchDocumentsMock(tx, inputs),
+  deleteSearchDocuments: (tx: unknown, type: unknown, ids: unknown) =>
+    deleteSearchDocumentsMock(tx, type, ids),
   deleteSearchDocument: vi.fn(async () => undefined),
 }));
 
 const measure = {
+  id: "measure-1",
   slug: "camille-riviere-construire-des-logements-publics",
   electionId: "election-1",
   election: { slug: "election-reelle" },
@@ -73,5 +81,25 @@ describe("synchronisation recherche des mesures", () => {
       tx,
       expect.objectContaining({ visibility: "ADMIN_ONLY" })
     );
+  });
+
+  it("regroupe la reconstruction de plusieurs mesures en une écriture bornée", async () => {
+    const { syncSearchDocuments } = await import("../search-sync");
+    const tx = {
+      measure: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([measure])
+          .mockResolvedValueOnce([{ id: "measure-1" }]),
+      },
+    };
+
+    await syncSearchDocuments(tx as never, ["measure-1"]);
+
+    expect(tx.measure.findMany).toHaveBeenCalledTimes(2);
+    expect(deleteSearchDocumentsMock).toHaveBeenCalledWith(tx, "MEASURE", []);
+    expect(upsertSearchDocumentsMock).toHaveBeenCalledWith(tx, [
+      expect.objectContaining({ entityId: "measure-1", visibility: "PUBLIC" }),
+    ]);
   });
 });

--- a/src/lib/measures/__tests__/subtopics.test.ts
+++ b/src/lib/measures/__tests__/subtopics.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   createAssignments: vi.fn(),
   createAudit: vi.fn(),
   invalidateMeasureTags: vi.fn(),
+  syncSearchDocument: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -35,6 +36,9 @@ vi.mock("@/lib/api/mistral", () => ({
 }));
 vi.mock("@/lib/measures/cache", () => ({
   invalidateMeasureTags: mocks.invalidateMeasureTags,
+}));
+vi.mock("@/lib/measures/search-sync", () => ({
+  syncSearchDocument: mocks.syncSearchDocument,
 }));
 
 const transactionClient = {
@@ -190,5 +194,24 @@ describe("classification des sous-sujets de mesure", () => {
     });
 
     expect(mocks.invalidateMeasureTags).toHaveBeenCalledWith("measure-1", "election-1");
+    expect(mocks.syncSearchDocument).toHaveBeenCalledWith(transactionClient, "measure-1");
+  });
+
+  it("ne réindexe pas une proposition refusée qui n’était pas publique", async () => {
+    mocks.findAssignment.mockResolvedValue({
+      status: "SUGGESTED",
+      revision: { measure: { id: "measure-1", electionId: "election-1" } },
+    });
+    mocks.updateAssignments.mockResolvedValue({ count: 1 });
+    const { reviewMeasureRevisionSubtopic } = await import("../subtopics");
+
+    await reviewMeasureRevisionSubtopic({
+      revisionId: "revision-1",
+      subtopicId: "subtopic-1",
+      status: "REJECTED",
+      reviewedBy: "admin",
+    });
+
+    expect(mocks.syncSearchDocument).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/measures/search-sync.ts
+++ b/src/lib/measures/search-sync.ts
@@ -1,4 +1,5 @@
 import type { DbTransactionClient } from "@/lib/db";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
 import { deleteSearchDocument, upsertSearchDocument } from "@/lib/search/documents";
 import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
 
@@ -31,10 +32,39 @@ export async function syncSearchDocument(
       slug: true,
       electionId: true,
       election: { select: { slug: true } },
+      theme: true,
+      candidacy: {
+        select: {
+          candidateName: true,
+          party: { select: { name: true, shortName: true } },
+        },
+      },
       publicationStatus: true,
       publishedRevisionId: true,
-      publishedRevision: { select: { id: true, text: true, details: true, updatedAt: true } },
-      latestRevision: { select: { id: true, text: true, details: true, updatedAt: true } },
+      publishedRevision: {
+        select: {
+          id: true,
+          text: true,
+          details: true,
+          updatedAt: true,
+          subtopics: {
+            where: { status: "APPROVED" },
+            select: { subtopic: { select: { label: true, aliases: true } } },
+          },
+        },
+      },
+      latestRevision: {
+        select: {
+          id: true,
+          text: true,
+          details: true,
+          updatedAt: true,
+          subtopics: {
+            where: { status: "APPROVED" },
+            select: { subtopic: { select: { label: true, aliases: true } } },
+          },
+        },
+      },
     },
   });
 
@@ -56,12 +86,28 @@ export async function syncSearchDocument(
     return;
   }
 
+  const partyLabel = measure.candidacy?.party?.shortName ?? measure.candidacy?.party?.name;
+  const subtopicTerms = reference.subtopics.flatMap(({ subtopic }) => [
+    subtopic.label,
+    ...subtopic.aliases,
+  ]);
+  const contextualBody = [
+    reference.text,
+    reference.details,
+    measure.candidacy?.candidateName,
+    partyLabel,
+    THEME_CATEGORY_LABELS[measure.theme],
+    ...subtopicTerms,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
   await upsertSearchDocument(tx, {
     entityType: "MEASURE",
     entityId: measureId,
     electionId: measure.electionId,
     title: reference.text.slice(0, MAX_TITLE_LENGTH),
-    body: [reference.text, reference.details].filter(Boolean).join("\n\n"),
+    body: contextualBody,
     url: `/elections/${measure.election.slug}/mesures/${measure.slug}`,
     visibility: isPublic ? "PUBLIC" : "ADMIN_ONLY",
     sourceRevisionId: reference.id,

--- a/src/lib/measures/search-sync.ts
+++ b/src/lib/measures/search-sync.ts
@@ -1,9 +1,94 @@
+import { Prisma } from "@/generated/prisma";
 import type { DbTransactionClient } from "@/lib/db";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
-import { deleteSearchDocument, upsertSearchDocument } from "@/lib/search/documents";
+import {
+  deleteSearchDocument,
+  deleteSearchDocuments,
+  upsertSearchDocument,
+  upsertSearchDocuments,
+  type SearchDocumentInput,
+} from "@/lib/search/documents";
 import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
 
 const MAX_TITLE_LENGTH = 200;
+
+const SEARCH_MEASURE_SELECT = {
+  id: true,
+  slug: true,
+  electionId: true,
+  election: { select: { slug: true } },
+  theme: true,
+  candidacy: {
+    select: {
+      candidateName: true,
+      party: { select: { name: true, shortName: true } },
+    },
+  },
+  publicationStatus: true,
+  publishedRevisionId: true,
+  publishedRevision: {
+    select: {
+      id: true,
+      text: true,
+      details: true,
+      updatedAt: true,
+      subtopics: {
+        where: { status: "APPROVED" },
+        select: { subtopic: { select: { label: true, aliases: true } } },
+      },
+    },
+  },
+  latestRevision: {
+    select: {
+      id: true,
+      text: true,
+      details: true,
+      updatedAt: true,
+      subtopics: {
+        where: { status: "APPROVED" },
+        select: { subtopic: { select: { label: true, aliases: true } } },
+      },
+    },
+  },
+} satisfies Prisma.MeasureSelect;
+
+type SearchableMeasure = Prisma.MeasureGetPayload<{ select: typeof SEARCH_MEASURE_SELECT }>;
+
+function buildSearchDocument(
+  measure: SearchableMeasure,
+  isPublic: boolean
+): SearchDocumentInput | null {
+  const reference = isPublic ? measure.publishedRevision : measure.latestRevision;
+  if (!reference) return null;
+
+  const partyLabel = measure.candidacy?.party?.shortName ?? measure.candidacy?.party?.name;
+  const subtopicTerms = reference.subtopics.flatMap(({ subtopic }) => [
+    subtopic.label,
+    ...subtopic.aliases,
+  ]);
+  const contextualBody = [
+    reference.text,
+    reference.details,
+    measure.candidacy?.candidateName,
+    partyLabel,
+    THEME_CATEGORY_LABELS[measure.theme],
+    ...subtopicTerms,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return {
+    entityType: "MEASURE",
+    entityId: measure.id,
+    electionId: measure.electionId,
+    title: reference.text.slice(0, MAX_TITLE_LENGTH),
+    body: contextualBody,
+    url: `/elections/${measure.election.slug}/mesures/${measure.slug}`,
+    visibility: isPublic ? "PUBLIC" : "ADMIN_ONLY",
+    sourceRevisionId: reference.id,
+    sourceUpdatedAt: reference.updatedAt,
+  };
+}
 
 /**
  * Derives the SearchDocument from the measure's pointers, inside the caller's transaction.
@@ -28,44 +113,7 @@ export async function syncSearchDocument(
 ): Promise<void> {
   const measure = await tx.measure.findUniqueOrThrow({
     where: { id: measureId },
-    select: {
-      slug: true,
-      electionId: true,
-      election: { select: { slug: true } },
-      theme: true,
-      candidacy: {
-        select: {
-          candidateName: true,
-          party: { select: { name: true, shortName: true } },
-        },
-      },
-      publicationStatus: true,
-      publishedRevisionId: true,
-      publishedRevision: {
-        select: {
-          id: true,
-          text: true,
-          details: true,
-          updatedAt: true,
-          subtopics: {
-            where: { status: "APPROVED" },
-            select: { subtopic: { select: { label: true, aliases: true } } },
-          },
-        },
-      },
-      latestRevision: {
-        select: {
-          id: true,
-          text: true,
-          details: true,
-          updatedAt: true,
-          subtopics: {
-            where: { status: "APPROVED" },
-            select: { subtopic: { select: { label: true, aliases: true } } },
-          },
-        },
-      },
-    },
+    select: SEARCH_MEASURE_SELECT,
   });
 
   // Re-query through the shared public authority. PublicationStatus alone is insufficient: a
@@ -75,44 +123,48 @@ export async function syncSearchDocument(
     select: { id: true },
   });
   const isPublic = publicMeasure !== null;
-  const reference = isPublic ? measure.publishedRevision : measure.latestRevision;
+  const document = buildSearchDocument(measure, isPublic);
 
   // Nothing left to represent: no published revision and no active draft. Happens when
   // the only draft of a never-published measure is discarded. Removing the row is the
   // coherent answer, and it is why the audit only demands a document for measures that
   // do have a reference revision.
-  if (!reference) {
+  if (!document) {
     await deleteSearchDocument(tx, "MEASURE", measureId);
     return;
   }
 
-  const partyLabel = measure.candidacy?.party?.shortName ?? measure.candidacy?.party?.name;
-  const subtopicTerms = reference.subtopics.flatMap(({ subtopic }) => [
-    subtopic.label,
-    ...subtopic.aliases,
-  ]);
-  const contextualBody = [
-    reference.text,
-    reference.details,
-    measure.candidacy?.candidateName,
-    partyLabel,
-    THEME_CATEGORY_LABELS[measure.theme],
-    ...subtopicTerms,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
+  await upsertSearchDocument(tx, document);
+}
 
-  await upsertSearchDocument(tx, {
-    entityType: "MEASURE",
-    entityId: measureId,
-    electionId: measure.electionId,
-    title: reference.text.slice(0, MAX_TITLE_LENGTH),
-    body: contextualBody,
-    url: `/elections/${measure.election.slug}/mesures/${measure.slug}`,
-    visibility: isPublic ? "PUBLIC" : "ADMIN_ONLY",
-    sourceRevisionId: reference.id,
-    // The revision's own updatedAt, read after the transition's writes. Passing `now`
-    // would make the future search:audit report a few milliseconds of drift.
-    sourceUpdatedAt: reference.updatedAt,
-  });
+/** Rebuilds many measure documents with two reads and bounded bulk writes. */
+export async function syncSearchDocuments(
+  tx: DbTransactionClient,
+  measureIds: string[]
+): Promise<void> {
+  if (measureIds.length === 0) return;
+
+  const [measures, publicMeasures] = await Promise.all([
+    tx.measure.findMany({
+      where: { id: { in: measureIds } },
+      select: SEARCH_MEASURE_SELECT,
+      orderBy: { id: "asc" },
+    }),
+    tx.measure.findMany({
+      where: { id: { in: measureIds }, ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE },
+      select: { id: true },
+    }),
+  ]);
+  const publicIds = new Set(publicMeasures.map(({ id }) => id));
+  const documents: SearchDocumentInput[] = [];
+  const deletions: string[] = [];
+
+  for (const measure of measures) {
+    const document = buildSearchDocument(measure, publicIds.has(measure.id));
+    if (document) documents.push(document);
+    else deletions.push(measure.id);
+  }
+
+  await deleteSearchDocuments(tx, "MEASURE", deletions);
+  await upsertSearchDocuments(tx, documents);
 }

--- a/src/lib/measures/subtopics.ts
+++ b/src/lib/measures/subtopics.ts
@@ -8,6 +8,7 @@ import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mis
 import { db } from "@/lib/db";
 import { invalidateMeasureTags } from "@/lib/measures/cache";
 import { MeasureValidationError } from "@/lib/measures/errors";
+import { syncSearchDocument } from "@/lib/measures/search-sync";
 
 const CLASSIFIER_MODEL = "mistral-small-latest";
 
@@ -239,6 +240,9 @@ export async function reviewMeasureRevisionSubtopic(input: {
         userId: input.reviewedBy,
       },
     });
+    if (input.status === "APPROVED") {
+      await syncSearchDocument(tx, assignment.revision.measure.id);
+    }
 
     return assignment.revision.measure;
   });

--- a/src/lib/presidentielle/__tests__/corpus-search.test.ts
+++ b/src/lib/presidentielle/__tests__/corpus-search.test.ts
@@ -101,4 +101,23 @@ describe("searchPresidentialCorpus", () => {
     expect(result).toMatchObject({ total: 0, subjects: [], candidacies: [], measures: [] });
     expect(searchPublicPage).not.toHaveBeenCalled();
   });
+
+  it("retire la formulation d’une question avant la recherche lexicale", async () => {
+    searchPublicPage.mockResolvedValue({ total: 0, hits: [] });
+
+    await searchPresidentialCorpus(
+      "presidentielle-test",
+      "Que proposent les candidats pour réduire le coût du logement ?",
+      8
+    );
+
+    expect(searchPublicPage).toHaveBeenNthCalledWith(1, "réduire coût logement", {
+      electionId: "election-1",
+      limit: 8,
+    });
+    expect(searchPublicPage).toHaveBeenNthCalledWith(2, "Logement et urbanisme", {
+      electionId: "election-1",
+      limit: 8,
+    });
+  });
 });

--- a/src/lib/presidentielle/__tests__/natural-query.test.ts
+++ b/src/lib/presidentielle/__tests__/natural-query.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { toPresidentialLexicalQuery } from "../natural-query";
+
+describe("toPresidentialLexicalQuery", () => {
+  it("conserve une recherche courte déjà utile", () => {
+    expect(toPresidentialLexicalQuery("loge")).toBe("loge");
+    expect(toPresidentialLexicalQuery("Marine Le Pen")).toBe("Marine Pen");
+  });
+
+  it("retire la formulation d’une question sans inventer de synonymes", () => {
+    expect(
+      toPresidentialLexicalQuery("Que proposent les candidats pour réduire le coût du logement ?")
+    ).toBe("réduire coût logement");
+  });
+
+  it("normalise la ponctuation et borne la requête", () => {
+    expect(toPresidentialLexicalQuery("  santé, hôpital !  ")).toBe("santé hôpital");
+    expect(toPresidentialLexicalQuery("x".repeat(250))).toHaveLength(200);
+  });
+});

--- a/src/lib/presidentielle/__tests__/search-sync.test.ts
+++ b/src/lib/presidentielle/__tests__/search-sync.test.ts
@@ -112,6 +112,7 @@ describe("synchronisation recherche des candidatures présidentielles", () => {
       orderBy: { id: "asc" },
     });
     expect(upsertSearchDocumentMock).toHaveBeenCalledTimes(3);
+    expect(syncMeasureSearchDocumentMock).toHaveBeenCalledTimes(6);
     expect(electionIds).toEqual(["election-1", "election-2"]);
   });
 });

--- a/src/lib/presidentielle/__tests__/search-sync.test.ts
+++ b/src/lib/presidentielle/__tests__/search-sync.test.ts
@@ -4,7 +4,9 @@ const upsertSearchDocumentMock = vi.fn(async (_tx: unknown, _input: unknown) => 
 const deleteSearchDocumentMock = vi.fn(
   async (_tx: unknown, _entityType: unknown, _entityId: unknown) => undefined
 );
-const syncMeasureSearchDocumentMock = vi.fn(async (_tx: unknown, _entityId: unknown) => undefined);
+const syncMeasureSearchDocumentsMock = vi.fn(
+  async (_tx: unknown, _entityIds: unknown) => undefined
+);
 
 vi.mock("@/lib/search/documents", () => ({
   upsertSearchDocument: (tx: unknown, input: unknown) => upsertSearchDocumentMock(tx, input),
@@ -12,8 +14,8 @@ vi.mock("@/lib/search/documents", () => ({
     deleteSearchDocumentMock(tx, entityType, entityId),
 }));
 vi.mock("@/lib/measures/search-sync", () => ({
-  syncSearchDocument: (tx: unknown, entityId: unknown) =>
-    syncMeasureSearchDocumentMock(tx, entityId),
+  syncSearchDocuments: (tx: unknown, entityIds: unknown) =>
+    syncMeasureSearchDocumentsMock(tx, entityIds),
 }));
 
 const now = new Date("2026-08-27T12:00:00Z");
@@ -89,10 +91,7 @@ describe("synchronisation recherche des candidatures présidentielles", () => {
 
     await syncPresidentialSearchDocumentsForCandidacy(tx as never, candidate.id);
 
-    expect(syncMeasureSearchDocumentMock.mock.calls).toEqual([
-      [tx, "measure-1"],
-      [tx, "measure-2"],
-    ]);
+    expect(syncMeasureSearchDocumentsMock).toHaveBeenCalledWith(tx, ["measure-1", "measure-2"]);
   });
 
   it("réindexe les candidatures présidentielles après le renommage d'un parti", async () => {
@@ -112,7 +111,7 @@ describe("synchronisation recherche des candidatures présidentielles", () => {
       orderBy: { id: "asc" },
     });
     expect(upsertSearchDocumentMock).toHaveBeenCalledTimes(3);
-    expect(syncMeasureSearchDocumentMock).toHaveBeenCalledTimes(6);
+    expect(syncMeasureSearchDocumentsMock).toHaveBeenCalledTimes(3);
     expect(electionIds).toEqual(["election-1", "election-2"]);
   });
 });

--- a/src/lib/presidentielle/__tests__/themes.test.ts
+++ b/src/lib/presidentielle/__tests__/themes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   findMatchingThemes,
+  findThemesMentionedInQuery,
   getPresidentialThemeIndexOrder,
   themeToSlug,
   parseThemeSlug,
@@ -53,5 +54,10 @@ describe("theme route helpers", () => {
   });
   it("ne transforme pas un mot étranger à la taxonomie en thème", () => {
     expect(findMatchingThemes("introuvable")).toEqual([]);
+  });
+  it("retrouve un thème cité dans une question complète", () => {
+    expect(
+      findThemesMentionedInQuery("Que proposent les candidats pour réduire le coût du logement ?")
+    ).toEqual(["LOGEMENT_URBANISME"]);
   });
 });

--- a/src/lib/presidentielle/corpus-search.ts
+++ b/src/lib/presidentielle/corpus-search.ts
@@ -8,12 +8,17 @@ import type {
 } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { searchPublicPage } from "@/lib/search/query";
+import { toPresidentialLexicalQuery } from "@/lib/presidentielle/natural-query";
 import {
   PUBLIC_HUB_CANDIDACY_WHERE,
   PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
 } from "@/lib/presidentielle/publication";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
-import { findMatchingThemes, themeToSlug } from "@/lib/presidentielle/themes";
+import {
+  findMatchingThemes,
+  findThemesMentionedInQuery,
+  themeToSlug,
+} from "@/lib/presidentielle/themes";
 
 const MAX_RESULTS = 50;
 
@@ -79,17 +84,31 @@ export async function searchPresidentialCorpus(
     return { query, total: 0, subjects: [], candidacies: [], measures: [] };
   }
 
-  const subjects: PresidentialSubjectSearchResult[] = findMatchingThemes(query).map((theme) => ({
+  const matchingThemes = [
+    ...new Set([...findMatchingThemes(query), ...findThemesMentionedInQuery(query)]),
+  ];
+  const subjects: PresidentialSubjectSearchResult[] = matchingThemes.map((theme) => ({
     type: "subject",
     theme,
     label: THEME_CATEGORY_LABELS[theme],
     url: `/elections/${election.slug}/themes/${themeToSlug(theme)}`,
   }));
 
-  const page = await searchPublicPage(query, {
+  const lexicalQuery = toPresidentialLexicalQuery(query);
+  let page = await searchPublicPage(lexicalQuery, {
     electionId: election.id,
     limit: clampLimit(limit),
   });
+  // A sentence may still contain a verb absent from every formulation. If it names one known
+  // theme, fall back to that controlled label. This broadens only within the public taxonomy and
+  // keeps the lexical engine available while the semantic index is being built.
+  const [singleMatchingTheme] = matchingThemes;
+  if (page.total === 0 && matchingThemes.length === 1 && singleMatchingTheme !== undefined) {
+    page = await searchPublicPage(THEME_CATEGORY_LABELS[singleMatchingTheme], {
+      electionId: election.id,
+      limit: clampLimit(limit),
+    });
+  }
   const candidacyIds = page.hits
     .filter((hit) => hit.entityType === "CANDIDACY")
     .map((hit) => hit.entityId);

--- a/src/lib/presidentielle/natural-query.ts
+++ b/src/lib/presidentielle/natural-query.ts
@@ -1,0 +1,70 @@
+const MAX_QUERY_LENGTH = 200;
+
+// These words describe the question, not the political subject. The list is deliberately
+// conservative: removing a domain noun would create broader results than the user requested.
+const QUESTION_WORDS = new Set([
+  "au",
+  "aux",
+  "avec",
+  "candidat",
+  "candidate",
+  "candidates",
+  "candidats",
+  "ce",
+  "ces",
+  "comment",
+  "dans",
+  "de",
+  "des",
+  "du",
+  "elle",
+  "elles",
+  "en",
+  "est",
+  "et",
+  "font",
+  "il",
+  "ils",
+  "la",
+  "le",
+  "les",
+  "pour",
+  "propose",
+  "proposent",
+  "qu",
+  "que",
+  "quel",
+  "quelle",
+  "quelles",
+  "quels",
+  "qui",
+  "quoi",
+  "sur",
+  "un",
+  "une",
+]);
+
+function normalize(value: string): string {
+  return value
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, MAX_QUERY_LENGTH)
+    .trim();
+}
+
+/**
+ * Keep the nouns and verbs that carry the user's subject while removing only common question
+ * scaffolding. This is a lexical bridge for full sentences, not a semantic interpretation.
+ */
+export function toPresidentialLexicalQuery(rawQuery: string): string {
+  const normalized = normalize(rawQuery);
+  if (normalized === "") return "";
+
+  const meaningful = normalized
+    .split(" ")
+    .filter((term) => !QUESTION_WORDS.has(term.toLocaleLowerCase("fr")))
+    .join(" ");
+
+  return meaningful || normalized;
+}

--- a/src/lib/presidentielle/search-sync.ts
+++ b/src/lib/presidentielle/search-sync.ts
@@ -79,7 +79,7 @@ export async function syncCandidacySearchDocument(
 }
 
 /**
- * Refresh presidential candidacy documents whose searchable party label changed.
+ * Refresh presidential candidacy and measure documents whose searchable party label changed.
  *
  * The party write and these index writes must share a transaction: otherwise a failed refresh
  * would leave the former party name searchable until the next explicit reconstruction.
@@ -95,7 +95,7 @@ export async function syncCandidacySearchDocumentsForParty(
   });
 
   for (const candidacy of candidacies) {
-    await syncCandidacySearchDocument(tx, candidacy.id);
+    await syncPresidentialSearchDocumentsForCandidacy(tx, candidacy.id);
   }
 
   return [...new Set(candidacies.map((candidacy) => candidacy.electionId))];

--- a/src/lib/presidentielle/search-sync.ts
+++ b/src/lib/presidentielle/search-sync.ts
@@ -1,7 +1,7 @@
 import type { DbTransactionClient } from "@/lib/db";
 import { CANDIDACY_STATUS_LABELS } from "@/config/labels";
 import { deleteSearchDocument, upsertSearchDocument } from "@/lib/search/documents";
-import { syncSearchDocument as syncMeasureSearchDocument } from "@/lib/measures/search-sync";
+import { syncSearchDocuments as syncMeasureSearchDocuments } from "@/lib/measures/search-sync";
 import { PUBLIC_HUB_CANDIDACY_WHERE } from "./publication";
 
 function latestDate(dates: Array<Date | null | undefined>): Date {
@@ -117,7 +117,8 @@ export async function syncPresidentialSearchDocumentsForCandidacy(
     select: { id: true },
     orderBy: { id: "asc" },
   });
-  for (const measure of measures) {
-    await syncMeasureSearchDocument(tx, measure.id);
-  }
+  await syncMeasureSearchDocuments(
+    tx,
+    measures.map((measure) => measure.id)
+  );
 }

--- a/src/lib/presidentielle/themes.ts
+++ b/src/lib/presidentielle/themes.ts
@@ -134,3 +134,18 @@ export function findMatchingThemes(query: string): ThemeCategory[] {
     );
   });
 }
+
+/** Find subjects named inside a full sentence, instead of treating every word as a filter. */
+export function findThemesMentionedInQuery(query: string): ThemeCategory[] {
+  const queryTerms = new Set(normalizeThemeSearch(query).split(" ").filter(Boolean));
+  if (queryTerms.size === 0) return [];
+
+  return THEMES_IN_ORDER.filter((theme) => {
+    const labels = [THEME_CATEGORY_LABELS[theme], ...PRESIDENTIAL_THEME_SEARCH_ALIASES[theme]];
+    return labels.some((label) =>
+      normalizeThemeSearch(label)
+        .split(" ")
+        .some((term) => term.length >= 3 && queryTerms.has(term))
+    );
+  });
+}

--- a/src/lib/search/__tests__/documents.test.ts
+++ b/src/lib/search/__tests__/documents.test.ts
@@ -16,7 +16,7 @@ const makeInput = (index: number) => ({
 describe("écritures groupées des documents de recherche", () => {
   it("borne chaque lot à cent documents", async () => {
     const tx = {
-      searchDocument: { createMany: vi.fn(async () => ({ count: 0 })) },
+      searchDocument: { createMany: vi.fn(async (_args: { data: unknown[] }) => ({ count: 0 })) },
       $executeRaw: vi.fn(async () => 0),
     };
 
@@ -26,8 +26,8 @@ describe("écritures groupées des documents de recherche", () => {
     );
 
     expect(tx.searchDocument.createMany).toHaveBeenCalledTimes(2);
-    expect(tx.searchDocument.createMany.mock.calls[0]?.[0].data).toHaveLength(100);
-    expect(tx.searchDocument.createMany.mock.calls[1]?.[0].data).toHaveLength(1);
+    expect(tx.searchDocument.createMany.mock.calls[0]?.[0]?.data).toHaveLength(100);
+    expect(tx.searchDocument.createMany.mock.calls[1]?.[0]?.data).toHaveLength(1);
     expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
   });
 

--- a/src/lib/search/__tests__/documents.test.ts
+++ b/src/lib/search/__tests__/documents.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteSearchDocuments, upsertSearchDocuments } from "../documents";
+
+const makeInput = (index: number) => ({
+  entityType: "MEASURE" as const,
+  entityId: `measure-${index}`,
+  electionId: "election-1",
+  title: `Mesure ${index}`,
+  body: `Contenu ${index}`,
+  url: `/mesures/measure-${index}`,
+  visibility: "PUBLIC" as const,
+  sourceRevisionId: `revision-${index}`,
+  sourceUpdatedAt: new Date("2026-08-30T00:00:00.000Z"),
+});
+
+describe("écritures groupées des documents de recherche", () => {
+  it("borne chaque lot à cent documents", async () => {
+    const tx = {
+      searchDocument: { createMany: vi.fn(async () => ({ count: 0 })) },
+      $executeRaw: vi.fn(async () => 0),
+    };
+
+    await upsertSearchDocuments(
+      tx as never,
+      Array.from({ length: 101 }, (_, index) => makeInput(index))
+    );
+
+    expect(tx.searchDocument.createMany).toHaveBeenCalledTimes(2);
+    expect(tx.searchDocument.createMany.mock.calls[0]?.[0].data).toHaveLength(100);
+    expect(tx.searchDocument.createMany.mock.calls[1]?.[0].data).toHaveLength(1);
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("supprime plusieurs documents en une seule requête", async () => {
+    const tx = { searchDocument: { deleteMany: vi.fn(async () => ({ count: 2 })) } };
+
+    await deleteSearchDocuments(tx as never, "MEASURE", ["measure-1", "measure-2"]);
+
+    expect(tx.searchDocument.deleteMany).toHaveBeenCalledWith({
+      where: { entityType: "MEASURE", entityId: { in: ["measure-1", "measure-2"] } },
+    });
+  });
+});

--- a/src/lib/search/documents.ts
+++ b/src/lib/search/documents.ts
@@ -1,4 +1,4 @@
-import type { SearchEntityType, SearchVisibility } from "@/generated/prisma";
+import { Prisma, type SearchEntityType, type SearchVisibility } from "@/generated/prisma";
 import type { DbTransactionClient } from "@/lib/db";
 
 export type SearchDocumentInput = {
@@ -57,6 +57,86 @@ export async function upsertSearchDocument(
   `;
 }
 
+const BULK_WRITE_SIZE = 100;
+
+/**
+ * Writes search documents in bounded SQL batches.
+ *
+ * `createMany` lets PostgreSQL allocate ids for new rows. The following UPDATE applies the full
+ * payload to both new and existing rows and rebuilds their vectors in the same statement. This
+ * keeps large editorial mutations inside their transaction without two round trips per entity.
+ */
+export async function upsertSearchDocuments(
+  tx: DbTransactionClient,
+  inputs: SearchDocumentInput[]
+): Promise<void> {
+  for (let start = 0; start < inputs.length; start += BULK_WRITE_SIZE) {
+    const chunk = inputs.slice(start, start + BULK_WRITE_SIZE);
+    const indexedAt = new Date();
+
+    await tx.searchDocument.createMany({
+      data: chunk.map((input) => ({
+        entityType: input.entityType,
+        entityId: input.entityId,
+        electionId: input.electionId,
+        title: input.title,
+        body: input.body,
+        url: input.url,
+        visibility: input.visibility,
+        sourceRevisionId: input.sourceRevisionId,
+        sourceUpdatedAt: input.sourceUpdatedAt,
+        indexedAt,
+      })),
+      skipDuplicates: true,
+    });
+
+    const rows = Prisma.join(
+      chunk.map(
+        (input) => Prisma.sql`(
+          ${input.entityType}::"SearchEntityType",
+          ${input.entityId},
+          ${input.electionId},
+          ${input.title},
+          ${input.body},
+          ${input.url},
+          ${input.visibility}::"SearchVisibility",
+          ${input.sourceRevisionId},
+          ${input.sourceUpdatedAt},
+          ${indexedAt}
+        )`
+      )
+    );
+
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE "SearchDocument" AS document
+      SET
+        "electionId" = source."electionId",
+        title = source.title,
+        body = source.body,
+        url = source.url,
+        visibility = source.visibility,
+        "sourceRevisionId" = source."sourceRevisionId",
+        "sourceUpdatedAt" = source."sourceUpdatedAt",
+        "indexedAt" = source."indexedAt",
+        "searchVector" = to_tsvector('simple', unaccent(source.title || ' ' || source.body))
+      FROM (VALUES ${rows}) AS source(
+        "entityType",
+        "entityId",
+        "electionId",
+        title,
+        body,
+        url,
+        visibility,
+        "sourceRevisionId",
+        "sourceUpdatedAt",
+        "indexedAt"
+      )
+      WHERE document."entityType" = source."entityType"
+        AND document."entityId" = source."entityId"
+    `);
+  }
+}
+
 /**
  * Entity deletion path, and the only one that removes a row.
  *
@@ -72,4 +152,13 @@ export async function deleteSearchDocument(
   entityId: string
 ): Promise<void> {
   await tx.searchDocument.deleteMany({ where: { entityType, entityId } });
+}
+
+export async function deleteSearchDocuments(
+  tx: DbTransactionClient,
+  entityType: SearchEntityType,
+  entityIds: string[]
+): Promise<void> {
+  if (entityIds.length === 0) return;
+  await tx.searchDocument.deleteMany({ where: { entityType, entityId: { in: entityIds } } });
 }

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/db", () => ({ db: {} }));
 
 import { generateMetadata as votesGenerateMetadata } from "@/app/parlement/votes/page";
 import { metadata as presidentialComparisonMetadata } from "@/app/elections/presidentielle-2027/comparer/page";
+import { metadata as presidentialMeasuresMethodologyMetadata } from "@/app/methodologie/mesures-presidentielle-2027/page";
 
 // Living map of the index-bloat doctrine. If any representative surface flips, this
 // file fails: a strong page must never become noindex, a thin one must never become
@@ -294,6 +295,21 @@ describe("doctrine — sitemap shares the indexability thresholds (no drift)", (
 
   it("keeps an unknown scrutin type fail-open", () => {
     expect(scrutinShardQuery).toContain("IS DISTINCT FROM");
+  });
+});
+
+describe("doctrine — presidential measure methodology stays indexable and discoverable", () => {
+  const sitemapSource = readFileSync(join(process.cwd(), "src/app/sitemap.ts"), "utf8");
+
+  it("keeps a self-canonical indexable page", () => {
+    expect(presidentialMeasuresMethodologyMetadata.alternates?.canonical).toBe(
+      "/methodologie/mesures-presidentielle-2027"
+    );
+    expect(presidentialMeasuresMethodologyMetadata.robots).not.toMatchObject({ index: false });
+  });
+
+  it("keeps the page in the static sitemap", () => {
+    expect(sitemapSource).toContain("url: `${SITE_URL}/methodologie/mesures-presidentielle-2027`");
   });
 });
 

--- a/src/services/factcheckStats.test.ts
+++ b/src/services/factcheckStats.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  count: vi.fn(),
+  groupBy: vi.fn(),
+  queryRaw: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    factCheck: { count: mocks.count, groupBy: mocks.groupBy },
+    $queryRaw: mocks.queryRaw,
+  },
+}));
+
+import { factcheckStatsService } from "./factcheckStats";
+
+describe("statistiques publiques des fact-checks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.count.mockResolvedValue(0);
+    mocks.groupBy.mockResolvedValue([]);
+    mocks.queryRaw.mockResolvedValue([]);
+  });
+
+  it("aplatit le prédicat public dans la requête Prisma au lieu de le lier comme une valeur", async () => {
+    await factcheckStatsService.getStatisticsData();
+
+    expect(mocks.queryRaw).toHaveBeenCalledTimes(1);
+    const call = mocks.queryRaw.mock.calls[0] ?? [];
+    expect(call).toHaveLength(1);
+    expect(call[0]).toMatchObject({
+      sql: expect.stringContaining('fc."publicationStatus" = ?'),
+      values: expect.arrayContaining(["PUBLISHED"]),
+    });
+    expect(call[0].values.every((value: unknown) => typeof value !== "object")).toBe(true);
+  });
+});

--- a/src/services/factcheckStats.ts
+++ b/src/services/factcheckStats.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { Prisma } from "@/generated/prisma";
 import { VERDICT_GROUPS } from "@/config/labels";
 import { bayesianScore } from "@/lib/bayesianScore";
 import { getPublicFactCheckSqlWhere, getPublicFactCheckWhere } from "@/lib/api/public-contract";
@@ -144,7 +145,7 @@ async function getPageStats(): Promise<FactCheckPageStats> {
       _count: true,
       orderBy: { _count: { source: "desc" } },
     }),
-    db.$queryRaw<Array<{ fullName: string; slug: string; count: bigint }>>`
+    db.$queryRaw<Array<{ fullName: string; slug: string; count: bigint }>>(Prisma.sql`
       SELECT p."fullName", p.slug, COUNT(*) as count
       FROM "FactCheckMention" m
       JOIN "FactCheck" fc ON m."factCheckId" = fc.id
@@ -154,7 +155,7 @@ async function getPageStats(): Promise<FactCheckPageStats> {
       GROUP BY p.id, p."fullName", p.slug
       ORDER BY count DESC
       LIMIT 10
-    `,
+    `),
   ]);
 
   const byRating = byRatingRaw.reduce(
@@ -218,7 +219,7 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
         verdictRating: string;
         mentionCount: bigint;
       }>
-    >`
+    >(Prisma.sql`
       SELECT
         p.id AS "politicianId",
         p."fullName",
@@ -240,7 +241,7 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
       GROUP BY p.id, p."fullName", p.slug, p."photoUrl",
                party.name, party."shortName", party.color, party.slug,
                fc."verdictRating"
-    `,
+    `),
   ]);
 
   const ratingMap: Record<string, number> = {};
@@ -408,12 +409,12 @@ interface GlobalVerdictRow {
 }
 
 async function getGlobalByVerdict(): Promise<GlobalVerdictRow[]> {
-  return db.$queryRaw<GlobalVerdictRow[]>`
+  return db.$queryRaw<GlobalVerdictRow[]>(Prisma.sql`
     SELECT fc."verdictRating", COUNT(*) as count
     FROM "FactCheck" fc
     WHERE ${getPublicFactCheckSqlWhere()}
     GROUP BY fc."verdictRating"
-  `;
+  `);
 }
 
 interface PartyVerdictRow {
@@ -427,7 +428,7 @@ interface PartyVerdictRow {
 }
 
 async function getByParty(): Promise<PartyVerdictRow[]> {
-  return db.$queryRaw<PartyVerdictRow[]>`
+  return db.$queryRaw<PartyVerdictRow[]>(Prisma.sql`
     SELECT
       p.id as "partyId",
       p.name as "partyName",
@@ -444,7 +445,7 @@ async function getByParty(): Promise<PartyVerdictRow[]> {
       AND pol."publicationStatus" = 'PUBLISHED'
     GROUP BY p.id, p.name, p."shortName", p.color, p.slug, fc."verdictRating"
     ORDER BY COUNT(*) DESC
-  `;
+  `);
 }
 
 interface PoliticianVerdictRow {
@@ -457,7 +458,7 @@ interface PoliticianVerdictRow {
 }
 
 async function getByPolitician(limit: number): Promise<PoliticianVerdictRow[]> {
-  return db.$queryRaw<PoliticianVerdictRow[]>`
+  return db.$queryRaw<PoliticianVerdictRow[]>(Prisma.sql`
     SELECT
       sub."politicianId",
       sub."fullName",
@@ -487,7 +488,7 @@ async function getByPolitician(limit: number): Promise<PoliticianVerdictRow[]> {
         LIMIT ${limit}
       )
     GROUP BY sub."politicianId", sub."fullName", sub.slug, sub."partyShortName", fc."verdictRating"
-  `;
+  `);
 }
 
 interface SourceVerdictRow {
@@ -497,13 +498,13 @@ interface SourceVerdictRow {
 }
 
 async function getBySource(): Promise<SourceVerdictRow[]> {
-  return db.$queryRaw<SourceVerdictRow[]>`
+  return db.$queryRaw<SourceVerdictRow[]>(Prisma.sql`
     SELECT fc.source, fc."verdictRating", COUNT(*) as count
     FROM "FactCheck" fc
     WHERE ${getPublicFactCheckSqlWhere()}
     GROUP BY fc.source, fc."verdictRating"
     ORDER BY COUNT(*) DESC
-  `;
+  `);
 }
 
 // ============================================


### PR DESCRIPTION
## Résumé

- améliore la recherche lexicale et prépare les requêtes en langage naturel
- ajoute un vrai parcours d'enrichissement éditorial dans la file admin des mesures
- enrichit les pages mesure et crée une méthodologie dédiée à la présidentielle 2027
- ajoute les chiffres présidentiels à la page statistiques et met en cache leur agrégation
- corrige la composition des fragments Prisma.sql sur plusieurs statistiques publiques

## Vérifications

- `npm run typecheck`
- `npm run lint`
- 60 tests ciblés passés, 14 tests d'intégration ignorés faute de base de test dédiée
- contrôle Chromium desktop et mobile de `/statistiques` et `/admin/mesures?enrichissement=SUBTOPICS_PENDING`
- aucune erreur console ni overlay Next.js, aucun débordement horizontal mobile
- `/statistiques` à cache chaud : 9,53 s avant, 1,88 s après

Le build local atteint la compilation Webpack puis échoue uniquement sur le téléchargement de Google Fonts, bloqué par le réseau du bac à sable. La CI GitHub valide le build dans son environnement réseau.