### PR TITLE
feat: mailler les repères citoyens du corpus présidentiel

### DIFF
--- a/docs/editorial/reperes-mesures.md
+++ b/docs/editorial/reperes-mesures.md
@@ -61,6 +61,22 @@ L'application crée uniquement des suggestions. Leur validation se fait sur la f
 mesure. Une validation resynchronise le document de recherche concerné et invalide uniquement les
 caches de cette mesure et de son élection.
 
+## Publication et maillage public
+
+Le site construit le glossaire public à partir des mesures publiques, jamais directement à partir
+du catalogue. Un repère apparaît seulement si son statut est `PUBLISHED`, s'il a été relu et si au
+moins une mention `APPROVED` existe sur la révision publiée d'une mesure encore défendue par une
+candidature publique.
+
+Chaque page de repère relie la définition à sa source, aux mesures qui emploient le terme, aux
+candidats concernés et aux pages thématiques. Les fiches de mesure et les pages thématiques font le
+lien inverse. Le hub ne montre qu'une sélection bornée de repères afin de ne pas devenir un nuage de
+mots sans hiérarchie.
+
+Une définition trop courte ou un repère sans mesure publique reste en `noindex,follow` et n'entre
+pas dans le sitemap. La page d'ensemble suit la même règle tant qu'aucun repère ne produit une page
+substantielle. Cette porte est centralisée dans `src/lib/seo/reader-guide-robots.ts`.
+
 ## Limites
 
 La détection ne consulte pas le Web et ne produit pas de définition. Un terme nouveau demande donc

--- a/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
+++ b/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
@@ -117,6 +117,8 @@ const PARTY_SURFACES = [
   "src/app/elections/presidentielle-2027/page.tsx",
   "src/app/elections/presidentielle-2027/priorites/page.tsx",
   "src/app/elections/presidentielle-2027/recherche/page.tsx",
+  "src/app/elections/presidentielle-2027/reperes/[slug]/page.tsx",
+  "src/app/elections/presidentielle-2027/reperes/page.tsx",
   "src/app/elections/presidentielle-2027/themes/[theme]/page.tsx",
   "src/app/elections/presidentielle-2027/themes/page.tsx",
   "src/app/factchecks/[slug]/page.tsx",

--- a/src/app/elections/presidentielle-2027/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/__tests__/page.test.ts
@@ -26,6 +26,7 @@ function context(over: Partial<HubMeasureContext> = {}): HubMeasureContext {
     lastReviewedAt: null,
     themes: [],
     featuredSubtopics: [],
+    featuredReaderGuides: [],
     ...over,
   };
 }

