### PR TITLE
feat(mesures): ajouter des repères sourcés pour comprendre

### DIFF
--- a/docs/editorial/reperes-mesures.md
+++ b/docs/editorial/reperes-mesures.md
@@ -18,6 +18,15 @@ Une suggestion n'est jamais publique. Le site affiche uniquement un rattachement
 un repère actif et `PUBLISHED`. Chaque création, publication, suggestion et décision produit une
 entrée dans `AuditLog`.
 
+Une source de programme doit être une source primaire de type programme de parti, programme de
+candidature ou propositions de candidature déjà rattachée à la révision. Une interview ou un
+article de presse ne peut pas être présenté comme une source de programme.
+
+Un repère publié dont la définition ou la source devient incorrecte peut être désactivé depuis
+`/admin/mesures/reperes`. La désactivation est auditée, le retire immédiatement des pages publiques
+et resynchronise les documents de recherche concernés. Une définition corrigée est ensuite créée et
+validée comme un nouveau repère, afin de conserver l'historique de la version retirée.
+
 ## Synchroniser le catalogue
 
 Le catalogue relu dans `src/config/measure-reader-guides.ts` crée des brouillons et ne remplace

--- a/docs/editorial/reperes-mesures.md
+++ b/docs/editorial/reperes-mesures.md
@@ -1,0 +1,59 @@
+# Repères pour comprendre les mesures
+
+Les repères expliquent un sigle, un mécanisme juridique, un dispositif administratif ou un terme
+employé dans un sens technique. Ils ne résument pas la mesure et ne portent aucun jugement sur son
+coût, sa faisabilité ou son opportunité.
+
+## Séparation des responsabilités
+
+1. Mistral détecte des termes candidats dans la formulation et le contexte déjà publié.
+2. Une correspondance exacte avec le libellé ou un alias peut rattacher la suggestion à un repère
+   existant. Une suggestion inconnue reste conservée sans définition.
+3. Une personne rédige ou vérifie le repère à partir de la source du programme ou d'une source
+   institutionnelle officielle.
+4. La publication du repère et son rattachement à une révision sont deux décisions humaines
+   distinctes.
+
+Une suggestion n'est jamais publique. Le site affiche uniquement un rattachement `APPROVED` vers
+un repère actif et `PUBLISHED`. Chaque création, publication, suggestion et décision produit une
+entrée dans `AuditLog`.
+
+## Synchroniser le catalogue
+
+Le catalogue relu dans `src/config/measure-reader-guides.ts` crée des brouillons et ne remplace
+jamais un repère déjà publié.
+
+```bash
+npm run measures:sync-reader-guides
+npm run measures:sync-reader-guides -- --apply
+```
+
+Les brouillons sont relus puis publiés dans `/admin/mesures/reperes`.
+
+## Analyser le corpus
+
+Le script est cursorisé. Le dry-run ne produit aucune écriture et place son rapport dans
+`scripts/.local/`, qui est ignoré par Git.
+
+```bash
+npm run measures:detect-reader-guides -- \
+  --election presidentielle-2027 \
+  --limit 100 \
+  --dry-run
+
+npm run measures:detect-reader-guides -- \
+  --election presidentielle-2027 \
+  --limit 100 \
+  --after IDENTIFIANT \
+  --apply
+```
+
+L'application crée uniquement des suggestions. Leur validation se fait sur la fiche admin de la
+mesure. Une validation resynchronise le document de recherche concerné et invalide uniquement les
+caches de cette mesure et de son élection.
+
+## Limites
+
+La détection ne consulte pas le Web et ne produit pas de définition. Un terme nouveau demande donc
+une recherche éditoriale séparée. La liste de domaines officiels est volontairement restrictive ;
+un nouvel organisme public doit être ajouté avec un test avant de pouvoir servir de source.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "measures:classify-subtopic-delta": "tsx --env-file=.env scripts/classify-measure-subtopic-delta.ts",
     "measures:generate-contexts": "tsx --env-file=.env scripts/generate-measure-contexts.ts",
     "measures:regenerate-contexts": "tsx --env-file=.env scripts/regenerate-measure-contexts.ts",
+    "measures:sync-reader-guides": "tsx --env-file=.env scripts/sync-measure-reader-guides.ts",
+    "measures:detect-reader-guides": "tsx --env-file=.env scripts/detect-measure-reader-guides.ts",
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/prisma/migrations/20260831143000_add_measure_reader_guides/migration.sql
+++ b/prisma/migrations/20260831143000_add_measure_reader_guides/migration.sql
@@ -1,0 +1,55 @@
+CREATE TYPE "MeasureReaderGuideSourceKind" AS ENUM ('OFFICIAL_INSTITUTION', 'PROGRAM_SOURCE');
+CREATE TYPE "MeasureReaderGuideMentionStatus" AS ENUM ('SUGGESTED', 'APPROVED', 'REJECTED');
+
+CREATE TABLE "MeasureReaderGuide" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "definition" TEXT NOT NULL,
+    "aliases" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "sourceKind" "MeasureReaderGuideSourceKind" NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "sourceLabel" TEXT NOT NULL,
+    "sourcePublisher" TEXT NOT NULL,
+    "sourceRevisionId" TEXT,
+    "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+    "reviewedAt" TIMESTAMP(3),
+    "reviewedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MeasureReaderGuide_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "MeasureRevisionReaderGuide" (
+    "id" TEXT NOT NULL,
+    "revisionId" TEXT NOT NULL,
+    "guideId" TEXT,
+    "term" TEXT NOT NULL,
+    "normalizedTerm" TEXT NOT NULL,
+    "evidenceSpan" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "status" "MeasureReaderGuideMentionStatus" NOT NULL DEFAULT 'SUGGESTED',
+    "method" TEXT NOT NULL,
+    "detectorVersion" TEXT NOT NULL,
+    "proposedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewedAt" TIMESTAMP(3),
+    "reviewedBy" TEXT,
+
+    CONSTRAINT "MeasureRevisionReaderGuide_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MeasureReaderGuide_slug_key" ON "MeasureReaderGuide"("slug");
+CREATE INDEX "MeasureReaderGuide_publicationStatus_active_idx" ON "MeasureReaderGuide"("publicationStatus", "active");
+CREATE UNIQUE INDEX "MeasureRevisionReaderGuide_revisionId_normalizedTerm_key" ON "MeasureRevisionReaderGuide"("revisionId", "normalizedTerm");
+CREATE INDEX "MeasureRevisionReaderGuide_revisionId_status_idx" ON "MeasureRevisionReaderGuide"("revisionId", "status");
+CREATE INDEX "MeasureRevisionReaderGuide_guideId_status_idx" ON "MeasureRevisionReaderGuide"("guideId", "status");
+
+ALTER TABLE "MeasureReaderGuide" ADD CONSTRAINT "MeasureReaderGuide_sourceRevisionId_fkey" FOREIGN KEY ("sourceRevisionId") REFERENCES "MeasureRevision"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "MeasureRevisionReaderGuide" ADD CONSTRAINT "MeasureRevisionReaderGuide_revisionId_fkey" FOREIGN KEY ("revisionId") REFERENCES "MeasureRevision"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "MeasureRevisionReaderGuide" ADD CONSTRAINT "MeasureRevisionReaderGuide_guideId_fkey" FOREIGN KEY ("guideId") REFERENCES "MeasureReaderGuide"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "MeasureReaderGuide" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "MeasureRevisionReaderGuide" ENABLE ROW LEVEL SECURITY;

