### PR TITLE
fix(admin): rendre visibles les blocages de publication présidentielle

### DIFF
--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -51,7 +51,9 @@ const SYNTHESIS_STYLES: Record<SynthesisState, string> = {
 export type CandidateRowView = {
   candidacyId: string;
   candidateName: string;
+  politicianId: string | null;
   politicianSlug: string | null;
+  politicianPublicationStatus: PublicationStatus | null;
   partyLabel: string | null;
   status: CandidacyStatus | null;
   sourceUrl: string | null;
@@ -95,6 +97,10 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
   const held = rows.filter(isHoldingBackMeasures);
   const heldMeasureCount = held.reduce((total, row) => total + row.readiness.measureCount, 0);
   const contradicted = rows.filter((row) => row.synthesisState === "CONTRADICTED");
+  const identityBlocked = rows.filter(
+    (row) =>
+      row.publicationStatus === "PUBLISHED" && row.politicianPublicationStatus !== "PUBLISHED"
+  );
 
   async function patchPresidential(id: string, body: Record<string, unknown>) {
     setBusy(id);
@@ -143,6 +149,24 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
             {heldMeasureCount} mesures relues, publiées et sourcées ne sortent sur aucune surface
             publique tant que la fiche candidature reste en brouillon :{" "}
             {held.map((row) => row.candidateName).join(", ")}.
+          </p>
+        </div>
+      )}
+
+      {identityBlocked.length > 0 && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+        >
+          <p className="font-semibold">
+            {identityBlocked.length === 1
+              ? "1 candidature publiée reste invisible"
+              : `${identityBlocked.length} candidatures publiées restent invisibles`}
+          </p>
+          <p className="mt-1">
+            La personnalité liée doit aussi être publiée. Le moteur de recherche et les pages
+            publiques la masquent actuellement :{" "}
+            {identityBlocked.map((row) => row.candidateName).join(", ")}.
           </p>
         </div>
       )}
@@ -236,6 +260,14 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                       </Link>
                     ) : (
                       <span>{row.candidateName}</span>
+                    )}
+                    {row.politicianId && row.politicianPublicationStatus !== "PUBLISHED" && (
+                      <Link
+                        href={`/admin/politiques/${row.politicianId}`}
+                        className="mt-2 block text-xs font-semibold text-primary underline underline-offset-2"
+                      >
+                        Publier la personnalité
+                      </Link>
                     )}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">{row.partyLabel ?? "Sans parti"}</td>