--- a/src/app/elections/presidentielle-2027/_components/HubReaderGuides.tsx
+++ b/src/app/elections/presidentielle-2027/_components/HubReaderGuides.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import type { HubMeasureContext } from "@/lib/data/hub";
+import {
+  presidentialReaderGuidePath,
+  presidentialReaderGuidesPath,
+} from "@/lib/presidentielle/reader-guide-paths";
+
+export function HubReaderGuides({ guides }: { guides: HubMeasureContext["featuredReaderGuides"] }) {
+  if (guides.length === 0) return null;
+  return (
+    <section aria-labelledby="hub-reader-guides" className="space-y-4">
+      <div className="space-y-1.5">
+        <h2 id="hub-reader-guides" className="font-display text-xl font-bold md:text-2xl">
+          Comprendre les termes des programmes
+        </h2>
+        <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          Définitions sourcées des sigles et dispositifs techniques présents dans les mesures
+          publiées.
+        </p>
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {guides.map((guide) => (
+          <li key={guide.slug}>
+            <Link
+              href={presidentialReaderGuidePath(guide.slug)}
+              className="flex min-h-20 h-full flex-col justify-center rounded-xl border border-border bg-card px-4 py-3 hover:border-primary/60 hover:bg-accent/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              <span className="font-bold text-primary">{guide.label}</span>
+              <span className="mt-1 text-xs text-muted-foreground">
+                {guide.measureCount} {guide.measureCount === 1 ? "mesure" : "mesures"} ·{" "}
+                {guide.candidateCount} {guide.candidateCount === 1 ? "candidat" : "candidats"}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Link
+        href={presidentialReaderGuidesPath()}
+        className="inline-flex min-h-11 items-center gap-2 font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      >
+        Voir tout le glossaire
+        <ArrowRight aria-hidden="true" className="h-4 w-4" />
+      </Link>
+    </section>
+  );
+}

--- a/src/app/elections/presidentielle-2027/_components/__tests__/HubReaderGuides.test.tsx
+++ b/src/app/elections/presidentielle-2027/_components/__tests__/HubReaderGuides.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HubReaderGuides } from "../HubReaderGuides";
+
+describe("HubReaderGuides", () => {
+  it("ne réserve aucun espace sans repère validé", () => {
+    const { container } = render(<HubReaderGuides guides={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("relie le hub aux repères et au glossaire", () => {
+    render(
+      <HubReaderGuides
+        guides={[
+          {
+            slug: "zones-faibles-emissions",
+            label: "Zone à faibles émissions (ZFE)",
+            measureCount: 3,
+            candidateCount: 2,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: /Zone à faibles émissions/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/reperes/zones-faibles-emissions"
+    );
+    expect(screen.getByRole("link", { name: /Voir tout le glossaire/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/reperes"
+    );
+  });
+});

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -201,7 +201,7 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
                   <h3 className="font-display text-lg font-bold">
                     <Link
                       href={presidentialReaderGuidePath(guide.slug)}
-                      className="text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      className="inline-flex min-h-11 items-center text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                     >
                       {guide.label}
                     </Link>

--- a/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
+++ b/src/app/elections/presidentielle-2027/mesures/[id]/page.tsx
@@ -18,6 +18,10 @@ import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
 import { buildMeasureSeoDescription, truncateAtWord } from "@/lib/presidentielle/measure-seo";
 import { themeToSlug } from "@/lib/presidentielle/themes";
+import {
+  presidentialReaderGuidePath,
+  presidentialReaderGuidesPath,
+} from "@/lib/presidentielle/reader-guide-paths";
 import { formatDate } from "@/lib/utils";
 import { PresidentialSubtopicLink } from "../../_components/PresidentialSubtopicLink";
 
@@ -194,7 +198,14 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
             <div className="mt-5 grid gap-4 lg:grid-cols-2">
               {measure.readerGuides.map((guide) => (
                 <article key={guide.slug} className="rounded-2xl border border-border bg-card p-5">
-                  <h3 className="font-display text-lg font-bold">{guide.label}</h3>
+                  <h3 className="font-display text-lg font-bold">
+                    <Link
+                      href={presidentialReaderGuidePath(guide.slug)}
+                      className="text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    >
+                      {guide.label}
+                    </Link>
+                  </h3>
                   <p className="mt-2 leading-relaxed text-foreground">{guide.definition}</p>
                   <a
                     href={guide.sourceUrl}
@@ -209,6 +220,12 @@ export default async function PresidentialMeasurePage({ params }: PageProps) {
                 </article>
               ))}
             </div>
+            <Link
+              href={presidentialReaderGuidesPath()}
+              className="mt-4 inline-flex min-h-11 items-center font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              Consulter tous les repères de la présidentielle 2027
+            </Link>
           </section>
         )}
 

--- a/src/app/elections/presidentielle-2027/page.tsx
+++ b/src/app/elections/presidentielle-2027/page.tsx
@@ -14,6 +14,7 @@ import { HubCorpusState } from "./_components/HubCorpusState";
 import { HubComparisonLauncher } from "./_components/HubComparisonLauncher";
 import { HubSubjects } from "./_components/HubSubjects";
 import { HubTopics } from "./_components/HubTopics";
+import { HubReaderGuides } from "./_components/HubReaderGuides";
 import { PresidentialHubNav } from "./_components/PresidentialHubNav";
 import { PresidentialCorpusSearch } from "./_components/PresidentialCorpusSearch";
 
@@ -121,6 +122,8 @@ export default async function PresidentialHubPage() {
         <HubTopics subtopics={context.featuredSubtopics} />
 
         <HubSubjects themes={context.themes} />
+
+        <HubReaderGuides guides={context.featuredReaderGuides} />
 
         <HubCandidacyOverview candidacies={field} />
 

--- a/src/app/elections/presidentielle-2027/reperes/[slug]/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/reperes/[slug]/__tests__/page.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/data/presidential-reader-guides", () => ({
+  getPresidentialReaderGuide: vi.fn(),
+}));
+
+import { getPresidentialReaderGuide } from "@/lib/data/presidential-reader-guides";
+import { generateMetadata } from "../page";
+
+const mockGet = vi.mocked(getPresidentialReaderGuide);
+
+function props(slug = "zones-faibles-emissions") {
+  return { params: Promise.resolve({ slug }) };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("métadonnées d'un repère présidentiel", () => {
+  it("rend un repère substantiel indexable avec un canonical stable", async () => {
+    mockGet.mockResolvedValue({
+      slug: "zones-faibles-emissions",
+      label: "Zone à faibles émissions (ZFE)",
+      definition:
+        "Une zone à faibles émissions limite la circulation des véhicules les plus polluants dans un périmètre défini.",
+      indexable: true,
+    } as never);
+
+    const metadata = await generateMetadata(props());
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe(
+      "/elections/presidentielle-2027/reperes/zones-faibles-emissions"
+    );
+    expect(String(metadata.title)).toContain("Zone à faibles émissions");
+  });
+
+  it("garde un repère mince hors index", async () => {
+    mockGet.mockResolvedValue({
+      slug: "terme-court",
+      label: "Terme court",
+      definition: "Définition courte.",
+      indexable: false,
+    } as never);
+
+    const metadata = await generateMetadata(props("terme-court"));
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("garde une URL inconnue hors index", async () => {
+    mockGet.mockResolvedValue(null);
+    const metadata = await generateMetadata(props("inconnu"));
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+});

--- a/src/app/elections/presidentielle-2027/reperes/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/reperes/[slug]/page.tsx
@@ -138,7 +138,7 @@ export default async function PresidentialReaderGuidePage({ params }: PageProps)
                   <h3 className="font-display text-xl font-bold">
                     <Link
                       href={`/elections/presidentielle-2027/candidats/${candidateSlug}`}
-                      className="text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      className="inline-flex min-h-11 items-center text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                     >
                       {candidate.candidateName}
                     </Link>
@@ -151,7 +151,7 @@ export default async function PresidentialReaderGuidePage({ params }: PageProps)
                       <li key={measure.slug} className="py-3 first:pt-0 last:pb-0">
                         <Link
                           href={`/elections/presidentielle-2027/mesures/${measure.slug}`}
-                          className="leading-relaxed text-foreground underline decoration-border underline-offset-2 hover:text-primary hover:decoration-current focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                          className="inline-flex min-h-11 items-center leading-relaxed text-foreground underline decoration-border underline-offset-2 hover:text-primary hover:decoration-current focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                         >
                           {measure.text}
                         </Link>

--- a/src/app/elections/presidentielle-2027/reperes/[slug]/page.tsx
+++ b/src/app/elections/presidentielle-2027/reperes/[slug]/page.tsx
@@ -1,0 +1,184 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ExternalLink } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { DefinedTermJsonLd } from "@/components/seo/JsonLd";
+import { SITE_URL } from "@/config/site";
+import { getPresidentialReaderGuide } from "@/lib/data/presidential-reader-guides";
+import {
+  presidentialReaderGuidePath,
+  presidentialReaderGuidesPath,
+} from "@/lib/presidentielle/reader-guide-paths";
+import { truncateAtWord } from "@/lib/presidentielle/measure-seo";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+import { formatDate } from "@/lib/utils";
+
+export const revalidate = 86400;
+
+type PageProps = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const guide = await getPresidentialReaderGuide(PRESIDENTIELLE_2027_SLUG, slug);
+  if (!guide) {
+    return { title: "Repère indisponible | Poligraph", robots: { index: false, follow: true } };
+  }
+  const canonical = presidentialReaderGuidePath(guide.slug);
+  return {
+    title: `${guide.label} : définition et mesures | Présidentielle 2027`,
+    description: truncateAtWord(
+      `${guide.definition} Retrouvez les mesures de la présidentielle 2027 qui emploient ce terme.`,
+      155
+    ),
+    robots: guide.indexable ? undefined : { index: false, follow: true },
+    alternates: { canonical },
+  };
+}
+
+export default async function PresidentialReaderGuidePage({ params }: PageProps) {
+  const { slug } = await params;
+  const guide = await getPresidentialReaderGuide(PRESIDENTIELLE_2027_SLUG, slug);
+  if (!guide) notFound();
+
+  const canonical = presidentialReaderGuidePath(guide.slug);
+  const groupedByCandidate = new Map<string, typeof guide.measures>();
+  for (const measure of guide.measures) {
+    const current = groupedByCandidate.get(measure.candidateSlug) ?? [];
+    current.push(measure);
+    groupedByCandidate.set(measure.candidateSlug, current);
+  }
+
+  return (
+    <main className="pb-14">
+      <DefinedTermJsonLd
+        name={guide.label}
+        description={guide.definition}
+        alternateNames={guide.aliases}
+        sourceUrl={guide.sourceUrl}
+        url={`${SITE_URL}${canonical}`}
+        termSetUrl={`${SITE_URL}${presidentialReaderGuidesPath()}`}
+      />
+      <Breadcrumb
+        items={[
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: "/elections/presidentielle-2027" },
+          { label: "Repères", href: presidentialReaderGuidesPath() },
+          { label: guide.label },
+        ]}
+      />
+
+      <article className="container mx-auto max-w-6xl px-4">
+        <header className="max-w-4xl border-b border-border pb-8 pt-3">
+          <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
+            Repère pour comprendre
+          </p>
+          <h1 className="mt-3 max-w-[28ch] font-display text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            {guide.label}
+          </h1>
+          <p className="mt-5 max-w-[76ch] text-lg leading-relaxed text-foreground">
+            {guide.definition}
+          </p>
+          {guide.aliases.length > 0 && (
+            <p className="mt-4 text-sm text-muted-foreground">
+              Aussi recherché sous : {guide.aliases.join(", ")}.
+            </p>
+          )}
+          <a
+            href={guide.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Consulter ${guide.sourceLabel}, source publiée par ${guide.sourcePublisher}, lien externe`}
+            className="mt-4 inline-flex min-h-11 items-center gap-2 font-bold text-primary underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Source : {guide.sourcePublisher}
+            <ExternalLink aria-hidden="true" className="h-4 w-4" />
+          </a>
+          <p className="text-xs text-muted-foreground">
+            Définition vérifiée le {formatDate(guide.reviewedAt)}
+          </p>
+        </header>
+
+        <section aria-labelledby="themes-title" className="border-b border-border py-8">
+          <h2 id="themes-title" className="font-display text-2xl font-extrabold">
+            Thèmes concernés
+          </h2>
+          <ul className="mt-4 flex flex-wrap gap-2">
+            {guide.themes.map((theme) => (
+              <li key={theme.theme}>
+                <Link
+                  href={`/elections/presidentielle-2027/themes/${theme.slug}`}
+                  className="inline-flex min-h-11 items-center rounded-full border border-border px-4 py-2 text-sm font-bold hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                >
+                  {theme.label} · {theme.measureCount}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section aria-labelledby="measures-title" className="py-8">
+          <h2 id="measures-title" className="font-display text-2xl font-extrabold">
+            Mesures qui mentionnent ce terme
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            {guide.measures.length}{" "}
+            {guide.measures.length === 1 ? "mesure publiée" : "mesures publiées"} par{" "}
+            {guide.candidateCount} {guide.candidateCount === 1 ? "candidat" : "candidats"}. Ce
+            regroupement décrit la présence du terme, sans évaluer les propositions.
+          </p>
+          <div className="mt-6 grid gap-5 lg:grid-cols-2">
+            {[...groupedByCandidate.entries()].map(([candidateSlug, measures]) => {
+              const candidate = measures[0]!;
+              return (
+                <section
+                  key={candidateSlug}
+                  className="rounded-2xl border border-border bg-card p-5"
+                >
+                  <h3 className="font-display text-xl font-bold">
+                    <Link
+                      href={`/elections/presidentielle-2027/candidats/${candidateSlug}`}
+                      className="text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    >
+                      {candidate.candidateName}
+                    </Link>
+                  </h3>
+                  {candidate.partyLabel && (
+                    <p className="mt-1 text-sm text-muted-foreground">{candidate.partyLabel}</p>
+                  )}
+                  <ul className="mt-4 divide-y divide-border">
+                    {measures.map((measure) => (
+                      <li key={measure.slug} className="py-3 first:pt-0 last:pb-0">
+                        <Link
+                          href={`/elections/presidentielle-2027/mesures/${measure.slug}`}
+                          className="leading-relaxed text-foreground underline decoration-border underline-offset-2 hover:text-primary hover:decoration-current focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                        >
+                          {measure.text}
+                        </Link>
+                        <Link
+                          href={`/elections/presidentielle-2027/themes/${measure.themeSlug}`}
+                          className="mt-1 block min-h-11 py-2 text-xs font-semibold text-muted-foreground-strong hover:text-primary hover:underline"
+                        >
+                          {measure.themeLabel}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+
+        <footer className="border-t border-border pt-6">
+          <Link
+            href={presidentialReaderGuidesPath()}
+            className="inline-flex min-h-11 items-center font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Voir tous les repères de la présidentielle 2027
+          </Link>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/src/app/elections/presidentielle-2027/reperes/__tests__/page.test.ts
+++ b/src/app/elections/presidentielle-2027/reperes/__tests__/page.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/data/presidential-reader-guides", () => ({
+  getPresidentialReaderGuideIndex: vi.fn(),
+}));
+
+import { getPresidentialReaderGuideIndex } from "@/lib/data/presidential-reader-guides";
+import { generateMetadata } from "../page";
+
+const mockGet = vi.mocked(getPresidentialReaderGuideIndex);
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("métadonnées du glossaire présidentiel", () => {
+  it("reste noindex tant qu'aucun repère ne porte une page substantielle", async () => {
+    mockGet.mockResolvedValue([]);
+    const metadata = await generateMetadata();
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("devient indexable avec un repère indexable et garde son URL canonique", async () => {
+    mockGet.mockResolvedValue([{ indexable: true }] as never);
+    const metadata = await generateMetadata();
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe("/elections/presidentielle-2027/reperes");
+  });
+});

--- a/src/app/elections/presidentielle-2027/reperes/page.tsx
+++ b/src/app/elections/presidentielle-2027/reperes/page.tsx
@@ -83,14 +83,7 @@ export default async function PresidentialReaderGuidesPage() {
             {guides.map((guide) => (
               <li key={guide.slug}>
                 <article className="flex h-full flex-col rounded-2xl border border-border bg-card p-5">
-                  <h2 className="font-display text-xl font-bold">
-                    <Link
-                      href={presidentialReaderGuidePath(guide.slug)}
-                      className="rounded text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                    >
-                      {guide.label}
-                    </Link>
-                  </h2>
+                  <h2 className="font-display text-xl font-bold">{guide.label}</h2>
                   <p className="mt-3 flex-1 text-sm leading-relaxed text-foreground">
                     {guide.definition}
                   </p>

--- a/src/app/elections/presidentielle-2027/reperes/page.tsx
+++ b/src/app/elections/presidentielle-2027/reperes/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { CollectionPageJsonLd, DefinedTermSetJsonLd } from "@/components/seo/JsonLd";
+import { SITE_URL } from "@/config/site";
+import { getPresidentialReaderGuideIndex } from "@/lib/data/presidential-reader-guides";
+import {
+  presidentialReaderGuidePath,
+  presidentialReaderGuidesPath,
+} from "@/lib/presidentielle/reader-guide-paths";
+import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
+
+export const revalidate = 86400;
+
+const PAGE_PATH = presidentialReaderGuidesPath();
+
+export async function generateMetadata(): Promise<Metadata> {
+  const guides = await getPresidentialReaderGuideIndex(PRESIDENTIELLE_2027_SLUG);
+  return {
+    title: "Glossaire des programmes et mesures | Présidentielle 2027",
+    description:
+      "Comprendre les sigles, dispositifs et notions techniques cités dans les mesures de la présidentielle 2027, avec des définitions sourcées.",
+    robots: guides.some((guide) => guide.indexable) ? undefined : { index: false, follow: true },
+    alternates: { canonical: PAGE_PATH },
+  };
+}
+
+export default async function PresidentialReaderGuidesPage() {
+  const guides = await getPresidentialReaderGuideIndex(PRESIDENTIELLE_2027_SLUG);
+  const indexableGuides = guides.filter((guide) => guide.indexable);
+
+  return (
+    <main className="pb-14">
+      <CollectionPageJsonLd
+        name="Glossaire des programmes de la présidentielle 2027"
+        description="Définitions sourcées des sigles, dispositifs et notions techniques présents dans les mesures publiées."
+        url={`${SITE_URL}${PAGE_PATH}`}
+        numberOfItems={indexableGuides.length}
+      />
+      <DefinedTermSetJsonLd
+        name="Repères pour comprendre les programmes de la présidentielle 2027"
+        description="Définitions sourcées des termes techniques réellement présents dans le corpus public."
+        url={`${SITE_URL}${PAGE_PATH}`}
+        terms={indexableGuides.map((guide) => ({
+          name: guide.label,
+          url: `${SITE_URL}${presidentialReaderGuidePath(guide.slug)}`,
+        }))}
+      />
+      <Breadcrumb
+        items={[
+          { label: "Élections", href: "/elections" },
+          { label: "Présidentielle 2027", href: "/elections/presidentielle-2027" },
+          { label: "Repères pour comprendre" },
+        ]}
+      />
+
+      <div className="container mx-auto max-w-6xl px-4">
+        <header className="max-w-3xl space-y-3 py-4">
+          <p className="text-xs font-bold uppercase tracking-widest text-brand-on-surface">
+            Présidentielle 2027
+          </p>
+          <h1 className="font-display text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            Comprendre les termes des programmes
+          </h1>
+          <p className="text-sm leading-relaxed text-muted-foreground md:text-lg">
+            Ce glossaire explique les sigles, dispositifs publics et notions techniques réellement
+            cités dans les mesures publiées. Chaque définition est relue, sourcée et reliée aux
+            propositions concernées.
+          </p>
+        </header>
+
+        {guides.length === 0 ? (
+          <section className="mt-6 rounded-2xl border border-border bg-card p-6">
+            <h2 className="font-display text-xl font-bold">Le glossaire est en préparation</h2>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+              Les premiers repères seront affichés après validation de leur définition et de leur
+              rattachement à une mesure publique.
+            </p>
+          </section>
+        ) : (
+          <ul className="mt-8 grid gap-4 md:grid-cols-2">
+            {guides.map((guide) => (
+              <li key={guide.slug}>
+                <article className="flex h-full flex-col rounded-2xl border border-border bg-card p-5">
+                  <h2 className="font-display text-xl font-bold">
+                    <Link
+                      href={presidentialReaderGuidePath(guide.slug)}
+                      className="rounded text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    >
+                      {guide.label}
+                    </Link>
+                  </h2>
+                  <p className="mt-3 flex-1 text-sm leading-relaxed text-foreground">
+                    {guide.definition}
+                  </p>
+                  <p className="mt-4 text-xs text-muted-foreground-strong">
+                    {guide.measures.length} {guide.measures.length === 1 ? "mesure" : "mesures"} ·{" "}
+                    {guide.candidateCount} {guide.candidateCount === 1 ? "candidat" : "candidats"}
+                  </p>
+                  <ul
+                    aria-label={`Thèmes liés à ${guide.label}`}
+                    className="mt-2 flex flex-wrap gap-2"
+                  >
+                    {guide.themes.map((theme) => (
+                      <li key={theme.theme}>
+                        <Link
+                          href={`/elections/presidentielle-2027/themes/${theme.slug}`}
+                          className="inline-flex min-h-11 items-center rounded-full border border-border px-3 py-2 text-xs font-semibold hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                        >
+                          {theme.label}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                  <Link
+                    href={presidentialReaderGuidePath(guide.slug)}
+                    className="mt-3 inline-flex min-h-11 items-center gap-2 self-start font-bold text-primary hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  >
+                    Voir la définition et les mesures
+                    <ArrowRight aria-hidden="true" className="h-4 w-4" />
+                  </Link>
+                </article>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/SubjectComparison.tsx
@@ -15,6 +15,7 @@ import type { PublicMeasure } from "@/lib/data/measures";
 import type { PublicVoteReference } from "@/lib/measures/vote-links";
 import type { SubjectCandidateEntry, SubjectPageData } from "@/lib/data/subject-page";
 import { themeToSlug } from "@/lib/presidentielle/themes";
+import { presidentialReaderGuidePath } from "@/lib/presidentielle/reader-guide-paths";
 import { formatDate } from "@/lib/utils";
 import { SubjectGate } from "./SubjectGate";
 import { SubjectSidebar } from "./SubjectSidebar";
@@ -357,6 +358,7 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
         ) : (
           <>
             <ComparisonTable data={data} />
+            <ReaderGuideLinks guides={data.readerGuides} />
             <MeasureMentionsGuide />
             <FooterCard
               documented={documented}
@@ -369,6 +371,32 @@ export function SubjectComparison({ data }: { data: SubjectPageData }) {
         )}
       </div>
     </div>
+  );
+}
+
+function ReaderGuideLinks({ guides }: { guides: SubjectPageData["readerGuides"] }) {
+  if (guides.length === 0) return null;
+  return (
+    <section aria-labelledby="reader-guides-theme" className="rounded-xl border border-border p-5">
+      <h2 id="reader-guides-theme" className="font-display text-lg font-bold">
+        Repères pour comprendre ce thème
+      </h2>
+      <p className="mt-1 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Définitions sourcées des dispositifs et termes techniques présents dans ces mesures.
+      </p>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {guides.map((guide) => (
+          <li key={guide.slug}>
+            <Link
+              href={presidentialReaderGuidePath(guide.slug)}
+              className="inline-flex min-h-11 items-center rounded-full border border-border px-4 py-2 text-sm font-bold hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              {guide.label} · {guide.measureCount}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectComparison.test.tsx
@@ -103,11 +103,28 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
       { theme: "SANTE", label: "Santé", slug: "sante", measureCount: 0, publishable: false },
     ],
     totalMeasuresOnTheme: 4,
+    readerGuides: [],
     ...over,
   };
 }
 
 describe("SubjectComparison", () => {
+  it("relie les repères techniques du thème à leur page éditoriale", () => {
+    render(
+      <SubjectComparison
+        data={data({
+          readerGuides: [
+            { slug: "zones-faibles-emissions", label: "Zone à faibles émissions", measureCount: 2 },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByRole("link", { name: /Zone à faibles émissions/ })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/reperes/zones-faibles-emissions"
+    );
+  });
+
   it("annonce le critère de tri réellement appliqué", () => {
     render(<SubjectComparison data={data()} />);
     expect(screen.getByText(/Classées par nom de famille/)).toBeInTheDocument();

--- a/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectGate.test.tsx
+++ b/src/app/elections/presidentielle-2027/themes/[theme]/_components/__tests__/SubjectGate.test.tsx
@@ -26,6 +26,7 @@ function data(over: Partial<SubjectPageData> = {}): SubjectPageData {
       { theme: "SANTE", label: "Santé", slug: "sante", measureCount: 0, publishable: false },
     ],
     totalMeasuresOnTheme: 4,
+    readerGuides: [],
     ...over,
   };
 }

--- a/src/app/methodologie/mesures-presidentielle-2027/page.tsx
+++ b/src/app/methodologie/mesures-presidentielle-2027/page.tsx
@@ -141,6 +141,17 @@ export default function PresidentialMeasuresMethodologyPage() {
               rattachement à une mesure est validé séparément et conservé dans le journal
               d&apos;audit.
             </p>
+            <p>
+              Les définitions validées sont regroupées dans un glossaire et reliées aux mesures, aux
+              thèmes et aux candidats concernés.{" "}
+              <Link
+                href="/elections/presidentielle-2027/reperes"
+                className="font-semibold text-primary underline underline-offset-2 hover:text-primary/80"
+              >
+                Consulter les repères de la présidentielle 2027
+              </Link>
+              .
+            </p>
           </div>
         </section>
 

--- a/src/app/programmes/__tests__/page.test.tsx
+++ b/src/app/programmes/__tests__/page.test.tsx
@@ -26,6 +26,7 @@ const context: HubMeasureContext = {
   lastReviewedAt: new Date("2026-08-30"),
   themes: [],
   featuredSubtopics: [],
+  featuredReaderGuides: [],
 };
 
 beforeEach(() => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -494,7 +494,7 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
       : [];
 
   const presidentialReaderGuidePages: MetadataRoute.Sitemap =
-    presidentielleHubPublishable && indexablePresidentialReaderGuides.length > 0
+    indexablePresidentialReaderGuides.length > 0
       ? [
           {
             url: `${SITE_URL}${presidentialReaderGuidesPath()}`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,6 +14,11 @@ import { PRESIDENTIELLE_2027_SLUG } from "@/lib/presidentielle/themes";
 import { PUBLIC_PRESIDENTIAL_MEASURE_WHERE } from "@/lib/presidentielle/publication";
 import { getPublicPresidentialCandidates } from "@/lib/data/presidential-candidates-public";
 import { getPublicMeasureStatsByCandidacy } from "@/lib/data/measures";
+import { loadPresidentialReaderGuideIndex } from "@/lib/data/presidential-reader-guides";
+import {
+  presidentialReaderGuidePath,
+  presidentialReaderGuidesPath,
+} from "@/lib/presidentielle/reader-guide-paths";
 import {
   SIGNIFICANT_MANDATE_TYPES,
   MAIRE_MIN_COMMUNE_POPULATION,
@@ -409,6 +414,15 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
     presidentielle2027 === undefined
       ? null
       : await loadThemesIndex(presidentielle2027.id, PRESIDENTIELLE_2027_SLUG);
+  // The loader applies isIndexableReaderGuide(), the same pure predicate used by route metadata.
+  // The sitemap therefore cannot announce a glossary stub that the detail route marks noindex.
+  const presidentialReaderGuides =
+    presidentielle2027 === undefined
+      ? []
+      : await loadPresidentialReaderGuideIndex(presidentielle2027.id);
+  const indexablePresidentialReaderGuides = presidentialReaderGuides.filter(
+    (guide) => guide.indexable
+  );
   const presidentielleHubPublishable =
     presidentialThemesIndex !== null &&
     isHubPublishable(presidentialThemesIndex.publishableSubjectPageCount);
@@ -476,6 +490,27 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
               changeFrequency: "weekly" as const,
               priority: 0.6,
             })),
+        ]
+      : [];
+
+  const presidentialReaderGuidePages: MetadataRoute.Sitemap =
+    presidentielleHubPublishable && indexablePresidentialReaderGuides.length > 0
+      ? [
+          {
+            url: `${SITE_URL}${presidentialReaderGuidesPath()}`,
+            lastModified: indexablePresidentialReaderGuides.reduce(
+              (latest, guide) => (guide.updatedAt > latest ? guide.updatedAt : latest),
+              presidentielle2027?.updatedAt ?? new Date(0)
+            ),
+            changeFrequency: "weekly" as const,
+            priority: 0.5,
+          },
+          ...indexablePresidentialReaderGuides.map((guide) => ({
+            url: `${SITE_URL}${presidentialReaderGuidePath(guide.slug)}`,
+            lastModified: guide.updatedAt,
+            changeFrequency: "weekly" as const,
+            priority: 0.5,
+          })),
         ]
       : [];
 
@@ -558,6 +593,7 @@ async function buildAffairsPartiesElectionsDepartmentsSitemap(): Promise<Metadat
     ...electionPages,
     ...presidentialDirectoryPages,
     ...presidentialSubjectPages,
+    ...presidentialReaderGuidePages,
     ...candidateFichePages,
     ...presidentialMeasurePages,
     ...departmentPages,

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -207,6 +207,70 @@ export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
   );
 }
 
+interface DefinedTermJsonLdProps {
+  name: string;
+  description: string;
+  url: string;
+  alternateNames?: string[];
+  sourceUrl: string;
+  termSetUrl: string;
+}
+
+/** A reviewed civic definition attached to its source and to the presidential glossary. */
+export function DefinedTermJsonLd({
+  name,
+  description,
+  url,
+  alternateNames = [],
+  sourceUrl,
+  termSetUrl,
+}: DefinedTermJsonLdProps) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTerm",
+    name,
+    description,
+    url,
+    ...(alternateNames.length > 0 && { alternateName: alternateNames }),
+    sameAs: sourceUrl,
+    inDefinedTermSet: {
+      "@type": "DefinedTermSet",
+      name: "Repères pour comprendre les programmes de la présidentielle 2027",
+      url: termSetUrl,
+    },
+  };
+
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
+  );
+}
+
+interface DefinedTermSetJsonLdProps {
+  name: string;
+  description: string;
+  url: string;
+  terms: Array<{ name: string; url: string }>;
+}
+
+export function DefinedTermSetJsonLd({ name, description, url, terms }: DefinedTermSetJsonLdProps) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTermSet",
+    name,
+    description,
+    url,
+    hasDefinedTerm: terms.map((term) => ({
+      "@type": "DefinedTerm",
+      name: term.name,
+      url: term.url,
+    })),
+  };
+
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
+  );
+}
+
 interface FAQJsonLdProps {
   questions: Array<{
     question: string;

--- a/src/lib/data/__tests__/presidential-reader-guides.test.ts
+++ b/src/lib/data/__tests__/presidential-reader-guides.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    measure: { findMany: mocks.findMany },
+  },
+}));
+
+import { loadPresidentialReaderGuideIndex } from "../presidential-reader-guides";
+
+const reviewedAt = new Date("2026-08-31T08:00:00Z");
+const guide = {
+  slug: "zones-faibles-emissions",
+  label: "Zone à faibles émissions (ZFE)",
+  definition:
+    "Une zone à faibles émissions limite la circulation des véhicules les plus polluants dans un périmètre défini.",
+  aliases: ["ZFE"],
+  sourceUrl: "https://www.ecologie.gouv.fr/zfe",
+  sourceLabel: "Zones à faibles émissions",
+  sourcePublisher: "Ministère de la Transition écologique",
+  reviewedAt,
+  updatedAt: reviewedAt,
+};
+
+function measure(over: Record<string, unknown> = {}) {
+  return {
+    slug: "camille-exemple-supprimer-les-zfe",
+    theme: "TRANSPORTS",
+    publishedRevision: {
+      text: "Supprimer les zones à faibles émissions.",
+      reviewedAt,
+      // The acronym and its expansion can both resolve to the same canonical concept.
+      readerGuideMentions: [{ guide }, { guide }],
+    },
+    candidacy: {
+      candidateName: "Camille Exemple",
+      politician: { slug: "camille-exemple" },
+      party: { name: "Parti exemple", shortName: "PE" },
+    },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mocks.findMany.mockReset();
+  mocks.findMany.mockResolvedValue([measure()]);
+});
+
+describe("loadPresidentialReaderGuideIndex", () => {
+  it("part de l'autorité des mesures publiques et des mentions approuvées", async () => {
+    await loadPresidentialReaderGuideIndex("election-1");
+
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          electionId: "election-1",
+          publicationStatus: "PUBLISHED",
+          withdrawnAt: null,
+          publishedRevision: {
+            is: expect.objectContaining({
+              reviewedAt: { not: null },
+              publishedAt: { not: null },
+              readerGuideMentions: {
+                some: expect.objectContaining({ status: "APPROVED" }),
+              },
+            }),
+          },
+        }),
+      })
+    );
+  });
+
+  it("agrège sans compter deux fois une mesure qui mentionne deux alias", async () => {
+    const result = await loadPresidentialReaderGuideIndex("election-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slug: "zones-faibles-emissions",
+      candidateCount: 1,
+      indexable: true,
+      measures: [{ slug: "camille-exemple-supprimer-les-zfe" }],
+      themes: [{ theme: "TRANSPORTS", measureCount: 1 }],
+    });
+  });
+
+  it("n'indexe pas une définition trop courte", async () => {
+    mocks.findMany.mockResolvedValue([
+      measure({
+        publishedRevision: {
+          text: "Supprimer les zones à faibles émissions.",
+          reviewedAt,
+          readerGuideMentions: [{ guide: { ...guide, definition: "Définition trop courte." } }],
+        },
+      }),
+    ]);
+
+    const result = await loadPresidentialReaderGuideIndex("election-1");
+    expect(result[0]?.indexable).toBe(false);
+  });
+});

--- a/src/lib/data/hub.ts
+++ b/src/lib/data/hub.ts
@@ -10,6 +10,7 @@ import {
 import { loadThemesIndex } from "./themes-index";
 import type { FeaturedSubtopic } from "./themes-index";
 import { getLatestPresidentialReviewDate } from "./measures";
+import { loadPresidentialReaderGuideIndex } from "./presidential-reader-guides";
 
 /**
  * The two read authorities for the presidential hub page.
@@ -63,6 +64,13 @@ export type HubMeasureContext = {
   themes: HubTheme[];
   /** A bounded, diversified set of human-approved subtopics for direct corpus exploration. */
   featuredSubtopics: FeaturedSubtopic[];
+  /** A bounded set of reviewed definitions with the broadest current corpus coverage. */
+  featuredReaderGuides: Array<{
+    slug: string;
+    label: string;
+    measureCount: number;
+    candidateCount: number;
+  }>;
 };
 
 /**
@@ -84,7 +92,7 @@ export async function loadHubMeasureContext(
   electionId: string,
   electionSlug: string
 ): Promise<HubMeasureContext> {
-  const [election, themesIndex, lastReviewedAt] = await Promise.all([
+  const [election, themesIndex, lastReviewedAt, readerGuides] = await Promise.all([
     db.election.findUniqueOrThrow({
       where: { id: electionId },
       select: {
@@ -97,6 +105,7 @@ export async function loadHubMeasureContext(
     }),
     loadThemesIndex(electionId, electionSlug),
     getLatestPresidentialReviewDate(electionId),
+    loadPresidentialReaderGuideIndex(electionId),
   ]);
 
   // Derived from the themes index rather than a fresh getPublicMeasuresByElection() read: the
@@ -125,6 +134,16 @@ export async function loadHubMeasureContext(
       publishable,
     })),
     featuredSubtopics: themesIndex.featuredSubtopics,
+    featuredReaderGuides: readerGuides
+      .filter((guide) => guide.indexable)
+      .sort((a, b) => b.measures.length - a.measures.length || a.label.localeCompare(b.label, "fr"))
+      .slice(0, 6)
+      .map((guide) => ({
+        slug: guide.slug,
+        label: guide.label,
+        measureCount: guide.measures.length,
+        candidateCount: guide.candidateCount,
+      })),
   };
 }
 

--- a/src/lib/data/presidential-reader-guides.ts
+++ b/src/lib/data/presidential-reader-guides.ts
@@ -1,0 +1,220 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+import { cache } from "react";
+import type { ThemeCategory } from "@/generated/prisma";
+import { THEME_CATEGORY_LABELS } from "@/config/labels";
+import { db } from "@/lib/db";
+import {
+  PUBLIC_MEASURE_REVISION_WHERE,
+  PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+} from "@/lib/presidentielle/publication";
+import { themeToSlug } from "@/lib/presidentielle/themes";
+import { isIndexableReaderGuide } from "@/lib/seo/reader-guide-robots";
+
+const PUBLIC_READER_GUIDE_WHERE = {
+  active: true,
+  publicationStatus: "PUBLISHED" as const,
+  reviewedAt: { not: null },
+};
+
+export type PresidentialReaderGuideMeasure = {
+  slug: string;
+  text: string;
+  reviewedAt: Date;
+  theme: ThemeCategory;
+  themeLabel: string;
+  themeSlug: string;
+  candidateName: string;
+  candidateSlug: string;
+  partyLabel: string | null;
+};
+
+export type PresidentialReaderGuideIndexItem = {
+  slug: string;
+  label: string;
+  definition: string;
+  aliases: string[];
+  sourceUrl: string;
+  sourceLabel: string;
+  sourcePublisher: string;
+  reviewedAt: Date;
+  updatedAt: Date;
+  indexable: boolean;
+  candidateCount: number;
+  themes: Array<{
+    theme: ThemeCategory;
+    label: string;
+    slug: string;
+    measureCount: number;
+  }>;
+  measures: PresidentialReaderGuideMeasure[];
+};
+
+/**
+ * Plain loader shared by pages and the sitemap. It starts from the public measure authority so an
+ * approved mention on an old, draft or otherwise unreachable revision can never create a public
+ * glossary page.
+ */
+export async function loadPresidentialReaderGuideIndex(
+  electionId: string
+): Promise<PresidentialReaderGuideIndexItem[]> {
+  const measures = await db.measure.findMany({
+    where: {
+      electionId,
+      ...PUBLIC_PRESIDENTIAL_MEASURE_WHERE,
+      publishedRevision: {
+        is: {
+          ...PUBLIC_MEASURE_REVISION_WHERE,
+          readerGuideMentions: {
+            some: { status: "APPROVED", guide: { is: PUBLIC_READER_GUIDE_WHERE } },
+          },
+        },
+      },
+    },
+    select: {
+      slug: true,
+      theme: true,
+      publishedRevision: {
+        select: {
+          text: true,
+          reviewedAt: true,
+          readerGuideMentions: {
+            where: { status: "APPROVED", guide: { is: PUBLIC_READER_GUIDE_WHERE } },
+            select: {
+              guide: {
+                select: {
+                  slug: true,
+                  label: true,
+                  definition: true,
+                  aliases: true,
+                  sourceUrl: true,
+                  sourceLabel: true,
+                  sourcePublisher: true,
+                  reviewedAt: true,
+                  updatedAt: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      candidacy: {
+        select: {
+          candidateName: true,
+          politician: { select: { slug: true } },
+          party: { select: { name: true, shortName: true } },
+        },
+      },
+    },
+    orderBy: [{ candidacy: { candidateName: "asc" } }, { slug: "asc" }],
+  });
+
+  const guides = new Map<
+    string,
+    Omit<PresidentialReaderGuideIndexItem, "candidateCount" | "themes" | "indexable"> & {
+      measureSlugs: Set<string>;
+      candidateSlugs: Set<string>;
+      themeCounts: Map<ThemeCategory, number>;
+    }
+  >();
+
+  for (const measure of measures) {
+    const revision = measure.publishedRevision;
+    const candidacy = measure.candidacy;
+    if (!revision?.reviewedAt || !candidacy?.politician) continue;
+    const linkedMeasure: PresidentialReaderGuideMeasure = {
+      slug: measure.slug,
+      text: revision.text,
+      reviewedAt: revision.reviewedAt,
+      theme: measure.theme,
+      themeLabel: THEME_CATEGORY_LABELS[measure.theme],
+      themeSlug: themeToSlug(measure.theme),
+      candidateName: candidacy.candidateName,
+      candidateSlug: candidacy.politician.slug,
+      partyLabel: candidacy.party?.shortName ?? candidacy.party?.name ?? null,
+    };
+
+    for (const mention of revision.readerGuideMentions) {
+      const guide = mention.guide;
+      if (!guide?.reviewedAt) continue;
+      const current = guides.get(guide.slug) ?? {
+        slug: guide.slug,
+        label: guide.label,
+        definition: guide.definition,
+        aliases: guide.aliases,
+        sourceUrl: guide.sourceUrl,
+        sourceLabel: guide.sourceLabel,
+        sourcePublisher: guide.sourcePublisher,
+        reviewedAt: guide.reviewedAt,
+        updatedAt: guide.updatedAt,
+        measures: [],
+        measureSlugs: new Set<string>(),
+        candidateSlugs: new Set<string>(),
+        themeCounts: new Map<ThemeCategory, number>(),
+      };
+      // One revision can mention both an acronym and its expanded form. They may resolve to the
+      // same guide, but the public page must count and render the measure only once.
+      if (!current.measureSlugs.has(linkedMeasure.slug)) {
+        current.measureSlugs.add(linkedMeasure.slug);
+        current.measures.push(linkedMeasure);
+        current.candidateSlugs.add(linkedMeasure.candidateSlug);
+        current.themeCounts.set(measure.theme, (current.themeCounts.get(measure.theme) ?? 0) + 1);
+      }
+      if (linkedMeasure.reviewedAt > current.updatedAt)
+        current.updatedAt = linkedMeasure.reviewedAt;
+      guides.set(guide.slug, current);
+    }
+  }
+
+  return [...guides.values()]
+    .map(({ measureSlugs: _measureSlugs, candidateSlugs, themeCounts, ...guide }) => ({
+      ...guide,
+      candidateCount: candidateSlugs.size,
+      themes: [...themeCounts.entries()]
+        .map(([theme, measureCount]) => ({
+          theme,
+          label: THEME_CATEGORY_LABELS[theme],
+          slug: themeToSlug(theme),
+          measureCount,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label, "fr")),
+      indexable: isIndexableReaderGuide({
+        active: true,
+        published: true,
+        reviewedAt: guide.reviewedAt,
+        sourceUrl: guide.sourceUrl,
+        definition: guide.definition,
+        publicMeasureCount: guide.measures.length,
+      }),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label, "fr"));
+}
+
+export const getPresidentialReaderGuideIndex = cache(async function getPresidentialReaderGuideIndex(
+  electionSlug: string
+): Promise<PresidentialReaderGuideIndexItem[]> {
+  const election = await db.election.findUnique({
+    where: { slug: electionSlug },
+    select: { id: true },
+  });
+  if (!election) return [];
+  return getPresidentialReaderGuideIndexCached(election.id);
+});
+
+async function getPresidentialReaderGuideIndexCached(
+  electionId: string
+): Promise<PresidentialReaderGuideIndexItem[]> {
+  "use cache";
+  cacheTag(`election-measures:${electionId}`);
+  cacheLife("synced");
+  return loadPresidentialReaderGuideIndex(electionId);
+}
+
+export async function getPresidentialReaderGuide(
+  electionSlug: string,
+  guideSlug: string
+): Promise<PresidentialReaderGuideIndexItem | null> {
+  const guides = await getPresidentialReaderGuideIndex(electionSlug);
+  return guides.find((guide) => guide.slug === guideSlug) ?? null;
+}

--- a/src/lib/data/subject-page.ts
+++ b/src/lib/data/subject-page.ts
@@ -81,6 +81,8 @@ export type SubjectPageData = {
   }[];
   /** Currently-defended measures on this theme, across the whole published population. */
   totalMeasuresOnTheme: number;
+  /** Reviewed technical terms present in currently defended measures on this theme. */
+  readerGuides: Array<{ slug: string; label: string; measureCount: number }>;
 };
 
 /**
@@ -173,6 +175,19 @@ export async function loadSubjectPageData(
     entries.push({ candidate, measures: subjectMeasures });
   }
 
+  const readerGuideCounts = new Map<string, { label: string; measureIds: Set<string> }>();
+  for (const measure of measures) {
+    if (measure.withdrawal !== null) continue;
+    for (const guide of measure.readerGuides) {
+      const current = readerGuideCounts.get(guide.slug) ?? {
+        label: guide.label,
+        measureIds: new Set<string>(),
+      };
+      current.measureIds.add(measure.id);
+      readerGuideCounts.set(guide.slug, current);
+    }
+  }
+
   return {
     theme,
     electionSlug,
@@ -194,6 +209,13 @@ export async function loadSubjectPageData(
     })),
     totalMeasuresOnTheme:
       themesIndex.themes.find((t) => t.theme === theme)?.currentlyDefendedMeasureCount ?? 0,
+    readerGuides: [...readerGuideCounts.entries()]
+      .map(([slug, guide]) => ({
+        slug,
+        label: guide.label,
+        measureCount: guide.measureIds.size,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label, "fr")),
   };
 }
 

--- a/src/lib/presidentielle/reader-guide-paths.ts
+++ b/src/lib/presidentielle/reader-guide-paths.ts
@@ -1,0 +1,9 @@
+const READER_GUIDE_BASE_PATH = "/elections/presidentielle-2027/reperes";
+
+export function presidentialReaderGuidesPath(): string {
+  return READER_GUIDE_BASE_PATH;
+}
+
+export function presidentialReaderGuidePath(slug: string): string {
+  return `${READER_GUIDE_BASE_PATH}/${slug}`;
+}

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -373,6 +373,15 @@ describe("doctrine — presidentielle-2027 hub stays out of the sitemap while un
     );
     expect(electionShard).toContain("...presidentialMeasurePages");
   });
+
+  it("annonce uniquement les repères substantiels reliés au corpus public", () => {
+    expect(electionShard).toContain("loadPresidentialReaderGuideIndex");
+    expect(electionShard).toContain("guide.indexable");
+    expect(electionShard).toContain("const presidentialReaderGuidePages");
+    expect(electionShard).toContain("presidentialReaderGuidesPath()");
+    expect(electionShard).toContain("presidentialReaderGuidePath(guide.slug)");
+    expect(electionShard).toContain("...presidentialReaderGuidePages");
+  });
 });
 
 describe("doctrine — la recherche présidentielle reste une surface utilitaire", () => {

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -381,6 +381,9 @@ describe("doctrine — presidentielle-2027 hub stays out of the sitemap while un
     expect(electionShard).toContain("presidentialReaderGuidesPath()");
     expect(electionShard).toContain("presidentialReaderGuidePath(guide.slug)");
     expect(electionShard).toContain("...presidentialReaderGuidePages");
+    expect(electionShard).toMatch(
+      /const presidentialReaderGuidePages:[\s\S]*=\s*indexablePresidentialReaderGuides\.length > 0/
+    );
   });
 });
 

--- a/src/lib/seo/reader-guide-robots.test.ts
+++ b/src/lib/seo/reader-guide-robots.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isIndexableReaderGuide, MIN_READER_GUIDE_DEFINITION_LENGTH } from "./reader-guide-robots";
+
+const valid = {
+  active: true,
+  published: true,
+  reviewedAt: new Date("2027-01-01T00:00:00Z"),
+  sourceUrl: "https://www.ecologie.gouv.fr/zfe",
+  definition: "D".repeat(MIN_READER_GUIDE_DEFINITION_LENGTH),
+  publicMeasureCount: 1,
+};
+
+describe("indexation des repères citoyens", () => {
+  it("indexe une définition sourcée et réellement employée dans le corpus public", () => {
+    expect(isIndexableReaderGuide(valid)).toBe(true);
+  });
+
+  it("refuse une page sans mesure publique ou avec une définition trop courte", () => {
+    expect(isIndexableReaderGuide({ ...valid, publicMeasureCount: 0 })).toBe(false);
+    expect(
+      isIndexableReaderGuide({
+        ...valid,
+        definition: "D".repeat(MIN_READER_GUIDE_DEFINITION_LENGTH - 1),
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/seo/reader-guide-robots.ts
+++ b/src/lib/seo/reader-guide-robots.ts
@@ -1,0 +1,27 @@
+/** A sourced definition shorter than this is too thin to earn its own search result. */
+export const MIN_READER_GUIDE_DEFINITION_LENGTH = 80;
+
+export type ReaderGuideIndexSignals = {
+  active: boolean;
+  published: boolean;
+  reviewedAt: Date | null;
+  sourceUrl: string;
+  definition: string;
+  publicMeasureCount: number;
+};
+
+/**
+ * A repère page is indexable only when it combines reviewed editorial content with at least one
+ * public use in the corpus. The source and the measure make it a useful definition page rather
+ * than an isolated glossary stub.
+ */
+export function isIndexableReaderGuide(signals: ReaderGuideIndexSignals): boolean {
+  return (
+    signals.active &&
+    signals.published &&
+    signals.reviewedAt !== null &&
+    signals.sourceUrl.trim().length > 0 &&
+    signals.definition.trim().length >= MIN_READER_GUIDE_DEFINITION_LENGTH &&
+    signals.publicMeasureCount >= 1
+  );
+}


### PR DESCRIPTION
## Résultat

- ajoute un glossaire public sourcé pour les sigles, dispositifs et notions techniques du corpus 2027
- crée une page canonique par repère, reliée aux mesures, candidats et thèmes concernés
- relie les fiches mesure, pages thématiques, méthodologie et hub aux repères validés
- ajoute les schémas JSON-LD DefinedTerm/DefinedTermSet et les entrées sitemap
- garde les pages minces hors index avec une porte SEO centralisée
- documente la publication, le maillage et les limites éditoriales

## Garde-fous éditoriaux

- autorité construite depuis les seules mesures et révisions publiques
- mention APPROVED et repère PUBLISHED, relu et sourcé obligatoires
- aucun jugement sur les propositions
- aucun nuage de mots libre ni contenu généré sans validation

## Vérifications

- typecheck : vert
- lint : vert, 57 avertissements préexistants, 0 erreur
- 132 tests ciblés initiaux puis 113 tests ciblés après finalisation : verts
- compilation Next.js : verte
- collecte statique locale : échec sur /affaires/[slug], route hors diff, la CI fera la vérification dans son environnement

Aucune migration ni écriture de production dans ce lot.