### PR TITLE
fix(sync): préserver les profils des candidats publiés

### DIFF
--- a/scripts/assign-publication-status.ts
+++ b/scripts/assign-publication-status.ts
@@ -5,11 +5,13 @@
  *   1. statusOverride = true → skip (manual override)
  *   2. Deceased before 1958 → EXCLUDED
  *   3. Born before 1920 AND no current mandate AND low score → EXCLUDED
- *   4. Has current mandate → PUBLISHED
- *   5. prominenceScore >= 150 AND has photo or biography → PUBLISHED
- *   6. Deceased > 10 years → ARCHIVED
- *   7. prominenceScore < 50 AND no current mandate → ARCHIVED
- *   8. Otherwise → DRAFT
+ *   4. Published profile with a sourced published presidential candidacy → keep PUBLISHED
+ *   5. Published direct affair → PUBLISHED
+ *   6. Has current mandate → PUBLISHED
+ *   7. prominenceScore >= 150 AND has photo or biography → PUBLISHED
+ *   8. Deceased > 10 years → ARCHIVED
+ *   9. prominenceScore < 50 AND no current mandate → ARCHIVED
+ *   10. Otherwise → DRAFT
  *
  * Usage:
  *   npx tsx scripts/assign-publication-status.ts              # Apply changes

--- a/src/services/sync/__tests__/publication-status.test.ts
+++ b/src/services/sync/__tests__/publication-status.test.ts
@@ -13,6 +13,7 @@ function row(over: Partial<PoliticianRow> = {}): PoliticianRow {
     prominenceScore: 15,
     hasCurrentMandate: false,
     hasPublishedDirectAffair: false,
+    hasPublishedPresidentialCandidacy: false,
     ...over,
   };
 }
@@ -27,6 +28,21 @@ describe("determineStatus", () => {
     // affair while leaving the profile out of both would link readers to a page
     // the site itself does not acknowledge.
     expect(determineStatus(row({ hasPublishedDirectAffair: true }))).toBe("PUBLISHED");
+  });
+
+  it("keeps a sourced published presidential candidate profile public", () => {
+    expect(
+      determineStatus(
+        row({
+          publicationStatus: "PUBLISHED",
+          hasPublishedPresidentialCandidacy: true,
+        })
+      )
+    ).toBe("PUBLISHED");
+  });
+
+  it("does not publish a draft profile from the candidacy signal alone", () => {
+    expect(determineStatus(row({ hasPublishedPresidentialCandidacy: true }))).toBe("ARCHIVED");
   });
 
   it("keeps publishing anyone holding a current mandate", () => {
@@ -44,6 +60,17 @@ describe("determineStatus", () => {
     // drag a nineteenth-century figure back into the directory.
     expect(
       determineStatus(row({ deathDate: new Date("1935-04-02"), hasPublishedDirectAffair: true }))
+    ).toBe("EXCLUDED");
+  });
+
+  it("leaves pre-1958 deceased figures excluded even with a presidential candidacy", () => {
+    expect(
+      determineStatus(
+        row({
+          deathDate: new Date("1935-04-02"),
+          hasPublishedPresidentialCandidacy: true,
+        })
+      )
     ).toBe("EXCLUDED");
   });
 

--- a/src/services/sync/publication-status-rules.ts
+++ b/src/services/sync/publication-status-rules.ts
@@ -17,6 +17,7 @@ export type PoliticianRow = {
   prominenceScore: number;
   hasCurrentMandate: boolean;
   hasPublishedDirectAffair: boolean;
+  hasPublishedPresidentialCandidacy: boolean;
 };
 
 export function determineStatus(p: PoliticianRow): PublicationStatus | null {
@@ -40,7 +41,15 @@ export function determineStatus(p: PoliticianRow): PublicationStatus | null {
     return PublicationStatus.EXCLUDED;
   }
 
-  // Rule 3b: Publishing someone's judicial affair publishes their profile.
+  // Rule 3b: A sourced presidential candidacy keeps an already-published profile public.
+  // Candidate pages and their measures require a PUBLISHED Politician, so the prominence
+  // pass must not undo that explicit editorial decision. This is deliberately sticky rather
+  // than promotional: a DRAFT profile still requires its own publication decision.
+  if (p.hasPublishedPresidentialCandidacy && p.publicationStatus === PublicationStatus.PUBLISHED) {
+    return PublicationStatus.PUBLISHED;
+  }
+
+  // Rule 3c: Publishing someone's judicial affair publishes their profile.
   // /politiques and the sitemap only list PUBLISHED profiles, so leaving the
   // profile ARCHIVED or DRAFT would link readers from a published affair to a
   // page the site excludes from its own directory and index. Prominence has

--- a/src/services/sync/publication-status.ts
+++ b/src/services/sync/publication-status.ts
@@ -56,6 +56,20 @@ export async function assignPublicationStatus(
         select: { id: true },
         take: 1,
       },
+      // A published presidential fiche is an explicit editorial decision, just like a
+      // published direct affair. Require the identity fields enforced by the admin
+      // publication action so an incomplete legacy row cannot publish a profile.
+      candidacies: {
+        where: {
+          election: { type: "PRESIDENTIELLE" },
+          status: { not: null },
+          sourceUrl: { not: null },
+          sourceLabel: { not: null },
+          presidentialData: { is: { publicationStatus: PublicationStatus.PUBLISHED } },
+        },
+        select: { id: true },
+        take: 1,
+      },
     },
   });
 
@@ -75,6 +89,7 @@ export async function assignPublicationStatus(
       prominenceScore: p.prominenceScore,
       hasCurrentMandate: p.mandates.length > 0,
       hasPublishedDirectAffair: p.affairs.length > 0,
+      hasPublishedPresidentialCandidacy: p.candidacies.length > 0,
     };
 
     const targetStatus = determineStatus(row);


### PR DESCRIPTION
## Problème

Le recalcul automatique des statuts archivait les profils sans mandat courant et sous le seuil de notoriété, même lorsqu'une candidature présidentielle publiée et sourcée dépendait de ce profil. Juan Branco a ainsi été reclassé en ARCHIVED par sync-daily.

## Correctif

- charge le signal de candidature présidentielle publiée et sourcée dans le service de statuts
- conserve PUBLISHED uniquement pour un profil déjà publié
- ne publie pas automatiquement un profil DRAFT
- laisse les règles d'exclusion historique prioritaires
- documente la règle dans le script opératoire

## Vérifications

- test de régression rouge avant correctif, vert après correctif
- 9 tests ciblés passent
- TypeScript passe
- lint passe sans erreur
- suite complète : 6 109 tests passent dans l'équivalent d'un checkout CI ; un garde nécessitant git ls-files passe séparément hors sandbox
- dry-run production : 37 686 profils examinés, zéro changement proposé
- audit des 25 candidatures présidentielles publiées : aucun profil menacé

Aucune écriture en base et aucun déploiement Vercel.