--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -264,7 +264,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                     {row.politicianId && row.politicianPublicationStatus !== "PUBLISHED" && (
                       <Link
                         href={`/admin/politiques/${row.politicianId}`}
-                        className="mt-2 block text-xs font-semibold text-primary underline underline-offset-2"
+                        className="mt-1 inline-flex min-h-11 items-center rounded px-2 text-xs font-semibold text-primary underline underline-offset-2"
                       >
                         Publier la personnalité
                       </Link>

--- a/src/app/admin/candidats/[slug]/page.tsx
+++ b/src/app/admin/candidats/[slug]/page.tsx
@@ -1,328 +1,104 @@
-import { notFound } from "next/navigation";
 import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getCandidatePresidentialBySlug } from "@/lib/data/candidates";
+import { EMPTY_MEASURE_READINESS, getMeasureReadinessByCandidacies } from "@/lib/data/measures";
 import { db } from "@/lib/db";
-import { getCandidatePresidentialBySlug, getCandidateCrossCycle } from "@/lib/data/candidates";
-import { CandidateHero } from "@/components/candidates/CandidateHero";
-import { ThemeFocusRadar } from "@/components/candidates/ThemeFocusRadar";
-import { PromisesSection } from "@/components/candidates/PromisesSection";
-import { CompareToggle } from "@/components/candidates/CompareToggle";
-import { MANDATE_TYPE_LABELS } from "@/config/labels";
-import { formatDate } from "@/lib/utils";
-import { getProbityStats, formatProbityBreakdown } from "@/lib/affairs/probity-stats";
-import type { ThemeCategory } from "@/types";
+import { isSynthesisContradictedByMeasures } from "@/lib/presidentielle/candidate-synthesis";
+import { CandidatesListClient, type CandidateRowView } from "../CandidatesListClient";
 
 export const metadata = {
-  title: "Profil candidat 2027 (admin) | Poligraph",
+  title: "Modifier une candidature présidentielle (admin) | Poligraph",
   robots: { index: false },
 };
+
+export const maxDuration = 120;
 
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
-const SECTIONS = [
-  {
-    id: "vision",
-    index: 1,
-    kicker: "VISION",
-    title: "Ce qu'il propose",
-    bg: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  },
-  {
-    id: "boussole",
-    index: 2,
-    kicker: "BOUSSOLE",
-    title: "Où il se situe",
-    bg: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-  },
-  {
-    id: "action",
-    index: 3,
-    kicker: "ACTION PARLEMENTAIRE",
-    title: "Comment il vote",
-    bg: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
-  },
-  {
-    id: "parcours",
-    index: 4,
-    kicker: "PARCOURS",
-    title: "D'où il vient",
-    bg: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-  },
-  {
-    id: "integrite",
-    index: 5,
-    kicker: "INTÉGRITÉ",
-    title: "Déclarations HATVP",
-    bg: "bg-pink-100 text-pink-800 dark:bg-pink-950 dark:text-pink-300",
-  },
-  {
-    id: "affaires",
-    index: 6,
-    kicker: "AFFAIRES",
-    title: "Procédures judiciaires",
-    bg: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
-  },
-] as const;
-
-interface SectionHeaderProps {
-  id: string;
-  index: number;
-  kicker: string;
-  title: React.ReactNode;
-  bg: string;
-}
-
-function SectionHeader({ id, index, kicker, title, bg }: SectionHeaderProps) {
-  return (
-    <>
-      <span className={`inline-block rounded px-2 py-1 text-xs font-semibold ${bg}`}>
-        {index}. {kicker}
-      </span>
-      <h2
-        id={`${id}-heading`}
-        className="text-lg font-display font-bold text-slate-900 dark:text-slate-100"
-      >
-        {title}
-      </h2>
-    </>
-  );
-}
-
-export default async function AdminCandidatProfilePage({ params }: PageProps) {
+export default async function AdminCandidacyPage({ params }: PageProps) {
   const { slug } = await params;
   const candidacy = await getCandidatePresidentialBySlug("presidentielle-2027", slug);
-  if (!candidacy || !candidacy.politician) notFound();
+  if (!candidacy) notFound();
 
-  const politician = candidacy.politician;
-
-  const [
-    promiseGroups,
-    promisesList,
-    mandates,
-    affairsCount,
-    declarationsCount,
-    crossCycle,
-    probityStats,
-  ] = await Promise.all([
-    db.promise.groupBy({
-      by: ["theme"],
-      where: { politicianId: politician.id, extractionStatus: "PUBLISHED" },
-      _count: { _all: true },
+  const [readinessByCandidacy, editions] = await Promise.all([
+    getMeasureReadinessByCandidacies([candidacy.id]),
+    db.programEdition.findMany({
+      where: { candidacyId: candidacy.id },
+      select: { id: true, candidacyId: true, label: true, version: true, publicationStatus: true },
+      orderBy: [{ publishedAt: "asc" }, { version: "asc" }],
     }),
-    db.promise.findMany({
-      where: { politicianId: politician.id, extractionStatus: "PUBLISHED" },
-      orderBy: { publishedAt: "desc" },
-      select: {
-        id: true,
-        text: true,
-        theme: true,
-        sourceLabel: true,
-        sourceUrl: true,
-      },
-      take: 20,
-    }),
-    db.mandate.findMany({
-      where: { politicianId: politician.id },
-      orderBy: { startDate: "desc" },
-      take: 10,
-    }),
-    db.affair.count({
-      where: { politicianId: politician.id, publicationStatus: "PUBLISHED" },
-    }),
-    db.declaration.count({ where: { politicianId: politician.id } }),
-    getCandidateCrossCycle(politician.id, "presidentielle-2027"),
-    getProbityStats(politician.id),
   ]);
-
-  const promisesCount = promiseGroups.reduce((s, g) => s + g._count._all, 0);
-  const participationPct = null;
-
-  const radarItems = promiseGroups.map((g) => ({
-    theme: g.theme as ThemeCategory,
-    count: g._count._all,
-  }));
-
-  const accentColor =
-    candidacy.presidentialData?.accentColor ?? politician.currentParty?.color ?? undefined;
-  const politicianSlug = politician.slug ?? slug;
+  const readiness = readinessByCandidacy.get(candidacy.id) ?? EMPTY_MEASURE_READINESS;
+  const row: CandidateRowView = {
+    candidacyId: candidacy.id,
+    candidateName: candidacy.candidateName,
+    politicianId: candidacy.politician?.id ?? null,
+    politicianSlug: candidacy.politician?.slug ?? null,
+    politicianPublicationStatus: candidacy.politician?.publicationStatus ?? null,
+    partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
+    status: candidacy.status,
+    sourceUrl: candidacy.sourceUrl,
+    sourceLabel: candidacy.sourceLabel,
+    sourced: Boolean(candidacy.status && candidacy.sourceUrl && candidacy.sourceLabel),
+    presidentialId: candidacy.presidentialData?.id ?? null,
+    publicationStatus: candidacy.presidentialData?.publicationStatus ?? null,
+    slogan: candidacy.presidentialData?.slogan ?? null,
+    rank: candidacy.presidentialData?.rank ?? null,
+    readiness,
+    synthesisState: !candidacy.presidentialData?.synthesis
+      ? "MISSING"
+      : isSynthesisContradictedByMeasures({
+            generatedAt: candidacy.presidentialData.synthesisGeneratedAt,
+            firstMeasurePublishedAt: readiness.firstPublishedAt,
+          })
+        ? "CONTRADICTED"
+        : "CURRENT",
+    synthesisGeneratedAt: candidacy.presidentialData?.synthesisGeneratedAt ?? null,
+    editions: editions.map((edition) => ({
+      id: edition.id,
+      label: edition.label,
+      version: edition.version,
+      publicationStatus: edition.publicationStatus,
+    })),
+  };
 
   return (
-    <div className="relative space-y-8 pb-24">
-      <CandidateHero
-        candidacy={candidacy}
-        crossCycle={crossCycle}
-        promisesCount={promisesCount}
-        votesParticipationPct={participationPct}
-        probityStats={probityStats}
-      />
-
-      <section aria-labelledby="vision-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[0].id}
-          index={SECTIONS[0].index}
-          kicker={SECTIONS[0].kicker}
-          title={<>Ce qu{"'"}il propose</>}
-          bg={SECTIONS[0].bg}
-        />
-        <div className="grid gap-3 lg:grid-cols-[280px_1fr]">
-          <ThemeFocusRadar
-            items={radarItems}
-            candidateName={candidacy.candidateName}
-            accentColor={accentColor}
-          />
-          <PromisesSection promises={promisesList} politicianSlug={politicianSlug} />
-        </div>
-      </section>
-
-      <section aria-labelledby="boussole-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[1].id}
-          index={SECTIONS[1].index}
-          kicker={SECTIONS[1].kicker}
-          title={SECTIONS[1].title}
-          bg={SECTIONS[1].bg}
-        />
-        <div className="rounded-md border border-slate-200 bg-white p-4 text-sm dark:border-slate-700 dark:bg-slate-900">
-          <p className="text-slate-600 dark:text-slate-300">
-            Alignement boussole détaillé en cours de connexion avec le module Programmes.
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <Link href="/admin/candidats" className="text-sm text-primary underline underline-offset-2">
+          Retour aux candidatures
+        </Link>
+        <div>
+          <h1 className="text-2xl font-display font-bold tracking-tight">
+            Modifier la candidature de {candidacy.candidateName}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Statut et source de candidature, publication, programme et synthèses.
           </p>
-          <Link
-            href="/programmes"
-            className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
-          >
-            Tester votre alignement →
-          </Link>
         </div>
-      </section>
-
-      <section aria-labelledby="action-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[2].id}
-          index={SECTIONS[2].index}
-          kicker={SECTIONS[2].kicker}
-          title={SECTIONS[2].title}
-          bg={SECTIONS[2].bg}
-        />
-        <div className="rounded-md border border-slate-200 bg-white p-4 text-sm dark:border-slate-700 dark:bg-slate-900">
-          <p className="text-slate-600 dark:text-slate-300">
-            L{"'"}analyse des votes parlementaires (votes enregistrés et prises de position par
-            thème) sera reliée ici depuis la fiche politicien. Un taux de participation ne peut être
-            affiché que lorsque son périmètre d{"'"}éligibilité est résolu.
-          </p>
-          <Link
-            href={`/politiques/${politicianSlug}#votes`}
-            className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
-          >
-            Voir les votes →
-          </Link>
-        </div>
-      </section>
-
-      <section aria-labelledby="parcours-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[3].id}
-          index={SECTIONS[3].index}
-          kicker={SECTIONS[3].kicker}
-          title={<>D{"'"}où il vient</>}
-          bg={SECTIONS[3].bg}
-        />
-        {mandates.length === 0 ? (
-          <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-            Aucun mandat référencé pour ce candidat.
-          </div>
-        ) : (
-          <div className="rounded-md border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
-            <ol className="space-y-2 text-sm">
-              {mandates.map((m) => (
-                <li key={m.id} className="border-l-4 border-primary pl-3">
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">
-                    {MANDATE_TYPE_LABELS[m.type]}
-                  </span>
-                  <span className="text-slate-700 dark:text-slate-200"> · {m.title}</span>
-                  <span className="block text-xs text-slate-500 dark:text-slate-400">
-                    {formatDate(m.startDate)} → {m.endDate ? formatDate(m.endDate) : "en cours"}
-                  </span>
-                </li>
-              ))}
-            </ol>
+        <nav aria-label="Autres outils pour cette candidature" className="flex flex-wrap gap-3">
+          {candidacy.politician && (
             <Link
-              href={`/politiques/${politicianSlug}`}
-              className="mt-3 inline-block text-xs font-semibold text-primary hover:underline"
+              href={`/admin/politiques/${candidacy.politician.id}`}
+              className="inline-flex min-h-11 items-center rounded-md border px-4 text-sm font-semibold hover:bg-muted"
             >
-              Voir la fiche complète →
+              Modifier la personnalité
             </Link>
-          </div>
-        )}
-      </section>
-
-      <section aria-labelledby="integrite-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[4].id}
-          index={SECTIONS[4].index}
-          kicker={SECTIONS[4].kicker}
-          title={SECTIONS[4].title}
-          bg={SECTIONS[4].bg}
-        />
-        <div className="rounded-md border border-slate-200 bg-white p-4 text-sm dark:border-slate-700 dark:bg-slate-900">
-          {declarationsCount === 0 ? (
-            <p className="text-slate-600 dark:text-slate-300">
-              Aucune déclaration HATVP disponible pour ce candidat.
-            </p>
-          ) : (
-            <>
-              <p className="text-slate-700 dark:text-slate-200">
-                {declarationsCount} déclaration{declarationsCount > 1 ? "s" : ""} HATVP référencée
-                {declarationsCount > 1 ? "s" : ""}.
-              </p>
-              <Link
-                href={`/politiques/${politicianSlug}#declarations`}
-                className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
-              >
-                Voir les déclarations →
-              </Link>
-            </>
           )}
-        </div>
-      </section>
-
-      <section aria-labelledby="affaires-heading" className="space-y-3">
-        <SectionHeader
-          id={SECTIONS[5].id}
-          index={SECTIONS[5].index}
-          kicker={SECTIONS[5].kicker}
-          title={SECTIONS[5].title}
-          bg={SECTIONS[5].bg}
-        />
-        <div className="rounded-md border border-slate-200 bg-white p-4 text-sm dark:border-slate-700 dark:bg-slate-900">
-          {affairsCount === 0 ? (
-            <p className="text-slate-600 dark:text-slate-300">
-              Aucune affaire judiciaire publiée pour ce candidat.
-            </p>
-          ) : (
-            <>
-              <p className="text-slate-700 dark:text-slate-200">
-                <strong>Atteintes à la probité : {probityStats.total}</strong>
-                {probityStats.total > 0 && ` (${formatProbityBreakdown(probityStats)}).`}
-              </p>
-              <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
-                {affairsCount} affaire{affairsCount > 1 ? "s" : ""} judiciaire
-                {affairsCount > 1 ? "s" : ""} référencée{affairsCount > 1 ? "s" : ""} au total
-                (toutes catégories). Présomption d{"'"}innocence respectée, les procédures en cours
-                ne préjugent pas de la culpabilité.
-              </p>
-              <Link
-                href={`/politiques/${politicianSlug}#affaires`}
-                className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
-              >
-                Voir les affaires →
-              </Link>
-            </>
+          {candidacy.politician?.slug && (
+            <Link
+              href={`/admin/candidats/${candidacy.politician.slug}/syntheses-thematiques`}
+              className="inline-flex min-h-11 items-center rounded-md border px-4 text-sm font-semibold hover:bg-muted"
+            >
+              Gérer les synthèses thématiques
+            </Link>
           )}
-        </div>
-      </section>
+        </nav>
+      </header>
 
-      <CompareToggle currentSlug={slug} currentName={candidacy.candidateName} />
+      <CandidatesListClient rows={[row]} />
     </div>
   );
 }

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -30,7 +30,9 @@ function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
   return {
     candidacyId: "cand-1",
     candidateName: "Alix Démonstration",
+    politicianId: "pol-1",
     politicianSlug: "alix-demonstration",
+    politicianPublicationStatus: "PUBLISHED",
     partyLabel: "PD",
     status: "DECLARE",
     sourceUrl: "https://example.org/annonce",
@@ -76,6 +78,25 @@ describe("CandidatesListClient", () => {
 
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dépublier" })).toBeInTheDocument();
+  });
+
+  it("signale une candidature publiée dont la personnalité reste masquée", () => {
+    render(
+      <CandidatesListClient
+        rows={[
+          row({
+            publicationStatus: "PUBLISHED",
+            politicianPublicationStatus: "ARCHIVED",
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("1 candidature publiée reste invisible");
+    expect(screen.getByRole("link", { name: "Publier la personnalité" })).toHaveAttribute(
+      "href",
+      "/admin/politiques/pol-1"
+    );
   });
 
   it("publie la fiche depuis la liste", async () => {

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -36,7 +36,9 @@ export default async function AdminCandidatsPage() {
     return {
       candidacyId: candidacy.id,
       candidateName: candidacy.candidateName,
+      politicianId: candidacy.politician?.id ?? null,
       politicianSlug: candidacy.politician?.slug ?? null,
+      politicianPublicationStatus: candidacy.politician?.publicationStatus ?? null,
       partyLabel: candidacy.party?.shortName ?? candidacy.partyLabel ?? null,
       status: candidacy.status,
       sourceUrl: candidacy.sourceUrl,

--- a/src/app/api/search/global/route.test.ts
+++ b/src/app/api/search/global/route.test.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+const { queryRaw } = vi.hoisted(() => ({ queryRaw: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/lib/db", () => ({ db: { $queryRaw: queryRaw } }));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({}) };
+
+describe("GET recherche globale", () => {
+  it("ne met pas en cache une réponse de recherche nominative", async () => {
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/search/global?q=Juan%20Branco"),
+      context
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -237,6 +237,8 @@ export const GET = withPublicRoute(async (request) => {
         population: c.population,
       })),
     }),
-    "daily"
+    // Free-text results must reflect editorial publication changes immediately. A cached empty
+    // response otherwise keeps a newly published person invisible until the CDN entry expires.
+    "none"
   );
 });

--- a/src/app/api/search/politicians/route.test.ts
+++ b/src/app/api/search/politicians/route.test.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+const { findMany } = vi.hoisted(() => ({ findMany: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/lib/db", () => ({ db: { politician: { findMany } } }));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({}) };
+
+describe("GET recherche de personnalités", () => {
+  it("ne met pas en cache une réponse de recherche nominative", async () => {
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/search/politicians?q=S%C3%A9gol%C3%A8ne%20Royal"),
+      context
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/src/app/api/search/politicians/route.ts
+++ b/src/app/api/search/politicians/route.ts
@@ -98,5 +98,7 @@ export const GET = withPublicRoute(async (request) => {
     mandate: p.mandates[0]?.type || null,
   }));
 
-  return withCache(NextResponse.json(results), "daily");
+  // This endpoint backs autocompletion in editorial and public flows. Free-text responses cannot
+  // be invalidated by entity tag, so caching them would hide a newly published person.
+  return withCache(NextResponse.json(results), "none");
 });

--- a/src/lib/data/candidates.ts
+++ b/src/lib/data/candidates.ts
@@ -8,6 +8,7 @@ const PRESIDENTIAL_INCLUDE = {
       slug: true,
       fullName: true,
       photoUrl: true,
+      publicationStatus: true,
       currentParty: { select: { id: true, slug: true, name: true, shortName: true, color: true } },
     },
   },


### PR DESCRIPTION
## Problème

Une extension de candidature présidentielle pouvait être publiée alors que la personnalité liée restait en brouillon ou archivée. La candidature apparaissait alors comme publiée dans l'administration, mais restait absente des pages publiques et des moteurs de recherche.

Le clic sur le nom ouvrait en outre une ancienne expérimentation de fiche présidentielle, sans contrôles éditoriaux utiles.

## Changements

- affiche une alerte explicite lorsqu'une candidature publiée reste masquée par le statut de la personnalité liée
- ajoute un accès direct à la publication de la personnalité
- remplace l'ancienne fiche admin par la vraie page d'édition de la candidature
- conserve les contrôles de statut, source, publication, programme et synthèse
- ajoute les accès aux synthèses thématiques et à la fiche administrative de la personnalité
- désactive le cache CDN des recherches libres globale et nominative afin qu'une publication soit visible immédiatement

## Garanties

- aucune donnée de production modifiée
- aucune publication automatisée
- la publication de la personnalité reste une décision humaine distincte
- la synchronisation ciblée existante du document de recherche est réutilisée
- aucun fichier local sous specs ou scripts/.local n'est inclus

## Vérifications

- typecheck vert
- lint vert, avertissements préexistants uniquement
- 22 tests ciblés verts
- suite complète : 5718 tests verts ; quatre échecs causés uniquement par des fichiers gitignorés sous scripts/.local absents de la CI
- compilation Next.js production avec Webpack en mode compile verte
- le build complet compile puis échoue pendant le pré-rendu de 788 pages, lorsque 13 workers saturent la connexion Prisma sur une page non modifiée
