### PR TITLE
fix(recherche): isoler le quota d’autocomplétion

### DIFF
--- a/src/app/elections/presidentielle-2027/_components/PresidentialCorpusSearch.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PresidentialCorpusSearch.tsx
@@ -17,6 +17,7 @@ import type {
 import { cn } from "@/lib/utils";
 
 const MIN_QUERY_LENGTH = 2;
+const AUTOCOMPLETE_DELAY_MS = 500;
 const RESULTS_PATH = "/elections/presidentielle-2027/recherche";
 
 type ApiResponse = {
@@ -99,7 +100,7 @@ export function PresidentialCorpusSearch() {
         if ((error as Error).name === "AbortError" || currentRequest !== requestId.current) return;
         setStatus("error");
       }
-    }, 150);
+    }, AUTOCOMPLETE_DELAY_MS);
     return () => {
       window.clearTimeout(timer);
       controller.abort();

--- a/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialCorpusSearch.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/PresidentialCorpusSearch.test.tsx
@@ -63,7 +63,7 @@ describe("PresidentialCorpusSearch", () => {
 
   async function runDebounce() {
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(500);
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -79,6 +79,27 @@ describe("PresidentialCorpusSearch", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(screen.getByRole("combobox")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("n'envoie qu'une suggestion pendant la saisie continue d'une phrase naturelle", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => response() });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<PresidentialCorpusSearch />);
+    const input = screen.getByRole("combobox");
+    const sentence = "Je veux des informations sur les mesures de retraite";
+
+    for (let index = 1; index <= sentence.length; index += 1) {
+      fireEvent.change(input, { target: { value: sentence.slice(0, index) } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+    }
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("affiche les thématiques avant les personnalités et les mesures", async () => {

--- a/src/proxy-search-rate-limit.test.ts
+++ b/src/proxy-search-rate-limit.test.ts
@@ -3,9 +3,9 @@ import { NextRequest } from "next/server";
 import { buildRateLimitExceededResponse, getRateLimitTier } from "@/proxy";
 
 describe("quota de la recherche présidentielle", () => {
-  it("applique le quota recherche à la page hybride et à son autocomplétion", () => {
+  it("isole le quota de la page hybride de celui de son autocomplétion", () => {
     expect(getRateLimitTier("/elections/presidentielle-2027/recherche")).toBe("search");
-    expect(getRateLimitTier("/api/elections/presidentielle-2027/recherche")).toBe("search");
+    expect(getRateLimitTier("/api/elections/presidentielle-2027/recherche")).toBe("autocomplete");
   });
 
   it("réécrit une page limitée vers un état HTML sans exposer la réponse JSON de l'API", async () => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,13 +16,14 @@ import { getLegacyMeasureId } from "@/lib/presidentielle/measure-route";
 
 // ─── Rate limit tiers ────────────────────────────────────────────
 
-type RateLimitTier = "general" | "search" | "export" | "admin" | "subscribe";
+type RateLimitTier = "general" | "search" | "autocomplete" | "export" | "admin" | "subscribe";
 
 const PRESIDENTIAL_SEARCH_PAGE_PATH = "/elections/presidentielle-2027/recherche";
 
 const TIER_CONFIG: Record<RateLimitTier, { tokens: number; window: string }> = {
   general: { tokens: 60, window: "1m" },
   search: { tokens: 30, window: "1m" },
+  autocomplete: { tokens: 60, window: "1m" },
   export: { tokens: 5, window: "1m" },
   admin: { tokens: 30, window: "1m" },
   subscribe: { tokens: 8, window: "1m" },
@@ -164,11 +165,9 @@ export function getRateLimitTier(pathname: string): RateLimitTier | null {
     return "subscribe";
   }
   if (pathname.startsWith("/api/export")) return "export";
-  if (
-    pathname === PRESIDENTIAL_SEARCH_PAGE_PATH ||
-    pathname.startsWith("/api/elections/presidentielle-2027/recherche")
-  ) {
-    return "search";
+  if (pathname === PRESIDENTIAL_SEARCH_PAGE_PATH) return "search";
+  if (pathname.startsWith("/api/elections/presidentielle-2027/recherche")) {
+    return "autocomplete";
   }
   if (pathname.startsWith("/api/search")) return "search";
   if (pathname.startsWith("/api/")) return "general";


### PR DESCRIPTION
## Cause

Une phrase saisie à une cadence normale déclenchait jusqu’à un appel d’autocomplétion par caractère après seulement 150 ms. Ces appels partageaient le même compteur de 30 requêtes par minute que la recherche hybride finale. La phrase signalée reproduisait 51 appels avant validation.

## Correction

- porte le debounce de l’autocomplétion à 500 ms
- crée un quota distinct de 60 requêtes par minute pour les suggestions lexicales
- conserve le quota de 30 requêtes par minute pour les recherches hybrides
- garantit par test qu’une saisie continue de la phrase signalée ne produit qu’un appel

## Vérifications

- 22 tests ciblés réussis
- typecheck réussi
- lint ciblé réussi