### PR TITLE
feat(mesures): accélérer la couverture des contextes

### DIFF
--- a/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
+++ b/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
@@ -175,8 +175,10 @@ npm run measures:audit-contexts -- --election presidentielle-2027
 
 Le rapport distingue les contextes publics, les brouillons en attente, les mesures sans preuve
 structurée, les sources qui ne contiennent aucun contexte distinct de la formulation et les
-tentatives déjà terminées. Un faible taux public ne signifie donc pas automatiquement que toutes
-les autres mesures peuvent recevoir un résumé utile.
+tentatives déjà terminées. Les résultats terminaux sont séparés entre absence de contexte utile et
+échec répété de validation. Les réservations actives, les erreurs encore réessayables et les
+exclusions inexpliquées possèdent aussi leur propre compteur. Un faible taux public ne signifie donc
+pas automatiquement que toutes les autres mesures peuvent recevoir un résumé utile.
 
 Prévisualiser le nombre de mesures éligibles sans appeler Mistral ni écrire en base :
 
@@ -200,19 +202,35 @@ reprenable : une nouvelle exécution écarte les révisions déjà traitées, le
 utile et les erreurs de validation déjà auditées. `--all` et `--limit` sont volontairement
 incompatibles afin que le périmètre de l'opération soit explicite.
 
-La régénération depuis une ancienne version de prompt accepte le même mode :
+La régénération depuis une ancienne version de prompt accepte le même mode. Commencer par une
+simulation ciblée sur les brouillons :
 
 ```bash
 npm run measures:regenerate-contexts -- \
   --election presidentielle-2027 \
-  --from-prompt measure-context-v8 \
-  --scope all \
+  --from-prompt measure-context-v6 \
+  --scope drafts \
+  --all \
+  --dry-run
+```
+
+Après vérification du nombre et du périmètre, remplacer `--dry-run` par `--apply`. Répéter la
+commande pour chaque ancienne version réellement présente dans le rapport d'audit. Ne pas lancer
+une régénération de contexte déjà publié sans décision éditoriale explicite.
+
+```bash
+npm run measures:regenerate-contexts -- \
+  --election presidentielle-2027 \
+  --from-prompt measure-context-v6 \
+  --scope drafts \
   --all \
   --apply
 ```
 
 Ces commandes créent uniquement des brouillons. La relecture et la publication restent des décisions
-éditoriales distinctes dans l'administration.
+éditoriales distinctes dans l'administration. Les lots « Corrections de contexte » sont séparés des
+premières publications. Chaque ligne mène à la fiche d'administration qui expose les extraits de
+preuve avant confirmation.
 
 ## Ordre de livraison
 

--- a/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
+++ b/docs/design/enrichissement-pages-mesure-presidentielle-2027.md
@@ -167,6 +167,17 @@ ne permet honnêtement aucun enrichissement.
 
 ### Commandes de génération
 
+Mesurer l'entonnoir complet avant une génération ou une campagne de relecture :
+
+```bash
+npm run measures:audit-contexts -- --election presidentielle-2027
+```
+
+Le rapport distingue les contextes publics, les brouillons en attente, les mesures sans preuve
+structurée, les sources qui ne contiennent aucun contexte distinct de la formulation et les
+tentatives déjà terminées. Un faible taux public ne signifie donc pas automatiquement que toutes
+les autres mesures peuvent recevoir un résumé utile.
+
 Prévisualiser le nombre de mesures éligibles sans appeler Mistral ni écrire en base :
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "prisma generate && next build --webpack",
     "build:net-check": "tsx scripts/check-build-network.mts",
     "measures:audit": "tsx scripts/audit-measures.ts",
+    "measures:audit-contexts": "tsx --env-file=.env scripts/audit-measure-contexts.ts",
     "search:audit": "tsx scripts/search-audit.ts",
     "search:evaluate": "tsx --env-file=.env scripts/evaluate-presidential-search.ts",
     "search:reindex": "tsx --env-file=.env scripts/search-reindex.ts",

