### PR TITLE
feat(mesures): générer tous les contextes en une fois

### DIFF
--- a/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
+++ b/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
@@ -165,6 +165,44 @@ Ajouter à l'administration d'une révision publiée :
 Le contrôle de complétude signale les champs manquants, mais ne bloque pas une mesure dont la source
 ne permet honnêtement aucun enrichissement.
 
+### Commandes de génération
+
+Prévisualiser le nombre de mesures éligibles sans appeler Mistral ni écrire en base :
+
+```bash
+npm run measures:generate-contexts -- \
+  --election presidentielle-2027 \
+  --all
+```
+
+Créer tous les brouillons manquants en une seule exécution :
+
+```bash
+npm run measures:generate-contexts -- \
+  --election presidentielle-2027 \
+  --all \
+  --apply
+```
+
+Le traitement reste séquentiel pour maîtriser la charge sur Mistral et sur la base. Il est
+reprenable : une nouvelle exécution écarte les révisions déjà traitées, les résultats sans contexte
+utile et les erreurs de validation déjà auditées. `--all` et `--limit` sont volontairement
+incompatibles afin que le périmètre de l'opération soit explicite.
+
+La régénération depuis une ancienne version de prompt accepte le même mode :
+
+```bash
+npm run measures:regenerate-contexts -- \
+  --election presidentielle-2027 \
+  --from-prompt measure-context-v8 \
+  --scope all \
+  --all \
+  --apply
+```
+
+Ces commandes créent uniquement des brouillons. La relecture et la publication restent des décisions
+éditoriales distinctes dans l'administration.
+
 ## Ordre de livraison
 
 1. Mesurer la couverture réelle des signaux et définir le tableau de bord d'enrichissement.

--- a/scripts/generate-measure-contexts.ts
+++ b/scripts/generate-measure-contexts.ts
@@ -4,31 +4,20 @@ import {
   findMeasureContextCandidateIds,
   generateMeasureContextDraft,
 } from "../src/lib/measures/context-generation";
+import { parseMeasureContextGenerationOptions } from "../src/lib/measures/context-generation-options";
 
