### PR TITLE
Fiabiliser la génération des contextes de mesures

### DIFF
--- a/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
+++ b/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
@@ -43,11 +43,19 @@ Règles proposées :
 - 80 à 250 mots lorsque la source contient réellement ces informations ;
 - aucune reformulation sur la faisabilité, l'intention ou les effets supposés ;
 - chaque élément doit être vérifiable dans une source attachée à la révision ;
+- chaque affirmation générée doit conserver les identifiants exacts des extraits qui la soutiennent ;
+- une quantité est admise uniquement lorsqu'elle figure dans l'extrait cité par l'affirmation ;
 - génération par IA autorisée comme proposition de brouillon, jamais comme publication automatique ;
 - validation humaine et date de revue obligatoires.
 
 Lorsque la source ne dit rien de plus que le titre, le bloc reste absent. Un texte redondant ferait
 baisser la valeur de la page au lieu de l'améliorer.
+
+Les définitions externes ne doivent pas être enregistrées dans `MeasureRevision.details`. Ce champ
+décrit le contenu du programme et son origine ne doit pas devenir ambiguë. Un futur bloc « Repères
+pour comprendre » utilisera un circuit distinct, avec une source fournie par le document lui-même ou
+une source institutionnelle officielle, son URL, sa date de vérification et une validation humaine.
+Une source journalistique ou généraliste ne suffira pas pour générer automatiquement une définition.
 
 ### 2. Repères structurés
 

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -18,6 +18,13 @@ const detail = {
   theme: "LOGEMENT_URBANISME",
   text: "Construire davantage de logements accessibles",
   details: "La source précise les **territoires concernés** et le calendrier annoncé.",
+  contextClaims: [
+    {
+      text: "La source précise les territoires concernés et le calendrier annoncé.",
+      documentUrl: "https://example.org/programme",
+      references: [{ unitId: "pdf-12-u001", page: 12 }],
+    },
+  ],
   precision: "CHIFFREE",
   attribution: "PERSONAL",
   reviewedAt: new Date("2026-08-20T00:00:00Z"),
@@ -73,9 +80,10 @@ describe("page publique d'une mesure présidentielle", () => {
     expect(screen.getByText("Source primaire")).toBeInTheDocument();
     expect(screen.getByText("Programme de candidature")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Ce que prévoit la mesure" })).toBeInTheDocument();
+    expect(screen.getByText("Vérifier les affirmations dans la source")).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Voir les sources utilisées pour ce contexte" })
-    ).toHaveAttribute("href", "#sources");
+      screen.getByRole("link", { name: "Consulter l'extrait source, page 12, lien externe" })
+    ).toHaveAttribute("href", "https://example.org/programme");
     expect(screen.getByRole("heading", { name: "Dans le programme" })).toBeInTheDocument();
     expect(screen.getByText("Formulée personnellement")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Consulter le programme/ })).toHaveAttribute(

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -73,6 +73,9 @@ describe("page publique d'une mesure présidentielle", () => {
     expect(screen.getByText("Source primaire")).toBeInTheDocument();
     expect(screen.getByText("Programme de candidature")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Ce que prévoit la mesure" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Voir les sources utilisées pour ce contexte" })
+    ).toHaveAttribute("href", "#sources");
     expect(screen.getByRole("heading", { name: "Dans le programme" })).toBeInTheDocument();
     expect(screen.getByText("Formulée personnellement")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Consulter le programme/ })).toHaveAttribute(

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -134,14 +134,44 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
               {measure.details}
             </MarkdownText>
-            {measure.sources.length > 0 && (
+            {measure.contextClaims.length > 0 ? (
+              <details className="group mt-5 max-w-[72ch] rounded-xl border border-border bg-card">
+                <summary className="flex min-h-11 cursor-pointer list-none items-center px-4 py-3 font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary [&::-webkit-details-marker]:hidden">
+                  Vérifier les affirmations dans la source
+                </summary>
+                <ol className="space-y-4 border-t border-border px-4 py-4">
+                  {measure.contextClaims.map((claim, claimIndex) => (
+                    <li key={`${claim.text}-${claimIndex}`}>
+                      <p className="text-sm leading-relaxed text-foreground">{claim.text}</p>
+                      <ul className="mt-2 flex flex-wrap gap-3">
+                        {claim.references.map((reference) => (
+                          <li key={reference.unitId}>
+                            <a
+                              href={claim.documentUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={`Consulter l'extrait source${reference.page === null ? "" : `, page ${reference.page}`}, lien externe`}
+                              className="inline-flex min-h-11 items-center gap-2 text-sm font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                            >
+                              Extrait source
+                              {reference.page === null ? "" : `, page ${reference.page}`}
+                              <ExternalLink aria-hidden="true" className="h-4 w-4" />
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ol>
+              </details>
+            ) : measure.sources.length > 0 ? (
               <Link
                 href="#sources"
                 className="mt-3 inline-flex min-h-11 items-center font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               >
                 Voir les sources utilisées pour ce contexte
               </Link>
-            )}
+            ) : null}
           </section>
         )}
 

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -134,6 +134,14 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
               {measure.details}
             </MarkdownText>
+            {measure.sources.length > 0 && (
+              <Link
+                href="#sources"
+                className="mt-3 inline-flex min-h-11 items-center font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                Voir les sources utilisées pour ce contexte
+              </Link>
+            )}
           </section>
         )}
 
@@ -282,7 +290,11 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
           </section>
         )}
 
-        <section aria-labelledby="sources-title" className="border-t border-border py-8">
+        <section
+          id="sources"
+          aria-labelledby="sources-title"
+          className="border-t border-border py-8"
+        >
           <h2 id="sources-title" className="font-display text-2xl font-extrabold">
             Sources
           </h2>

--- a/src/app/methodologie/mesures-presidentielle-2027/page.tsx
+++ b/src/app/methodologie/mesures-presidentielle-2027/page.tsx
@@ -69,6 +69,13 @@ export default function PresidentialMeasuresMethodologyPage() {
               édition de programme existe, la fiche indique le document, sa date et
               l&apos;emplacement connu de la mesure.
             </p>
+            <p>
+              Le contexte qui explique ce que prévoit une mesure repose uniquement sur sa source
+              attachée. Une définition ajoutée pour expliquer une notion technique suit un circuit
+              distinct : elle doit provenir de la source elle-même ou d&apos;un site institutionnel
+              officiel, avec son URL et sa date de vérification. Elle n&apos;est jamais présentée
+              comme un élément du programme.
+            </p>
           </div>
         </section>
 
@@ -86,6 +93,11 @@ export default function PresidentialMeasuresMethodologyPage() {
               L&apos;intelligence artificielle peut aider à extraire ou classer un contenu. Elle ne
               publie pas une mesure, ne lui prête pas une intention et ne décide pas seule des
               rapprochements présentés au public.
+            </p>
+            <p>
+              Lorsqu&apos;elle propose un contexte, chaque affirmation est rattachée aux extraits
+              qui la soutiennent. Une quantité n&apos;est conservée que si elle figure dans
+              l&apos;extrait cité. Le résultat reste un brouillon soumis à une relecture humaine.
             </p>
           </div>
         </section>

--- a/src/app/methodologie/methodologie.test.tsx
+++ b/src/app/methodologie/methodologie.test.tsx
@@ -30,6 +30,8 @@ describe("pages de méthodologie", () => {
       screen.getByRole("heading", { name: "Extraction, relecture et publication" })
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Thèmes et sous-thèmes" })).toBeInTheDocument();
+    expect(screen.getByText(/site institutionnel officiel/)).toBeInTheDocument();
+    expect(screen.getByText(/chaque affirmation est rattachée aux extraits/)).toBeInTheDocument();
     expect(screen.queryByText("Objectif quantifié")).not.toBeInTheDocument();
     expect(
       screen.getByText(/Elle ne prouve pas qu'une proposition n'existe pas/)

--- a/src/lib/data/presidential-measure-detail.ts
+++ b/src/lib/data/presidential-measure-detail.ts
@@ -15,6 +15,11 @@ import {
   PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
 } from "@/lib/presidentielle/publication";
 import { deriveVoteRelation, type VoteRelation } from "@/lib/measures/vote-relation";
+import { readEvidenceSnapshot } from "@/lib/measures/evidence-snapshot";
+import {
+  GENERATED_CONTEXT_DRAFT_ACTION,
+  readGeneratedContextClaims,
+} from "@/lib/measures/context-provenance";
 
 export type PublicPresidentialMeasureDetail = {
   id: string;
@@ -23,6 +28,11 @@ export type PublicPresidentialMeasureDetail = {
   theme: ThemeCategory;
   text: string;
   details: string | null;
+  contextClaims: Array<{
+    text: string;
+    documentUrl: string;
+    references: Array<{ unitId: string; page: number | null }>;
+  }>;
   precision: MeasurePrecision | null;
   attribution: MeasureAttribution;
   reviewedAt: Date;
@@ -102,6 +112,7 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
         select: {
           text: true,
           details: true,
+          evidenceSnapshot: true,
           precision: true,
           reviewedAt: true,
           publishedAt: true,
@@ -178,53 +189,86 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
   const currentSubtopics = revision.subtopics.map(({ subtopic }) => subtopic);
   const currentSubtopicSlugs = new Set(currentSubtopics.map((subtopic) => subtopic.slug));
 
-  const relatedRows = await db.measure.findMany({
-    where: {
-      id: { not: row.id },
-      electionId: row.election.id,
-      theme: row.theme,
-      ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
-      ...(currentSubtopics.length > 0
-        ? {
-            publishedRevision: {
-              is: {
-                ...PUBLIC_MEASURE_REVISION_WHERE,
-                subtopics: {
-                  some: {
-                    status: "APPROVED" as const,
-                    subtopic: {
-                      active: true,
-                      slug: { in: currentSubtopics.map((subtopic) => subtopic.slug) },
+  const [contextAudit, relatedRows] = await Promise.all([
+    revision.details === null
+      ? Promise.resolve(null)
+      : db.auditLog.findFirst({
+          where: {
+            action: GENERATED_CONTEXT_DRAFT_ACTION,
+            entityType: "MeasureRevision",
+            entityId: publishedRevisionId,
+          },
+          orderBy: { createdAt: "desc" },
+          select: { changes: true },
+        }),
+    db.measure.findMany({
+      where: {
+        id: { not: row.id },
+        electionId: row.election.id,
+        theme: row.theme,
+        ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+        ...(currentSubtopics.length > 0
+          ? {
+              publishedRevision: {
+                is: {
+                  ...PUBLIC_MEASURE_REVISION_WHERE,
+                  subtopics: {
+                    some: {
+                      status: "APPROVED" as const,
+                      subtopic: {
+                        active: true,
+                        slug: { in: currentSubtopics.map((subtopic) => subtopic.slug) },
+                      },
                     },
                   },
                 },
               },
+            }
+          : {}),
+      },
+      select: {
+        slug: true,
+        publishedRevision: {
+          select: {
+            text: true,
+            subtopics: {
+              where: { status: "APPROVED", subtopic: { active: true } },
+              select: { subtopic: { select: { slug: true, label: true } } },
             },
-          }
-        : {}),
-    },
-    select: {
-      slug: true,
-      publishedRevision: {
-        select: {
-          text: true,
-          subtopics: {
-            where: { status: "APPROVED", subtopic: { active: true } },
-            select: { subtopic: { select: { slug: true, label: true } } },
+          },
+        },
+        candidacy: {
+          select: {
+            candidateName: true,
+            party: { select: { name: true, shortName: true } },
+            politician: { select: { slug: true } },
           },
         },
       },
-      candidacy: {
-        select: {
-          candidateName: true,
-          party: { select: { name: true, shortName: true } },
-          politician: { select: { slug: true } },
-        },
-      },
-    },
-    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-    take: 100,
-  });
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: 100,
+    }),
+  ]);
+
+  const evidence = readEvidenceSnapshot(revision.evidenceSnapshot);
+  const contextClaims =
+    contextAudit !== null && evidence.status === "VALID"
+      ? readGeneratedContextClaims(contextAudit.changes).flatMap((claim) => {
+          const references = claim.evidenceUnitIds.flatMap((unitId) => {
+            const unit = evidence.snapshot.units.find((candidate) => candidate.unitId === unitId);
+            return unit ? [{ unitId, page: unit.page }] : [];
+          });
+          return references.length > 0
+            ? [
+                {
+                  text: claim.text,
+                  documentUrl: evidence.snapshot.documentUrl,
+                  references,
+                },
+              ]
+            : [];
+        })
+      : [];
 
   // One proposal per other personality keeps this a navigation aid rather than another long list.
   // Alphabetical sorting is explicit and carries no editorial ranking.
@@ -258,6 +302,7 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
     theme: row.theme,
     text: revision.text,
     details: revision.details,
+    contextClaims,
     precision: revision.precision,
     attribution: row.attribution,
     reviewedAt: revision.reviewedAt,

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/db", () => ({
           findUniqueOrThrow: mocks.findMeasureForUpdate,
           update: mocks.updateMeasure,
         },
-        auditLog: { create: mocks.createAuditLog },
+        auditLog: { create: mocks.createAuditLog, findMany: mocks.findAuditLogs },
       })
     ),
   },
@@ -313,7 +313,7 @@ describe("génération de contexte sourcé", () => {
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
-      "écrire les quantités sourcées en chiffres"
+      "quantité absente de la preuve citée"
     );
   });
 
@@ -328,7 +328,23 @@ describe("génération de contexte sourcé", () => {
       const { generateMeasureContextDraft } = await import("../context-generation");
 
       await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
-        "écrire les quantités sourcées en chiffres"
+        "quantité absente de la preuve citée"
+      );
+    }
+  );
+
+  it.each(["aucun logement", "un bénéficiaire", "une première phase", "un tiers des Français"])(
+    "refuse la quantité non sourcée « %s »",
+    async (quantity) => {
+      mocks.parseMistralJSON.mockReturnValue(
+        generatedContext(
+          `Le programme rattache cette proposition à ${quantity} dans les territoires concernés et la présente comme un élément de contexte distinct.`
+        )
+      );
+      const { generateMeasureContextDraft } = await import("../context-generation");
+
+      await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+        "quantité absente de la preuve citée"
       );
     }
   );
@@ -559,6 +575,48 @@ describe("génération de contexte sourcé", () => {
     const { filterMeasureContextCandidateIds } = await import("../context-generation");
 
     await expect(filterMeasureContextCandidateIds(["measure-exhausted"])).resolves.toEqual([]);
+  });
+
+  it("exclut temporairement une révision réservée par une autre génération", async () => {
+    const candidate = {
+      id: "measure-reserved",
+      latestRevisionId: "revision-reserved",
+      publishedRevisionId: "revision-reserved",
+      publishedRevision: { evidenceSnapshot: validEvidenceSnapshot() },
+    };
+    mocks.findMeasures.mockResolvedValue([candidate]);
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "RESERVE_CONTEXT_GENERATION",
+        changes: { expiresAt: "2999-01-01T00:00:00.000Z" },
+        entityId: "revision-reserved",
+      },
+    ]);
+    const { filterMeasureContextCandidateIds } = await import("../context-generation");
+
+    await expect(filterMeasureContextCandidateIds(["measure-reserved"])).resolves.toEqual([]);
+  });
+
+  it("réautorise une génération dont la réservation a expiré", async () => {
+    const candidate = {
+      id: "measure-expired",
+      latestRevisionId: "revision-expired",
+      publishedRevisionId: "revision-expired",
+      publishedRevision: { evidenceSnapshot: validEvidenceSnapshot() },
+    };
+    mocks.findMeasures.mockResolvedValue([candidate]);
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "RESERVE_CONTEXT_GENERATION",
+        changes: { expiresAt: "2020-01-01T00:00:00.000Z" },
+        entityId: "revision-expired",
+      },
+    ]);
+    const { filterMeasureContextCandidateIds } = await import("../context-generation");
+
+    await expect(filterMeasureContextCandidateIds(["measure-expired"])).resolves.toEqual([
+      "measure-expired",
+    ]);
   });
 
   it("réautorise une nouvelle révision publiée après un ancien contexte généré", async () => {

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   parseMistralJSON: vi.fn(),
   draftMeasureRevision: vi.fn(),
   findAuditLogs: vi.fn(),
-  findAuditLog: vi.fn(),
   createAuditLog: vi.fn(),
   findMeasureForUpdate: vi.fn(),
   updateMeasure: vi.fn(),
@@ -22,7 +21,6 @@ vi.mock("@/lib/db", () => ({
     measure: { findUnique: mocks.findMeasure, findMany: mocks.findMeasures },
     auditLog: {
       findMany: mocks.findAuditLogs,
-      findFirst: mocks.findAuditLog,
       create: mocks.createAuditLog,
     },
     $transaction: vi.fn(async (callback: (tx: unknown) => unknown) =>
@@ -65,6 +63,13 @@ function measure(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function generatedContext(details: string, evidenceUnitIds = ["pdf-12-2-u001", "pdf-13-1-u001"]) {
+  return {
+    details,
+    claims: [{ text: details, evidenceUnitIds }],
+  };
+}
+
 describe("génération de contexte sourcé", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,16 +80,15 @@ describe("génération de contexte sourcé", () => {
       updatedAt: new Date("2026-08-30T00:00:00Z"),
     });
     mocks.findAuditLogs.mockResolvedValue([]);
-    mocks.findAuditLog.mockResolvedValue(null);
     mocks.createAuditLog.mockResolvedValue({ id: "audit-1" });
     mocks.updateMeasure.mockResolvedValue({ id: "measure-1" });
     mocks.callMistral.mockResolvedValue({ model: "mistral-small-2506", choices: [] });
     mocks.extractMistralText.mockReturnValue("{}");
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit aux vacances. Il part du constat qu’une partie de la population ne part pas en vacances et rattache la mesure à cet enjeu.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit aux vacances. Il part du constat qu’une partie de la population ne part pas en vacances et rattache la mesure à cet enjeu."
+      )
+    );
     mocks.draftMeasureRevision.mockResolvedValue({ revisionId: "revision-2" });
   });
 
@@ -104,13 +108,18 @@ describe("génération de contexte sourcé", () => {
         preserveEvidenceFromRevisionId: "revision-1",
         revision: expect.objectContaining({
           extractionMethod: "AI_ASSISTED",
-          extractorVersion: "mistral-small-2506:measure-context-v6",
+          extractorVersion: "mistral-small-2506:measure-context-v7",
           details: expect.stringContaining("droit aux vacances"),
         }),
         generatedContext: expect.objectContaining({
+          claims: [
+            expect.objectContaining({
+              evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
+            }),
+          ],
           evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
           ipAddress: "203.0.113.8",
-          promptVersion: "measure-context-v6",
+          promptVersion: "measure-context-v7",
           userAgent: "vitest-agent",
         }),
       })
@@ -157,6 +166,9 @@ describe("génération de contexte sourcé", () => {
     );
     expect(mocks.callMistral.mock.calls[0]?.[0]?.[0]?.content).toContain(
       "ne doit jamais être attribuée au programme"
+    );
+    expect(mocks.callMistral.mock.calls[0]?.[0]?.[0]?.content).toContain(
+      "proviennent exclusivement de la source attachée à la mesure"
     );
   });
 
@@ -230,85 +242,109 @@ describe("génération de contexte sourcé", () => {
     expect(mocks.callMistral).not.toHaveBeenCalled();
   });
 
-  it("refuse toute quantité chiffrée dans le contexte automatique", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit aux vacances destiné à 80 millions de personnes, avec une application générale à toute la population.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+  it("refuse une quantité absente des preuves citées après une seule correction", async () => {
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit aux vacances destiné à 80 millions de personnes, avec une application générale à toute la population."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
+    expect(mocks.callMistral).toHaveBeenCalledTimes(2);
     expect(mocks.draftMeasureRevision).not.toHaveBeenCalled();
   });
 
-  it("refuse aussi une quantité pourtant présente dans la preuve", async () => {
+  it("accepte une quantité exacte lorsqu'elle est rattachée à la preuve qui la contient", async () => {
+    const firstClaim =
+      "Le programme présente cette proposition comme un droit destiné à 67 millions de personnes.";
+    const secondClaim =
+      "Le document la rattache au constat qu’une partie de la population ne part pas en vacances.";
     mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit destiné à 67 millions de personnes et décrit une partie de la population qui ne part pas en vacances.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
+      details: `${firstClaim} ${secondClaim}`,
+      claims: [
+        { text: firstClaim, evidenceUnitIds: ["pdf-12-2-u001"] },
+        { text: secondClaim, evidenceUnitIds: ["pdf-13-1-u001"] },
+      ],
     });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
-    expect(mocks.draftMeasureRevision).not.toHaveBeenCalled();
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
+      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
+    });
   });
 
   it("refuse qu'un numéro de proposition justifie une quantité inventée", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit aux vacances de 2 heures pour toute la population, sans apporter davantage de précisions.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit aux vacances de 2 heures pour toute la population, sans apporter davantage de précisions."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
     expect(mocks.draftMeasureRevision).not.toHaveBeenCalled();
   });
 
   it("refuse de réattribuer une quantité à une autre unité", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un dispositif qui créerait 1 500 emplois, en s’appuyant sur les éléments de contexte cités.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un dispositif qui créerait 1 500 emplois, en s’appuyant sur les éléments de contexte cités."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
   });
 
   it("refuse les quantités écrites en lettres", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit destiné à quatre-vingts millions de personnes, sans apporter d'autre précision.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit destiné à quatre-vingts millions de personnes, sans apporter d'autre précision."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "écrire les quantités sourcées en chiffres"
+    );
   });
 
   it.each(["plusieurs milliers d’emplois", "une centaine de bénéficiaires"])(
     "refuse aussi la quantité approximative « %s »",
     async (quantity) => {
-      mocks.parseMistralJSON.mockReturnValue({
-        details: `Le programme rattache cette proposition à un objectif qui concernerait ${quantity}, sans apporter davantage d'éléments de contexte.`,
-        evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-      });
+      mocks.parseMistralJSON.mockReturnValue(
+        generatedContext(
+          `Le programme rattache cette proposition à un objectif qui concernerait ${quantity}, sans apporter davantage d'éléments de contexte.`
+        )
+      );
       const { generateMeasureContextDraft } = await import("../context-generation");
 
       await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
-        "contient une quantité"
+        "écrire les quantités sourcées en chiffres"
       );
     }
   );
 
   it("cherche l'historique du contexte sur la révision publiée uniquement", async () => {
-    mocks.findAuditLog.mockResolvedValue({ id: "audit-context" });
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_DRAFT",
+        changes: { previousRevisionId: "revision-published" },
+        entityId: "revision-generated",
+      },
+    ]);
     const { hasContextAttemptForRevision } = await import("../context-generation");
 
     await expect(hasContextAttemptForRevision("revision-published")).resolves.toBe(true);
