### PR TITLE
fix(presidentielle): fiabiliser les synthèses générées

### DIFF
--- a/src/lib/api/__tests__/mistral.test.ts
+++ b/src/lib/api/__tests__/mistral.test.ts
@@ -108,4 +108,14 @@ describe("parseMistralJSON", () => {
     const result = parseMistralJSON<{ b: string }>('{"b": "hello"}');
     expect(result).toEqual({ b: "hello" });
   });
+
+  it("extrait un unique objet JSON entouré d'un commentaire du fournisseur", () => {
+    const result = parseMistralJSON<{ a: number }>('Voici la réponse :\n{"a": 1}\nFin.');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("décode une réponse JSON sérialisée une seconde fois", () => {
+    const result = parseMistralJSON<{ a: number }>('"{\\"a\\":1}"');
+    expect(result).toEqual({ a: 1 });
+  });
 });

--- a/src/lib/api/mistral.ts
+++ b/src/lib/api/mistral.ts
@@ -125,5 +125,21 @@ export function parseMistralJSON<T = unknown>(text: string): T {
   let cleaned = text.trim();
   const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (fenceMatch) cleaned = fenceMatch[1]!.trim();
-  return safeJsonParseOrThrow<T>(cleaned);
+
+  try {
+    const parsed = safeJsonParseOrThrow<unknown>(cleaned);
+    // Some model responses serialize the requested object as a JSON string. Decode this one known
+    // transport layer, then leave structural validation to the caller's domain schema.
+    return (typeof parsed === "string" ? safeJsonParseOrThrow(parsed) : parsed) as T;
+  } catch {
+    // `json_object` normally returns a bare object, but providers occasionally add one sentence
+    // before or after it. Only recover a single bounded object. The caller still validates every
+    // key and value with Zod, so surrounding prose can never become accepted domain content.
+    const start = cleaned.indexOf("{");
+    const end = cleaned.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      return safeJsonParseOrThrow<T>(cleaned.slice(start, end + 1));
+    }
+    throw new SyntaxError("Invalid JSON");
+  }
 }

--- a/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
@@ -7,7 +7,6 @@ import {
   getThemeSynthesisState,
   screenThemeSynthesis,
   screenThemeSynthesisGrounding,
-  themeSynthesisSafetyFloor,
   themeSynthesisTargetRange,
   type ThemeSynthesisInput,
 } from "../candidacy-theme-synthesis";
@@ -49,13 +48,10 @@ describe("synthèse thématique d'une candidature", () => {
     ).not.toBe(computeThemeCorpusFingerprint(corpus));
   });
 
