### PR TITLE
fix(mesures): fiabiliser et régénérer les contextes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "measures:classify-subtopics": "tsx --env-file=.env scripts/classify-measure-subtopics.ts",
     "measures:classify-subtopic-delta": "tsx --env-file=.env scripts/classify-measure-subtopic-delta.ts",
     "measures:generate-contexts": "tsx --env-file=.env scripts/generate-measure-contexts.ts",
+    "measures:regenerate-contexts": "tsx --env-file=.env scripts/regenerate-measure-contexts.ts",
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/scripts/regenerate-measure-contexts.ts
+++ b/scripts/regenerate-measure-contexts.ts
@@ -1,0 +1,61 @@
+import { getMistralTokensUsed } from "../src/lib/api/mistral";
+import { db } from "../src/lib/db";
+import {
+  findMeasureContextRegenerationCandidateIds,
+  generateMeasureContextDraft,
+} from "../src/lib/measures/context-generation";
+import { parseMeasureContextRegenerationOptions } from "../src/lib/measures/context-regeneration-options";
+
+async function main(): Promise<void> {
+  const options = parseMeasureContextRegenerationOptions(process.argv.slice(2));
+  const candidateIds = await findMeasureContextRegenerationCandidateIds({
+    electionSlug: options.electionSlug,
+    fromPromptVersion: options.fromPromptVersion,
+    limit: options.limit,
+    scope: options.scope,
+  });
+
+  console.log(
+    `${candidateIds.length} contexte(s) ${options.fromPromptVersion} éligible(s) à une régénération (${options.scope}).`
+  );
+  if (options.dryRun) {
+    console.log("Simulation uniquement. Ajouter --apply pour créer les nouveaux brouillons.");
+    for (const measureId of candidateIds) console.log(measureId);
+    return;
+  }
+  if (!process.env.MISTRAL_API_KEY) throw new Error("MISTRAL_API_KEY doit être définie dans .env");
+
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const measureId of candidateIds) {
+    try {
+      const result = await generateMeasureContextDraft(measureId, {
+        generatedBy: "cli",
+        regenerateFromPromptVersion: options.fromPromptVersion,
+      });
+      if (result.status === "CREATED") {
+        created += 1;
+        console.log(`${measureId}: brouillon ${result.revisionId} créé`);
+      } else {
+        skipped += 1;
+        console.log(`${measureId}: ignorée (${result.reason})`);
+      }
+    } catch (error) {
+      failed += 1;
+      console.error(`${measureId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  console.log(
+    `${created} brouillon(s), ${skipped} ignorée(s), ${failed} erreur(s), ${getMistralTokensUsed()} tokens Mistral.`
+  );
+  if (failed > 0) process.exitCode = 1;
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
+++ b/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/config/labels";
 import type { PublicMeasure } from "@/lib/data/measures";
 import type { ModerationState } from "@/lib/measures/moderation-state";
+import { MarkdownText } from "@/components/ui/markdown";
 
 /**
  * What the public actually gets for this measure.
@@ -51,6 +52,15 @@ export function PublicVisibilityCard({
           <blockquote className="border-l-2 border-border pl-3 text-sm">
             {publicMeasure.text}
           </blockquote>
+
+          {publicMeasure.details !== null && (
+            <div>
+              <h3 className="text-sm font-medium">Contexte publié</h3>
+              <MarkdownText className="mt-2 text-sm leading-relaxed text-foreground">
+                {publicMeasure.details}
+              </MarkdownText>
+            </div>
+          )}
 
           {publicMeasure.withdrawal !== null && (
             <div className="rounded border border-border bg-muted/40 p-3 text-sm">

--- a/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
@@ -25,6 +25,8 @@ function publicMeasure(over: Partial<PublicMeasure> = {}): PublicMeasure {
     slug: "camille-riviere-encadrer-les-loyers",
     publishedRevisionId: "rev-1",
     text: "Encadrer les loyers dans les zones tendues.",
+    details:
+      "Selon la source citée, cette mesure cible les communes où la demande de logements dépasse l'offre disponible.",
     reviewedAt: new Date("2027-01-16T00:00:00Z"),
     precision: "OBJECTIF_SANS_CHIFFRE",
     theme: "LOGEMENT_URBANISME",
@@ -56,6 +58,8 @@ describe("PublicVisibilityCard", () => {
     render(<PublicVisibilityCard state={state()} publicMeasure={publicMeasure()} />);
 
     expect(screen.getByText("Encadrer les loyers dans les zones tendues.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Contexte publié" })).toBeInTheDocument();
+    expect(screen.getByText(/cette mesure cible les communes/)).toBeInTheDocument();
     expect(screen.getByText("1 source citée")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Programme de parti" })).toHaveAttribute(
       "href",

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -189,6 +189,8 @@ function contextSkipMessage(reason: ContextGenerationSkipReason): string {
       return "Une génération a déjà conclu que cette révision ne pouvait pas produire de contexte exploitable.";
     case "NO_USEFUL_CONTEXT":
       return "Mistral n'a trouvé aucun contexte utile distinct de la formulation.";
+    case "NOT_REGENERATABLE_CONTEXT":
+      return "Ce contexte ne correspond pas à une ancienne génération remplaçable.";
   }
 }
 

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -22,7 +22,10 @@ const detail = {
     {
       text: "La source précise les territoires concernés et le calendrier annoncé.",
       documentUrl: "https://example.org/programme",
-      references: [{ unitId: "pdf-12-u001", page: 12 }],
+      references: [
+        { unitId: "pdf-12-u001", page: 12 },
+        { unitId: "pdf-12-u002", page: 12 },
+      ],
     },
   ],
   precision: "CHIFFREE",
@@ -79,11 +82,13 @@ describe("page publique d'une mesure présidentielle", () => {
     expect(screen.queryByText("Objectif quantifié")).not.toBeInTheDocument();
     expect(screen.getByText("Source primaire")).toBeInTheDocument();
     expect(screen.getByText("Programme de candidature")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Ce que prévoit la mesure" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Contexte et précisions" })).toBeInTheDocument();
     expect(screen.getByText("Vérifier les affirmations dans la source")).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: "Consulter l'extrait source, page 12, lien externe" })
-    ).toHaveAttribute("href", "https://example.org/programme");
+    const evidenceLinks = screen.getAllByRole("link", {
+      name: "Consulter l'extrait source, page 12, lien externe",
+    });
+    expect(evidenceLinks).toHaveLength(1);
+    expect(evidenceLinks[0]).toHaveAttribute("href", "https://example.org/programme");
     expect(screen.getByRole("heading", { name: "Dans le programme" })).toBeInTheDocument();
     expect(screen.getByText("Formulée personnellement")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Consulter le programme/ })).toHaveAttribute(

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -78,7 +78,10 @@ describe("page publique d'une mesure présidentielle", () => {
         {await Page({ params: Promise.resolve({ id: "measure-1" }) })}
       </TooltipProvider>
     );
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(detail.text);
+    const title = screen.getByRole("heading", { level: 1 });
+    expect(title).toHaveTextContent(detail.text);
+    expect(title).toHaveClass("max-w-[36ch]");
+    expect(title.closest("article")).toHaveClass("max-w-6xl");
     expect(screen.queryByText("Objectif quantifié")).not.toBeInTheDocument();
     expect(screen.getByText("Source primaire")).toBeInTheDocument();
     expect(screen.getByText("Programme de candidature")).toBeInTheDocument();

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -100,7 +100,7 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
           { label: "Mesure", href: canonical },
         ]}
       />
-      <article className="container mx-auto max-w-5xl px-4">
+      <article className="container mx-auto max-w-6xl px-4">
         <header className="border-b border-border pb-8 pt-3">
           <Link
             href={themeUrl}
@@ -109,7 +109,7 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             {themeLabel}
           </Link>
           <h1
-            className={`mt-3 max-w-[28ch] font-display font-extrabold leading-[1.08] tracking-tight ${titleClass}`}
+            className={`mt-3 max-w-[36ch] font-display font-extrabold leading-[1.08] tracking-tight ${titleClass}`}
           >
             {measure.text}
           </h1>
@@ -131,11 +131,11 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <h2 id="details-title" className="font-display text-2xl font-extrabold">
               Contexte et précisions
             </h2>
-            <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
+            <MarkdownText className="mt-4 max-w-[80ch] leading-relaxed text-foreground">
               {measure.details}
             </MarkdownText>
             {measure.contextClaims.length > 0 ? (
-              <details className="group mt-5 max-w-[72ch] rounded-xl border border-border bg-card">
+              <details className="group mt-5 max-w-[80ch] rounded-xl border border-border bg-card">
                 <summary className="flex min-h-11 cursor-pointer list-none items-center px-4 py-3 font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary [&::-webkit-details-marker]:hidden">
                   Vérifier les affirmations dans la source
                 </summary>

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
         {measure.details !== null && (
           <section aria-labelledby="details-title" className="border-b border-border py-8">
             <h2 id="details-title" className="font-display text-2xl font-extrabold">
-              Ce que prévoit la mesure
+              Contexte et précisions
             </h2>
             <MarkdownText className="mt-4 max-w-[72ch] leading-relaxed text-foreground">
               {measure.details}
@@ -144,21 +144,28 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
                     <li key={`${claim.text}-${claimIndex}`}>
                       <p className="text-sm leading-relaxed text-foreground">{claim.text}</p>
                       <ul className="mt-2 flex flex-wrap gap-3">
-                        {claim.references.map((reference) => (
-                          <li key={reference.unitId}>
-                            <a
-                              href={claim.documentUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              aria-label={`Consulter l'extrait source${reference.page === null ? "" : `, page ${reference.page}`}, lien externe`}
-                              className="inline-flex min-h-11 items-center gap-2 text-sm font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                            >
-                              Extrait source
-                              {reference.page === null ? "" : `, page ${reference.page}`}
-                              <ExternalLink aria-hidden="true" className="h-4 w-4" />
-                            </a>
-                          </li>
-                        ))}
+                        {claim.references
+                          .filter(
+                            (reference, index, references) =>
+                              references.findIndex(
+                                (candidate) => candidate.page === reference.page
+                              ) === index
+                          )
+                          .map((reference) => (
+                            <li key={reference.page ?? "unknown-page"}>
+                              <a
+                                href={claim.documentUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={`Consulter l'extrait source${reference.page === null ? "" : `, page ${reference.page}`}, lien externe`}
+                                className="inline-flex min-h-11 items-center gap-2 text-sm font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                              >
+                                Extrait source
+                                {reference.page === null ? "" : `, page ${reference.page}`}
+                                <ExternalLink aria-hidden="true" className="h-4 w-4" />
+                              </a>
+                            </li>
+                          ))}
                       </ul>
                     </li>
                   ))}

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -12,6 +12,7 @@ function measure(over: Partial<PublicMeasure> = {}): PublicMeasure {
     slug: "camille-riviere-encadrer-les-loyers",
     publishedRevisionId: "rev-1",
     text: "Encadrer les loyers.",
+    details: null,
     reviewedAt: new Date("2027-01-16T00:00:00Z"),
     precision: "OBJECTIF_SANS_CHIFFRE",
     theme: "LOGEMENT_URBANISME",

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -60,6 +60,8 @@ export type PublicMeasure = {
   /** The published revision this measure points at. Non-null here: the where clause requires it. */
   publishedRevisionId: string;
   text: string;
+  /** Source-backed context published with the reviewed formulation, when available. */
+  details: string | null;
   /** Date of the human review that authorized the published formulation. */
   reviewedAt: Date;
   precision: PublishedRevision["precision"];
@@ -90,6 +92,7 @@ function toPublicMeasure(row: MeasureRow): PublicMeasure | null {
     slug: row.slug,
     publishedRevisionId: revision.id,
     text: revision.text,
+    details: revision.details,
     reviewedAt: revision.reviewedAt!,
     precision: revision.precision,
     theme: row.theme,

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -107,7 +107,7 @@ describe("génération de contexte sourcé", () => {
     mocks.extractMistralText.mockReturnValue("{}");
     mocks.parseMistralJSON.mockReturnValue(
       generatedContext(
-        "Le programme présente cette proposition comme un droit aux vacances. Il part du constat qu’une partie de la population ne part pas en vacances et rattache la mesure à cet enjeu."
+        "Selon la source citée, une partie de la population ne part pas en vacances. La mesure prévoit de créer un droit aux vacances en réponse à ce constat."
       )
     );
     mocks.draftMeasureRevision.mockResolvedValue({ revisionId: "revision-2" });
@@ -129,7 +129,7 @@ describe("génération de contexte sourcé", () => {
         preserveEvidenceFromRevisionId: "revision-1",
         revision: expect.objectContaining({
           extractionMethod: "AI_ASSISTED",
-          extractorVersion: "mistral-small-2506:measure-context-v8",
+          extractorVersion: "mistral-small-2506:measure-context-v9",
           details: expect.stringContaining("droit aux vacances"),
         }),
         generatedContext: expect.objectContaining({
@@ -140,7 +140,7 @@ describe("génération de contexte sourcé", () => {
           ],
           evidenceUnitIds: ["pdf-12-2-u001", "pdf-13-1-u001"],
           ipAddress: "203.0.113.8",
-          promptVersion: "measure-context-v8",
+          promptVersion: "measure-context-v9",
           userAgent: "vitest-agent",
         }),
       })
@@ -155,6 +155,22 @@ describe("génération de contexte sourcé", () => {
       ],
       expect.any(Object)
     );
+    const prompt = mocks.callMistral.mock.calls[0]?.[0]?.[0]?.content;
+    expect(prompt).toContain("Selon la source citée");
+    expect(prompt).toContain("La mesure prévoit");
+    expect(prompt).toContain("N'écris jamais « Le document » ni « Le programme »");
+  });
+
+  it("refuse les attributions mécaniques avant de créer un brouillon", async () => {
+    mocks.parseMistralJSON.mockReturnValue(
+      generatedContext(
+        "Le document présente cette proposition comme une réponse au constat qu'une partie de la population ne part pas en vacances."
+      )
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("attribution mécanique");
+    expect(mocks.callMistral).toHaveBeenCalledTimes(2);
   });
 
   it("transmet au modèle le locuteur et le rôle discursif de chaque preuve", async () => {
@@ -279,10 +295,9 @@ describe("génération de contexte sourcé", () => {
   });
 
   it("accepte une quantité exacte lorsqu'elle est rattachée à la preuve qui la contient", async () => {
-    const firstClaim =
-      "Le programme présente cette proposition comme un droit destiné à 67 millions de personnes.";
+    const firstClaim = "La mesure prévoit un droit destiné à 67 millions de personnes.";
     const secondClaim =
-      "Le document la rattache au constat qu’une partie de la population ne part pas en vacances.";
+      "Selon la source citée, une partie de la population ne part pas en vacances.";
     mocks.parseMistralJSON.mockReturnValue({
       claims: [
         { text: firstClaim, evidenceUnitIds: ["pdf-12-2-u001"] },
@@ -306,7 +321,7 @@ describe("génération de contexte sourcé", () => {
     );
     mocks.parseMistralJSON.mockReturnValue(
       generatedContext(
-        "Le programme présente cette proposition comme une aide de 2000 euros destinée aux personnes concernées par le dispositif.",
+        "La mesure prévoit une aide de 2000 euros destinée aux personnes concernées par le dispositif.",
         ["pdf-13-1-u001"]
       )
     );
@@ -338,7 +353,7 @@ describe("génération de contexte sourcé", () => {
 
   it("construit le contexte depuis les seules affirmations sourcées", async () => {
     const claim =
-      "Le programme présente cette proposition comme un droit aux vacances et la rattache au constat qu’une partie de la population ne part pas en vacances.";
+      "Selon la source citée, une partie de la population ne part pas en vacances. La mesure prévoit de créer un droit aux vacances en réponse à ce constat.";
     mocks.parseMistralJSON.mockReturnValue({
       claims: [
         {
@@ -711,7 +726,7 @@ describe("génération de contexte sourcé", () => {
         action: "GENERATE_CONTEXT_INVALID_RESULT",
         changes: {
           outcome: "INVALID_GENERATED_CONTEXT",
-          promptVersion: "measure-context-v7",
+          promptVersion: "measure-context-v8",
         },
         entityId: "revision-old-prompt",
       },
@@ -719,7 +734,7 @@ describe("génération de contexte sourcé", () => {
         action: "GENERATE_CONTEXT_TERMINAL_RESULT",
         changes: {
           outcome: "INVALID_GENERATED_CONTEXT",
-          promptVersion: "measure-context-v7",
+          promptVersion: "measure-context-v8",
         },
         entityId: "revision-old-prompt",
       },
@@ -798,7 +813,7 @@ describe("génération de contexte sourcé", () => {
 
   it("accepte un sous-ensemble pertinent des unités fournies au modèle", async () => {
     const details =
-      "Le programme rattache cette proposition au constat qu'une partie de la population ne part pas en vacances, sans ajouter d'autre justification dans cet extrait.";
+      "Selon la source citée, une partie de la population ne part pas en vacances. Cet extrait n'apporte pas d'autre justification à la mesure.";
     mocks.parseMistralJSON.mockReturnValue(generatedContext(details, ["pdf-13-1-u001"]));
     const { generateMeasureContextDraft } = await import("../context-generation");
 
@@ -848,7 +863,7 @@ describe("génération de contexte sourcé", () => {
   it("accepte l'attribution des propos à un tiers sans la confondre avec une fraction", async () => {
     mocks.parseMistralJSON.mockReturnValue(
       generatedContext(
-        "Le document rapporte les propos d'un tiers et les distingue de la position défendue par le programme dans cette proposition."
+        "Selon la source citée, ces propos viennent d'un tiers et sont distincts de la position défendue dans cette proposition."
       )
     );
     const { generateMeasureContextDraft } = await import("../context-generation");
@@ -861,7 +876,7 @@ describe("génération de contexte sourcé", () => {
   it("accepte le titre de Première ministre sans le confondre avec un ordinal", async () => {
     mocks.parseMistralJSON.mockReturnValue(
       generatedContext(
-        "Le document attribue cette proposition à la Première ministre et la présente comme une orientation défendue par le programme."
+        "Selon la source citée, cette proposition est attribuée à la Première ministre et constitue une orientation défendue dans cette mesure."
       )
     );
     const { generateMeasureContextDraft } = await import("../context-generation");

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -45,19 +45,27 @@ vi.mock("@/lib/measures/transitions", () => ({
 }));
 
 function measure(overrides: Record<string, unknown> = {}) {
+  const revision = {
+    id: "revision-1",
+    text: "Créer un droit aux vacances.",
+    details: null,
+    precision: "OBJECTIF_SANS_CHIFFRE",
+    validFrom: new Date("2026-08-01T00:00:00Z"),
+    evidenceSnapshot: validEvidenceSnapshot(),
+    reviewedAt: new Date("2026-08-20T00:00:00Z"),
+    publishedAt: new Date("2026-08-21T00:00:00Z"),
+    discardedAt: null,
+    rejectedAt: null,
+    extractionMethod: "AI_ASSISTED",
+    extractorVersion: null,
+  };
   return {
     id: "measure-1",
     updatedAt: new Date("2026-08-30T00:00:00Z"),
     latestRevisionId: "revision-1",
     publishedRevisionId: "revision-1",
-    publishedRevision: {
-      id: "revision-1",
-      text: "Créer un droit aux vacances.",
-      details: null,
-      precision: "OBJECTIF_SANS_CHIFFRE",
-      validFrom: new Date("2026-08-01T00:00:00Z"),
-      evidenceSnapshot: validEvidenceSnapshot(),
-    },
+    publishedRevision: revision,
+    latestRevision: revision,
     revisions: [],
     ...overrides,
   };
@@ -171,6 +179,130 @@ describe("génération de contexte sourcé", () => {
 
     await expect(generateMeasureContextDraft("measure-1")).rejects.toThrow("attribution mécanique");
     expect(mocks.callMistral).toHaveBeenCalledTimes(2);
+  });
+
+  it("régénère un contexte publié dans un nouveau brouillon sans toucher à la révision publique", async () => {
+    const oldContextRevision = {
+      ...measure().publishedRevision,
+      details: "Ancien contexte publié et validé par la rédaction.",
+      extractorVersion: "mistral-small-2506:measure-context-v8",
+    };
+    mocks.findMeasure.mockResolvedValue(
+      measure({ publishedRevision: oldContextRevision, latestRevision: oldContextRevision })
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(
+      generateMeasureContextDraft("measure-1", {
+        regenerateFromPromptVersion: "measure-context-v8",
+      })
+    ).resolves.toMatchObject({ status: "CREATED" });
+    expect(mocks.draftMeasureRevision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preserveEvidenceFromRevisionId: "revision-1",
+        revision: expect.objectContaining({
+          extractorVersion: "mistral-small-2506:measure-context-v9",
+        }),
+      })
+    );
+  });
+
+  it("remplace uniquement un brouillon IA non relu provenant de la version demandée", async () => {
+    const activeDraft = {
+      ...measure().publishedRevision,
+      id: "revision-v8-draft",
+      details: "Ancien contexte généré en attente de relecture.",
+      reviewedAt: null,
+      publishedAt: null,
+      extractorVersion: "mistral-small-2506:measure-context-v8",
+    };
+    mocks.findMeasure.mockResolvedValue(
+      measure({ latestRevisionId: activeDraft.id, latestRevision: activeDraft })
+    );
+    mocks.findMeasureForUpdate.mockResolvedValue({
+      latestRevisionId: activeDraft.id,
+      publishedRevisionId: "revision-1",
+      updatedAt: new Date("2026-08-30T00:00:00Z"),
+    });
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(
+      generateMeasureContextDraft("measure-1", {
+        regenerateFromPromptVersion: "measure-context-v8",
+      })
+    ).resolves.toMatchObject({ status: "CREATED" });
+    expect(mocks.draftMeasureRevision).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveEvidenceFromRevisionId: activeDraft.id })
+    );
+  });
+
+  it("refuse de remplacer un brouillon humain ou une version différente", async () => {
+    const activeDraft = {
+      ...measure().publishedRevision,
+      id: "revision-human-draft",
+      details: "Correction éditoriale en cours.",
+      reviewedAt: null,
+      publishedAt: null,
+      extractionMethod: "MANUAL",
+      extractorVersion: null,
+    };
+    mocks.findMeasure.mockResolvedValue(
+      measure({ latestRevisionId: activeDraft.id, latestRevision: activeDraft })
+    );
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(
+      generateMeasureContextDraft("measure-1", {
+        regenerateFromPromptVersion: "measure-context-v8",
+      })
+    ).resolves.toEqual({ status: "SKIPPED", reason: "NOT_REGENERATABLE_CONTEXT" });
+    expect(mocks.callMistral).not.toHaveBeenCalled();
+  });
+
+  it("sélectionne les contextes publiés et les brouillons IA de l'ancienne version", async () => {
+    mocks.findMeasures.mockResolvedValue([
+      {
+        id: "measure-published-v8",
+        latestRevisionId: "revision-published-v8",
+        publishedRevisionId: "revision-published-v8",
+        latestRevision: {
+          evidenceSnapshot: validEvidenceSnapshot(),
+          reviewedAt: new Date("2026-08-20T00:00:00Z"),
+          publishedAt: new Date("2026-08-21T00:00:00Z"),
+        },
+      },
+      {
+        id: "measure-draft-v8",
+        latestRevisionId: "revision-draft-v8",
+        publishedRevisionId: "revision-base",
+        latestRevision: {
+          evidenceSnapshot: validEvidenceSnapshot(),
+          reviewedAt: null,
+          publishedAt: null,
+        },
+      },
+    ]);
+    const { findMeasureContextRegenerationCandidateIds } = await import("../context-generation");
+
+    await expect(
+      findMeasureContextRegenerationCandidateIds({
+        electionSlug: "presidentielle-2027",
+        fromPromptVersion: "measure-context-v8",
+        limit: 10,
+        scope: "all",
+      })
+    ).resolves.toEqual(["measure-published-v8", "measure-draft-v8"]);
+    expect(mocks.findMeasures).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          latestRevision: {
+            is: expect.objectContaining({
+              extractorVersion: { endsWith: ":measure-context-v8" },
+            }),
+          },
+        }),
+      })
+    );
   });
 
   it("transmet au modèle le locuteur et le rôle discursif de chaque preuve", async () => {

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -305,6 +305,48 @@ describe("génération de contexte sourcé", () => {
     );
   });
 
+  it("écarte les tentatives terminales avant d'appliquer la limite de régénération", async () => {
+    const regenerationCandidate = (id: string) => ({
+      id: `measure-${id}`,
+      latestRevisionId: `revision-${id}`,
+      publishedRevisionId: `revision-${id}`,
+      latestRevision: {
+        evidenceSnapshot: validEvidenceSnapshot(),
+        reviewedAt: new Date("2026-08-20T00:00:00Z"),
+        publishedAt: new Date("2026-08-21T00:00:00Z"),
+      },
+    });
+    mocks.findMeasures
+      .mockResolvedValueOnce([regenerationCandidate("terminal"), regenerationCandidate("eligible")])
+      .mockResolvedValueOnce([regenerationCandidate("next")]);
+    mocks.findAuditLogs
+      .mockResolvedValueOnce([
+        {
+          action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+          changes: { outcome: "NO_USEFUL_CONTEXT" },
+          entityId: "revision-terminal",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const { findMeasureContextRegenerationCandidateIds } = await import("../context-generation");
+
+    await expect(
+      findMeasureContextRegenerationCandidateIds(
+        {
+          electionSlug: "presidentielle-2027",
+          fromPromptVersion: "measure-context-v8",
+          limit: 2,
+          scope: "published",
+        },
+        2
+      )
+    ).resolves.toEqual(["measure-eligible", "measure-next"]);
+    expect(mocks.findMeasures).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: { id: "measure-eligible" }, skip: 1 })
+    );
+  });
+
   it("transmet au modèle le locuteur et le rôle discursif de chaque preuve", async () => {
     const snapshot = validEvidenceSnapshot();
     const supportingUnit = snapshot.units.find((unit) => unit.unitId === "pdf-13-1-u001");

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -393,6 +393,49 @@ describe("génération de contexte sourcé", () => {
     );
   });
 
+  it.each([
+    {
+      action: "GENERATE_CONTEXT_TERMINAL_RESULT",
+      changes: {
+        outcome: "NO_USEFUL_CONTEXT",
+        promptVersion: "measure-context-v8",
+      },
+      entityId: "revision-old-attempt",
+    },
+    {
+      action: "GENERATE_CONTEXT_DRAFT",
+      changes: {
+        previousRevisionId: "revision-old-attempt",
+        promptVersion: "measure-context-v8",
+      },
+      entityId: "revision-generated-v8",
+    },
+  ])("ignore une tentative terminale d'une ancienne version du prompt", async (attempt) => {
+    mocks.findMeasures.mockResolvedValue([
+      {
+        id: "measure-old-attempt",
+        latestRevisionId: "revision-old-attempt",
+        publishedRevisionId: "revision-old-attempt",
+        latestRevision: {
+          evidenceSnapshot: validEvidenceSnapshot(),
+          reviewedAt: new Date("2026-08-20T00:00:00Z"),
+          publishedAt: new Date("2026-08-21T00:00:00Z"),
+        },
+      },
+    ]);
+    mocks.findAuditLogs.mockResolvedValue([attempt]);
+    const { findMeasureContextRegenerationCandidateIds } = await import("../context-generation");
+
+    await expect(
+      findMeasureContextRegenerationCandidateIds({
+        electionSlug: "presidentielle-2027",
+        fromPromptVersion: "measure-context-v8",
+        limit: 1,
+        scope: "published",
+      })
+    ).resolves.toEqual(["measure-old-attempt"]);
+  });
+
   it("transmet au modèle le locuteur et le rôle discursif de chaque preuve", async () => {
     const snapshot = validEvidenceSnapshot();
     const supportingUnit = snapshot.units.find((unit) => unit.unitId === "pdf-13-1-u001");

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -107,6 +107,12 @@ describe("génération de contexte sourcé", () => {
       latestRevisionId: "revision-1",
       publishedRevisionId: "revision-1",
       updatedAt: new Date("2026-08-30T00:00:00Z"),
+      latestRevision: {
+        reviewedAt: new Date("2026-08-20T00:00:00Z"),
+        publishedAt: new Date("2026-08-21T00:00:00Z"),
+        discardedAt: null,
+        rejectedAt: null,
+      },
     });
     mocks.findAuditLogs.mockResolvedValue([]);
     mocks.createAuditLog.mockResolvedValue({ id: "audit-1" });
@@ -223,6 +229,12 @@ describe("génération de contexte sourcé", () => {
       latestRevisionId: activeDraft.id,
       publishedRevisionId: "revision-1",
       updatedAt: new Date("2026-08-30T00:00:00Z"),
+      latestRevision: {
+        reviewedAt: null,
+        publishedAt: null,
+        discardedAt: null,
+        rejectedAt: null,
+      },
     });
     const { generateMeasureContextDraft } = await import("../context-generation");
 
@@ -234,6 +246,40 @@ describe("génération de contexte sourcé", () => {
     expect(mocks.draftMeasureRevision).toHaveBeenCalledWith(
       expect.objectContaining({ preserveEvidenceFromRevisionId: activeDraft.id })
     );
+  });
+
+  it("protège un brouillon relu pendant la réservation de sa régénération", async () => {
+    const activeDraft = {
+      ...measure().publishedRevision,
+      id: "revision-v8-draft",
+      details: "Ancien contexte généré en attente de relecture.",
+      reviewedAt: null,
+      publishedAt: null,
+      extractorVersion: "mistral-small-2506:measure-context-v8",
+    };
+    mocks.findMeasure.mockResolvedValue(
+      measure({ latestRevisionId: activeDraft.id, latestRevision: activeDraft })
+    );
+    mocks.findMeasureForUpdate.mockResolvedValue({
+      latestRevisionId: activeDraft.id,
+      publishedRevisionId: "revision-1",
+      updatedAt: new Date("2026-08-30T00:00:00Z"),
+      latestRevision: {
+        reviewedAt: new Date("2026-08-30T00:01:00Z"),
+        publishedAt: null,
+        discardedAt: null,
+        rejectedAt: null,
+      },
+    });
+    const { generateMeasureContextDraft } = await import("../context-generation");
+
+    await expect(
+      generateMeasureContextDraft("measure-1", {
+        regenerateFromPromptVersion: "measure-context-v8",
+      })
+    ).rejects.toThrow("Le brouillon a été relu");
+    expect(mocks.callMistral).not.toHaveBeenCalled();
+    expect(mocks.draftMeasureRevision).not.toHaveBeenCalled();
   });
 
   it("refuse de remplacer un brouillon humain ou une version différente", async () => {

--- a/src/lib/measures/__tests__/draft-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/draft-revision.integration.test.ts
@@ -43,6 +43,42 @@ describeIfDisposableDb("draftMeasureRevision", () => {
     expect(abandoned.reviewedBy).toBeNull();
   });
 
+  it("ne remplace pas automatiquement un brouillon relu pendant une génération", async () => {
+    const { measureId, revisionId } = await seedMeasureWithDraft();
+    await db.measureRevision.update({
+      where: { id: revisionId },
+      data: { reviewedAt: new Date(), reviewedBy: "relecteur" },
+    });
+    const input = draftInput(measureId, "Contexte régénéré qui ne doit pas survivre.");
+
+    await expect(
+      draftMeasureRevision({
+        ...input,
+        preserveEvidenceFromRevisionId: revisionId,
+        revision: {
+          ...input.revision,
+          details: "Contexte régénéré qui ne doit pas remplacer la revue humaine.",
+          extractionMethod: "AI_ASSISTED",
+          extractorVersion: "mistral-small-latest:measure-context-v9",
+        },
+        generatedContext: {
+          claims: [],
+          evidenceUnitIds: [],
+          generatedBy: "system",
+          ipAddress: "unknown",
+          model: "mistral-small-latest",
+          promptVersion: "measure-context-v9",
+          userAgent: "vitest",
+        },
+      })
+    ).rejects.toThrow("Un brouillon relu ou modéré");
+
+    const revisions = await db.measureRevision.findMany({ where: { measureId } });
+    expect(revisions.map(({ id }) => id)).toEqual([revisionId]);
+    expect(revisions[0]?.discardedAt).toBeNull();
+    expect(revisions[0]?.reviewedAt).not.toBeNull();
+  });
+
   it("does not discard the published revision when drafting a correction", async () => {
     const { measureId, revisionId: publishedId } = await seedMeasureWithDraft();
 

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -13,7 +13,7 @@ import { lockMeasure } from "@/lib/measures/lock";
 import { draftMeasureRevision } from "@/lib/measures/transitions";
 
 const MODEL = "mistral-small-latest";
-const PROMPT_VERSION = "measure-context-v8";
+const PROMPT_VERSION = "measure-context-v9";
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
 const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
 const RESERVED_CONTEXT_GENERATION_ACTION = "RESERVE_CONTEXT_GENERATION";
@@ -353,6 +353,14 @@ function normalizeGeneratedText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function assertNaturalAttribution(text: string): void {
+  if (/(?:^|[.!?]\s+)(?:Le document|Le programme)\b/iu.test(text)) {
+    throw new MeasureValidationError(
+      "Le contexte généré emploie une attribution mécanique au document ou au programme"
+    );
+  }
+}
+
 function validateGeneratedContext(
   parsed: z.infer<typeof generatedContextSchema>,
   units: Array<{
@@ -389,6 +397,7 @@ function validateGeneratedContext(
       return unit ? [unit] : [];
     });
     assertGroundedNumbers(claim.text, citedUnits);
+    assertNaturalAttribution(claim.text);
     for (const id of citedIds) allCitedIds.add(id);
   }
   if (![...allCitedIds].some((id) => supportingIds.has(id))) {
@@ -638,14 +647,16 @@ Règles :
 - utilise uniquement les faits explicitement présents dans les unités ;
 - ces unités proviennent exclusivement de la source attachée à la mesure, ne complète jamais avec une connaissance ou un site externe ;
 - n'ajoute aucune conséquence, faisabilité, intention, appréciation ou connaissance extérieure ;
-- attribue au document toute analyse, tout diagnostic ou toute appréciation qu'il formule, par exemple avec « Le programme estime que » ou « Le document présente » ;
+- attribue toute analyse, tout diagnostic ou toute appréciation à sa source avec une seule formulation naturelle, par exemple « Selon la source citée, ... » ;
+- décris ensuite l'engagement avec « La mesure prévoit ... » ou « La mesure propose ... » lorsque cela apporte une information distincte du titre ;
+- N'écris jamais « Le document » ni « Le programme » en début de phrase ;
 - respecte le locuteur de chaque unité : une parole de QUOTED_THIRD_PARTY, LEGAL_OR_INSTITUTIONAL_SOURCE ou HISTORICAL_ACTOR ne doit jamais être attribuée au programme ;
 - si tu utilises une telle unité, indique explicitement qu'elle rapporte les propos ou la position d'un tiers, d'une source juridique ou institutionnelle, ou d'un acteur historique, sans inventer son identité ;
 - n'utilise pas une unité dont le locuteur est UNRESOLVED pour attribuer une affirmation au programme ;
 - une quantité n'est autorisée que si elle figure exactement dans l'unité citée par l'affirmation ; conserve sa valeur et écris-la en chiffres ;
 - ne présente jamais l'argumentaire du programme comme un fait établi ;
 - ne répète pas simplement la formulation de la mesure ;
-- écris entre 40 et 120 mots, en français clair ;
+- écris une ou deux phrases, entre 40 et 100 mots, en français clair ;
 - découpe le texte en affirmations et rattache chaque affirmation uniquement aux unités qui la prouvent ;
 - si les unités n'apportent aucun contexte distinct, renvoie claims à un tableau vide.
 

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -72,7 +72,7 @@ function readAuditOutcome(changes: unknown): string | null {
   return typeof outcome === "string" ? outcome : null;
 }
 
-function isInvalidResultForCurrentPrompt(changes: unknown): boolean {
+function isAttemptForCurrentPrompt(changes: unknown): boolean {
   if (!changes || typeof changes !== "object" || Array.isArray(changes)) return true;
   const promptVersion = (changes as Record<string, unknown>).promptVersion;
   return typeof promptVersion !== "string" || promptVersion === PROMPT_VERSION;
@@ -86,10 +86,16 @@ function getContextAttemptState(
   let hasActiveReservation = false;
   for (const attempt of attempts) {
     if (attempt.action === GENERATED_CONTEXT_DRAFT_ACTION) {
-      if (getGeneratedContextSourceRevisionId(attempt.changes) === revisionId) return "TERMINAL";
+      if (
+        isAttemptForCurrentPrompt(attempt.changes) &&
+        getGeneratedContextSourceRevisionId(attempt.changes) === revisionId
+      ) {
+        return "TERMINAL";
+      }
       continue;
     }
     if (attempt.entityId !== revisionId) continue;
+    if (!isAttemptForCurrentPrompt(attempt.changes)) continue;
     if (attempt.action === RESERVED_CONTEXT_GENERATION_ACTION) {
       const changes =
         attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
@@ -100,12 +106,12 @@ function getContextAttemptState(
       continue;
     }
     if (attempt.action === INVALID_CONTEXT_RESULT_ACTION) {
-      if (isInvalidResultForCurrentPrompt(attempt.changes)) invalidResults += 1;
+      invalidResults += 1;
       continue;
     }
     const outcome = readAuditOutcome(attempt.changes);
     if (outcome === "INVALID_GENERATED_CONTEXT") {
-      if (isInvalidResultForCurrentPrompt(attempt.changes)) invalidResults += 1;
+      invalidResults += 1;
       continue;
     }
     // Old terminal rows without an outcome and explicit NO_USEFUL_CONTEXT results stay terminal.

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -561,7 +561,19 @@ async function reserveContextGeneration(input: {
     await lockMeasure(tx, input.measureId);
     const currentMeasure = await tx.measure.findUniqueOrThrow({
       where: { id: input.measureId },
-      select: { latestRevisionId: true, publishedRevisionId: true, updatedAt: true },
+      select: {
+        latestRevisionId: true,
+        publishedRevisionId: true,
+        updatedAt: true,
+        latestRevision: {
+          select: {
+            reviewedAt: true,
+            publishedAt: true,
+            discardedAt: true,
+            rejectedAt: true,
+          },
+        },
+      },
     });
     if (currentMeasure.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
       throw new MeasureConcurrencyError(
@@ -575,6 +587,16 @@ async function reserveContextGeneration(input: {
       (!input.allowUnpublishedDraft && currentMeasure.publishedRevisionId !== input.revisionId)
     ) {
       throw new MeasureValidationError("La révision publiée a changé avant la génération");
+    }
+    if (
+      input.allowUnpublishedDraft &&
+      (!currentMeasure.latestRevision ||
+        currentMeasure.latestRevision.reviewedAt !== null ||
+        currentMeasure.latestRevision.publishedAt !== null ||
+        currentMeasure.latestRevision.discardedAt !== null ||
+        currentMeasure.latestRevision.rejectedAt !== null)
+    ) {
+      throw new MeasureValidationError("Le brouillon a été relu ou a changé avant la régénération");
     }
     const attempts = await tx.auditLog.findMany({
       where: {

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -321,9 +321,19 @@ export async function findMeasureContextRegenerationCandidateIds(
       ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     });
 
+    const attemptedContextRevisionIds = await getAttemptedContextRevisionIds(
+      candidates.flatMap(({ latestRevisionId }) => (latestRevisionId ? [latestRevisionId] : []))
+    );
+
     for (const candidate of candidates) {
       const revision = candidate.latestRevision;
       if (!revision) continue;
+      if (
+        candidate.latestRevisionId &&
+        attemptedContextRevisionIds.has(candidate.latestRevisionId)
+      ) {
+        continue;
+      }
       const evidence = readEvidenceSnapshot(revision.evidenceSnapshot);
       if (evidence.status !== "VALID" || evidence.snapshot.supportingIds.length === 0) continue;
       const isPublished =

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -4,6 +4,7 @@ import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mis
 import { db } from "@/lib/db";
 import {
   GENERATED_CONTEXT_DRAFT_ACTION,
+  MEASURE_CONTEXT_PROMPT_VERSION,
   generatedContextClaimSchema,
   type GeneratedContextClaim,
 } from "@/lib/measures/context-provenance";
@@ -11,9 +12,10 @@ import { readEvidenceSnapshot } from "@/lib/measures/evidence-snapshot";
 import { MeasureConcurrencyError, MeasureValidationError } from "@/lib/measures/errors";
 import { lockMeasure } from "@/lib/measures/lock";
 import { draftMeasureRevision } from "@/lib/measures/transitions";
+import type { MeasureContextRegenerationScope } from "./context-regeneration-options";
 
 const MODEL = "mistral-small-latest";
-const PROMPT_VERSION = "measure-context-v9";
+const PROMPT_VERSION = MEASURE_CONTEXT_PROMPT_VERSION;
 const TERMINAL_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_TERMINAL_RESULT";
 const INVALID_CONTEXT_RESULT_ACTION = "GENERATE_CONTEXT_INVALID_RESULT";
 const RESERVED_CONTEXT_GENERATION_ACTION = "RESERVE_CONTEXT_GENERATION";
@@ -36,7 +38,8 @@ export type ContextGenerationSkipReason =
   | "NO_VALID_EVIDENCE"
   | "NO_SUPPORTING_CONTEXT"
   | "PREVIOUS_CONTEXT_ATTEMPT"
-  | "NO_USEFUL_CONTEXT";
+  | "NO_USEFUL_CONTEXT"
+  | "NOT_REGENERATABLE_CONTEXT";
 
 export type ContextGenerationResult =
   | {
@@ -245,6 +248,105 @@ export async function findMeasureContextCandidateIds(
   return eligibleIds;
 }
 
+export async function findMeasureContextRegenerationCandidateIds(
+  input: {
+    electionSlug: string;
+    fromPromptVersion: string;
+    limit: number;
+    scope: MeasureContextRegenerationScope;
+  },
+  pageSize = 250
+): Promise<string[]> {
+  if (input.limit < 1 || input.limit > 100) {
+    throw new MeasureValidationError("La limite de régénération doit être comprise entre 1 et 100");
+  }
+  if (input.fromPromptVersion === PROMPT_VERSION) {
+    throw new MeasureValidationError(
+      "La version à régénérer doit être antérieure à la version courante"
+    );
+  }
+
+  const lifecycleFilters = [
+    ...(input.scope === "drafts" || input.scope === "all"
+      ? [
+          {
+            extractionMethod: "AI_ASSISTED" as const,
+            reviewedAt: null,
+            publishedAt: null,
+          },
+        ]
+      : []),
+    ...(input.scope === "published" || input.scope === "all"
+      ? [
+          {
+            reviewedAt: { not: null },
+            publishedAt: { not: null },
+            supersededAt: null,
+          },
+        ]
+      : []),
+  ];
+  const eligibleIds: string[] = [];
+  let cursor: string | undefined;
+
+  while (eligibleIds.length < input.limit) {
+    const candidates = await db.measure.findMany({
+      where: {
+        election: { slug: input.electionSlug },
+        publicationStatus: "PUBLISHED",
+        latestRevision: {
+          is: {
+            details: { not: null },
+            extractorVersion: { endsWith: `:${input.fromPromptVersion}` },
+            discardedAt: null,
+            rejectedAt: null,
+            OR: lifecycleFilters,
+          },
+        },
+      },
+      select: {
+        id: true,
+        latestRevisionId: true,
+        publishedRevisionId: true,
+        latestRevision: {
+          select: {
+            evidenceSnapshot: true,
+            reviewedAt: true,
+            publishedAt: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: pageSize,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+
+    for (const candidate of candidates) {
+      const revision = candidate.latestRevision;
+      if (!revision) continue;
+      const evidence = readEvidenceSnapshot(revision.evidenceSnapshot);
+      if (evidence.status !== "VALID" || evidence.snapshot.supportingIds.length === 0) continue;
+      const isPublished =
+        candidate.latestRevisionId === candidate.publishedRevisionId &&
+        revision.reviewedAt !== null &&
+        revision.publishedAt !== null;
+      const isDraft =
+        candidate.latestRevisionId !== candidate.publishedRevisionId &&
+        revision.reviewedAt === null &&
+        revision.publishedAt === null;
+      if (!isPublished && !isDraft) continue;
+      eligibleIds.push(candidate.id);
+      if (eligibleIds.length === input.limit) break;
+    }
+
+    if (candidates.length < pageSize) break;
+    cursor = candidates.at(-1)?.id;
+    if (!cursor) break;
+  }
+
+  return eligibleIds;
+}
+
 function sanitizeSourceText(value: string): string {
   return value
     .replace(/[<>&"\n\r]/g, " ")
@@ -437,6 +539,7 @@ async function recordInvalidContextResult(input: {
 }
 
 async function reserveContextGeneration(input: {
+  allowUnpublishedDraft: boolean;
   expectedUpdatedAt: Date;
   generatedBy: string;
   ipAddress: string;
@@ -459,7 +562,7 @@ async function reserveContextGeneration(input: {
     }
     if (
       currentMeasure.latestRevisionId !== input.revisionId ||
-      currentMeasure.publishedRevisionId !== input.revisionId
+      (!input.allowUnpublishedDraft && currentMeasure.publishedRevisionId !== input.revisionId)
     ) {
       throw new MeasureValidationError("La révision publiée a changé avant la génération");
     }
@@ -509,6 +612,7 @@ async function reserveContextGeneration(input: {
 }
 
 async function recordTerminalContextResult(input: {
+  allowUnpublishedDraft: boolean;
   generatedBy: string;
   measureId: string;
   model: string;
@@ -534,7 +638,7 @@ async function recordTerminalContextResult(input: {
     }
     if (
       currentMeasure.latestRevisionId !== input.revisionId ||
-      currentMeasure.publishedRevisionId !== input.revisionId
+      (!input.allowUnpublishedDraft && currentMeasure.publishedRevisionId !== input.revisionId)
     ) {
       throw new MeasureValidationError("La révision publiée a changé pendant la génération");
     }
@@ -575,6 +679,7 @@ export async function generateMeasureContextDraft(
     expectedUpdatedAt?: Date;
     generatedBy?: string;
     ipAddress?: string;
+    regenerateFromPromptVersion?: string;
     userAgent?: string;
   } = {}
 ): Promise<ContextGenerationResult> {
@@ -593,6 +698,28 @@ export async function generateMeasureContextDraft(
           precision: true,
           validFrom: true,
           evidenceSnapshot: true,
+          reviewedAt: true,
+          publishedAt: true,
+          discardedAt: true,
+          rejectedAt: true,
+          extractionMethod: true,
+          extractorVersion: true,
+        },
+      },
+      latestRevision: {
+        select: {
+          id: true,
+          text: true,
+          details: true,
+          precision: true,
+          validFrom: true,
+          evidenceSnapshot: true,
+          reviewedAt: true,
+          publishedAt: true,
+          discardedAt: true,
+          rejectedAt: true,
+          extractionMethod: true,
+          extractorVersion: true,
         },
       },
     },
@@ -604,13 +731,47 @@ export async function generateMeasureContextDraft(
   ) {
     throw new MeasureConcurrencyError(measureId, options.expectedUpdatedAt, measure.updatedAt);
   }
-  const revision = measure.publishedRevision;
-  if (!revision || !measure.publishedRevisionId) {
+  if (!measure.publishedRevision || !measure.publishedRevisionId) {
     return { status: "SKIPPED", reason: "NO_PUBLISHED_REVISION" };
   }
-  if (revision.details?.trim()) return { status: "SKIPPED", reason: "ALREADY_HAS_DETAILS" };
-  if (measure.latestRevisionId !== measure.publishedRevisionId) {
-    return { status: "SKIPPED", reason: "ACTIVE_DRAFT" };
+  const regenerationVersion = options.regenerateFromPromptVersion?.trim();
+  if (regenerationVersion === PROMPT_VERSION) {
+    throw new MeasureValidationError(
+      "La version à régénérer doit être antérieure à la version courante"
+    );
+  }
+
+  const revision = regenerationVersion ? measure.latestRevision : measure.publishedRevision;
+  if (!revision) return { status: "SKIPPED", reason: "NOT_REGENERATABLE_CONTEXT" };
+
+  if (regenerationVersion) {
+    const isRequestedVersion =
+      revision.extractorVersion?.endsWith(`:${regenerationVersion}`) === true;
+    const isCurrentPublishedRevision =
+      revision.id === measure.publishedRevisionId &&
+      measure.latestRevisionId === measure.publishedRevisionId &&
+      revision.reviewedAt !== null &&
+      revision.publishedAt !== null;
+    const isReplaceableDraft =
+      revision.id === measure.latestRevisionId &&
+      revision.id !== measure.publishedRevisionId &&
+      revision.extractionMethod === "AI_ASSISTED" &&
+      revision.reviewedAt === null &&
+      revision.publishedAt === null;
+    if (
+      !isRequestedVersion ||
+      !revision.details?.trim() ||
+      revision.discardedAt !== null ||
+      revision.rejectedAt !== null ||
+      (!isCurrentPublishedRevision && !isReplaceableDraft)
+    ) {
+      return { status: "SKIPPED", reason: "NOT_REGENERATABLE_CONTEXT" };
+    }
+  } else {
+    if (revision.details?.trim()) return { status: "SKIPPED", reason: "ALREADY_HAS_DETAILS" };
+    if (measure.latestRevisionId !== measure.publishedRevisionId) {
+      return { status: "SKIPPED", reason: "ACTIVE_DRAFT" };
+    }
   }
   const evidence = readEvidenceSnapshot(revision.evidenceSnapshot);
   if (evidence.status !== "VALID") {
@@ -624,6 +785,7 @@ export async function generateMeasureContextDraft(
     return { status: "SKIPPED", reason: "NO_SUPPORTING_CONTEXT" };
   }
   const attemptState = await reserveContextGeneration({
+    allowUnpublishedDraft: revision.id !== measure.publishedRevisionId,
     expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
     generatedBy: options.generatedBy ?? "system",
     ipAddress: options.ipAddress ?? "unknown",
@@ -701,6 +863,7 @@ Réponds uniquement en JSON :
       const validated = validateGeneratedContext(parsed, units, supportingIds);
       if (validated === null) {
         await recordTerminalContextResult({
+          allowUnpublishedDraft: revision.id !== measure.publishedRevisionId,
           generatedBy: options.generatedBy ?? "system",
           expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
           ipAddress: options.ipAddress ?? "unknown",
@@ -735,6 +898,7 @@ Réponds uniquement en JSON :
         await recordInvalidContextResult(auditInput);
       } else {
         await recordTerminalContextResult({
+          allowUnpublishedDraft: revision.id !== measure.publishedRevisionId,
           ...auditInput,
           expectedUpdatedAt: options.expectedUpdatedAt ?? measure.updatedAt,
           outcome: "INVALID_GENERATED_CONTEXT",

--- a/src/lib/measures/context-provenance.ts
+++ b/src/lib/measures/context-provenance.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const GENERATED_CONTEXT_DRAFT_ACTION = "GENERATE_CONTEXT_DRAFT";
+export const MEASURE_CONTEXT_PROMPT_VERSION = "measure-context-v9";
 
 export const generatedContextClaimSchema = z
   .object({

--- a/src/lib/measures/context-regeneration-options.test.ts
+++ b/src/lib/measures/context-regeneration-options.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseMeasureContextRegenerationOptions } from "./context-regeneration-options";
+
+describe("arguments de régénération des contextes", () => {
+  it("accepte les syntaxes avec espaces et signe égal", () => {
+    expect(
+      parseMeasureContextRegenerationOptions([
+        "--from-prompt",
+        "measure-context-v8",
+        "--election=presidentielle-2027",
+        "--scope",
+        "all",
+        "--limit=100",
+        "--dry-run",
+      ])
+    ).toEqual({
+      apply: false,
+      dryRun: true,
+      electionSlug: "presidentielle-2027",
+      fromPromptVersion: "measure-context-v8",
+      limit: 100,
+      scope: "all",
+    });
+  });
+
+  it("exige une ancienne version et refuse les modes ambigus", () => {
+    expect(() => parseMeasureContextRegenerationOptions([])).toThrow("--from-prompt");
+    expect(() =>
+      parseMeasureContextRegenerationOptions([
+        "--from-prompt=measure-context-v8",
+        "--dry-run",
+        "--apply",
+      ])
+    ).toThrow("simultanément");
+    expect(() =>
+      parseMeasureContextRegenerationOptions(["--from-prompt=measure-context-v9", "--apply"])
+    ).toThrow("version courante");
+  });
+});

--- a/src/lib/measures/context-regeneration-options.ts
+++ b/src/lib/measures/context-regeneration-options.ts
@@ -1,0 +1,58 @@
+import { parseCLIOptions } from "@/lib/cli/parse-options";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "./context-provenance";
+
+export type MeasureContextRegenerationScope = "drafts" | "published" | "all";
+
+export type MeasureContextRegenerationOptions = {
+  apply: boolean;
+  dryRun: boolean;
+  electionSlug: string;
+  fromPromptVersion: string;
+  limit: number;
+  scope: MeasureContextRegenerationScope;
+};
+
+const OPTION_DEFINITIONS = [
+  { name: "--from-prompt", type: "string" },
+  { name: "--election", type: "string" },
+  { name: "--scope", type: "string" },
+  { name: "--limit", type: "number" },
+  { name: "--dry-run", type: "boolean" },
+  { name: "--apply", type: "boolean" },
+] as const;
+
+export function parseMeasureContextRegenerationOptions(
+  args: string[]
+): MeasureContextRegenerationOptions {
+  const parsed = parseCLIOptions(args, OPTION_DEFINITIONS);
+  const fromPromptVersion = typeof parsed.fromPrompt === "string" ? parsed.fromPrompt.trim() : "";
+  if (!fromPromptVersion) throw new Error("--from-prompt est obligatoire");
+  if (fromPromptVersion === MEASURE_CONTEXT_PROMPT_VERSION) {
+    throw new Error("--from-prompt doit désigner une version antérieure à la version courante");
+  }
+
+  const limit = parsed.limit ?? 30;
+  if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("--limit doit être un entier compris entre 1 et 100");
+  }
+
+  const scope = parsed.scope ?? "all";
+  if (scope !== "drafts" && scope !== "published" && scope !== "all") {
+    throw new Error("--scope doit valoir drafts, published ou all");
+  }
+
+  const apply = parsed.apply === true;
+  const explicitDryRun = parsed.dryRun === true;
+  if (apply && explicitDryRun) {
+    throw new Error("--dry-run et --apply ne peuvent pas être utilisés simultanément");
+  }
+
+  return {
+    apply,
+    dryRun: !apply,
+    electionSlug: typeof parsed.election === "string" ? parsed.election : "presidentielle-2027",
+    fromPromptVersion,
+    limit,
+    scope,
+  };
+}

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -311,6 +311,10 @@ export async function draftMeasureRevision(
         select: {
           measureId: true,
           evidenceSnapshot: true,
+          reviewedAt: true,
+          publishedAt: true,
+          discardedAt: true,
+          rejectedAt: true,
           reviewReadiness: true,
           reviewWarnings: true,
           sources: {
@@ -326,6 +330,18 @@ export async function draftMeasureRevision(
       });
       if (!previous || previous.measureId !== input.measureId) {
         throw new MeasureValidationError("La révision source de la preuve est introuvable");
+      }
+      if (
+        input.generatedContext &&
+        measure.latestRevisionId !== measure.publishedRevisionId &&
+        (previous.reviewedAt !== null ||
+          previous.publishedAt !== null ||
+          previous.discardedAt !== null ||
+          previous.rejectedAt !== null)
+      ) {
+        throw new MeasureValidationError(
+          "Un brouillon relu ou modéré ne peut pas être remplacé automatiquement"
+        );
       }
       revisionInput = {
         ...input.revision,


### PR DESCRIPTION
## Résumé

- affiche le contexte publié dans l’aperçu administrateur et évite les liens de preuve dupliqués
- rend la rédaction v9 plus naturelle et rejette les formulations mécaniques
- ajoute une régénération auditable et idempotente des brouillons et contextes publiés v8, sans remplacer directement le contenu public
- élargit la fiche mesure sur desktop sans modifier le rendu mobile

## Validation

- tests ciblés : 65 réussis
- typecheck : réussi
- lint : 0 erreur, 57 avertissements préexistants
- tests complets : 5 574 réussis, 408 ignorés ; les 2 échecs locaux viennent uniquement de scripts gitignorés dans scripts/.local, les suites concernées passent dans une copie propre (76/76)
- build ciblé Webpack de la route mesure : réussi, compilation, TypeScript et génération

Le build global compile et passe TypeScript, puis échoue lors de la collecte d’une route municipale non modifiée : /elections/municipales-2026/communes/[inseeCode].