### PR TITLE
Fiabiliser la sortie des contextes de mesures

### DIFF
--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -65,12 +65,14 @@ function measure(overrides: Record<string, unknown> = {}) {
 
 function generatedContext(details: string, evidenceUnitIds = ["pdf-12-2-u001", "pdf-13-1-u001"]) {
   return {
-    details,
     claims: [{ text: details, evidenceUnitIds }],
   };
 }
 
-function measureWithSupportingContext(context: string) {
+function measureWithSupportingContext(
+  context: string,
+  numbers: Array<{ raw: string; normalized: string; role: "STRUCTURAL" | "CONTENT" }> = []
+) {
   const snapshot = validEvidenceSnapshot();
   const anchor = snapshot.units.find((unit) => unit.role === "COMMITMENT_ANCHOR");
   const supporting = snapshot.units.find((unit) => unit.role === "SUPPORTING_CONTEXT");
@@ -78,6 +80,7 @@ function measureWithSupportingContext(context: string) {
   const hash = createHash("sha256").update(context, "utf8").digest("hex");
   supporting.rawExactText = context;
   supporting.canonicalText = context;
+  supporting.numbers = numbers;
   supporting.rawTextHash = hash;
   supporting.canonicalTextHash = hash;
   snapshot.canonicalEvidenceHash = createHash("sha256")
@@ -126,7 +129,7 @@ describe("génération de contexte sourcé", () => {
         preserveEvidenceFromRevisionId: "revision-1",
         revision: expect.objectContaining({
           extractionMethod: "AI_ASSISTED",
-          extractorVersion: "mistral-small-2506:measure-context-v7",
+          extractorVersion: "mistral-small-2506:measure-context-v8",
           details: expect.stringContaining("droit aux vacances"),
         }),
         generatedContext: expect.objectContaining({
@@ -137,7 +140,7 @@ describe("génération de contexte sourcé", () => {
           ],
           evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
           ipAddress: "203.0.113.8",
-          promptVersion: "measure-context-v7",
+          promptVersion: "measure-context-v8",
           userAgent: "vitest-agent",
         }),
       })
@@ -281,7 +284,6 @@ describe("génération de contexte sourcé", () => {
     const secondClaim =
       "Le document la rattache au constat qu’une partie de la population ne part pas en vacances.";
     mocks.parseMistralJSON.mockReturnValue({
-      details: `${firstClaim} ${secondClaim}`,
       claims: [
         { text: firstClaim, evidenceUnitIds: ["pdf-12-2-u001"] },
         { text: secondClaim, evidenceUnitIds: ["pdf-13-1-u001"] },
@@ -293,6 +295,71 @@ describe("génération de contexte sourcé", () => {
       status: "CREATED",
       evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
     });
+  });
+
+  it("reconnaît le symbole euro et son libellé comme la même unité", async () => {
+    mocks.findMeasure.mockResolvedValue(
+      measureWithSupportingContext(
+        "Le programme prévoit une aide de 2 000 € pour les personnes concernées.",
+        [{ raw: "2 000", normalized: "2000", role: "CONTENT" }]
+      )
+    );
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme une aide de 2000 euros destinée aux personnes concernées par le dispositif.",
+        ["pdf-13-1-u001"]
+      )
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
+    });
+  });
+
+  it("refuse d'ajouter l'unité euro à un nombre qui n'en a pas dans la preuve", async () => {
+    mocks.findMeasure.mockResolvedValue(
+      measureWithSupportingContext("Le programme évoque 2000 personnes concernées.", [
+        { raw: "2000", normalized: "2000", role: "CONTENT" },
+      ])
+    );
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le programme présente cette proposition comme une aide de 2000 euros destinée aux personnes concernées par le dispositif.",
+        ["pdf-13-1-u001"]
+      )
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow(
+      "quantité absente de la preuve citée"
+    );
+  });
+
+  it("construit le contexte depuis les seules affirmations sourcées", async () => {
+    const claim =
+      "Le programme présente cette proposition comme un droit aux vacances et la rattache au constat qu’une partie de la population ne part pas en vacances.";
+    mocks.parseMistralJSON.mockReturnValue({
+      claims: [
+        {
+          text: claim,
+          evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
+        },
+      ],
+    });
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(generateMeasureContextDraft("measure-1")).resolves.toMatchObject({
+      status: "CREATED",
+      details: claim,
+    });
+    expect(mocks.draftMeasureRevision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        measureId: "measure-1",
+        revision: expect.objectContaining({ details: claim }),
+      })
+    );
+    expect(mocks.callMistral.mock.calls[0]?.[0]?.[0]?.content).not.toContain('"details"');
   });
 
   it("refuse d'inverser le signe d'une quantité présente dans la preuve", async () => {
@@ -512,7 +579,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("accepte que le modèle juge le contexte insuffisant sans créer de brouillon", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
+    mocks.parseMistralJSON.mockReturnValue({ claims: [] });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await expect(generateMeasureContextDraft("measure-1")).resolves.toEqual({
@@ -530,7 +597,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("refuse de tracer une issue terminale à partir d'une version devenue obsolète", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
+    mocks.parseMistralJSON.mockReturnValue({ claims: [] });
     mocks.findMeasureForUpdate.mockResolvedValue({
       latestRevisionId: "revision-1",
       publishedRevisionId: "revision-1",
@@ -629,6 +696,39 @@ describe("génération de contexte sourcé", () => {
     const { filterMeasureContextCandidateIds } = await import("../context-generation");
 
     await expect(filterMeasureContextCandidateIds(["measure-exhausted"])).resolves.toEqual([]);
+  });
+
+  it("réouvre le budget après une évolution du générateur", async () => {
+    const candidate = {
+      id: "measure-old-prompt",
+      latestRevisionId: "revision-old-prompt",
+      publishedRevisionId: "revision-old-prompt",
+      publishedRevision: { evidenceSnapshot: validEvidenceSnapshot() },
+    };
+    mocks.findMeasures.mockResolvedValue([candidate]);
+    mocks.findAuditLogs.mockResolvedValue([
+      {
+        action: "GENERATE_CONTEXT_INVALID_RESULT",
+        changes: {
+          outcome: "INVALID_GENERATED_CONTEXT",
+          promptVersion: "measure-context-v7",
+        },
+        entityId: "revision-old-prompt",
+      },
+      {
+        action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+        changes: {
+          outcome: "INVALID_GENERATED_CONTEXT",
+          promptVersion: "measure-context-v7",
+        },
+        entityId: "revision-old-prompt",
+      },
+    ]);
+    const { filterMeasureContextCandidateIds } = await import("../context-generation");
+
+    await expect(filterMeasureContextCandidateIds(["measure-old-prompt"])).resolves.toEqual([
+      "measure-old-prompt",
+    ]);
   });
 
   it("exclut temporairement une révision réservée par une autre génération", async () => {
@@ -772,7 +872,7 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("invalide le jeton de version avec l'issue terminale", async () => {
-    mocks.parseMistralJSON.mockReturnValue({ details: null, claims: [] });
+    mocks.parseMistralJSON.mockReturnValue({ claims: [] });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
     await generateMeasureContextDraft("measure-1");

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -13,7 +13,7 @@ import { lockMeasure } from "@/lib/measures/lock";
 import { draftMeasureRevision } from "@/lib/measures/transitions";
 
 const MODEL = "mistral-small-latest";
-const PROMPT_VERSION = "measure-context-v7";
+const PROMPT_VERSION = "measure-context-v8";
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
 const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
 const RESERVED_CONTEXT_GENERATION_ACTION = "RESERVE_CONTEXT_GENERATION";
@@ -21,23 +21,13 @@ const CONTEXT_GENERATION_LEASE_MS = 15 * 60 * 1_000;
 const MIN_DETAILS_LENGTH = 80;
 const MAX_DETAILS_LENGTH = 1_000;
 
+const generatedDetailsSchema = z.string().min(MIN_DETAILS_LENGTH).max(MAX_DETAILS_LENGTH);
+
 const generatedContextSchema = z
   .object({
-    details: z.string().trim().min(MIN_DETAILS_LENGTH).max(MAX_DETAILS_LENGTH).nullable(),
     claims: z.array(generatedContextClaimSchema).max(6),
   })
-  .strict()
-  .superRefine((value, context) => {
-    if (value.details === null && value.claims.length > 0) {
-      context.addIssue({
-        code: "custom",
-        message: "Un contexte absent ne peut pas avoir de preuve",
-      });
-    }
-    if (value.details !== null && value.claims.length === 0) {
-      context.addIssue({ code: "custom", message: "Chaque contexte doit avoir une preuve" });
-    }
-  });
+  .strict();
 
 export type ContextGenerationSkipReason =
   | "ACTIVE_DRAFT"
@@ -79,6 +69,12 @@ function readAuditOutcome(changes: unknown): string | null {
   return typeof outcome === "string" ? outcome : null;
 }
 
+function isInvalidResultForCurrentPrompt(changes: unknown): boolean {
+  if (!changes || typeof changes !== "object" || Array.isArray(changes)) return true;
+  const promptVersion = (changes as Record<string, unknown>).promptVersion;
+  return typeof promptVersion !== "string" || promptVersion === PROMPT_VERSION;
+}
+
 function getContextAttemptState(
   revisionId: string,
   attempts: Array<{ action: string; changes: unknown; entityId: string }>
@@ -101,12 +97,12 @@ function getContextAttemptState(
       continue;
     }
     if (attempt.action === INVALID_CONTEXT_RESULT_ACTION) {
-      invalidResults += 1;
+      if (isInvalidResultForCurrentPrompt(attempt.changes)) invalidResults += 1;
       continue;
     }
     const outcome = readAuditOutcome(attempt.changes);
     if (outcome === "INVALID_GENERATED_CONTEXT") {
-      invalidResults += 1;
+      if (isInvalidResultForCurrentPrompt(attempt.changes)) invalidResults += 1;
       continue;
     }
     // Old terminal rows without an outcome and explicit NO_USEFUL_CONTEXT results stay terminal.
@@ -258,7 +254,7 @@ function sanitizeSourceText(value: string): string {
 }
 
 const NUMERIC_TOKEN_PATTERN =
-  /(?<![\p{L}\p{N}_])[+\-\u2212]?(?:\d{1,3}(?:[\s\u00a0\u202f]\d{3})+|\d+)(?:[.,]\d+)?(?:[\s\u00a0\u202f]*(?:%|millions?|milliards?|euros?))?(?![\p{L}\p{N}_])/giu;
+  /(?<![\p{L}\p{N}_])[+\-\u2212]?(?:\d{1,3}(?:[\s\u00a0\u202f]\d{3})+|\d+)(?:[.,]\d+)?(?:[\s\u00a0\u202f]*(?:%|€|millions?|milliards?|euros?))?(?![\p{L}\p{N}_])/giu;
 
 function numericTokens(value: string): Set<string> {
   const tokens = value.match(NUMERIC_TOKEN_PATTERN);
@@ -269,6 +265,9 @@ function numericTokens(value: string): Set<string> {
         .replace(/\u2212/g, "-")
         .replace(/(?<=\d)[\s\u00a0\u202f](?=\d)/g, "")
         .replace(/[\s\u00a0\u202f]+/g, " ")
+        .replace(/[\s\u00a0\u202f]*(?:€|euros?)$/u, " euro")
+        .replace(/[\s\u00a0\u202f]+millions?$/u, " million")
+        .replace(/[\s\u00a0\u202f]+milliards?$/u, " milliard")
     )
   );
 }
@@ -367,14 +366,10 @@ function validateGeneratedContext(
   details: string;
   evidenceUnitIds: string[];
 } | null {
-  if (parsed.details === null) return null;
-  const details = normalizeGeneratedText(parsed.details);
-  const claimedText = normalizeGeneratedText(parsed.claims.map((claim) => claim.text).join(" "));
-  if (details !== claimedText) {
-    throw new MeasureValidationError(
-      "Le contexte généré contient du texte qui n'est rattaché à aucune preuve"
-    );
-  }
+  if (parsed.claims.length === 0) return null;
+  const details = generatedDetailsSchema.parse(
+    normalizeGeneratedText(parsed.claims.map((claim) => claim.text).join(" "))
+  );
 
   const unitsById = new Map(units.map((unit) => [unit.unitId, unit]));
   const allCitedIds = new Set<string>();
@@ -652,8 +647,7 @@ Règles :
 - ne répète pas simplement la formulation de la mesure ;
 - écris entre 40 et 120 mots, en français clair ;
 - découpe le texte en affirmations et rattache chaque affirmation uniquement aux unités qui la prouvent ;
-- la concaténation des champs text, dans leur ordre, doit être exactement égale à details ;
-- si les unités n'apportent aucun contexte distinct, renvoie details à null et claims à un tableau vide.
+- si les unités n'apportent aucun contexte distinct, renvoie claims à un tableau vide.
 
 <formulation>${sanitizeSourceText(revision.text)}</formulation>
 <preuves>
@@ -661,7 +655,7 @@ ${sourceUnits}
 </preuves>
 
 Réponds uniquement en JSON :
-{"details":"texte ou null","claims":[{"text":"affirmation","evidenceUnitIds":["identifiant"]}]}`;
+{"claims":[{"text":"affirmation","evidenceUnitIds":["identifiant"]}]}`;
 
   const maxAttempts = attemptState === "ONE_INVALID_RESULT" ? 1 : 2;
   let generated:


### PR DESCRIPTION
## Résultat

Le générateur v8 ne demande plus deux copies du même texte. Mistral renvoie uniquement des affirmations reliées à leurs preuves, puis le contexte public est construit déterministement depuis ces affirmations.

Le lot reconnaît aussi les graphies équivalentes 2 000 € et 2000 euros sans autoriser l'ajout d'une unité absente de la source.

Les échecs INVALID_GENERATED_CONTEXT sont désormais comptés par version du générateur. Les erreurs v7 ne bloquent donc pas une nouvelle tentative v8, tandis que NO_USEFUL_CONTEXT reste terminal.

## Vérifications

- 119 tests ciblés
- TypeScript
- ESLint
- Prettier

Aucune migration et aucune écriture de données de production.