--- a/scripts/audit-measure-contexts.ts
+++ b/scripts/audit-measure-contexts.ts
@@ -30,6 +30,7 @@ async function main() {
     terminalNoUsefulContext: 0,
     terminalInvalidContext: 0,
     terminalHistoricalContext: 0,
+    terminalGeneratedContextDraft: 0,
     retryableInvalidContext: 0,
     generationInProgress: 0,
     unexplainedEligibleExclusions: 0,
@@ -95,14 +96,22 @@ async function main() {
         : await db.auditLog.findMany({
             where: {
               entityType: "MeasureRevision",
-              entityId: { in: eligibleRevisionIds },
-              action: {
-                in: [
-                  "GENERATE_CONTEXT_TERMINAL_RESULT",
-                  "GENERATE_CONTEXT_INVALID_RESULT",
-                  "RESERVE_CONTEXT_GENERATION",
-                ],
-              },
+              OR: [
+                {
+                  entityId: { in: eligibleRevisionIds },
+                  action: {
+                    in: [
+                      "GENERATE_CONTEXT_TERMINAL_RESULT",
+                      "GENERATE_CONTEXT_INVALID_RESULT",
+                      "RESERVE_CONTEXT_GENERATION",
+                    ],
+                  },
+                },
+                ...eligibleRevisionIds.map((revisionId) => ({
+                  action: "GENERATE_CONTEXT_DRAFT",
+                  changes: { path: ["previousRevisionId"], equals: revisionId },
+                })),
+              ],
             },
             select: { action: true, entityId: true, changes: true },
           });
@@ -121,12 +130,20 @@ async function main() {
       ) {
         continue;
       }
-      const state = states.get(attempt.entityId) ?? {
+      const sourceRevisionId =
+        attempt.action === "GENERATE_CONTEXT_DRAFT" &&
+        typeof changes.previousRevisionId === "string"
+          ? changes.previousRevisionId
+          : attempt.entityId;
+      if (!eligibleRevisionIds.includes(sourceRevisionId)) continue;
+      const state = states.get(sourceRevisionId) ?? {
         activeReservation: false,
         invalidCount: 0,
         terminal: null,
       };
-      if (attempt.action === "GENERATE_CONTEXT_TERMINAL_RESULT") {
+      if (attempt.action === "GENERATE_CONTEXT_DRAFT") {
+        state.terminal = "GENERATED_CONTEXT_DRAFT";
+      } else if (attempt.action === "GENERATE_CONTEXT_TERMINAL_RESULT") {
         state.terminal = typeof changes.outcome === "string" ? changes.outcome : "TERMINAL";
       } else if (attempt.action === "GENERATE_CONTEXT_INVALID_RESULT") {
         state.invalidCount += 1;
@@ -134,12 +151,14 @@ async function main() {
         const expiresAt = typeof changes.expiresAt === "string" ? Date.parse(changes.expiresAt) : 0;
         if (Number.isFinite(expiresAt) && expiresAt > Date.now()) state.activeReservation = true;
       }
-      states.set(attempt.entityId, state);
+      states.set(sourceRevisionId, state);
     }
     for (const state of states.values()) {
       if (state.terminal === "NO_USEFUL_CONTEXT") report.terminalNoUsefulContext += 1;
       else if (state.terminal === "INVALID_GENERATED_CONTEXT" || state.invalidCount >= 2) {
         report.terminalInvalidContext += 1;
+      } else if (state.terminal === "GENERATED_CONTEXT_DRAFT") {
+        report.terminalGeneratedContextDraft += 1;
       } else if (state.terminal !== null) report.terminalHistoricalContext += 1;
       else if (state.activeReservation) report.generationInProgress += 1;
       else if (state.invalidCount === 1) report.retryableInvalidContext += 1;
@@ -156,6 +175,7 @@ async function main() {
       report.terminalNoUsefulContext -
       report.terminalInvalidContext -
       report.terminalHistoricalContext -
+      report.terminalGeneratedContextDraft -
       report.retryableInvalidContext -
       report.generationInProgress
   );

--- a/scripts/audit-measure-contexts.ts
+++ b/scripts/audit-measure-contexts.ts
@@ -1,0 +1,84 @@
+import { db } from "../src/lib/db";
+import { parseCLIOptions } from "../src/lib/cli/parse-options";
+import { findMeasureContextCandidateIds } from "../src/lib/measures/context-generation";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "../src/lib/measures/context-provenance";
+import { readEvidenceSnapshot } from "../src/lib/measures/evidence-snapshot";
+import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "../src/lib/presidentielle/publication";
+
+const ALL_CANDIDATES = Number.MAX_SAFE_INTEGER;
+
+async function main() {
+  const parsed = parseCLIOptions(process.argv.slice(2), [
+    { name: "--election", type: "string" },
+  ] as const);
+  const electionSlug =
+    typeof parsed.election === "string" ? parsed.election : "presidentielle-2027";
+
+  const [measures, queuedIds] = await Promise.all([
+    db.measure.findMany({
+      where: {
+        election: { slug: electionSlug },
+        ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+      },
+      select: {
+        latestRevisionId: true,
+        publishedRevisionId: true,
+        publishedRevision: { select: { details: true, evidenceSnapshot: true } },
+        latestRevision: { select: { details: true, extractorVersion: true } },
+      },
+    }),
+    findMeasureContextCandidateIds(electionSlug, ALL_CANDIDATES),
+  ]);
+
+  const report = {
+    election: electionSlug,
+    promptVersion: MEASURE_CONTEXT_PROMPT_VERSION,
+    totalPublicMeasures: measures.length,
+    publishedContexts: 0,
+    pendingContextDrafts: 0,
+    pendingDraftsByExtractorVersion: {} as Record<string, number>,
+    activeDraftWithoutContext: 0,
+    missingEvidenceSnapshot: 0,
+    invalidEvidenceSnapshot: 0,
+    sourceWithoutDistinctContext: 0,
+    evidenceEligible: 0,
+    queuedForGeneration: queuedIds.length,
+    previousAttemptOrTerminalResult: 0,
+  };
+
+  for (const measure of measures) {
+    if (measure.publishedRevision?.details?.trim()) {
+      report.publishedContexts += 1;
+      continue;
+    }
+    if (measure.latestRevisionId !== measure.publishedRevisionId) {
+      if (measure.latestRevision?.details?.trim()) {
+        report.pendingContextDrafts += 1;
+        const version = measure.latestRevision.extractorVersion ?? "unknown";
+        report.pendingDraftsByExtractorVersion[version] =
+          (report.pendingDraftsByExtractorVersion[version] ?? 0) + 1;
+      } else report.activeDraftWithoutContext += 1;
+      continue;
+    }
+
+    const evidence = readEvidenceSnapshot(measure.publishedRevision?.evidenceSnapshot);
+    if (evidence.status === "ABSENT") report.missingEvidenceSnapshot += 1;
+    else if (evidence.status === "INVALID") report.invalidEvidenceSnapshot += 1;
+    else if (evidence.snapshot.supportingIds.length === 0) {
+      report.sourceWithoutDistinctContext += 1;
+    } else report.evidenceEligible += 1;
+  }
+  report.previousAttemptOrTerminalResult = Math.max(
+    0,
+    report.evidenceEligible - report.queuedForGeneration
+  );
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/audit-measure-contexts.ts
+++ b/scripts/audit-measure-contexts.ts
@@ -46,6 +46,7 @@ async function main() {
     queuedForGeneration: queuedIds.length,
     terminalNoUsefulContext: 0,
     terminalInvalidContext: 0,
+    terminalHistoricalContext: 0,
     retryableInvalidContext: 0,
     generationInProgress: 0,
     unexplainedEligibleExclusions: 0,
@@ -103,7 +104,12 @@ async function main() {
       attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
         ? (attempt.changes as Record<string, unknown>)
         : {};
-    if (changes.promptVersion !== MEASURE_CONTEXT_PROMPT_VERSION) continue;
+    if (
+      typeof changes.promptVersion === "string" &&
+      changes.promptVersion !== MEASURE_CONTEXT_PROMPT_VERSION
+    ) {
+      continue;
+    }
     const state = states.get(attempt.entityId) ?? {
       activeReservation: false,
       invalidCount: 0,
@@ -124,7 +130,8 @@ async function main() {
     if (state.terminal === "NO_USEFUL_CONTEXT") report.terminalNoUsefulContext += 1;
     else if (state.terminal === "INVALID_GENERATED_CONTEXT" || state.invalidCount >= 2) {
       report.terminalInvalidContext += 1;
-    } else if (state.activeReservation) report.generationInProgress += 1;
+    } else if (state.terminal !== null) report.terminalHistoricalContext += 1;
+    else if (state.activeReservation) report.generationInProgress += 1;
     else if (state.invalidCount === 1) report.retryableInvalidContext += 1;
   }
   report.unexplainedEligibleExclusions = Math.max(
@@ -133,6 +140,7 @@ async function main() {
       report.queuedForGeneration -
       report.terminalNoUsefulContext -
       report.terminalInvalidContext -
+      report.terminalHistoricalContext -
       report.retryableInvalidContext -
       report.generationInProgress
   );

--- a/scripts/audit-measure-contexts.ts
+++ b/scripts/audit-measure-contexts.ts
@@ -30,6 +30,7 @@ async function main() {
     findMeasureContextCandidateIds(electionSlug, ALL_CANDIDATES),
   ]);
 
+  const eligibleRevisionIds: string[] = [];
   const report = {
     election: electionSlug,
     promptVersion: MEASURE_CONTEXT_PROMPT_VERSION,
@@ -43,7 +44,11 @@ async function main() {
     sourceWithoutDistinctContext: 0,
     evidenceEligible: 0,
     queuedForGeneration: queuedIds.length,
-    previousAttemptOrTerminalResult: 0,
+    terminalNoUsefulContext: 0,
+    terminalInvalidContext: 0,
+    retryableInvalidContext: 0,
+    generationInProgress: 0,
+    unexplainedEligibleExclusions: 0,
   };
 
   for (const measure of measures) {
@@ -66,11 +71,70 @@ async function main() {
     else if (evidence.status === "INVALID") report.invalidEvidenceSnapshot += 1;
     else if (evidence.snapshot.supportingIds.length === 0) {
       report.sourceWithoutDistinctContext += 1;
-    } else report.evidenceEligible += 1;
+    } else {
+      report.evidenceEligible += 1;
+      if (measure.publishedRevisionId) eligibleRevisionIds.push(measure.publishedRevisionId);
+    }
   }
-  report.previousAttemptOrTerminalResult = Math.max(
+
+  const attempts =
+    eligibleRevisionIds.length === 0
+      ? []
+      : await db.auditLog.findMany({
+          where: {
+            entityType: "MeasureRevision",
+            entityId: { in: eligibleRevisionIds },
+            action: {
+              in: [
+                "GENERATE_CONTEXT_TERMINAL_RESULT",
+                "GENERATE_CONTEXT_INVALID_RESULT",
+                "RESERVE_CONTEXT_GENERATION",
+              ],
+            },
+          },
+          select: { action: true, entityId: true, changes: true },
+        });
+  const states = new Map<
+    string,
+    { activeReservation: boolean; invalidCount: number; terminal: string | null }
+  >();
+  for (const attempt of attempts) {
+    const changes =
+      attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
+        ? (attempt.changes as Record<string, unknown>)
+        : {};
+    if (changes.promptVersion !== MEASURE_CONTEXT_PROMPT_VERSION) continue;
+    const state = states.get(attempt.entityId) ?? {
+      activeReservation: false,
+      invalidCount: 0,
+      terminal: null,
+    };
+    if (attempt.action === "GENERATE_CONTEXT_TERMINAL_RESULT") {
+      state.terminal = typeof changes.outcome === "string" ? changes.outcome : "TERMINAL";
+    } else if (attempt.action === "GENERATE_CONTEXT_INVALID_RESULT") {
+      state.invalidCount += 1;
+    } else if (attempt.action === "RESERVE_CONTEXT_GENERATION") {
+      const expiresAt = typeof changes.expiresAt === "string" ? Date.parse(changes.expiresAt) : 0;
+      if (Number.isFinite(expiresAt) && expiresAt > Date.now()) state.activeReservation = true;
+    }
+    states.set(attempt.entityId, state);
+  }
+
+  for (const state of states.values()) {
+    if (state.terminal === "NO_USEFUL_CONTEXT") report.terminalNoUsefulContext += 1;
+    else if (state.terminal === "INVALID_GENERATED_CONTEXT" || state.invalidCount >= 2) {
+      report.terminalInvalidContext += 1;
+    } else if (state.activeReservation) report.generationInProgress += 1;
+    else if (state.invalidCount === 1) report.retryableInvalidContext += 1;
+  }
+  report.unexplainedEligibleExclusions = Math.max(
     0,
-    report.evidenceEligible - report.queuedForGeneration
+    report.evidenceEligible -
+      report.queuedForGeneration -
+      report.terminalNoUsefulContext -
+      report.terminalInvalidContext -
+      report.retryableInvalidContext -
+      report.generationInProgress
   );
 
   console.log(JSON.stringify(report, null, 2));

--- a/scripts/audit-measure-contexts.ts
+++ b/scripts/audit-measure-contexts.ts
@@ -1,11 +1,11 @@
 import { db } from "../src/lib/db";
 import { parseCLIOptions } from "../src/lib/cli/parse-options";
-import { findMeasureContextCandidateIds } from "../src/lib/measures/context-generation";
+import { filterMeasureContextCandidateIds } from "../src/lib/measures/context-generation";
 import { MEASURE_CONTEXT_PROMPT_VERSION } from "../src/lib/measures/context-provenance";
 import { readEvidenceSnapshot } from "../src/lib/measures/evidence-snapshot";
 import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "../src/lib/presidentielle/publication";
 
-const ALL_CANDIDATES = Number.MAX_SAFE_INTEGER;
+const PAGE_SIZE = 250;
 
 async function main() {
   const parsed = parseCLIOptions(process.argv.slice(2), [
@@ -14,27 +14,10 @@ async function main() {
   const electionSlug =
     typeof parsed.election === "string" ? parsed.election : "presidentielle-2027";
 
-  const [measures, queuedIds] = await Promise.all([
-    db.measure.findMany({
-      where: {
-        election: { slug: electionSlug },
-        ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
-      },
-      select: {
-        latestRevisionId: true,
-        publishedRevisionId: true,
-        publishedRevision: { select: { details: true, evidenceSnapshot: true } },
-        latestRevision: { select: { details: true, extractorVersion: true } },
-      },
-    }),
-    findMeasureContextCandidateIds(electionSlug, ALL_CANDIDATES),
-  ]);
-
-  const eligibleRevisionIds: string[] = [];
   const report = {
     election: electionSlug,
     promptVersion: MEASURE_CONTEXT_PROMPT_VERSION,
-    totalPublicMeasures: measures.length,
+    totalPublicMeasures: 0,
     publishedContexts: 0,
     pendingContextDrafts: 0,
     pendingDraftsByExtractorVersion: {} as Record<string, number>,
@@ -43,7 +26,7 @@ async function main() {
     invalidEvidenceSnapshot: 0,
     sourceWithoutDistinctContext: 0,
     evidenceEligible: 0,
-    queuedForGeneration: queuedIds.length,
+    queuedForGeneration: 0,
     terminalNoUsefulContext: 0,
     terminalInvalidContext: 0,
     terminalHistoricalContext: 0,
@@ -52,87 +35,119 @@ async function main() {
     unexplainedEligibleExclusions: 0,
   };
 
-  for (const measure of measures) {
-    if (measure.publishedRevision?.details?.trim()) {
-      report.publishedContexts += 1;
-      continue;
-    }
-    if (measure.latestRevisionId !== measure.publishedRevisionId) {
-      if (measure.latestRevision?.details?.trim()) {
-        report.pendingContextDrafts += 1;
-        const version = measure.latestRevision.extractorVersion ?? "unknown";
-        report.pendingDraftsByExtractorVersion[version] =
-          (report.pendingDraftsByExtractorVersion[version] ?? 0) + 1;
-      } else report.activeDraftWithoutContext += 1;
-      continue;
+  let cursor: string | undefined;
+  while (true) {
+    const measures = await db.measure.findMany({
+      where: {
+        election: { slug: electionSlug },
+        ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+      },
+      select: {
+        id: true,
+        latestRevisionId: true,
+        publishedRevisionId: true,
+        publishedRevision: { select: { details: true, evidenceSnapshot: true } },
+        latestRevision: { select: { details: true, extractorVersion: true } },
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: PAGE_SIZE,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    if (measures.length === 0) break;
+    report.totalPublicMeasures += measures.length;
+    report.queuedForGeneration += (
+      await filterMeasureContextCandidateIds(
+        measures.map(({ id }) => id),
+        measures.length
+      )
+    ).length;
+
+    const eligibleRevisionIds: string[] = [];
+    for (const measure of measures) {
+      if (measure.publishedRevision?.details?.trim()) {
+        report.publishedContexts += 1;
+        continue;
+      }
+      if (measure.latestRevisionId !== measure.publishedRevisionId) {
+        if (measure.latestRevision?.details?.trim()) {
+          report.pendingContextDrafts += 1;
+          const version = measure.latestRevision.extractorVersion ?? "unknown";
+          report.pendingDraftsByExtractorVersion[version] =
+            (report.pendingDraftsByExtractorVersion[version] ?? 0) + 1;
+        } else report.activeDraftWithoutContext += 1;
+        continue;
+      }
+
+      const evidence = readEvidenceSnapshot(measure.publishedRevision?.evidenceSnapshot);
+      if (evidence.status === "ABSENT") report.missingEvidenceSnapshot += 1;
+      else if (evidence.status === "INVALID") report.invalidEvidenceSnapshot += 1;
+      else if (evidence.snapshot.supportingIds.length === 0) {
+        report.sourceWithoutDistinctContext += 1;
+      } else {
+        report.evidenceEligible += 1;
+        if (measure.publishedRevisionId) eligibleRevisionIds.push(measure.publishedRevisionId);
+      }
     }
 
-    const evidence = readEvidenceSnapshot(measure.publishedRevision?.evidenceSnapshot);
-    if (evidence.status === "ABSENT") report.missingEvidenceSnapshot += 1;
-    else if (evidence.status === "INVALID") report.invalidEvidenceSnapshot += 1;
-    else if (evidence.snapshot.supportingIds.length === 0) {
-      report.sourceWithoutDistinctContext += 1;
-    } else {
-      report.evidenceEligible += 1;
-      if (measure.publishedRevisionId) eligibleRevisionIds.push(measure.publishedRevisionId);
-    }
-  }
-
-  const attempts =
-    eligibleRevisionIds.length === 0
-      ? []
-      : await db.auditLog.findMany({
-          where: {
-            entityType: "MeasureRevision",
-            entityId: { in: eligibleRevisionIds },
-            action: {
-              in: [
-                "GENERATE_CONTEXT_TERMINAL_RESULT",
-                "GENERATE_CONTEXT_INVALID_RESULT",
-                "RESERVE_CONTEXT_GENERATION",
-              ],
+    const attempts =
+      eligibleRevisionIds.length === 0
+        ? []
+        : await db.auditLog.findMany({
+            where: {
+              entityType: "MeasureRevision",
+              entityId: { in: eligibleRevisionIds },
+              action: {
+                in: [
+                  "GENERATE_CONTEXT_TERMINAL_RESULT",
+                  "GENERATE_CONTEXT_INVALID_RESULT",
+                  "RESERVE_CONTEXT_GENERATION",
+                ],
+              },
             },
-          },
-          select: { action: true, entityId: true, changes: true },
-        });
-  const states = new Map<
-    string,
-    { activeReservation: boolean; invalidCount: number; terminal: string | null }
-  >();
-  for (const attempt of attempts) {
-    const changes =
-      attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
-        ? (attempt.changes as Record<string, unknown>)
-        : {};
-    if (
-      typeof changes.promptVersion === "string" &&
-      changes.promptVersion !== MEASURE_CONTEXT_PROMPT_VERSION
-    ) {
-      continue;
+            select: { action: true, entityId: true, changes: true },
+          });
+    const states = new Map<
+      string,
+      { activeReservation: boolean; invalidCount: number; terminal: string | null }
+    >();
+    for (const attempt of attempts) {
+      const changes =
+        attempt.changes && typeof attempt.changes === "object" && !Array.isArray(attempt.changes)
+          ? (attempt.changes as Record<string, unknown>)
+          : {};
+      if (
+        typeof changes.promptVersion === "string" &&
+        changes.promptVersion !== MEASURE_CONTEXT_PROMPT_VERSION
+      ) {
+        continue;
+      }
+      const state = states.get(attempt.entityId) ?? {
+        activeReservation: false,
+        invalidCount: 0,
+        terminal: null,
+      };
+      if (attempt.action === "GENERATE_CONTEXT_TERMINAL_RESULT") {
+        state.terminal = typeof changes.outcome === "string" ? changes.outcome : "TERMINAL";
+      } else if (attempt.action === "GENERATE_CONTEXT_INVALID_RESULT") {
+        state.invalidCount += 1;
+      } else if (attempt.action === "RESERVE_CONTEXT_GENERATION") {
+        const expiresAt = typeof changes.expiresAt === "string" ? Date.parse(changes.expiresAt) : 0;
+        if (Number.isFinite(expiresAt) && expiresAt > Date.now()) state.activeReservation = true;
+      }
+      states.set(attempt.entityId, state);
     }
-    const state = states.get(attempt.entityId) ?? {
-      activeReservation: false,
-      invalidCount: 0,
-      terminal: null,
-    };
-    if (attempt.action === "GENERATE_CONTEXT_TERMINAL_RESULT") {
-      state.terminal = typeof changes.outcome === "string" ? changes.outcome : "TERMINAL";
-    } else if (attempt.action === "GENERATE_CONTEXT_INVALID_RESULT") {
-      state.invalidCount += 1;
-    } else if (attempt.action === "RESERVE_CONTEXT_GENERATION") {
-      const expiresAt = typeof changes.expiresAt === "string" ? Date.parse(changes.expiresAt) : 0;
-      if (Number.isFinite(expiresAt) && expiresAt > Date.now()) state.activeReservation = true;
+    for (const state of states.values()) {
+      if (state.terminal === "NO_USEFUL_CONTEXT") report.terminalNoUsefulContext += 1;
+      else if (state.terminal === "INVALID_GENERATED_CONTEXT" || state.invalidCount >= 2) {
+        report.terminalInvalidContext += 1;
+      } else if (state.terminal !== null) report.terminalHistoricalContext += 1;
+      else if (state.activeReservation) report.generationInProgress += 1;
+      else if (state.invalidCount === 1) report.retryableInvalidContext += 1;
     }
-    states.set(attempt.entityId, state);
-  }
 
-  for (const state of states.values()) {
-    if (state.terminal === "NO_USEFUL_CONTEXT") report.terminalNoUsefulContext += 1;
-    else if (state.terminal === "INVALID_GENERATED_CONTEXT" || state.invalidCount >= 2) {
-      report.terminalInvalidContext += 1;
-    } else if (state.terminal !== null) report.terminalHistoricalContext += 1;
-    else if (state.activeReservation) report.generationInProgress += 1;
-    else if (state.invalidCount === 1) report.retryableInvalidContext += 1;
+    if (measures.length < PAGE_SIZE) break;
+    cursor = measures.at(-1)?.id;
+    if (!cursor) break;
   }
   report.unexplainedEligibleExclusions = Math.max(
     0,

--- a/src/app/admin/mesures/__tests__/access-control.test.ts
+++ b/src/app/admin/mesures/__tests__/access-control.test.ts
@@ -35,6 +35,7 @@ const filterMeasureContextCandidateIdsMock = vi.fn(async (_ids?: string[]) => []
 const queryMeasureEnrichmentCoverageMock = vi.fn(async () => ({
   total: 0,
   withDetails: 0,
+  withPendingContextDrafts: 0,
   withApprovedSubtopics: 0,
   withQualifications: 0,
   withVoteLinks: 0,

--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -453,11 +453,13 @@ describe("publication par lot", () => {
         measureId: "m-1",
         revisionId: "rev-1",
         expectedUpdatedAt: "2027-01-16T10:00:00.000Z",
+        batchKind: "FIRST_PUBLICATION",
       },
       {
         measureId: "m-2",
         revisionId: "rev-2",
         expectedUpdatedAt: "2027-01-17T10:00:00.000Z",
+        batchKind: "FIRST_PUBLICATION",
       },
     ],
   };
@@ -481,12 +483,14 @@ describe("publication par lot", () => {
       measureId: "m-1",
       revisionId: "rev-1",
       expectedUpdatedAt: new Date("2027-01-16T10:00:00.000Z"),
+      batchKind: "FIRST_PUBLICATION",
       publishedBy: "admin",
     });
     expect(transitionsMock.publishMeasureRevision).toHaveBeenNthCalledWith(2, {
       measureId: "m-2",
       revisionId: "rev-2",
       expectedUpdatedAt: new Date("2027-01-17T10:00:00.000Z"),
+      batchKind: "FIRST_PUBLICATION",
       publishedBy: "admin",
     });
   });
@@ -509,8 +513,8 @@ describe("relecture par lot", () => {
 
   const input = {
     items: [
-      { measureId: "m-1", revisionId: "rev-1" },
-      { measureId: "m-2", revisionId: "rev-2" },
+      { measureId: "m-1", revisionId: "rev-1", batchKind: "FIRST_PUBLICATION" },
+      { measureId: "m-2", revisionId: "rev-2", batchKind: "FIRST_PUBLICATION" },
     ],
   };
 
@@ -532,11 +536,13 @@ describe("relecture par lot", () => {
     expect(transitionsMock.reviewMeasureRevision).toHaveBeenNthCalledWith(1, {
       measureId: "m-1",
       revisionId: "rev-1",
+      batchKind: "FIRST_PUBLICATION",
       reviewedBy: "admin",
     });
     expect(transitionsMock.reviewMeasureRevision).toHaveBeenNthCalledWith(2, {
       measureId: "m-2",
       revisionId: "rev-2",
+      batchKind: "FIRST_PUBLICATION",
       reviewedBy: "admin",
     });
   });

--- a/src/app/admin/mesures/_components/BatchPublishPanel.tsx
+++ b/src/app/admin/mesures/_components/BatchPublishPanel.tsx
@@ -15,10 +15,11 @@ function BatchPublishCard({ group }: { group: BatchPublishGroup }) {
     startTransition(async () => {
       setResult(
         await publishReviewedBatchAction({
-          items: group.items.map(({ measureId, revisionId, expectedUpdatedAt }) => ({
+          items: group.items.map(({ measureId, revisionId, expectedUpdatedAt, batchKind }) => ({
             measureId,
             revisionId,
             expectedUpdatedAt,
+            batchKind,
           })),
         })
       );
@@ -33,7 +34,10 @@ function BatchPublishCard({ group }: { group: BatchPublishGroup }) {
             {group.ownerLabel}, {group.editionLabel} (version {group.editionVersion})
           </h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            {group.electionTitle}, {count} révision{count > 1 ? "s" : ""} relue
+            {group.batchKind === "CONTEXT_CORRECTION"
+              ? "Corrections de contexte"
+              : "Premières publications"}
+            , {group.electionTitle}, {count} révision{count > 1 ? "s" : ""} relue
             {count > 1 ? "s" : ""} et sourcée{count > 1 ? "s" : ""}
           </p>
         </div>
@@ -50,6 +54,15 @@ function BatchPublishCard({ group }: { group: BatchPublishGroup }) {
                     Contexte relu : {item.details}
                   </span>
                 ) : null}
+                <a
+                  href={`/admin/mesures/${item.measureId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Vérifier la mesure et ses preuves dans un nouvel onglet : ${item.text}`}
+                  className="mt-2 inline-flex min-h-11 items-center text-primary underline"
+                >
+                  Vérifier la mesure et ses preuves
+                </a>
               </li>
             ))}
           </ol>
@@ -133,7 +146,7 @@ export function BatchPublishPanel({ groups }: { groups: BatchPublishGroup[] }) {
       </p>
       <div className="mt-4 space-y-3">
         {groups.map((group) => (
-          <BatchPublishCard key={group.programEditionId} group={group} />
+          <BatchPublishCard key={group.groupKey} group={group} />
         ))}
       </div>
     </section>

--- a/src/app/admin/mesures/_components/BatchPublishPanel.tsx
+++ b/src/app/admin/mesures/_components/BatchPublishPanel.tsx
@@ -41,9 +41,16 @@ function BatchPublishCard({ group }: { group: BatchPublishGroup }) {
           <summary className="min-h-11 cursor-pointer py-2 text-primary underline">
             Vérifier le contenu du lot
           </summary>
-          <ol className="mt-2 max-h-72 max-w-2xl list-decimal space-y-2 overflow-y-auto pl-5">
+          <ol className="mt-2 max-h-96 max-w-3xl list-decimal space-y-4 overflow-y-auto pl-5">
             {group.items.map((item) => (
-              <li key={item.revisionId}>{item.text}</li>
+              <li key={item.revisionId}>
+                <span className="font-medium">{item.text}</span>
+                {item.details ? (
+                  <span className="mt-1 block text-muted-foreground">
+                    Contexte relu : {item.details}
+                  </span>
+                ) : null}
+              </li>
             ))}
           </ol>
         </details>
@@ -120,8 +127,9 @@ export function BatchPublishPanel({ groups }: { groups: BatchPublishGroup[] }) {
         Publication par lot
       </h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Seules les premières publications déjà relues et sourcées sont proposées. Une transition
-        complète contrôle encore chaque révision au moment de la publication.
+        Les premières publications et les corrections de contexte déjà relues sont proposées. Une
+        correction de contexte ne peut entrer dans un lot que si elle conserve exactement la
+        formulation publique. Une transition complète contrôle encore chaque révision.
       </p>
       <div className="mt-4 space-y-3">
         {groups.map((group) => (

--- a/src/app/admin/mesures/_components/BatchReviewPanel.tsx
+++ b/src/app/admin/mesures/_components/BatchReviewPanel.tsx
@@ -44,9 +44,16 @@ function BatchReviewCard({ group }: { group: BatchReviewGroup }) {
           <summary className="min-h-11 cursor-pointer py-2 text-primary underline">
             Vérifier le contenu du lot
           </summary>
-          <ol className="mt-2 max-h-72 max-w-2xl list-decimal space-y-2 overflow-y-auto pl-5">
+          <ol className="mt-2 max-h-96 max-w-3xl list-decimal space-y-4 overflow-y-auto pl-5">
             {group.items.map((item) => (
-              <li key={item.revisionId}>{item.text}</li>
+              <li key={item.revisionId}>
+                <span className="font-medium">{item.text}</span>
+                {item.details ? (
+                  <span className="mt-1 block text-muted-foreground">
+                    Contexte proposé : {item.details}
+                  </span>
+                ) : null}
+              </li>
             ))}
           </ol>
         </details>
@@ -112,8 +119,9 @@ export function BatchReviewPanel({ groups }: { groups: BatchReviewGroup[] }) {
         Relecture par lot
       </h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Chaque lot contient uniquement les brouillons actifs et sourcés d{"'"}une édition. Cette
-        étape ne publie rien. Une fois la relecture enregistrée, le lot passe dans la section de
+        Chaque lot contient uniquement des brouillons actifs et sourcés. Les corrections de contexte
+        sont incluses seulement si la formulation publique reste strictement identique. Cette étape
+        ne publie rien. Une fois la relecture enregistrée, le lot passe dans la section de
         publication.
       </p>
       <div className="mt-4 space-y-3">

--- a/src/app/admin/mesures/_components/BatchReviewPanel.tsx
+++ b/src/app/admin/mesures/_components/BatchReviewPanel.tsx
@@ -18,7 +18,11 @@ function BatchReviewCard({ group }: { group: BatchReviewGroup }) {
     if (!confirmed || isPending) return;
     startTransition(async () => {
       const actionResult = await reviewDraftBatchAction({
-        items: group.items.map(({ measureId, revisionId }) => ({ measureId, revisionId })),
+        items: group.items.map(({ measureId, revisionId, batchKind }) => ({
+          measureId,
+          revisionId,
+          batchKind,
+        })),
       });
       if (actionResult.ok) {
         router.refresh();
@@ -36,7 +40,10 @@ function BatchReviewCard({ group }: { group: BatchReviewGroup }) {
             {group.ownerLabel}, {group.editionLabel} (version {group.editionVersion})
           </h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            {group.electionTitle}, {count} brouillon{count > 1 ? "s" : ""} sourcé
+            {group.batchKind === "CONTEXT_CORRECTION"
+              ? "Corrections de contexte"
+              : "Premières publications"}
+            , {group.electionTitle}, {count} brouillon{count > 1 ? "s" : ""} sourcé
             {count > 1 ? "s" : ""}
           </p>
         </div>
@@ -53,6 +60,15 @@ function BatchReviewCard({ group }: { group: BatchReviewGroup }) {
                     Contexte proposé : {item.details}
                   </span>
                 ) : null}
+                <a
+                  href={`/admin/mesures/${item.measureId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Vérifier la mesure et ses preuves dans un nouvel onglet : ${item.text}`}
+                  className="mt-2 inline-flex min-h-11 items-center text-primary underline"
+                >
+                  Vérifier la mesure et ses preuves
+                </a>
               </li>
             ))}
           </ol>
@@ -126,7 +142,7 @@ export function BatchReviewPanel({ groups }: { groups: BatchReviewGroup[] }) {
       </p>
       <div className="mt-4 space-y-3">
         {groups.map((group) => (
-          <BatchReviewCard key={group.programEditionId} group={group} />
+          <BatchReviewCard key={group.groupKey} group={group} />
         ))}
       </div>
     </section>

--- a/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
+++ b/src/app/admin/mesures/_components/EnrichmentCoveragePanel.tsx
@@ -17,6 +17,11 @@ const METRICS: Array<{
     help: "La fiche explique ce que prévoit la mesure à partir de sa source.",
   },
   {
+    key: "withPendingContextDrafts",
+    label: "Contextes en attente",
+    help: "Un brouillon sourcé doit encore être relu puis publié.",
+  },
+  {
     key: "withApprovedSubtopics",
     label: "Sous-thèmes validés",
     help: "Au moins un rattachement éditorial validé.",

--- a/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/EnrichmentCoveragePanel.test.tsx
@@ -9,6 +9,7 @@ describe("EnrichmentCoveragePanel", () => {
         coverage={{
           total: 2200,
           withDetails: 98,
+          withPendingContextDrafts: 374,
           withApprovedSubtopics: 982,
           withQualifications: 0,
           withVoteLinks: 0,
@@ -22,6 +23,7 @@ describe("EnrichmentCoveragePanel", () => {
       screen.getByRole("heading", { name: "Couverture des fiches publiques 2027" })
     ).toBeInTheDocument();
     expect(screen.getByText("4 %")).toBeInTheDocument();
+    expect(screen.getByText("17 %")).toBeInTheDocument();
     expect(screen.getByText("45 %")).toBeInTheDocument();
     expect(screen.getByText("58 %")).toBeInTheDocument();
     expect(
@@ -38,6 +40,7 @@ describe("EnrichmentCoveragePanel", () => {
         coverage={{
           total: 2,
           withDetails: 2,
+          withPendingContextDrafts: 0,
           withApprovedSubtopics: 2,
           withQualifications: 0,
           withVoteLinks: 0,

--- a/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
@@ -67,24 +67,20 @@ describe("queryBatchPublishGroups", () => {
 
     await queryBatchPublishGroups();
 
-    expect(findManyMock).toHaveBeenCalledWith(
+    expect(findManyMock).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         where: expect.objectContaining({
           measures: {
-            some: {
-              OR: expect.arrayContaining([
-                expect.objectContaining({ publicationStatus: "DRAFT" }),
-                expect.objectContaining({
-                  publicationStatus: "PUBLISHED",
-                  latestRevision: {
-                    is: expect.objectContaining({
-                      extractorVersion: { endsWith: ":measure-context-v9" },
-                      reviewedAt: { not: null },
-                    }),
-                  },
+            some: expect.objectContaining({
+              publicationStatus: "PUBLISHED",
+              latestRevision: {
+                is: expect.objectContaining({
+                  extractorVersion: { endsWith: ":measure-context-v9" },
+                  reviewedAt: { not: null },
                 }),
-              ]),
-            },
+              },
+            }),
           },
         }),
       })

--- a/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
@@ -40,13 +40,16 @@ describe("queryBatchPublishGroups", () => {
 
     await expect(queryBatchPublishGroups()).resolves.toEqual([
       {
+        batchKind: "FIRST_PUBLICATION",
         programEditionId: "edition-1",
+        groupKey: "edition-1:FIRST_PUBLICATION",
         editionLabel: "Cahier 1",
         editionVersion: 1,
         ownerLabel: "Candidate Exemple",
         electionTitle: "Élection présidentielle de 2027",
         items: [
           {
+            batchKind: "FIRST_PUBLICATION",
             measureId: "measure-1",
             revisionId: "revision-1",
             expectedUpdatedAt: "2027-01-16T10:00:00.000Z",

--- a/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-publish-query.test.ts
@@ -26,7 +26,13 @@ describe("queryBatchPublishGroups", () => {
           {
             id: "measure-1",
             updatedAt: new Date("2027-01-16T10:00:00.000Z"),
-            latestRevision: { id: "revision-1", text: "Créer un service public du logement." },
+            publicationStatus: "DRAFT",
+            publishedRevision: null,
+            latestRevision: {
+              id: "revision-1",
+              text: "Créer un service public du logement.",
+              details: null,
+            },
           },
         ],
       },
@@ -45,6 +51,7 @@ describe("queryBatchPublishGroups", () => {
             revisionId: "revision-1",
             expectedUpdatedAt: "2027-01-16T10:00:00.000Z",
             text: "Créer un service public du logement.",
+            details: null,
           },
         ],
         hasMore: false,
@@ -52,29 +59,68 @@ describe("queryBatchPublishGroups", () => {
     ]);
   });
 
-  it("demande uniquement les premières publications relues et sourcées", async () => {
+  it("demande les premières publications et les contextes v9 relus", async () => {
     findManyMock.mockResolvedValue([]);
 
     await queryBatchPublishGroups();
 
     expect(findManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
+        where: expect.objectContaining({
           measures: {
-            some: expect.objectContaining({
-              publicationStatus: "DRAFT",
-              publishedRevisionId: null,
-              latestRevision: {
-                is: expect.objectContaining({
-                  reviewedAt: { not: null },
-                  sources: { some: {} },
+            some: {
+              OR: expect.arrayContaining([
+                expect.objectContaining({ publicationStatus: "DRAFT" }),
+                expect.objectContaining({
+                  publicationStatus: "PUBLISHED",
+                  latestRevision: {
+                    is: expect.objectContaining({
+                      extractorVersion: { endsWith: ":measure-context-v9" },
+                      reviewedAt: { not: null },
+                    }),
+                  },
                 }),
-              },
-            }),
+              ]),
+            },
           },
-        },
+        }),
       })
     );
+  });
+
+  it("inclut une correction de contexte relue sans changement de formulation", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "edition-1",
+        label: "Cahier 1",
+        version: 1,
+        candidacy: { candidateName: "Candidate Exemple" },
+        party: null,
+        election: { title: "Élection présidentielle de 2027" },
+        measures: [
+          {
+            id: "measure-1",
+            updatedAt: new Date("2027-01-16T10:00:00.000Z"),
+            publicationStatus: "PUBLISHED",
+            publishedRevision: { text: "Créer un service public du logement." },
+            latestRevision: {
+              id: "revision-context",
+              text: "Créer un service public du logement.",
+              details: "La mesure prévoit une gestion publique des logements concernés.",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const [group] = await queryBatchPublishGroups();
+
+    expect(group?.items).toEqual([
+      expect.objectContaining({
+        revisionId: "revision-context",
+        details: "La mesure prévoit une gestion publique des logements concernés.",
+      }),
+    ]);
   });
 
   it("borne le lot à la candidature sélectionnée", async () => {

--- a/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
@@ -25,7 +25,13 @@ describe("queryBatchReviewGroups", () => {
         measures: [
           {
             id: "measure-1",
-            latestRevision: { id: "revision-1", text: "Créer un service public du logement." },
+            publicationStatus: "DRAFT",
+            publishedRevision: null,
+            latestRevision: {
+              id: "revision-1",
+              text: "Créer un service public du logement.",
+              details: null,
+            },
           },
         ],
       },
@@ -43,6 +49,7 @@ describe("queryBatchReviewGroups", () => {
             measureId: "measure-1",
             revisionId: "revision-1",
             text: "Créer un service public du logement.",
+            details: null,
           },
         ],
         hasMore: false,
@@ -50,30 +57,94 @@ describe("queryBatchReviewGroups", () => {
     ]);
   });
 
-  it("demande uniquement les premières publications non relues et sourcées", async () => {
+  it("demande les premières publications et les contextes v9 non relus", async () => {
     findManyMock.mockResolvedValue([]);
 
     await queryBatchReviewGroups();
 
     expect(findManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
+        where: expect.objectContaining({
           measures: {
-            some: expect.objectContaining({
-              publicationStatus: "DRAFT",
-              publishedRevisionId: null,
-              latestRevision: {
-                is: expect.objectContaining({
-                  reviewedAt: null,
-                  rejectedAt: null,
-                  sources: { some: {} },
+            some: {
+              OR: expect.arrayContaining([
+                expect.objectContaining({ publicationStatus: "DRAFT" }),
+                expect.objectContaining({
+                  publicationStatus: "PUBLISHED",
+                  latestRevision: {
+                    is: expect.objectContaining({
+                      extractorVersion: { endsWith: ":measure-context-v9" },
+                      reviewedAt: null,
+                    }),
+                  },
                 }),
-              },
-            }),
+              ]),
+            },
           },
-        },
+        }),
       })
     );
+  });
+
+  it("inclut une correction de contexte sans changement de formulation", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "edition-1",
+        label: "Cahier 1",
+        version: 1,
+        candidacy: { candidateName: "Candidate Exemple" },
+        party: null,
+        election: { title: "Élection présidentielle de 2027" },
+        measures: [
+          {
+            id: "measure-1",
+            publicationStatus: "PUBLISHED",
+            publishedRevision: { text: "Créer un service public du logement." },
+            latestRevision: {
+              id: "revision-context",
+              text: "Créer un service public du logement.",
+              details: "La mesure prévoit une gestion publique des logements concernés.",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const [group] = await queryBatchReviewGroups();
+
+    expect(group?.items).toEqual([
+      expect.objectContaining({
+        revisionId: "revision-context",
+        details: "La mesure prévoit une gestion publique des logements concernés.",
+      }),
+    ]);
+  });
+
+  it("exclut une correction de contexte qui modifie la formulation publique", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "edition-1",
+        label: "Cahier 1",
+        version: 1,
+        candidacy: { candidateName: "Candidate Exemple" },
+        party: null,
+        election: { title: "Élection présidentielle de 2027" },
+        measures: [
+          {
+            id: "measure-1",
+            publicationStatus: "PUBLISHED",
+            publishedRevision: { text: "Texte public" },
+            latestRevision: {
+              id: "revision-context",
+              text: "Texte modifié",
+              details: "Contexte",
+            },
+          },
+        ],
+      },
+    ]);
+
+    await expect(queryBatchReviewGroups()).resolves.toEqual([]);
   });
 
   it("borne le lot à la candidature sélectionnée", async () => {

--- a/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
@@ -123,7 +123,7 @@ describe("queryBatchReviewGroups", () => {
     ]);
   });
 
-  it("exclut une correction de contexte qui modifie la formulation publique", async () => {
+  it("laisse la transition verrouillée refuser une correction incohérente", async () => {
     findManyMock.mockResolvedValue([
       {
         id: "edition-1",
@@ -147,7 +147,10 @@ describe("queryBatchReviewGroups", () => {
       },
     ]);
 
-    await expect(queryBatchReviewGroups()).resolves.toEqual([]);
+    const [group] = await queryBatchReviewGroups();
+    expect(group?.items).toEqual([
+      expect.objectContaining({ revisionId: "revision-context", batchKind: "CONTEXT_CORRECTION" }),
+    ]);
   });
 
   it("borne le lot à la candidature sélectionnée", async () => {

--- a/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
@@ -39,13 +39,16 @@ describe("queryBatchReviewGroups", () => {
 
     await expect(queryBatchReviewGroups()).resolves.toEqual([
       {
+        batchKind: "FIRST_PUBLICATION",
         programEditionId: "edition-1",
+        groupKey: "edition-1:FIRST_PUBLICATION",
         editionLabel: "Cahier 1",
         editionVersion: 1,
         ownerLabel: "Candidate Exemple",
         electionTitle: "Élection présidentielle de 2027",
         items: [
           {
+            batchKind: "FIRST_PUBLICATION",
             measureId: "measure-1",
             revisionId: "revision-1",
             text: "Créer un service public du logement.",

--- a/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/batch-review-query.test.ts
@@ -65,24 +65,20 @@ describe("queryBatchReviewGroups", () => {
 
     await queryBatchReviewGroups();
 
-    expect(findManyMock).toHaveBeenCalledWith(
+    expect(findManyMock).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         where: expect.objectContaining({
           measures: {
-            some: {
-              OR: expect.arrayContaining([
-                expect.objectContaining({ publicationStatus: "DRAFT" }),
-                expect.objectContaining({
-                  publicationStatus: "PUBLISHED",
-                  latestRevision: {
-                    is: expect.objectContaining({
-                      extractorVersion: { endsWith: ":measure-context-v9" },
-                      reviewedAt: null,
-                    }),
-                  },
+            some: expect.objectContaining({
+              publicationStatus: "PUBLISHED",
+              latestRevision: {
+                is: expect.objectContaining({
+                  extractorVersion: { endsWith: ":measure-context-v9" },
+                  reviewedAt: null,
                 }),
-              ]),
-            },
+              },
+            }),
           },
         }),
       })
@@ -123,7 +119,7 @@ describe("queryBatchReviewGroups", () => {
     ]);
   });
 
-  it("laisse la transition verrouillée refuser une correction incohérente", async () => {
+  it("exclut de l'interface une correction de contexte incohérente", async () => {
     findManyMock.mockResolvedValue([
       {
         id: "edition-1",
@@ -147,10 +143,7 @@ describe("queryBatchReviewGroups", () => {
       },
     ]);
 
-    const [group] = await queryBatchReviewGroups();
-    expect(group?.items).toEqual([
-      expect.objectContaining({ revisionId: "revision-context", batchKind: "CONTEXT_CORRECTION" }),
-    ]);
+    await expect(queryBatchReviewGroups()).resolves.toEqual([]);
   });
 
   it("borne le lot à la candidature sélectionnée", async () => {

--- a/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
@@ -94,4 +94,22 @@ describe("queryMeasureEnrichmentCoverage", () => {
       },
     });
   });
+
+  it("conserve les contextes relus dans la file tant qu'ils ne sont pas publiés", async () => {
+    measureCountMock.mockResolvedValue(0);
+    revisionCountMock.mockResolvedValue(0);
+
+    await queryMeasureEnrichmentCoverage();
+
+    expect(measureCountMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          latestRevision: {
+            is: expect.not.objectContaining({ reviewedAt: expect.anything() }),
+          },
+        }),
+      })
+    );
+  });
 });

--- a/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
+++ b/src/app/admin/mesures/_data/__tests__/enrichment-coverage-query.test.ts
@@ -19,10 +19,11 @@ describe("queryMeasureEnrichmentCoverage", () => {
     vi.clearAllMocks();
   });
 
-  it("retourne les sept compteurs exacts du corpus public", async () => {
+  it("retourne les huit compteurs exacts du corpus public", async () => {
     measureCountMock
       .mockResolvedValueOnce(2200)
       .mockResolvedValueOnce(98)
+      .mockResolvedValueOnce(374)
       .mockResolvedValueOnce(982)
       .mockResolvedValueOnce(12)
       .mockResolvedValueOnce(1277)
@@ -32,6 +33,7 @@ describe("queryMeasureEnrichmentCoverage", () => {
     await expect(queryMeasureEnrichmentCoverage()).resolves.toEqual({
       total: 2200,
       withDetails: 98,
+      withPendingContextDrafts: 374,
       withApprovedSubtopics: 982,
       withQualifications: 12,
       withVoteLinks: 8,
@@ -39,7 +41,7 @@ describe("queryMeasureEnrichmentCoverage", () => {
       withHistory: 4,
     });
 
-    expect(measureCountMock).toHaveBeenCalledTimes(6);
+    expect(measureCountMock).toHaveBeenCalledTimes(7);
     expect(revisionCountMock).toHaveBeenCalledOnce();
     for (const [request] of measureCountMock.mock.calls) {
       expect(request.where).toEqual(
@@ -59,7 +61,7 @@ describe("queryMeasureEnrichmentCoverage", () => {
     await queryMeasureEnrichmentCoverage();
 
     expect(measureCountMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       expect.objectContaining({
         where: expect.objectContaining({
           publishedRevision: {

--- a/src/app/admin/mesures/_data/batch-eligibility.ts
+++ b/src/app/admin/mesures/_data/batch-eligibility.ts
@@ -1,0 +1,49 @@
+import type { Prisma } from "@/generated/prisma";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
+
+type BatchStage = "REVIEW" | "PUBLISH";
+
+export function buildFirstPublicationWhere(stage: BatchStage): Prisma.MeasureWhereInput {
+  return {
+    publicationStatus: "DRAFT",
+    publishedRevisionId: null,
+    latestRevision: {
+      is: {
+        reviewedAt: stage === "REVIEW" ? null : { not: null },
+        publishedAt: null,
+        discardedAt: null,
+        supersededAt: null,
+        rejectedAt: null,
+        sources: { some: {} },
+      },
+    },
+  };
+}
+
+export function buildGeneratedContextCorrectionWhere(stage: BatchStage): Prisma.MeasureWhereInput {
+  return {
+    publicationStatus: "PUBLISHED",
+    publishedRevision: {
+      is: {
+        reviewedAt: { not: null },
+        publishedAt: { not: null },
+        supersededAt: null,
+        discardedAt: null,
+        rejectedAt: null,
+      },
+    },
+    latestRevision: {
+      is: {
+        details: { not: null },
+        extractionMethod: "AI_ASSISTED",
+        extractorVersion: { endsWith: `:${MEASURE_CONTEXT_PROMPT_VERSION}` },
+        reviewedAt: stage === "REVIEW" ? null : { not: null },
+        publishedAt: null,
+        discardedAt: null,
+        supersededAt: null,
+        rejectedAt: null,
+        sources: { some: {} },
+      },
+    },
+  };
+}

--- a/src/app/admin/mesures/_data/batch-publish-query.ts
+++ b/src/app/admin/mesures/_data/batch-publish-query.ts
@@ -1,8 +1,9 @@
 import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_PUBLICATION_BATCH_SIZE } from "@/lib/measures/batch-publication";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
 
-const ELIGIBLE_MEASURE_WHERE = {
+const FIRST_PUBLICATION_WHERE = {
   publicationStatus: "DRAFT",
   publishedRevisionId: null,
   latestRevision: {
@@ -16,11 +17,42 @@ const ELIGIBLE_MEASURE_WHERE = {
   },
 } satisfies Prisma.MeasureWhereInput;
 
+const GENERATED_CONTEXT_CORRECTION_WHERE = {
+  publicationStatus: "PUBLISHED",
+  publishedRevision: {
+    is: {
+      reviewedAt: { not: null },
+      publishedAt: { not: null },
+      supersededAt: null,
+      discardedAt: null,
+      rejectedAt: null,
+    },
+  },
+  latestRevision: {
+    is: {
+      details: { not: null },
+      extractionMethod: "AI_ASSISTED",
+      extractorVersion: { endsWith: `:${MEASURE_CONTEXT_PROMPT_VERSION}` },
+      reviewedAt: { not: null },
+      publishedAt: null,
+      discardedAt: null,
+      supersededAt: null,
+      rejectedAt: null,
+      sources: { some: {} },
+    },
+  },
+} satisfies Prisma.MeasureWhereInput;
+
+const ELIGIBLE_MEASURE_WHERE = {
+  OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
+} satisfies Prisma.MeasureWhereInput;
+
 export type BatchPublishItem = {
   measureId: string;
   revisionId: string;
   expectedUpdatedAt: string;
   text: string;
+  details: string | null;
 };
 
 export type BatchPublishGroup = {
@@ -64,7 +96,9 @@ export async function queryBatchPublishGroups(
         select: {
           id: true,
           updatedAt: true,
-          latestRevision: { select: { id: true, text: true } },
+          publicationStatus: true,
+          publishedRevision: { select: { text: true } },
+          latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
         take: MAX_MEASURE_PUBLICATION_BATCH_SIZE + 1,
@@ -78,12 +112,20 @@ export async function queryBatchPublishGroups(
       .slice(0, MAX_MEASURE_PUBLICATION_BATCH_SIZE)
       .flatMap((measure): BatchPublishItem[] => {
         if (measure.latestRevision === null) return [];
+        const isContextCorrection = measure.publicationStatus === "PUBLISHED";
+        if (
+          isContextCorrection &&
+          measure.latestRevision.text !== measure.publishedRevision?.text
+        ) {
+          return [];
+        }
         return [
           {
             measureId: measure.id,
             revisionId: measure.latestRevision.id,
             expectedUpdatedAt: measure.updatedAt.toISOString(),
             text: measure.latestRevision.text,
+            details: measure.latestRevision.details,
           },
         ];
       });

--- a/src/app/admin/mesures/_data/batch-publish-query.ts
+++ b/src/app/admin/mesures/_data/batch-publish-query.ts
@@ -1,48 +1,14 @@
 import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_PUBLICATION_BATCH_SIZE } from "@/lib/measures/batch-publication";
-import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
 import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
+import {
+  buildFirstPublicationWhere,
+  buildGeneratedContextCorrectionWhere,
+} from "./batch-eligibility";
 
-const FIRST_PUBLICATION_WHERE = {
-  publicationStatus: "DRAFT",
-  publishedRevisionId: null,
-  latestRevision: {
-    is: {
-      reviewedAt: { not: null },
-      publishedAt: null,
-      discardedAt: null,
-      supersededAt: null,
-      sources: { some: {} },
-    },
-  },
-} satisfies Prisma.MeasureWhereInput;
-
-const GENERATED_CONTEXT_CORRECTION_WHERE = {
-  publicationStatus: "PUBLISHED",
-  publishedRevision: {
-    is: {
-      reviewedAt: { not: null },
-      publishedAt: { not: null },
-      supersededAt: null,
-      discardedAt: null,
-      rejectedAt: null,
-    },
-  },
-  latestRevision: {
-    is: {
-      details: { not: null },
-      extractionMethod: "AI_ASSISTED",
-      extractorVersion: { endsWith: `:${MEASURE_CONTEXT_PROMPT_VERSION}` },
-      reviewedAt: { not: null },
-      publishedAt: null,
-      discardedAt: null,
-      supersededAt: null,
-      rejectedAt: null,
-      sources: { some: {} },
-    },
-  },
-} satisfies Prisma.MeasureWhereInput;
+const FIRST_PUBLICATION_WHERE = buildFirstPublicationWhere("PUBLISH");
+const GENERATED_CONTEXT_CORRECTION_WHERE = buildGeneratedContextCorrectionWhere("PUBLISH");
 
 const ELIGIBLE_MEASURE_WHERE = {
   OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
@@ -104,6 +70,7 @@ export async function queryBatchPublishGroups(
           latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
+        take: MAX_MEASURE_PUBLICATION_BATCH_SIZE + 1,
       },
     },
     orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
@@ -112,12 +79,6 @@ export async function queryBatchPublishGroups(
   return editions.flatMap((edition) => {
     const items = edition.measures.flatMap((measure): BatchPublishItem[] => {
       if (measure.latestRevision === null) return [];
-      if (
-        measure.publicationStatus === "PUBLISHED" &&
-        measure.latestRevision.text !== measure.publishedRevision?.text
-      ) {
-        return [];
-      }
       const batchKind: MeasureBatchKind =
         measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
       return [

--- a/src/app/admin/mesures/_data/batch-publish-query.ts
+++ b/src/app/admin/mesures/_data/batch-publish-query.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_PUBLICATION_BATCH_SIZE } from "@/lib/measures/batch-publication";
 import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
+import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
 
 const FIRST_PUBLICATION_WHERE = {
   publicationStatus: "DRAFT",
@@ -53,6 +54,7 @@ export type BatchPublishItem = {
   expectedUpdatedAt: string;
   text: string;
   details: string | null;
+  batchKind: MeasureBatchKind;
 };
 
 export type BatchPublishGroup = {
@@ -63,12 +65,13 @@ export type BatchPublishGroup = {
   electionTitle: string;
   items: BatchPublishItem[];
   hasMore: boolean;
+  batchKind: MeasureBatchKind;
+  groupKey: string;
 };
 
 /**
- * Returns only first publications whose active revision was already reviewed. Corrections and
- * republications remain individual actions because replacing public text or reversing a legal
- * depublication requires a decision tied to that exact measure.
+ * Returns first publications and generated context corrections already reviewed. Corrections that
+ * alter the public formulation and republications remain individual decisions.
  */
 export async function queryBatchPublishGroups(
   filters: {
@@ -101,47 +104,56 @@ export async function queryBatchPublishGroups(
           latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
-        take: MAX_MEASURE_PUBLICATION_BATCH_SIZE + 1,
       },
     },
     orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
   });
 
   return editions.flatMap((edition) => {
-    const items = edition.measures
-      .slice(0, MAX_MEASURE_PUBLICATION_BATCH_SIZE)
-      .flatMap((measure): BatchPublishItem[] => {
-        if (measure.latestRevision === null) return [];
-        const isContextCorrection = measure.publicationStatus === "PUBLISHED";
-        if (
-          isContextCorrection &&
-          measure.latestRevision.text !== measure.publishedRevision?.text
-        ) {
-          return [];
-        }
-        return [
-          {
-            measureId: measure.id,
-            revisionId: measure.latestRevision.id,
-            expectedUpdatedAt: measure.updatedAt.toISOString(),
-            text: measure.latestRevision.text,
-            details: measure.latestRevision.details,
-          },
-        ];
-      });
+    const items = edition.measures.flatMap((measure): BatchPublishItem[] => {
+      if (measure.latestRevision === null) return [];
+      if (
+        measure.publicationStatus === "PUBLISHED" &&
+        measure.latestRevision.text !== measure.publishedRevision?.text
+      ) {
+        return [];
+      }
+      const batchKind: MeasureBatchKind =
+        measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
+      return [
+        {
+          measureId: measure.id,
+          revisionId: measure.latestRevision.id,
+          expectedUpdatedAt: measure.updatedAt.toISOString(),
+          text: measure.latestRevision.text,
+          details: measure.latestRevision.details,
+          batchKind,
+        },
+      ];
+    });
 
     if (items.length === 0) return [];
-    return [
-      {
-        programEditionId: edition.id,
-        editionLabel: edition.label,
-        editionVersion: edition.version,
-        ownerLabel:
-          edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
-        electionTitle: edition.election.title,
-        items,
-        hasMore: edition.measures.length > MAX_MEASURE_PUBLICATION_BATCH_SIZE,
-      },
-    ];
+    return (["FIRST_PUBLICATION", "CONTEXT_CORRECTION"] as const).flatMap((batchKind) => {
+      const kindItems = items
+        .filter((item) => item.batchKind === batchKind)
+        .slice(0, MAX_MEASURE_PUBLICATION_BATCH_SIZE);
+      if (kindItems.length === 0) return [];
+      return [
+        {
+          programEditionId: edition.id,
+          editionLabel: edition.label,
+          editionVersion: edition.version,
+          ownerLabel:
+            edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
+          electionTitle: edition.election.title,
+          items: kindItems,
+          hasMore:
+            items.filter((item) => item.batchKind === batchKind).length >
+            MAX_MEASURE_PUBLICATION_BATCH_SIZE,
+          batchKind,
+          groupKey: `${edition.id}:${batchKind}`,
+        },
+      ];
+    });
   });
 }

--- a/src/app/admin/mesures/_data/batch-publish-query.ts
+++ b/src/app/admin/mesures/_data/batch-publish-query.ts
@@ -10,10 +10,6 @@ import {
 const FIRST_PUBLICATION_WHERE = buildFirstPublicationWhere("PUBLISH");
 const GENERATED_CONTEXT_CORRECTION_WHERE = buildGeneratedContextCorrectionWhere("PUBLISH");
 
-const ELIGIBLE_MEASURE_WHERE = {
-  OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
-} satisfies Prisma.MeasureWhereInput;
-
 export type BatchPublishItem = {
   measureId: string;
   revisionId: string;
@@ -44,61 +40,77 @@ export async function queryBatchPublishGroups(
     candidacyId?: string;
   } = {}
 ): Promise<BatchPublishGroup[]> {
-  const eligibleWhere: Prisma.MeasureWhereInput = filters.candidacyId
-    ? { ...ELIGIBLE_MEASURE_WHERE, candidacyId: filters.candidacyId }
-    : ELIGIBLE_MEASURE_WHERE;
-
-  const editions = await db.programEdition.findMany({
-    where: {
-      ...(filters.candidacyId ? { candidacyId: filters.candidacyId } : {}),
-      measures: { some: eligibleWhere },
-    },
-    select: {
-      id: true,
-      label: true,
-      version: true,
-      candidacy: { select: { candidateName: true } },
-      party: { select: { name: true } },
-      election: { select: { title: true } },
-      measures: {
-        where: eligibleWhere,
-        select: {
-          id: true,
-          updatedAt: true,
-          publicationStatus: true,
-          publishedRevision: { select: { text: true } },
-          latestRevision: { select: { id: true, text: true, details: true } },
-        },
-        orderBy: { createdAt: "asc" },
-        take: MAX_MEASURE_PUBLICATION_BATCH_SIZE + 1,
+  const queryKind = (where: Prisma.MeasureWhereInput) => {
+    const eligibleWhere = filters.candidacyId
+      ? { ...where, candidacyId: filters.candidacyId }
+      : where;
+    return db.programEdition.findMany({
+      where: {
+        ...(filters.candidacyId ? { candidacyId: filters.candidacyId } : {}),
+        measures: { some: eligibleWhere },
       },
-    },
-    orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
-  });
-
-  return editions.flatMap((edition) => {
-    const items = edition.measures.flatMap((measure): BatchPublishItem[] => {
-      if (measure.latestRevision === null) return [];
-      const batchKind: MeasureBatchKind =
-        measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
-      return [
-        {
-          measureId: measure.id,
-          revisionId: measure.latestRevision.id,
-          expectedUpdatedAt: measure.updatedAt.toISOString(),
-          text: measure.latestRevision.text,
-          details: measure.latestRevision.details,
-          batchKind,
+      select: {
+        id: true,
+        label: true,
+        version: true,
+        candidacy: { select: { candidateName: true } },
+        party: { select: { name: true } },
+        election: { select: { title: true } },
+        measures: {
+          where: eligibleWhere,
+          select: {
+            id: true,
+            updatedAt: true,
+            publicationStatus: true,
+            publishedRevision: { select: { text: true } },
+            latestRevision: { select: { id: true, text: true, details: true } },
+          },
+          orderBy: { createdAt: "asc" },
+          take: MAX_MEASURE_PUBLICATION_BATCH_SIZE + 1,
         },
-      ];
+      },
+      orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
     });
+  };
 
-    if (items.length === 0) return [];
-    return (["FIRST_PUBLICATION", "CONTEXT_CORRECTION"] as const).flatMap((batchKind) => {
-      const kindItems = items
-        .filter((item) => item.batchKind === batchKind)
-        .slice(0, MAX_MEASURE_PUBLICATION_BATCH_SIZE);
-      if (kindItems.length === 0) return [];
+  const [firstPublicationEditions, contextCorrectionEditions] = await Promise.all([
+    queryKind(FIRST_PUBLICATION_WHERE),
+    queryKind(GENERATED_CONTEXT_CORRECTION_WHERE),
+  ]);
+
+  const serialize = (
+    editions: Awaited<ReturnType<typeof queryKind>>,
+    batchKind: MeasureBatchKind
+  ): BatchPublishGroup[] =>
+    editions.flatMap((edition) => {
+      const items = edition.measures.flatMap((measure): BatchPublishItem[] => {
+        if (measure.latestRevision === null) return [];
+        if (
+          (batchKind === "FIRST_PUBLICATION" && measure.publicationStatus !== "DRAFT") ||
+          (batchKind === "CONTEXT_CORRECTION" && measure.publicationStatus !== "PUBLISHED")
+        ) {
+          return [];
+        }
+        if (
+          batchKind === "CONTEXT_CORRECTION" &&
+          measure.latestRevision.text !== measure.publishedRevision?.text
+        ) {
+          return [];
+        }
+        return [
+          {
+            measureId: measure.id,
+            revisionId: measure.latestRevision.id,
+            expectedUpdatedAt: measure.updatedAt.toISOString(),
+            text: measure.latestRevision.text,
+            details: measure.latestRevision.details,
+            batchKind,
+          },
+        ];
+      });
+
+      if (items.length === 0) return [];
+      const kindItems = items.slice(0, MAX_MEASURE_PUBLICATION_BATCH_SIZE);
       return [
         {
           programEditionId: edition.id,
@@ -108,13 +120,15 @@ export async function queryBatchPublishGroups(
             edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
           electionTitle: edition.election.title,
           items: kindItems,
-          hasMore:
-            items.filter((item) => item.batchKind === batchKind).length >
-            MAX_MEASURE_PUBLICATION_BATCH_SIZE,
+          hasMore: items.length > MAX_MEASURE_PUBLICATION_BATCH_SIZE,
           batchKind,
           groupKey: `${edition.id}:${batchKind}`,
         },
       ];
     });
-  });
+
+  return [
+    ...serialize(firstPublicationEditions, "FIRST_PUBLICATION"),
+    ...serialize(contextCorrectionEditions, "CONTEXT_CORRECTION"),
+  ];
 }

--- a/src/app/admin/mesures/_data/batch-review-query.ts
+++ b/src/app/admin/mesures/_data/batch-review-query.ts
@@ -10,10 +10,6 @@ import {
 const FIRST_PUBLICATION_WHERE = buildFirstPublicationWhere("REVIEW");
 const GENERATED_CONTEXT_CORRECTION_WHERE = buildGeneratedContextCorrectionWhere("REVIEW");
 
-const ELIGIBLE_MEASURE_WHERE = {
-  OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
-} satisfies Prisma.MeasureWhereInput;
-
 export type BatchReviewItem = {
   measureId: string;
   revisionId: string;
@@ -40,59 +36,75 @@ export async function queryBatchReviewGroups(
     candidacyId?: string;
   } = {}
 ): Promise<BatchReviewGroup[]> {
-  const eligibleWhere: Prisma.MeasureWhereInput = filters.candidacyId
-    ? { ...ELIGIBLE_MEASURE_WHERE, candidacyId: filters.candidacyId }
-    : ELIGIBLE_MEASURE_WHERE;
-
-  const editions = await db.programEdition.findMany({
-    where: {
-      ...(filters.candidacyId ? { candidacyId: filters.candidacyId } : {}),
-      measures: { some: eligibleWhere },
-    },
-    select: {
-      id: true,
-      label: true,
-      version: true,
-      candidacy: { select: { candidateName: true } },
-      party: { select: { name: true } },
-      election: { select: { title: true } },
-      measures: {
-        where: eligibleWhere,
-        select: {
-          id: true,
-          publicationStatus: true,
-          publishedRevision: { select: { text: true } },
-          latestRevision: { select: { id: true, text: true, details: true } },
-        },
-        orderBy: { createdAt: "asc" },
-        take: MAX_MEASURE_REVIEW_BATCH_SIZE + 1,
+  const queryKind = (where: Prisma.MeasureWhereInput) => {
+    const eligibleWhere = filters.candidacyId
+      ? { ...where, candidacyId: filters.candidacyId }
+      : where;
+    return db.programEdition.findMany({
+      where: {
+        ...(filters.candidacyId ? { candidacyId: filters.candidacyId } : {}),
+        measures: { some: eligibleWhere },
       },
-    },
-    orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
-  });
-
-  return editions.flatMap((edition) => {
-    const items = edition.measures.flatMap((measure): BatchReviewItem[] => {
-      if (measure.latestRevision === null) return [];
-      const batchKind: MeasureBatchKind =
-        measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
-      return [
-        {
-          measureId: measure.id,
-          revisionId: measure.latestRevision.id,
-          text: measure.latestRevision.text,
-          details: measure.latestRevision.details,
-          batchKind,
+      select: {
+        id: true,
+        label: true,
+        version: true,
+        candidacy: { select: { candidateName: true } },
+        party: { select: { name: true } },
+        election: { select: { title: true } },
+        measures: {
+          where: eligibleWhere,
+          select: {
+            id: true,
+            publicationStatus: true,
+            publishedRevision: { select: { text: true } },
+            latestRevision: { select: { id: true, text: true, details: true } },
+          },
+          orderBy: { createdAt: "asc" },
+          take: MAX_MEASURE_REVIEW_BATCH_SIZE + 1,
         },
-      ];
+      },
+      orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
     });
+  };
 
-    if (items.length === 0) return [];
-    return (["FIRST_PUBLICATION", "CONTEXT_CORRECTION"] as const).flatMap((batchKind) => {
-      const kindItems = items
-        .filter((item) => item.batchKind === batchKind)
-        .slice(0, MAX_MEASURE_REVIEW_BATCH_SIZE);
-      if (kindItems.length === 0) return [];
+  const [firstPublicationEditions, contextCorrectionEditions] = await Promise.all([
+    queryKind(FIRST_PUBLICATION_WHERE),
+    queryKind(GENERATED_CONTEXT_CORRECTION_WHERE),
+  ]);
+
+  const serialize = (
+    editions: Awaited<ReturnType<typeof queryKind>>,
+    batchKind: MeasureBatchKind
+  ): BatchReviewGroup[] =>
+    editions.flatMap((edition) => {
+      const items = edition.measures.flatMap((measure): BatchReviewItem[] => {
+        if (measure.latestRevision === null) return [];
+        if (
+          (batchKind === "FIRST_PUBLICATION" && measure.publicationStatus !== "DRAFT") ||
+          (batchKind === "CONTEXT_CORRECTION" && measure.publicationStatus !== "PUBLISHED")
+        ) {
+          return [];
+        }
+        if (
+          batchKind === "CONTEXT_CORRECTION" &&
+          measure.latestRevision.text !== measure.publishedRevision?.text
+        ) {
+          return [];
+        }
+        return [
+          {
+            measureId: measure.id,
+            revisionId: measure.latestRevision.id,
+            text: measure.latestRevision.text,
+            details: measure.latestRevision.details,
+            batchKind,
+          },
+        ];
+      });
+
+      if (items.length === 0) return [];
+      const kindItems = items.slice(0, MAX_MEASURE_REVIEW_BATCH_SIZE);
       return [
         {
           programEditionId: edition.id,
@@ -102,13 +114,15 @@ export async function queryBatchReviewGroups(
             edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
           electionTitle: edition.election.title,
           items: kindItems,
-          hasMore:
-            items.filter((item) => item.batchKind === batchKind).length >
-            MAX_MEASURE_REVIEW_BATCH_SIZE,
+          hasMore: items.length > MAX_MEASURE_REVIEW_BATCH_SIZE,
           batchKind,
           groupKey: `${edition.id}:${batchKind}`,
         },
       ];
     });
-  });
+
+  return [
+    ...serialize(firstPublicationEditions, "FIRST_PUBLICATION"),
+    ...serialize(contextCorrectionEditions, "CONTEXT_CORRECTION"),
+  ];
 }

--- a/src/app/admin/mesures/_data/batch-review-query.ts
+++ b/src/app/admin/mesures/_data/batch-review-query.ts
@@ -1,8 +1,9 @@
 import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_REVIEW_BATCH_SIZE } from "@/lib/measures/batch-review";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
 
-const ELIGIBLE_MEASURE_WHERE = {
+const FIRST_PUBLICATION_WHERE = {
   publicationStatus: "DRAFT",
   publishedRevisionId: null,
   latestRevision: {
@@ -17,10 +18,41 @@ const ELIGIBLE_MEASURE_WHERE = {
   },
 } satisfies Prisma.MeasureWhereInput;
 
+const GENERATED_CONTEXT_CORRECTION_WHERE = {
+  publicationStatus: "PUBLISHED",
+  publishedRevision: {
+    is: {
+      reviewedAt: { not: null },
+      publishedAt: { not: null },
+      supersededAt: null,
+      discardedAt: null,
+      rejectedAt: null,
+    },
+  },
+  latestRevision: {
+    is: {
+      details: { not: null },
+      extractionMethod: "AI_ASSISTED",
+      extractorVersion: { endsWith: `:${MEASURE_CONTEXT_PROMPT_VERSION}` },
+      reviewedAt: null,
+      publishedAt: null,
+      discardedAt: null,
+      supersededAt: null,
+      rejectedAt: null,
+      sources: { some: {} },
+    },
+  },
+} satisfies Prisma.MeasureWhereInput;
+
+const ELIGIBLE_MEASURE_WHERE = {
+  OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
+} satisfies Prisma.MeasureWhereInput;
+
 export type BatchReviewItem = {
   measureId: string;
   revisionId: string;
   text: string;
+  details: string | null;
 };
 
 export type BatchReviewGroup = {
@@ -59,7 +91,9 @@ export async function queryBatchReviewGroups(
         where: eligibleWhere,
         select: {
           id: true,
-          latestRevision: { select: { id: true, text: true } },
+          publicationStatus: true,
+          publishedRevision: { select: { text: true } },
+          latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
         take: MAX_MEASURE_REVIEW_BATCH_SIZE + 1,
@@ -73,11 +107,21 @@ export async function queryBatchReviewGroups(
       .slice(0, MAX_MEASURE_REVIEW_BATCH_SIZE)
       .flatMap((measure): BatchReviewItem[] => {
         if (measure.latestRevision === null) return [];
+        const isContextCorrection = measure.publicationStatus === "PUBLISHED";
+        // Context batches may only add sourced details to an unchanged public formulation.
+        // Every other correction remains an individual editorial decision.
+        if (
+          isContextCorrection &&
+          measure.latestRevision.text !== measure.publishedRevision?.text
+        ) {
+          return [];
+        }
         return [
           {
             measureId: measure.id,
             revisionId: measure.latestRevision.id,
             text: measure.latestRevision.text,
+            details: measure.latestRevision.details,
           },
         ];
       });

--- a/src/app/admin/mesures/_data/batch-review-query.ts
+++ b/src/app/admin/mesures/_data/batch-review-query.ts
@@ -1,49 +1,14 @@
 import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_REVIEW_BATCH_SIZE } from "@/lib/measures/batch-review";
-import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
 import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
+import {
+  buildFirstPublicationWhere,
+  buildGeneratedContextCorrectionWhere,
+} from "./batch-eligibility";
 
-const FIRST_PUBLICATION_WHERE = {
-  publicationStatus: "DRAFT",
-  publishedRevisionId: null,
-  latestRevision: {
-    is: {
-      reviewedAt: null,
-      publishedAt: null,
-      discardedAt: null,
-      supersededAt: null,
-      rejectedAt: null,
-      sources: { some: {} },
-    },
-  },
-} satisfies Prisma.MeasureWhereInput;
-
-const GENERATED_CONTEXT_CORRECTION_WHERE = {
-  publicationStatus: "PUBLISHED",
-  publishedRevision: {
-    is: {
-      reviewedAt: { not: null },
-      publishedAt: { not: null },
-      supersededAt: null,
-      discardedAt: null,
-      rejectedAt: null,
-    },
-  },
-  latestRevision: {
-    is: {
-      details: { not: null },
-      extractionMethod: "AI_ASSISTED",
-      extractorVersion: { endsWith: `:${MEASURE_CONTEXT_PROMPT_VERSION}` },
-      reviewedAt: null,
-      publishedAt: null,
-      discardedAt: null,
-      supersededAt: null,
-      rejectedAt: null,
-      sources: { some: {} },
-    },
-  },
-} satisfies Prisma.MeasureWhereInput;
+const FIRST_PUBLICATION_WHERE = buildFirstPublicationWhere("REVIEW");
+const GENERATED_CONTEXT_CORRECTION_WHERE = buildGeneratedContextCorrectionWhere("REVIEW");
 
 const ELIGIBLE_MEASURE_WHERE = {
   OR: [FIRST_PUBLICATION_WHERE, GENERATED_CONTEXT_CORRECTION_WHERE],
@@ -100,6 +65,7 @@ export async function queryBatchReviewGroups(
           latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
+        take: MAX_MEASURE_REVIEW_BATCH_SIZE + 1,
       },
     },
     orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
@@ -108,12 +74,6 @@ export async function queryBatchReviewGroups(
   return editions.flatMap((edition) => {
     const items = edition.measures.flatMap((measure): BatchReviewItem[] => {
       if (measure.latestRevision === null) return [];
-      if (
-        measure.publicationStatus === "PUBLISHED" &&
-        measure.latestRevision.text !== measure.publishedRevision?.text
-      ) {
-        return [];
-      }
       const batchKind: MeasureBatchKind =
         measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
       return [

--- a/src/app/admin/mesures/_data/batch-review-query.ts
+++ b/src/app/admin/mesures/_data/batch-review-query.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { MAX_MEASURE_REVIEW_BATCH_SIZE } from "@/lib/measures/batch-review";
 import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
+import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
 
 const FIRST_PUBLICATION_WHERE = {
   publicationStatus: "DRAFT",
@@ -53,6 +54,7 @@ export type BatchReviewItem = {
   revisionId: string;
   text: string;
   details: string | null;
+  batchKind: MeasureBatchKind;
 };
 
 export type BatchReviewGroup = {
@@ -63,6 +65,8 @@ export type BatchReviewGroup = {
   electionTitle: string;
   items: BatchReviewItem[];
   hasMore: boolean;
+  batchKind: MeasureBatchKind;
+  groupKey: string;
 };
 
 /** Lists sourced active drafts by programme edition, ready for one explicit human decision. */
@@ -96,48 +100,55 @@ export async function queryBatchReviewGroups(
           latestRevision: { select: { id: true, text: true, details: true } },
         },
         orderBy: { createdAt: "asc" },
-        take: MAX_MEASURE_REVIEW_BATCH_SIZE + 1,
       },
     },
     orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
   });
 
   return editions.flatMap((edition) => {
-    const items = edition.measures
-      .slice(0, MAX_MEASURE_REVIEW_BATCH_SIZE)
-      .flatMap((measure): BatchReviewItem[] => {
-        if (measure.latestRevision === null) return [];
-        const isContextCorrection = measure.publicationStatus === "PUBLISHED";
-        // Context batches may only add sourced details to an unchanged public formulation.
-        // Every other correction remains an individual editorial decision.
-        if (
-          isContextCorrection &&
-          measure.latestRevision.text !== measure.publishedRevision?.text
-        ) {
-          return [];
-        }
-        return [
-          {
-            measureId: measure.id,
-            revisionId: measure.latestRevision.id,
-            text: measure.latestRevision.text,
-            details: measure.latestRevision.details,
-          },
-        ];
-      });
+    const items = edition.measures.flatMap((measure): BatchReviewItem[] => {
+      if (measure.latestRevision === null) return [];
+      if (
+        measure.publicationStatus === "PUBLISHED" &&
+        measure.latestRevision.text !== measure.publishedRevision?.text
+      ) {
+        return [];
+      }
+      const batchKind: MeasureBatchKind =
+        measure.publicationStatus === "PUBLISHED" ? "CONTEXT_CORRECTION" : "FIRST_PUBLICATION";
+      return [
+        {
+          measureId: measure.id,
+          revisionId: measure.latestRevision.id,
+          text: measure.latestRevision.text,
+          details: measure.latestRevision.details,
+          batchKind,
+        },
+      ];
+    });
 
     if (items.length === 0) return [];
-    return [
-      {
-        programEditionId: edition.id,
-        editionLabel: edition.label,
-        editionVersion: edition.version,
-        ownerLabel:
-          edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
-        electionTitle: edition.election.title,
-        items,
-        hasMore: edition.measures.length > MAX_MEASURE_REVIEW_BATCH_SIZE,
-      },
-    ];
+    return (["FIRST_PUBLICATION", "CONTEXT_CORRECTION"] as const).flatMap((batchKind) => {
+      const kindItems = items
+        .filter((item) => item.batchKind === batchKind)
+        .slice(0, MAX_MEASURE_REVIEW_BATCH_SIZE);
+      if (kindItems.length === 0) return [];
+      return [
+        {
+          programEditionId: edition.id,
+          editionLabel: edition.label,
+          editionVersion: edition.version,
+          ownerLabel:
+            edition.candidacy?.candidateName ?? edition.party?.name ?? "Propriétaire inconnu",
+          electionTitle: edition.election.title,
+          items: kindItems,
+          hasMore:
+            items.filter((item) => item.batchKind === batchKind).length >
+            MAX_MEASURE_REVIEW_BATCH_SIZE,
+          batchKind,
+          groupKey: `${edition.id}:${batchKind}`,
+        },
+      ];
+    });
   });
 }

--- a/src/app/admin/mesures/_data/enrichment-coverage-query.ts
+++ b/src/app/admin/mesures/_data/enrichment-coverage-query.ts
@@ -65,7 +65,6 @@ export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmen
             details: { not: null },
             extractionMethod: "AI_ASSISTED",
             extractorVersion: { contains: ":measure-context-" },
-            reviewedAt: null,
             publishedAt: null,
             discardedAt: null,
             rejectedAt: null,

--- a/src/app/admin/mesures/_data/enrichment-coverage-query.ts
+++ b/src/app/admin/mesures/_data/enrichment-coverage-query.ts
@@ -10,6 +10,7 @@ const PRESIDENTIAL_ELECTION_SLUG = "presidentielle-2027";
 export type MeasureEnrichmentCoverage = {
   total: number;
   withDetails: number;
+  withPendingContextDrafts: number;
   withApprovedSubtopics: number;
   withQualifications: number;
   withVoteLinks: number;
@@ -47,6 +48,7 @@ export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmen
   const [
     total,
     withDetails,
+    withPendingContextDrafts,
     withApprovedSubtopics,
     withQualifications,
     withVoteLinks,
@@ -55,6 +57,22 @@ export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmen
   ] = await Promise.all([
     db.measure.count({ where: base }),
     db.measure.count({ where: withPublishedRevision({ details: { not: null } }) }),
+    db.measure.count({
+      where: {
+        ...withPublishedRevision({ details: null }),
+        latestRevision: {
+          is: {
+            details: { not: null },
+            extractionMethod: "AI_ASSISTED",
+            extractorVersion: { contains: ":measure-context-" },
+            reviewedAt: null,
+            publishedAt: null,
+            discardedAt: null,
+            rejectedAt: null,
+          },
+        },
+      },
+    }),
     db.measure.count({
       where: withPublishedRevision({
         subtopics: {
@@ -85,6 +103,7 @@ export async function queryMeasureEnrichmentCoverage(): Promise<MeasureEnrichmen
   return {
     total,
     withDetails,
+    withPendingContextDrafts,
     withApprovedSubtopics,
     withQualifications,
     withVoteLinks,

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -101,6 +101,7 @@ const batchPublicationInputSchema = z
             measureId: z.string().min(1),
             revisionId: z.string().min(1),
             expectedUpdatedAt: z.string().min(1),
+            batchKind: z.enum(["FIRST_PUBLICATION", "CONTEXT_CORRECTION"]),
           })
           .strict()
       )
@@ -117,6 +118,7 @@ const batchReviewInputSchema = z
           .object({
             measureId: z.string().min(1),
             revisionId: z.string().min(1),
+            batchKind: z.enum(["FIRST_PUBLICATION", "CONTEXT_CORRECTION"]),
           })
           .strict()
       )
@@ -494,6 +496,7 @@ export async function reviewDraftBatchAction(input: unknown): Promise<BatchRevie
         {
           measureId: "batch",
           revisionId: "batch",
+          batchKind: "FIRST_PUBLICATION",
           message: failure.message,
         },
       ],
@@ -554,6 +557,7 @@ export async function publishReviewedBatchAction(input: unknown): Promise<BatchA
       measureId: item.measureId,
       revisionId: item.revisionId,
       expectedUpdatedAt: parseDate(item.expectedUpdatedAt, "La version attendue"),
+      batchKind: item.batchKind,
     }));
     const result = await publishMeasureRevisionBatch(items, ACTOR);
 

--- a/src/lib/measures/__tests__/batch-kind.test.ts
+++ b/src/lib/measures/__tests__/batch-kind.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { assertMeasureBatchKind } from "../batch-kind";
+
+const publicMeasure = {
+  publicationStatus: "PUBLISHED",
+  publishedRevisionId: "published-revision",
+  publishedRevision: { text: "Texte public" },
+};
+
+const generatedContext = {
+  text: "Texte public",
+  details: "Contexte sourcé.",
+  extractionMethod: "AI_ASSISTED" as const,
+  extractorVersion: "mistral:measure-context-v9",
+};
+
+describe("assertMeasureBatchKind", () => {
+  it("accepte une première publication réellement inédite", () => {
+    expect(() =>
+      assertMeasureBatchKind(
+        "FIRST_PUBLICATION",
+        { publicationStatus: "DRAFT", publishedRevisionId: null, publishedRevision: null },
+        { ...generatedContext, text: "Nouvelle mesure" }
+      )
+    ).not.toThrow();
+  });
+
+  it("accepte seulement une correction de contexte générée sans changement de formulation", () => {
+    expect(() =>
+      assertMeasureBatchKind("CONTEXT_CORRECTION", publicMeasure, generatedContext)
+    ).not.toThrow();
+    expect(() =>
+      assertMeasureBatchKind("CONTEXT_CORRECTION", publicMeasure, {
+        ...generatedContext,
+        text: "Texte modifié",
+      })
+    ).toThrow(/type de lot/i);
+    expect(() =>
+      assertMeasureBatchKind("CONTEXT_CORRECTION", publicMeasure, {
+        ...generatedContext,
+        extractorVersion: "mistral:measure-context-v8",
+      })
+    ).toThrow(/type de lot/i);
+  });
+});

--- a/src/lib/measures/__tests__/batch-publication.test.ts
+++ b/src/lib/measures/__tests__/batch-publication.test.ts
@@ -17,6 +17,7 @@ import {
 const item = (number: number) => ({
   measureId: `measure-${number}`,
   revisionId: `revision-${number}`,
+  batchKind: "FIRST_PUBLICATION" as const,
   expectedUpdatedAt: new Date(`2027-01-${String(number).padStart(2, "0")}T10:00:00.000Z`),
 });
 

--- a/src/lib/measures/__tests__/batch-review.test.ts
+++ b/src/lib/measures/__tests__/batch-review.test.ts
@@ -14,6 +14,7 @@ import { MAX_MEASURE_REVIEW_BATCH_SIZE, reviewMeasureRevisionBatch } from "../ba
 const item = (number: number) => ({
   measureId: `measure-${number}`,
   revisionId: `revision-${number}`,
+  batchKind: "FIRST_PUBLICATION" as const,
 });
 
 describe("reviewMeasureRevisionBatch", () => {
@@ -58,6 +59,7 @@ describe("reviewMeasureRevisionBatch", () => {
         Array.from({ length: MAX_MEASURE_REVIEW_BATCH_SIZE + 1 }, (_, index) => ({
           measureId: `measure-${index}`,
           revisionId: `revision-${index}`,
+          batchKind: "FIRST_PUBLICATION" as const,
         })),
         "admin"
       )

--- a/src/lib/measures/__tests__/publish-revision.integration.test.ts
+++ b/src/lib/measures/__tests__/publish-revision.integration.test.ts
@@ -30,6 +30,7 @@ it("keeps the publication input free of any review field", () => {
     revisionId: string;
     publishedBy?: string;
     expectedUpdatedAt?: Date;
+    batchKind?: "FIRST_PUBLICATION" | "CONTEXT_CORRECTION";
   }>();
 });
 

--- a/src/lib/measures/batch-kind.ts
+++ b/src/lib/measures/batch-kind.ts
@@ -1,0 +1,41 @@
+import type { MeasureExtractionMethod } from "@/generated/prisma";
+import { MEASURE_CONTEXT_PROMPT_VERSION } from "@/lib/measures/context-provenance";
+import { MeasureValidationError } from "@/lib/measures/errors";
+
+export type MeasureBatchKind = "FIRST_PUBLICATION" | "CONTEXT_CORRECTION";
+
+export function assertMeasureBatchKind(
+  kind: MeasureBatchKind | undefined,
+  measure: {
+    publicationStatus: string;
+    publishedRevisionId: string | null;
+    publishedRevision: { text: string } | null;
+  },
+  revision: {
+    text: string;
+    details: string | null;
+    extractionMethod: MeasureExtractionMethod;
+    extractorVersion: string | null;
+  }
+): void {
+  if (kind === undefined) return;
+  if (
+    kind === "FIRST_PUBLICATION" &&
+    measure.publicationStatus === "DRAFT" &&
+    measure.publishedRevisionId === null
+  ) {
+    return;
+  }
+  if (
+    kind === "CONTEXT_CORRECTION" &&
+    measure.publicationStatus === "PUBLISHED" &&
+    measure.publishedRevision !== null &&
+    revision.text === measure.publishedRevision.text &&
+    revision.details?.trim() &&
+    revision.extractionMethod === "AI_ASSISTED" &&
+    revision.extractorVersion?.endsWith(`:${MEASURE_CONTEXT_PROMPT_VERSION}`)
+  ) {
+    return;
+  }
+  throw new MeasureValidationError("Cette révision ne correspond pas au type de lot annoncé");
+}

--- a/src/lib/measures/batch-publication.ts
+++ b/src/lib/measures/batch-publication.ts
@@ -1,5 +1,6 @@
 import { MeasureConcurrencyError, MeasureValidationError } from "@/lib/measures/errors";
 import { publishMeasureRevision } from "@/lib/measures/transitions";
+import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
 
 /**
  * A bounded batch keeps one explicit human decision manageable and prevents an authenticated
@@ -12,6 +13,7 @@ export type MeasurePublicationBatchItem = {
   measureId: string;
   revisionId: string;
   expectedUpdatedAt: Date;
+  batchKind: MeasureBatchKind;
 };
 
 export type MeasurePublicationBatchFailure = {

--- a/src/lib/measures/batch-review.ts
+++ b/src/lib/measures/batch-review.ts
@@ -1,5 +1,6 @@
 import { MeasureValidationError } from "@/lib/measures/errors";
 import { reviewMeasureRevision } from "@/lib/measures/transitions";
+import type { MeasureBatchKind } from "@/lib/measures/batch-kind";
 
 /**
  * A human must be able to inspect the complete batch before confirming it. Keeping the same
@@ -10,6 +11,7 @@ export const MAX_MEASURE_REVIEW_BATCH_SIZE = 100;
 export type MeasureReviewBatchItem = {
   measureId: string;
   revisionId: string;
+  batchKind: MeasureBatchKind;
 };
 
 export type MeasureReviewBatchFailure = MeasureReviewBatchItem & {

--- a/src/lib/measures/transitions.ts
+++ b/src/lib/measures/transitions.ts
@@ -14,6 +14,7 @@ import {
   GENERATED_CONTEXT_DRAFT_ACTION,
   type GeneratedContextClaim,
 } from "@/lib/measures/context-provenance";
+import { assertMeasureBatchKind, type MeasureBatchKind } from "@/lib/measures/batch-kind";
 import { invalidateMeasureTags } from "./cache";
 import {
   createV6CorrectionFingerprint,
@@ -440,6 +441,7 @@ export async function reviewMeasureRevision(input: {
   measureId: string;
   revisionId: string;
   reviewedBy: string;
+  batchKind?: MeasureBatchKind;
 }): Promise<void> {
   if (input.reviewedBy.trim() === "") {
     throw new MeasureValidationError("Le relecteur doit être identifié");
@@ -450,7 +452,12 @@ export async function reviewMeasureRevision(input: {
 
     const measure = await tx.measure.findUniqueOrThrow({
       where: { id: input.measureId },
-      select: { latestRevisionId: true, publishedRevisionId: true },
+      select: {
+        latestRevisionId: true,
+        publicationStatus: true,
+        publishedRevisionId: true,
+        publishedRevision: { select: { text: true } },
+      },
     });
 
     const revision = await tx.measureRevision.findUnique({
@@ -461,6 +468,10 @@ export async function reviewMeasureRevision(input: {
         supersededAt: true,
         rejectedAt: true,
         reviewedAt: true,
+        text: true,
+        details: true,
+        extractionMethod: true,
+        extractorVersion: true,
         _count: { select: { sources: true } },
       },
     });
@@ -493,6 +504,7 @@ export async function reviewMeasureRevision(input: {
     if (revision.reviewedAt) {
       throw new MeasureValidationError("Cette révision a déjà été relue");
     }
+    assertMeasureBatchKind(input.batchKind, measure, revision);
 
     await tx.measureRevision.update({
       where: { id: input.revisionId },
@@ -656,6 +668,7 @@ export async function publishMeasureRevision(input: {
    * version from them would be a check with nothing to check.
    */
   expectedUpdatedAt?: Date;
+  batchKind?: MeasureBatchKind;
 }): Promise<void> {
   const { electionId } = await db.$transaction(async (tx) => {
     await lockMeasure(tx, input.measureId);
@@ -668,6 +681,8 @@ export async function publishMeasureRevision(input: {
         publishedRevisionId: true,
         latestRevisionId: true,
         updatedAt: true,
+        publicationStatus: true,
+        publishedRevision: { select: { text: true } },
       },
     });
 
@@ -687,6 +702,9 @@ export async function publishMeasureRevision(input: {
       select: {
         measureId: true,
         text: true,
+        details: true,
+        extractionMethod: true,
+        extractorVersion: true,
         reviewedAt: true,
         discardedAt: true,
         supersededAt: true,
@@ -712,6 +730,7 @@ export async function publishMeasureRevision(input: {
     if (revision._count.sources === 0) {
       throw new MeasureValidationError("Une révision publiée doit porter au moins une source");
     }
+    assertMeasureBatchKind(input.batchKind, measure, revision);
     if (revision.reviewReadiness !== null) {
       const evidence = validateRevisionEvidence({
         importEngine: "V6",


### PR DESCRIPTION
## Résultat

- ajoute un audit durable de l’entonnoir de couverture des contextes
- expose les contextes en attente dans l’administration
- permet leur relecture puis leur publication par lots distincts
- revérifie sous verrou qu’une correction de contexte ne change pas la formulation publique
- rend les preuves accessibles avant la confirmation du lot
- documente la génération et la régénération des anciennes versions

## Diagnostic actuel

- 145 contextes publiés sur 2 764 mesures
- 374 brouillons en attente, dont 310 en version v9
- 61 anciens brouillons v2/v6 régénérables
- 402 mesures sans preuve structurée
- 1 800 mesures dont la source ne contient pas de contexte distinct du titre

## Vérifications

- 
> poligraph@0.1.0 typecheck
> tsc --noEmit
- 63 tests ciblés
- ESLint sur les fichiers concernés
- simulations en lecture seule de l’audit et des régénérations v2/v6/v8

Aucune écriture en production n’a été exécutée.