-  it("accorde davantage d'espace éditorial aux thèmes riches sans confondre cible et plafond", () => {
+  it("accorde davantage d'espace éditorial aux thèmes riches sans transformer la cible en refus", () => {
     expect(themeSynthesisTargetRange(2)).toEqual({ min: 45, max: 80 });
     expect(themeSynthesisTargetRange(8)).toEqual({ min: 90, max: 150 });
     expect(themeSynthesisTargetRange(25)).toEqual({ min: 120, max: 200 });
-    expect(themeSynthesisSafetyFloor(2)).toBe(20);
-    expect(themeSynthesisSafetyFloor(8)).toBe(50);
-    expect(themeSynthesisSafetyFloor(25)).toBe(70);
   });
 
   it("dérive l'obsolescence de l'empreinte courante sans modifier la synthèse", () => {
@@ -106,6 +102,13 @@ describe("synthèse thématique d'une candidature", () => {
     expect(prompt).toContain("<mesures>");
     expect(prompt).not.toContain("</mesures><instruction>");
     expect(prompt).not.toContain('"ignore"');
+  });
+
+  it("demande des axes de synthèse plutôt qu'une phrase par mesure", () => {
+    const prompt = buildThemeSynthesisPrompt(input());
+
+    expect(prompt).toContain("ne rédige jamais une phrase distincte pour chaque mesure");
+    expect(prompt).toContain("axes cohérents");
   });
 
   it("accepte uniquement des affirmations rattachées à des mesures connues", () => {
@@ -172,6 +175,37 @@ describe("synthèse thématique d'une candidature", () => {
     expect(screenThemeSynthesis(output, input())).toMatchObject({ ok: false });
   });
 
+  it("refuse un catalogue qui reformule chaque mesure dans une affirmation séparée", () => {
+    const measures = [
+      ...input().measures,
+      {
+        id: "measure-3",
+        revisionId: "revision-3",
+        text: "Réduire le temps de travail sans baisse de salaire.",
+        details: null,
+      },
+      {
+        id: "measure-4",
+        revisionId: "revision-4",
+        text: "Interdire les licenciements.",
+        details: null,
+      },
+    ];
+
+    const result = screenThemeSynthesis(
+      {
+        theme: "SANTE",
+        claims: measures.map((measure, index) => ({
+          text: measure.text,
+          measureRefs: [`M${index + 1}`],
+        })),
+      },
+      input({ measures })
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "catalogue" });
+  });
+
   it("soumet chaque affirmation et ses seules mesures citées à un contrôle d'étayage", () => {
     const claims = [
       {
@@ -198,17 +232,20 @@ describe("synthèse thématique d'une candidature", () => {
     ).toEqual({ ok: false, detail: "La gratuité est absente." });
   });
 
-  it("refuse une sortie trop courte selon la taille du corpus", () => {
+  it("accepte une synthèse concise quand le thème ne contient qu'une mesure", () => {
     const result = screenThemeSynthesis(
       {
         theme: "SANTE",
         claims: [
-          { text: "Rouvrir partout les maternités de proximité rapidement.", measureRefs: ["M1"] },
+          {
+            text: "Rouvrir des maternités de proximité.",
+            measureRefs: ["M1"],
+          },
         ],
       },
-      input()
+      input({ measures: [input().measures[0]!] })
     );
 
-    expect(result).toMatchObject({ ok: false, reason: "trop_court" });
+    expect(result).toMatchObject({ ok: true });
   });
 });

--- a/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
@@ -206,6 +206,30 @@ describe("synthèse thématique d'une candidature", () => {
     expect(result).toMatchObject({ ok: false, reason: "catalogue" });
   });
 
+  it("refuse une synthèse qui ne représente presque rien d'un corpus riche", () => {
+    const measures = Array.from({ length: 25 }, (_, index) => ({
+      id: `measure-${index + 1}`,
+      revisionId: `revision-${index + 1}`,
+      text: `Mesure publiée numéro ${index + 1}.`,
+      details: null,
+    }));
+
+    const result = screenThemeSynthesis(
+      {
+        theme: "SANTE",
+        claims: [
+          {
+            text: "Deux mesures portent sur les services publics.",
+            measureRefs: ["M1", "M2"],
+          },
+        ],
+      },
+      input({ measures })
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "couverture" });
+  });
+
   it("soumet chaque affirmation et ses seules mesures citées à un contrôle d'étayage", () => {
     const claims = [
       {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -173,6 +173,20 @@ describe("screenCandidateSynthesis", () => {
     expect(result.ok && result.text).not.toMatch(/<engagement|<synthese>/);
   });
 
+  it("accepte une réponse structurée entourée d'un unique bloc de code Markdown", () => {
+    const result = screenCandidateSynthesis(`\`\`\`xml\n${structured(["M1", "M3"])}\n\`\`\``, BASE);
+
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it("accepte la structure complète quand seule l'enveloppe synthèse est omise", () => {
+    const inner = structured(["M1", "M3"])
+      .replace(/^<synthese>/u, "")
+      .replace(/<\/synthese>$/u, "");
+
+    expect(screenCandidateSynthesis(inner, BASE)).toMatchObject({ ok: true });
+  });
+
   it("preserves question and exclamation marks from published measures", () => {
     const input: CandidateSynthesisInput = {
       ...BASE,

--- a/src/lib/presidentielle/candidacy-theme-synthesis.ts
+++ b/src/lib/presidentielle/candidacy-theme-synthesis.ts
@@ -144,9 +144,17 @@ function themeSynthesisMaxClaims(measureCount: number): number {
   return 3;
 }
 
+function themeSynthesisMinimumEvidenceBreadth(measureCount: number): number {
+  if (measureCount <= 1) return 1;
+  if (measureCount <= 6) return 2;
+  if (measureCount <= 15) return 3;
+  return 4;
+}
+
 export function buildThemeSynthesisPrompt(input: ThemeSynthesisInput): string {
   const target = themeSynthesisTargetRange(input.measures.length);
   const maxClaims = themeSynthesisMaxClaims(input.measures.length);
+  const minimumEvidenceBreadth = themeSynthesisMinimumEvidenceBreadth(input.measures.length);
   const exampleReferences = input.measures.length > 1 ? '["M1","M2"]' : '["M1"]';
   const measures = sortedMeasures(input.measures)
     .map((measure, index) => {
@@ -164,6 +172,7 @@ Règles absolues :
 - n'ajoute aucun fait, chiffre, engagement, conséquence, intention ou appréciation absent des mesures citées ;
 - organise les mesures liées en ${maxClaims} axes cohérents au maximum, sans chercher à toutes les citer ;
 - ne rédige jamais une phrase distincte pour chaque mesure : une suite de reformulations n'est pas une synthèse ;
+- appuie ces axes sur au moins ${minimumEvidenceBreadth} mesure${minimumEvidenceBreadth > 1 ? "s" : ""} distincte${minimumEvidenceBreadth > 1 ? "s" : ""} du corpus ;
 - conserve les conditions, limites et nuances importantes ;
 - ne compare jamais cette candidature à une autre ;
 - ne déduis jamais une absence de position ;
@@ -308,6 +317,15 @@ export function screenThemeSynthesis(
   }
 
   const maxClaims = themeSynthesisMaxClaims(measures.length);
+  const citedReferences = new Set(parsed.data.claims.flatMap((claim) => claim.measureRefs));
+  const minimumEvidenceBreadth = themeSynthesisMinimumEvidenceBreadth(measures.length);
+  if (citedReferences.size < minimumEvidenceBreadth) {
+    return {
+      ok: false,
+      reason: "couverture",
+      detail: `La synthèse s'appuie sur ${citedReferences.size} mesure${citedReferences.size > 1 ? "s" : ""}, au moins ${minimumEvidenceBreadth} sont nécessaires pour représenter ce corpus.`,
+    };
+  }
   const groupsSeveralMeasures = parsed.data.claims.some((claim) => claim.measureRefs.length > 1);
   if (parsed.data.claims.length > maxClaims || (measures.length >= 3 && !groupsSeveralMeasures)) {
     return {

--- a/src/lib/presidentielle/candidacy-theme-synthesis.ts
+++ b/src/lib/presidentielle/candidacy-theme-synthesis.ts
@@ -5,7 +5,7 @@ import { THEME_CATEGORY_LABELS } from "@/config/labels";
 
 const PROMPT_FIELD_LIMIT = 2_000;
 export const THEME_SYNTHESIS_HARD_MAX_WORDS = 260;
-export const THEME_SYNTHESIS_PROMPT_VERSION = "candidacy-theme-synthesis-v1";
+export const THEME_SYNTHESIS_PROMPT_VERSION = "candidacy-theme-synthesis-v2";
 
 export type ThemeSynthesisMeasure = {
   id: string;
@@ -138,16 +138,16 @@ export function themeSynthesisTargetRange(measureCount: number): { min: number; 
   return { min: 120, max: 200 };
 }
 
-/** Refusal floor, intentionally below the editorial target while still following corpus size. */
-export function themeSynthesisSafetyFloor(measureCount: number): number {
-  if (measureCount <= 2) return 20;
-  if (measureCount <= 6) return 35;
-  if (measureCount <= 15) return 50;
-  return 70;
+function themeSynthesisMaxClaims(measureCount: number): number {
+  if (measureCount <= 2) return 1;
+  if (measureCount <= 6) return 2;
+  return 3;
 }
 
 export function buildThemeSynthesisPrompt(input: ThemeSynthesisInput): string {
   const target = themeSynthesisTargetRange(input.measures.length);
+  const maxClaims = themeSynthesisMaxClaims(input.measures.length);
+  const exampleReferences = input.measures.length > 1 ? '["M1","M2"]' : '["M1"]';
   const measures = sortedMeasures(input.measures)
     .map((measure, index) => {
       const details = measure.details
@@ -162,13 +162,14 @@ export function buildThemeSynthesisPrompt(input: ThemeSynthesisInput): string {
 Règles absolues :
 - utilise uniquement les mesures délimitées ci-dessous ;
 - n'ajoute aucun fait, chiffre, engagement, conséquence, intention ou appréciation absent des mesures citées ;
-- regroupe les principaux axes sans énumérer toutes les mesures ;
+- organise les mesures liées en ${maxClaims} axes cohérents au maximum, sans chercher à toutes les citer ;
+- ne rédige jamais une phrase distincte pour chaque mesure : une suite de reformulations n'est pas une synthèse ;
 - conserve les conditions, limites et nuances importantes ;
 - ne compare jamais cette candidature à une autre ;
 - ne déduis jamais une absence de position ;
 - rédige entre ${target.min} et ${target.max} mots, sans dépasser ${THEME_SYNTHESIS_HARD_MAX_WORDS} mots ;
 - écris en français clair, sans titre, sans liste, sans tiret cadratin ni demi-cadratin ;
-- découpe la synthèse en affirmations et rattache chacune aux seules mesures qui l'étayent.
+- chaque axe forme une affirmation cohérente et cite ensemble les mesures qui l'étayent.
 
 <candidature>${sanitizePromptValue(input.candidateName)}</candidature>
 <theme code="${input.theme}">${sanitizePromptValue(THEME_CATEGORY_LABELS[input.theme])}</theme>
@@ -177,7 +178,7 @@ ${measures}
 </mesures>
 
 Réponds uniquement en JSON :
-{"theme":"${input.theme}","claims":[{"text":"affirmation étayée","measureRefs":["M1"]}]}`;
+{"theme":"${input.theme}","claims":[{"text":"axe de synthèse étayé","measureRefs":${exampleReferences}}]}`;
 }
 
 const groundingResponseSchema = z
@@ -306,20 +307,27 @@ export function screenThemeSynthesis(
     }
   }
 
+  const maxClaims = themeSynthesisMaxClaims(measures.length);
+  const groupsSeveralMeasures = parsed.data.claims.some((claim) => claim.measureRefs.length > 1);
+  if (parsed.data.claims.length > maxClaims || (measures.length >= 3 && !groupsSeveralMeasures)) {
+    return {
+      ok: false,
+      reason: "catalogue",
+      detail:
+        "La réponse reformule les mesures l'une après l'autre au lieu de les regrouper en axes cohérents.",
+    };
+  }
+
   const claims = parsed.data.claims.map((claim) => ({
     text: normalizeText(claim.text),
     measureRefs: claim.measureRefs,
   }));
   const text = claims.map((claim) => claim.text).join(" ");
   const wordCount = text.split(/\s+/u).filter(Boolean).length;
-  const safetyFloor = themeSynthesisSafetyFloor(input.measures.length);
-  if (wordCount < safetyFloor) {
-    return {
-      ok: false,
-      reason: "trop_court",
-      detail: `La réponse contient ${wordCount} mots, sous le minimum de sécurité de ${safetyFloor} mots pour ce corpus.`,
-    };
-  }
+  // A minimum word count is not a safety property. For a theme backed by one short measure, an
+  // accurate sentence may legitimately stay below the editorial target. The schema already
+  // requires a non-empty claim tied to a known measure, and the second model pass verifies that
+  // claim against its evidence. Only the runaway ceiling belongs in this rejection gate.
   if (wordCount > THEME_SYNTHESIS_HARD_MAX_WORDS) {
     return {
       ok: false,

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -377,8 +377,20 @@ export function screenCandidateSynthesis(
   raw: string,
   input: CandidateSynthesisInput
 ): SynthesisScreen {
+  // Mistral entoure parfois un XML pourtant conforme d'un bloc de code Markdown, y compris après un
+  // second rappel du format. Cette enveloppe est un artefact de transport, pas du contenu libre.
+  // Nous ne la retirons que lorsqu'elle contient toute la réponse, afin de ne jamais accepter un
+  // commentaire ajouté avant ou après la structure contrôlée.
+  const trimmed = raw.trim();
+  const markdownFence = /^```(?:xml)?\s*\n?([\s\S]*?)\n?```$/iu.exec(trimmed);
+  const unfenced = (markdownFence?.[1] ?? trimmed).trim();
+  // L'enveloppe extérieure ne porte aucune preuve. Si le modèle l'omet mais rend exactement les
+  // deux sections attendues, la reconstruire ne détend aucun contrôle sur leur contenu.
+  const structured = /^<parcours>[\s\S]*(?:<\/programme>|<programme-vide\s*\/>)$/u.test(unfenced)
+    ? `<synthese>${unfenced}</synthese>`
+    : unfenced;
   const wrapper =
-    /^<synthese>\s*<parcours>([\s\S]*?)<\/parcours>\s*([\s\S]*?)\s*<\/synthese>$/u.exec(raw.trim());
+    /^<synthese>\s*<parcours>([\s\S]*?)<\/parcours>\s*([\s\S]*?)\s*<\/synthese>$/u.exec(structured);
   if (!wrapper) {
     return {
       ok: false,

--- a/src/services/candidacy-theme-synthesis/__tests__/generation.test.ts
+++ b/src/services/candidacy-theme-synthesis/__tests__/generation.test.ts
@@ -180,6 +180,39 @@ describe("generateCandidacyThemeSynthesis", () => {
     expect(mocks.callMistral.mock.calls[1]![0][0].content).toContain("réponse précédente");
   });
 
+  it("régénère une suite de mesures qui ne constitue pas une synthèse", async () => {
+    mocks.findMeasures.mockResolvedValue(
+      Array.from({ length: 4 }, (_, index) => ({
+        id: `measure-${index + 1}`,
+        publishedRevisionId: `revision-${index + 1}`,
+        publishedRevision: {
+          text: `Mesure de démonstration numéro ${index + 1}.`,
+          details: null,
+        },
+      }))
+    );
+    const catalogue = JSON.stringify({
+      theme: "SANTE",
+      claims: Array.from({ length: 4 }, (_, index) => ({
+        text: `Mesure de démonstration numéro ${index + 1}.`,
+        measureRefs: [`M${index + 1}`],
+      })),
+    });
+    mocks.callMistral
+      .mockResolvedValueOnce({ model: "mistral-large-2508", text: catalogue })
+      .mockResolvedValueOnce({ model: "mistral-large-2508", text: validOutput })
+      .mockResolvedValueOnce({ model: "mistral-large-2508", text: validVerification });
+    const { generateCandidacyThemeSynthesis } = await import("../generation");
+
+    const result = await generateCandidacyThemeSynthesis("cand-1", "SANTE", {
+      persist: false,
+      actor: { id: "admin", ipAddress: "127.0.0.1", userAgent: "vitest" },
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(mocks.callMistral.mock.calls[1]![0][0].content).toContain("regrouper en axes cohérents");
+  });
+
   it("régénère une sortie que le second passage Mistral juge non étayée", async () => {
     mocks.callMistral
       .mockResolvedValueOnce({ model: "mistral-large-2508", text: validOutput })


### PR DESCRIPTION
## Problème

Trois faux négatifs empêchaient la génération de synthèses exploitables : une structure XML valide était refusée avec un bloc Markdown, une synthèse exacte de moins de 20 mots était rejetée, et une suite de phrases par mesure passait pour une synthèse.

Mistral pouvait aussi ajouter du texte autour du JSON ou sérialiser l’objet une seconde fois.

## Correctif

- normalise uniquement les variantes de transport entièrement bornées avant les contrôles existants
- récupère un unique objet JSON entouré de texte ou doublement sérialisé, puis conserve la validation Zod stricte
- retire le minimum de mots sans toucher au plafond, aux références obligatoires ni au contrôle d’étayage
- demande 1 à 3 axes cohérents selon la taille du corpus
- refuse les catalogues où chaque affirmation reformule une seule mesure
- versionne le nouveau prompt en candidacy-theme-synthesis-v2

## Vérifications

- npm run typecheck
- npm run lint, 0 erreur, avertissements préexistants
- 111 tests ciblés sur les parseurs, contrôles et services de génération
- tests de régression rouges avant correctif pour les trois symptômes

Aucune donnée de production, migration ou publication automatique.