--- a/prisma/migrations/20260831190000_harden_measure_reader_guides/migration.sql
+++ b/prisma/migrations/20260831190000_harden_measure_reader_guides/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "MeasureReaderGuideDetectionRun" (
+    "id" TEXT NOT NULL,
+    "revisionId" TEXT NOT NULL,
+    "detectorVersion" TEXT NOT NULL,
+    "resultCount" INTEGER NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MeasureReaderGuideDetectionRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MeasureReaderGuideDetectionRun_revisionId_detectorVersion_key"
+    ON "MeasureReaderGuideDetectionRun"("revisionId", "detectorVersion");
+CREATE INDEX "MeasureReaderGuideDetectionRun_detectorVersion_completedAt_idx"
+    ON "MeasureReaderGuideDetectionRun"("detectorVersion", "completedAt");
+
+-- A revision can expose a reusable guide only once, even if two detected aliases are approved
+-- concurrently. Prisma cannot represent a partial unique index, so this invariant lives here.
+CREATE UNIQUE INDEX "MeasureRevisionReaderGuide_one_approved_guide_per_revision_key"
+    ON "MeasureRevisionReaderGuide"("revisionId", "guideId")
+    WHERE "status" = 'APPROVED' AND "guideId" IS NOT NULL;
+
+ALTER TABLE "MeasureReaderGuideDetectionRun"
+    ADD CONSTRAINT "MeasureReaderGuideDetectionRun_revisionId_fkey"
+    FOREIGN KEY ("revisionId") REFERENCES "MeasureRevision"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MeasureReaderGuideDetectionRun" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3085,14 +3085,15 @@ model MeasureRevision {
   rejectionReason MeasureRejectionReason?
   rejectionDetail String?                 @db.Text
 
-  sources             MeasureSource[]
-  qualifications      MeasureQualification[]
-  assessments         MeasureSimilarityAssessment[]
-  equivalentOf        MeasureSimilarityMatch[]      @relation("EquivalentRevision")
-  applicableVoteLinks MeasureVoteLink[]             @relation("ApplicableRevisionVoteLinks")
-  subtopics           MeasureRevisionSubtopic[]
-  readerGuideMentions MeasureRevisionReaderGuide[]  @relation("MeasureRevisionReaderGuides")
-  sourcedReaderGuides MeasureReaderGuide[]          @relation("MeasureReaderGuideProgramSource")
+  sources                  MeasureSource[]
+  qualifications           MeasureQualification[]
+  assessments              MeasureSimilarityAssessment[]
+  equivalentOf             MeasureSimilarityMatch[]         @relation("EquivalentRevision")
+  applicableVoteLinks      MeasureVoteLink[]                @relation("ApplicableRevisionVoteLinks")
+  subtopics                MeasureRevisionSubtopic[]
+  readerGuideMentions      MeasureRevisionReaderGuide[]     @relation("MeasureRevisionReaderGuides")
+  readerGuideDetectionRuns MeasureReaderGuideDetectionRun[]
+  sourcedReaderGuides      MeasureReaderGuide[]             @relation("MeasureReaderGuideProgramSource")
 
   latestOf    Measure? @relation("MeasureLatest")
   publishedOf Measure? @relation("MeasurePublished")
@@ -3160,6 +3161,22 @@ model MeasureRevisionReaderGuide {
   @@unique([revisionId, normalizedTerm])
   @@index([revisionId, status])
   @@index([guideId, status])
+}
+
+// Records a completed detector pass independently from its result count. Without this marker,
+// revisions with no technical term would be sent to the model again on every corpus run.
+model MeasureReaderGuideDetectionRun {
+  id String @id @default(cuid())
+
+  revision   MeasureRevision @relation(fields: [revisionId], references: [id], onDelete: Cascade)
+  revisionId String
+
+  detectorVersion String
+  resultCount     Int
+  completedAt     DateTime @default(now())
+
+  @@unique([revisionId, detectorVersion])
+  @@index([detectorVersion, completedAt])
 }
 
 enum MeasureVoteLinkKind {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2935,6 +2935,17 @@ enum MeasureSubtopicAssignmentStatus {
   REJECTED
 }
 
+enum MeasureReaderGuideSourceKind {
+  OFFICIAL_INSTITUTION
+  PROGRAM_SOURCE
+}
+
+enum MeasureReaderGuideMentionStatus {
+  SUGGESTED
+  APPROVED
+  REJECTED
+}
+
 // Closed, versioned navigation vocabulary. A subtopic belongs to one broad theme; it is not a
 // free-form tag and therefore cannot silently split into synonyms over successive imports.
 model MeasureSubtopic {
@@ -3080,6 +3091,8 @@ model MeasureRevision {
   equivalentOf        MeasureSimilarityMatch[]      @relation("EquivalentRevision")
   applicableVoteLinks MeasureVoteLink[]             @relation("ApplicableRevisionVoteLinks")
   subtopics           MeasureRevisionSubtopic[]
+  readerGuideMentions MeasureRevisionReaderGuide[]  @relation("MeasureRevisionReaderGuides")
+  sourcedReaderGuides MeasureReaderGuide[]          @relation("MeasureReaderGuideProgramSource")
 
   latestOf    Measure? @relation("MeasureLatest")
   publishedOf Measure? @relation("MeasurePublished")
@@ -3090,6 +3103,63 @@ model MeasureRevision {
   @@index([measureId, validFrom])
   @@index([measureId, supersededAt])
   @@index([measureId, discardedAt])
+}
+
+// Reusable, sourced explanation of a technical term found in political programmes. The AI never
+// writes or publishes this text: it only proposes mentions. Publication is a separate human action.
+model MeasureReaderGuide {
+  id         String   @id @default(cuid())
+  slug       String   @unique
+  label      String
+  definition String   @db.Text
+  aliases    String[] @default([])
+  active     Boolean  @default(true)
+
+  sourceKind       MeasureReaderGuideSourceKind
+  sourceUrl        String
+  sourceLabel      String
+  sourcePublisher  String
+  sourceRevision   MeasureRevision?             @relation("MeasureReaderGuideProgramSource", fields: [sourceRevisionId], references: [id], onDelete: SetNull)
+  sourceRevisionId String?
+
+  publicationStatus PublicationStatus @default(DRAFT)
+  reviewedAt        DateTime?
+  reviewedBy        String?
+
+  mentions MeasureRevisionReaderGuide[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([publicationStatus, active])
+}
+
+// Attached to a revision because a rewritten measure may no longer contain the term. The optional
+// guide relation lets detection retain novel terms for editorial triage without inventing a public
+// definition. Only APPROVED rows linked to a PUBLISHED guide are visible publicly.
+model MeasureRevisionReaderGuide {
+  id String @id @default(cuid())
+
+  revision   MeasureRevision     @relation("MeasureRevisionReaderGuides", fields: [revisionId], references: [id], onDelete: Cascade)
+  revisionId String
+  guide      MeasureReaderGuide? @relation(fields: [guideId], references: [id], onDelete: SetNull)
+  guideId    String?
+
+  term            String
+  normalizedTerm  String
+  evidenceSpan    String
+  reason          String                          @db.Text
+  confidence      Float
+  status          MeasureReaderGuideMentionStatus @default(SUGGESTED)
+  method          String
+  detectorVersion String
+  proposedAt      DateTime                        @default(now())
+  reviewedAt      DateTime?
+  reviewedBy      String?
+
+  @@unique([revisionId, normalizedTerm])
+  @@index([revisionId, status])
+  @@index([guideId, status])
 }
 
 enum MeasureVoteLinkKind {

--- a/scripts/detect-measure-reader-guides.ts
+++ b/scripts/detect-measure-reader-guides.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getMistralTokensUsed } from "../src/lib/api/mistral";
+import { parseReaderGuideDetectionOptions } from "../src/lib/measures/reader-guide-options";
+import {
+  detectReaderGuidesForRevision,
+  listReaderGuideDetectionCandidates,
+  proposeReaderGuidesForRevision,
+} from "../src/lib/measures/reader-guides";
+
+async function main(): Promise<void> {
+  const options = parseReaderGuideDetectionOptions(process.argv.slice(2));
+  const runId = randomUUID();
+  const rows = await listReaderGuideDetectionCandidates(options);
+  const results: Array<Record<string, unknown>> = [];
+  for (const row of rows) {
+    if (!row.publishedRevisionId) continue;
+    try {
+      const result = options.apply
+        ? await proposeReaderGuidesForRevision(row.publishedRevisionId, `cli:${runId}`)
+        : await detectReaderGuidesForRevision(row.publishedRevisionId);
+      results.push({
+        measureId: row.id,
+        revisionId: row.publishedRevisionId,
+        candidateName: row.candidacy?.candidateName ?? null,
+        theme: row.theme,
+        ...result,
+      });
+      console.log(`${row.id}: ${result.proposals.length} proposition(s)`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({ measureId: row.id, revisionId: row.publishedRevisionId, error: message });
+      console.error(`${row.id}: ${message}`);
+    }
+  }
+  const reportDir = join(process.cwd(), "scripts", ".local");
+  await mkdir(reportDir, { recursive: true });
+  const reportPath = join(reportDir, `reader-guides-${runId}.json`);
+  await writeFile(
+    reportPath,
+    JSON.stringify(
+      {
+        runId,
+        createdAt: new Date().toISOString(),
+        mode: options.apply ? "apply" : "dry-run",
+        parameters: options,
+        processed: results.length,
+        nextAfter: rows.at(-1)?.id ?? null,
+        mistralTokens: getMistralTokensUsed(),
+        results,
+      },
+      null,
+      2
+    )
+  );
+  console.log(`Rapport : ${reportPath}`);
+  if (rows.length === options.limit && rows.at(-1)) {
+    console.log(`Lot suivant : --after ${rows.at(-1)!.id}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/detect-measure-reader-guides.ts
+++ b/scripts/detect-measure-reader-guides.ts
@@ -14,6 +14,8 @@ async function main(): Promise<void> {
   const runId = randomUUID();
   const rows = await listReaderGuideDetectionCandidates(options);
   const results: Array<Record<string, unknown>> = [];
+  let lastCompletedId = options.after ?? null;
+  let failed = false;
   for (const row of rows) {
     if (!row.publishedRevisionId) continue;
     try {
@@ -28,10 +30,13 @@ async function main(): Promise<void> {
         ...result,
       });
       console.log(`${row.id}: ${result.proposals.length} proposition(s)`);
+      lastCompletedId = row.id;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       results.push({ measureId: row.id, revisionId: row.publishedRevisionId, error: message });
       console.error(`${row.id}: ${message}`);
+      failed = true;
+      break;
     }
   }
   const reportDir = join(process.cwd(), "scripts", ".local");
@@ -46,7 +51,7 @@ async function main(): Promise<void> {
         mode: options.apply ? "apply" : "dry-run",
         parameters: options,
         processed: results.length,
-        nextAfter: rows.at(-1)?.id ?? null,
+        nextAfter: lastCompletedId,
         mistralTokens: getMistralTokensUsed(),
         results,
       },
@@ -55,8 +60,14 @@ async function main(): Promise<void> {
     )
   );
   console.log(`Rapport : ${reportPath}`);
-  if (rows.length === options.limit && rows.at(-1)) {
-    console.log(`Lot suivant : --after ${rows.at(-1)!.id}`);
+  if (failed) {
+    console.log(
+      lastCompletedId
+        ? `Reprendre après correction : --after ${lastCompletedId}`
+        : "Reprendre après correction sans modifier le curseur"
+    );
+  } else if (rows.length === options.limit && lastCompletedId) {
+    console.log(`Lot suivant : --after ${lastCompletedId}`);
   }
 }
 

--- a/scripts/sync-measure-reader-guides.ts
+++ b/scripts/sync-measure-reader-guides.ts
@@ -1,0 +1,22 @@
+import { MEASURE_READER_GUIDES } from "../src/config/measure-reader-guides";
+import { syncReaderGuideCatalog } from "../src/lib/measures/reader-guides";
+import { parseCLIOptions } from "../src/lib/cli/parse-options";
+
+async function main(): Promise<void> {
+  const parsed = parseCLIOptions(process.argv.slice(2), [{ name: "--apply", type: "boolean" }]);
+  const apply = parsed.apply === true;
+  if (!apply) {
+    console.log(`${MEASURE_READER_GUIDES.length} repère(s) du catalogue à synchroniser.`);
+    console.log("Simulation uniquement. Ajouter --apply pour créer ou actualiser les brouillons.");
+    return;
+  }
+  const result = await syncReaderGuideCatalog("cli:sync-reader-guides");
+  console.log(
+    `${result.created} créé(s), ${result.updated} actualisé(s), ${result.preserved} publié(s) préservé(s).`
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app/admin/mesures/[id]/page.tsx
+++ b/src/app/admin/mesures/[id]/page.tsx
@@ -251,6 +251,7 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
               guideId: mention.guideId,
               guideLabel: mention.guide?.label ?? null,
               guidePublicationStatus: mention.guide?.publicationStatus ?? null,
+              guideActive: mention.guide?.active ?? null,
             }))}
             guides={readerGuides}
           />

--- a/src/app/admin/mesures/[id]/page.tsx
+++ b/src/app/admin/mesures/[id]/page.tsx
@@ -17,12 +17,13 @@ import { AnomalyList } from "../_components/AnomalyList";
 import { MeasureActionPanel } from "../_components/MeasureActionPanel";
 import { MeasureMetadataPanel } from "../_components/MeasureMetadataPanel";
 import { MeasureSubtopicsPanel } from "../_components/MeasureSubtopicsPanel";
+import { MeasureReaderGuidesPanel } from "../_components/MeasureReaderGuidesPanel";
 import { ModerationStateBadge } from "../_components/ModerationStateBadge";
 import { PublicVisibilityCard } from "../_components/PublicVisibilityCard";
 import { RevisionTimeline } from "../_components/RevisionTimeline";
 import { VoteLinkForm } from "../_components/VoteLinkForm";
 import { availableActions, hasAmbiguousPointers } from "../_data/available-actions";
-import { getMeasureContext } from "../_data/detail-query";
+import { getMeasureContext, listReaderGuidesForModeration } from "../_data/detail-query";
 import { getMeasureVoteLinksForModeration } from "../_data/vote-links-query";
 
 export const metadata = {
@@ -74,11 +75,12 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
 
   // Three reads, three different questions: the moderation read applies no filter, the public
   // read applies both, and the context read carries who and which election.
-  const [measure, context, publicMeasure, voteLinks] = await Promise.all([
+  const [measure, context, publicMeasure, voteLinks, readerGuides] = await Promise.all([
     getMeasureForModeration(id),
     getMeasureContext(id),
     getPublicMeasure(id),
     getMeasureVoteLinksForModeration(id),
+    listReaderGuidesForModeration(),
   ]);
 
   if (measure === null || context === null) notFound();
@@ -221,6 +223,36 @@ export default async function AdminMeasureDetailPage({ params }: PageProps) {
               status: assignment.status,
               confidence: assignment.confidence,
             }))}
+          />
+        </div>
+      </section>
+
+      <section aria-labelledby="reader-guides-heading">
+        <h2 id="reader-guides-heading" className="text-base font-semibold">
+          Repères pour comprendre
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            termes techniques proposés par l’IA, définitions rédigées et validées séparément
+          </span>
+        </h2>
+        <div className="mt-3">
+          <MeasureReaderGuidesPanel
+            measureId={id}
+            revisionId={referenceRevisionId}
+            mentions={(
+              measure.revisions.find((revision) => revision.id === referenceRevisionId)
+                ?.readerGuideMentions ?? []
+            ).map((mention) => ({
+              id: mention.id,
+              term: mention.term,
+              evidenceSpan: mention.evidenceSpan,
+              reason: mention.reason,
+              confidence: mention.confidence,
+              status: mention.status,
+              guideId: mention.guideId,
+              guideLabel: mention.guide?.label ?? null,
+              guidePublicationStatus: mention.guide?.publicationStatus ?? null,
+            }))}
+            guides={readerGuides}
           />
         </div>
       </section>

--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -175,6 +175,7 @@ async function everyAction(): Promise<{ name: string; call: () => Promise<unknow
           definition:
             "Un périmètre routier où la circulation des véhicules polluants est restreinte.",
           aliases: ["ZFE"],
+          sourceKind: "OFFICIAL_INSTITUTION",
           sourceUrl: "https://www.ecologie.gouv.fr/zfe",
           sourceLabel: "Zones à faibles émissions",
           sourcePublisher: "Ministère de la Transition écologique",
@@ -282,6 +283,22 @@ describe("actions éditoriales : la session", () => {
     expect(readerGuidesMock.saveReaderGuideDraft).toHaveBeenCalledTimes(1);
     expect(readerGuidesMock.publishReaderGuide).toHaveBeenCalledTimes(1);
     expect(contextGenerationMock.generateMeasureContextDraft).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.proposeReaderGuidesForRevision).toHaveBeenCalledWith("rev-1", "admin", {
+      ipAddress: "203.0.113.8",
+      userAgent: "vitest-agent",
+    });
+    expect(readerGuidesMock.reviewReaderGuideMention).toHaveBeenCalledWith(
+      expect.objectContaining({ ipAddress: "203.0.113.8", userAgent: "vitest-agent" })
+    );
+    expect(readerGuidesMock.saveReaderGuideDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceKind: "OFFICIAL_INSTITUTION" }),
+      "admin",
+      { ipAddress: "203.0.113.8", userAgent: "vitest-agent" }
+    );
+    expect(readerGuidesMock.publishReaderGuide).toHaveBeenCalledWith("guide-1", "admin", {
+      ipAddress: "203.0.113.8",
+      userAgent: "vitest-agent",
+    });
   });
 });
 

--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -67,6 +67,14 @@ const subtopicsMock = {
 };
 vi.mock("@/lib/measures/subtopics", () => subtopicsMock);
 
+const readerGuidesMock = {
+  proposeReaderGuidesForRevision: vi.fn(async () => ({ created: 0, proposals: [] })),
+  reviewReaderGuideMention: vi.fn(async () => undefined),
+  saveReaderGuideDraft: vi.fn(async () => "guide-1"),
+  publishReaderGuide: vi.fn(async () => undefined),
+};
+vi.mock("@/lib/measures/reader-guides", () => readerGuidesMock);
+
 const contextGenerationMock = {
   generateMeasureContextDraft: vi.fn(async () => ({
     status: "CREATED" as const,
@@ -145,6 +153,38 @@ async function everyAction(): Promise<{ name: string; call: () => Promise<unknow
         }),
     },
     {
+      name: "proposeReaderGuidesAction",
+      call: () => a.proposeReaderGuidesAction({ measureId: "m-1", revisionId: "rev-1" }),
+    },
+    {
+      name: "reviewReaderGuideMentionAction",
+      call: () =>
+        a.reviewReaderGuideMentionAction({
+          measureId: "m-1",
+          mentionId: "mention-1",
+          guideId: "guide-1",
+          status: "APPROVED",
+        }),
+    },
+    {
+      name: "saveReaderGuideDraftAction",
+      call: () =>
+        a.saveReaderGuideDraftAction({
+          slug: "zones-faibles-emissions",
+          label: "Zone à faibles émissions",
+          definition:
+            "Un périmètre routier où la circulation des véhicules polluants est restreinte.",
+          aliases: ["ZFE"],
+          sourceUrl: "https://www.ecologie.gouv.fr/zfe",
+          sourceLabel: "Zones à faibles émissions",
+          sourcePublisher: "Ministère de la Transition écologique",
+        }),
+    },
+    {
+      name: "publishReaderGuideAction",
+      call: () => a.publishReaderGuideAction({ guideId: "guide-1" }),
+    },
+    {
       name: "generateContextDraftAction",
       call: () =>
         a.generateContextDraftAction({
@@ -215,6 +255,10 @@ describe("actions éditoriales : la session", () => {
     }
     expect(subtopicsMock.proposeMeasureRevisionSubtopics).not.toHaveBeenCalled();
     expect(subtopicsMock.reviewMeasureRevisionSubtopic).not.toHaveBeenCalled();
+    expect(readerGuidesMock.proposeReaderGuidesForRevision).not.toHaveBeenCalled();
+    expect(readerGuidesMock.reviewReaderGuideMention).not.toHaveBeenCalled();
+    expect(readerGuidesMock.saveReaderGuideDraft).not.toHaveBeenCalled();
+    expect(readerGuidesMock.publishReaderGuide).not.toHaveBeenCalled();
     expect(contextGenerationMock.generateMeasureContextDraft).not.toHaveBeenCalled();
     expect(revalidatePathMock).not.toHaveBeenCalled();
   });
@@ -233,6 +277,10 @@ describe("actions éditoriales : la session", () => {
     }
     expect(subtopicsMock.proposeMeasureRevisionSubtopics).toHaveBeenCalledTimes(1);
     expect(subtopicsMock.reviewMeasureRevisionSubtopic).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.proposeReaderGuidesForRevision).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.reviewReaderGuideMention).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.saveReaderGuideDraft).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.publishReaderGuide).toHaveBeenCalledTimes(1);
     expect(contextGenerationMock.generateMeasureContextDraft).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/admin/mesures/__tests__/actions.test.ts
+++ b/src/app/admin/mesures/__tests__/actions.test.ts
@@ -72,6 +72,7 @@ const readerGuidesMock = {
   reviewReaderGuideMention: vi.fn(async () => undefined),
   saveReaderGuideDraft: vi.fn(async () => "guide-1"),
   publishReaderGuide: vi.fn(async () => undefined),
+  deactivateReaderGuide: vi.fn(async () => 1),
 };
 vi.mock("@/lib/measures/reader-guides", () => readerGuidesMock);
 
@@ -186,6 +187,10 @@ async function everyAction(): Promise<{ name: string; call: () => Promise<unknow
       call: () => a.publishReaderGuideAction({ guideId: "guide-1" }),
     },
     {
+      name: "deactivateReaderGuideAction",
+      call: () => a.deactivateReaderGuideAction({ guideId: "guide-1" }),
+    },
+    {
       name: "generateContextDraftAction",
       call: () =>
         a.generateContextDraftAction({
@@ -260,6 +265,7 @@ describe("actions éditoriales : la session", () => {
     expect(readerGuidesMock.reviewReaderGuideMention).not.toHaveBeenCalled();
     expect(readerGuidesMock.saveReaderGuideDraft).not.toHaveBeenCalled();
     expect(readerGuidesMock.publishReaderGuide).not.toHaveBeenCalled();
+    expect(readerGuidesMock.deactivateReaderGuide).not.toHaveBeenCalled();
     expect(contextGenerationMock.generateMeasureContextDraft).not.toHaveBeenCalled();
     expect(revalidatePathMock).not.toHaveBeenCalled();
   });
@@ -282,6 +288,7 @@ describe("actions éditoriales : la session", () => {
     expect(readerGuidesMock.reviewReaderGuideMention).toHaveBeenCalledTimes(1);
     expect(readerGuidesMock.saveReaderGuideDraft).toHaveBeenCalledTimes(1);
     expect(readerGuidesMock.publishReaderGuide).toHaveBeenCalledTimes(1);
+    expect(readerGuidesMock.deactivateReaderGuide).toHaveBeenCalledTimes(1);
     expect(contextGenerationMock.generateMeasureContextDraft).toHaveBeenCalledTimes(1);
     expect(readerGuidesMock.proposeReaderGuidesForRevision).toHaveBeenCalledWith("rev-1", "admin", {
       ipAddress: "203.0.113.8",
@@ -296,6 +303,10 @@ describe("actions éditoriales : la session", () => {
       { ipAddress: "203.0.113.8", userAgent: "vitest-agent" }
     );
     expect(readerGuidesMock.publishReaderGuide).toHaveBeenCalledWith("guide-1", "admin", {
+      ipAddress: "203.0.113.8",
+      userAgent: "vitest-agent",
+    });
+    expect(readerGuidesMock.deactivateReaderGuide).toHaveBeenCalledWith("guide-1", "admin", {
       ipAddress: "203.0.113.8",
       userAgent: "vitest-agent",
     });

--- a/src/app/admin/mesures/_components/MeasureReaderGuidesPanel.tsx
+++ b/src/app/admin/mesures/_components/MeasureReaderGuidesPanel.tsx
@@ -21,6 +21,7 @@ type Mention = {
   guideId: string | null;
   guideLabel: string | null;
   guidePublicationStatus: PublicationStatus | null;
+  guideActive: boolean | null;
 };
 
 type GuideOption = { id: string; label: string; publicationStatus: PublicationStatus };
@@ -93,8 +94,10 @@ export function MeasureReaderGuidesPanel({
           <h3 className="text-sm font-bold">Propositions à examiner</h3>
           <ul className="mt-2 space-y-3">
             {suggested.map((mention) => {
-              const guideId = selected[mention.id] ?? mention.guideId ?? "";
-              const matchedPublished = mention.guidePublicationStatus === "PUBLISHED";
+              const matchedPublished =
+                mention.guidePublicationStatus === "PUBLISHED" && mention.guideActive === true;
+              const guideId =
+                selected[mention.id] ?? (matchedPublished ? (mention.guideId ?? "") : "");
               return (
                 <li key={mention.id} className="rounded border border-border p-3">
                   <p className="font-bold">{mention.term}</p>
@@ -129,6 +132,12 @@ export function MeasureReaderGuidesPanel({
                       Le repère correspondant doit d’abord être publié.
                     </p>
                   )}
+                  {mention.guidePublicationStatus === "PUBLISHED" &&
+                    mention.guideActive === false && (
+                      <p className="mt-2 text-sm text-amber-700">
+                        Le repère correspondant a été désactivé. Choisissez un repère actif.
+                      </p>
+                    )}
                   <div className="mt-3 flex flex-wrap gap-2">
                     <Button
                       disabled={pending || !guideId || (!matchedPublished && !selected[mention.id])}

--- a/src/app/admin/mesures/_components/MeasureReaderGuidesPanel.tsx
+++ b/src/app/admin/mesures/_components/MeasureReaderGuidesPanel.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import type { MeasureReaderGuideMentionStatus, PublicationStatus } from "@/generated/prisma";
+import {
+  proposeReaderGuidesAction,
+  reviewReaderGuideMentionAction,
+  type ActionResult,
+} from "../actions";
+
+type Mention = {
+  id: string;
+  term: string;
+  evidenceSpan: string;
+  reason: string;
+  confidence: number;
+  status: MeasureReaderGuideMentionStatus;
+  guideId: string | null;
+  guideLabel: string | null;
+  guidePublicationStatus: PublicationStatus | null;
+};
+
+type GuideOption = { id: string; label: string; publicationStatus: PublicationStatus };
+
+export function MeasureReaderGuidesPanel({
+  measureId,
+  revisionId,
+  mentions,
+  guides,
+}: {
+  measureId: string;
+  revisionId: string | null;
+  mentions: Mention[];
+  guides: GuideOption[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [failure, setFailure] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Record<string, string>>({});
+
+  function run(action: () => Promise<ActionResult>): void {
+    setFailure(null);
+    startTransition(async () => {
+      const result = await action();
+      if (!result.ok) return setFailure(result.message);
+      router.refresh();
+    });
+  }
+
+  if (!revisionId)
+    return <p className="text-sm text-muted-foreground">Aucune révision à analyser.</p>;
+  const suggested = mentions.filter((mention) => mention.status === "SUGGESTED");
+  const approved = mentions.filter((mention) => mention.status === "APPROVED");
+  const publishedGuides = guides.filter((guide) => guide.publicationStatus === "PUBLISHED");
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border p-4">
+      <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+        L’IA repère les termes potentiellement techniques. Elle ne rédige aucune définition et ne
+        publie aucun rattachement.
+      </p>
+      <Link
+        href="/admin/mesures/reperes"
+        className="inline-flex min-h-11 items-center text-sm font-bold text-primary underline"
+      >
+        Gérer le référentiel des repères
+      </Link>
+      {failure && (
+        <p
+          role="alert"
+          className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800"
+        >
+          {failure}
+        </p>
+      )}
+      {approved.length > 0 && (
+        <div>
+          <h3 className="text-sm font-bold">Repères validés</h3>
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {approved.map((mention) => (
+              <li key={mention.id} className="rounded-full bg-primary/10 px-3 py-1 text-sm">
+                {mention.guideLabel ?? mention.term}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {suggested.length > 0 ? (
+        <div>
+          <h3 className="text-sm font-bold">Propositions à examiner</h3>
+          <ul className="mt-2 space-y-3">
+            {suggested.map((mention) => {
+              const guideId = selected[mention.id] ?? mention.guideId ?? "";
+              const matchedPublished = mention.guidePublicationStatus === "PUBLISHED";
+              return (
+                <li key={mention.id} className="rounded border border-border p-3">
+                  <p className="font-bold">{mention.term}</p>
+                  <p className="mt-1 text-sm">Extrait : « {mention.evidenceSpan} »</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {mention.reason} · confiance {Math.round(mention.confidence * 100)} %
+                  </p>
+                  {!matchedPublished && (
+                    <label className="mt-3 block text-sm font-medium">
+                      Repère publié
+                      <select
+                        value={guideId}
+                        onChange={(event) =>
+                          setSelected((current) => ({
+                            ...current,
+                            [mention.id]: event.target.value,
+                          }))
+                        }
+                        className="mt-1 min-h-11 w-full rounded border border-border bg-background px-3 sm:max-w-md"
+                      >
+                        <option value="">Choisir un repère</option>
+                        {publishedGuides.map((guide) => (
+                          <option key={guide.id} value={guide.id}>
+                            {guide.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  {mention.guidePublicationStatus === "DRAFT" && (
+                    <p className="mt-2 text-sm text-amber-700">
+                      Le repère correspondant doit d’abord être publié.
+                    </p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      disabled={pending || !guideId || (!matchedPublished && !selected[mention.id])}
+                      className="min-h-11"
+                      onClick={() =>
+                        run(() =>
+                          reviewReaderGuideMentionAction({
+                            measureId,
+                            mentionId: mention.id,
+                            guideId,
+                            status: "APPROVED",
+                          })
+                        )
+                      }
+                    >
+                      Valider
+                    </Button>
+                    <Button
+                      variant="outline"
+                      disabled={pending}
+                      className="min-h-11"
+                      onClick={() =>
+                        run(() =>
+                          reviewReaderGuideMentionAction({
+                            measureId,
+                            mentionId: mention.id,
+                            status: "REJECTED",
+                          })
+                        )
+                      }
+                    >
+                      Refuser
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">Aucune proposition en attente.</p>
+      )}
+      <Button
+        variant="outline"
+        disabled={pending}
+        className="min-h-11"
+        onClick={() => run(() => proposeReaderGuidesAction({ measureId, revisionId }))}
+      >
+        {pending ? "Analyse en cours…" : "Repérer les termes à expliquer"}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
+++ b/src/app/admin/mesures/_components/PublicVisibilityCard.tsx
@@ -62,6 +62,20 @@ export function PublicVisibilityCard({
             </div>
           )}
 
+          {publicMeasure.readerGuides.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium">Repères publiés</h3>
+              <ul className="mt-2 space-y-2">
+                {publicMeasure.readerGuides.map((guide) => (
+                  <li key={guide.slug} className="rounded border border-border p-3 text-sm">
+                    <p className="font-bold">{guide.label}</p>
+                    <p className="mt-1 leading-relaxed">{guide.definition}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {publicMeasure.withdrawal !== null && (
             <div className="rounded border border-border bg-muted/40 p-3 text-sm">
               <p className="font-medium">

--- a/src/app/admin/mesures/_components/RevisionTimeline.tsx
+++ b/src/app/admin/mesures/_components/RevisionTimeline.tsx
@@ -71,6 +71,9 @@ function RevisionCard({
           </span>
         )}
       </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Identifiant de révision : <code className="select-all font-mono">{revision.id}</code>
+      </p>
 
       {revision.reviewReadiness !== null && (
         <div className="mt-3">

--- a/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
+++ b/src/app/admin/mesures/_components/__tests__/PublicVisibilityCard.test.tsx
@@ -49,6 +49,7 @@ function publicMeasure(over: Partial<PublicMeasure> = {}): PublicMeasure {
     ],
     qualifications: [],
     subtopics: [],
+    readerGuides: [],
     ...over,
   };
 }

--- a/src/app/admin/mesures/_data/detail-query.ts
+++ b/src/app/admin/mesures/_data/detail-query.ts
@@ -25,3 +25,16 @@ export async function getMeasureContext(measureId: string) {
 }
 
 export type MeasureContext = NonNullable<Awaited<ReturnType<typeof getMeasureContext>>>;
+
+export async function listReaderGuidesForModeration() {
+  return db.measureReaderGuide.findMany({
+    where: { active: true },
+    orderBy: [{ publicationStatus: "asc" }, { label: "asc" }],
+    select: {
+      id: true,
+      slug: true,
+      label: true,
+      publicationStatus: true,
+    },
+  });
+}

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -40,6 +40,7 @@ import {
   reviewMeasureRevisionSubtopic,
 } from "@/lib/measures/subtopics";
 import {
+  deactivateReaderGuide,
   proposeReaderGuidesForRevision,
   publishReaderGuide,
   reviewReaderGuideMention,
@@ -488,6 +489,23 @@ export async function publishReaderGuideAction(input: unknown): Promise<ActionRe
     if (!parsed.success) throw new MeasureValidationError("Repère invalide");
     const requestMetadata = await getAuditRequestMetadata();
     await publishReaderGuide(parsed.data.guideId, ACTOR, requestMetadata);
+    revalidatePath("/admin/mesures/reperes");
+    return { ok: true };
+  } catch (error) {
+    return toFailure(error);
+  }
+}
+
+export async function deactivateReaderGuideAction(input: unknown): Promise<ActionResult> {
+  await assertAuthenticated();
+  try {
+    const parsed = z
+      .object({ guideId: z.string().min(1) })
+      .strict()
+      .safeParse(input);
+    if (!parsed.success) throw new MeasureValidationError("Repère invalide");
+    const requestMetadata = await getAuditRequestMetadata();
+    await deactivateReaderGuide(parsed.data.guideId, ACTOR, requestMetadata);
     revalidatePath("/admin/mesures/reperes");
     return { ok: true };
   } catch (error) {

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -172,9 +172,11 @@ const readerGuideDraftInputSchema = z
     label: z.string().min(3).max(160),
     definition: z.string().min(40).max(2_000),
     aliases: z.array(z.string().max(160)).max(30),
+    sourceKind: z.enum(["OFFICIAL_INSTITUTION", "PROGRAM_SOURCE"]),
     sourceUrl: z.string().url().max(2_000),
     sourceLabel: z.string().min(3).max(300),
     sourcePublisher: z.string().min(3).max(200),
+    sourceRevisionId: z.string().min(1).nullable().optional(),
   })
   .strict();
 
@@ -432,7 +434,8 @@ export async function proposeReaderGuidesAction(input: unknown): Promise<ActionR
   try {
     const parsed = readerGuideProposalInputSchema.safeParse(input);
     if (!parsed.success) throw new MeasureValidationError("Révision à analyser invalide");
-    await proposeReaderGuidesForRevision(parsed.data.revisionId, ACTOR);
+    const requestMetadata = await getAuditRequestMetadata();
+    await proposeReaderGuidesForRevision(parsed.data.revisionId, ACTOR, requestMetadata);
     revalidate(parsed.data.measureId);
     return { ok: true };
   } catch (error) {
@@ -446,11 +449,13 @@ export async function reviewReaderGuideMentionAction(input: unknown): Promise<Ac
   try {
     const parsed = readerGuideReviewInputSchema.safeParse(input);
     if (!parsed.success) throw new MeasureValidationError("Proposition de repère invalide");
+    const requestMetadata = await getAuditRequestMetadata();
     await reviewReaderGuideMention({
       mentionId: parsed.data.mentionId,
       guideId: parsed.data.guideId,
       status: parsed.data.status,
       reviewedBy: ACTOR,
+      ...requestMetadata,
     });
     revalidate(parsed.data.measureId);
     return { ok: true };
@@ -464,10 +469,8 @@ export async function saveReaderGuideDraftAction(input: unknown): Promise<Action
   try {
     const parsed = readerGuideDraftInputSchema.safeParse(input);
     if (!parsed.success) throw new MeasureValidationError("Le brouillon de repère est invalide");
-    const id = await saveReaderGuideDraft(
-      { ...parsed.data, sourceKind: "OFFICIAL_INSTITUTION" },
-      ACTOR
-    );
+    const requestMetadata = await getAuditRequestMetadata();
+    const id = await saveReaderGuideDraft(parsed.data, ACTOR, requestMetadata);
     revalidatePath("/admin/mesures/reperes");
     return { ok: true, measureId: id };
   } catch (error) {
@@ -483,7 +486,8 @@ export async function publishReaderGuideAction(input: unknown): Promise<ActionRe
       .strict()
       .safeParse(input);
     if (!parsed.success) throw new MeasureValidationError("Repère invalide");
-    await publishReaderGuide(parsed.data.guideId, ACTOR);
+    const requestMetadata = await getAuditRequestMetadata();
+    await publishReaderGuide(parsed.data.guideId, ACTOR, requestMetadata);
     revalidatePath("/admin/mesures/reperes");
     return { ok: true };
   } catch (error) {

--- a/src/app/admin/mesures/actions.ts
+++ b/src/app/admin/mesures/actions.ts
@@ -40,6 +40,12 @@ import {
   reviewMeasureRevisionSubtopic,
 } from "@/lib/measures/subtopics";
 import {
+  proposeReaderGuidesForRevision,
+  publishReaderGuide,
+  reviewReaderGuideMention,
+  saveReaderGuideDraft,
+} from "@/lib/measures/reader-guides";
+import {
   createMeasure,
   depublishMeasure,
   discardMeasureRevision,
@@ -144,6 +150,32 @@ const contextGenerationInputSchema = z
 
 const contextGenerationBatchInputSchema = z
   .object({ measureIds: z.array(z.string().min(1)).min(1).max(10) })
+  .strict();
+
+const readerGuideProposalInputSchema = z
+  .object({ measureId: z.string().min(1), revisionId: z.string().min(1) })
+  .strict();
+
+const readerGuideReviewInputSchema = z
+  .object({
+    measureId: z.string().min(1),
+    mentionId: z.string().min(1),
+    guideId: z.string().min(1).optional(),
+    status: z.enum(["APPROVED", "REJECTED"]),
+  })
+  .strict();
+
+const readerGuideDraftInputSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    slug: z.string().min(1).max(120),
+    label: z.string().min(3).max(160),
+    definition: z.string().min(40).max(2_000),
+    aliases: z.array(z.string().max(160)).max(30),
+    sourceUrl: z.string().url().max(2_000),
+    sourceLabel: z.string().min(3).max(300),
+    sourcePublisher: z.string().min(3).max(200),
+  })
   .strict();
 
 async function assertAuthenticated(): Promise<void> {
@@ -389,6 +421,70 @@ export async function reviewSubtopicAction(input: {
       reviewedBy: ACTOR,
     });
     revalidate(parsed.data.measureId);
+    return { ok: true };
+  } catch (error) {
+    return toFailure(error);
+  }
+}
+
+export async function proposeReaderGuidesAction(input: unknown): Promise<ActionResult> {
+  await assertAuthenticated();
+  try {
+    const parsed = readerGuideProposalInputSchema.safeParse(input);
+    if (!parsed.success) throw new MeasureValidationError("Révision à analyser invalide");
+    await proposeReaderGuidesForRevision(parsed.data.revisionId, ACTOR);
+    revalidate(parsed.data.measureId);
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof MeasureValidationError) return toFailure(error);
+    return { ok: false, message: "L’analyse automatique a échoué. Réessayez plus tard." };
+  }
+}
+
+export async function reviewReaderGuideMentionAction(input: unknown): Promise<ActionResult> {
+  await assertAuthenticated();
+  try {
+    const parsed = readerGuideReviewInputSchema.safeParse(input);
+    if (!parsed.success) throw new MeasureValidationError("Proposition de repère invalide");
+    await reviewReaderGuideMention({
+      mentionId: parsed.data.mentionId,
+      guideId: parsed.data.guideId,
+      status: parsed.data.status,
+      reviewedBy: ACTOR,
+    });
+    revalidate(parsed.data.measureId);
+    return { ok: true };
+  } catch (error) {
+    return toFailure(error);
+  }
+}
+
+export async function saveReaderGuideDraftAction(input: unknown): Promise<ActionResult> {
+  await assertAuthenticated();
+  try {
+    const parsed = readerGuideDraftInputSchema.safeParse(input);
+    if (!parsed.success) throw new MeasureValidationError("Le brouillon de repère est invalide");
+    const id = await saveReaderGuideDraft(
+      { ...parsed.data, sourceKind: "OFFICIAL_INSTITUTION" },
+      ACTOR
+    );
+    revalidatePath("/admin/mesures/reperes");
+    return { ok: true, measureId: id };
+  } catch (error) {
+    return toFailure(error);
+  }
+}
+
+export async function publishReaderGuideAction(input: unknown): Promise<ActionResult> {
+  await assertAuthenticated();
+  try {
+    const parsed = z
+      .object({ guideId: z.string().min(1) })
+      .strict()
+      .safeParse(input);
+    if (!parsed.success) throw new MeasureValidationError("Repère invalide");
+    await publishReaderGuide(parsed.data.guideId, ACTOR);
+    revalidatePath("/admin/mesures/reperes");
     return { ok: true };
   } catch (error) {
     return toFailure(error);

--- a/src/app/admin/mesures/page.tsx
+++ b/src/app/admin/mesures/page.tsx
@@ -160,13 +160,22 @@ export default async function AdminMeasuresPage({ searchParams }: PageProps) {
             . Ordre : de la plus anciennement saisie à la plus récente.
           </p>
         </div>
-        <Link
-          href="/admin/mesures/nouvelle"
-          prefetch={false}
-          className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
-        >
-          Nouvelle mesure
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/admin/mesures/reperes"
+            prefetch={false}
+            className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Repères pour comprendre
+          </Link>
+          <Link
+            href="/admin/mesures/nouvelle"
+            prefetch={false}
+            className="inline-flex min-h-11 items-center rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Nouvelle mesure
+          </Link>
+        </div>
       </header>
 
       {result.scanCapped && (

--- a/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
+++ b/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import type { PublicationStatus } from "@/generated/prisma";
+import {
+  publishReaderGuideAction,
+  saveReaderGuideDraftAction,
+  type ActionResult,
+} from "../actions";
+
+type Guide = {
+  id: string;
+  slug: string;
+  label: string;
+  definition: string;
+  aliases: string[];
+  sourceUrl: string;
+  sourceLabel: string;
+  sourcePublisher: string;
+  publicationStatus: PublicationStatus;
+};
+
+const EMPTY = {
+  slug: "",
+  label: "",
+  definition: "",
+  aliases: "",
+  sourceUrl: "",
+  sourceLabel: "",
+  sourcePublisher: "",
+};
+
+export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [editingId, setEditingId] = useState<string | undefined>();
+  const [form, setForm] = useState(EMPTY);
+  const [message, setMessage] = useState<string | null>(null);
+
+  function run(action: () => Promise<ActionResult>, success: string): void {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await action();
+      if (!result.ok) return setMessage(result.message);
+      setMessage(success);
+      setEditingId(undefined);
+      setForm(EMPTY);
+      router.refresh();
+    });
+  }
+
+  function edit(guide: Guide): void {
+    setEditingId(guide.id);
+    setForm({
+      slug: guide.slug,
+      label: guide.label,
+      definition: guide.definition,
+      aliases: guide.aliases.join("\n"),
+      sourceUrl: guide.sourceUrl,
+      sourceLabel: guide.sourceLabel,
+      sourcePublisher: guide.sourcePublisher,
+    });
+    document.getElementById("reader-guide-form")?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  return (
+    <div className="space-y-6">
+      {message && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="rounded border border-border bg-muted/40 p-3 text-sm"
+        >
+          {message}
+        </p>
+      )}
+      <section aria-labelledby="reader-guide-list-title">
+        <h2 id="reader-guide-list-title" className="text-lg font-bold">
+          Référentiel
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {guides.map((guide) => (
+            <li key={guide.id} className="rounded-lg border border-border p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="max-w-3xl">
+                  <p className="font-bold">{guide.label}</p>
+                  <p className="mt-1 text-sm leading-relaxed">{guide.definition}</p>
+                  <a
+                    href={guide.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex min-h-11 items-center text-sm font-bold text-primary underline"
+                  >
+                    {guide.sourcePublisher}
+                  </a>
+                  <p className="text-xs text-muted-foreground">
+                    Statut : {guide.publicationStatus === "PUBLISHED" ? "publié" : "brouillon"}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {guide.publicationStatus === "DRAFT" && (
+                    <>
+                      <Button
+                        variant="outline"
+                        className="min-h-11"
+                        disabled={pending}
+                        onClick={() => edit(guide)}
+                      >
+                        Modifier
+                      </Button>
+                      <Button
+                        className="min-h-11"
+                        disabled={pending}
+                        onClick={() =>
+                          run(
+                            () => publishReaderGuideAction({ guideId: guide.id }),
+                            "Repère publié."
+                          )
+                        }
+                      >
+                        Publier
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        id="reader-guide-form"
+        aria-labelledby="reader-guide-form-title"
+        className="rounded-lg border border-border p-4"
+      >
+        <h2 id="reader-guide-form-title" className="text-lg font-bold">
+          {editingId ? "Modifier le brouillon" : "Nouveau repère"}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          La source doit être une page institutionnelle officielle. La publication reste une action
+          distincte.
+        </p>
+        <form
+          className="mt-4 grid gap-4 sm:grid-cols-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            run(
+              () =>
+                saveReaderGuideDraftAction({
+                  ...(editingId ? { id: editingId } : {}),
+                  ...form,
+                  aliases: form.aliases
+                    .split("\n")
+                    .map((alias) => alias.trim())
+                    .filter(Boolean),
+                }),
+              "Brouillon enregistré."
+            );
+          }}
+        >
+          {(["slug", "label", "sourcePublisher", "sourceLabel", "sourceUrl"] as const).map(
+            (name) => (
+              <label key={name} className={name === "sourceUrl" ? "sm:col-span-2" : ""}>
+                <span className="text-sm font-medium">
+                  {
+                    {
+                      slug: "Slug",
+                      label: "Libellé",
+                      sourcePublisher: "Institution",
+                      sourceLabel: "Titre de la source",
+                      sourceUrl: "URL de la source",
+                    }[name]
+                  }
+                </span>
+                <input
+                  required
+                  value={form[name]}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, [name]: event.target.value }))
+                  }
+                  className="mt-1 min-h-11 w-full rounded border border-border bg-background px-3"
+                  type={name === "sourceUrl" ? "url" : "text"}
+                />
+              </label>
+            )
+          )}
+          <label className="sm:col-span-2">
+            <span className="text-sm font-medium">Définition factuelle</span>
+            <textarea
+              required
+              rows={5}
+              value={form.definition}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, definition: event.target.value }))
+              }
+              className="mt-1 w-full rounded border border-border bg-background p-3"
+            />
+          </label>
+          <label className="sm:col-span-2">
+            <span className="text-sm font-medium">Alias, un par ligne</span>
+            <textarea
+              rows={4}
+              value={form.aliases}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, aliases: event.target.value }))
+              }
+              className="mt-1 w-full rounded border border-border bg-background p-3"
+            />
+          </label>
+          <div className="flex flex-wrap gap-2 sm:col-span-2">
+            <Button type="submit" className="min-h-11" disabled={pending}>
+              {pending ? "Enregistrement…" : "Enregistrer le brouillon"}
+            </Button>
+            {editingId && (
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-11"
+                onClick={() => {
+                  setEditingId(undefined);
+                  setForm(EMPTY);
+                }}
+              >
+                Annuler
+              </Button>
+            )}
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
+++ b/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import type { MeasureReaderGuideSourceKind, PublicationStatus } from "@/generated/prisma";
 import {
+  deactivateReaderGuideAction,
   publishReaderGuideAction,
   saveReaderGuideDraftAction,
   type ActionResult,
@@ -16,6 +17,7 @@ type Guide = {
   label: string;
   definition: string;
   aliases: string[];
+  active: boolean;
   sourceKind: MeasureReaderGuideSourceKind;
   sourceUrl: string;
   sourceLabel: string;
@@ -102,7 +104,12 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
                     {guide.sourcePublisher}
                   </a>
                   <p className="text-xs text-muted-foreground">
-                    Statut : {guide.publicationStatus === "PUBLISHED" ? "publié" : "brouillon"}
+                    Statut :{" "}
+                    {guide.publicationStatus === "DRAFT"
+                      ? "brouillon"
+                      : guide.active
+                        ? "publié"
+                        : "désactivé"}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -129,6 +136,27 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
                         Publier
                       </Button>
                     </>
+                  )}
+                  {guide.publicationStatus === "PUBLISHED" && guide.active && (
+                    <Button
+                      variant="outline"
+                      className="min-h-11 text-destructive"
+                      disabled={pending}
+                      onClick={() => {
+                        if (
+                          !window.confirm(
+                            "Désactiver ce repère ? Il disparaîtra immédiatement de toutes les mesures publiques."
+                          )
+                        )
+                          return;
+                        run(
+                          () => deactivateReaderGuideAction({ guideId: guide.id }),
+                          "Repère désactivé."
+                        );
+                      }}
+                    >
+                      Désactiver
+                    </Button>
                   )}
                 </div>
               </div>
@@ -205,7 +233,8 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
                 id="reader-guide-source-revision-help"
                 className="mt-1 block text-xs text-muted-foreground"
               >
-                Identifiant visible dans l’URL de la révision depuis la fiche d’administration.
+                Identifiant affiché dans l’historique des révisions sur la fiche d’administration de
+                la mesure.
               </span>
             </label>
           )}

--- a/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
+++ b/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import type { PublicationStatus } from "@/generated/prisma";
+import type { MeasureReaderGuideSourceKind, PublicationStatus } from "@/generated/prisma";
 import {
   publishReaderGuideAction,
   saveReaderGuideDraftAction,
@@ -16,9 +16,11 @@ type Guide = {
   label: string;
   definition: string;
   aliases: string[];
+  sourceKind: MeasureReaderGuideSourceKind;
   sourceUrl: string;
   sourceLabel: string;
   sourcePublisher: string;
+  sourceRevisionId: string | null;
   publicationStatus: PublicationStatus;
 };
 
@@ -27,9 +29,11 @@ const EMPTY = {
   label: "",
   definition: "",
   aliases: "",
+  sourceKind: "OFFICIAL_INSTITUTION" as MeasureReaderGuideSourceKind,
   sourceUrl: "",
   sourceLabel: "",
   sourcePublisher: "",
+  sourceRevisionId: "",
 };
 
 export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
@@ -58,9 +62,11 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
       label: guide.label,
       definition: guide.definition,
       aliases: guide.aliases.join("\n"),
+      sourceKind: guide.sourceKind,
       sourceUrl: guide.sourceUrl,
       sourceLabel: guide.sourceLabel,
       sourcePublisher: guide.sourcePublisher,
+      sourceRevisionId: guide.sourceRevisionId ?? "",
     });
     document.getElementById("reader-guide-form")?.scrollIntoView({ behavior: "smooth" });
   }
@@ -140,8 +146,8 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
           {editingId ? "Modifier le brouillon" : "Nouveau repère"}
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          La source doit être une page institutionnelle officielle. La publication reste une action
-          distincte.
+          La source doit être une page institutionnelle officielle ou une source déjà rattachée à
+          une révision de mesure. La publication reste une action distincte.
         </p>
         <form
           className="mt-4 grid gap-4 sm:grid-cols-2"
@@ -152,6 +158,8 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
                 saveReaderGuideDraftAction({
                   ...(editingId ? { id: editingId } : {}),
                   ...form,
+                  sourceRevisionId:
+                    form.sourceKind === "PROGRAM_SOURCE" ? form.sourceRevisionId : null,
                   aliases: form.aliases
                     .split("\n")
                     .map((alias) => alias.trim())
@@ -161,6 +169,46 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
             );
           }}
         >
+          <label>
+            <span className="text-sm font-medium">Nature de la source</span>
+            <select
+              value={form.sourceKind}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  sourceKind: event.target.value as MeasureReaderGuideSourceKind,
+                }))
+              }
+              className="mt-1 min-h-11 w-full rounded border border-border bg-background px-3"
+            >
+              <option value="OFFICIAL_INSTITUTION">Institution officielle</option>
+              <option value="PROGRAM_SOURCE">Source du programme</option>
+            </select>
+          </label>
+          {form.sourceKind === "PROGRAM_SOURCE" && (
+            <label>
+              <span className="text-sm font-medium">Identifiant de la révision source</span>
+              <input
+                required
+                value={form.sourceRevisionId}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    sourceRevisionId: event.target.value,
+                  }))
+                }
+                className="mt-1 min-h-11 w-full rounded border border-border bg-background px-3"
+                type="text"
+                aria-describedby="reader-guide-source-revision-help"
+              />
+              <span
+                id="reader-guide-source-revision-help"
+                className="mt-1 block text-xs text-muted-foreground"
+              >
+                Identifiant visible dans l’URL de la révision depuis la fiche d’administration.
+              </span>
+            </label>
+          )}
           {(["slug", "label", "sourcePublisher", "sourceLabel", "sourceUrl"] as const).map(
             (name) => (
               <label key={name} className={name === "sourceUrl" ? "sm:col-span-2" : ""}>
@@ -169,7 +217,7 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
                     {
                       slug: "Slug",
                       label: "Libellé",
-                      sourcePublisher: "Institution",
+                      sourcePublisher: "Éditeur de la source",
                       sourceLabel: "Titre de la source",
                       sourceUrl: "URL de la source",
                     }[name]

--- a/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
+++ b/src/app/admin/mesures/reperes/ReaderGuideAdmin.tsx
@@ -70,7 +70,10 @@ export function ReaderGuideAdmin({ guides }: { guides: Guide[] }) {
       sourcePublisher: guide.sourcePublisher,
       sourceRevisionId: guide.sourceRevisionId ?? "",
     });
-    document.getElementById("reader-guide-form")?.scrollIntoView({ behavior: "smooth" });
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    document
+      .getElementById("reader-guide-form")
+      ?.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth" });
   }
 
   return (

--- a/src/app/admin/mesures/reperes/page.tsx
+++ b/src/app/admin/mesures/reperes/page.tsx
@@ -19,6 +19,7 @@ export default async function ReaderGuidesAdminPage() {
       label: true,
       definition: true,
       aliases: true,
+      active: true,
       sourceKind: true,
       sourceUrl: true,
       sourceLabel: true,

--- a/src/app/admin/mesures/reperes/page.tsx
+++ b/src/app/admin/mesures/reperes/page.tsx
@@ -19,9 +19,11 @@ export default async function ReaderGuidesAdminPage() {
       label: true,
       definition: true,
       aliases: true,
+      sourceKind: true,
       sourceUrl: true,
       sourceLabel: true,
       sourcePublisher: true,
+      sourceRevisionId: true,
       publicationStatus: true,
     },
   });

--- a/src/app/admin/mesures/reperes/page.tsx
+++ b/src/app/admin/mesures/reperes/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { isAuthenticated } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { ReaderGuideAdmin } from "./ReaderGuideAdmin";
+
+export const metadata = {
+  title: "Repères des mesures (admin) | Poligraph",
+  robots: { index: false },
+};
+
+export default async function ReaderGuidesAdminPage() {
+  if (!(await isAuthenticated())) redirect("/admin/login");
+  const guides = await db.measureReaderGuide.findMany({
+    orderBy: [{ publicationStatus: "asc" }, { label: "asc" }],
+    select: {
+      id: true,
+      slug: true,
+      label: true,
+      definition: true,
+      aliases: true,
+      sourceUrl: true,
+      sourceLabel: true,
+      sourcePublisher: true,
+      publicationStatus: true,
+    },
+  });
+  return (
+    <div className="space-y-6">
+      <header>
+        <Link
+          href="/admin/mesures"
+          className="inline-flex min-h-11 items-center text-sm font-bold text-primary underline"
+        >
+          Retour aux mesures
+        </Link>
+        <h1 className="font-display text-2xl font-bold tracking-tight">Repères pour comprendre</h1>
+        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          Définitions réutilisables, sourcées et validées indépendamment des suggestions produites
+          pour chaque mesure.
+        </p>
+      </header>
+      <ReaderGuideAdmin guides={guides} />
+    </div>
+  );
+}

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.test.tsx
@@ -51,6 +51,7 @@ const detail = {
       description: "Construction, attribution et financement du logement social.",
     },
   ],
+  readerGuides: [],
   sources: [
     {
       id: "source-1",
@@ -159,6 +160,35 @@ describe("page publique d'une mesure présidentielle", () => {
       "href",
       "/elections/presidentielle-2027/recherche?sous-theme=encadrement-loyers"
     );
+  });
+
+  it("affiche un repère sourcé dans le contenu plutôt que dans une infobulle", async () => {
+    getDetail.mockResolvedValue({
+      ...detail,
+      readerGuides: [
+        {
+          slug: "zones-faibles-emissions",
+          label: "Zone à faibles émissions (ZFE)",
+          definition:
+            "Un périmètre routier où la circulation des véhicules les plus polluants est restreinte.",
+          sourceUrl: "https://www.ecologie.gouv.fr/zfe",
+          sourceLabel: "Zones à faibles émissions",
+          sourcePublisher: "Ministère de la Transition écologique",
+          reviewedAt: new Date("2026-08-31T00:00:00Z"),
+        },
+      ],
+    });
+    const { default: Page } = await import("./page");
+    render(
+      <TooltipProvider>
+        {await Page({ params: Promise.resolve({ id: "measure-1" }) })}
+      </TooltipProvider>
+    );
+    expect(screen.getByRole("heading", { name: "Repères pour comprendre" })).toBeInTheDocument();
+    expect(screen.getByText(/Un périmètre routier/)).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /Consulter la source Zones à faibles émissions/ })
+    ).toHaveAttribute("href", "https://www.ecologie.gouv.fr/zfe");
   });
 
   it("n'invente aucun vote quand aucun lien public n'existe", async () => {

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -182,6 +182,36 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
           </section>
         )}
 
+        {measure.readerGuides.length > 0 && (
+          <section aria-labelledby="reader-guides-title" className="border-b border-border py-8">
+            <h2 id="reader-guides-title" className="font-display text-2xl font-extrabold">
+              Repères pour comprendre
+            </h2>
+            <p className="mt-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground">
+              Des définitions factuelles pour comprendre les dispositifs cités, sans évaluer la
+              mesure.
+            </p>
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+              {measure.readerGuides.map((guide) => (
+                <article key={guide.slug} className="rounded-2xl border border-border bg-card p-5">
+                  <h3 className="font-display text-lg font-bold">{guide.label}</h3>
+                  <p className="mt-2 leading-relaxed text-foreground">{guide.definition}</p>
+                  <a
+                    href={guide.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Consulter la source ${guide.sourceLabel} publiée par ${guide.sourcePublisher}, lien externe`}
+                    className="mt-3 inline-flex min-h-11 items-center gap-2 text-sm font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  >
+                    Source : {guide.sourcePublisher}, vérifiée le {formatDate(guide.reviewedAt)}
+                    <ExternalLink aria-hidden="true" className="h-4 w-4" />
+                  </a>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+
         {measure.subtopics.length > 0 && (
           <section aria-labelledby="concepts-title" className="border-b border-border py-8">
             <h2 id="concepts-title" className="font-display text-2xl font-extrabold">

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -24,6 +24,7 @@ function measure(over: Partial<PublicMeasure> = {}): PublicMeasure {
     sources: [],
     qualifications: [],
     subtopics: [],
+    readerGuides: [],
     ...over,
   };
 }

--- a/src/app/methodologie/mesures-presidentielle-2027/page.tsx
+++ b/src/app/methodologie/mesures-presidentielle-2027/page.tsx
@@ -123,6 +123,27 @@ export default function PresidentialMeasuresMethodologyPage() {
           </div>
         </section>
 
+        <section aria-labelledby="reader-guides-title">
+          <h2 id="reader-guides-title" className="font-display text-2xl font-bold">
+            Repères pour comprendre
+          </h2>
+          <div className="mt-4 space-y-4 leading-relaxed text-muted-foreground">
+            <p>
+              Certains programmes utilisent des sigles, des mécanismes juridiques ou des dispositifs
+              administratifs sans les expliquer. Poligraph peut alors afficher une courte définition
+              factuelle dans un bloc distinct du contenu de la mesure.
+            </p>
+            <p>
+              L&apos;intelligence artificielle repère seulement les termes susceptibles de demander
+              une explication. Elle ne rédige ni ne publie la définition. Chaque repère appartient à
+              un référentiel réutilisable, cite la source du programme ou une source
+              institutionnelle officielle, puis fait l&apos;objet d&apos;une validation humaine. Son
+              rattachement à une mesure est validé séparément et conservé dans le journal
+              d&apos;audit.
+            </p>
+          </div>
+        </section>
+
         <section aria-labelledby="history-title">
           <h2 id="history-title" className="font-display text-2xl font-bold">
             Corrections, évolutions et retraits

--- a/src/config/measure-reader-guides.test.ts
+++ b/src/config/measure-reader-guides.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { MEASURE_READER_GUIDES } from "./measure-reader-guides";
+import { isOfficialInstitutionUrl } from "@/lib/measures/reader-guide-source";
+
+describe("catalogue des repères citoyens", () => {
+  it("utilise des slugs et alias uniques avec une source officielle", () => {
+    const slugs = new Set<string>();
+    const aliases = new Set<string>();
+    for (const guide of MEASURE_READER_GUIDES) {
+      expect(slugs.has(guide.slug)).toBe(false);
+      slugs.add(guide.slug);
+      expect(isOfficialInstitutionUrl(guide.sourceUrl)).toBe(true);
+      expect(guide.definition.length).toBeGreaterThan(40);
+      for (const alias of [guide.label, ...guide.aliases]) {
+        const normalized = alias.toLocaleLowerCase("fr");
+        expect(aliases.has(normalized)).toBe(false);
+        aliases.add(normalized);
+      }
+    }
+  });
+});

--- a/src/config/measure-reader-guides.ts
+++ b/src/config/measure-reader-guides.ts
@@ -1,0 +1,35 @@
+export type MeasureReaderGuideDefinition = {
+  slug: string;
+  label: string;
+  definition: string;
+  aliases: readonly string[];
+  sourceUrl: string;
+  sourceLabel: string;
+  sourcePublisher: string;
+};
+
+/**
+ * Human-reviewed starting vocabulary. Synchronisation creates DRAFT rows only: code review checks
+ * the source and wording, while publication remains an explicit editorial action in the admin.
+ */
+export const MEASURE_READER_GUIDES: readonly MeasureReaderGuideDefinition[] = [
+  {
+    slug: "zones-faibles-emissions",
+    label: "Zone à faibles émissions (ZFE)",
+    definition:
+      "Une zone à faibles émissions est un périmètre routier où la circulation des véhicules " +
+      "les plus polluants est restreinte selon des règles fixées localement. Le dispositif vise " +
+      "à améliorer la qualité de l’air.",
+    aliases: [
+      "ZFE",
+      "ZFE-m",
+      "zone à faibles émissions",
+      "zones à faibles émissions",
+      "zone à faibles émissions mobilité",
+      "zones à faibles émissions mobilité",
+    ],
+    sourceUrl: "https://www.ecologie.gouv.fr/politiques-publiques/zones-faibles-emissions-zfe",
+    sourceLabel: "Zones à faibles émissions (ZFE)",
+    sourcePublisher: "Ministère de la Transition écologique",
+  },
+];

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -32,6 +32,20 @@ const PUBLIC_MEASURE_INCLUDE = {
         include: { subtopic: true },
         orderBy: { subtopic: { sortOrder: "asc" } },
       },
+      readerGuideMentions: {
+        where: {
+          status: "APPROVED",
+          guide: {
+            is: {
+              active: true,
+              publicationStatus: "PUBLISHED",
+              reviewedAt: { not: null },
+            },
+          },
+        },
+        include: { guide: true },
+        orderBy: { guide: { label: "asc" } },
+      },
     },
   },
 } satisfies Prisma.MeasureInclude;
@@ -79,6 +93,7 @@ export type PublicMeasure = {
   sources: PublishedRevision["sources"];
   qualifications: PublishedRevision["qualifications"];
   subtopics: Array<{ slug: string; label: string }>;
+  readerGuides: Array<{ slug: string; label: string; definition: string }>;
 };
 
 function toPublicMeasure(row: MeasureRow): PublicMeasure | null {
@@ -113,6 +128,9 @@ function toPublicMeasure(row: MeasureRow): PublicMeasure | null {
       slug: subtopic.slug,
       label: subtopic.label,
     })),
+    readerGuides: revision.readerGuideMentions.flatMap(({ guide }) =>
+      guide ? [{ slug: guide.slug, label: guide.label, definition: guide.definition }] : []
+    ),
   };
 }
 
@@ -455,6 +473,10 @@ export async function getMeasureForModeration(measureId: string) {
           subtopics: {
             include: { subtopic: true },
             orderBy: [{ status: "asc" }, { subtopic: { sortOrder: "asc" } }],
+          },
+          readerGuideMentions: {
+            include: { guide: true },
+            orderBy: [{ status: "asc" }, { proposedAt: "asc" }],
           },
         },
         orderBy: { validFrom: "desc" },

--- a/src/lib/data/presidential-measure-detail.ts
+++ b/src/lib/data/presidential-measure-detail.ts
@@ -54,6 +54,15 @@ export type PublicPresidentialMeasureDetail = {
     label: string;
     description: string;
   }>;
+  readerGuides: Array<{
+    slug: string;
+    label: string;
+    definition: string;
+    sourceUrl: string;
+    sourceLabel: string;
+    sourcePublisher: string;
+    reviewedAt: Date;
+  }>;
   sources: Array<{
     id: string;
     sourceKind: MeasureSourceKind;
@@ -133,6 +142,32 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
               subtopic: { select: { slug: true, label: true, description: true, sortOrder: true } },
             },
             orderBy: { subtopic: { sortOrder: "asc" } },
+          },
+          readerGuideMentions: {
+            where: {
+              status: "APPROVED",
+              guide: {
+                is: {
+                  active: true,
+                  publicationStatus: "PUBLISHED",
+                  reviewedAt: { not: null },
+                },
+              },
+            },
+            select: {
+              guide: {
+                select: {
+                  slug: true,
+                  label: true,
+                  definition: true,
+                  sourceUrl: true,
+                  sourceLabel: true,
+                  sourcePublisher: true,
+                  reviewedAt: true,
+                },
+              },
+            },
+            orderBy: { guide: { label: "asc" } },
           },
         },
       },
@@ -327,6 +362,9 @@ async function loadPublicPresidentialMeasureDetail(electionSlug: string, measure
       label,
       description,
     })),
