### PR TITLE
feat(mesures): enrichir le catalogue des repères citoyens

### DIFF
--- a/src/config/measure-reader-guides.ts
+++ b/src/config/measure-reader-guides.ts
@@ -179,7 +179,7 @@ export const MEASURE_READER_GUIDES: readonly MeasureReaderGuideDefinition[] = [
       "Un marché public est un contrat conclu contre paiement entre un acheteur public et un " +
       "opérateur économique pour répondre à un besoin en travaux, fournitures ou services. Sa " +
       "passation obéit aux règles de la commande publique.",
-    aliases: ["marchés publics", "commande publique", "contrat de la commande publique"],
+    aliases: ["marchés publics"],
     sourceUrl:
       "https://www.economie.gouv.fr/files/files/directions_services/daj/marches_publics/conseil_acheteurs/fiches-techniques/champs-application/contrats-cp-et-autres-contrats-2019.pdf",
     sourceLabel: "Les contrats de la commande publique et autres contrats",

--- a/src/config/measure-reader-guides.ts
+++ b/src/config/measure-reader-guides.ts
@@ -14,6 +14,214 @@ export type MeasureReaderGuideDefinition = {
  */
 export const MEASURE_READER_GUIDES: readonly MeasureReaderGuideDefinition[] = [
   {
+    slug: "autorite-administrative-independante",
+    label: "Autorité administrative indépendante (AAI)",
+    definition:
+      "Une autorité administrative indépendante agit au nom de l’État sans être placée sous " +
+      "l’autorité du Gouvernement. Des garanties d’autonomie protègent l’exercice de ses " +
+      "missions, souvent liées à la régulation ou à la protection des droits.",
+    aliases: [
+      "AAI",
+      "autorité indépendante",
+      "autorités indépendantes",
+      "autorité administrative indépendante",
+      "autorités administratives indépendantes",
+    ],
+    sourceUrl: "https://www.vie-publique.fr/files/rapport/pdf/194000149.pdf",
+    sourceLabel: "Autorités administratives et publiques indépendantes",
+    sourcePublisher: "Vie publique",
+  },
+  {
+    slug: "carte-scolaire",
+    label: "Carte scolaire",
+    definition:
+      "La carte scolaire organise la répartition des élèves entre les établissements publics " +
+      "selon leur lieu de résidence. L’expression désigne aussi la répartition territoriale des " +
+      "classes et des moyens d’enseignement.",
+    aliases: ["sectorisation scolaire", "secteur scolaire", "secteurs scolaires"],
+    sourceUrl:
+      "https://www.education.gouv.fr/ecole-college-lycee-l-affectation-des-eleves-et-l-attribution-des-moyens-2486",
+    sourceLabel: "École, collège, lycée : l’affectation des élèves et l’attribution des moyens",
+    sourcePublisher: "Ministère de l’Éducation nationale",
+  },
+  {
+    slug: "centre-formation-apprentis",
+    label: "Centre de formation d’apprentis (CFA)",
+    definition:
+      "Un centre de formation d’apprentis assure la partie théorique d’une formation en " +
+      "apprentissage. L’apprenti alterne cette formation avec une activité pratique chez un " +
+      "employeur.",
+    aliases: [
+      "CFA",
+      "centre de formation d'apprentis",
+      "centres de formation d'apprentis",
+      "centre de formation des apprentis",
+      "centres de formation des apprentis",
+    ],
+    sourceUrl: "https://www.service-public.gouv.fr/particuliers/vosdroits/F2918",
+    sourceLabel: "Contrat d’apprentissage",
+    sourcePublisher: "Service Public",
+  },
+  {
+    slug: "charge-preuve",
+    label: "Charge de la preuve",
+    definition:
+      "La charge de la preuve détermine à qui il revient d’établir un fait devant la justice. En " +
+      "matière civile, celui qui réclame l’exécution d’une obligation doit en apporter la preuve, " +
+      "et celui qui affirme en être libéré doit le justifier.",
+    aliases: ["charge de preuve", "renversement de la charge de la preuve"],
+    sourceUrl: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032042341",
+    sourceLabel: "Article 1353 du Code civil",
+    sourcePublisher: "Légifrance",
+  },
+  {
+    slug: "conflit-interets",
+    label: "Conflit d’intérêts",
+    definition:
+      "Un conflit d’intérêts est une situation dans laquelle un intérêt public interfère avec " +
+      "d’autres intérêts et peut influencer, ou sembler influencer, l’exercice indépendant, " +
+      "impartial et objectif d’une fonction.",
+    aliases: ["conflits d'intérêts", "prévention des conflits d'intérêts"],
+    sourceUrl:
+      "https://www.hatvp.fr/la-haute-autorite/la-deontologie-des-responsables-publics/prevention-des-conflits-dinterets/",
+    sourceLabel: "La prévention des conflits d’intérêts",
+    sourcePublisher: "Haute Autorité pour la transparence de la vie publique",
+  },
+  {
+    slug: "convention-judiciaire-interet-public",
+    label: "Convention judiciaire d’intérêt public (CJIP)",
+    definition:
+      "Une convention judiciaire d’intérêt public permet au procureur de proposer à une personne " +
+      "morale des obligations, comme une amende ou un programme de conformité, sans engager un " +
+      "procès pénal. Son exécution éteint l’action publique sans déclaration de culpabilité.",
+    aliases: [
+      "CJIP",
+      "convention judiciaire d'intérêt public",
+      "conventions judiciaires d'intérêt public",
+    ],
+    sourceUrl:
+      "https://www.justice.gouv.fr/sites/default/files/2025-05/rapport_mission_urgence_dejudiciarisation_annexes.pdf",
+    sourceLabel: "Rapport de la mission d’urgence relative à la déjudiciarisation",
+    sourcePublisher: "Ministère de la Justice",
+  },
+  {
+    slug: "cotisations-sociales",
+    label: "Cotisations sociales",
+    definition:
+      "Les cotisations et contributions sociales financent la protection sociale, notamment la " +
+      "santé, la retraite, la famille et l’assurance chômage. Elles sont prélevées principalement " +
+      "sur les revenus d’activité puis redistribuées aux organismes concernés.",
+    aliases: [
+      "cotisation sociale",
+      "cotisations patronales",
+      "cotisations salariales",
+      "charges sociales",
+    ],
+    sourceUrl: "https://www.urssaf.fr/accueil/a-quoi-servent-les-cotisations.html",
+    sourceLabel: "À quoi servent les cotisations ?",
+    sourcePublisher: "Urssaf",
+  },
+  {
+    slug: "cour-justice-republique",
+    label: "Cour de justice de la République (CJR)",
+    definition:
+      "La Cour de justice de la République juge les membres du Gouvernement pour les crimes ou " +
+      "délits commis dans l’exercice de leurs fonctions. Elle réunit des parlementaires et des " +
+      "magistrats de la Cour de cassation.",
+    aliases: ["CJR", "Cour de justice de la République"],
+    sourceUrl:
+      "https://www.assemblee-nationale.fr/dyn/17/organes/cjr/cour-de-justice-de-la-republique",
+    sourceLabel: "Cour de justice de la République",
+    sourcePublisher: "Assemblée nationale",
+  },
+  {
+    slug: "defenseur-droits",
+    label: "Défenseur des droits",
+    definition:
+      "Le Défenseur des droits est une autorité administrative indépendante chargée de défendre " +
+      "les personnes dont les droits ne sont pas respectés et de promouvoir l’égalité. Il peut " +
+      "être saisi gratuitement dans les domaines relevant de ses missions.",
+    aliases: ["Défenseure des droits", "DDD"],
+    sourceUrl: "https://www.defenseurdesdroits.fr/decouvrir-le-defenseur-des-droits-197",
+    sourceLabel: "Découvrir le Défenseur des droits",
+    sourcePublisher: "Défenseur des droits",
+  },
+  {
+    slug: "dossier-medical-partage",
+    label: "Dossier médical partagé (DMP)",
+    definition:
+      "Le dossier médical partagé est un carnet de santé numérique qui rassemble des informations " +
+      "utiles aux soins. Il permet au patient et aux professionnels autorisés de partager ces " +
+      "informations dans Mon espace santé.",
+    aliases: ["DMP", "dossier médical partagé", "dossiers médicaux partagés"],
+    sourceUrl:
+      "https://www.ameli.fr/medecin/sante-prevention/dmp-et-mon-espace-sante/dmp-en-pratique",
+    sourceLabel: "Le DMP en pratique",
+    sourcePublisher: "Assurance Maladie",
+  },
+  {
+    slug: "kafala-judiciaire",
+    label: "Kafala judiciaire",
+    definition:
+      "La kafala est une mesure de recueil légal d’un enfant prévue dans plusieurs pays de droit " +
+      "musulman. En France, elle produit selon les situations des effets comparables à une tutelle " +
+      "ou à une délégation d’autorité parentale, sans créer de lien de filiation comme l’adoption.",
+    aliases: ["kafala", "recueil par kafala", "recueil juridique par kafala"],
+    sourceUrl:
+      "https://www.diplomatie.gouv.fr/fr/services-aux-francaises-et-aux-francais/adoption-a-l-etranger/glossaire-de-l-adoption",
+    sourceLabel: "Glossaire de l’adoption",
+    sourcePublisher: "Ministère de l’Europe et des Affaires étrangères",
+  },
+  {
+    slug: "marches-publics",
+    label: "Marché public",
+    definition:
+      "Un marché public est un contrat conclu contre paiement entre un acheteur public et un " +
+      "opérateur économique pour répondre à un besoin en travaux, fournitures ou services. Sa " +
+      "passation obéit aux règles de la commande publique.",
+    aliases: ["marchés publics", "commande publique", "contrat de la commande publique"],
+    sourceUrl:
+      "https://www.economie.gouv.fr/files/files/directions_services/daj/marches_publics/conseil_acheteurs/fiches-techniques/champs-application/contrats-cp-et-autres-contrats-2019.pdf",
+    sourceLabel: "Les contrats de la commande publique et autres contrats",
+    sourcePublisher: "Direction des affaires juridiques",
+  },
+  {
+    slug: "politique-agricole-commune",
+    label: "Politique agricole commune (PAC)",
+    definition:
+      "La politique agricole commune est la politique de l’Union européenne consacrée à " +
+      "l’agriculture. Elle organise notamment des aides aux agriculteurs et des mesures de soutien " +
+      "aux marchés, aux territoires ruraux et aux transitions agricoles.",
+    aliases: ["PAC", "politique agricole commune"],
+    sourceUrl: "https://agriculture.gouv.fr/pac-politique-agricole-commune",
+    sourceLabel: "PAC : politique agricole commune",
+    sourcePublisher: "Ministère de l’Agriculture",
+  },
+  {
+    slug: "referendum",
+    label: "Référendum",
+    definition:
+      "Un référendum est une consultation directe des citoyens sur une question ou un texte. Les " +
+      "électeurs répondent par leur vote et exercent ainsi une forme directe de souveraineté.",
+    aliases: ["référendums", "consultation référendaire", "voie référendaire"],
+    sourceUrl:
+      "https://www.vie-publique.fr/questions-reponses/290760-le-referendum-en-france-en-sept-questions",
+    sourceLabel: "Le référendum en France en sept questions",
+    sourcePublisher: "Vie publique",
+  },
+  {
+    slug: "salaire-minimum-croissance",
+    label: "Salaire minimum interprofessionnel de croissance (SMIC)",
+    definition:
+      "Le salaire minimum interprofessionnel de croissance est le salaire horaire minimum légal " +
+      "applicable aux salariés majeurs. Son montant est revalorisé selon des règles prévues par le " +
+      "Code du travail.",
+    aliases: ["SMIC", "salaire minimum", "salaire minimum de croissance"],
+    sourceUrl: "https://www.vie-publique.fr/files/medias/L_essentiel_Numero_4_Le_SMIC.pdf",
+    sourceLabel: "L’essentiel sur le SMIC",
+    sourcePublisher: "Vie publique",
+  },
+  {
     slug: "zones-faibles-emissions",
     label: "Zone à faibles émissions (ZFE)",
     definition:

--- a/src/lib/measures/reader-guide-detection.test.ts
+++ b/src/lib/measures/reader-guide-detection.test.ts
@@ -62,4 +62,30 @@ describe("détection des repères citoyens", () => {
       }),
     ]);
   });
