### PR TITLE
feat(admin): piloter l’enrichissement des mesures 2027

### DIFF
--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -180,6 +180,25 @@ describe("accès aux écrans de modération des mesures", () => {
     });
   });
 
+  it("transmet le périmètre public présidentiel à la file", async () => {
+    isAuthenticatedMock.mockResolvedValue(true);
+    const { default: QueuePage } = await import("../page");
+
+    await QueuePage({
+      searchParams: Promise.resolve({
+        corpus: "presidentielle-2027",
+        enrichissement: "DETAILS_MISSING",
+      }),
+    });
+
+    expect(queryMeasureQueueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enrichment: "DETAILS_MISSING",
+        publicCorpus: "PRESIDENTIELLE_2027",
+      })
+    );
+  });
+
   it("garde les trois écrans hors des index", async () => {
     // A crawled admin page would publish unreviewed editorial text under our name.
     const queue = await import("../page");

--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -32,6 +32,15 @@ const listMeasureQueueCandidatesMock = vi.fn(async () => []);
 const queryBatchReviewGroupsMock = vi.fn(async (_filters?: unknown) => []);
 const queryBatchPublishGroupsMock = vi.fn(async (_filters?: unknown) => []);
 const filterMeasureContextCandidateIdsMock = vi.fn(async (_ids?: string[]) => []);
+const queryMeasureEnrichmentCoverageMock = vi.fn(async () => ({
+  total: 0,
+  withDetails: 0,
+  withApprovedSubtopics: 0,
+  withQualifications: 0,
+  withVoteLinks: 0,
+  withSourceLocation: 0,
+  withHistory: 0,
+}));
 
 vi.mock("next/navigation", () => ({
   redirect: (path: string) => redirectMock(path),
@@ -62,6 +71,10 @@ vi.mock("../_data/batch-publish-query", () => ({
 
 vi.mock("../_data/batch-review-query", () => ({
   queryBatchReviewGroups: (filters: unknown) => queryBatchReviewGroupsMock(filters),
+}));
+
+vi.mock("../_data/enrichment-coverage-query", () => ({
+  queryMeasureEnrichmentCoverage: () => queryMeasureEnrichmentCoverageMock(),
 }));
 
 vi.mock("../_data/detail-query", () => ({
@@ -114,6 +127,7 @@ describe("accès aux écrans de modération des mesures", () => {
     expect(queryBatchReviewGroupsMock).not.toHaveBeenCalled();
     expect(queryBatchPublishGroupsMock).not.toHaveBeenCalled();
     expect(filterMeasureContextCandidateIdsMock).not.toHaveBeenCalled();
+    expect(queryMeasureEnrichmentCoverageMock).not.toHaveBeenCalled();
   });
 
   it("redirige le détail vers la connexion en l'absence de session", async () => {
@@ -146,6 +160,7 @@ describe("accès aux écrans de modération des mesures", () => {
     expect(listMeasureQueueCandidatesMock).toHaveBeenCalledTimes(1);
     expect(queryBatchReviewGroupsMock).toHaveBeenCalledTimes(1);
     expect(queryBatchPublishGroupsMock).toHaveBeenCalledTimes(1);
+    expect(queryMeasureEnrichmentCoverageMock).toHaveBeenCalledTimes(1);
   });
 
   it("transmet le filtre de candidature à toute la file et aux deux actions par lot", async () => {

--- a/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
+++ b/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import type { MeasureEnrichmentCoverage } from "../_data/enrichment-coverage-query";
+
+function percentage(value: number, total: number): string {
+  if (total === 0) return "0 %";
+  return `${Math.round((value / total) * 100)} %`;
+}
+
+const METRICS: Array<{
+  key: Exclude<keyof MeasureEnrichmentCoverage, "total">;
+  label: string;
+  help: string;
+}> = [
+  {
+    key: "withDetails",
+    label: "Contexte rédigé",
+    help: "La fiche explique ce que prévoit la mesure à partir de sa source.",
+  },
+  {
+    key: "withApprovedSubtopics",
+    label: "Sous-thèmes validés",
+    help: "Au moins un rattachement éditorial validé.",
+  },
+  {
+    key: "withSourceLocation",
+    label: "Source localisée",
+    help: "Au moins une page ou une section est indiquée dans la source.",
+  },
+  {
+    key: "withQualifications",
+    label: "Qualifications",
+    help: "Au moins une conclusion éditoriale datée et justifiée.",
+  },
+  {
+    key: "withVoteLinks",
+    label: "Votes rapprochés",
+    help: "Au moins un rapprochement parlementaire a été vérifié.",
+  },
+  {
+    key: "withHistory",
+    label: "Historique",
+    help: "La mesure est reliée à une formulation antérieure ou ultérieure.",
+  },
+];
+
+export function EnrichmentCoveragePanel({ coverage }: { coverage: MeasureEnrichmentCoverage }) {
+  const missingDetails = Math.max(0, coverage.total - coverage.withDetails);
+
+  return (
+    <section aria-labelledby="coverage-heading" className="rounded-lg border border-border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="coverage-heading" className="font-display text-lg font-bold">
+            Couverture des fiches publiques 2027
+          </h2>
+          <p className="mt-1 max-w-3xl text-sm leading-relaxed text-muted-foreground-strong">
+            Compteurs exacts sur {coverage.total.toLocaleString("fr-FR")} mesures actuellement
+            visibles. Ils ne dépendent ni des filtres ni de la limite de la file de modération.
+          </p>
+        </div>
+        {missingDetails > 0 ? (
+          <Link
+            href="/admin/mesures?enrichissement=DETAILS_MISSING"
+            prefetch={false}
+            className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Compléter {missingDetails.toLocaleString("fr-FR")} contextes
+          </Link>
+        ) : null}
+      </div>
+
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {METRICS.map((metric) => {
+          const value = coverage[metric.key];
+          return (
+            <div key={metric.key} className="rounded-md bg-muted/50 p-3">
+              <dt className="text-sm font-medium">{metric.label}</dt>
+              <dd className="mt-1 flex items-baseline gap-2">
+                <span className="font-display text-2xl font-bold">
+                  {value.toLocaleString("fr-FR")}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {percentage(value, coverage.total)}
+                </span>
+              </dd>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{metric.help}</p>
+            </div>
+          );
+        })}
+      </dl>
+    </section>
+  );
+}

--- a/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
+++ b/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
@@ -60,7 +60,7 @@ export function EnrichmentCoveragePanel({ coverage }: { coverage: MeasureEnrichm
         </div>
         {missingDetails > 0 ? (
           <Link
-            href="/admin/mesures?enrichissement=DETAILS_MISSING"
+            href="/admin/mesures?corpus=presidentielle-2027&enrichissement=DETAILS_MISSING"
             prefetch={false}
             className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
           >

--- a/src/app/admin/mesures/_components/QueueFilters.tsx
+++ b/src/app/admin/mesures/_components/QueueFilters.tsx
@@ -25,6 +25,7 @@ export type QueueFilterState = {
   enrichment: EnrichmentState | undefined;
   withdrawn: "only" | "exclude" | undefined;
   q: string | undefined;
+  publicCorpus: "PRESIDENTIELLE_2027" | undefined;
 };
 
 const BASE_PATH = "/admin/mesures";
@@ -53,6 +54,9 @@ function hrefWith(current: QueueFilterState, patch: Partial<QueueFilterState>): 
   if (next.enrichment) params.set("enrichissement", next.enrichment);
   if (next.withdrawn) params.set("retrait", next.withdrawn);
   if (next.q) params.set("q", next.q);
+  if (next.publicCorpus === "PRESIDENTIELLE_2027") {
+    params.set("corpus", "presidentielle-2027");
+  }
 
   const query = params.toString();
   return query === "" ? BASE_PATH : `${BASE_PATH}?${query}`;
@@ -244,6 +248,9 @@ export function QueueFilters({
           <input type="hidden" name="enrichissement" value={current.enrichment} />
         )}
         {current.withdrawn && <input type="hidden" name="retrait" value={current.withdrawn} />}
+        {current.publicCorpus === "PRESIDENTIELLE_2027" ? (
+          <input type="hidden" name="corpus" value="presidentielle-2027" />
+        ) : null}
 
         <div className="flex-1">
           <label

--- a/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
@@ -26,7 +26,7 @@ describe("EnrichmentCoveragePanel", () => {
     expect(screen.getByText("58 %")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Compléter 2.102 contextes/ })).toHaveAttribute(
       "href",
-      "/admin/mesures?enrichissement=DETAILS_MISSING"
+      "/admin/mesures?corpus=presidentielle-2027&enrichissement=DETAILS_MISSING"
     );
   });
 

--- a/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EnrichmentCoveragePanel } from "../EnrichmentCoveragePanel";
+
+describe("EnrichmentCoveragePanel", () => {
+  it("présente la couverture et une action accessible vers les contextes manquants", () => {
+    render(
+      <EnrichmentCoveragePanel
+        coverage={{
+          total: 2200,
+          withDetails: 98,
+          withApprovedSubtopics: 982,
+          withQualifications: 0,
+          withVoteLinks: 0,
+          withSourceLocation: 1277,
+          withHistory: 0,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Couverture des fiches publiques 2027" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("4 %")).toBeInTheDocument();
+    expect(screen.getByText("45 %")).toBeInTheDocument();
+    expect(screen.getByText("58 %")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Compléter 2.102 contextes/ })).toHaveAttribute(
+      "href",
+      "/admin/mesures?enrichissement=DETAILS_MISSING"
+    );
+  });
+
+  it("ne propose plus l’action quand tous les contextes sont renseignés", () => {
+    render(
+      <EnrichmentCoveragePanel
+        coverage={{
+          total: 2,
+          withDetails: 2,
+          withApprovedSubtopics: 2,
+          withQualifications: 0,
+          withVoteLinks: 0,
+          withSourceLocation: 2,
+          withHistory: 0,
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: /Compléter/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
@@ -21,6 +21,7 @@ const CURRENT: QueueFilterState = {
   enrichment: "SUBTOPICS_PENDING",
   withdrawn: "exclude",
   q: "hôpital",
+  publicCorpus: undefined,
 };
 
 const CANDIDATES = [
@@ -79,5 +80,21 @@ describe("QueueFilters", () => {
       "true"
     );
     expect(screen.getByRole("link", { name: "Contexte à compléter 8" })).toBeInTheDocument();
+  });
+
+  it("conserve le périmètre du corpus public dans les liens et la recherche", () => {
+    const { container } = render(
+      <QueueFilters
+        current={{ ...CURRENT, publicCorpus: "PRESIDENTIELLE_2027" }}
+        result={RESULT}
+        candidates={CANDIDATES}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Camille Exemple" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("corpus=presidentielle-2027")
+    );
+    expect(container.querySelector('input[name="corpus"]')).toHaveValue("presidentielle-2027");
   });
 });

--- a/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { countMock } = vi.hoisted(() => ({ countMock: vi.fn() }));
+const { measureCountMock, revisionCountMock } = vi.hoisted(() => ({
+  measureCountMock: vi.fn(),
+  revisionCountMock: vi.fn(),
+}));
 
 vi.mock("@/lib/db", () => ({
-  db: { measure: { count: countMock } },
+  db: {
+    measure: { count: measureCountMock },
+    measureRevision: { count: revisionCountMock },
+  },
 }));
 
 import { queryMeasureEnrichmentCoverage } from "../enrichment-coverage-query";
@@ -14,14 +20,14 @@ describe("queryMeasureEnrichmentCoverage", () => {
   });
 
   it("retourne les sept compteurs exacts du corpus public", async () => {
-    countMock
+    measureCountMock
       .mockResolvedValueOnce(2200)
       .mockResolvedValueOnce(98)
       .mockResolvedValueOnce(982)
       .mockResolvedValueOnce(12)
-      .mockResolvedValueOnce(8)
       .mockResolvedValueOnce(1277)
       .mockResolvedValueOnce(4);
+    revisionCountMock.mockResolvedValueOnce(8);
 
     await expect(queryMeasureEnrichmentCoverage()).resolves.toEqual({
       total: 2200,
@@ -33,8 +39,9 @@ describe("queryMeasureEnrichmentCoverage", () => {
       withHistory: 4,
     });
 
-    expect(countMock).toHaveBeenCalledTimes(7);
-    for (const [request] of countMock.mock.calls) {
+    expect(measureCountMock).toHaveBeenCalledTimes(6);
+    expect(revisionCountMock).toHaveBeenCalledOnce();
+    for (const [request] of measureCountMock.mock.calls) {
       expect(request.where).toEqual(
         expect.objectContaining({
           election: { slug: "presidentielle-2027" },
@@ -46,11 +53,12 @@ describe("queryMeasureEnrichmentCoverage", () => {
   });
 
   it("compte uniquement les sous-thèmes validés et actifs", async () => {
-    countMock.mockResolvedValue(0);
+    measureCountMock.mockResolvedValue(0);
+    revisionCountMock.mockResolvedValue(0);
 
     await queryMeasureEnrichmentCoverage();
 
-    expect(countMock).toHaveBeenNthCalledWith(
+    expect(measureCountMock).toHaveBeenNthCalledWith(
       3,
       expect.objectContaining({
         where: expect.objectContaining({
@@ -64,5 +72,24 @@ describe("queryMeasureEnrichmentCoverage", () => {
         }),
       })
     );
+  });
+
+  it("compte uniquement les votes applicables à la révision publiée", async () => {
+    measureCountMock.mockResolvedValue(0);
+    revisionCountMock.mockResolvedValue(0);
+
+    await queryMeasureEnrichmentCoverage();
+
+    expect(revisionCountMock).toHaveBeenCalledWith({
+      where: {
+        publishedOf: {
+          is: expect.objectContaining({
+            election: { slug: "presidentielle-2027" },
+            publicationStatus: "PUBLISHED",
+          }),
+        },
+        applicableVoteLinks: { some: {} },
+      },
+    });
   });
 });

--- a/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { countMock } = vi.hoisted(() => ({ countMock: vi.fn() }));
+
+vi.mock("@/lib/db", () => ({
+  db: { measure: { count: countMock } },
+}));
+
+import { queryMeasureEnrichmentCoverage } from "../enrichment-coverage-query";
+
+describe("queryMeasureEnrichmentCoverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retourne les sept compteurs exacts du corpus public", async () => {
+    countMock
+      .mockResolvedValueOnce(2200)
+      .mockResolvedValueOnce(98)
+      .mockResolvedValueOnce(982)
+      .mockResolvedValueOnce(12)
+      .mockResolvedValueOnce(8)
+      .mockResolvedValueOnce(1277)
+      .mockResolvedValueOnce(4);
+
+    await expect(queryMeasureEnrichmentCoverage()).resolves.toEqual({
+      total: 2200,
+      withDetails: 98,
+      withApprovedSubtopics: 982,
+      withQualifications: 12,
+      withVoteLinks: 8,
+      withSourceLocation: 1277,
+      withHistory: 4,
+    });
+
+    expect(countMock).toHaveBeenCalledTimes(7);
+    for (const [request] of countMock.mock.calls) {
+      expect(request.where).toEqual(
+        expect.objectContaining({
+          election: { slug: "presidentielle-2027" },
+          publicationStatus: "PUBLISHED",
+          withdrawnAt: null,
+        })
+      );
+    }
+  });
+
+  it("compte uniquement les sous-thèmes validés et actifs", async () => {
+    countMock.mockResolvedValue(0);
+
+    await queryMeasureEnrichmentCoverage();
+
+    expect(countMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          publishedRevision: {
+            is: expect.objectContaining({
+              subtopics: {
+                some: { status: "APPROVED", subtopic: { active: true } },
+              },
+            }),
+          },
+        }),
+      })
+    );
+  });
+});

--- a/src/app/admin/mesures/_data/enrichment-coverage-query.ts
+++ b/src/app/admin/mesures/_data/enrichment-coverage-query.ts
@@ -65,7 +65,12 @@ export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmen
     db.measure.count({
       where: withPublishedRevision({ qualifications: { some: {} } }),
     }),
-    db.measure.count({ where: { ...base, voteLinks: { some: {} } } }),
+    db.measureRevision.count({
+      where: {
+        publishedOf: { is: base },
+        applicableVoteLinks: { some: {} },
+      },
+    }),
     db.measure.count({
       where: withPublishedRevision({ sources: { some: { page: { not: null } } } }),
     }),

--- a/src/app/admin/mesures/_data/enrichment-coverage-query.ts
+++ b/src/app/admin/mesures/_data/enrichment-coverage-query.ts
@@ -1,0 +1,89 @@
+import type { Prisma } from "@/generated/prisma";
+import { db } from "@/lib/db";
+import {
+  PUBLIC_MEASURE_REVISION_WHERE,
+  PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+} from "@/lib/presidentielle/publication";
+
+const PRESIDENTIAL_ELECTION_SLUG = "presidentielle-2027";
+
+export type MeasureEnrichmentCoverage = {
+  total: number;
+  withDetails: number;
+  withApprovedSubtopics: number;
+  withQualifications: number;
+  withVoteLinks: number;
+  withSourceLocation: number;
+  withHistory: number;
+};
+
+function publicMeasureWhere(): Prisma.MeasureWhereInput {
+  return {
+    election: { slug: PRESIDENTIAL_ELECTION_SLUG },
+    ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+  };
+}
+
+function withPublishedRevision(
+  condition: Prisma.MeasureRevisionWhereInput
+): Prisma.MeasureWhereInput {
+  return {
+    ...publicMeasureWhere(),
+    // Reapply the shared public revision gate because this condition replaces the relation
+    // predicate carried by PUBLIC_PRESIDENTIAL_MEASURE_WHERE.
+    publishedRevision: {
+      is: {
+        ...PUBLIC_MEASURE_REVISION_WHERE,
+        ...condition,
+      },
+    },
+  };
+}
+
+/** Exact coverage of the public presidential measure corpus, independent of queue pagination. */
+export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmentCoverage> {
+  const base = publicMeasureWhere();
+
+  const [
+    total,
+    withDetails,
+    withApprovedSubtopics,
+    withQualifications,
+    withVoteLinks,
+    withSourceLocation,
+    withHistory,
+  ] = await Promise.all([
+    db.measure.count({ where: base }),
+    db.measure.count({ where: withPublishedRevision({ details: { not: null } }) }),
+    db.measure.count({
+      where: withPublishedRevision({
+        subtopics: {
+          some: { status: "APPROVED", subtopic: { active: true } },
+        },
+      }),
+    }),
+    db.measure.count({
+      where: withPublishedRevision({ qualifications: { some: {} } }),
+    }),
+    db.measure.count({ where: { ...base, voteLinks: { some: {} } } }),
+    db.measure.count({
+      where: withPublishedRevision({ sources: { some: { page: { not: null } } } }),
+    }),
+    db.measure.count({
+      where: {
+        ...base,
+        OR: [{ precedingMeasureId: { not: null } }, { followingMeasures: { some: {} } }],
+      },
+    }),
+  ]);
+
+  return {
+    total,
+    withDetails,
+    withApprovedSubtopics,
+    withQualifications,
+    withVoteLinks,
+    withSourceLocation,
+    withHistory,
+  };
+}

--- a/src/app/admin/mesures/_data/queue-query.ts
+++ b/src/app/admin/mesures/_data/queue-query.ts
@@ -1,5 +1,6 @@
 import type { Prisma, ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
+import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
 import {
   deriveModerationState,
   MODERATION_MEASURE_SELECT,
@@ -41,6 +42,7 @@ export type MeasureQueueFilters = {
   withdrawn?: "only" | "exclude";
   anomaliesOnly?: boolean;
   enrichment?: EnrichmentState;
+  publicCorpus?: "PRESIDENTIELLE_2027";
   q?: string;
   take?: number;
   skip?: number;
@@ -111,6 +113,13 @@ function clampSkip(skip: number | undefined): number {
 function buildWhere(filters: MeasureQueueFilters): Prisma.MeasureWhereInput {
   const where: Prisma.MeasureWhereInput = {};
 
+  if (filters.publicCorpus === "PRESIDENTIELLE_2027") {
+    Object.assign(where, {
+      election: { slug: "presidentielle-2027" },
+      ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+    });
+  }
+
   if (filters.theme && filters.theme.length > 0) where.theme = { in: filters.theme };
   if (filters.electionId) where.electionId = filters.electionId;
   if (filters.candidacyId) where.candidacyId = filters.candidacyId;
@@ -124,6 +133,24 @@ function buildWhere(filters: MeasureQueueFilters): Prisma.MeasureWhereInput {
     // the substring behaviour the index refuses to give.
     const like = filters.q.trim();
     where.revisions = { some: { text: { contains: like, mode: "insensitive" } } };
+  }
+
+  if (filters.enrichment === "DETAILS_MISSING") {
+    const missingDetails = { OR: [{ details: null }, { details: "" }] };
+    where.AND = [
+      {
+        OR: [
+          {
+            publishedRevisionId: { not: null },
+            publishedRevision: { is: missingDetails },
+          },
+          {
+            publishedRevisionId: null,
+            latestRevision: { is: missingDetails },
+          },
+        ],
+      },
+    ];
   }
 
   return where;
@@ -203,14 +230,27 @@ export async function queryMeasureQueue(
   const take = clampTake(filters.take);
   const skip = clampSkip(filters.skip);
 
-  const scanned = await db.measure.findMany({
-    where: buildWhere(filters),
+  const where = buildWhere(filters);
+  const scanQuery = {
+    where,
     select: QUEUE_SELECT,
-    // Oldest first: a queue that shows the newest extractions first leaves the oldest
-    // untreated measures at the bottom forever. The page states the order.
-    orderBy: { createdAt: "asc" },
+    orderBy: { createdAt: "asc" } as const,
     take: QUEUE_SCAN_CAP + 1,
-  });
+  };
+  const detailsMissingIsDatabaseFiltered = filters.enrichment === "DETAILS_MISSING";
+  const [scanned, exactPage, exactTotal] = await Promise.all([
+    db.measure.findMany(scanQuery),
+    detailsMissingIsDatabaseFiltered
+      ? db.measure.findMany({
+          where,
+          select: QUEUE_SELECT,
+          orderBy: { createdAt: "asc" },
+          skip,
+          take,
+        })
+      : Promise.resolve(null),
+    detailsMissingIsDatabaseFiltered ? db.measure.count({ where }) : Promise.resolve(null),
+  ]);
 
   const scanCapped = scanned.length > QUEUE_SCAN_CAP;
   const rows = scanned.slice(0, QUEUE_SCAN_CAP).map(toQueueRow);
@@ -232,6 +272,20 @@ export async function queryMeasureQueue(
     if (row.suggestedSubtopicCount > 0) enrichmentCounts.SUBTOPICS_PENDING += 1;
     if (row.approvedSubtopicCount > 0) enrichmentCounts.SUBTOPICS_APPROVED += 1;
     if (!row.hasDetails) enrichmentCounts.DETAILS_MISSING += 1;
+  }
+
+  if (exactTotal !== null) enrichmentCounts.DETAILS_MISSING = exactTotal;
+
+  if (exactPage !== null && exactTotal !== null) {
+    return {
+      rows: exactPage.map(toQueueRow).filter((row) => matchesDerivedFilters(row, filters)),
+      total: exactTotal,
+      counts,
+      anomalyCount,
+      withdrawnCount,
+      enrichmentCounts,
+      scanCapped,
+    };
   }
 
   const matching = rows.filter((row) => matchesDerivedFilters(row, filters));

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -76,6 +76,8 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
     : undefined;
   const candidacyId = asString(params.candidat);
   const q = asString(params.q);
+  const publicCorpus =
+    asString(params.corpus) === "presidentielle-2027" ? "PRESIDENTIELLE_2027" : undefined;
 
   const pageParam = Number(asString(params.page) ?? "1");
   const page = Number.isFinite(pageParam) ? Math.max(1, Math.trunc(pageParam)) : 1;
@@ -89,6 +91,7 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
         withdrawn,
         anomaliesOnly,
         enrichment,
+        publicCorpus,
         q,
         take: PAGE_SIZE,
         skip: (page - 1) * PAGE_SIZE,
@@ -107,6 +110,7 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
     enrichment,
     withdrawn,
     q,
+    publicCorpus,
   };
   const totalPages = Math.max(1, Math.ceil(result.total / PAGE_SIZE));
   const contextCandidateIds =
@@ -227,6 +231,9 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
             if (enrichment) query.set("enrichissement", enrichment);
             if (withdrawn) query.set("retrait", withdrawn);
             if (q) query.set("q", q);
+            if (publicCorpus === "PRESIDENTIELLE_2027") {
+              query.set("corpus", "presidentielle-2027");
+            }
             query.set("page", String(number));
 
             return (

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -10,11 +10,13 @@ import { BatchReviewPanel } from "./_components/BatchReviewPanel";
 import { QueueFilters, type QueueFilterState } from "./_components/QueueFilters";
 import { QueueTable } from "./_components/QueueTable";
 import { ContextGenerationBatchPanel } from "./_components/ContextGenerationBatchPanel";
+import { EnrichmentCoveragePanel } from "./_components/EnrichmentCoveragePanel";
 import { buttonVariants } from "@/components/ui/button";
 import { filterMeasureContextCandidateIds } from "@/lib/measures/context-generation";
 import { cn } from "@/lib/utils";
 import { queryBatchPublishGroups } from "./_data/batch-publish-query";
 import { queryBatchReviewGroups } from "./_data/batch-review-query";
+import { queryMeasureEnrichmentCoverage } from "./_data/enrichment-coverage-query";
 import {
   listMeasureQueueCandidates,
   queryMeasureQueue,
@@ -78,22 +80,24 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
   const pageParam = Number(asString(params.page) ?? "1");
   const page = Number.isFinite(pageParam) ? Math.max(1, Math.trunc(pageParam)) : 1;
 
-  const [result, candidates, batchReviewGroups, batchPublishGroups] = await Promise.all([
-    queryMeasureQueue({
-      publication,
-      theme,
-      candidacyId,
-      withdrawn,
-      anomaliesOnly,
-      enrichment,
-      q,
-      take: PAGE_SIZE,
-      skip: (page - 1) * PAGE_SIZE,
-    }),
-    listMeasureQueueCandidates(),
-    queryBatchReviewGroups({ candidacyId }),
-    queryBatchPublishGroups({ candidacyId }),
-  ]);
+  const [result, candidates, batchReviewGroups, batchPublishGroups, enrichmentCoverage] =
+    await Promise.all([
+      queryMeasureQueue({
+        publication,
+        theme,
+        candidacyId,
+        withdrawn,
+        anomaliesOnly,
+        enrichment,
+        q,
+        take: PAGE_SIZE,
+        skip: (page - 1) * PAGE_SIZE,
+      }),
+      listMeasureQueueCandidates(),
+      queryBatchReviewGroups({ candidacyId }),
+      queryBatchPublishGroups({ candidacyId }),
+      queryMeasureEnrichmentCoverage(),
+    ]);
 
   const current: QueueFilterState = {
     publication,
@@ -171,6 +175,8 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
           des chiffres complets.
         </p>
       )}
+
+      <EnrichmentCoveragePanel coverage={enrichmentCoverage} />
 
       <QueueFilters current={current} result={result} candidates={candidates} />
 


### PR DESCRIPTION
## Objectif

Ajouter le premier jalon du plan d’enrichissement des fiches mesures : une vue exacte de la couverture du corpus public présidentiel, indépendante de la limite de 500 lignes de la file.

## Changements

- affiche les contextes, sous-thèmes validés, sources localisées, qualifications, votes rapprochés et historiques
- calcule les agrégats avec les mêmes règles de publication que les fiches publiques
- donne un accès direct à la file des contextes manquants
- conserve le contrôle d’accès avant toute requête éditoriale

## Vérifications

- typecheck
- ESLint ciblé
- Prettier ciblé
- 10 tests ciblés
- requête vérifiée sur les 2 200 mesures publiques
- simulation du prochain lot de 30 contextes, sans écriture