+    readerGuides: revision.readerGuideMentions.flatMap(({ guide }) =>
+      guide?.reviewedAt ? [{ ...guide, reviewedAt: guide.reviewedAt }] : []
+    ),
     sources: revision.sources,
     votes: row.voteLinks.map((link) => ({
       id: link.id,

--- a/src/lib/measures/__tests__/search-sync.test.ts
+++ b/src/lib/measures/__tests__/search-sync.test.ts
@@ -31,6 +31,7 @@ const measure = {
     text: "Construire des logements publics.",
     details: "Dans les zones tendues.",
     subtopics: [{ subtopic: { label: "Logement social", aliases: ["HLM", "habitat social"] } }],
+    readerGuideMentions: [],
     updatedAt: new Date("2026-08-27T12:00:00Z"),
   },
   latestRevision: {
@@ -38,6 +39,7 @@ const measure = {
     text: "Construire des logements publics.",
     details: "Dans les zones tendues.",
     subtopics: [{ subtopic: { label: "Logement social", aliases: ["HLM", "habitat social"] } }],
+    readerGuideMentions: [],
     updatedAt: new Date("2026-08-27T12:00:00Z"),
   },
 };
@@ -101,5 +103,39 @@ describe("synchronisation recherche des mesures", () => {
     expect(upsertSearchDocumentsMock).toHaveBeenCalledWith(tx, [
       expect.objectContaining({ entityId: "measure-1", visibility: "PUBLIC" }),
     ]);
+  });
+
+  it("indexe les repères validés avec leurs alias et leur définition", async () => {
+    const { syncSearchDocument } = await import("../search-sync");
+    const withGuide = {
+      ...measure,
+      publishedRevision: {
+        ...measure.publishedRevision,
+        readerGuideMentions: [
+          {
+            guide: {
+              label: "Zone à faibles émissions (ZFE)",
+              aliases: ["ZFE"],
+              definition: "Périmètre où les véhicules les plus polluants sont restreints.",
+            },
+          },
+        ],
+      },
+    };
+    const tx = {
+      measure: {
+        findUniqueOrThrow: vi.fn(async () => withGuide),
+        findFirst: vi.fn(async () => ({ id: "measure-1" })),
+      },
+    };
+
+    await syncSearchDocument(tx as never, "measure-1");
+
+    expect(upsertSearchDocumentMock).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        body: expect.stringContaining("Périmètre où les véhicules les plus polluants"),
+      })
+    );
   });
 });

