### PR TITLE
fix(mesures): ignorer le cache Next depuis le CLI

### DIFF
--- a/src/lib/measures/reader-guides.test.ts
+++ b/src/lib/measures/reader-guides.test.ts
@@ -237,6 +237,35 @@ describe("workflow des repères citoyens", () => {
     expect(mocks.invalidate).toHaveBeenCalledWith("measure-1", "election-1");
   });
 
+  it("n'invalide pas le cache Next quand la validation vient d'un processus CLI", async () => {
+    mocks.tx.measureRevisionReaderGuide.findUnique.mockResolvedValue({
+      status: "SUGGESTED",
+      guideId: "guide-1",
+      revisionId: "revision-1",
+      revision: {
+        measure: { id: "measure-1", electionId: "election-1", candidacyId: "candidacy-1" },
+      },
+    });
+    mocks.tx.measureReaderGuide.findUnique.mockResolvedValue({
+      publicationStatus: "PUBLISHED",
+      active: true,
+    });
+    mocks.tx.measureRevisionReaderGuide.findFirst.mockResolvedValue(null);
+    mocks.tx.measureRevisionReaderGuide.updateMany.mockResolvedValue({ count: 1 });
+    const { reviewReaderGuideMention } = await import("./reader-guides");
+    const input = {
+      mentionId: "mention-1",
+      status: "APPROVED" as const,
+      reviewedBy: "cli:reader-guides:test",
+      invalidateCache: false,
+    };
+
+    await reviewReaderGuideMention(input);
+
+    expect(mocks.syncSearch).toHaveBeenCalledWith(mocks.tx, "measure-1");
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+  });
+
   it("refuse un lot si la révision relue n'est plus la révision publique", async () => {
     mocks.tx.measureRevisionReaderGuide.findUnique.mockResolvedValue({
       status: "SUGGESTED",

--- a/src/lib/measures/reader-guides.ts
+++ b/src/lib/measures/reader-guides.ts
@@ -265,6 +265,7 @@ export async function reviewReaderGuideMention(input: {
   expectedPublicRevisionId?: string;
   status: "APPROVED" | "REJECTED";
   reviewedBy: string;
+  invalidateCache?: boolean;
   ipAddress?: string;
   userAgent?: string;
 }): Promise<void> {
@@ -366,7 +367,7 @@ export async function reviewReaderGuideMention(input: {
     }
     throw error;
   }
-  invalidateMeasureTags(measure.id, measure.electionId);
+  if (input.invalidateCache !== false) invalidateMeasureTags(measure.id, measure.electionId);
 }
 
 export type ReaderGuideDraftInput = {

--- a/src/services/measures/reader-guide-finalization.test.ts
+++ b/src/services/measures/reader-guide-finalization.test.ts
@@ -227,6 +227,7 @@ describe("finalisation en lot des repères", () => {
       expectedPublicRevisionId: "revision-1",
       status: "APPROVED",
       reviewedBy: "cli:reader-guides:run-1",
+      invalidateCache: false,
     });
   });
 

--- a/src/services/measures/reader-guide-finalization.ts
+++ b/src/services/measures/reader-guide-finalization.ts
@@ -451,6 +451,9 @@ export async function applyReaderGuideFinalization(
               expectedPublicRevisionId: item.revisionId,
               status: "APPROVED",
               reviewedBy: actor,
+              // revalidateTag requires a Next request store, which a CLI process does not have.
+              // Search documents are still synchronized inside reviewReaderGuideMention().
+              invalidateCache: false,
             });
             groupApproved += 1;
           } catch (error) {


### PR DESCRIPTION
## Diagnostic
La finalisation en CLI validait correctement les rattachements puis appelait revalidateTag hors d’un contexte Next.js. Les transactions étaient déjà validées, mais une fausse alerte était écrite pour chaque mesure.

## Correctif
- conserve l’invalidation de cache pour les actions admin
- la désactive explicitement pour la finalisation CLI
- conserve la synchronisation du SearchDocument dans la transaction
- ajoute un test de régression reproduisant exactement l’appel CLI

## Vérifications
- npm run test:run -- src/lib/measures/reader-guides.test.ts src/services/measures/reader-guide-finalization.test.ts
- npm run typecheck
- ESLint ciblé
- vérification de factorisation : aucun blocage