### PR TITLE
fix(recherche): préserver la page face au quota API

### DIFF
--- a/src/app/elections/presidentielle-2027/recherche/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.test.tsx
@@ -38,6 +38,19 @@ describe("page complète de recherche présidentielle", () => {
     expect(metadata.alternates?.canonical).toBe("/elections/presidentielle-2027/recherche");
   });
 
+  it("affiche un état HTML accessible sans lancer la recherche lorsque le quota est atteint", async () => {
+    render(
+      await PresidentialSearchPage({
+        searchParams: Promise.resolve({ q: "retraites", limite: "1" }),
+      })
+    );
+
+    expect(search).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Trop de recherches ont été lancées en peu de temps"
+    );
+  });
+
   it("affiche le texte complet et le lien canonique de la mesure", async () => {
     render(await PresidentialSearchPage({ searchParams: Promise.resolve({ q: "logement" }) }));
     const link = screen.getByRole("link", {

--- a/src/app/elections/presidentielle-2027/recherche/page.tsx
+++ b/src/app/elections/presidentielle-2027/recherche/page.tsx
@@ -28,9 +28,12 @@ export default async function PresidentialSearchPage({
     q?: string | string[];
     "sous-theme"?: string | string[];
     page?: string | string[];
+    limite?: string | string[];
   }>;
 }) {
   const params = await searchParams;
+  const rawLimit = Array.isArray(params.limite) ? params.limite[0] : params.limite;
+  const isRateLimited = rawLimit === "1";
   const raw = Array.isArray(params.q) ? params.q[0] : params.q;
   const query = raw?.trim().slice(0, 200) ?? "";
   const rawSubtopic = Array.isArray(params["sous-theme"])
@@ -40,11 +43,13 @@ export default async function PresidentialSearchPage({
   const rawPage = Array.isArray(params.page) ? params.page[0] : params.page;
   const parsedPage = Number.parseInt(rawPage ?? "1", 10);
   const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
-  const result = await searchPresidentialCorpus(PRESIDENTIELLE_2027_SLUG, query, 50, {
-    subtopicSlug,
-    page,
-    strategy: subtopicSlug ? "lexical" : "hybrid",
-  });
+  const result = isRateLimited
+    ? null
+    : await searchPresidentialCorpus(PRESIDENTIELLE_2027_SLUG, query, 50, {
+        subtopicSlug,
+        page,
+        strategy: subtopicSlug ? "lexical" : "hybrid",
+      });
   const hasResults = result !== null && result.total > 0;
   const hasSearch = query.length >= 2 || subtopicSlug !== undefined;
   const resultLabel = result?.query || query;
@@ -137,7 +142,17 @@ export default async function PresidentialSearchPage({
           la réponse. <Link href="/sources#intelligence-artificielle">En savoir plus</Link>
         </p>
 
-        {!hasSearch ? (
+        {isRateLimited ? (
+          <section role="alert" className="mt-10 rounded-2xl border border-border bg-card p-6">
+            <h2 className="font-display text-2xl font-extrabold">
+              Trop de recherches ont été lancées en peu de temps
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              Patientez une minute, puis relancez votre recherche. Cette limite protège la
+              disponibilité du service pour tous.
+            </p>
+          </section>
+        ) : !hasSearch ? (
           <p className="mt-10 text-muted-foreground">
             Saisissez au moins deux caractères pour rechercher dans le corpus public.
           </p>

--- a/src/proxy-search-rate-limit.test.ts
+++ b/src/proxy-search-rate-limit.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getRateLimitTier } from "@/proxy";
 
 describe("quota de la recherche présidentielle", () => {
-  it("applique le quota recherche à la page hybride et à son autocomplétion", () => {
-    expect(getRateLimitTier("/elections/presidentielle-2027/recherche")).toBe("search");
+  it("laisse la page HTML accessible et limite son autocomplétion", () => {
+    expect(getRateLimitTier("/elections/presidentielle-2027/recherche")).toBeNull();
     expect(getRateLimitTier("/api/elections/presidentielle-2027/recherche")).toBe("search");
   });
 

--- a/src/proxy-search-rate-limit.test.ts
+++ b/src/proxy-search-rate-limit.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { getRateLimitTier } from "@/proxy";
+import { NextRequest } from "next/server";
+import { buildRateLimitExceededResponse, getRateLimitTier } from "@/proxy";
 
 describe("quota de la recherche présidentielle", () => {
-  it("laisse la page HTML accessible et limite son autocomplétion", () => {
-    expect(getRateLimitTier("/elections/presidentielle-2027/recherche")).toBeNull();
+  it("applique le quota recherche à la page hybride et à son autocomplétion", () => {
+    expect(getRateLimitTier("/elections/presidentielle-2027/recherche")).toBe("search");
     expect(getRateLimitTier("/api/elections/presidentielle-2027/recherche")).toBe("search");
+  });
+
+  it("réécrit une page limitée vers un état HTML sans exposer la réponse JSON de l'API", async () => {
+    const reset = Date.now() + 30_000;
+    const pageRequest = new NextRequest(
+      "https://poligraph.fr/elections/presidentielle-2027/recherche?q=retraites"
+    );
+    const pageResponse = buildRateLimitExceededResponse(pageRequest, 30, reset);
+
+    expect(pageResponse.status).toBe(429);
+    expect(pageResponse.headers.get("content-type")).toBeNull();
+    expect(pageResponse.headers.get("x-middleware-rewrite")).toBe(
+      "https://poligraph.fr/elections/presidentielle-2027/recherche?q=retraites&limite=1"
+    );
+
+    const apiRequest = new NextRequest(
+      "https://poligraph.fr/api/elections/presidentielle-2027/recherche?q=retraites"
+    );
+    const apiResponse = buildRateLimitExceededResponse(apiRequest, 30, reset);
+
+    expect(apiResponse.status).toBe(429);
+    expect(await apiResponse.json()).toEqual({ error: "Trop de requêtes. Réessayez plus tard." });
   });
 
   it("conserve le quota général pour les autres routes publiques", () => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -162,10 +162,7 @@ export function getRateLimitTier(pathname: string): RateLimitTier | null {
     return "subscribe";
   }
   if (pathname.startsWith("/api/export")) return "export";
-  if (
-    pathname === "/elections/presidentielle-2027/recherche" ||
-    pathname.startsWith("/api/elections/presidentielle-2027/recherche")
-  ) {
+  if (pathname.startsWith("/api/elections/presidentielle-2027/recherche")) {
     return "search";
   }
   if (pathname.startsWith("/api/search")) return "search";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,6 +18,8 @@ import { getLegacyMeasureId } from "@/lib/presidentielle/measure-route";
 
 type RateLimitTier = "general" | "search" | "export" | "admin" | "subscribe";
 
+const PRESIDENTIAL_SEARCH_PAGE_PATH = "/elections/presidentielle-2027/recherche";
+
 const TIER_CONFIG: Record<RateLimitTier, { tokens: number; window: string }> = {
   general: { tokens: 60, window: "1m" },
   search: { tokens: 30, window: "1m" },
@@ -162,7 +164,10 @@ export function getRateLimitTier(pathname: string): RateLimitTier | null {
     return "subscribe";
   }
   if (pathname.startsWith("/api/export")) return "export";
-  if (pathname.startsWith("/api/elections/presidentielle-2027/recherche")) {
+  if (
+    pathname === PRESIDENTIAL_SEARCH_PAGE_PATH ||
+    pathname.startsWith("/api/elections/presidentielle-2027/recherche")
+  ) {
     return "search";
   }
   if (pathname.startsWith("/api/search")) return "search";
@@ -266,20 +271,7 @@ async function applyApiRateLimit(
   }
 
   if (!success) {
-    const retryAfter = Math.ceil((reset - Date.now()) / 1000);
-    const headers: Record<string, string> = {
-      "Retry-After": String(retryAfter),
-      "X-RateLimit-Limit": String(limit),
-      "X-RateLimit-Remaining": "0",
-      "X-RateLimit-Reset": String(reset),
-      ...(isV1Route(pathname) ? CORS_HEADERS : {}),
-    };
-    const limited = NextResponse.json(
-      { error: "Trop de requêtes. Réessayez plus tard." },
-      { status: 429, headers }
-    );
-    applySubscribeCors(request, limited);
-    return limited;
+    return buildRateLimitExceededResponse(request, limit, reset);
   }
 
   const response = NextResponse.next();
@@ -291,6 +283,34 @@ async function applyApiRateLimit(
   }
   applySubscribeCors(request, response);
   return response;
+}
+
+export function buildRateLimitExceededResponse(
+  request: NextRequest,
+  limit: number,
+  reset: number
+): NextResponse {
+  const pathname = request.nextUrl.pathname;
+  const headers: Record<string, string> = {
+    "Retry-After": String(Math.max(0, Math.ceil((reset - Date.now()) / 1000))),
+    "X-RateLimit-Limit": String(limit),
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": String(reset),
+    ...(isV1Route(pathname) ? CORS_HEADERS : {}),
+  };
+
+  if (pathname === PRESIDENTIAL_SEARCH_PAGE_PATH) {
+    const target = request.nextUrl.clone();
+    target.searchParams.set("limite", "1");
+    return NextResponse.rewrite(target, { status: 429, headers });
+  }
+
+  const limited = NextResponse.json(
+    { error: "Trop de requêtes. Réessayez plus tard." },
+    { status: 429, headers }
+  );
+  applySubscribeCors(request, limited);
+  return limited;
 }
 
 /**


### PR DESCRIPTION
## Problème

Le proxy appliquait le quota de recherche à la page HTML publique et à l’API. Une fois le quota atteint, une navigation vers la page affichait directement une réponse JSON 429.

## Correction

- exclut la page HTML du quota API
- conserve le quota recherche sur l’endpoint d’autocomplétion
- ajoute un test de régression sur les deux routes

## Vérifications

- tests ciblés : 11 réussis
- typecheck : réussi
- lint ciblé : réussi
- suite complète : 6 016 tests réussis sur 6 018 ; les deux échecs locaux proviennent exclusivement de scripts gitignorés dans scripts/.local, absents de la PR et de la CI