--- a/src/lib/measures/reader-guide-detection.test.ts
+++ b/src/lib/measures/reader-guide-detection.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { callMistral } from "@/lib/api/mistral";
+import { detectReaderGuideTerms, normalizeReaderGuideTerm } from "./reader-guide-detection";
+
+vi.mock("@/lib/api/mistral", () => ({
+  callMistral: vi.fn(),
+  extractMistralText: (response: { content: string }) => response.content,
+  parseMistralJSON: (value: string) => JSON.parse(value),
+}));
+
+describe("détection des repères citoyens", () => {
+  beforeEach(() => vi.mocked(callMistral).mockReset());
+
+  it("normalise les accents, sigles et tirets pour la correspondance d'alias", () => {
+    expect(normalizeReaderGuideTerm("Zones à faibles émissions (ZFE-m)")).toBe(
+      "zones a faibles emissions zfe m"
+    );
+  });
+
+  it("conserve uniquement une détection structurée dont l'extrait figure dans la mesure", async () => {
+    vi.mocked(callMistral).mockResolvedValue({
+      content: JSON.stringify({
+        detections: [
+          {
+            term: "zones à faibles émissions",
+            canonicalLabel: "Zone à faibles émissions",
+            evidenceSpan: "Supprimer les zones à faibles émissions",
+            needsExplanation: true,
+            reason: "Dispositif réglementaire non expliqué",
+            confidence: 1.4,
+          },
+          {
+            term: "péage urbain",
+            canonicalLabel: "Péage urbain",
+            evidenceSpan: "Extrait absent",
+            needsExplanation: true,
+            reason: "Terme technique",
+            confidence: 0.8,
+          },
+        ],
+      }),
+    } as never);
+
+    const result = await detectReaderGuideTerms({
+      text: "Supprimer les zones à faibles émissions.",
+      details: null,
+      knownLabels: ["Zone à faibles émissions (ZFE)"],
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        term: "zones à faibles émissions",
+        evidenceSpan: "Supprimer les zones à faibles émissions",
+        confidence: 1,
+      }),
+    ]);
+    const prompt = vi.mocked(callMistral).mock.calls[0]![0][0]!.content;
+    expect(prompt).toContain("ne rédige aucune définition");
+    expect(prompt).toContain("<mesure>Supprimer les zones à faibles émissions.</mesure>");
+  });
+});