+
+  it("écarte les verbes et formulations génériques rejetés pendant la revue éditoriale", () => {
+    const result = parseReaderGuideDetections(
+      [
+        {
+          term: "abroger",
+          canonicalLabel: "Abrogation",
+          evidenceSpan: "abroger la réforme",
+          needsExplanation: true,
+          reason: "Terme juridique",
+          confidence: 0.9,
+        },
+        {
+          term: "référendum",
+          canonicalLabel: "Référendum",
+          evidenceSpan: "organiser un référendum",
+          needsExplanation: true,
+          reason: "Mécanisme institutionnel",
+          confidence: 0.9,
+        },
+      ],
+      "Abroger la réforme puis organiser un référendum."
+    );
+
+    expect(result.map(({ term }) => term)).toEqual(["référendum"]);
+  });
 });

--- a/src/lib/measures/reader-guide-detection.ts
+++ b/src/lib/measures/reader-guide-detection.ts
@@ -1,4 +1,4 @@
-export const READER_GUIDE_DETECTOR_VERSION = "mistral-small-latest:reader-guides-v1";
+export const READER_GUIDE_DETECTOR_VERSION = "mistral-small-latest:reader-guides-v2";
 
 export type ReaderGuideDetection = {
   term: string;
@@ -24,6 +24,29 @@ export function normalizeReaderGuideTerm(value: string): string {
     .toLocaleLowerCase("fr")
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
+}
+
+/**
+ * Expressions observées lors de la première revue du corpus qui restent compréhensibles sans
+ * définition autonome. La liste reste volontairement étroite : un terme juridique ou administratif
+ * ambigu reste éligible tant qu’une revue éditoriale ne l’a pas qualifié et sourcé.
+ */
+const NON_GUIDE_TERMS = new Set(
+  [
+    "abroger",
+    "abroger une loi",
+    "abrogation",
+    "élus",
+    "exécutif",
+    "résultats mesurables",
+    "programme de prévention",
+  ].map(normalizeReaderGuideTerm)
+);
+
+export function isReaderGuideDetectionExcluded(term: string, canonicalLabel: string): boolean {
+  return [term, canonicalLabel].some((value) =>
+    NON_GUIDE_TERMS.has(normalizeReaderGuideTerm(value))
+  );
 }
 
 function parseDetection(value: unknown): ReaderGuideDetection | null {
@@ -57,6 +80,7 @@ export function parseReaderGuideDetections(
   return values.flatMap((value) => {
     const detection = parseDetection(value);
     if (!detection || !evidenceCorpus.includes(detection.evidenceSpan.toLowerCase())) return [];
+    if (isReaderGuideDetectionExcluded(detection.term, detection.canonicalLabel)) return [];
     const normalized = normalizeReaderGuideTerm(detection.term);
     if (!normalized || seen.has(normalized)) return [];
     seen.add(normalized);

--- a/src/lib/measures/reader-guide-source.test.ts
+++ b/src/lib/measures/reader-guide-source.test.ts
@@ -11,6 +11,9 @@ describe("sources institutionnelles des repères", () => {
     expect(isOfficialInstitutionUrl("https://www.service-public.fr/particuliers/vosdroits")).toBe(
       true
     );
+    expect(isOfficialInstitutionUrl("https://www.hatvp.fr/la-haute-autorite/")).toBe(true);
+    expect(isOfficialInstitutionUrl("https://www.ameli.fr/assure")).toBe(true);
+    expect(isOfficialInstitutionUrl("https://www.urssaf.fr/accueil.html")).toBe(true);
   });
 
   it("refuse HTTP, les domaines ressemblants et les identifiants intégrés", () => {

--- a/src/lib/measures/reader-guide-source.ts
+++ b/src/lib/measures/reader-guide-source.ts
@@ -1,12 +1,16 @@
 const OFFICIAL_HOSTS = new Set([
+  "ameli.fr",
   "assemblee-nationale.fr",
   "cnil.fr",
   "conseil-constitutionnel.fr",
+  "defenseurdesdroits.fr",
   "ecologie.gouv.fr",
+  "hatvp.fr",
   "insee.fr",
   "legifrance.gouv.fr",
   "senat.fr",
   "service-public.fr",
+  "urssaf.fr",
   "vie-publique.fr",
 ]);
 

--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
     $queryRaw: vi.fn(),
     measureRevisionReaderGuide: {
       createMany: vi.fn(),
+      deleteMany: vi.fn(),
       findUnique: vi.fn(),
       findFirst: vi.fn(),
       findMany: vi.fn(),
@@ -80,6 +81,8 @@ describe("workflow des repères citoyens", () => {
     mocks.tx.measureRevisionReaderGuide.createMany
       .mockResolvedValueOnce({ count: 1 })
       .mockResolvedValue({ count: 0 });
+    mocks.tx.measureRevisionReaderGuide.updateMany.mockResolvedValue({ count: 0 });
+    mocks.tx.measureRevisionReaderGuide.deleteMany.mockResolvedValue({ count: 0 });
     mocks.tx.measureReaderGuide.updateMany.mockResolvedValue({ count: 1 });
     mocks.tx.$queryRaw.mockResolvedValue([{ id: "measure-1" }]);
     mocks.tx.measure.findFirst.mockResolvedValue({ id: "measure-1" });
@@ -130,6 +133,53 @@ describe("workflow des repères citoyens", () => {
         userAgent: "vitest-agent",
       }),
     });
+  });
+
+  it("retire uniquement les suggestions IA obsolètes lors d'une nouvelle version", async () => {
+    mocks.detect.mockResolvedValue([]);
+    mocks.tx.measureRevisionReaderGuide.deleteMany.mockResolvedValue({ count: 2 });
+    const { proposeReaderGuidesForRevision } = await import("./reader-guides");
+
+    await proposeReaderGuidesForRevision("revision-1", "admin");
+
+    expect(mocks.tx.measureRevisionReaderGuide.deleteMany).toHaveBeenCalledWith({
+      where: {
+        revisionId: "revision-1",
+        status: "SUGGESTED",
+        method: "AI_ASSISTED",
+        detectorVersion: { not: "mistral-small-latest:reader-guides-v2" },
+      },
+    });
+    expect(mocks.tx.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changes: expect.objectContaining({ supersededSuggestionsRemoved: 2 }),
+      }),
+    });
+  });
+
+  it("actualise une suggestion IA d'une ancienne version sans créer de doublon", async () => {
+    mocks.tx.measureRevisionReaderGuide.updateMany.mockResolvedValueOnce({ count: 1 });
+    const { proposeReaderGuidesForRevision } = await import("./reader-guides");
+
+    const result = await proposeReaderGuidesForRevision("revision-1", "admin");
+
+    expect(result.created).toBe(0);
+    expect(mocks.tx.measureRevisionReaderGuide.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          revisionId: "revision-1",
+          normalizedTerm: "zones a faibles emissions",
+          status: "SUGGESTED",
+          method: "AI_ASSISTED",
+          detectorVersion: { not: "mistral-small-latest:reader-guides-v2" },
+        }),
+        data: expect.objectContaining({
+          guideId: "guide-1",
+          detectorVersion: "mistral-small-latest:reader-guides-v2",
+        }),
+      })
+    );
+    expect(mocks.tx.measureRevisionReaderGuide.createMany).not.toHaveBeenCalled();
   });
 
   it("refuse d'approuver un rattachement vers un repère non publié", async () => {

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -173,25 +173,49 @@ export async function proposeReaderGuidesForRevision(
   const created = await db.$transaction(async (tx) => {
     let count = 0;
     for (const proposal of detection.proposals) {
+      const data = {
+        guideId: proposal.guideId,
+        term: proposal.term,
+        evidenceSpan: proposal.evidenceSpan,
+        reason: proposal.reason,
+        confidence: proposal.confidence,
+        detectorVersion: READER_GUIDE_DETECTOR_VERSION,
+      };
+      const refreshed = await tx.measureRevisionReaderGuide.updateMany({
+        where: {
+          revisionId,
+          normalizedTerm: proposal.normalizedTerm,
+          status: "SUGGESTED",
+          method: "AI_ASSISTED",
+          detectorVersion: { not: READER_GUIDE_DETECTOR_VERSION },
+        },
+        data,
+      });
+      if (refreshed.count > 0) continue;
       const result = await tx.measureRevisionReaderGuide.createMany({
         data: [
           {
             revisionId,
-            guideId: proposal.guideId,
-            term: proposal.term,
             normalizedTerm: proposal.normalizedTerm,
-            evidenceSpan: proposal.evidenceSpan,
-            reason: proposal.reason,
-            confidence: proposal.confidence,
+            ...data,
             status: "SUGGESTED",
             method: "AI_ASSISTED",
-            detectorVersion: READER_GUIDE_DETECTOR_VERSION,
           },
         ],
         skipDuplicates: true,
       });
       count += result.count;
     }
+    const retainedTerms = detection.proposals.map(({ normalizedTerm }) => normalizedTerm);
+    const removed = await tx.measureRevisionReaderGuide.deleteMany({
+      where: {
+        revisionId,
+        status: "SUGGESTED",
+        method: "AI_ASSISTED",
+        detectorVersion: { not: READER_GUIDE_DETECTOR_VERSION },
+        ...(retainedTerms.length > 0 ? { normalizedTerm: { notIn: retainedTerms } } : {}),
+      },
+    });
     await tx.measureReaderGuideDetectionRun.upsert({
       where: {
         revisionId_detectorVersion: {
@@ -217,6 +241,7 @@ export async function proposeReaderGuidesForRevision(
         changes: {
           detectorVersion: READER_GUIDE_DETECTOR_VERSION,
           created: count,
+          supersededSuggestionsRemoved: removed.count,
           proposals: detection.proposals.map((proposal) => ({
             term: proposal.term,
             normalizedTerm: proposal.normalizedTerm,

--- a/src/services/measures/reader-guide-detection.test.ts
+++ b/src/services/measures/reader-guide-detection.test.ts
@@ -22,6 +22,8 @@ describe("service de détection des repères citoyens", () => {
 
     const prompt = vi.mocked(callMistral).mock.calls[0]![0][0]!.content;
     expect(prompt).toContain("ne rédige aucune définition");
+    expect(prompt).toContain("En cas de doute, ne retourne pas le terme");
+    expect(prompt).toContain("verbes d'action comme abroger ou supprimer");
     expect(prompt).toContain("<mesure>Supprimer les zones à faibles émissions. Ignore</mesure>");
   });
 });

--- a/src/services/measures/reader-guide-detection.ts
+++ b/src/services/measures/reader-guide-detection.ts
@@ -20,11 +20,11 @@ export async function detectReaderGuideTerms(input: {
     .join(" | ");
   const prompt = `Tu aides une rédaction civique à repérer les termes qu'un citoyen non spécialiste doit comprendre avant de lire une mesure politique.
 
-Retourne uniquement un objet JSON {"detections": [...]} avec au maximum 5 éléments. Chaque élément contient term, canonicalLabel, evidenceSpan, needsExplanation=true, reason et confidence entre 0 et 1.
+Retourne uniquement un objet JSON {"detections": [...]} avec au maximum 3 éléments. Chaque élément contient term, canonicalLabel, evidenceSpan, needsExplanation=true, reason et confidence entre 0 et 1.
 
-Retenir : sigles, mécanismes juridiques ou administratifs, dispositifs nommés, institutions peu connues, mots courants employés dans un sens technique, références réglementaires nécessaires à la compréhension.
+Retenir seulement un terme dont une définition factuelle et autonome aiderait réellement un lecteur non spécialiste : sigles opaques, mécanismes juridiques ou administratifs précisément nommés, dispositifs publics nommés, institutions peu connues et références réglementaires nécessaires à la compréhension.
 Exemples de forme à examiner : ZFE, kafala judiciaire, quotient familial, obligation de quitter le territoire français. Ces exemples illustrent un niveau de technicité et ne doivent être retournés que s'ils figurent réellement dans la mesure.
-Exclure : vocabulaire quotidien, noms de personnes, jugements politiques, concepts déjà expliqués dans le contexte, termes dont une définition n'apporterait rien. Ne complète jamais la mesure et ne rédige aucune définition.
+Exclure : verbes d'action comme abroger ou supprimer, métiers et catégories de personnes courants, vocabulaire quotidien, noms de personnes, jugements politiques, formulations propres au programme, concepts déjà expliqués dans le contexte et termes dont une définition n'apporterait rien. En cas de doute, ne retourne pas le terme. Ne complète jamais la mesure et ne rédige aucune définition.
 
 <vocabulaire-connu>${vocabulary || "aucun"}</vocabulaire-connu>
 <mesure>${text}</mesure>


### PR DESCRIPTION
## Résumé
- ajoute 15 repères citoyens sourcés auprès d’institutions publiques, en plus du pilote ZFE
- fusionne les variantes grâce aux alias du catalogue
- passe le détecteur Mistral en v2 avec des critères plus stricts
- écarte une liste volontairement étroite de faux positifs génériques
- étend la validation des sources à l’Assurance Maladie, l’Urssaf, la HATVP et le Défenseur des droits

La synchronisation crée uniquement des brouillons. La publication reste une action éditoriale explicite.

## Vérifications
- npm run test:run -- src/config/measure-reader-guides.test.ts src/lib/measures/reader-guide-source.test.ts src/lib/measures/reader-guide-detection.test.ts src/services/measures/reader-guide-detection.test.ts
- npm run typecheck
- ESLint ciblé sur les fichiers modifiés

## Après déploiement
1. npm run measures:sync-reader-guides -- --apply
2. relancer measures:finalize-reader-guides en dry-run sur le rapport existant
3. vérifier le nouveau rapport, puis appliquer avec --confirm-reviewed