### PR TITLE
feat: améliorer la découverte des programmes 2027

### DIFF
--- a/src/app/elections/presidentielle-2027/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/__tests__/page.test.ts
@@ -25,6 +25,7 @@ function context(over: Partial<HubMeasureContext> = {}): HubMeasureContext {
     verifiedMeasureCount: 0,
     lastReviewedAt: null,
     themes: [],
+    featuredSubtopics: [],
     ...over,
   };
 }

--- a/src/app/elections/presidentielle-2027/_components/HubTopics.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubTopics.tsx
@@ -27,7 +27,7 @@ export function HubTopics({ subtopics }: { subtopics: FeaturedSubtopic[] }) {
             <Link
               href={{
                 pathname: "/elections/presidentielle-2027/recherche",
-                query: { q: subtopic.label },
+                query: { "sous-theme": subtopic.slug },
               }}
               prefetch={false}
               className={cn(

--- a/src/app/elections/presidentielle-2027/_components/HubTopics.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubTopics.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import type { FeaturedSubtopic } from "@/lib/data/themes-index";
+import { cn } from "@/lib/utils";
+
+/** Compact browse entry points inspired by documentary collections, with one stable visual weight. */
+export function HubTopics({ subtopics }: { subtopics: FeaturedSubtopic[] }) {
+  if (subtopics.length === 0) return null;
+
+  return (
+    <section aria-labelledby="hub-sous-themes" className="space-y-4">
+      <div className="space-y-1.5">
+        <h2
+          id="hub-sous-themes"
+          className="font-display text-xl font-bold tracking-tight md:text-2xl"
+        >
+          Explorer un sujet précis
+        </h2>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Accédez directement aux sous-thèmes validés dans les mesures publiées.
+        </p>
+      </div>
+
+      <ul className="flex flex-wrap gap-2">
+        {subtopics.map((subtopic) => (
+          <li key={subtopic.slug}>
+            <Link
+              href={{
+                pathname: "/elections/presidentielle-2027/recherche",
+                query: { q: subtopic.label },
+              }}
+              prefetch={false}
+              className={cn(
+                buttonVariants({ variant: "outline" }),
+                "h-auto min-h-11 rounded-full px-4 py-2 text-left"
+              )}
+            >
+              <span className="flex flex-col leading-tight">
+                <span className="font-semibold">{subtopic.label}</span>
+                <span className="mt-0.5 text-[11px] font-normal text-muted-foreground">
+                  {subtopic.themeLabel}
+                </span>
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubTopics.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubTopics.test.tsx
@@ -23,7 +23,7 @@ describe("HubTopics", () => {
     expect(screen.getByText("Santé")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Accès aux soins/ })).toHaveAttribute(
       "href",
-      "/elections/presidentielle-2027/recherche?q=Acc%C3%A8s+aux+soins"
+      "/elections/presidentielle-2027/recherche?sous-theme=acces-aux-soins"
     );
   });
 

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubTopics.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubTopics.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HubTopics } from "../HubTopics";
+
+describe("HubTopics", () => {
+  it("propose des liens de recherche compacts avec leur thématique", () => {
+    render(
+      <HubTopics
+        subtopics={[
+          {
+            slug: "acces-aux-soins",
+            label: "Accès aux soins",
+            theme: "SANTE",
+            themeLabel: "Santé",
+            measureCount: 12,
+            candidacyCount: 7,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Explorer un sujet précis" })).toBeInTheDocument();
+    expect(screen.getByText("Santé")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Accès aux soins/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/recherche?q=Acc%C3%A8s+aux+soins"
+    );
+  });
+
+  it("ne rend pas de section sans sous-thème validé", () => {
+    const { container } = render(<HubTopics subtopics={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -13,6 +13,7 @@ import { HubClosedState } from "./_components/HubClosedState";
 import { HubCorpusState } from "./_components/HubCorpusState";
 import { HubComparisonLauncher } from "./_components/HubComparisonLauncher";
 import { HubSubjects } from "./_components/HubSubjects";
+import { HubTopics } from "./_components/HubTopics";
 import { PresidentialHubNav } from "./_components/PresidentialHubNav";
 import { PresidentialCorpusSearch } from "./_components/PresidentialCorpusSearch";
 
@@ -116,6 +117,8 @@ export default async function PresidentialHubPage() {
             themeCount={themeCount}
           />
         )}
+
+        <HubTopics subtopics={context.featuredSubtopics} />
 
         <HubSubjects themes={context.themes} />
 

--- a/src/app/elections/presidentielle-2027/recherche/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.test.tsx
@@ -42,7 +42,49 @@ describe("page complète de recherche présidentielle", () => {
       name: /Construire davantage de logements accessibles sur tout le territoire/,
     });
     expect(link).toHaveAttribute("href", "/elections/presidentielle-2027/mesures/m1");
-    expect(search).toHaveBeenCalledWith("presidentielle-2027", "logement", 50);
+    expect(search).toHaveBeenCalledWith("presidentielle-2027", "logement", 50, {
+      subtopicSlug: undefined,
+      page: 1,
+    });
+  });
+
+  it("transmet le slug validé et affiche la pagination d'un sous-thème", async () => {
+    search.mockResolvedValue({
+      query: "Accès aux soins",
+      total: 74,
+      subjects: [],
+      candidacies: [],
+      measures: [
+        {
+          type: "measure",
+          id: "m2",
+          text: "Ouvrir des centres de santé",
+          url: "/elections/presidentielle-2027/mesures/m2",
+          candidateName: "Camille Rivière",
+          theme: "SANTE",
+          precision: null,
+          sourceLabel: null,
+        },
+      ],
+      filter: { type: "subtopic", slug: "acces-aux-soins", label: "Accès aux soins" },
+      page: 1,
+      totalPages: 2,
+    });
+
+    render(
+      await PresidentialSearchPage({
+        searchParams: Promise.resolve({ "sous-theme": "acces-aux-soins" }),
+      })
+    );
+
+    expect(search).toHaveBeenCalledWith("presidentielle-2027", "", 50, {
+      subtopicSlug: "acces-aux-soins",
+      page: 1,
+    });
+    expect(screen.getByRole("link", { name: "Suivant" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/recherche?sous-theme=acces-aux-soins&page=2"
+    );
   });
 
   it("présente un thème comme un résultat sans message vide ni promesse de comparabilité", async () => {

--- a/src/app/elections/presidentielle-2027/recherche/page.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { SimplePagination } from "@/components/ui/SimplePagination";
 import { PoliticianAvatar } from "@/components/politicians/PoliticianAvatar";
 import {
   CANDIDACY_STATUS_LABELS,
@@ -23,13 +24,29 @@ export const metadata: Metadata = {
 export default async function PresidentialSearchPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string | string[] }>;
+  searchParams: Promise<{
+    q?: string | string[];
+    "sous-theme"?: string | string[];
+    page?: string | string[];
+  }>;
 }) {
   const params = await searchParams;
   const raw = Array.isArray(params.q) ? params.q[0] : params.q;
   const query = raw?.trim().slice(0, 200) ?? "";
-  const result = await searchPresidentialCorpus(PRESIDENTIELLE_2027_SLUG, query, 50);
+  const rawSubtopic = Array.isArray(params["sous-theme"])
+    ? params["sous-theme"][0]
+    : params["sous-theme"];
+  const subtopicSlug = rawSubtopic?.trim().slice(0, 100) || undefined;
+  const rawPage = Array.isArray(params.page) ? params.page[0] : params.page;
+  const parsedPage = Number.parseInt(rawPage ?? "1", 10);
+  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+  const result = await searchPresidentialCorpus(PRESIDENTIELLE_2027_SLUG, query, 50, {
+    subtopicSlug,
+    page,
+  });
   const hasResults = result !== null && result.total > 0;
+  const hasSearch = query.length >= 2 || subtopicSlug !== undefined;
+  const resultLabel = result?.query || query;
 
   return (
     <main className="container mx-auto px-4 pb-12 pt-4">
@@ -72,14 +89,16 @@ export default async function PresidentialSearchPage({
           </button>
         </form>
 
-        {query.length < 2 ? (
+        {!hasSearch ? (
           <p className="mt-10 text-muted-foreground">
             Saisissez au moins deux caractères pour rechercher dans le corpus public.
           </p>
         ) : !hasResults ? (
           <section className="mt-10 rounded-2xl border border-border bg-card p-6">
             <h2 className="font-display text-2xl font-extrabold">
-              Aucun résultat pour « {query} »
+              {subtopicSlug
+                ? "Aucune mesure publiée dans ce sous-thème"
+                : `Aucun résultat pour « ${resultLabel} »`}
             </h2>
             <p className="mt-3 text-muted-foreground">
               Le corpus public de Poligraph ne contient, à ce jour, aucune mesure publiée ni
@@ -187,6 +206,17 @@ export default async function PresidentialSearchPage({
                   })}
                 </ul>
               </section>
+            )}
+            {result.filter?.type === "subtopic" && result.page && result.totalPages && (
+              <SimplePagination
+                page={result.page}
+                totalPages={result.totalPages}
+                buildUrl={(targetPage) => {
+                  const search = new URLSearchParams({ "sous-theme": result.filter!.slug });
+                  if (targetPage > 1) search.set("page", String(targetPage));
+                  return `${PAGE_PATH}?${search.toString()}`;
+                }}
+              />
             )}
           </div>
         )}

--- a/src/app/elections/presidentielle-2027/themes/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/themes/__tests__/page.test.ts
@@ -18,6 +18,7 @@ describe("generateMetadata de l'index des thématiques", () => {
     mockGet.mockResolvedValue({
       electionSlug: "presidentielle-2027",
       themes: [],
+      featuredSubtopics: [],
       publishableSubjectPageCount: 1,
     });
     const meta = await generateMetadata();
@@ -28,6 +29,7 @@ describe("generateMetadata de l'index des thématiques", () => {
     mockGet.mockResolvedValue({
       electionSlug: "presidentielle-2027",
       themes: [],
+      featuredSubtopics: [],
       publishableSubjectPageCount: 0,
     });
     const meta = await generateMetadata();
@@ -38,6 +40,7 @@ describe("generateMetadata de l'index des thématiques", () => {
     mockGet.mockResolvedValue({
       electionSlug: "presidentielle-2027",
       themes: [],
+      featuredSubtopics: [],
       publishableSubjectPageCount: 1,
     });
     const meta = await generateMetadata();
@@ -54,6 +57,7 @@ describe("generateMetadata de l'index des thématiques", () => {
     mockGet.mockResolvedValue({
       electionSlug: "presidentielle-2027",
       themes: [],
+      featuredSubtopics: [],
       publishableSubjectPageCount: 1,
     });
     const meta = await generateMetadata();

--- a/src/app/elections/presidentielle-2027/themes/_components/__tests__/ThemesIndexList.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/_components/__tests__/ThemesIndexList.test.tsx
@@ -7,6 +7,7 @@ function data(over: Partial<ThemesIndexData> = {}): ThemesIndexData {
   return {
     electionSlug: "presidentielle-2027",
     publishableSubjectPageCount: 1,
+    featuredSubtopics: [],
     themes: [
       {
         theme: "LOGEMENT_URBANISME",

--- a/src/app/programmes/__tests__/page.test.tsx
+++ b/src/app/programmes/__tests__/page.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubMeasureContext } from "@/lib/data/hub";
+
+vi.mock("@/lib/feature-flags", () => ({ isFeatureEnabled: vi.fn() }));
+vi.mock("@/lib/data/platforms", () => ({ getLatestPlatformsPerParty: vi.fn() }));
+vi.mock("@/lib/data/hub", () => ({
+  getHubMeasureContext: vi.fn(),
+  getHubCandidacyField: vi.fn(),
+}));
+
+import { isFeatureEnabled } from "@/lib/feature-flags";
+import { getLatestPlatformsPerParty } from "@/lib/data/platforms";
+import { getHubCandidacyField, getHubMeasureContext } from "@/lib/data/hub";
+import ProgrammesPage, { metadata } from "../page";
+
+const context: HubMeasureContext = {
+  electionTitle: "Présidentielle 2027",
+  round1Date: new Date("2027-04-11"),
+  round2Date: new Date("2027-04-25"),
+  dateConfirmed: true,
+  electionDescription: null,
+  publishableSubjectPageCount: 12,
+  hubPublishable: true,
+  verifiedMeasureCount: 845,
+  lastReviewedAt: new Date("2026-08-30"),
+  themes: [],
+  featuredSubtopics: [],
+};
+
+beforeEach(() => {
+  vi.mocked(isFeatureEnabled).mockResolvedValue(true);
+  vi.mocked(getLatestPlatformsPerParty).mockResolvedValue([]);
+  vi.mocked(getHubMeasureContext).mockResolvedValue(context);
+  vi.mocked(getHubCandidacyField).mockResolvedValue([
+    {
+      id: "candidature-1",
+      candidateName: "Camille Exemple",
+      politicianSlug: "camille-exemple",
+      photoUrl: null,
+      blobPhotoUrl: null,
+      status: "DECLARE",
+      sourceUrl: "https://example.com/source",
+      sourceLabel: "Source officielle",
+      partyLabel: null,
+      partyColor: null,
+      partyShortName: null,
+      partyLogoUrl: null,
+      measureCount: 14,
+      themesCoveredCount: 6,
+      programmeAbsence: null,
+    },
+    {
+      id: "candidature-2",
+      candidateName: "Alex Exemple",
+      politicianSlug: "alex-exemple",
+      photoUrl: null,
+      blobPhotoUrl: null,
+      status: "PRESSENTI",
+      sourceUrl: "https://example.com/source-2",
+      sourceLabel: "Source officielle",
+      partyLabel: null,
+      partyColor: null,
+      partyShortName: null,
+      partyLogoUrl: null,
+      measureCount: 0,
+      themesCoveredCount: 0,
+      programmeAbsence: "non_depouille",
+    },
+  ]);
+});
+
+describe("page programmes", () => {
+  it("centre les métadonnées sur les programmes et la présidentielle 2027", () => {
+    expect(metadata.title).toBe("Programmes politiques 2027 et programmes des partis");
+    expect(metadata.description).toContain("présidentielle 2027");
+    expect(metadata.alternates?.canonical).toBe("/programmes");
+  });
+
+  it("met le corpus présidentiel en avant sans compter les candidatures non documentées", async () => {
+    render(await ProgrammesPage());
+
+    expect(
+      screen.getByRole("heading", { name: "Comparer les programmes des candidats" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("845")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Explorer la présidentielle 2027/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027"
+    );
+  });
+});

--- a/src/app/programmes/__tests__/page.test.tsx
+++ b/src/app/programmes/__tests__/page.test.tsx
@@ -63,9 +63,9 @@ beforeEach(() => {
       partyColor: null,
       partyShortName: null,
       partyLogoUrl: null,
-      measureCount: 0,
-      themesCoveredCount: 0,
-      programmeAbsence: "non_depouille",
+      measureCount: 2,
+      themesCoveredCount: 1,
+      programmeAbsence: null,
     },
   ]);
 });
@@ -77,7 +77,7 @@ describe("page programmes", () => {
     expect(metadata.alternates?.canonical).toBe("/programmes");
   });
 
-  it("met le corpus présidentiel en avant sans compter les candidatures non documentées", async () => {
+  it("compte neutralement les personnalités documentées quel que soit leur statut", async () => {
     render(await ProgrammesPage());
 
     expect(
@@ -85,7 +85,8 @@ describe("page programmes", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("845")).toBeInTheDocument();
     expect(screen.getByText("12")).toBeInTheDocument();
-    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("Personnalités documentées")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Explorer la présidentielle 2027/ })).toHaveAttribute(
       "href",
       "/elections/presidentielle-2027"

--- a/src/app/programmes/__tests__/page.test.tsx
+++ b/src/app/programmes/__tests__/page.test.tsx
@@ -91,4 +91,21 @@ describe("page programmes", () => {
       "/elections/presidentielle-2027"
     );
   });
+
+  it("ne promet pas de comparaison avant le seuil de publication du hub", async () => {
+    vi.mocked(getHubMeasureContext).mockResolvedValue({
+      ...context,
+      hubPublishable: false,
+      publishableSubjectPageCount: 0,
+    });
+
+    render(await ProgrammesPage());
+
+    expect(
+      screen.queryByRole("heading", { name: "Comparer les programmes des candidats" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Explorer la présidentielle 2027/ })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/app/programmes/page.tsx
+++ b/src/app/programmes/page.tsx
@@ -2,101 +2,202 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
-import { Info } from "lucide-react";
+import { ArrowRight, FileCheck2, Info, UsersRound } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { buttonVariants } from "@/components/ui/button";
+import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { getHubCandidacyField, getHubMeasureContext } from "@/lib/data/hub";
 import { getLatestPlatformsPerParty } from "@/lib/data/platforms";
 import { isFeatureEnabled } from "@/lib/feature-flags";
-import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { cn } from "@/lib/utils";
 
 export const revalidate = 300;
 
+const PRESIDENTIAL_HUB_PATH = `/elections/${PRESIDENTIELLE_2027_SLUG}`;
+
 export const metadata: Metadata = {
-  title: "Programmes des partis",
+  title: "Programmes politiques 2027 et programmes des partis",
   description:
-    "Comparez les positions des partis politiques français sur les grands axes thématiques : économie, société, écologie, sécurité, institutions.",
+    "Consultez les programmes et mesures sourcées des candidats à la présidentielle 2027, ainsi que les derniers programmes documentés des partis politiques français.",
   alternates: { canonical: "/programmes" },
 };
 
 export default async function ProgrammesPage() {
   if (!(await isFeatureEnabled("PROGRAMMES_ENABLED"))) notFound();
 
-  const platforms = await getLatestPlatformsPerParty();
+  const [platforms, presidentialContext, candidacies] = await Promise.all([
+    getLatestPlatformsPerParty(),
+    getHubMeasureContext(PRESIDENTIELLE_2027_SLUG),
+    getHubCandidacyField(PRESIDENTIELLE_2027_SLUG),
+  ]);
+  const candidaciesWithMeasures = candidacies.filter((candidacy) => candidacy.measureCount > 0);
 
   return (
     <div className="container mx-auto px-4 pt-4 pb-8">
       <CollectionPageJsonLd
-        name="Programmes des partis politiques"
-        description="Comparez les positions des partis politiques français sur les grands axes thématiques : économie, société, écologie, sécurité, institutions."
+        name="Programmes politiques et présidentielle 2027"
+        description="Les mesures des candidats à la présidentielle 2027 et les derniers programmes officiels documentés des partis politiques français."
         url="https://poligraph.fr/programmes"
-        numberOfItems={platforms.length}
+        numberOfItems={platforms.length + (presidentialContext === null ? 0 : 1)}
       />
       <Breadcrumb items={[{ label: "Programmes" }]} />
 
-      <div className="mt-6 space-y-8">
-        {/* Header */}
-        <div>
-          <h1 className="text-2xl font-bold">Programmes des partis</h1>
-          <p className="text-muted-foreground mt-1">
-            Comparez les positions des partis politiques sur les grands enjeux
+      <main className="mt-6 space-y-10">
+        <header className="max-w-3xl space-y-2">
+          <h1 className="font-display text-3xl font-extrabold tracking-tight md:text-5xl">
+            Programmes politiques et présidentielle 2027
+          </h1>
+          <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
+            Explorez les mesures publiées pour l’élection présidentielle et retrouvez les programmes
+            officiels déjà documentés par Poligraph.
           </p>
-        </div>
+        </header>
 
-        {/* Info box */}
-        <div className="flex gap-3 rounded-lg border bg-muted/30 p-4">
-          <Info className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" aria-hidden="true" />
-          <p className="text-sm text-muted-foreground">
-            Les positions affichées sont issues des derniers programmes officiels publiés par chaque
-            parti. Pour la plupart, il s{"'"}agit des législatives de 2024. Ces positions sont mises
-            à jour lors de chaque nouvelle élection.{" "}
-            <Link href="/sources" className="text-primary hover:underline">
-              En savoir plus
-            </Link>
-          </p>
-        </div>
-
-        {platforms.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-muted-foreground">Aucun programme enregistré pour le moment.</p>
-          </div>
-        ) : (
-          <>
-            {/* Party cards grid */}
-            <section aria-labelledby="parties-heading">
-              <h2 id="parties-heading" className="text-lg font-semibold mb-4">
-                Programmes par parti
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {platforms.map((p) => (
-                  <Link
-                    key={p.id}
-                    href={`/partis/${p.party?.slug}/programme`}
-                    className="flex items-center gap-3 border rounded-lg p-4 hover:bg-muted/50 transition-colors"
-                    prefetch={false}
-                  >
-                    {p.party?.logoUrl && (
-                      <Image
-                        src={p.party.logoUrl}
-                        alt={p.party.name}
-                        width={40}
-                        height={40}
-                        className="h-10 w-10 rounded-full object-cover"
-                      />
-                    )}
-                    <div>
-                      <p className="font-medium">{p.party?.name ?? "Parti inconnu"}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {p._count.proposals} axe{p._count.proposals > 1 ? "s" : ""} documenté
-                        {p._count.proposals > 1 ? "s" : ""}
-                      </p>
-                      <p className="text-xs text-muted-foreground">{p.election.title}</p>
-                    </div>
-                  </Link>
-                ))}
+        {presidentialContext !== null && (
+          <section
+            aria-labelledby="presidentielle-programmes-title"
+            className="overflow-hidden rounded-2xl border border-primary/25 bg-primary/[0.035]"
+          >
+            <div className="space-y-6 p-5 sm:p-7">
+              <div className="max-w-3xl space-y-2">
+                <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
+                  Élection présidentielle 2027
+                </p>
+                <h2
+                  id="presidentielle-programmes-title"
+                  className="font-display text-2xl font-bold tracking-tight md:text-3xl"
+                >
+                  Comparer les programmes des candidats
+                </h2>
+                <p className="leading-relaxed text-muted-foreground">
+                  Les mesures sont extraites de sources datées, relues puis organisées par thème et
+                  sous-thème. Elles sont présentées sans score ni jugement sur leur contenu.
+                </p>
               </div>
-            </section>
-          </>
+
+              <dl className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-xl border bg-background p-4">
+                  <dt className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <FileCheck2 className="h-4 w-4" aria-hidden="true" />
+                    Mesures publiées
+                  </dt>
+                  <dd className="mt-1 font-display text-2xl font-bold">
+                    {presidentialContext.verifiedMeasureCount.toLocaleString("fr-FR")}
+                  </dd>
+                </div>
+                <div className="rounded-xl border bg-background p-4">
+                  <dt className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <UsersRound className="h-4 w-4" aria-hidden="true" />
+                    Candidats documentés
+                  </dt>
+                  <dd className="mt-1 font-display text-2xl font-bold">
+                    {candidaciesWithMeasures.length.toLocaleString("fr-FR")}
+                  </dd>
+                </div>
+                <div className="rounded-xl border bg-background p-4">
+                  <dt className="text-sm text-muted-foreground">Thèmes comparables</dt>
+                  <dd className="mt-1 font-display text-2xl font-bold">
+                    {presidentialContext.publishableSubjectPageCount.toLocaleString("fr-FR")}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                <Link
+                  href={PRESIDENTIAL_HUB_PATH}
+                  className={cn(buttonVariants({ variant: "default" }), "min-h-11")}
+                >
+                  Explorer la présidentielle 2027
+                  <ArrowRight aria-hidden="true" />
+                </Link>
+                <Link
+                  href={`${PRESIDENTIAL_HUB_PATH}/candidats`}
+                  className={cn(buttonVariants({ variant: "outline" }), "min-h-11")}
+                >
+                  Voir les candidats
+                </Link>
+                <Link
+                  href={`${PRESIDENTIAL_HUB_PATH}/themes`}
+                  className={cn(buttonVariants({ variant: "link" }), "min-h-11")}
+                >
+                  Parcourir les thèmes
+                </Link>
+              </div>
+            </div>
+          </section>
         )}
-      </div>
+
+        <section aria-labelledby="parties-heading" className="space-y-5">
+          <div className="max-w-3xl space-y-2">
+            <h2 id="parties-heading" className="font-display text-2xl font-bold tracking-tight">
+              Derniers programmes documentés par parti
+            </h2>
+            <p className="leading-relaxed text-muted-foreground">
+              Cette collection rassemble les programmes officiels associés à une élection. Elle
+              complète le suivi des programmes propres aux candidats à la présidentielle.
+            </p>
+          </div>
+
+          <div className="flex gap-3 rounded-xl border bg-muted/30 p-4">
+            <Info className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Une partie du corpus correspond encore aux élections législatives de 2024. La date et
+              l’élection de référence sont indiquées sur chaque programme.{" "}
+              <Link
+                href="/sources"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Consulter nos sources
+              </Link>
+            </p>
+          </div>
+
+          {platforms.length === 0 ? (
+            <p className="rounded-xl border p-6 text-muted-foreground">
+              Aucun programme de parti n’est enregistré pour le moment.
+            </p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {platforms.map((platform) => (
+                <Link
+                  key={platform.id}
+                  href={`/partis/${platform.party?.slug}/programme`}
+                  className="group flex min-h-24 items-center gap-3 rounded-xl border bg-card p-4 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  prefetch={false}
+                >
+                  {platform.party?.logoUrl && (
+                    <Image
+                      src={platform.party.logoUrl}
+                      alt={`Logo de ${platform.party.name}`}
+                      width={48}
+                      height={48}
+                      className="h-12 w-12 shrink-0 rounded-lg border object-contain p-1"
+                    />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold">
+                      {platform.party?.name ?? "Parti inconnu"}
+                    </span>
+                    <span className="mt-1 block text-sm text-muted-foreground">
+                      {platform._count.proposals} axe
+                      {platform._count.proposals > 1 ? "s" : ""} documenté
+                      {platform._count.proposals > 1 ? "s" : ""}
+                    </span>
+                    <span className="block text-sm text-muted-foreground">
+                      {platform.election.title}
+                    </span>
+                  </span>
+                  <ArrowRight
+                    className="h-4 w-4 shrink-0 transition-transform group-hover:translate-x-0.5"
+                    aria-hidden="true"
+                  />
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
     </div>
   );
 }

--- a/src/app/programmes/page.tsx
+++ b/src/app/programmes/page.tsx
@@ -89,7 +89,7 @@ export default async function ProgrammesPage() {
                 <div className="rounded-xl border bg-background p-4">
                   <dt className="flex items-center gap-2 text-sm text-muted-foreground">
                     <UsersRound className="h-4 w-4" aria-hidden="true" />
-                    Candidats documentés
+                    Personnalités documentées
                   </dt>
                   <dd className="mt-1 font-display text-2xl font-bold">
                     {candidaciesWithMeasures.length.toLocaleString("fr-FR")}

--- a/src/app/programmes/page.tsx
+++ b/src/app/programmes/page.tsx
@@ -39,7 +39,7 @@ export default async function ProgrammesPage() {
         name="Programmes politiques et présidentielle 2027"
         description="Les mesures des candidats à la présidentielle 2027 et les derniers programmes officiels documentés des partis politiques français."
         url="https://poligraph.fr/programmes"
-        numberOfItems={platforms.length + (presidentialContext === null ? 0 : 1)}
+        numberOfItems={platforms.length + (presidentialContext?.hubPublishable === true ? 1 : 0)}
       />
       <Breadcrumb items={[{ label: "Programmes" }]} />
 
@@ -54,7 +54,7 @@ export default async function ProgrammesPage() {
           </p>
         </header>
 
-        {presidentialContext !== null && (
+        {presidentialContext?.hubPublishable === true && (
           <section
             aria-labelledby="presidentielle-programmes-title"
             className="overflow-hidden rounded-2xl border border-primary/25 bg-primary/[0.035]"

--- a/src/lib/data/__tests__/hub-fixture.ts
+++ b/src/lib/data/__tests__/hub-fixture.ts
@@ -123,18 +123,39 @@ export async function seedHubFixture(
   const alpha = await candidacyWithPublishedExtension("Alpha", "PRESSENTI", "#123456");
   const bravo = await candidacyWithPublishedExtension("Bravo", "DECLARE");
 
-  await publishMeasure(
+  const alphaHousing = await publishMeasure(
     alpha.politicianId,
     alpha.candidacyId,
     THEME_LOGEMENT,
     "Encadrer les loyers dans les zones tendues."
   );
-  await publishMeasure(
+  const bravoHousing = await publishMeasure(
     bravo.politicianId,
     bravo.candidacyId,
     THEME_LOGEMENT,
     "Construire 500 000 logements sociaux sur le quinquennat."
   );
+
+  const housingSubtopic = await db.measureSubtopic.create({
+    data: {
+      slug: `${options.electionSlug}-acces-logement`,
+      label: "Accès au logement",
+      description: "Mesures relatives à l'accès au logement.",
+      theme: THEME_LOGEMENT,
+    },
+  });
+  await db.measureRevisionSubtopic.createMany({
+    data: [alphaHousing.revisionId, bravoHousing.revisionId].map((revisionId) => ({
+      revisionId,
+      subtopicId: housingSubtopic.id,
+      status: "APPROVED" as const,
+      method: "MANUAL",
+      classifierVersion: "fixture",
+      taxonomyVersion: "fixture",
+      reviewedAt: new Date("2027-01-02T00:00:00Z"),
+      reviewedBy: "fixture",
+    })),
+  });
 
   // Charlie: envisagé, complete source, DRAFT CandidacyPresidential extension carrying a
   // published measure. Must surface in the hub field (the field != the published fiches), but

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -35,6 +35,7 @@ describeIfDisposableDb("hub", () => {
     await db.politician.deleteMany({ where: { slug: { startsWith: SLUG } } });
     await db.election.deleteMany({ where: { slug: SLUG } });
     await db.party.deleteMany({ where: { slug: { startsWith: SLUG } } });
+    await db.measureSubtopic.deleteMany({ where: { slug: { startsWith: SLUG } } });
     await db.$disconnect();
   });
 
@@ -177,6 +178,19 @@ describeIfDisposableDb("hub", () => {
       expect(context.themes.filter((t) => t.publishable).length).toBe(
         context.publishableSubjectPageCount
       );
+    });
+
+    it("met en avant les sous-thèmes validés selon le nombre de candidatures", async () => {
+      const context = await loadHubMeasureContext(electionId, SLUG);
+
+      expect(context.featuredSubtopics).toContainEqual({
+        slug: `${SLUG}-acces-logement`,
+        label: "Accès au logement",
+        theme: THEME_LOGEMENT,
+        themeLabel: "Logement et urbanisme",
+        measureCount: 2,
+        candidacyCount: 2,
+      });
     });
 
     it("rend null pour une élection inconnue (getHubMeasureContext, avant la frontière cache)", async () => {

--- a/src/lib/data/__tests__/hub.integration.test.ts
+++ b/src/lib/data/__tests__/hub.integration.test.ts
@@ -186,7 +186,7 @@ describeIfDisposableDb("hub", () => {
       expect(context.featuredSubtopics).toContainEqual({
         slug: `${SLUG}-acces-logement`,
         label: "Accès au logement",
-        theme: THEME_LOGEMENT,
+        theme: "LOGEMENT_URBANISME",
         themeLabel: "Logement et urbanisme",
         measureCount: 2,
         candidacyCount: 2,

--- a/src/lib/data/__tests__/themes-index-featured-subtopics.test.ts
+++ b/src/lib/data/__tests__/themes-index-featured-subtopics.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { selectFeaturedSubtopics } from "@/lib/presidentielle/featured-subtopics";
+
+type MeasureInput = Parameters<typeof selectFeaturedSubtopics>[0][number];
+
+function measure({
+  id,
+  candidacyId,
+  theme,
+  subtopic,
+  withdrawn = false,
+}: {
+  id: string;
+  candidacyId: string | null;
+  theme: MeasureInput["theme"];
+  subtopic: { slug: string; label: string };
+  withdrawn?: boolean;
+}): MeasureInput {
+  return {
+    id,
+    candidacyId,
+    theme,
+    subtopics: [subtopic],
+    withdrawal: withdrawn
+      ? { withdrawnAt: new Date("2026-01-01"), sourceUrl: null, sourceLabel: null }
+      : null,
+  };
+}
+
+describe("selectFeaturedSubtopics", () => {
+  it("privilégie la diversité des candidatures au volume brut de mesures", () => {
+    const measures = [
+      ...Array.from({ length: 5 }, (_, index) =>
+        measure({
+          id: `volume-${index}`,
+          candidacyId: "candidature-a",
+          theme: "ECONOMIE_BUDGET",
+          subtopic: { slug: "fiscalite", label: "Fiscalité" },
+        })
+      ),
+      measure({
+        id: "diversite-a",
+        candidacyId: "candidature-a",
+        theme: "SANTE",
+        subtopic: { slug: "acces-aux-soins", label: "Accès aux soins" },
+      }),
+      measure({
+        id: "diversite-b",
+        candidacyId: "candidature-b",
+        theme: "SANTE",
+        subtopic: { slug: "acces-aux-soins", label: "Accès aux soins" },
+      }),
+    ];
+
+    expect(selectFeaturedSubtopics(measures).map((subtopic) => subtopic.slug)).toEqual([
+      "acces-aux-soins",
+      "fiscalite",
+    ]);
+  });
+
+  it("limite chaque grande thématique à deux entrées et ignore les retraits", () => {
+    const measures = [
+      measure({
+        id: "eco-1",
+        candidacyId: "a",
+        theme: "ECONOMIE_BUDGET",
+        subtopic: { slug: "fiscalite", label: "Fiscalité" },
+      }),
+      measure({
+        id: "eco-2",
+        candidacyId: "b",
+        theme: "ECONOMIE_BUDGET",
+        subtopic: { slug: "industrie", label: "Entreprises et industrie" },
+      }),
+      measure({
+        id: "eco-3",
+        candidacyId: "c",
+        theme: "ECONOMIE_BUDGET",
+        subtopic: { slug: "budget", label: "Budget de l'État" },
+      }),
+      measure({
+        id: "sante-retiree",
+        candidacyId: "d",
+        theme: "SANTE",
+        subtopic: { slug: "hopital", label: "Hôpital" },
+        withdrawn: true,
+      }),
+    ];
+
+    const selected = selectFeaturedSubtopics(measures);
+
+    expect(selected.filter((subtopic) => subtopic.theme === "ECONOMIE_BUDGET")).toHaveLength(2);
+    expect(selected.map((subtopic) => subtopic.slug)).not.toContain("hopital");
+  });
+});

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -8,6 +8,7 @@ import {
   type PublicPresidentialCandidacyFieldEntry,
 } from "./presidential-candidacy-field";
 import { loadThemesIndex } from "./themes-index";
+import type { FeaturedSubtopic } from "./themes-index";
 import { getLatestPresidentialReviewDate } from "./measures";
 
 /**
@@ -60,6 +61,8 @@ export type HubMeasureContext = {
   lastReviewedAt: Date | null;
   /** The thirteen subjects in reading order, so the hub can name them without a second read. */
   themes: HubTheme[];
+  /** A bounded, diversified set of human-approved subtopics for direct corpus exploration. */
+  featuredSubtopics: FeaturedSubtopic[];
 };
 
 /**
@@ -121,6 +124,7 @@ export async function loadHubMeasureContext(
       slug,
       publishable,
     })),
+    featuredSubtopics: themesIndex.featuredSubtopics,
   };
 }
 

--- a/src/lib/data/themes-index.ts
+++ b/src/lib/data/themes-index.ts
@@ -4,9 +4,15 @@ import type { ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { isSubjectPagePublishable } from "@/config/publication-gates";
 import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import {
+  selectFeaturedSubtopics,
+  type FeaturedSubtopic,
+} from "@/lib/presidentielle/featured-subtopics";
 import { getPresidentialThemeIndexOrder, themeToSlug } from "@/lib/presidentielle/themes";
 import { getPublicMeasuresByElection, type PublicMeasure } from "./measures";
 import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
+
+export type { FeaturedSubtopic } from "@/lib/presidentielle/featured-subtopics";
 
 /**
  * The read authority for the themes index / hub gate.
@@ -36,6 +42,7 @@ export type ThemeIndexEntry = {
 export type ThemesIndexData = {
   electionSlug: string;
   themes: ThemeIndexEntry[];
+  featuredSubtopics: FeaturedSubtopic[];
   publishableSubjectPageCount: number;
 };
 
@@ -89,6 +96,11 @@ export async function loadThemesIndex(
   return {
     electionSlug,
     themes,
+    featuredSubtopics: selectFeaturedSubtopics(
+      measures.filter(
+        (measure) => measure.candidacyId !== null && publicIds.has(measure.candidacyId)
+      )
+    ),
     publishableSubjectPageCount: themes.filter((t) => t.publishable).length,
   };
 }

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -76,7 +76,7 @@ describe("buildCandidateSynthesisPrompt", () => {
     expect(prompt).toContain("[M1] Rouvrir des maternités de proximité.");
   });
 
-  it("asks a large programme to cover its eight most represented themes", () => {
+  it("asks a large programme to cover its five most represented themes", () => {
     const themes = [
       "SANTE",
       "TRANSPORTS",
@@ -95,7 +95,7 @@ describe("buildCandidateSynthesisPrompt", () => {
     const prompt = buildCandidateSynthesisPrompt({ ...BASE, measures });
     const coverage = prompt.match(/<couverture_attendue>\n(.+)\n<\/couverture_attendue>/)?.[1];
 
-    expect(coverage?.match(/,/g)).toHaveLength(7);
+    expect(coverage?.match(/,/g)).toHaveLength(4);
     expect(coverage).not.toContain("Transports");
   });
 
@@ -165,8 +165,10 @@ describe("screenCandidateSynthesis", () => {
     const result = screenCandidateSynthesis(structured(["M1", "M3"]), BASE);
 
     expect(result).toMatchObject({ ok: true });
-    expect(result.ok && result.text).toContain("Rouvrir des maternités de proximité.");
-    expect(result.ok && result.text).toContain("Rétablir des trains de nuit sur six lignes.");
+    expect(result.ok && result.text).toContain(
+      "Parmi les mesures publiées figurent « Rouvrir des maternités de proximité » et « Rétablir des trains de nuit sur six lignes »."
+    );
+    expect(result.ok && result.text).not.toContain("engagements suivants");
     expect(result.ok && result.text).not.toMatch(/<engagement|<synthese>/);
   });
 
@@ -201,7 +203,7 @@ describe("screenCandidateSynthesis", () => {
       reason: "format_structure",
     });
     const accepted = screenCandidateSynthesis(structured(["M1"]), input);
-    expect(accepted.ok && accepted.text).toContain("Augmenter les impôts des entreprises.");
+    expect(accepted.ok && accepted.text).toContain("« Augmenter les impôts des entreprises »");
     expect(accepted.ok && accepted.text).not.toContain("Supprimer");
   });
 
@@ -253,7 +255,7 @@ describe("screenCandidateSynthesis", () => {
     const generated = `<synthese><parcours>${career}. Il a comparu devant un tribunal.</parcours><programme><engagement ref="M1" /></programme></synthese>`;
 
     expect(sourced).toMatchObject({ ok: true });
-    expect(sourced.ok && sourced.text).toContain("Créer un tribunal spécialisé.");
+    expect(sourced.ok && sourced.text).toContain("« Créer un tribunal spécialisé »");
     expect(screenCandidateSynthesis(generated, input)).toMatchObject({
       ok: false,
       reason: "judiciaire",
@@ -282,7 +284,7 @@ describe("screenCandidateSynthesis", () => {
     const result = screenCandidateSynthesis(structured(["M1"]), input);
 
     expect(result).toMatchObject({ ok: true });
-    expect(result.ok && result.text).toContain("source219.");
+    expect(result.ok && result.text).toContain("source219 »");
   });
 
   it("charges an optional second source from the same theme against the maximum", () => {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -172,6 +172,18 @@ describe("screenCandidateSynthesis", () => {
     expect(result.ok && result.text).not.toMatch(/<engagement|<synthese>/);
   });
 
+  it("preserves question and exclamation marks from published measures", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [{ theme: "SANTE", text: "Créer un droit opposable à la santé ?" }],
+    };
+    const result = screenCandidateSynthesis(structured(["M1"]), input);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain("« Créer un droit opposable à la santé ? »");
+    expect(result.ok && result.text).not.toContain("santé ».");
+  });
+
   it("refuses valid-length prose that omits an expected theme", () => {
     expect(screenCandidateSynthesis(structured(["M1"]), BASE)).toMatchObject({
       ok: false,

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -184,6 +184,18 @@ describe("screenCandidateSynthesis", () => {
     expect(result.ok && result.text).not.toContain("santé ».");
   });
 
+  it("preserves terminal ellipses from published measures", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [{ theme: "SANTE", text: "Créer des centres de santé..." }],
+    };
+    const result = screenCandidateSynthesis(structured(["M1"]), input);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain("« Créer des centres de santé... »");
+    expect(result.ok && result.text).not.toContain("santé... ».");
+  });
+
   it("refuses valid-length prose that omits an expected theme", () => {
     expect(screenCandidateSynthesis(structured(["M1"]), BASE)).toMatchObject({
       ok: false,

--- a/src/lib/presidentielle/__tests__/corpus-search.test.ts
+++ b/src/lib/presidentielle/__tests__/corpus-search.test.ts
@@ -3,13 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const findElection = vi.fn();
 const findCandidacies = vi.fn();
 const findMeasures = vi.fn();
+const findSubtopic = vi.fn();
+const listMeasures = vi.fn();
 const searchPublicPage = vi.fn();
 vi.mock("@/lib/db", () => ({
   db: {
     election: { findUnique: (...args: unknown[]) => findElection(...args) },
     candidacy: { findMany: (...args: unknown[]) => findCandidacies(...args) },
     measure: { findMany: (...args: unknown[]) => findMeasures(...args) },
+    measureSubtopic: { findUnique: (...args: unknown[]) => findSubtopic(...args) },
   },
+}));
+vi.mock("@/lib/data/measures", () => ({
+  listPublicPresidentialMeasures: (...args: unknown[]) => listMeasures(...args),
 }));
 vi.mock("@/lib/search/query", () => ({
   searchPublicPage: (...args: unknown[]) => searchPublicPage(...args),
@@ -100,6 +106,49 @@ describe("searchPresidentialCorpus", () => {
     const result = await searchPresidentialCorpus("presidentielle-test", "a", 8);
     expect(result).toMatchObject({ total: 0, subjects: [], candidacies: [], measures: [] });
     expect(searchPublicPage).not.toHaveBeenCalled();
+  });
+
+  it("filtre un sous-thème sur son rattachement validé et conserve la pagination", async () => {
+    findSubtopic.mockResolvedValue({
+      slug: "acces-aux-soins",
+      label: "Accès aux soins",
+      active: true,
+    });
+    listMeasures.mockResolvedValue({
+      total: 74,
+      data: [
+        {
+          measureId: "measure-subtopic",
+          text: "Ouvrir des centres de santé",
+          publicUrl: "/elections/presidentielle-test/mesures/ouvrir-des-centres-de-sante",
+          candidacy: { candidateName: "Alice Martin" },
+          theme: { code: "SANTE" },
+          precision: { code: null },
+          sources: [{ sourceKind: "PROGRAMME_CANDIDAT" }],
+        },
+      ],
+    });
+
+    const result = await searchPresidentialCorpus("presidentielle-test", "", 50, {
+      subtopicSlug: "acces-aux-soins",
+      page: 2,
+    });
+
+    expect(listMeasures).toHaveBeenCalledWith({
+      electionId: "election-1",
+      electionSlug: "presidentielle-test",
+      subtopicSlug: "acces-aux-soins",
+      page: 2,
+      limit: 50,
+    });
+    expect(searchPublicPage).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      query: "Accès aux soins",
+      total: 74,
+      page: 2,
+      totalPages: 2,
+      filter: { type: "subtopic", slug: "acces-aux-soins", label: "Accès aux soins" },
+    });
   });
 
   it("retire la formulation d’une question avant la recherche lexicale", async () => {

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -339,15 +339,14 @@ function formatFrenchList(values: string[]): string {
   return `${values.slice(0, -1).join(", ")} et ${values.at(-1)}`;
 }
 
-function sourceTextWithoutTerminalPunctuation(value: string): string {
-  return value.replace(/[.!?]+$/u, "");
+function sourceTextForQuote(value: string): string {
+  return value.replace(/[.]+$/u, "");
 }
 
 function formatProgrammeText(references: ProgrammeReference[]): string {
-  const quotedMeasures = references.map(
-    (reference) => `« ${sourceTextWithoutTerminalPunctuation(reference.text)} »`
-  );
-  return `Parmi les mesures publiées figurent ${formatFrenchList(quotedMeasures)}.`;
+  const quotedMeasures = references.map((reference) => `« ${sourceTextForQuote(reference.text)} »`);
+  const terminalPunctuation = /[!?] »$/u.test(quotedMeasures.at(-1) ?? "") ? "" : ".";
+  return `Parmi les mesures publiées figurent ${formatFrenchList(quotedMeasures)}${terminalPunctuation}`;
 }
 
 function wordCount(value: string): number {
@@ -483,7 +482,7 @@ export function screenCandidateSynthesis(
     (theme) =>
       selectedReferences
         .filter((reference) => reference.theme === theme)
-        .map((reference) => sourceTextWithoutTerminalPunctuation(reference.text))
+        .map((reference) => sourceTextForQuote(reference.text))
         .sort((a, b) => wordCount(a) - wordCount(b))[0]!
   );
   return screenSynthesis({

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -340,12 +340,12 @@ function formatFrenchList(values: string[]): string {
 }
 
 function sourceTextForQuote(value: string): string {
-  return value.replace(/[.]+$/u, "");
+  return value.replace(/(?<!\.)\.$/u, "");
 }
 
 function formatProgrammeText(references: ProgrammeReference[]): string {
   const quotedMeasures = references.map((reference) => `« ${sourceTextForQuote(reference.text)} »`);
-  const terminalPunctuation = /[!?] »$/u.test(quotedMeasures.at(-1) ?? "") ? "" : ".";
+  const terminalPunctuation = /(?:[!?…]|\.\.\.) »$/u.test(quotedMeasures.at(-1) ?? "") ? "" : ".";
   return `Parmi les mesures publiées figurent ${formatFrenchList(quotedMeasures)}${terminalPunctuation}`;
 }
 

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -43,7 +43,7 @@ const FIELD_LIMIT = 240;
  * the tightest margin being 27 words against a floor of 25.
  */
 export const SYNTHESIS_MAX_WORDS = 200;
-/** Eight programme themes plus a career paragraph fit without turning into a list. */
+/** Five programme themes plus a career paragraph fit without turning into a catalogue. */
 export const LARGE_SYNTHESIS_MAX_WORDS = 250;
 /** Below one hundred measures, the existing 200-word format already carries the material. */
 export const LARGE_PROGRAMME_MEASURES = 100;
@@ -243,8 +243,9 @@ function buildProgrammePlan(input: CandidateSynthesisInput): ProgrammePlan {
   );
   // Theme frequency is context, not an editorial ranking. It gives a stable, candidate-agnostic
   // answer to “principal themes” while the explicit cap prevents the largest family swallowing the
-  // paragraph. Eight short examples fit the large 250-word format; five fit the standard one.
-  const coverageLimit = input.measures.length >= LARGE_PROGRAMME_MEASURES ? 8 : 5;
+  // paragraph. Five examples fit the large 250-word format; three fit the standard one. A longer
+  // selection reads like an extraction dump rather than a summary, especially on mobile.
+  const coverageLimit = input.measures.length >= LARGE_PROGRAMME_MEASURES ? 5 : 3;
   return {
     references,
     expectedThemes: themes.slice(0, coverageLimit).map(([theme]) => theme),
@@ -332,8 +333,21 @@ export type SynthesisScreen =
 export const EMPTY_PROGRAMME_SENTENCE =
   "Aucune mesure n'est publiée dans le cadre de son programme.";
 
-function asSentence(value: string): string {
-  return /[.!?]$/u.test(value) ? value : `${value}.`;
+function formatFrenchList(values: string[]): string {
+  if (values.length <= 1) return values[0] ?? "";
+  if (values.length === 2) return `${values[0]} et ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")} et ${values.at(-1)}`;
+}
+
+function sourceTextWithoutTerminalPunctuation(value: string): string {
+  return value.replace(/[.!?]+$/u, "");
+}
+
+function formatProgrammeText(references: ProgrammeReference[]): string {
+  const quotedMeasures = references.map(
+    (reference) => `« ${sourceTextWithoutTerminalPunctuation(reference.text)} »`
+  );
+  return `Parmi les mesures publiées figurent ${formatFrenchList(quotedMeasures)}.`;
 }
 
 function wordCount(value: string): number {
@@ -461,9 +475,7 @@ export function screenCandidateSynthesis(
     }
   }
 
-  const programmeText = `Son programme comprend notamment les engagements suivants. ${selectedReferences
-    .map((reference) => asSentence(reference.text))
-    .join(" ")}`;
+  const programmeText = formatProgrammeText(selectedReferences);
   // Coverage needs one measure per expected theme, never every measure the provider selected. When
   // it chose two, exempt the shorter one: the second is optional and remains inside the cap. Text
   // from a non-required theme is optional too and is never deducted.
@@ -471,7 +483,7 @@ export function screenCandidateSynthesis(
     (theme) =>
       selectedReferences
         .filter((reference) => reference.theme === theme)
-        .map((reference) => asSentence(reference.text))
+        .map((reference) => sourceTextWithoutTerminalPunctuation(reference.text))
         .sort((a, b) => wordCount(a) - wordCount(b))[0]!
   );
   return screenSynthesis({

--- a/src/lib/presidentielle/corpus-search.ts
+++ b/src/lib/presidentielle/corpus-search.ts
@@ -7,6 +7,7 @@ import type {
   ThemeCategory,
 } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { listPublicPresidentialMeasures } from "@/lib/data/measures";
 import { searchPublicPage } from "@/lib/search/query";
 import { toPresidentialLexicalQuery } from "@/lib/presidentielle/natural-query";
 import {
@@ -57,6 +58,14 @@ export type PresidentialCorpusSearchResult = {
   subjects: PresidentialSubjectSearchResult[];
   candidacies: PresidentialCandidacySearchResult[];
   measures: PresidentialMeasureSearchResult[];
+  filter?: { type: "subtopic"; slug: string; label: string };
+  page?: number;
+  totalPages?: number;
+};
+
+export type PresidentialCorpusSearchOptions = {
+  subtopicSlug?: string;
+  page?: number;
 };
 
 function clampLimit(limit: number): number {
@@ -72,7 +81,8 @@ function clampLimit(limit: number): number {
 export async function searchPresidentialCorpus(
   electionSlug: string,
   rawQuery: string,
-  limit = 12
+  limit = 12,
+  options: PresidentialCorpusSearchOptions = {}
 ): Promise<PresidentialCorpusSearchResult | null> {
   const query = rawQuery.trim().slice(0, 200);
   const election = await db.election.findUnique({
@@ -80,6 +90,60 @@ export async function searchPresidentialCorpus(
     select: { id: true, slug: true },
   });
   if (election === null) return null;
+
+  const subtopicSlug = options.subtopicSlug?.trim().slice(0, 100);
+  if (subtopicSlug) {
+    const subtopic = await db.measureSubtopic.findUnique({
+      where: { slug: subtopicSlug },
+      select: { slug: true, label: true, active: true },
+    });
+    if (subtopic === null || !subtopic.active) {
+      return { query: "", total: 0, subjects: [], candidacies: [], measures: [] };
+    }
+
+    let page = Math.min(Math.max(Math.trunc(options.page ?? 1), 1), 1_000);
+    const pageSize = clampLimit(limit);
+    let measurePage = await listPublicPresidentialMeasures({
+      electionId: election.id,
+      electionSlug: election.slug,
+      subtopicSlug: subtopic.slug,
+      page,
+      limit: pageSize,
+    });
+    const totalPages = Math.max(1, Math.ceil(measurePage.total / pageSize));
+    if (page > totalPages) {
+      page = totalPages;
+      measurePage = await listPublicPresidentialMeasures({
+        electionId: election.id,
+        electionSlug: election.slug,
+        subtopicSlug: subtopic.slug,
+        page,
+        limit: pageSize,
+      });
+    }
+    const measures: PresidentialMeasureSearchResult[] = measurePage.data.map((measure) => ({
+      type: "measure",
+      id: measure.measureId,
+      text: measure.text,
+      url: measure.publicUrl,
+      candidateName: measure.candidacy.candidateName,
+      theme: measure.theme.code,
+      precision: measure.precision.code,
+      sourceLabel: measure.sources[0]?.sourceKind ?? null,
+    }));
+
+    return {
+      query: subtopic.label,
+      total: measurePage.total,
+      subjects: [],
+      candidacies: [],
+      measures,
+      filter: { type: "subtopic", slug: subtopic.slug, label: subtopic.label },
+      page,
+      totalPages,
+    };
+  }
+
   if (query.length < 2) {
     return { query, total: 0, subjects: [], candidacies: [], measures: [] };
   }

--- a/src/lib/presidentielle/featured-subtopics.ts
+++ b/src/lib/presidentielle/featured-subtopics.ts
@@ -1,0 +1,82 @@
+import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+
+export type FeaturedSubtopic = {
+  slug: string;
+  label: string;
+  theme: ThemeCategory;
+  themeLabel: string;
+  measureCount: number;
+  candidacyCount: number;
+};
+
+export type FeaturedSubtopicMeasure = {
+  id: string;
+  withdrawal: unknown | null;
+  candidacyId: string | null;
+  theme: ThemeCategory;
+  subtopics: Array<{ slug: string; label: string }>;
+};
+
+const FEATURED_SUBTOPIC_LIMIT = 10;
+const FEATURED_SUBTOPICS_PER_THEME = 2;
+
+/**
+ * A compact browse entry point, never a word cloud. Font size and colour stay constant because a
+ * frequency is a property of the current corpus, not a measure of political importance. Ranking by
+ * distinct candidacies before raw volume also prevents one very long programme from filling the
+ * home page with its own vocabulary. The per-theme cap keeps the entry points varied.
+ */
+export function selectFeaturedSubtopics(measures: FeaturedSubtopicMeasure[]): FeaturedSubtopic[] {
+  const candidates = new Map<
+    string,
+    {
+      slug: string;
+      label: string;
+      theme: ThemeCategory;
+      measureIds: Set<string>;
+      candidacyIds: Set<string>;
+    }
+  >();
+
+  for (const measure of measures) {
+    if (measure.withdrawal !== null || measure.candidacyId === null) continue;
+    for (const subtopic of measure.subtopics) {
+      const current = candidates.get(subtopic.slug) ?? {
+        slug: subtopic.slug,
+        label: subtopic.label,
+        theme: measure.theme,
+        measureIds: new Set<string>(),
+        candidacyIds: new Set<string>(),
+      };
+      current.measureIds.add(measure.id);
+      current.candidacyIds.add(measure.candidacyId);
+      candidates.set(subtopic.slug, current);
+    }
+  }
+
+  const ranked = [...candidates.values()].sort(
+    (a, b) =>
+      b.candidacyIds.size - a.candidacyIds.size ||
+      b.measureIds.size - a.measureIds.size ||
+      a.label.localeCompare(b.label, "fr")
+  );
+  const perTheme = new Map<ThemeCategory, number>();
+  const selected: FeaturedSubtopic[] = [];
+
+  for (const subtopic of ranked) {
+    if ((perTheme.get(subtopic.theme) ?? 0) >= FEATURED_SUBTOPICS_PER_THEME) continue;
+    selected.push({
+      slug: subtopic.slug,
+      label: subtopic.label,
+      theme: subtopic.theme,
+      themeLabel: THEME_CATEGORY_LABELS[subtopic.theme],
+      measureCount: subtopic.measureIds.size,
+      candidacyCount: subtopic.candidacyIds.size,
+    });
+    perTheme.set(subtopic.theme, (perTheme.get(subtopic.theme) ?? 0) + 1);
+    if (selected.length === FEATURED_SUBTOPIC_LIMIT) break;
+  }
+
+  return selected;
+}

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -37,7 +37,7 @@ const providerOutput = (refs: string[], career = CAREER) =>
     .join("")}</programme></synthese>`;
 /** Internal provider output and the reader-facing text obtained after evidence screening. */
 const ACCEPTED = providerOutput(["M1"]);
-const STORED = `${CAREER}.\n\nSon programme comprend notamment les engagements suivants. Rouvrir des maternités de proximité.`;
+const STORED = `${CAREER}.\n\nParmi les mesures publiées figurent « Rouvrir des maternités de proximité ».`;
 
 function anthropicText(text: string) {
   return { content: [{ type: "text", text }] };
@@ -256,7 +256,7 @@ describe("generateCandidateSynthesis", () => {
     expect(result).toMatchObject({ ok: true });
     expect(callAnthropicMock).toHaveBeenCalledTimes(2);
     const stored = dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis as string;
-    expect(stored).toContain("Augmenter les impôts des entreprises.");
+    expect(stored).toContain("« Augmenter les impôts des entreprises »");
     expect(stored).not.toContain("Supprimer");
   });
 
@@ -304,7 +304,7 @@ describe("generateCandidateSynthesis", () => {
     const retryPrompt = callAnthropicMock.mock.calls[1]![0][0].content as string;
     expect(retryPrompt).toContain("mention « tribunal »");
     expect(dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis).toContain(
-      "Créer un tribunal spécialisé."
+      "« Créer un tribunal spécialisé »"
     );
   });
 
@@ -335,7 +335,7 @@ describe("generateCandidateSynthesis", () => {
     expect(result).toMatchObject({ ok: true });
     expect(callAnthropicMock).toHaveBeenCalledTimes(1);
     expect(dbMock.candidacyPresidential.update.mock.calls[0]![0].data.synthesis).toContain(
-      "source219."
+      "source219 »"
     );
   });
 


### PR DESCRIPTION
## Objectif

Rendre le corpus présidentiel plus facile à explorer, améliorer les résumés candidats et faire de la page Programmes un véritable point entrée vers la présidentielle 2027.

## Changements

- ajoute au hub une sélection compacte de sous-thèmes validés, de poids visuel égal
- classe les sous-thèmes par nombre de candidatures puis par volume, avec deux entrées maximum par grande thématique
- remplace les listes de mesures des résumés par une phrase composée uniquement à partir de formulations publiées
- limite la couverture à trois mesures en temps normal et cinq pour les très gros corpus
- recentre les métadonnées et le contenu de /programmes sur la présidentielle 2027
- ajoute les chiffres du corpus et des accès directs au hub, aux candidats et aux thèmes
- conserve séparément les derniers programmes documentés par parti

## Vérifications

- npm run typecheck
- npm run lint
- 80 tests ciblés
- rendu Playwright contrôlé sur desktop et mobile

## Données

Aucune donnée de production ni aucun schéma Prisma ne sont modifiés par cette PR. La correction du mouvement de campagne de Karim Bouamrane et la régénération de sa synthèse feront l objet du rituel de mutation de production après merge.