-    expect(mocks.findAuditLog).toHaveBeenCalledWith({
+    expect(mocks.findAuditLogs).toHaveBeenCalledWith({
       where: expect.objectContaining({
         OR: expect.arrayContaining([
           expect.objectContaining({
@@ -317,19 +353,24 @@ describe("génération de contexte sourcé", () => {
           }),
         ]),
       }),
-      select: { id: true },
+      select: { action: true, changes: true, entityId: true },
     });
   });
 
-  it("ne régénère pas un contexte automatique déjà rejeté", async () => {
-    mocks.findAuditLog.mockResolvedValue({ id: "audit-rejected-context" });
+  it("réessaie une fois une réponse invalide enregistrée par l'ancienne version", async () => {
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+        changes: { outcome: "INVALID_GENERATED_CONTEXT" },
+        entityId: "revision-1",
+      },
+    ]);
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).resolves.toEqual({
-      status: "SKIPPED",
-      reason: "PREVIOUS_CONTEXT_ATTEMPT",
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
     });
-    expect(mocks.callMistral).not.toHaveBeenCalled();
+    expect(mocks.callMistral).toHaveBeenCalledOnce();
   });
 
   it("ne propose à l'admin que les mesures réellement éligibles", async () => {
@@ -401,7 +442,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("accepte que le modèle juge le contexte insuffisant sans créer de brouillon", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, evidenceUnitIds: [] });
+    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).resolves.toEqual({
@@ -419,7 +460,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("refuse de tracer une issue terminale à partir d'une version devenue obsolète", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, evidenceUnitIds: [] });
+    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
     mocks.findMeasureForUpdate.mockResolvedValue({
       latestRevisionId: "revision-1",
       publishedRevisionId: "revision-1",
@@ -436,7 +477,13 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("ne relance pas Mistral après un résultat sans contexte utile sur la même révision", async () => {
-    mocks.findAuditLog.mockResolvedValue({ id: "audit-previous-attempt" });
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+        changes: { outcome: "NO_USEFUL_CONTEXT" },
+        entityId: "revision-1",
+      },
+    ]);
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).resolves.toEqual({
@@ -467,6 +514,53 @@ describe("génération de contexte sourcé", () => {
     await expect(filterMeasureContextCandidateIds(["measure-terminal"])).resolves.toEqual([]);
   });
 
+  it("réinclut dans les lots une révision qui n'a produit qu'une réponse invalide", async () => {
+    const candidate = {
+      id: "measure-retry",
+      latestRevisionId: "revision-retry",
+      publishedRevisionId: "revision-retry",
+      publishedRevision: { evidenceSnapshot: validEvidenceSnapshot() },
+    };
+    mocks.findMeasures.mockResolvedValue([candidate]);
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+        changes: { outcome: "INVALID_GENERATED_CONTEXT" },
+        entityId: "revision-retry",
+      },
+    ]);
+    const { filterMeasureContextCandidateIds } = await import("../context-generation");
+
+    await expect(filterMeasureContextCandidateIds(["measure-retry"])).resolves.toEqual([
+      "measure-retry",
+    ]);
+  });
+
+  it("exclut une révision après deux réponses invalides", async () => {
+    const candidate = {
+      id: "measure-exhausted",
+      latestRevisionId: "revision-exhausted",
+      publishedRevisionId: "revision-exhausted",
+      publishedRevision: { evidenceSnapshot: validEvidenceSnapshot() },
+    };
+    mocks.findMeasures.mockResolvedValue([candidate]);
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_INVALID_RESULT",
+        changes: { outcome: "INVALID_GENERATED_CONTEXT" },
+        entityId: "revision-exhausted",
+      },
+      {
+        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+        changes: { outcome: "INVALID_GENERATED_CONTEXT" },
+        entityId: "revision-exhausted",
+      },
+    ]);
+    const { filterMeasureContextCandidateIds } = await import("../context-generation");
+
+    await expect(filterMeasureContextCandidateIds(["measure-exhausted"])).resolves.toEqual([]);
+  });
+
   it("réautorise une nouvelle révision publiée après un ancien contexte généré", async () => {
     mocks.findMeasures.mockResolvedValue([
       {
@@ -490,28 +584,20 @@ describe("génération de contexte sourcé", () => {
     ]);
   });
 
-  it("refuse une trace qui omet une unité fournie au modèle", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le programme présente cette proposition comme un droit aux vacances et la rattache au constat qu'une partie de la population ne part pas.",
-      evidenceUnitIds: ["pdf-13-1-u001"],
-    });
+  it("accepte un sous-ensemble pertinent des unités fournies au modèle", async () => {
+    const details =
+      "Le programme rattache cette proposition au constat qu'une partie de la population ne part pas en vacances, sans ajouter d'autre justification dans cet extrait.";
+    mocks.parseMistralJSON.mockReturnValue(generatedContext(details, ["pdf-13-1-u001"]));
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
-      "l'ensemble exact des preuves"
-    );
-    expect(mocks.draftMeasureRevision).not.toHaveBeenCalled();
-    expect(mocks.createAuditLog).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
-        changes: expect.objectContaining({ outcome: "INVALID_GENERATED_CONTEXT" }),
-      }),
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
+      evidenceUnitIds: ["pdf-13-1-u001"],
     });
   });
 
   it("trace une réponse JSON invalide avant de remonter l'erreur", async () => {
-    mocks.parseMistralJSON.mockImplementationOnce(() => {
+    mocks.parseMistralJSON.mockImplementation(() => {
       throw new SyntaxError("Invalid JSON");
     });
     const { generateMeasureContextDraft } = await import("../context-generation");
@@ -524,39 +610,35 @@ describe("génération de contexte sourcé", () => {
         changes: expect.objectContaining({ outcome: "INVALID_GENERATED_CONTEXT" }),
       }),
     });
+    expect(mocks.callMistral).toHaveBeenCalledTimes(2);
   });
 
