### PR TITLE
feat(presidentielle): rendre les sous-thèmes cliquables

### DIFF
--- a/src/app/elections/presidentielle-2027/_components/PresidentialSubtopicLink.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PresidentialSubtopicLink.tsx
@@ -1,0 +1,37 @@
+import type { LinkProps } from "next/link";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type PresidentialSubtopicLinkProps = {
+  slug: string;
+  label: string;
+  href?: LinkProps["href"];
+  className?: string;
+};
+
+export function PresidentialSubtopicLink({
+  slug,
+  label,
+  href,
+  className,
+}: PresidentialSubtopicLinkProps) {
+  return (
+    <Link
+      href={
+        href ?? {
+          pathname: "/elections/presidentielle-2027/recherche",
+          query: { "sous-theme": slug },
+        }
+      }
+      prefetch={false}
+      className={cn(
+        buttonVariants({ variant: "outline" }),
+        "h-auto min-h-11 rounded-full whitespace-normal px-3 py-2 text-left text-xs",
+        className
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.test.tsx
@@ -66,7 +66,7 @@ describe("page des mesures d'une candidature", () => {
             label: "Logement & Urbanisme",
           },
           sources: [{ url: "https://example.org/programme.pdf" }],
-          subtopics: [],
+          subtopics: [{ slug: "encadrement-loyers", label: "Encadrement des loyers" }],
         },
       ],
     });
@@ -164,6 +164,10 @@ describe("page des mesures d'une candidature", () => {
     expect(screen.getByRole("link", { name: /source externe de la mesure/i })).toHaveAttribute(
       "rel",
       expect.stringContaining("noopener")
+    );
+    expect(screen.getByRole("link", { name: "Encadrement des loyers" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/candidats/camille-riviere/mesures?theme=logement-urbanisme&sous-theme=encadrement-loyers"
     );
   });
 

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/mesures/page.tsx
@@ -25,6 +25,7 @@ import { getPoliticianPresidentialCandidacy } from "@/lib/data/politician-candid
 import { getPolitician } from "@/lib/data/politicians";
 import { parseThemeSlug, THEMES_IN_ORDER, themeToSlug } from "@/lib/presidentielle/themes";
 import { cn } from "@/lib/utils";
+import { PresidentialSubtopicLink } from "../../../_components/PresidentialSubtopicLink";
 
 const ELECTION_SLUG = "presidentielle-2027";
 const PAGE_SIZE = 20;
@@ -318,11 +319,15 @@ export default async function CandidateMeasuresPage({ params, searchParams }: Pa
                         {measure.subtopics.length > 0 && (
                           <ul aria-label="Sous-thèmes" className="mt-3 flex flex-wrap gap-2">
                             {measure.subtopics.map((item) => (
-                              <li
-                                key={item.slug}
-                                className="rounded-full border border-border bg-muted/50 px-2.5 py-1 text-xs font-medium"
-                              >
-                                {item.label}
+                              <li key={item.slug}>
+                                <PresidentialSubtopicLink
+                                  slug={item.slug}
+                                  label={item.label}
+                                  href={buildMeasuresUrl(slug, {
+                                    theme: measure.theme.code,
+                                    subtopic: item.slug,
+                                  })}
+                                />
                               </li>
                             ))}
                           </ul>

--- a/src/app/elections/presidentielle-2027/comparer/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/comparer/page.test.tsx
@@ -31,7 +31,7 @@ describe("comparaison présidentielle", () => {
               slug: "ouvrir-un-centre",
               text: "Ouvrir un centre de santé.",
               sourceUrl: "https://example.org/source",
-              subtopics: [],
+              subtopics: [{ slug: "acces-aux-soins", label: "Accès aux soins" }],
               precision: "CHIFFREE",
               qualifications: [{ id: "q1", label: "Financement précisé" }],
               withdrawal: null,
@@ -64,6 +64,10 @@ describe("comparaison présidentielle", () => {
     expect(screen.getByText("Ouvrir un centre de santé.")).toBeInTheDocument();
     expect(screen.queryByText("Objectif quantifié")).not.toBeInTheDocument();
     expect(screen.getByText("Financement précisé")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Accès aux soins" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/recherche?sous-theme=acces-aux-soins"
+    );
     expect(screen.getByText(/Poligraph n'a pas encore trouvé ou traité/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Voir la mesure" })).toHaveAttribute(
       "href",

--- a/src/app/elections/presidentielle-2027/comparer/page.tsx
+++ b/src/app/elections/presidentielle-2027/comparer/page.tsx
@@ -9,6 +9,7 @@ import { Select } from "@/components/ui/select";
 import { getPresidentialComparison } from "@/lib/data/presidential-comparison";
 import { cn, formatDate } from "@/lib/utils";
 import { PresidentialHubNav } from "../_components/PresidentialHubNav";
+import { PresidentialSubtopicLink } from "../_components/PresidentialSubtopicLink";
 
 const ELECTION_SLUG = "presidentielle-2027";
 const COMPARISON_PATH = `/elections/${ELECTION_SLUG}/comparer`;
@@ -268,11 +269,11 @@ export default async function PresidentialComparisonPage({
                             {measure.subtopics.length > 0 && (
                               <ul aria-label="Sous-thèmes" className="mt-3 flex flex-wrap gap-1.5">
                                 {measure.subtopics.map((subtopic) => (
-                                  <li
-                                    key={subtopic.slug}
-                                    className="rounded-full border bg-muted/40 px-2.5 py-1 text-xs"
-                                  >
-                                    {subtopic.label}
+                                  <li key={subtopic.slug}>
+                                    <PresidentialSubtopicLink
+                                      slug={subtopic.slug}
+                                      label={subtopic.label}
+                                    />
                                   </li>
                                 ))}
                               </ul>

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -82,6 +82,10 @@ describe("page publique d'une mesure présidentielle", () => {
     expect(screen.getByText("territoires concernés")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Notions abordées" })).toBeInTheDocument();
     expect(screen.getByText("Logement social")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Logement social" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/recherche?sous-theme=logement-social"
+    );
     expect(
       screen.getByText("Construction, attribution et financement du logement social.")
     ).toBeInTheDocument();
@@ -113,7 +117,7 @@ describe("page publique d'une mesure présidentielle", () => {
           candidateName: "Alex Martin",
           candidateSlug: "alex-martin",
           party: "Parti Test",
-          sharedSubtopics: ["Encadrement des loyers"],
+          sharedSubtopics: [{ slug: "encadrement-loyers", label: "Encadrement des loyers" }],
         },
       ],
     });
@@ -132,6 +136,10 @@ describe("page publique d'une mesure présidentielle", () => {
       "/elections/presidentielle-2027/mesures/alex-martin-encadrer-les-loyers"
     );
     expect(screen.getByText("Encadrement des loyers")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Encadrement des loyers" })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/recherche?sous-theme=encadrement-loyers"
+    );
   });
 
   it("n'invente aucun vote quand aucun lien public n'existe", async () => {

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -19,6 +19,7 @@ import { SITE_URL } from "@/config/site";
 import { buildMeasureSeoDescription, truncateAtWord } from "@/lib/presidentielle/measure-seo";
 import { themeToSlug } from "@/lib/presidentielle/themes";
 import { formatDate } from "@/lib/utils";
+import { PresidentialSubtopicLink } from "../../_components/PresidentialSubtopicLink";
 
 const ELECTION_SLUG = "presidentielle-2027";
 
@@ -148,7 +149,13 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <dl className="mt-5 grid gap-3 sm:grid-cols-2">
               {measure.subtopics.map((subtopic) => (
                 <div key={subtopic.slug} className="rounded-xl border border-border bg-card p-4">
-                  <dt className="font-display text-lg font-bold">{subtopic.label}</dt>
+                  <dt>
+                    <PresidentialSubtopicLink
+                      slug={subtopic.slug}
+                      label={subtopic.label}
+                      className="justify-start border-0 bg-transparent px-0 font-display text-lg font-bold shadow-none hover:bg-transparent hover:underline"
+                    />
+                  </dt>
                   <dd className="mt-1 text-sm leading-relaxed text-muted-foreground-strong">
                     {subtopic.description}
                   </dd>
@@ -243,25 +250,32 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             </div>
             <ul className="mt-5 grid gap-3 md:grid-cols-2">
               {measure.relatedMeasures.map((related) => (
-                <li key={related.slug}>
+                <li
+                  key={related.slug}
+                  className="flex h-full min-h-32 flex-col rounded-2xl border border-border bg-card p-5"
+                >
                   <Link
                     href={`/elections/${ELECTION_SLUG}/mesures/${related.slug}`}
                     prefetch={false}
-                    className="group flex h-full min-h-32 flex-col rounded-2xl border border-border bg-card p-5 hover:border-primary/60 hover:bg-accent/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    className="group min-h-11 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                   >
-                    <span className="text-sm font-bold text-primary">
+                    <span className="block text-sm font-bold text-primary">
                       {related.candidateName}
                       {related.party ? ` · ${related.party}` : ""}
                     </span>
-                    <span className="mt-2 line-clamp-3 leading-relaxed text-foreground group-hover:underline">
+                    <span className="mt-2 line-clamp-3 block leading-relaxed text-foreground group-hover:underline">
                       {related.text}
                     </span>
-                    {related.sharedSubtopics.length > 0 && (
-                      <span className="mt-3 text-xs text-muted-foreground">
-                        {related.sharedSubtopics.join(" · ")}
-                      </span>
-                    )}
                   </Link>
+                  {related.sharedSubtopics.length > 0 && (
+                    <ul aria-label="Sous-thèmes partagés" className="mt-3 flex flex-wrap gap-2">
+                      {related.sharedSubtopics.map((subtopic) => (
+                        <li key={subtopic.slug}>
+                          <PresidentialSubtopicLink slug={subtopic.slug} label={subtopic.label} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/lib/data/presidential-measure-detail.ts
+++ b/src/lib/data/presidential-measure-detail.ts
@@ -72,7 +72,7 @@ export type PublicPresidentialMeasureDetail = {
     candidateName: string;
     candidateSlug: string;
     party: string | null;
-    sharedSubtopics: string[];
+    sharedSubtopics: Array<{ slug: string; label: string }>;
   }>;
 };
 
@@ -240,7 +240,7 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
           party: related.candidacy.party?.shortName ?? related.candidacy.party?.name ?? null,
           sharedSubtopics: related.publishedRevision.subtopics
             .filter(({ subtopic }) => currentSubtopicSlugs.has(subtopic.slug))
-            .map(({ subtopic }) => subtopic.label),
+            .map(({ subtopic }) => ({ slug: subtopic.slug, label: subtopic.label })),
         },
       ];
     })


### PR DESCRIPTION
## Résumé

- ajoute un lien réutilisable vers le corpus filtré par sous-thème
- rend cliquables les sous-thèmes des fiches mesure et des comparaisons
- conserve le contexte candidat depuis les pages de programme
- rend navigables les sous-thèmes partagés des mesures connexes

## Vérifications

- tests ciblés : 14 réussis
- typecheck : réussi
- lint : aucune erreur
- build de production : réussi
- contrôle Playwright desktop et mobile : HTTP 200, aucune surcouche d'erreur, cibles de 44 px

La suite complète locale valide 5 418 tests. Deux gardes locales restent affectées par des scripts gitignorés présents dans scripts/.local et absents de la PR.