--- a/src/lib/measures/reader-guide-detection.test.ts
+++ b/src/lib/measures/reader-guide-detection.test.ts
@@ -1,51 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { callMistral } from "@/lib/api/mistral";
-import { detectReaderGuideTerms, normalizeReaderGuideTerm } from "./reader-guide-detection";
-
-vi.mock("@/lib/api/mistral", () => ({
-  callMistral: vi.fn(),
-  extractMistralText: (response: { content: string }) => response.content,
-  parseMistralJSON: (value: string) => JSON.parse(value),
-}));
+import { describe, expect, it } from "vitest";
+import { normalizeReaderGuideTerm, parseReaderGuideDetections } from "./reader-guide-detection";
 
 describe("détection des repères citoyens", () => {
-  beforeEach(() => vi.mocked(callMistral).mockReset());
-
   it("normalise les accents, sigles et tirets pour la correspondance d'alias", () => {
     expect(normalizeReaderGuideTerm("Zones à faibles émissions (ZFE-m)")).toBe(
       "zones a faibles emissions zfe m"
     );
   });
 
-  it("conserve uniquement une détection structurée dont l'extrait figure dans la mesure", async () => {
-    vi.mocked(callMistral).mockResolvedValue({
-      content: JSON.stringify({
-        detections: [
-          {
-            term: "zones à faibles émissions",
-            canonicalLabel: "Zone à faibles émissions",
-            evidenceSpan: "Supprimer les zones à faibles émissions",
-            needsExplanation: true,
-            reason: "Dispositif réglementaire non expliqué",
-            confidence: 1.4,
-          },
-          {
-            term: "péage urbain",
-            canonicalLabel: "Péage urbain",
-            evidenceSpan: "Extrait absent",
-            needsExplanation: true,
-            reason: "Terme technique",
-            confidence: 0.8,
-          },
-        ],
-      }),
-    } as never);
-
-    const result = await detectReaderGuideTerms({
-      text: "Supprimer les zones à faibles émissions.",
-      details: null,
-      knownLabels: ["Zone à faibles émissions (ZFE)"],
-    });
+  it("conserve uniquement une détection structurée dont l'extrait figure dans la mesure", () => {
+    const result = parseReaderGuideDetections(
+      [
+        {
+          term: "zones à faibles émissions",
+          canonicalLabel: "Zone à faibles émissions",
+          evidenceSpan: "Supprimer les zones à faibles émissions",
+          needsExplanation: true,
+          reason: "Dispositif réglementaire non expliqué",
+          confidence: 1.4,
+        },
+        {
+          term: "péage urbain",
+          canonicalLabel: "Péage urbain",
+          evidenceSpan: "Extrait absent",
+          needsExplanation: true,
+          reason: "Terme technique",
+          confidence: 0.8,
+        },
+      ],
+      "Supprimer les zones à faibles émissions."
+    );
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -54,32 +38,22 @@ describe("détection des repères citoyens", () => {
         confidence: 1,
       }),
     ]);
-    const prompt = vi.mocked(callMistral).mock.calls[0]![0][0]!.content;
-    expect(prompt).toContain("ne rédige aucune définition");
-    expect(prompt).toContain("<mesure>Supprimer les zones à faibles émissions.</mesure>");
   });
 
-  it("accepte un extrait probant présent uniquement dans le contexte documenté", async () => {
-    vi.mocked(callMistral).mockResolvedValue({
-      content: JSON.stringify({
-        detections: [
-          {
-            term: "kafala judiciaire",
-            canonicalLabel: "Kafala judiciaire",
-            evidenceSpan: "recours à la kafala judiciaire",
-            needsExplanation: true,
-            reason: "Mécanisme juridique non expliqué",
-            confidence: 0.91,
-          },
-        ],
-      }),
-    } as never);
-
-    const result = await detectReaderGuideTerms({
-      text: "Modifier les règles d'adoption.",
-      details: "La mesure prévoit un recours à la kafala judiciaire.",
-      knownLabels: [],
-    });
+  it("accepte un extrait probant présent uniquement dans le contexte documenté", () => {
+    const result = parseReaderGuideDetections(
+      [
+        {
+          term: "kafala judiciaire",
+          canonicalLabel: "Kafala judiciaire",
+          evidenceSpan: "recours à la kafala judiciaire",
+          needsExplanation: true,
+          reason: "Mécanisme juridique non expliqué",
+          confidence: 0.91,
+        },
+      ],
+      "Modifier les règles d'adoption. La mesure prévoit un recours à la kafala judiciaire."
+    );
 
     expect(result).toEqual([
       expect.objectContaining({

--- a/src/lib/measures/reader-guide-detection.test.ts
+++ b/src/lib/measures/reader-guide-detection.test.ts
@@ -58,4 +58,34 @@ describe("détection des repères citoyens", () => {
     expect(prompt).toContain("ne rédige aucune définition");
     expect(prompt).toContain("<mesure>Supprimer les zones à faibles émissions.</mesure>");
   });
+
+  it("accepte un extrait probant présent uniquement dans le contexte documenté", async () => {
+    vi.mocked(callMistral).mockResolvedValue({
+      content: JSON.stringify({
+        detections: [
+          {
+            term: "kafala judiciaire",
+            canonicalLabel: "Kafala judiciaire",
+            evidenceSpan: "recours à la kafala judiciaire",
+            needsExplanation: true,
+            reason: "Mécanisme juridique non expliqué",
+            confidence: 0.91,
+          },
+        ],
+      }),
+    } as never);
+
+    const result = await detectReaderGuideTerms({
+      text: "Modifier les règles d'adoption.",
+      details: "La mesure prévoit un recours à la kafala judiciaire.",
+      knownLabels: [],
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        term: "kafala judiciaire",
+        evidenceSpan: "recours à la kafala judiciaire",
+      }),
+    ]);
+  });
 });

--- a/src/lib/measures/reader-guide-detection.ts
+++ b/src/lib/measures/reader-guide-detection.ts
@@ -81,9 +81,10 @@ Exclure : vocabulaire quotidien, noms de personnes, jugements politiques, concep
   });
   const parsed = parseMistralJSON<{ detections?: unknown[] }>(extractMistralText(response));
   const seen = new Set<string>();
+  const evidenceCorpus = `${text} ${details}`.toLowerCase();
   return (parsed.detections ?? []).flatMap((value) => {
     const detection = parseDetection(value);
-    if (!detection || !text.toLowerCase().includes(detection.evidenceSpan.toLowerCase())) return [];
+    if (!detection || !evidenceCorpus.includes(detection.evidenceSpan.toLowerCase())) return [];
     const normalized = normalizeReaderGuideTerm(detection.term);
     if (!normalized || seen.has(normalized)) return [];
     seen.add(normalized);

--- a/src/lib/measures/reader-guide-detection.ts
+++ b/src/lib/measures/reader-guide-detection.ts
@@ -1,7 +1,4 @@
-import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
-
 export const READER_GUIDE_DETECTOR_VERSION = "mistral-small-latest:reader-guides-v1";
-const MODEL = "mistral-small-latest";
 
 export type ReaderGuideDetection = {
   term: string;
@@ -12,7 +9,7 @@ export type ReaderGuideDetection = {
   confidence: number;
 };
 
-function sanitize(value: string, maxLength: number): string {
+export function sanitizeReaderGuideDetectionText(value: string, maxLength: number): string {
   return value
     .replace(/["\n\r<>]/g, " ")
     .replace(/\s+/g, " ")
@@ -43,46 +40,21 @@ function parseDetection(value: unknown): ReaderGuideDetection | null {
     return null;
   }
   const confidence = Math.max(0, Math.min(1, item.confidence));
-  const term = sanitize(item.term, 120);
-  const canonicalLabel = sanitize(item.canonicalLabel, 120);
-  const evidenceSpan = sanitize(item.evidenceSpan, 240);
-  const reason = sanitize(item.reason, 300);
+  const term = sanitizeReaderGuideDetectionText(item.term, 120);
+  const canonicalLabel = sanitizeReaderGuideDetectionText(item.canonicalLabel, 120);
+  const evidenceSpan = sanitizeReaderGuideDetectionText(item.evidenceSpan, 240);
+  const reason = sanitizeReaderGuideDetectionText(item.reason, 300);
   if (!term || !canonicalLabel || !evidenceSpan || !reason) return null;
   return { term, canonicalLabel, evidenceSpan, needsExplanation: true, reason, confidence };
 }
 
-export async function detectReaderGuideTerms(input: {
-  text: string;
-  details: string | null;
-  knownLabels: string[];
-}): Promise<ReaderGuideDetection[]> {
-  const text = sanitize(input.text, 4_000);
-  const details = sanitize(input.details ?? "", 4_000);
-  const vocabulary = input.knownLabels
-    .slice(0, 200)
-    .map((label) => sanitize(label, 120))
-    .join(" | ");
-  const prompt = `Tu aides une rédaction civique à repérer les termes qu'un citoyen non spécialiste doit comprendre avant de lire une mesure politique.
-
-Retourne uniquement un objet JSON {"detections": [...]} avec au maximum 5 éléments. Chaque élément contient term, canonicalLabel, evidenceSpan, needsExplanation=true, reason et confidence entre 0 et 1.
-
-Retenir : sigles, mécanismes juridiques ou administratifs, dispositifs nommés, institutions peu connues, mots courants employés dans un sens technique, références réglementaires nécessaires à la compréhension.
-Exemples de forme à examiner : ZFE, kafala judiciaire, quotient familial, obligation de quitter le territoire français. Ces exemples illustrent un niveau de technicité et ne doivent être retournés que s'ils figurent réellement dans la mesure.
-Exclure : vocabulaire quotidien, noms de personnes, jugements politiques, concepts déjà expliqués dans le contexte, termes dont une définition n'apporterait rien. Ne complète jamais la mesure et ne rédige aucune définition.
-
-<vocabulaire-connu>${vocabulary || "aucun"}</vocabulaire-connu>
-<mesure>${text}</mesure>
-<contexte>${details || "aucun"}</contexte>`;
-  const response = await callMistral([{ role: "user", content: prompt }], {
-    model: MODEL,
-    temperature: 0,
-    maxTokens: 1_000,
-    responseFormat: { type: "json_object" },
-  });
-  const parsed = parseMistralJSON<{ detections?: unknown[] }>(extractMistralText(response));
+export function parseReaderGuideDetections(
+  values: unknown[],
+  evidenceText: string
+): ReaderGuideDetection[] {
   const seen = new Set<string>();
-  const evidenceCorpus = `${text} ${details}`.toLowerCase();
-  return (parsed.detections ?? []).flatMap((value) => {
+  const evidenceCorpus = evidenceText.toLowerCase();
+  return values.flatMap((value) => {
     const detection = parseDetection(value);
     if (!detection || !evidenceCorpus.includes(detection.evidenceSpan.toLowerCase())) return [];
     const normalized = normalizeReaderGuideTerm(detection.term);

--- a/src/lib/measures/reader-guide-detection.ts
+++ b/src/lib/measures/reader-guide-detection.ts
@@ -1,0 +1,92 @@
+import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
+
+export const READER_GUIDE_DETECTOR_VERSION = "mistral-small-latest:reader-guides-v1";
+const MODEL = "mistral-small-latest";
+
+export type ReaderGuideDetection = {
+  term: string;
+  canonicalLabel: string;
+  evidenceSpan: string;
+  needsExplanation: true;
+  reason: string;
+  confidence: number;
+};
+
+function sanitize(value: string, maxLength: number): string {
+  return value
+    .replace(/["\n\r<>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function normalizeReaderGuideTerm(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("fr")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function parseDetection(value: unknown): ReaderGuideDetection | null {
+  if (!value || typeof value !== "object") return null;
+  const item = value as Record<string, unknown>;
+  if (
+    typeof item.term !== "string" ||
+    typeof item.canonicalLabel !== "string" ||
+    typeof item.evidenceSpan !== "string" ||
+    item.needsExplanation !== true ||
+    typeof item.reason !== "string" ||
+    typeof item.confidence !== "number"
+  ) {
+    return null;
+  }
+  const confidence = Math.max(0, Math.min(1, item.confidence));
+  const term = sanitize(item.term, 120);
+  const canonicalLabel = sanitize(item.canonicalLabel, 120);
+  const evidenceSpan = sanitize(item.evidenceSpan, 240);
+  const reason = sanitize(item.reason, 300);
+  if (!term || !canonicalLabel || !evidenceSpan || !reason) return null;
+  return { term, canonicalLabel, evidenceSpan, needsExplanation: true, reason, confidence };
+}
+
+export async function detectReaderGuideTerms(input: {
+  text: string;
+  details: string | null;
+  knownLabels: string[];
+}): Promise<ReaderGuideDetection[]> {
+  const text = sanitize(input.text, 4_000);
+  const details = sanitize(input.details ?? "", 4_000);
+  const vocabulary = input.knownLabels
+    .slice(0, 200)
+    .map((label) => sanitize(label, 120))
+    .join(" | ");
+  const prompt = `Tu aides une rédaction civique à repérer les termes qu'un citoyen non spécialiste doit comprendre avant de lire une mesure politique.
+
+Retourne uniquement un objet JSON {"detections": [...]} avec au maximum 5 éléments. Chaque élément contient term, canonicalLabel, evidenceSpan, needsExplanation=true, reason et confidence entre 0 et 1.
+
+Retenir : sigles, mécanismes juridiques ou administratifs, dispositifs nommés, institutions peu connues, mots courants employés dans un sens technique, références réglementaires nécessaires à la compréhension.
+Exemples de forme à examiner : ZFE, kafala judiciaire, quotient familial, obligation de quitter le territoire français. Ces exemples illustrent un niveau de technicité et ne doivent être retournés que s'ils figurent réellement dans la mesure.
+Exclure : vocabulaire quotidien, noms de personnes, jugements politiques, concepts déjà expliqués dans le contexte, termes dont une définition n'apporterait rien. Ne complète jamais la mesure et ne rédige aucune définition.
+
+<vocabulaire-connu>${vocabulary || "aucun"}</vocabulaire-connu>
+<mesure>${text}</mesure>
+<contexte>${details || "aucun"}</contexte>`;
+  const response = await callMistral([{ role: "user", content: prompt }], {
+    model: MODEL,
+    temperature: 0,
+    maxTokens: 1_000,
+    responseFormat: { type: "json_object" },
+  });
+  const parsed = parseMistralJSON<{ detections?: unknown[] }>(extractMistralText(response));
+  const seen = new Set<string>();
+  return (parsed.detections ?? []).flatMap((value) => {
+    const detection = parseDetection(value);
+    if (!detection || !text.toLowerCase().includes(detection.evidenceSpan.toLowerCase())) return [];
+    const normalized = normalizeReaderGuideTerm(detection.term);
+    if (!normalized || seen.has(normalized)) return [];
+    seen.add(normalized);
+    return [detection];
+  });
+}

--- a/src/lib/measures/reader-guide-options.test.ts
+++ b/src/lib/measures/reader-guide-options.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseReaderGuideDetectionOptions } from "./reader-guide-options";
+
+describe("options CLI de détection des repères", () => {
+  it("accepte les syntaxes séparée et avec signe égal", () => {
+    expect(
+      parseReaderGuideDetectionOptions([
+        "--election",
+        "presidentielle-2027",
+        "--limit=100",
+        "--after",
+        "measure-1",
+        "--dry-run",
+      ])
+    ).toMatchObject({
+      electionSlug: "presidentielle-2027",
+      limit: 100,
+      after: "measure-1",
+      dryRun: true,
+      apply: false,
+    });
+  });
+
+  it("refuse un mode ambigu ou absent", () => {
+    expect(() => parseReaderGuideDetectionOptions([])).toThrow(/exactement une/);
+    expect(() => parseReaderGuideDetectionOptions(["--apply", "--dry-run"])).toThrow(
+      /exactement une/
+    );
+  });
+});

--- a/src/lib/measures/reader-guide-options.ts
+++ b/src/lib/measures/reader-guide-options.ts
@@ -1,0 +1,33 @@
+import { parseCLIOptions } from "@/lib/cli/parse-options";
+
+export type ReaderGuideDetectionOptions = {
+  electionSlug: string;
+  limit: number;
+  after?: string;
+  apply: boolean;
+  dryRun: boolean;
+};
+
+export function parseReaderGuideDetectionOptions(args: string[]): ReaderGuideDetectionOptions {
+  const parsed = parseCLIOptions(args, [
+    { name: "--election", type: "string" },
+    { name: "--limit", type: "number" },
+    { name: "--after", type: "string" },
+    { name: "--dry-run", type: "boolean" },
+    { name: "--apply", type: "boolean" },
+  ]);
+  const apply = parsed.apply === true;
+  const dryRun = parsed.dryRun === true;
+  if (apply === dryRun) throw new Error("Choisir exactement une option parmi --dry-run et --apply");
+  const limit = parsed.limit ?? 50;
+  if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new Error("--limit doit être un entier compris entre 1 et 500");
+  }
+  return {
+    electionSlug: typeof parsed.election === "string" ? parsed.election : "presidentielle-2027",
+    limit,
+    ...(typeof parsed.after === "string" ? { after: parsed.after } : {}),
+    apply,
+    dryRun,
+  };
+}

--- a/src/lib/measures/reader-guide-source.test.ts
+++ b/src/lib/measures/reader-guide-source.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isOfficialInstitutionUrl } from "./reader-guide-source";
+
+describe("sources institutionnelles des repères", () => {
+  it("accepte les domaines publics officiels en HTTPS", () => {
+    expect(
+      isOfficialInstitutionUrl(
+        "https://www.ecologie.gouv.fr/politiques-publiques/zones-faibles-emissions-zfe"
+      )
+    ).toBe(true);
+    expect(isOfficialInstitutionUrl("https://www.service-public.fr/particuliers/vosdroits")).toBe(
+      true
+    );
+  });
+
+  it("refuse HTTP, les domaines ressemblants et les identifiants intégrés", () => {
+    expect(isOfficialInstitutionUrl("http://www.ecologie.gouv.fr/page")).toBe(false);
+    expect(isOfficialInstitutionUrl("https://ecologie.gouv.fr.example.org/page")).toBe(false);
+    expect(isOfficialInstitutionUrl("https://user@ecologie.gouv.fr/page")).toBe(false);
+  });
+});

--- a/src/lib/measures/reader-guide-source.ts
+++ b/src/lib/measures/reader-guide-source.ts
@@ -1,0 +1,29 @@
+const OFFICIAL_HOSTS = new Set([
+  "assemblee-nationale.fr",
+  "cnil.fr",
+  "conseil-constitutionnel.fr",
+  "ecologie.gouv.fr",
+  "insee.fr",
+  "legifrance.gouv.fr",
+  "senat.fr",
+  "service-public.fr",
+  "vie-publique.fr",
+]);
+
+function isHostOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+export function isOfficialInstitutionUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password || url.port) return false;
+    const hostname = url.hostname.toLowerCase();
+    return (
+      hostname.endsWith(".gouv.fr") ||
+      [...OFFICIAL_HOSTS].some((domain) => isHostOrSubdomain(hostname, domain))
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    measureRevisionReaderGuide: {
+      createMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    measureReaderGuide: { findUnique: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return {
+    tx,
+    measureRevision: { findUnique: vi.fn() },
+    measureReaderGuide: { findMany: vi.fn() },
+    detect: vi.fn(),
+    syncSearch: vi.fn(),
+    invalidate: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    measureRevision: mocks.measureRevision,
+    measureReaderGuide: mocks.measureReaderGuide,
+    $transaction: (callback: (tx: typeof mocks.tx) => unknown) => callback(mocks.tx),
+  },
+}));
+vi.mock("@/lib/measures/reader-guide-detection", async (importActual) => {
+  const actual = await importActual<typeof import("./reader-guide-detection")>();
+  return { ...actual, detectReaderGuideTerms: mocks.detect };
+});
+vi.mock("@/lib/measures/search-sync", () => ({ syncSearchDocument: mocks.syncSearch }));
+vi.mock("@/lib/measures/cache", () => ({ invalidateMeasureTags: mocks.invalidate }));
+
+describe("workflow des repères citoyens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.measureRevision.findUnique.mockResolvedValue({
+      text: "Supprimer les zones à faibles émissions.",
+      details: null,
+      measure: { id: "measure-1", electionId: "election-1" },
+    });
+    mocks.measureReaderGuide.findMany.mockResolvedValue([
+      {
+        id: "guide-1",
+        slug: "zones-faibles-emissions",
+        label: "Zone à faibles émissions (ZFE)",
+        aliases: ["zones à faibles émissions"],
+        publicationStatus: "PUBLISHED",
+      },
+    ]);
+    mocks.detect.mockResolvedValue([
+      {
+        term: "zones à faibles émissions",
+        canonicalLabel: "Zone à faibles émissions",
+        evidenceSpan: "Supprimer les zones à faibles émissions",
+        needsExplanation: true,
+        reason: "Dispositif réglementaire non expliqué",
+        confidence: 0.96,
+      },
+    ]);
+    mocks.tx.measureRevisionReaderGuide.createMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValue({ count: 0 });
+  });
+
+  it("crée uniquement une suggestion et reste idempotent", async () => {
+    const { proposeReaderGuidesForRevision } = await import("./reader-guides");
+
+    const first = await proposeReaderGuidesForRevision("revision-1", "admin");
+    const second = await proposeReaderGuidesForRevision("revision-1", "admin");
+
+    expect(first.created).toBe(1);
+    expect(second.created).toBe(0);
+    expect(mocks.tx.measureRevisionReaderGuide.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          revisionId: "revision-1",
+          guideId: "guide-1",
+          status: "SUGGESTED",
+          method: "AI_ASSISTED",
+        }),
+      ],
+      skipDuplicates: true,
+    });
+    expect(mocks.syncSearch).not.toHaveBeenCalled();
+  });
+
+  it("refuse d'approuver un rattachement vers un repère non publié", async () => {
+    mocks.tx.measureRevisionReaderGuide.findUnique.mockResolvedValue({
+      status: "SUGGESTED",
+      guideId: "guide-1",
+      revisionId: "revision-1",
+      revision: { measure: { id: "measure-1", electionId: "election-1" } },
+    });
+    mocks.tx.measureReaderGuide.findUnique.mockResolvedValue({
+      publicationStatus: "DRAFT",
+      active: true,
+    });
+    const { reviewReaderGuideMention } = await import("./reader-guides");
+
+    await expect(
+      reviewReaderGuideMention({
+        mentionId: "mention-1",
+        status: "APPROVED",
+        reviewedBy: "admin",
+      })
+    ).rejects.toThrow(/doit être publié/);
+    expect(mocks.tx.measureRevisionReaderGuide.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -34,10 +34,9 @@ vi.mock("@/lib/db", () => ({
     $transaction: (callback: (tx: typeof mocks.tx) => unknown) => callback(mocks.tx),
   },
 }));
-vi.mock("@/lib/measures/reader-guide-detection", async (importActual) => {
-  const actual = await importActual<typeof import("./reader-guide-detection")>();
-  return { ...actual, detectReaderGuideTerms: mocks.detect };
-});
+vi.mock("@/services/measures/reader-guide-detection", () => ({
+  detectReaderGuideTerms: mocks.detect,
+}));
 vi.mock("@/lib/measures/search-sync", () => ({
   syncSearchDocument: mocks.syncSearch,
   syncSearchDocuments: mocks.syncSearchMany,
@@ -208,5 +207,21 @@ describe("workflow des repères citoyens", () => {
       "measure-2",
     ]);
     expect(mocks.invalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("annule la désactivation si la resynchronisation de recherche échoue", async () => {
+    mocks.tx.measureReaderGuide.findUnique.mockResolvedValue({
+      active: true,
+      publicationStatus: "PUBLISHED",
+    });
+    mocks.tx.measureRevisionReaderGuide.findMany.mockResolvedValue([
+      { revision: { measure: { id: "measure-1", electionId: "election-1" } } },
+    ]);
+    mocks.syncSearchMany.mockRejectedValueOnce(new Error("search unavailable"));
+    const { deactivateReaderGuide } = await import("./reader-guides");
+
+    await expect(deactivateReaderGuide("guide-1", "admin")).rejects.toThrow("search unavailable");
+    expect(mocks.syncSearchMany).toHaveBeenCalledWith(expect.anything(), ["measure-1"]);
+    expect(mocks.invalidate).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
       updateMany: vi.fn(),
     },
     measureReaderGuide: { findUnique: vi.fn() },
+    measureReaderGuideDetectionRun: { upsert: vi.fn() },
     auditLog: { create: vi.fn() },
   };
   return {
@@ -87,6 +88,31 @@ describe("workflow des repères citoyens", () => {
       skipDuplicates: true,
     });
     expect(mocks.syncSearch).not.toHaveBeenCalled();
+    expect(mocks.tx.measureReaderGuideDetectionRun.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("mémorise aussi une analyse sans suggestion", async () => {
+    mocks.detect.mockResolvedValue([]);
+    const { proposeReaderGuidesForRevision } = await import("./reader-guides");
+
+    const result = await proposeReaderGuidesForRevision("revision-1", "admin", {
+      ipAddress: "203.0.113.8",
+      userAgent: "vitest-agent",
+    });
+
+    expect(result).toEqual({ created: 0, proposals: [] });
+    expect(mocks.tx.measureReaderGuideDetectionRun.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ resultCount: 0 }),
+        update: expect.objectContaining({ resultCount: 0 }),
+      })
+    );
+    expect(mocks.tx.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        ipAddress: "203.0.113.8",
+        userAgent: "vitest-agent",
+      }),
+    });
   });
 
   it("refuse d'approuver un rattachement vers un repère non publié", async () => {

--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -6,18 +6,22 @@ const mocks = vi.hoisted(() => {
       createMany: vi.fn(),
       findUnique: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       updateMany: vi.fn(),
     },
-    measureReaderGuide: { findUnique: vi.fn() },
+    measureReaderGuide: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
     measureReaderGuideDetectionRun: { upsert: vi.fn() },
+    measureSource: { findFirst: vi.fn() },
     auditLog: { create: vi.fn() },
   };
   return {
     tx,
     measureRevision: { findUnique: vi.fn() },
     measureReaderGuide: { findMany: vi.fn() },
+    measureSource: { findFirst: vi.fn() },
     detect: vi.fn(),
     syncSearch: vi.fn(),
+    syncSearchMany: vi.fn(),
     invalidate: vi.fn(),
   };
 });
@@ -26,6 +30,7 @@ vi.mock("@/lib/db", () => ({
   db: {
     measureRevision: mocks.measureRevision,
     measureReaderGuide: mocks.measureReaderGuide,
+    measureSource: mocks.measureSource,
     $transaction: (callback: (tx: typeof mocks.tx) => unknown) => callback(mocks.tx),
   },
 }));
@@ -33,7 +38,10 @@ vi.mock("@/lib/measures/reader-guide-detection", async (importActual) => {
   const actual = await importActual<typeof import("./reader-guide-detection")>();
   return { ...actual, detectReaderGuideTerms: mocks.detect };
 });
-vi.mock("@/lib/measures/search-sync", () => ({ syncSearchDocument: mocks.syncSearch }));
+vi.mock("@/lib/measures/search-sync", () => ({
+  syncSearchDocument: mocks.syncSearch,
+  syncSearchDocuments: mocks.syncSearchMany,
+}));
 vi.mock("@/lib/measures/cache", () => ({ invalidateMeasureTags: mocks.invalidate }));
 
 describe("workflow des repères citoyens", () => {
@@ -136,5 +144,69 @@ describe("workflow des repères citoyens", () => {
       })
     ).rejects.toThrow(/doit être publié/);
     expect(mocks.tx.measureRevisionReaderGuide.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("limite une source de programme aux documents programmatiques primaires", async () => {
+    mocks.measureSource.findFirst.mockResolvedValue({ id: "source-1" });
+    mocks.tx.measureReaderGuide.create.mockResolvedValue({ id: "guide-2" });
+    const { saveReaderGuideDraft } = await import("./reader-guides");
+
+    await saveReaderGuideDraft(
+      {
+        slug: "kafala-judiciaire",
+        label: "Kafala judiciaire",
+        definition:
+          "Mesure de recueil légal d'un enfant prévue par certains droits étrangers, sans adoption.",
+        aliases: ["kafala"],
+        sourceKind: "PROGRAM_SOURCE",
+        sourceUrl: "https://example.org/programme.pdf",
+        sourceLabel: "Programme présidentiel",
+        sourcePublisher: "Candidature",
+        sourceRevisionId: "revision-1",
+      },
+      "admin"
+    );
+
+    expect(mocks.measureSource.findFirst).toHaveBeenCalledWith({
+      where: {
+        measureRevisionId: "revision-1",
+        url: "https://example.org/programme.pdf",
+        tier: "PRIMARY",
+        sourceKind: {
+          in: ["PROGRAMME_PARTI", "PROGRAMME_CANDIDAT", "PROPOSITIONS_CANDIDAT"],
+        },
+      },
+      select: { id: true },
+    });
+  });
+
+  it("désactive un repère publié et resynchronise chaque mesure concernée une fois", async () => {
+    mocks.tx.measureReaderGuide.findUnique.mockResolvedValue({
+      active: true,
+      publicationStatus: "PUBLISHED",
+    });
+    mocks.tx.measureRevisionReaderGuide.findMany.mockResolvedValue([
+      { revision: { measure: { id: "measure-1", electionId: "election-1" } } },
+      { revision: { measure: { id: "measure-1", electionId: "election-1" } } },
+      { revision: { measure: { id: "measure-2", electionId: "election-1" } } },
+    ]);
+    const { deactivateReaderGuide } = await import("./reader-guides");
+
+    await expect(
+      deactivateReaderGuide("guide-1", "admin", {
+        ipAddress: "203.0.113.8",
+        userAgent: "vitest-agent",
+      })
+    ).resolves.toBe(2);
+
+    expect(mocks.tx.measureReaderGuide.update).toHaveBeenCalledWith({
+      where: { id: "guide-1" },
+      data: { active: false },
+    });
+    expect(mocks.syncSearchMany).toHaveBeenCalledWith(expect.anything(), [
+      "measure-1",
+      "measure-2",
+    ]);
+    expect(mocks.invalidate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -1,7 +1,7 @@
 import { MEASURE_READER_GUIDES } from "@/config/measure-reader-guides";
 import { db } from "@/lib/db";
 import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
-import { syncSearchDocument } from "@/lib/measures/search-sync";
+import { syncSearchDocument, syncSearchDocuments } from "@/lib/measures/search-sync";
 import { invalidateMeasureTags } from "@/lib/measures/cache";
 import { MeasureValidationError } from "@/lib/measures/errors";
 import {
@@ -32,6 +32,12 @@ export type ReaderGuideAuditMetadata = {
   ipAddress?: string;
   userAgent?: string;
 };
+
+const PROGRAM_SOURCE_KINDS = [
+  "PROGRAMME_PARTI",
+  "PROGRAMME_CANDIDAT",
+  "PROPOSITIONS_CANDIDAT",
+] as const;
 
 function findGuide(term: string, canonicalLabel: string, guides: GuideMatch[]): GuideMatch | null {
   const candidates = new Set([
@@ -335,7 +341,12 @@ async function validateReaderGuideDraft(input: ReaderGuideDraftInput): Promise<v
     throw new MeasureValidationError("Une source de programme doit être rattachée à une révision");
   }
   const source = await db.measureSource.findFirst({
-    where: { measureRevisionId: input.sourceRevisionId, url: input.sourceUrl },
+    where: {
+      measureRevisionId: input.sourceRevisionId,
+      url: input.sourceUrl,
+      tier: "PRIMARY",
+      sourceKind: { in: [...PROGRAM_SOURCE_KINDS] },
+    },
     select: { id: true },
   });
   if (!source)
@@ -420,7 +431,12 @@ export async function publishReaderGuide(
         throw new MeasureValidationError("La source de programme n'est pas rattachée");
       }
       const source = await tx.measureSource.findFirst({
-        where: { measureRevisionId: guide.sourceRevisionId, url: guide.sourceUrl },
+        where: {
+          measureRevisionId: guide.sourceRevisionId,
+          url: guide.sourceUrl,
+          tier: "PRIMARY",
+          sourceKind: { in: [...PROGRAM_SOURCE_KINDS] },
+        },
         select: { id: true },
       });
       if (!source) throw new MeasureValidationError("La source de programme n'est plus valide");
@@ -440,6 +456,54 @@ export async function publishReaderGuide(
       },
     });
   });
+}
+
+export async function deactivateReaderGuide(
+  guideId: string,
+  actor: string,
+  auditMetadata: ReaderGuideAuditMetadata = {}
+): Promise<number> {
+  const measures = await db.$transaction(async (tx) => {
+    const guide = await tx.measureReaderGuide.findUnique({
+      where: { id: guideId },
+      select: { active: true, publicationStatus: true },
+    });
+    if (!guide || guide.publicationStatus !== "PUBLISHED") {
+      throw new MeasureValidationError("Ce repère n'est pas publié");
+    }
+    if (guide.active) {
+      await tx.measureReaderGuide.update({ where: { id: guideId }, data: { active: false } });
+      await tx.auditLog.create({
+        data: {
+          action: "DEACTIVATE_READER_GUIDE",
+          entityType: "MeasureReaderGuide",
+          entityId: guideId,
+          changes: { active: false },
+          userId: actor,
+          ...auditMetadata,
+        },
+      });
+    }
+    const mentions = await tx.measureRevisionReaderGuide.findMany({
+      where: { guideId, status: "APPROVED" },
+      select: {
+        revision: { select: { measure: { select: { id: true, electionId: true } } } },
+      },
+    });
+    return [
+      ...new Map(
+        mentions.map(({ revision }) => [revision.measure.id, revision.measure] as const)
+      ).values(),
+    ];
+  });
+  for (let index = 0; index < measures.length; index += 25) {
+    await syncSearchDocuments(
+      db,
+      measures.slice(index, index + 25).map(({ id }) => id)
+    );
+  }
+  for (const measure of measures) invalidateMeasureTags(measure.id, measure.electionId);
+  return measures.length;
 }
 
 export async function listReaderGuideDetectionCandidates(input: {

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -5,11 +5,11 @@ import { syncSearchDocument, syncSearchDocuments } from "@/lib/measures/search-s
 import { invalidateMeasureTags } from "@/lib/measures/cache";
 import { MeasureValidationError } from "@/lib/measures/errors";
 import {
-  detectReaderGuideTerms,
   normalizeReaderGuideTerm,
   READER_GUIDE_DETECTOR_VERSION,
   type ReaderGuideDetection,
 } from "@/lib/measures/reader-guide-detection";
+import { detectReaderGuideTerms } from "@/services/measures/reader-guide-detection";
 import { isOfficialInstitutionUrl } from "@/lib/measures/reader-guide-source";
 import { Prisma } from "@/generated/prisma";
 
@@ -490,18 +490,17 @@ export async function deactivateReaderGuide(
         revision: { select: { measure: { select: { id: true, electionId: true } } } },
       },
     });
-    return [
+    const measures = [
       ...new Map(
         mentions.map(({ revision }) => [revision.measure.id, revision.measure] as const)
       ).values(),
     ];
-  });
-  for (let index = 0; index < measures.length; index += 25) {
     await syncSearchDocuments(
-      db,
-      measures.slice(index, index + 25).map(({ id }) => id)
+      tx,
+      measures.map(({ id }) => id)
     );
-  }
+    return measures;
+  });
   for (const measure of measures) invalidateMeasureTags(measure.id, measure.electionId);
   return measures.length;
 }

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -1,0 +1,430 @@
+import { MEASURE_READER_GUIDES } from "@/config/measure-reader-guides";
+import { db } from "@/lib/db";
+import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
+import { syncSearchDocument } from "@/lib/measures/search-sync";
+import { invalidateMeasureTags } from "@/lib/measures/cache";
+import { MeasureValidationError } from "@/lib/measures/errors";
+import {
+  detectReaderGuideTerms,
+  normalizeReaderGuideTerm,
+  READER_GUIDE_DETECTOR_VERSION,
+  type ReaderGuideDetection,
+} from "@/lib/measures/reader-guide-detection";
+import { isOfficialInstitutionUrl } from "@/lib/measures/reader-guide-source";
+
+type GuideMatch = {
+  id: string;
+  slug: string;
+  label: string;
+  aliases: string[];
+  publicationStatus: string;
+};
+
+export type ReaderGuideProposal = ReaderGuideDetection & {
+  normalizedTerm: string;
+  guideId: string | null;
+  guideSlug: string | null;
+  guideLabel: string | null;
+};
+
+function findGuide(term: string, canonicalLabel: string, guides: GuideMatch[]): GuideMatch | null {
+  const candidates = new Set([
+    normalizeReaderGuideTerm(term),
+    normalizeReaderGuideTerm(canonicalLabel),
+  ]);
+  return (
+    guides.find((guide) =>
+      [guide.label, ...guide.aliases].some((alias) =>
+        candidates.has(normalizeReaderGuideTerm(alias))
+      )
+    ) ?? null
+  );
+}
+
+export async function syncReaderGuideCatalog(actor = "system"): Promise<{
+  created: number;
+  updated: number;
+  preserved: number;
+}> {
+  let created = 0;
+  let updated = 0;
+  let preserved = 0;
+  for (const definition of MEASURE_READER_GUIDES) {
+    const outcome = await db.$transaction(async (tx) => {
+      const existing = await tx.measureReaderGuide.findUnique({
+        where: { slug: definition.slug },
+        select: { id: true, publicationStatus: true },
+      });
+      if (!existing) {
+        const guide = await tx.measureReaderGuide.create({
+          data: {
+            ...definition,
+            aliases: [...definition.aliases],
+            sourceKind: "OFFICIAL_INSTITUTION",
+            publicationStatus: "DRAFT",
+          },
+        });
+        await tx.auditLog.create({
+          data: {
+            action: "CREATE_READER_GUIDE_DRAFT",
+            entityType: "MeasureReaderGuide",
+            entityId: guide.id,
+            changes: { slug: definition.slug, catalog: true },
+            userId: actor,
+          },
+        });
+        return "created" as const;
+      }
+      if (existing.publicationStatus !== "DRAFT") return "preserved" as const;
+      await tx.measureReaderGuide.update({
+        where: { id: existing.id },
+        data: {
+          label: definition.label,
+          definition: definition.definition,
+          aliases: [...definition.aliases],
+          sourceUrl: definition.sourceUrl,
+          sourceLabel: definition.sourceLabel,
+          sourcePublisher: definition.sourcePublisher,
+          sourceKind: "OFFICIAL_INSTITUTION",
+        },
+      });
+      await tx.auditLog.create({
+        data: {
+          action: "SYNC_READER_GUIDE_DRAFT",
+          entityType: "MeasureReaderGuide",
+          entityId: existing.id,
+          changes: { slug: definition.slug, catalog: true },
+          userId: actor,
+        },
+      });
+      return "updated" as const;
+    });
+    if (outcome === "created") created += 1;
+    if (outcome === "updated") updated += 1;
+    if (outcome === "preserved") preserved += 1;
+  }
+  return { created, updated, preserved };
+}
+
+export async function detectReaderGuidesForRevision(revisionId: string): Promise<{
+  revisionId: string;
+  measureId: string;
+  electionId: string;
+  proposals: ReaderGuideProposal[];
+}> {
+  const [revision, guides] = await Promise.all([
+    db.measureRevision.findUnique({
+      where: { id: revisionId },
+      select: {
+        text: true,
+        details: true,
+        measure: { select: { id: true, electionId: true } },
+      },
+    }),
+    db.measureReaderGuide.findMany({
+      where: { active: true, publicationStatus: { in: ["DRAFT", "PUBLISHED"] } },
+      select: { id: true, slug: true, label: true, aliases: true, publicationStatus: true },
+      orderBy: { label: "asc" },
+    }),
+  ]);
+  if (!revision) throw new MeasureValidationError("Révision introuvable");
+  const detections = await detectReaderGuideTerms({
+    text: revision.text,
+    details: revision.details,
+    knownLabels: guides.flatMap((guide) => [guide.label, ...guide.aliases]),
+  });
+  return {
+    revisionId,
+    measureId: revision.measure.id,
+    electionId: revision.measure.electionId,
+    proposals: detections.map((detection) => {
+      const guide = findGuide(detection.term, detection.canonicalLabel, guides);
+      return {
+        ...detection,
+        normalizedTerm: normalizeReaderGuideTerm(detection.term),
+        guideId: guide?.id ?? null,
+        guideSlug: guide?.slug ?? null,
+        guideLabel: guide?.label ?? null,
+      };
+    }),
+  };
+}
+
+export async function proposeReaderGuidesForRevision(
+  revisionId: string,
+  actor = "system"
+): Promise<{ created: number; proposals: ReaderGuideProposal[] }> {
+  const detection = await detectReaderGuidesForRevision(revisionId);
+  const created = await db.$transaction(async (tx) => {
+    let count = 0;
+    for (const proposal of detection.proposals) {
+      const result = await tx.measureRevisionReaderGuide.createMany({
+        data: [
+          {
+            revisionId,
+            guideId: proposal.guideId,
+            term: proposal.term,
+            normalizedTerm: proposal.normalizedTerm,
+            evidenceSpan: proposal.evidenceSpan,
+            reason: proposal.reason,
+            confidence: proposal.confidence,
+            status: "SUGGESTED",
+            method: "AI_ASSISTED",
+            detectorVersion: READER_GUIDE_DETECTOR_VERSION,
+          },
+        ],
+        skipDuplicates: true,
+      });
+      count += result.count;
+    }
+    await tx.auditLog.create({
+      data: {
+        action: "PROPOSE_READER_GUIDES",
+        entityType: "MeasureRevision",
+        entityId: revisionId,
+        changes: {
+          detectorVersion: READER_GUIDE_DETECTOR_VERSION,
+          created: count,
+          proposals: detection.proposals.map((proposal) => ({
+            term: proposal.term,
+            normalizedTerm: proposal.normalizedTerm,
+            guideSlug: proposal.guideSlug,
+            reason: proposal.reason,
+            confidence: proposal.confidence,
+          })),
+        },
+        userId: actor,
+      },
+    });
+    return count;
+  });
+  return { created, proposals: detection.proposals };
+}
+
+export async function reviewReaderGuideMention(input: {
+  mentionId: string;
+  guideId?: string;
+  status: "APPROVED" | "REJECTED";
+  reviewedBy: string;
+}): Promise<void> {
+  const measure = await db.$transaction(async (tx) => {
+    const mention = await tx.measureRevisionReaderGuide.findUnique({
+      where: { id: input.mentionId },
+      select: {
+        status: true,
+        guideId: true,
+        revisionId: true,
+        revision: { select: { measure: { select: { id: true, electionId: true } } } },
+      },
+    });
+    if (!mention || mention.status !== "SUGGESTED") {
+      throw new MeasureValidationError("Cette proposition a déjà été traitée");
+    }
+    const guideId = input.guideId ?? mention.guideId;
+    if (input.status === "APPROVED") {
+      if (!guideId) throw new MeasureValidationError("Choisissez un repère avant de valider");
+      const guide = await tx.measureReaderGuide.findUnique({
+        where: { id: guideId },
+        select: { publicationStatus: true, active: true },
+      });
+      if (!guide || !guide.active || guide.publicationStatus !== "PUBLISHED") {
+        throw new MeasureValidationError("Le repère doit être publié avant son rattachement");
+      }
+      const duplicate = await tx.measureRevisionReaderGuide.findFirst({
+        where: {
+          id: { not: input.mentionId },
+          revisionId: mention.revisionId,
+          guideId,
+          status: "APPROVED",
+        },
+        select: { id: true },
+      });
+      if (duplicate) throw new MeasureValidationError("Ce repère est déjà validé pour la révision");
+    }
+    const updated = await tx.measureRevisionReaderGuide.updateMany({
+      where: { id: input.mentionId, status: "SUGGESTED" },
+      data: {
+        guideId: guideId ?? null,
+        status: input.status,
+        reviewedAt: new Date(),
+        reviewedBy: input.reviewedBy,
+      },
+    });
+    if (updated.count !== 1)
+      throw new MeasureValidationError("Cette proposition a déjà été traitée");
+    await tx.auditLog.create({
+      data: {
+        action: "REVIEW_READER_GUIDE_MENTION",
+        entityType: "MeasureRevisionReaderGuide",
+        entityId: input.mentionId,
+        changes: { status: input.status, guideId: guideId ?? null },
+        userId: input.reviewedBy,
+      },
+    });
+    await syncSearchDocument(tx, mention.revision.measure.id);
+    return mention.revision.measure;
+  });
+  invalidateMeasureTags(measure.id, measure.electionId);
+}
+
+export type ReaderGuideDraftInput = {
+  id?: string;
+  slug: string;
+  label: string;
+  definition: string;
+  aliases: string[];
+  sourceKind: "OFFICIAL_INSTITUTION" | "PROGRAM_SOURCE";
+  sourceUrl: string;
+  sourceLabel: string;
+  sourcePublisher: string;
+  sourceRevisionId?: string | null;
+};
+
+async function validateReaderGuideDraft(input: ReaderGuideDraftInput): Promise<void> {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(input.slug)) {
+    throw new MeasureValidationError("Le slug doit contenir uniquement des minuscules et tirets");
+  }
+  if (input.label.trim().length < 3 || input.definition.trim().length < 40) {
+    throw new MeasureValidationError("Le libellé ou la définition est trop court");
+  }
+  if (input.sourceKind === "OFFICIAL_INSTITUTION") {
+    if (!isOfficialInstitutionUrl(input.sourceUrl)) {
+      throw new MeasureValidationError("La source doit être une page institutionnelle officielle");
+    }
+    return;
+  }
+  if (!input.sourceRevisionId) {
+    throw new MeasureValidationError("Une source de programme doit être rattachée à une révision");
+  }
+  const source = await db.measureSource.findFirst({
+    where: { measureRevisionId: input.sourceRevisionId, url: input.sourceUrl },
+    select: { id: true },
+  });
+  if (!source)
+    throw new MeasureValidationError("Cette URL ne fait pas partie des sources de la révision");
+}
+
+export async function saveReaderGuideDraft(
+  input: ReaderGuideDraftInput,
+  actor: string
+): Promise<string> {
+  await validateReaderGuideDraft(input);
+  const data = {
+    slug: input.slug.trim(),
+    label: input.label.trim(),
+    definition: input.definition.trim(),
+    aliases: [...new Set(input.aliases.map((alias) => alias.trim()).filter(Boolean))],
+    sourceKind: input.sourceKind,
+    sourceUrl: input.sourceUrl.trim(),
+    sourceLabel: input.sourceLabel.trim(),
+    sourcePublisher: input.sourcePublisher.trim(),
+    sourceRevisionId: input.sourceRevisionId ?? null,
+  };
+  return db.$transaction(async (tx) => {
+    if (input.id) {
+      const existing = await tx.measureReaderGuide.findUnique({
+        where: { id: input.id },
+        select: { publicationStatus: true },
+      });
+      if (!existing || existing.publicationStatus !== "DRAFT") {
+        throw new MeasureValidationError("Seul un brouillon peut être modifié");
+      }
+      await tx.measureReaderGuide.update({ where: { id: input.id }, data });
+      await tx.auditLog.create({
+        data: {
+          action: "UPDATE_READER_GUIDE_DRAFT",
+          entityType: "MeasureReaderGuide",
+          entityId: input.id,
+          changes: data,
+          userId: actor,
+        },
+      });
+      return input.id;
+    }
+    const created = await tx.measureReaderGuide.create({
+      data: { ...data, publicationStatus: "DRAFT" },
+      select: { id: true },
+    });
+    await tx.auditLog.create({
+      data: {
+        action: "CREATE_READER_GUIDE_DRAFT",
+        entityType: "MeasureReaderGuide",
+        entityId: created.id,
+        changes: data,
+        userId: actor,
+      },
+    });
+    return created.id;
+  });
+}
+
+export async function publishReaderGuide(guideId: string, actor: string): Promise<void> {
+  await db.$transaction(async (tx) => {
+    const guide = await tx.measureReaderGuide.findUnique({ where: { id: guideId } });
+    if (!guide || guide.publicationStatus !== "DRAFT") {
+      throw new MeasureValidationError("Ce repère n'est pas un brouillon publiable");
+    }
+    if (!guide.sourceLabel.trim() || !guide.sourcePublisher.trim() || !guide.definition.trim()) {
+      throw new MeasureValidationError("Le repère ou sa source est incomplet");
+    }
+    if (guide.sourceKind === "OFFICIAL_INSTITUTION" && !isOfficialInstitutionUrl(guide.sourceUrl)) {
+      throw new MeasureValidationError("La source institutionnelle n'est pas valide");
+    }
+    if (guide.sourceKind === "PROGRAM_SOURCE") {
+      if (!guide.sourceRevisionId) {
+        throw new MeasureValidationError("La source de programme n'est pas rattachée");
+      }
+      const source = await tx.measureSource.findFirst({
+        where: { measureRevisionId: guide.sourceRevisionId, url: guide.sourceUrl },
+        select: { id: true },
+      });
+      if (!source) throw new MeasureValidationError("La source de programme n'est plus valide");
+    }
+    await tx.measureReaderGuide.update({
+      where: { id: guideId },
+      data: { publicationStatus: "PUBLISHED", reviewedAt: new Date(), reviewedBy: actor },
+    });
+    await tx.auditLog.create({
+      data: {
+        action: "PUBLISH_READER_GUIDE",
+        entityType: "MeasureReaderGuide",
+        entityId: guideId,
+        changes: { publicationStatus: "PUBLISHED" },
+        userId: actor,
+      },
+    });
+  });
+}
+
+export async function listReaderGuideDetectionCandidates(input: {
+  electionSlug: string;
+  limit: number;
+  after?: string;
+}) {
+  return db.measure.findMany({
+    where: {
+      AND: [
+        PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+        {
+          publishedRevision: {
+            is: {
+              readerGuideMentions: {
+                none: { detectorVersion: READER_GUIDE_DETECTOR_VERSION },
+              },
+            },
+          },
+        },
+      ],
+      election: { slug: input.electionSlug },
+      ...(input.after ? { id: { gt: input.after } } : {}),
+    },
+    orderBy: { id: "asc" },
+    take: input.limit,
+    select: {
+      id: true,
+      theme: true,
+      publishedRevisionId: true,
+      candidacy: { select: { candidateName: true } },
+    },
+  });
+}

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -11,6 +11,7 @@ import {
   type ReaderGuideDetection,
 } from "@/lib/measures/reader-guide-detection";
 import { isOfficialInstitutionUrl } from "@/lib/measures/reader-guide-source";
+import { Prisma } from "@/generated/prisma";
 
 type GuideMatch = {
   id: string;
@@ -25,6 +26,11 @@ export type ReaderGuideProposal = ReaderGuideDetection & {
   guideId: string | null;
   guideSlug: string | null;
   guideLabel: string | null;
+};
+
+export type ReaderGuideAuditMetadata = {
+  ipAddress?: string;
+  userAgent?: string;
 };
 
 function findGuide(term: string, canonicalLabel: string, guides: GuideMatch[]): GuideMatch | null {
@@ -152,7 +158,8 @@ export async function detectReaderGuidesForRevision(revisionId: string): Promise
 
 export async function proposeReaderGuidesForRevision(
   revisionId: string,
-  actor = "system"
+  actor = "system",
+  auditMetadata: ReaderGuideAuditMetadata = {}
 ): Promise<{ created: number; proposals: ReaderGuideProposal[] }> {
   const detection = await detectReaderGuidesForRevision(revisionId);
   const created = await db.$transaction(async (tx) => {
@@ -177,6 +184,23 @@ export async function proposeReaderGuidesForRevision(
       });
       count += result.count;
     }
+    await tx.measureReaderGuideDetectionRun.upsert({
+      where: {
+        revisionId_detectorVersion: {
+          revisionId,
+          detectorVersion: READER_GUIDE_DETECTOR_VERSION,
+        },
+      },
+      create: {
+        revisionId,
+        detectorVersion: READER_GUIDE_DETECTOR_VERSION,
+        resultCount: detection.proposals.length,
+      },
+      update: {
+        resultCount: detection.proposals.length,
+        completedAt: new Date(),
+      },
+    });
     await tx.auditLog.create({
       data: {
         action: "PROPOSE_READER_GUIDES",
@@ -194,6 +218,7 @@ export async function proposeReaderGuidesForRevision(
           })),
         },
         userId: actor,
+        ...auditMetadata,
       },
     });
     return count;
@@ -206,64 +231,77 @@ export async function reviewReaderGuideMention(input: {
   guideId?: string;
   status: "APPROVED" | "REJECTED";
   reviewedBy: string;
+  ipAddress?: string;
+  userAgent?: string;
 }): Promise<void> {
-  const measure = await db.$transaction(async (tx) => {
-    const mention = await tx.measureRevisionReaderGuide.findUnique({
-      where: { id: input.mentionId },
-      select: {
-        status: true,
-        guideId: true,
-        revisionId: true,
-        revision: { select: { measure: { select: { id: true, electionId: true } } } },
-      },
-    });
-    if (!mention || mention.status !== "SUGGESTED") {
-      throw new MeasureValidationError("Cette proposition a déjà été traitée");
-    }
-    const guideId = input.guideId ?? mention.guideId;
-    if (input.status === "APPROVED") {
-      if (!guideId) throw new MeasureValidationError("Choisissez un repère avant de valider");
-      const guide = await tx.measureReaderGuide.findUnique({
-        where: { id: guideId },
-        select: { publicationStatus: true, active: true },
-      });
-      if (!guide || !guide.active || guide.publicationStatus !== "PUBLISHED") {
-        throw new MeasureValidationError("Le repère doit être publié avant son rattachement");
-      }
-      const duplicate = await tx.measureRevisionReaderGuide.findFirst({
-        where: {
-          id: { not: input.mentionId },
-          revisionId: mention.revisionId,
-          guideId,
-          status: "APPROVED",
+  let measure: { id: string; electionId: string };
+  try {
+    measure = await db.$transaction(async (tx) => {
+      const mention = await tx.measureRevisionReaderGuide.findUnique({
+        where: { id: input.mentionId },
+        select: {
+          status: true,
+          guideId: true,
+          revisionId: true,
+          revision: { select: { measure: { select: { id: true, electionId: true } } } },
         },
-        select: { id: true },
       });
-      if (duplicate) throw new MeasureValidationError("Ce repère est déjà validé pour la révision");
+      if (!mention || mention.status !== "SUGGESTED") {
+        throw new MeasureValidationError("Cette proposition a déjà été traitée");
+      }
+      const guideId = input.guideId ?? mention.guideId;
+      if (input.status === "APPROVED") {
+        if (!guideId) throw new MeasureValidationError("Choisissez un repère avant de valider");
+        const guide = await tx.measureReaderGuide.findUnique({
+          where: { id: guideId },
+          select: { publicationStatus: true, active: true },
+        });
+        if (!guide || !guide.active || guide.publicationStatus !== "PUBLISHED") {
+          throw new MeasureValidationError("Le repère doit être publié avant son rattachement");
+        }
+        const duplicate = await tx.measureRevisionReaderGuide.findFirst({
+          where: {
+            id: { not: input.mentionId },
+            revisionId: mention.revisionId,
+            guideId,
+            status: "APPROVED",
+          },
+          select: { id: true },
+        });
+        if (duplicate)
+          throw new MeasureValidationError("Ce repère est déjà validé pour la révision");
+      }
+      const updated = await tx.measureRevisionReaderGuide.updateMany({
+        where: { id: input.mentionId, status: "SUGGESTED" },
+        data: {
+          guideId: guideId ?? null,
+          status: input.status,
+          reviewedAt: new Date(),
+          reviewedBy: input.reviewedBy,
+        },
+      });
+      if (updated.count !== 1)
+        throw new MeasureValidationError("Cette proposition a déjà été traitée");
+      await tx.auditLog.create({
+        data: {
+          action: "REVIEW_READER_GUIDE_MENTION",
+          entityType: "MeasureRevisionReaderGuide",
+          entityId: input.mentionId,
+          changes: { status: input.status, guideId: guideId ?? null },
+          userId: input.reviewedBy,
+          ipAddress: input.ipAddress,
+          userAgent: input.userAgent,
+        },
+      });
+      await syncSearchDocument(tx, mention.revision.measure.id);
+      return mention.revision.measure;
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      throw new MeasureValidationError("Ce repère est déjà validé pour la révision");
     }
-    const updated = await tx.measureRevisionReaderGuide.updateMany({
-      where: { id: input.mentionId, status: "SUGGESTED" },
-      data: {
-        guideId: guideId ?? null,
-        status: input.status,
-        reviewedAt: new Date(),
-        reviewedBy: input.reviewedBy,
-      },
-    });
-    if (updated.count !== 1)
-      throw new MeasureValidationError("Cette proposition a déjà été traitée");
-    await tx.auditLog.create({
-      data: {
-        action: "REVIEW_READER_GUIDE_MENTION",
-        entityType: "MeasureRevisionReaderGuide",
-        entityId: input.mentionId,
-        changes: { status: input.status, guideId: guideId ?? null },
-        userId: input.reviewedBy,
-      },
-    });
-    await syncSearchDocument(tx, mention.revision.measure.id);
-    return mention.revision.measure;
-  });
+    throw error;
+  }
   invalidateMeasureTags(measure.id, measure.electionId);
 }
 
@@ -306,7 +344,8 @@ async function validateReaderGuideDraft(input: ReaderGuideDraftInput): Promise<v
 
 export async function saveReaderGuideDraft(
   input: ReaderGuideDraftInput,
-  actor: string
+  actor: string,
+  auditMetadata: ReaderGuideAuditMetadata = {}
 ): Promise<string> {
   await validateReaderGuideDraft(input);
   const data = {
@@ -337,6 +376,7 @@ export async function saveReaderGuideDraft(
           entityId: input.id,
           changes: data,
           userId: actor,
+          ...auditMetadata,
         },
       });
       return input.id;
@@ -352,13 +392,18 @@ export async function saveReaderGuideDraft(
         entityId: created.id,
         changes: data,
         userId: actor,
+        ...auditMetadata,
       },
     });
     return created.id;
   });
 }
 
-export async function publishReaderGuide(guideId: string, actor: string): Promise<void> {
+export async function publishReaderGuide(
+  guideId: string,
+  actor: string,
+  auditMetadata: ReaderGuideAuditMetadata = {}
+): Promise<void> {
   await db.$transaction(async (tx) => {
     const guide = await tx.measureReaderGuide.findUnique({ where: { id: guideId } });
     if (!guide || guide.publicationStatus !== "DRAFT") {
@@ -391,6 +436,7 @@ export async function publishReaderGuide(guideId: string, actor: string): Promis
         entityId: guideId,
         changes: { publicationStatus: "PUBLISHED" },
         userId: actor,
+        ...auditMetadata,
       },
     });
   });
@@ -408,7 +454,7 @@ export async function listReaderGuideDetectionCandidates(input: {
         {
           publishedRevision: {
             is: {
-              readerGuideMentions: {
+              readerGuideDetectionRuns: {
                 none: { detectorVersion: READER_GUIDE_DETECTOR_VERSION },
               },
             },

--- a/src/lib/measures/search-sync.ts
+++ b/src/lib/measures/search-sync.ts
@@ -36,6 +36,21 @@ const SEARCH_MEASURE_SELECT = {
         where: { status: "APPROVED" },
         select: { subtopic: { select: { label: true, aliases: true } } },
       },
+      readerGuideMentions: {
+        where: {
+          status: "APPROVED",
+          guide: {
+            is: {
+              active: true,
+              publicationStatus: "PUBLISHED",
+              reviewedAt: { not: null },
+            },
+          },
+        },
+        select: {
+          guide: { select: { label: true, aliases: true, definition: true } },
+        },
+      },
     },
   },
   latestRevision: {
@@ -47,6 +62,21 @@ const SEARCH_MEASURE_SELECT = {
       subtopics: {
         where: { status: "APPROVED" },
         select: { subtopic: { select: { label: true, aliases: true } } },
+      },
+      readerGuideMentions: {
+        where: {
+          status: "APPROVED",
+          guide: {
+            is: {
+              active: true,
+              publicationStatus: "PUBLISHED",
+              reviewedAt: { not: null },
+            },
+          },
+        },
+        select: {
+          guide: { select: { label: true, aliases: true, definition: true } },
+        },
       },
     },
   },
@@ -66,6 +96,9 @@ function buildSearchDocument(
     subtopic.label,
     ...subtopic.aliases,
   ]);
+  const readerGuideTerms = reference.readerGuideMentions.flatMap(({ guide }) =>
+    guide ? [guide.label, ...guide.aliases, guide.definition] : []
+  );
   const contextualBody = [
     reference.text,
     reference.details,
@@ -73,6 +106,7 @@ function buildSearchDocument(
     partyLabel,
     THEME_CATEGORY_LABELS[measure.theme],
     ...subtopicTerms,
+    ...readerGuideTerms,
   ]
     .filter(Boolean)
     .join("\n\n");

--- a/src/lib/search/__tests__/documents.test.ts
+++ b/src/lib/search/__tests__/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { deleteSearchDocuments, upsertSearchDocuments } from "../documents";
+import { deleteSearchDocuments, upsertSearchDocument, upsertSearchDocuments } from "../documents";
 
 const makeInput = (index: number) => ({
   entityType: "MEASURE" as const,
@@ -14,6 +14,19 @@ const makeInput = (index: number) => ({
 });
 
 describe("écritures groupées des documents de recherche", () => {
+  it("invalide le vecteur sémantique avant de modifier le texte indexé", async () => {
+    const tx = {
+      searchDocument: { upsert: vi.fn(async () => ({ id: "document-1" })) },
+      $executeRaw: vi.fn(async () => 0),
+    };
+
+    await upsertSearchDocument(tx as never, makeInput(1));
+
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
+    const firstCall = tx.$executeRaw.mock.calls[0] as unknown as [TemplateStringsArray];
+    expect(firstCall[0].join("?")).toContain('DELETE FROM "SearchEmbedding"');
+  });
+
   it("borne chaque lot à cent documents", async () => {
     const tx = {
       searchDocument: { createMany: vi.fn(async (_args: { data: unknown[] }) => ({ count: 0 })) },
@@ -28,7 +41,7 @@ describe("écritures groupées des documents de recherche", () => {
     expect(tx.searchDocument.createMany).toHaveBeenCalledTimes(2);
     expect(tx.searchDocument.createMany.mock.calls[0]?.[0]?.data).toHaveLength(100);
     expect(tx.searchDocument.createMany.mock.calls[1]?.[0]?.data).toHaveLength(1);
-    expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(4);
   });
 
   it("type explicitement les dates du VALUES utilisé par PostgreSQL", async () => {
@@ -40,7 +53,7 @@ describe("écritures groupées des documents de recherche", () => {
     await upsertSearchDocuments(tx as never, [makeInput(1)]);
 
     const calls = tx.$executeRaw.mock.calls as unknown as Array<[{ strings: string[] }]>;
-    const query = calls[0]![0];
+    const query = calls[1]![0];
     expect(query.strings.join("?").match(/::timestamp/g)).toHaveLength(2);
   });
 

--- a/src/lib/search/documents.ts
+++ b/src/lib/search/documents.ts
@@ -43,6 +43,22 @@ export async function upsertSearchDocument(
     indexedAt: new Date(),
   };
 
+  // A semantic vector describes title + body, not only the source revision timestamp. Editorial
+  // enrichments such as an approved reader guide can change that text without rewriting the
+  // revision. Delete the old vector in the same transaction so hybrid search cannot treat it as
+  // current until the embedding worker rebuilds it.
+  await tx.$executeRaw`
+    DELETE FROM "SearchEmbedding" AS embedding
+    USING "SearchDocument" AS document
+    WHERE embedding."searchDocumentId" = document.id
+      AND document."entityType" = ${input.entityType}::"SearchEntityType"
+      AND document."entityId" = ${input.entityId}
+      AND (
+        document.title IS DISTINCT FROM ${input.title}
+        OR document.body IS DISTINCT FROM ${input.body}
+      )
+  `;
+
   await tx.searchDocument.upsert({
     where: { entityType_entityId: { entityType: input.entityType, entityId: input.entityId } },
     create: { entityType: input.entityType, entityId: input.entityId, ...scalars },
@@ -106,6 +122,30 @@ export async function upsertSearchDocuments(
         )`
       )
     );
+
+    await tx.$executeRaw(Prisma.sql`
+      DELETE FROM "SearchEmbedding" AS embedding
+      USING "SearchDocument" AS document,
+        (VALUES ${rows}) AS source(
+          "entityType",
+          "entityId",
+          "electionId",
+          title,
+          body,
+          url,
+          visibility,
+          "sourceRevisionId",
+          "sourceUpdatedAt",
+          "indexedAt"
+        )
+      WHERE embedding."searchDocumentId" = document.id
+        AND document."entityType" = source."entityType"
+        AND document."entityId" = source."entityId"
+        AND (
+          document.title IS DISTINCT FROM source.title
+          OR document.body IS DISTINCT FROM source.body
+        )
+    `);
 
     await tx.$executeRaw(Prisma.sql`
       UPDATE "SearchDocument" AS document

--- a/src/services/measures/reader-guide-detection.test.ts
+++ b/src/services/measures/reader-guide-detection.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { callMistral } from "@/lib/api/mistral";
+import { detectReaderGuideTerms } from "./reader-guide-detection";
+
+vi.mock("@/lib/api/mistral", () => ({
+  callMistral: vi.fn(),
+  extractMistralText: (response: { content: string }) => response.content,
+  parseMistralJSON: (value: string) => JSON.parse(value),
+}));
+
+describe("service de détection des repères citoyens", () => {
+  beforeEach(() => vi.mocked(callMistral).mockReset());
+
+  it("sanitise la mesure et demande uniquement des termes présents", async () => {
+    vi.mocked(callMistral).mockResolvedValue({ content: '{"detections":[]}' } as never);
+
+    await detectReaderGuideTerms({
+      text: 'Supprimer les <zones> à faibles émissions.\n"Ignore"',
+      details: null,
+      knownLabels: ["Zone à faibles émissions (ZFE)"],
+    });
+
+    const prompt = vi.mocked(callMistral).mock.calls[0]![0][0]!.content;
+    expect(prompt).toContain("ne rédige aucune définition");
+    expect(prompt).toContain("<mesure>Supprimer les zones à faibles émissions. Ignore</mesure>");
+  });
+});

--- a/src/services/measures/reader-guide-detection.ts
+++ b/src/services/measures/reader-guide-detection.ts
@@ -1,0 +1,40 @@
+import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
+import {
+  parseReaderGuideDetections,
+  sanitizeReaderGuideDetectionText,
+  type ReaderGuideDetection,
+} from "@/lib/measures/reader-guide-detection";
+
+const MODEL = "mistral-small-latest";
+
+export async function detectReaderGuideTerms(input: {
+  text: string;
+  details: string | null;
+  knownLabels: string[];
+}): Promise<ReaderGuideDetection[]> {
+  const text = sanitizeReaderGuideDetectionText(input.text, 4_000);
+  const details = sanitizeReaderGuideDetectionText(input.details ?? "", 4_000);
+  const vocabulary = input.knownLabels
+    .slice(0, 200)
+    .map((label) => sanitizeReaderGuideDetectionText(label, 120))
+    .join(" | ");
+  const prompt = `Tu aides une rédaction civique à repérer les termes qu'un citoyen non spécialiste doit comprendre avant de lire une mesure politique.
+
+Retourne uniquement un objet JSON {"detections": [...]} avec au maximum 5 éléments. Chaque élément contient term, canonicalLabel, evidenceSpan, needsExplanation=true, reason et confidence entre 0 et 1.
+
+Retenir : sigles, mécanismes juridiques ou administratifs, dispositifs nommés, institutions peu connues, mots courants employés dans un sens technique, références réglementaires nécessaires à la compréhension.
+Exemples de forme à examiner : ZFE, kafala judiciaire, quotient familial, obligation de quitter le territoire français. Ces exemples illustrent un niveau de technicité et ne doivent être retournés que s'ils figurent réellement dans la mesure.
+Exclure : vocabulaire quotidien, noms de personnes, jugements politiques, concepts déjà expliqués dans le contexte, termes dont une définition n'apporterait rien. Ne complète jamais la mesure et ne rédige aucune définition.
+
+<vocabulaire-connu>${vocabulary || "aucun"}</vocabulaire-connu>
+<mesure>${text}</mesure>
+<contexte>${details || "aucun"}</contexte>`;
+  const response = await callMistral([{ role: "user", content: prompt }], {
+    model: MODEL,
+    temperature: 0,
+    maxTokens: 1_000,
+    responseFormat: { type: "json_object" },
+  });
+  const parsed = parseMistralJSON<{ detections?: unknown[] }>(extractMistralText(response));
+  return parseReaderGuideDetections(parsed.detections ?? [], `${text} ${details}`);
+}


### PR DESCRIPTION
## Objectif

Aider les lecteurs à comprendre les sigles et dispositifs techniques cités dans les mesures, sans mélanger la définition factuelle avec le contenu du programme.

## Changements

- ajoute un référentiel réutilisable de repères avec source officielle ou source du programme
- sépare la publication du repère et la validation de son rattachement à une révision
- détecte avec Mistral des termes candidats, sans générer de définition ni publier automatiquement
- fournit des commandes cursorisées avec dry-run, rapport gitignoré et reprise idempotente
- ajoute la création, la publication et la modération dans l'administration
- affiche un bloc accessible « Repères pour comprendre » sur les fiches mesures
- enrichit le document de recherche avec les libellés, alias et définitions validés
- documente la méthode et initialise le repère ZFE comme brouillon synchronisable

## Sécurité éditoriale

- seules les suggestions `APPROVED` liées à un repère actif, `PUBLISHED` et relu sont publiques
- les définitions ne sont jamais écrites par le modèle
- les sources institutionnelles sont limitées à des domaines officiels HTTPS
- toutes les mutations sont authentifiées, validées et auditées
- RLS activée sur les deux nouvelles tables

## Vérifications

- `npm run typecheck`
- `npm run lint` (0 erreur, avertissements existants)
- 56 tests ciblés verts
- suite complète : 5 626 tests verts, 3 échecs locaux dus à des scripts gitignorés dans `scripts/.local` et à un timeout du garde sous concurrence
- build Next : compilation et TypeScript verts ; collecte statique bloquée ensuite sur la page existante `/affaires/parti/[slug]`
- migration Prisma appliquée et inscrite dans l'historique ; présence des tables et RLS vérifiées

## Après déploiement

```bash
npm run measures:sync-reader-guides -- --apply
npm run measures:detect-reader-guides -- --election presidentielle-2027 --limit 100 --dry-run
```

Le repère ZFE doit ensuite être relu et publié dans `/admin/mesures/reperes` avant validation des rattachements.