-  it.each([
-    "Le programme ne prévoit zéro bénéficiaire dans les territoires concernés.",
-    "Le programme vise mille bénéficiaires dans les territoires concernés.",
-    "Le programme ne prévoit aucun bénéficiaire dans les territoires concernés.",
-    "Le programme vise un bénéficiaire dans chaque territoire concerné par la mesure.",
-    "Le programme vise une personne dans chaque territoire concerné par la mesure.",
-    "Le programme présente la moitié des Français comme concernés par cette mesure.",
-    "Le programme prévoit une première phase consacrée à ce dispositif.",
-    "Le programme prévoit un deuxième pilier consacré à ce dispositif.",
-    "Le programme prévoit un troisième trimestre consacré à ce dispositif.",
-  ])("refuse la quantité singulière ou accentuée dans « %s »", async (details) => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details: `${details} Il rattache cette proposition au contexte décrit dans le document source.`,
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+  it("corrige une première réponse invalide sans dépasser deux appels", async () => {
+    mocks.parseMistralJSON.mockReturnValueOnce(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit destiné à 80 millions de personnes et la rattache au contexte décrit dans le document."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
-    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("contient une quantité");
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
+    });
+    expect(mocks.callMistral).toHaveBeenCalledTimes(2);
     expect(mocks.createAuditLog).toHaveBeenCalledWith({
       data: expect.objectContaining({
+        action: "GENERATE_CONTEXT_INVALID_RESULT",
         changes: expect.objectContaining({ outcome: "INVALID_GENERATED_CONTEXT" }),
       }),
     });
   });
 
   it("accepte l'attribution des propos à un tiers sans la confondre avec une fraction", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le document rapporte les propos d'un tiers et les distingue de la position défendue par le programme dans cette proposition.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le document rapporte les propos d'un tiers et les distingue de la position défendue par le programme dans cette proposition."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
@@ -565,11 +647,11 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("accepte le titre de Première ministre sans le confondre avec un ordinal", async () => {
-    mocks.parseMistralJSON.mockReturnValue({
-      details:
-        "Le document attribue cette proposition à la Première ministre et la présente comme une orientation défendue par le programme.",
-      evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
-    });
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le document attribue cette proposition à la Première ministre et la présente comme une orientation défendue par le programme."
+      )
+    );
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
@@ -578,7 +660,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("invalide le jeton de version avec l'issue terminale", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, evidenceUnitIds: [] });
+    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await generateMeasureContextDraft("measure-1");

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -295,6 +295,19 @@ describe("génération de contexte sourcé", () => {
     });
   });
 
