### PR TITLE
fix(admin): rendre la génération de contextes visible

### DIFF
--- a/src/app/admin/mesures/_components/ContextGenerationBatchPanel.tsx
+++ b/src/app/admin/mesures/_components/ContextGenerationBatchPanel.tsx
@@ -57,8 +57,9 @@ export function ContextGenerationBatchPanel({ measureIds }: { measureIds: string
         </>
       ) : (
         <p className="mt-3 rounded border border-border bg-muted/40 p-3 text-sm leading-relaxed">
-          Aucune mesure de cette page ne dispose actuellement d’extraits de preuve permettant une
-          génération automatique. Le contexte peut être rédigé manuellement depuis chaque fiche.
+          Aucune mesure de cette page n’est actuellement éligible à la génération automatique. Une
+          preuve contextuelle peut manquer, un brouillon peut être actif ou une tentative peut déjà
+          avoir été enregistrée. Consultez la fiche pour connaître sa situation.
         </p>
       )}
       {message && (

--- a/src/app/admin/mesures/_components/ContextGenerationBatchPanel.tsx
+++ b/src/app/admin/mesures/_components/ContextGenerationBatchPanel.tsx
@@ -10,8 +10,6 @@ export function ContextGenerationBatchPanel({ measureIds }: { measureIds: string
   const [message, setMessage] = useState<string | null>(null);
   const ids = measureIds.slice(0, 10);
 
-  if (ids.length === 0) return null;
-
   return (
     <section
       aria-labelledby="context-generation-title"
@@ -21,34 +19,48 @@ export function ContextGenerationBatchPanel({ measureIds }: { measureIds: string
         Génération assistée des contextes
       </h2>
       <p className="mt-1 max-w-3xl text-sm leading-relaxed text-muted-foreground">
-        Traite jusqu’à 10 mesures de cette page. Chaque résultat reste un brouillon non public,
-        fondé uniquement sur les preuves enregistrées.
+        Chaque résultat reste un brouillon non public, fondé uniquement sur les extraits de preuve
+        enregistrés. Une validation humaine reste nécessaire.
       </p>
-      <button
-        type="button"
-        disabled={pending}
-        className="mt-3 inline-flex min-h-11 items-center justify-center rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-        onClick={() => {
-          setMessage(null);
-          startTransition(async () => {
-            try {
-              const result = await generateContextDraftBatchAction({ measureIds: ids });
-              setMessage(
-                `${result.created} brouillon${result.created === 1 ? " créé" : "s créés"}, ${result.skipped} ignoré${result.skipped === 1 ? "" : "s"}, ${result.failed} échec${result.failed === 1 ? "" : "s"}.`
-              );
-              router.refresh();
-            } catch {
-              setMessage("La génération du lot a échoué. Réessayez plus tard.");
-            }
-          });
-        }}
-      >
-        {pending
-          ? "Génération en cours…"
-          : ids.length === 1
-            ? "Générer 1 contexte"
-            : `Générer jusqu’à ${ids.length} contextes`}
-      </button>
+      {ids.length > 0 ? (
+        <>
+          <p className="mt-2 text-sm">
+            {ids.length === 1
+              ? "1 mesure de cette page peut être traitée."
+              : `${ids.length} mesures de cette page peuvent être traitées.`}
+          </p>
+          <button
+            type="button"
+            disabled={pending}
+            className="mt-3 inline-flex min-h-11 items-center justify-center rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            onClick={() => {
+              setMessage(null);
+              startTransition(async () => {
+                try {
+                  const result = await generateContextDraftBatchAction({ measureIds: ids });
+                  setMessage(
+                    `${result.created} brouillon${result.created === 1 ? " créé" : "s créés"}, ${result.skipped} ignoré${result.skipped === 1 ? "" : "s"}, ${result.failed} échec${result.failed === 1 ? "" : "s"}.`
+                  );
+                  router.refresh();
+                } catch {
+                  setMessage("La génération du lot a échoué. Réessayez plus tard.");
+                }
+              });
+            }}
+          >
+            {pending
+              ? "Génération en cours…"
+              : ids.length === 1
+                ? "Générer 1 contexte"
+                : `Générer jusqu’à ${ids.length} contextes`}
+          </button>
+        </>
+      ) : (
+        <p className="mt-3 rounded border border-border bg-muted/40 p-3 text-sm leading-relaxed">
+          Aucune mesure de cette page ne dispose actuellement d’extraits de preuve permettant une
+          génération automatique. Le contexte peut être rédigé manuellement depuis chaque fiche.
+        </p>
+      )}
       {message && (
         <p role="status" aria-live="polite" className="mt-3 text-sm">
           {message}

--- a/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
+++ b/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
@@ -64,7 +64,7 @@ export function EnrichmentCoveragePanel({ coverage }: { coverage: MeasureEnrichm
             prefetch={false}
             className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
           >
-            Compléter {missingDetails.toLocaleString("fr-FR")} contextes
+            Voir les {missingDetails.toLocaleString("fr-FR")} contextes manquants
           </Link>
         ) : null}
       </div>

--- a/src/app/admin/mesures/_components/QueueFilters.tsx
+++ b/src/app/admin/mesures/_components/QueueFilters.tsx
@@ -157,7 +157,7 @@ export function QueueFilters({
             [
               ["SUBTOPICS_PENDING", "Sous-thèmes à valider"],
               ["SUBTOPICS_APPROVED", "Sous-thèmes validés"],
-              ["DETAILS_MISSING", "Contexte à compléter"],
+              ["DETAILS_MISSING", "Contextes manquants"],
             ] as const
           ).map(([state, label]) => (
             <Link

--- a/src/app/admin/mesures/_components/__tests__/ContextGenerationBatchPanel.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/ContextGenerationBatchPanel.test.tsx
@@ -50,4 +50,14 @@ describe("ContextGenerationBatchPanel", () => {
     );
     expect(refresh).not.toHaveBeenCalled();
   });
+
+  it("explique pourquoi aucune génération automatique n’est proposée", () => {
+    render(<ContextGenerationBatchPanel measureIds={[]} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Génération assistée des contextes" })
+    ).toBeVisible();
+    expect(screen.getByText(/Aucune mesure de cette page/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: /Générer/ })).not.toBeInTheDocument();
+  });
 });

--- a/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { EnrichmentCoveragePanel } from "../EnrichmentCoveragePanel";
 
 describe("EnrichmentCoveragePanel", () => {
-  it("présente la couverture et une action accessible vers les contextes manquants", () => {
+  it("présente la couverture et un lien explicite vers les contextes manquants", () => {
     render(
       <EnrichmentCoveragePanel
         coverage={{
@@ -24,7 +24,9 @@ describe("EnrichmentCoveragePanel", () => {
     expect(screen.getByText("4 %")).toBeInTheDocument();
     expect(screen.getByText("45 %")).toBeInTheDocument();
     expect(screen.getByText("58 %")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Compléter 2.102 contextes/ })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: /Voir les 2.102 contextes manquants/ })
+    ).toHaveAttribute(
       "href",
       "/admin/mesures?corpus=presidentielle-2027&enrichissement=DETAILS_MISSING"
     );
@@ -45,6 +47,6 @@ describe("EnrichmentCoveragePanel", () => {
       />
     );
 
-    expect(screen.queryByRole("link", { name: /Compléter/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /contextes manquants/ })).not.toBeInTheDocument();
   });
 });

--- a/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/QueueFilters.test.tsx
@@ -79,7 +79,7 @@ describe("QueueFilters", () => {
       "aria-current",
       "true"
     );
-    expect(screen.getByRole("link", { name: "Contexte à compléter 8" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Contextes manquants 8" })).toBeInTheDocument();
   });
 
   it("conserve le périmètre du corpus public dans les liens et la recherche", () => {

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -182,7 +182,9 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
 
       <EnrichmentCoveragePanel coverage={enrichmentCoverage} />
 
-      <QueueFilters current={current} result={result} candidates={candidates} />
+      {enrichment === "DETAILS_MISSING" && (
+        <ContextGenerationBatchPanel measureIds={contextCandidateIds} />
+      )}
 
       {enrichmentWorkflow !== null && firstMeasure !== undefined ? (
         <section
@@ -210,9 +212,7 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
         </section>
       ) : null}
 
-      {enrichment === "DETAILS_MISSING" && (
-        <ContextGenerationBatchPanel measureIds={contextCandidateIds} />
-      )}
+      <QueueFilters current={current} result={result} candidates={candidates} />
 
       <BatchReviewPanel groups={batchReviewGroups} />
 


### PR DESCRIPTION
## Résultat

- distingue le lien vers la file des contextes manquants d’une action de génération
- affiche la génération assistée avant le grand bloc de filtres
- indique combien de mesures de la page sont éligibles
- explique l’absence d’action quand aucune preuve contextuelle exploitable n’est disponible
- conserve des lots bornés à 10 brouillons non publics avec validation humaine

## Vérifications

- 9 tests ciblés
- ESLint ciblé
- Prettier ciblé
- typecheck

`AUDIT.md` local est resté hors du commit.