-type Options = { apply: boolean; electionSlug: string; limit: number };
-
-function valueAfter(args: string[], flag: string): string | undefined {
-  const index = args.indexOf(flag);
-  return index === -1 ? undefined : args[index + 1];
-}
-
-function parseOptions(args: string[]): Options {
-  const limit = Number(valueAfter(args, "--limit") ?? "30");
-  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
-    throw new Error("--limit doit être un entier compris entre 1 et 100");
-  }
-  return {
-    apply: args.includes("--apply"),
-    electionSlug: valueAfter(args, "--election") ?? "presidentielle-2027",
-    limit,
-  };
-}
+const ALL_ELIGIBLE_CONTEXTS = Number.MAX_SAFE_INTEGER;
 
 async function main(): Promise<void> {
-  const options = parseOptions(process.argv.slice(2));
-  const eligibleIds = await findMeasureContextCandidateIds(options.electionSlug, options.limit);
+  const options = parseMeasureContextGenerationOptions(process.argv.slice(2));
+  const eligibleIds = await findMeasureContextCandidateIds(
+    options.electionSlug,
+    options.all ? ALL_ELIGIBLE_CONTEXTS : options.limit
+  );
 
-  console.log(`${eligibleIds.length} mesure(s) éligible(s) dans ce lot.`);
+  console.log(
+    `${eligibleIds.length} mesure(s) éligible(s) ${options.all ? "dans la file complète" : "dans ce lot"}.`
+  );
   if (!options.apply) {
     console.log("Simulation uniquement. Ajouter --apply pour créer les brouillons.");
     return;

--- a/scripts/regenerate-measure-contexts.ts
+++ b/scripts/regenerate-measure-contexts.ts
@@ -6,17 +6,19 @@ import {
 } from "../src/lib/measures/context-generation";
 import { parseMeasureContextRegenerationOptions } from "../src/lib/measures/context-regeneration-options";
 
+const ALL_ELIGIBLE_CONTEXTS = Number.MAX_SAFE_INTEGER;
+
 async function main(): Promise<void> {
   const options = parseMeasureContextRegenerationOptions(process.argv.slice(2));
   const candidateIds = await findMeasureContextRegenerationCandidateIds({
     electionSlug: options.electionSlug,
     fromPromptVersion: options.fromPromptVersion,
-    limit: options.limit,
+    limit: options.all ? ALL_ELIGIBLE_CONTEXTS : options.limit,
     scope: options.scope,
   });
 
   console.log(
-    `${candidateIds.length} contexte(s) ${options.fromPromptVersion} éligible(s) à une régénération (${options.scope}).`
+    `${candidateIds.length} contexte(s) ${options.fromPromptVersion} éligible(s) à une régénération (${options.scope}${options.all ? ", file complète" : ""}).`
   );
   if (options.dryRun) {
     console.log("Simulation uniquement. Ajouter --apply pour créer les nouveaux brouillons.");

--- a/src/lib/measures/__tests__/context-generation.test.ts
+++ b/src/lib/measures/__tests__/context-generation.test.ts
@@ -393,6 +393,20 @@ describe("génération de contexte sourcé", () => {
     );
   });
 
+  it("accepte une limite non bornée pour parcourir toute la file de régénération", async () => {
+    mocks.findMeasures.mockResolvedValue([]);
+    const { findMeasureContextRegenerationCandidateIds } = await import("../context-generation");
+
+    await expect(
+      findMeasureContextRegenerationCandidateIds({
+        electionSlug: "presidentielle-2027",
+        fromPromptVersion: "measure-context-v8",
+        limit: Number.MAX_SAFE_INTEGER,
+        scope: "all",
+      })
+    ).resolves.toEqual([]);
+  });
+
   it.each([
     {
       action: "GENERATE_CONTEXT_TERMINAL_RESULT",

--- a/src/lib/measures/context-generation-options.test.ts
+++ b/src/lib/measures/context-generation-options.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseMeasureContextGenerationOptions } from "./context-generation-options";
+
+describe("arguments de génération des contextes", () => {
+  it("conserve le lot borné par défaut", () => {
+    expect(parseMeasureContextGenerationOptions([])).toEqual({
+      all: false,
+      apply: false,
+      electionSlug: "presidentielle-2027",
+      limit: 30,
+    });
+  });
+
+  it("accepte un traitement complet explicite", () => {
+    expect(
+      parseMeasureContextGenerationOptions(["--election=presidentielle-2027", "--all", "--apply"])
+    ).toEqual({
+      all: true,
+      apply: true,
+      electionSlug: "presidentielle-2027",
+      limit: 30,
+    });
+  });
+
+  it("refuse de combiner le traitement complet et une limite", () => {
+    expect(() => parseMeasureContextGenerationOptions(["--all", "--limit=100"])).toThrow(
+      "simultanément"
+    );
+  });
+});

--- a/src/lib/measures/context-generation-options.ts
+++ b/src/lib/measures/context-generation-options.ts
@@ -1,0 +1,37 @@
+import { parseCLIOptions } from "@/lib/cli/parse-options";
+
+export type MeasureContextGenerationOptions = {
+  all: boolean;
+  apply: boolean;
+  electionSlug: string;
+  limit: number;
+};
+
+const OPTION_DEFINITIONS = [
+  { name: "--election", type: "string" },
+  { name: "--limit", type: "number" },
+  { name: "--all", type: "boolean" },
+  { name: "--apply", type: "boolean" },
+] as const;
+
+export function parseMeasureContextGenerationOptions(
+  args: string[]
+): MeasureContextGenerationOptions {
+  const parsed = parseCLIOptions(args, OPTION_DEFINITIONS);
+  const all = parsed.all === true;
+  if (all && parsed.limit !== undefined) {
+    throw new Error("--all et --limit ne peuvent pas être utilisés simultanément");
+  }
+
+  const limit = parsed.limit ?? 30;
+  if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("--limit doit être un entier compris entre 1 et 100");
+  }
+
+  return {
+    all,
+    apply: parsed.apply === true,
+    electionSlug: typeof parsed.election === "string" ? parsed.election : "presidentielle-2027",
+    limit,
+  };
+}

--- a/src/lib/measures/context-generation.ts
+++ b/src/lib/measures/context-generation.ts
@@ -263,8 +263,8 @@ export async function findMeasureContextRegenerationCandidateIds(
   },
   pageSize = 250
 ): Promise<string[]> {
-  if (input.limit < 1 || input.limit > 100) {
-    throw new MeasureValidationError("La limite de régénération doit être comprise entre 1 et 100");
+  if (!Number.isSafeInteger(input.limit) || input.limit < 1) {
+    throw new MeasureValidationError("La limite de régénération doit être un entier positif");
   }
   if (input.fromPromptVersion === PROMPT_VERSION) {
     throw new MeasureValidationError(

--- a/src/lib/measures/context-regeneration-options.test.ts
+++ b/src/lib/measures/context-regeneration-options.test.ts
@@ -14,6 +14,7 @@ describe("arguments de régénération des contextes", () => {
         "--dry-run",
       ])
     ).toEqual({
+      all: false,
       apply: false,
       dryRun: true,
       electionSlug: "presidentielle-2027",
@@ -21,6 +22,24 @@ describe("arguments de régénération des contextes", () => {
       limit: 100,
       scope: "all",
     });
+  });
+
+  it("accepte un traitement complet et refuse de le combiner à une limite", () => {
+    expect(
+      parseMeasureContextRegenerationOptions([
+        "--from-prompt=measure-context-v8",
+        "--scope=all",
+        "--all",
+        "--apply",
+      ])
+    ).toMatchObject({ all: true, apply: true, limit: 30 });
+    expect(() =>
+      parseMeasureContextRegenerationOptions([
+        "--from-prompt=measure-context-v8",
+        "--all",
+        "--limit=100",
+      ])
+    ).toThrow("simultanément");
   });
 
   it("exige une ancienne version et refuse les modes ambigus", () => {

--- a/src/lib/measures/context-regeneration-options.ts
+++ b/src/lib/measures/context-regeneration-options.ts
@@ -4,6 +4,7 @@ import { MEASURE_CONTEXT_PROMPT_VERSION } from "./context-provenance";
 export type MeasureContextRegenerationScope = "drafts" | "published" | "all";
 
 export type MeasureContextRegenerationOptions = {
+  all: boolean;
   apply: boolean;
   dryRun: boolean;
   electionSlug: string;
@@ -17,6 +18,7 @@ const OPTION_DEFINITIONS = [
   { name: "--election", type: "string" },
   { name: "--scope", type: "string" },
   { name: "--limit", type: "number" },
+  { name: "--all", type: "boolean" },
   { name: "--dry-run", type: "boolean" },
   { name: "--apply", type: "boolean" },
 ] as const;
@@ -29,6 +31,11 @@ export function parseMeasureContextRegenerationOptions(
   if (!fromPromptVersion) throw new Error("--from-prompt est obligatoire");
   if (fromPromptVersion === MEASURE_CONTEXT_PROMPT_VERSION) {
     throw new Error("--from-prompt doit désigner une version antérieure à la version courante");
+  }
+
+  const all = parsed.all === true;
+  if (all && parsed.limit !== undefined) {
+    throw new Error("--all et --limit ne peuvent pas être utilisés simultanément");
   }
 
   const limit = parsed.limit ?? 30;
@@ -48,6 +55,7 @@ export function parseMeasureContextRegenerationOptions(
   }
 
   return {
+    all,
     apply,
     dryRun: !apply,
     electionSlug: typeof parsed.election === "string" ? parsed.election : "presidentielle-2027",


### PR DESCRIPTION
## Résultat

Ajoute un mode explicite `--all` aux commandes de génération et de régénération des contextes de mesure.

- draine toute la file éligible en une exécution séquentielle
- reste reprenable après interruption grâce aux tentatives auditées existantes
- refuse la combinaison ambiguë `--all --limit`
- crée uniquement des brouillons, sans relecture ni publication automatique
- documente les commandes d'exploitation

## Vérifications

- `npm run test:run -- src/lib/measures/context-generation-options.test.ts src/lib/measures/context-regeneration-options.test.ts src/lib/measures/__tests__/context-generation.test.ts` (61 tests)
- `npm run typecheck`
- ESLint ciblé
- Prettier ciblé
- vérification de factorisation sans anomalie