+  it("refuse d'inverser le signe d'une quantité présente dans la preuve", async () => {
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme un droit destiné à -67 millions de personnes."
+      )
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
+  });
+
   it("refuse qu'un numéro de proposition justifie une quantité inventée", async () => {
     mocks.parseMistralJSON.mockReturnValue(
       generatedContext(
@@ -335,21 +348,23 @@ describe("génération de contexte sourcé", () => {
     );
   });
 
-  it.each(["plusieurs milliers d’emplois", "une centaine de bénéficiaires"])(
-    "refuse aussi la quantité approximative « %s »",
-    async (quantity) => {
-      mocks.parseMistralJSON.mockReturnValue(
-        generatedContext(
-          `Le programme rattache cette proposition à un objectif qui concernerait ${quantity}, sans apporter davantage d'éléments de contexte.`
-        )
-      );
-      const { generateMeasureContextDraft } = await import("../context-generation");
+  it.each([
+    "plusieurs milliers d’emplois",
+    "une centaine de bénéficiaires",
+    "de nombreuses personnes",
+    "un grand nombre de personnes",
+  ])("refuse aussi la quantité approximative « %s »", async (quantity) => {
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        `Le programme rattache cette proposition à un objectif qui concernerait ${quantity}, sans apporter davantage d'éléments de contexte.`
+      )
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
 
-      await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
-        "quantité absente de la preuve citée"
-      );
-    }
-  );
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
+  });
 
   it.each(["aucun logement", "un bénéficiaire", "une première phase", "un tiers des Français"])(
     "refuse la quantité non sourcée « %s »",

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -70,6 +70,24 @@ function generatedContext(details: string, evidenceUnitIds = ["pdf-12-2-u001", "
   };
 }
 
+function measureWithSupportingContext(context: string) {
+  const snapshot = validEvidenceSnapshot();
+  const anchor = snapshot.units.find((unit) => unit.role === "COMMITMENT_ANCHOR");
+  const supporting = snapshot.units.find((unit) => unit.role === "SUPPORTING_CONTEXT");
+  if (!anchor || !supporting) throw new Error("Preuve de test incomplète");
+  const hash = createHash("sha256").update(context, "utf8").digest("hex");
+  supporting.rawExactText = context;
+  supporting.canonicalText = context;
+  supporting.rawTextHash = hash;
+  supporting.canonicalTextHash = hash;
+  snapshot.canonicalEvidenceHash = createHash("sha256")
+    .update(`${anchor.canonicalText}\n\n${context}`, "utf8")
+    .digest("hex");
+  return measure({
+    publishedRevision: { ...measure().publishedRevision, evidenceSnapshot: snapshot },
+  });
+}
+
 describe("génération de contexte sourcé", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -339,6 +357,27 @@ describe("génération de contexte sourcé", () => {
       mocks.parseMistralJSON.mockReturnValue(
         generatedContext(
           `Le programme rattache cette proposition à ${quantity} dans les territoires concernés et la présente comme un élément de contexte distinct.`
+        )
+      );
+      const { generateMeasureContextDraft } = await import("../context-generation");
+
+      await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+        "quantité absente de la preuve citée"
+      );
+    }
+  );
+
+  it.each([
+    { evidence: "Le document ne prévoit aucun logement vacant.", generated: "un logement" },
+    { evidence: "Le document prévoit un logement vacant.", generated: "aucun logement" },
+  ])(
+    "refuse d'inverser la quantité entre « $evidence » et « $generated »",
+    async ({ evidence, generated }) => {
+      mocks.findMeasure.mockResolvedValue(measureWithSupportingContext(evidence));
+      mocks.parseMistralJSON.mockReturnValue(
+        generatedContext(
+          `Le programme rattache cette proposition à ${generated} dans les territoires concernés et la présente comme un élément de contexte distinct.`,
+          ["pdf-13-1-u001"]
         )
       );
       const { generateMeasureContextDraft } = await import("../context-generation");

--- a/src/lib/measures/__tests__/context-provenance.test.ts
+++ b/src/lib/measures/__tests__/context-provenance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readGeneratedContextClaims } from "@/lib/measures/context-provenance";
+
+describe("preuve des contextes générés", () => {
+  it("lit uniquement les associations affirmation-preuves valides", () => {
+    expect(
+      readGeneratedContextClaims({
+        claims: [
+          {
+            text: "Le document rattache la mesure à ce constat précis.",
+            evidenceUnitIds: ["unit-1"],
+          },
+        ],
+        generatedBy: "admin",
+      })
+    ).toEqual([
+      {
+        text: "Le document rattache la mesure à ce constat précis.",
+        evidenceUnitIds: ["unit-1"],
+      },
+    ]);
+  });
+
+  it("n'expose pas une trace d'audit mal formée", () => {
+    expect(
+      readGeneratedContextClaims({ claims: [{ text: "Trop court", evidenceUnitIds: [] }] })
+    ).toEqual([]);
+  });
+});

--- a/src/lib/measures/__tests__/evidence-snapshot-fixture.ts
+++ b/src/lib/measures/__tests__/evidence-snapshot-fixture.ts
@@ -39,7 +39,7 @@ export function validEvidenceSnapshot(): EvidenceSnapshot {
         discourseReason: "Objectif formulé par le document.",
         numbers: [
           { raw: "2", normalized: "2", role: "STRUCTURAL" },
-          { raw: "67 millions", normalized: "67000000", role: "CONTENT" },
+          { raw: "67", normalized: "67", role: "CONTENT" },
         ],
       },
       {

--- a/src/lib/measures/__tests__/evidence-snapshot.test.ts
+++ b/src/lib/measures/__tests__/evidence-snapshot.test.ts
@@ -102,7 +102,7 @@ describe("EvidenceSnapshotV3 persistant", () => {
     expect(unit.rawExactText).not.toBe(unit.canonicalText);
     expect(unit.numbers).toEqual([
       { raw: "2", normalized: "2", role: "STRUCTURAL" },
-      { raw: "67 millions", normalized: "67000000", role: "CONTENT" },
+      { raw: "67", normalized: "67", role: "CONTENT" },
     ]);
   });
 });

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
 import { db } from "@/lib/db";
+import {
+  GENERATED_CONTEXT_DRAFT_ACTION,
+  generatedContextClaimSchema,
+  type GeneratedContextClaim,
+} from "@/lib/measures/context-provenance";
 import { readEvidenceSnapshot } from "@/lib/measures/evidence-snapshot";
 import { MeasureConcurrencyError, MeasureValidationError } from "@/lib/measures/errors";
 import { lockMeasure } from "@/lib/measures/lock";
@@ -12,19 +17,9 @@ const PROMPT_VERSION = "measure-context-v7";
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
 const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
 const RESERVED_CONTEXT_GENERATION_ACTION = "RESERVE_CONTEXT_GENERATION";
-const GENERATED_CONTEXT_DRAFT_ACTION = "GENERATE_CONTEXT_DRAFT";
 const CONTEXT_GENERATION_LEASE_MS = 15 * 60 * 1_000;
 const MIN_DETAILS_LENGTH = 80;
 const MAX_DETAILS_LENGTH = 1_000;
-
-const generatedContextClaimSchema = z
-  .object({
-    text: z.string().trim().min(10).max(500),
-    evidenceUnitIds: z.array(z.string().min(1)).max(8),
-  })
-  .strict();
-
-type GeneratedContextClaim = z.infer<typeof generatedContextClaimSchema>;
 
 const generatedContextSchema = z
   .object({
@@ -297,6 +292,11 @@ function normalizeEvidenceText(value: string): string {
     .trim();
 }
 
+function includesWholeEvidencePhrase(evidence: string, phrase: string): boolean {
+  const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?<![\\p{L}\\p{N}_])${escapedPhrase}(?![\\p{L}\\p{N}_])`, "u").test(evidence);
+}
+
 function assertGroundedLexicalQuantities(text: string, citedEvidenceText: string): void {
   const normalizedEvidence = normalizeEvidenceText(citedEvidenceText);
   const textWithoutMinisterialTitle = text.replace(
@@ -310,7 +310,7 @@ function assertGroundedLexicalQuantities(text: string, citedEvidenceText: string
     ...(text.match(FRACTIONAL_TIER_PATTERN) ?? []),
   ];
   for (const match of matches) {
-    if (!normalizedEvidence.includes(normalizeEvidenceText(match))) {
+    if (!includesWholeEvidencePhrase(normalizedEvidence, normalizeEvidenceText(match))) {
       throw new MeasureValidationError(
         `Le contexte généré contient une quantité absente de la preuve citée : ${match}`
       );

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -7,18 +7,37 @@ import { lockMeasure } from "@/lib/measures/lock";
 import { draftMeasureRevision } from "@/lib/measures/transitions";
 
 const MODEL = "mistral-small-latest";
-const PROMPT_VERSION = "measure-context-v6";
+const PROMPT_VERSION = "measure-context-v7";
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
+const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
 const GENERATED_CONTEXT_DRAFT_ACTION = "GENERATE_CONTEXT_DRAFT";
 const MIN_DETAILS_LENGTH = 80;
 const MAX_DETAILS_LENGTH = 1_000;
 
-const generatedContextSchema = z
+const generatedContextClaimSchema = z
   .object({
-    details: z.string().trim().min(MIN_DETAILS_LENGTH).max(MAX_DETAILS_LENGTH).nullable(),
+    text: z.string().trim().min(10).max(500),
     evidenceUnitIds: z.array(z.string().min(1)).max(8),
   })
   .strict();
+
+const generatedContextSchema = z
+  .object({
+    details: z.string().trim().min(MIN_DETAILS_LENGTH).max(MAX_DETAILS_LENGTH).nullable(),
+    claims: z.array(generatedContextClaimSchema).max(6),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.details === null && value.claims.length > 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Un contexte absent ne peut pas avoir de preuve",
+      });
+    }
+    if (value.details !== null && value.claims.length === 0) {
+      context.addIssue({ code: "custom", message: "Chaque contexte doit avoir une preuve" });
+    }
+  });
 
 export type ContextGenerationSkipReason =
   | "ACTIVE_DRAFT"
@@ -52,22 +71,65 @@ function getGeneratedContextSourceRevisionId(changes: unknown): string | null {
   return typeof previousRevisionId === "string" ? previousRevisionId : null;
 }
 
-export async function hasContextAttemptForRevision(revisionId: string | null): Promise<boolean> {
-  if (!revisionId) return false;
-  const result = await db.auditLog.findFirst({
+type ContextAttemptState = "AVAILABLE" | "ONE_INVALID_RESULT" | "TERMINAL";
+
+function readAuditOutcome(changes: unknown): string | null {
+  if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null;
+  const outcome = (changes as Record<string, unknown>).outcome;
+  return typeof outcome === "string" ? outcome : null;
+}
+
+function getContextAttemptState(
+  revisionId: string,
+  attempts: Array<{ action: string; changes: unknown; entityId: string }>
+): ContextAttemptState {
+  let invalidResults = 0;
+  for (const attempt of attempts) {
+    if (attempt.action === GENERATED_CONTEXT_DRAFT_ACTION) {
+      if (getGeneratedContextSourceRevisionId(attempt.changes) === revisionId) return "TERMINAL";
+      continue;
+    }
+    if (attempt.entityId !== revisionId) continue;
+    if (attempt.action === INVALID_CONTEXT_RESULT_ACTION) {
+      invalidResults += 1;
+      continue;
+    }
+    const outcome = readAuditOutcome(attempt.changes);
+    if (outcome === "INVALID_GENERATED_CONTEXT") {
+      invalidResults += 1;
+      continue;
+    }
+    // Old terminal rows without an outcome and explicit NO_USEFUL_CONTEXT results stay terminal.
+    return "TERMINAL";
+  }
+  if (invalidResults >= 2) return "TERMINAL";
+  return invalidResults === 1 ? "ONE_INVALID_RESULT" : "AVAILABLE";
+}
+
+async function findContextAttempts(revisionIds: string[]) {
+  if (revisionIds.length === 0) return [];
+  return db.auditLog.findMany({
     where: {
       entityType: "MeasureRevision",
       OR: [
-        { action: TERMINAL_CONTEXT_RESULT_ACTION, entityId: revisionId },
         {
+          action: { in: [TERMINAL_CONTEXT_RESULT_ACTION, INVALID_CONTEXT_RESULT_ACTION] },
+          entityId: { in: revisionIds },
+        },
+        ...revisionIds.map((revisionId) => ({
           action: GENERATED_CONTEXT_DRAFT_ACTION,
           changes: { path: ["previousRevisionId"], equals: revisionId },
-        },
+        })),
       ],
     },
-    select: { id: true },
+    select: { action: true, changes: true, entityId: true },
   });
-  return result !== null;
+}
+
+export async function hasContextAttemptForRevision(revisionId: string | null): Promise<boolean> {
+  if (!revisionId) return false;
+  const attempts = await findContextAttempts([revisionId]);
+  return getContextAttemptState(revisionId, attempts) === "TERMINAL";
 }
 
 function isEligibleContextCandidate(
@@ -83,26 +145,9 @@ function isEligibleContextCandidate(
 }
 
 async function getAttemptedContextRevisionIds(revisionIds: string[]): Promise<Set<string>> {
-  if (revisionIds.length === 0) return new Set();
-  const attempts = await db.auditLog.findMany({
-    where: {
-      entityType: "MeasureRevision",
-      OR: [
-        { action: TERMINAL_CONTEXT_RESULT_ACTION, entityId: { in: revisionIds } },
-        ...revisionIds.map((revisionId) => ({
-          action: GENERATED_CONTEXT_DRAFT_ACTION,
-          changes: { path: ["previousRevisionId"], equals: revisionId },
-        })),
-      ],
-    },
-    select: { action: true, changes: true, entityId: true },
-  });
+  const attempts = await findContextAttempts(revisionIds);
   return new Set(
-    attempts.flatMap((attempt) => {
-      if (attempt.action === TERMINAL_CONTEXT_RESULT_ACTION) return [attempt.entityId];
-      const sourceRevisionId = getGeneratedContextSourceRevisionId(attempt.changes);
-      return sourceRevisionId ? [sourceRevisionId] : [];
-    })
+    revisionIds.filter((revisionId) => getContextAttemptState(revisionId, attempts) === "TERMINAL")
   );
 }
 
@@ -191,34 +236,131 @@ function sanitizeSourceText(value: string): string {
     .slice(0, 200);
 }
 
-const SPELLED_OUT_NUMBER_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:zéro|aucun|aucune|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|nombre|nombreux|nombreuses|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/iu;
+const NUMERIC_TOKEN_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:\d{1,3}(?:[\s\u00a0\u202f]\d{3})+|\d+)(?:[.,]\d+)?(?:[\s\u00a0\u202f]*(?:%|millions?|milliards?|euros?))?(?![\p{L}\p{N}_])/giu;
 
-const SPELLED_OUT_ORDINAL_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:premi(?:er|ère|ers|ères)|seconds?|secondes?|deuxièmes?|troisièmes?|quatrièmes?|cinquièmes?|sixièmes?|septièmes?|huitièmes?|neuvièmes?|dixièmes?|onzièmes?|douzièmes?|treizièmes?|quatorzièmes?|quinzièmes?|seizièmes?|vingtièmes?|centièmes?|millièmes?)(?![\p{L}\p{N}_])/iu;
-
-const FRACTIONAL_TIER_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:un|deux|le)[\s\u00a0\u202f]+tiers?(?:[\s\u00a0\u202f]+)(?:des|du|de[\s\u00a0\u202f]+la|de[\s\u00a0\u202f]+l[’'])(?![\p{L}\p{N}_])/iu;
-
-const CONTEXTUAL_SINGULAR_QUANTITY_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:un|une)[\s\u00a0\u202f]+(?:bénéficiaire|personne|emploi|poste|euro|logement|place|année|mois|jour|heure|établissement|entreprise|agent|salarié|fonctionnaire|famille|ménage|enfant|élève|étudiant|enseignant|médecin|lit)(?:e|s|es)?(?![\p{L}\p{N}_])/iu;
-
-function assertNoGeneratedQuantities(details: string): void {
-  const detailsWithoutMinisterialTitle = details.replace(
-    /(?<![\p{L}\p{N}_])premi(?:er|ère)[\s\u00a0\u202f]+ministre(?![\p{L}\p{N}_])/giu,
-    ""
+function numericTokens(value: string): Set<string> {
+  const tokens = value.match(NUMERIC_TOKEN_PATTERN);
+  return new Set(
+    (tokens ?? []).map((token) =>
+      token
+        .toLocaleLowerCase("fr")
+        .replace(/(?<=\d)[\s\u00a0\u202f](?=\d)/g, "")
+        .replace(/[\s\u00a0\u202f]+/g, " ")
+    )
   );
-  if (
-    /\d/u.test(details) ||
-    SPELLED_OUT_NUMBER_PATTERN.test(details) ||
-    SPELLED_OUT_ORDINAL_PATTERN.test(detailsWithoutMinisterialTitle) ||
-    FRACTIONAL_TIER_PATTERN.test(details) ||
-    CONTEXTUAL_SINGULAR_QUANTITY_PATTERN.test(details)
-  ) {
+}
+
+const SPELLED_OUT_QUANTITY_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:zéro|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/iu;
+
+function assertGroundedNumbers(
+  text: string,
+  citedUnits: Array<{ numbers: Array<{ raw: string; normalized: string; role: string }> }>
+): void {
+  const textWithoutNumericTokens = text.replace(NUMERIC_TOKEN_PATTERN, "");
+  if (SPELLED_OUT_QUANTITY_PATTERN.test(textWithoutNumericTokens)) {
     throw new MeasureValidationError(
-      "Le contexte généré contient une quantité, interdite dans un brouillon automatique"
+      "Le contexte généré doit écrire les quantités sourcées en chiffres"
     );
   }
+  const allowedNumbers = new Set<string>();
+  for (const unit of citedUnits) {
+    for (const number of unit.numbers) {
+      if (number.role !== "CONTENT") continue;
+      for (const token of numericTokens(`${number.raw} ${number.normalized}`)) {
+        allowedNumbers.add(token);
+      }
+    }
+  }
+  for (const token of numericTokens(text)) {
+    if (!allowedNumbers.has(token)) {
+      throw new MeasureValidationError(
+        `Le contexte généré contient une quantité absente de la preuve citée : ${token}`
+      );
+    }
+  }
+}
+
+function normalizeGeneratedText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function validateGeneratedContext(
+  parsed: z.infer<typeof generatedContextSchema>,
+  units: Array<{
+    unitId: string;
+    numbers: Array<{ raw: string; normalized: string; role: string }>;
+  }>,
+  supportingIds: ReadonlySet<string>
+): {
+  claims: Array<{ text: string; evidenceUnitIds: string[] }>;
+  details: string;
+  evidenceUnitIds: string[];
+} | null {
+  if (parsed.details === null) return null;
+  const details = normalizeGeneratedText(parsed.details);
+  const claimedText = normalizeGeneratedText(parsed.claims.map((claim) => claim.text).join(" "));
+  if (details !== claimedText) {
+    throw new MeasureValidationError(
+      "Le contexte généré contient du texte qui n'est rattaché à aucune preuve"
+    );
+  }
+
+  const unitsById = new Map(units.map((unit) => [unit.unitId, unit]));
+  const allCitedIds = new Set<string>();
+  for (const claim of parsed.claims) {
+    const citedIds = new Set(claim.evidenceUnitIds);
+    if (
+      citedIds.size === 0 ||
+      citedIds.size !== claim.evidenceUnitIds.length ||
+      claim.evidenceUnitIds.some((id) => !unitsById.has(id))
+    ) {
+      throw new MeasureValidationError(
+        "Une affirmation du contexte ne cite pas une preuve autorisée"
+      );
+    }
+    const citedUnits = claim.evidenceUnitIds.flatMap((id) => {
+      const unit = unitsById.get(id);
+      return unit ? [unit] : [];
+    });
+    assertGroundedNumbers(claim.text, citedUnits);
+    for (const id of citedIds) allCitedIds.add(id);
+  }
+  if (![...allCitedIds].some((id) => supportingIds.has(id))) {
+    throw new MeasureValidationError(
+      "Le contexte généré ne cite aucun extrait de contexte distinct de la mesure"
+    );
+  }
+  return { claims: parsed.claims, details, evidenceUnitIds: [...allCitedIds] };
+}
+
+async function recordInvalidContextResult(input: {
+  generatedBy: string;
+  measureId: string;
+  model: string;
+  revisionId: string;
+  validationError: string;
+  ipAddress: string;
+  userAgent: string;
+}): Promise<void> {
+  await db.auditLog.create({
+    data: {
+      action: INVALID_CONTEXT_RESULT_ACTION,
+      entityType: "MeasureRevision",
+      entityId: input.revisionId,
+      changes: {
+        measureId: input.measureId,
+        model: input.model,
+        promptVersion: PROMPT_VERSION,
+        outcome: "INVALID_GENERATED_CONTEXT",
+        validationError: input.validationError.slice(0, 300),
+      },
+      userId: input.generatedBy,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+    },
+  });
 }
 
 async function recordTerminalContextResult(input: {
@@ -325,7 +467,9 @@ export async function generateMeasureContextDraft(
   if (measure.latestRevisionId !== measure.publishedRevisionId) {
     return { status: "SKIPPED", reason: "ACTIVE_DRAFT" };
   }
-  if (await hasContextAttemptForRevision(revision.id)) {
+  const previousAttempts = await findContextAttempts([revision.id]);
+  const attemptState = getContextAttemptState(revision.id, previousAttempts);
+  if (attemptState === "TERMINAL") {
     return { status: "SKIPPED", reason: "PREVIOUS_CONTEXT_ATTEMPT" };
   }
 
@@ -351,17 +495,19 @@ export async function generateMeasureContextDraft(
 
 Règles :
 - utilise uniquement les faits explicitement présents dans les unités ;
+- ces unités proviennent exclusivement de la source attachée à la mesure, ne complète jamais avec une connaissance ou un site externe ;
 - n'ajoute aucune conséquence, faisabilité, intention, appréciation ou connaissance extérieure ;
 - attribue au document toute analyse, tout diagnostic ou toute appréciation qu'il formule, par exemple avec « Le programme estime que » ou « Le document présente » ;
 - respecte le locuteur de chaque unité : une parole de QUOTED_THIRD_PARTY, LEGAL_OR_INSTITUTIONAL_SOURCE ou HISTORICAL_ACTOR ne doit jamais être attribuée au programme ;
 - si tu utilises une telle unité, indique explicitement qu'elle rapporte les propos ou la position d'un tiers, d'une source juridique ou institutionnelle, ou d'un acteur historique, sans inventer son identité ;
 - n'utilise pas une unité dont le locuteur est UNRESOLVED pour attribuer une affirmation au programme ;
-- n'inclus aucune quantité, aucun chiffre et aucun nombre écrit en lettres ; la formulation de la mesure porte déjà ces informations ;
+- une quantité n'est autorisée que si elle figure exactement dans l'unité citée par l'affirmation ; conserve sa valeur et écris-la en chiffres ;
 - ne présente jamais l'argumentaire du programme comme un fait établi ;
 - ne répète pas simplement la formulation de la mesure ;
 - écris entre 40 et 120 mots, en français clair ;
-- renvoie exactement les identifiants de toutes les unités fournies, sans en omettre ni en ajouter ;
-- si les unités n'apportent aucun contexte distinct, renvoie details à null.
+- découpe le texte en affirmations et rattache chaque affirmation uniquement aux unités qui la prouvent ;
+- la concaténation des champs text, dans leur ordre, doit être exactement égale à details ;
+- si les unités n'apportent aucun contexte distinct, renvoie details à null et claims à un tableau vide.
 
 <formulation>${sanitizeSourceText(revision.text)}</formulation>
 <preuves>
@@ -369,77 +515,84 @@ ${sourceUnits}
 </preuves>
 
 Réponds uniquement en JSON :
-{"details":"texte ou null","evidenceUnitIds":["identifiant"]}`;
+{"details":"texte ou null","claims":[{"text":"affirmation","evidenceUnitIds":["identifiant"]}]}`;
 
-  const response = await callMistral([{ role: "user", content: prompt }], {
-    model: MODEL,
-    maxTokens: 400,
-    temperature: 0,
-    responseFormat: { type: "json_object" },
-  });
-  const resolvedModel = response.model?.trim() || MODEL;
-  let parsed: z.infer<typeof generatedContextSchema>;
-  try {
-    parsed = generatedContextSchema.parse(parseMistralJSON<unknown>(extractMistralText(response)));
-  } catch (error) {
-    if (!(error instanceof SyntaxError || error instanceof z.ZodError)) throw error;
-    const validationError = "La réponse de génération ne respecte pas le format attendu";
-    await recordTerminalContextResult({
-      generatedBy: options.generatedBy ?? "system",
-      expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
-      ipAddress: options.ipAddress ?? "unknown",
-      measureId,
-      model: resolvedModel,
-      outcome: "INVALID_GENERATED_CONTEXT",
-      revisionId: revision.id,
-      userAgent: options.userAgent ?? "unknown",
-      validationError,
-    });
-    throw new MeasureValidationError(validationError);
-  }
-  if (parsed.details === null) {
-    await recordTerminalContextResult({
-      generatedBy: options.generatedBy ?? "system",
-      expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
-      ipAddress: options.ipAddress ?? "unknown",
-      measureId,
-      model: resolvedModel,
-      outcome: "NO_USEFUL_CONTEXT",
-      revisionId: revision.id,
-      userAgent: options.userAgent ?? "unknown",
-    });
-    return { status: "SKIPPED", reason: "NO_USEFUL_CONTEXT" };
-  }
+  const maxAttempts = attemptState === "ONE_INVALID_RESULT" ? 1 : 2;
+  let generated:
+    | {
+        claims: Array<{ text: string; evidenceUnitIds: string[] }>;
+        details: string;
+        evidenceUnitIds: string[];
+        model: string;
+      }
+    | undefined;
+  let validationError = "La réponse de génération ne respecte pas le format attendu";
 
-  try {
-    const unitsById = new Map(units.map((unit) => [unit.unitId, unit]));
-    const citedUnitIds = new Set(parsed.evidenceUnitIds);
-    if (
-      parsed.evidenceUnitIds.length !== unitsById.size ||
-      citedUnitIds.size !== unitsById.size ||
-      parsed.evidenceUnitIds.some((id) => !unitsById.has(id)) ||
-      !parsed.evidenceUnitIds.some((id) => supportingIds.has(id))
-    ) {
-      throw new MeasureValidationError(
-        "Le contexte généré ne cite pas l'ensemble exact des preuves fournies"
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const repairInstruction =
+      attempt === 0
+        ? ""
+        : `\n\nLa réponse précédente a été refusée pour cette raison : ${sanitizeSourceText(validationError)}. Corrige uniquement ce problème et respecte le même format JSON.`;
+    const response = await callMistral(
+      [{ role: "user", content: `${prompt}${repairInstruction}` }],
+      {
+        model: MODEL,
+        maxTokens: 600,
+        temperature: 0,
+        responseFormat: { type: "json_object" },
+      }
+    );
+    const resolvedModel = response.model?.trim() || MODEL;
+    try {
+      const parsed = generatedContextSchema.parse(
+        parseMistralJSON<unknown>(extractMistralText(response))
       );
+      const validated = validateGeneratedContext(parsed, units, supportingIds);
+      if (validated === null) {
+        await recordTerminalContextResult({
+          generatedBy: options.generatedBy ?? "system",
+          expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
+          ipAddress: options.ipAddress ?? "unknown",
+          measureId,
+          model: resolvedModel,
+          outcome: "NO_USEFUL_CONTEXT",
+          revisionId: revision.id,
+          userAgent: options.userAgent ?? "unknown",
+        });
+        return { status: "SKIPPED", reason: "NO_USEFUL_CONTEXT" };
+      }
+      generated = { ...validated, model: resolvedModel };
+      break;
+    } catch (error) {
+      if (error instanceof SyntaxError || error instanceof z.ZodError) {
+        validationError = "La réponse de génération ne respecte pas le format attendu";
+      } else if (error instanceof MeasureValidationError) {
+        validationError = error.message;
+      } else {
+        throw error;
+      }
+      const auditInput = {
+        generatedBy: options.generatedBy ?? "system",
+        ipAddress: options.ipAddress ?? "unknown",
+        measureId,
+        model: resolvedModel,
+        revisionId: revision.id,
+        userAgent: options.userAgent ?? "unknown",
+        validationError,
+      };
+      if (attempt + 1 < maxAttempts) {
+        await recordInvalidContextResult(auditInput);
+      } else {
+        await recordTerminalContextResult({
+          ...auditInput,
+          expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
+          outcome: "INVALID_GENERATED_CONTEXT",
+        });
+      }
     }
-    assertNoGeneratedQuantities(parsed.details);
-  } catch (error) {
-    if (!(error instanceof MeasureValidationError)) throw error;
-    await recordTerminalContextResult({
-      generatedBy: options.generatedBy ?? "system",
-      expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
-      ipAddress: options.ipAddress ?? "unknown",
-      measureId,
-      model: resolvedModel,
-      outcome: "INVALID_GENERATED_CONTEXT",
-      revisionId: revision.id,
-      userAgent: options.userAgent ?? "unknown",
-      validationError: error.message,
-    });
-    throw error;
   }
+
+  if (!generated) throw new MeasureValidationError(validationError);
 
   const { revisionId } = await draftMeasureRevision({
     measureId,
@@ -447,21 +600,22 @@ Réponds uniquement en JSON :
     preserveEvidenceFromRevisionId: revision.id,
     correctedBy: options.generatedBy ?? "system",
     generatedContext: {
-      evidenceUnitIds: parsed.evidenceUnitIds,
+      claims: generated.claims,
+      evidenceUnitIds: generated.evidenceUnitIds,
       generatedBy: options.generatedBy ?? "system",
       ipAddress: options.ipAddress ?? "unknown",
-      model: resolvedModel,
+      model: generated.model,
       promptVersion: PROMPT_VERSION,
       userAgent: options.userAgent ?? "unknown",
     },
     revision: {
       text: revision.text,
-      details: parsed.details,
+      details: generated.details,
       precision: revision.precision,
       validFrom: revision.validFrom,
       extractionMethod: "AI_ASSISTED",
       extractionConfidence: null,
-      extractorVersion: `${resolvedModel}:${PROMPT_VERSION}`,
+      extractorVersion: `${generated.model}:${PROMPT_VERSION}`,
     },
     sources: [],
   });
@@ -469,8 +623,8 @@ Réponds uniquement en JSON :
   return {
     status: "CREATED",
     revisionId,
-    details: parsed.details,
-    model: resolvedModel,
-    evidenceUnitIds: parsed.evidenceUnitIds,
+    details: generated.details,
+    model: generated.model,
+    evidenceUnitIds: generated.evidenceUnitIds,
   };
 }

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -258,7 +258,7 @@ function sanitizeSourceText(value: string): string {
 }
 
 const NUMERIC_TOKEN_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:\d{1,3}(?:[\s\u00a0\u202f]\d{3})+|\d+)(?:[.,]\d+)?(?:[\s\u00a0\u202f]*(?:%|millions?|milliards?|euros?))?(?![\p{L}\p{N}_])/giu;
+  /(?<![\p{L}\p{N}_])[+\-\u2212]?(?:\d{1,3}(?:[\s\u00a0\u202f]\d{3})+|\d+)(?:[.,]\d+)?(?:[\s\u00a0\u202f]*(?:%|millions?|milliards?|euros?))?(?![\p{L}\p{N}_])/giu;
 
 function numericTokens(value: string): Set<string> {
   const tokens = value.match(NUMERIC_TOKEN_PATTERN);
@@ -266,6 +266,7 @@ function numericTokens(value: string): Set<string> {
     (tokens ?? []).map((token) =>
       token
         .toLocaleLowerCase("fr")
+        .replace(/\u2212/g, "-")
         .replace(/(?<=\d)[\s\u00a0\u202f](?=\d)/g, "")
         .replace(/[\s\u00a0\u202f]+/g, " ")
     )
@@ -273,7 +274,7 @@ function numericTokens(value: string): Set<string> {
 }
 
 const SPELLED_OUT_QUANTITY_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:zéro|aucun|aucune|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/giu;
+  /(?<![\p{L}\p{N}_])(?:zéro|aucun|aucune|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|nombre|nombreux|nombreuses|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/giu;
 
 const CONTEXTUAL_SINGULAR_QUANTITY_PATTERN =
   /(?<![\p{L}\p{N}_])(?:un|une)[\s\u00a0\u202f]+(?:bénéficiaire|personne|emploi|poste|euro|logement|place|année|mois|jour|heure|établissement|entreprise|agent|salarié|fonctionnaire|famille|ménage|enfant|élève|étudiant|enseignant|médecin|lit)(?:e|s|es)?(?![\p{L}\p{N}_])/giu;

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
 import { db } from "@/lib/db";
@@ -10,7 +11,9 @@ const MODEL = "mistral-small-latest";
 const PROMPT_VERSION = "measure-context-v7";
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
 const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
+const RESERVED_CONTEXT_GENERATION_ACTION = "RESERVE_CONTEXT_GENERATION";
 const GENERATED_CONTEXT_DRAFT_ACTION = "GENERATE_CONTEXT_DRAFT";
+const CONTEXT_GENERATION_LEASE_MS = 15 * 60 * 1_000;
 const MIN_DETAILS_LENGTH = 80;
 const MAX_DETAILS_LENGTH = 1_000;
 
@@ -20,6 +23,8 @@ const generatedContextClaimSchema = z
     evidenceUnitIds: z.array(z.string().min(1)).max(8),
   })
   .strict();
+
+type GeneratedContextClaim = z.infer<typeof generatedContextClaimSchema>;
 
 const generatedContextSchema = z
   .object({
@@ -71,7 +76,7 @@ function getGeneratedContextSourceRevisionId(changes: unknown): string | null {
   return typeof previousRevisionId === "string" ? previousRevisionId : null;
 }
 
-type ContextAttemptState = "AVAILABLE" | "ONE_INVALID_RESULT" | "TERMINAL";
+type ContextAttemptState = "AVAILABLE" | "ONE_INVALID_RESULT" | "IN_PROGRESS" | "TERMINAL";
 
 function readAuditOutcome(changes: unknown): string | null {
   if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null;
@@ -84,12 +89,22 @@ function getContextAttemptState(
   attempts: Array<{ action: string; changes: unknown; entityId: string }>
 ): ContextAttemptState {
   let invalidResults = 0;
+  let hasActiveReservation = false;
   for (const attempt of attempts) {
     if (attempt.action === GENERATED_CONTEXT_DRAFT_ACTION) {
       if (getGeneratedContextSourceRevisionId(attempt.changes) === revisionId) return "TERMINAL";
       continue;
     }
     if (attempt.entityId !== revisionId) continue;
+    if (attempt.action === RESERVED_CONTEXT_GENERATION_ACTION) {
+      const changes =
+        attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
+          ? (attempt.changes as Record<string, unknown>)
+          : null;
+      const expiresAt = typeof changes?.expiresAt === "string" ? Date.parse(changes.expiresAt) : 0;
+      if (Number.isFinite(expiresAt) && expiresAt > Date.now()) hasActiveReservation = true;
+      continue;
+    }
     if (attempt.action === INVALID_CONTEXT_RESULT_ACTION) {
       invalidResults += 1;
       continue;
@@ -103,6 +118,7 @@ function getContextAttemptState(
     return "TERMINAL";
   }
   if (invalidResults >= 2) return "TERMINAL";
+  if (hasActiveReservation) return "IN_PROGRESS";
   return invalidResults === 1 ? "ONE_INVALID_RESULT" : "AVAILABLE";
 }
 
@@ -113,7 +129,13 @@ async function findContextAttempts(revisionIds: string[]) {
       entityType: "MeasureRevision",
       OR: [
         {
-          action: { in: [TERMINAL_CONTEXT_RESULT_ACTION, INVALID_CONTEXT_RESULT_ACTION] },
+          action: {
+            in: [
+              TERMINAL_CONTEXT_RESULT_ACTION,
+              INVALID_CONTEXT_RESULT_ACTION,
+              RESERVED_CONTEXT_GENERATION_ACTION,
+            ],
+          },
           entityId: { in: revisionIds },
         },
         ...revisionIds.map((revisionId) => ({
@@ -129,7 +151,8 @@ async function findContextAttempts(revisionIds: string[]) {
 export async function hasContextAttemptForRevision(revisionId: string | null): Promise<boolean> {
   if (!revisionId) return false;
   const attempts = await findContextAttempts([revisionId]);
-  return getContextAttemptState(revisionId, attempts) === "TERMINAL";
+  const state = getContextAttemptState(revisionId, attempts);
+  return state === "TERMINAL" || state === "IN_PROGRESS";
 }
 
 function isEligibleContextCandidate(
@@ -147,7 +170,10 @@ function isEligibleContextCandidate(
 async function getAttemptedContextRevisionIds(revisionIds: string[]): Promise<Set<string>> {
   const attempts = await findContextAttempts(revisionIds);
   return new Set(
-    revisionIds.filter((revisionId) => getContextAttemptState(revisionId, attempts) === "TERMINAL")
+    revisionIds.filter((revisionId) => {
+      const state = getContextAttemptState(revisionId, attempts);
+      return state === "TERMINAL" || state === "IN_PROGRESS";
+    })
   );
 }
 
@@ -252,24 +278,65 @@ function numericTokens(value: string): Set<string> {
 }
 
 const SPELLED_OUT_QUANTITY_PATTERN =
-  /(?<![\p{L}\p{N}_])(?:zéro|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/iu;
+  /(?<![\p{L}\p{N}_])(?:zéro|aucun|aucune|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|vingts?|trente|quarante|cinquante|soixante|cents?|mille|milliers?|millions?|milliards?|dizaines?|douzaines?|quinzaines?|vingtaines?|trentaines?|quarantaines?|cinquantaines?|soixantaines?|centaines?|plusieurs|quelques|majorité|minorité|moitié|quarts?|doubles?|triples?|quadruples?|pour[\s\u00a0\u202f]+cent)(?![\p{L}\p{N}_])/giu;
+
+const CONTEXTUAL_SINGULAR_QUANTITY_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:un|une)[\s\u00a0\u202f]+(?:bénéficiaire|personne|emploi|poste|euro|logement|place|année|mois|jour|heure|établissement|entreprise|agent|salarié|fonctionnaire|famille|ménage|enfant|élève|étudiant|enseignant|médecin|lit)(?:e|s|es)?(?![\p{L}\p{N}_])/giu;
+
+const SPELLED_OUT_ORDINAL_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:premi(?:er|ère|ers|ères)|seconds?|secondes?|deuxièmes?|troisièmes?|quatrièmes?|cinquièmes?|sixièmes?|septièmes?|huitièmes?|neuvièmes?|dixièmes?|onzièmes?|douzièmes?|treizièmes?|quatorzièmes?|quinzièmes?|seizièmes?|vingtièmes?|centièmes?|millièmes?)(?![\p{L}\p{N}_])/giu;
+
+const FRACTIONAL_TIER_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:un|deux|le)[\s\u00a0\u202f]+tiers?(?:[\s\u00a0\u202f]+)(?:des|du|de[\s\u00a0\u202f]+la|de[\s\u00a0\u202f]+l[’'])(?![\p{L}\p{N}_])/giu;
+
+function normalizeEvidenceText(value: string): string {
+  return value
+    .toLocaleLowerCase("fr")
+    .replace(/[’']/g, "'")
+    .replace(/[\s\u00a0\u202f]+/g, " ")
+    .trim();
+}
+
+function assertGroundedLexicalQuantities(text: string, citedEvidenceText: string): void {
+  const normalizedEvidence = normalizeEvidenceText(citedEvidenceText);
+  const textWithoutMinisterialTitle = text.replace(
+    /(?<![\p{L}\p{N}_])premi(?:er|ère)[\s\u00a0\u202f]+ministre(?![\p{L}\p{N}_])/giu,
+    ""
+  );
+  const matches = [
+    ...(textWithoutMinisterialTitle.match(SPELLED_OUT_QUANTITY_PATTERN) ?? []),
+    ...(text.match(CONTEXTUAL_SINGULAR_QUANTITY_PATTERN) ?? []),
+    ...(textWithoutMinisterialTitle.match(SPELLED_OUT_ORDINAL_PATTERN) ?? []),
+    ...(text.match(FRACTIONAL_TIER_PATTERN) ?? []),
+  ];
+  for (const match of matches) {
+    if (!normalizedEvidence.includes(normalizeEvidenceText(match))) {
+      throw new MeasureValidationError(
+        `Le contexte généré contient une quantité absente de la preuve citée : ${match}`
+      );
+    }
+  }
+}
 
 function assertGroundedNumbers(
   text: string,
-  citedUnits: Array<{ numbers: Array<{ raw: string; normalized: string; role: string }> }>
+  citedUnits: Array<{
+    numbers: Array<{ raw: string; normalized: string; role: string }>;
+    rawExactText: string;
+  }>
 ): void {
   const textWithoutNumericTokens = text.replace(NUMERIC_TOKEN_PATTERN, "");
-  if (SPELLED_OUT_QUANTITY_PATTERN.test(textWithoutNumericTokens)) {
-    throw new MeasureValidationError(
-      "Le contexte généré doit écrire les quantités sourcées en chiffres"
-    );
-  }
+  const citedEvidenceText = citedUnits.map((unit) => unit.rawExactText).join(" ");
+  assertGroundedLexicalQuantities(textWithoutNumericTokens, citedEvidenceText);
   const allowedNumbers = new Set<string>();
   for (const unit of citedUnits) {
+    const sourceTokens = numericTokens(unit.rawExactText);
     for (const number of unit.numbers) {
       if (number.role !== "CONTENT") continue;
-      for (const token of numericTokens(`${number.raw} ${number.normalized}`)) {
-        allowedNumbers.add(token);
+      const normalizedNumber = number.normalized.replace(",", ".");
+      for (const token of sourceTokens) {
+        const tokenNumber = token.match(/[\d.,]+/u)?.[0]?.replace(",", ".");
+        if (tokenNumber === normalizedNumber) allowedNumbers.add(token);
       }
     }
   }
@@ -291,10 +358,11 @@ function validateGeneratedContext(
   units: Array<{
     unitId: string;
     numbers: Array<{ raw: string; normalized: string; role: string }>;
+    rawExactText: string;
   }>,
   supportingIds: ReadonlySet<string>
 ): {
-  claims: Array<{ text: string; evidenceUnitIds: string[] }>;
+  claims: GeneratedContextClaim[];
   details: string;
   evidenceUnitIds: string[];
 } | null {
@@ -360,6 +428,78 @@ async function recordInvalidContextResult(input: {
       ipAddress: input.ipAddress,
       userAgent: input.userAgent,
     },
+  });
+}
+
+async function reserveContextGeneration(input: {
+  expectedUpdatedAt: Date;
+  generatedBy: string;
+  ipAddress: string;
+  measureId: string;
+  revisionId: string;
+  userAgent: string;
+}): Promise<Exclude<ContextAttemptState, "IN_PROGRESS" | "TERMINAL"> | null> {
+  return db.$transaction(async (tx) => {
+    await lockMeasure(tx, input.measureId);
+    const currentMeasure = await tx.measure.findUniqueOrThrow({
+      where: { id: input.measureId },
+      select: { latestRevisionId: true, publishedRevisionId: true, updatedAt: true },
+    });
+    if (currentMeasure.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+      throw new MeasureConcurrencyError(
+        input.measureId,
+        input.expectedUpdatedAt,
+        currentMeasure.updatedAt
+      );
+    }
+    if (
+      currentMeasure.latestRevisionId !== input.revisionId ||
+      currentMeasure.publishedRevisionId !== input.revisionId
+    ) {
+      throw new MeasureValidationError("La révision publiée a changé avant la génération");
+    }
+    const attempts = await tx.auditLog.findMany({
+      where: {
+        entityType: "MeasureRevision",
+        OR: [
+          {
+            action: {
+              in: [
+                TERMINAL_CONTEXT_RESULT_ACTION,
+                INVALID_CONTEXT_RESULT_ACTION,
+                RESERVED_CONTEXT_GENERATION_ACTION,
+              ],
+            },
+            entityId: input.revisionId,
+          },
+          {
+            action: GENERATED_CONTEXT_DRAFT_ACTION,
+            changes: { path: ["previousRevisionId"], equals: input.revisionId },
+          },
+        ],
+      },
+      select: { action: true, changes: true, entityId: true },
+    });
+    const state = getContextAttemptState(input.revisionId, attempts);
+    if (state === "TERMINAL" || state === "IN_PROGRESS") return null;
+    const now = new Date();
+    await tx.auditLog.create({
+      data: {
+        action: RESERVED_CONTEXT_GENERATION_ACTION,
+        entityType: "MeasureRevision",
+        entityId: input.revisionId,
+        changes: {
+          measureId: input.measureId,
+          runId: randomUUID(),
+          expiresAt: new Date(now.getTime() + CONTEXT_GENERATION_LEASE_MS).toISOString(),
+          promptVersion: PROMPT_VERSION,
+        },
+        userId: input.generatedBy,
+        ipAddress: input.ipAddress,
+        userAgent: input.userAgent,
+      },
+    });
+    return state;
   });
 }
 
@@ -467,12 +607,6 @@ export async function generateMeasureContextDraft(
   if (measure.latestRevisionId !== measure.publishedRevisionId) {
     return { status: "SKIPPED", reason: "ACTIVE_DRAFT" };
   }
-  const previousAttempts = await findContextAttempts([revision.id]);
-  const attemptState = getContextAttemptState(revision.id, previousAttempts);
-  if (attemptState === "TERMINAL") {
-    return { status: "SKIPPED", reason: "PREVIOUS_CONTEXT_ATTEMPT" };
-  }
-
   const evidence = readEvidenceSnapshot(revision.evidenceSnapshot);
   if (evidence.status !== "VALID") {
     return { status: "SKIPPED", reason: "NO_VALID_EVIDENCE" };
@@ -483,6 +617,17 @@ export async function generateMeasureContextDraft(
   );
   if (supportingIds.size === 0 || !units.some((unit) => supportingIds.has(unit.unitId))) {
     return { status: "SKIPPED", reason: "NO_SUPPORTING_CONTEXT" };
+  }
+  const attemptState = await reserveContextGeneration({
+    expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
+    generatedBy: options.generatedBy ?? "system",
+    ipAddress: options.ipAddress ?? "unknown",
+    measureId,
+    revisionId: revision.id,
+    userAgent: options.userAgent ?? "unknown",
+  });
+  if (attemptState === null) {
+    return { status: "SKIPPED", reason: "PREVIOUS_CONTEXT_ATTEMPT" };
   }
 
   const sourceUnits = units
@@ -520,7 +665,7 @@ Réponds uniquement en JSON :
   const maxAttempts = attemptState === "ONE_INVALID_RESULT" ? 1 : 2;
   let generated:
     | {
-        claims: Array<{ text: string; evidenceUnitIds: string[] }>;
+        claims: GeneratedContextClaim[];
         details: string;
         evidenceUnitIds: string[];
         model: string;

--- a/src/lib/measures/context-provenance.ts
+++ b/src/lib/measures/context-provenance.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const GENERATED_CONTEXT_DRAFT_ACTION = "GENERATE_CONTEXT_DRAFT";
+
+export const generatedContextClaimSchema = z
+  .object({
+    text: z.string().trim().min(10).max(500),
+    evidenceUnitIds: z.array(z.string().min(1)).min(1).max(8),
+  })
+  .strict();
+
+export type GeneratedContextClaim = z.infer<typeof generatedContextClaimSchema>;
+
+const generatedContextAuditSchema = z.object({
+  claims: z.array(generatedContextClaimSchema).max(6),
+});
+
+export function readGeneratedContextClaims(changes: unknown): GeneratedContextClaim[] {
+  const parsed = generatedContextAuditSchema.safeParse(changes);
+  return parsed.success ? parsed.data.claims : [];
+}

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -251,6 +251,7 @@ export type DraftMeasureRevisionInput = {
   preserveEvidenceFromRevisionId?: string;
   correctedBy?: string;
   generatedContext?: {
+    claims: Array<{ text: string; evidenceUnitIds: string[] }>;
     evidenceUnitIds: string[];
     generatedBy: string;
     ipAddress: string;
@@ -379,6 +380,7 @@ export async function draftMeasureRevision(
             evidenceSnapshotPreserved: true,
             ...(input.generatedContext
               ? {
+                  claims: input.generatedContext.claims,
                   evidenceUnitIds: input.generatedContext.evidenceUnitIds,
                   generatedBy: input.generatedContext.generatedBy,
                   model: input.generatedContext.model,

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -10,6 +10,10 @@ import type {
   ThemeCategory,
 } from "@/generated/prisma";
 import { db, type DbTransactionClient } from "@/lib/db";
+import {
+  GENERATED_CONTEXT_DRAFT_ACTION,
+  type GeneratedContextClaim,
+} from "@/lib/measures/context-provenance";
 import { invalidateMeasureTags } from "./cache";
 import {
   createV6CorrectionFingerprint,
@@ -251,7 +255,7 @@ export type DraftMeasureRevisionInput = {
   preserveEvidenceFromRevisionId?: string;
   correctedBy?: string;
   generatedContext?: {
-    claims: Array<{ text: string; evidenceUnitIds: string[] }>;
+    claims: GeneratedContextClaim[];
     evidenceUnitIds: string[];
     generatedBy: string;
     ipAddress: string;
@@ -372,7 +376,7 @@ export async function draftMeasureRevision(
     if (input.preserveEvidenceFromRevisionId) {
       await tx.auditLog.create({
         data: {
-          action: input.generatedContext ? "GENERATE_CONTEXT_DRAFT" : "CORRECT_DRAFT",
+          action: input.generatedContext ? GENERATED_CONTEXT_DRAFT_ACTION : "CORRECT_DRAFT",
           entityType: "MeasureRevision",
           entityId: revision.id,
           changes: {


### PR DESCRIPTION
## Résumé

- rattache chaque affirmation générée aux extraits qui la prouvent
- autorise les quantités présentes dans la preuve exacte et refuse les valeurs inventées ou inversées
- limite la correction automatique à un seul nouvel essai et réserve atomiquement chaque génération
- rend les 18 anciens résultats invalides éligibles à une dernière tentative
- expose la provenance phrase par phrase sur la fiche publique
- sépare la source du programme des futures définitions institutionnelles externes

## Garanties éditoriales

- aucune publication automatique
- aucune connaissance externe injectée dans le contexte du programme
- une définition externe devra provenir de la source ou d’un site institutionnel officiel
- les résultats sans contexte utile restent terminaux

## Vérifications

- `npm run typecheck`
- 112 tests ciblés
- ESLint et Prettier sur les fichiers modifiés
- double revue standards et spécification