### PR TITLE
fix(presidentielle): fiabiliser le format des synthèses

### DIFF
--- a/src/lib/api/mistral.ts
+++ b/src/lib/api/mistral.ts
@@ -14,7 +14,17 @@ export interface MistralOptions {
   maxTokens?: number;
   system?: string;
   temperature?: number;
-  responseFormat?: { type: "json_object" };
+  responseFormat?:
+    | { type: "json_object" }
+    | {
+        type: "json_schema";
+        json_schema: {
+          name: string;
+          description?: string;
+          schema: Record<string, unknown>;
+          strict?: boolean;
+        };
+      };
 }
 
 export interface MistralMessage {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -74,17 +74,15 @@ describe("buildCandidateSynthesisPrompt", () => {
     expect(prompt.match(/Santé \(2 mesures\) :/g)).toHaveLength(1);
   });
 
-  it("provides theme counts and an explicit coverage target", () => {
+  it("provides theme counts without imposing a catalogue", () => {
     const prompt = buildCandidateSynthesisPrompt(BASE);
     expect(prompt).toContain("Santé : 2 mesures");
     expect(prompt).toContain("Transports : 1 mesure");
-    expect(prompt).toContain(
-      "Représente au moins une mesure de chacun de ces thèmes : Santé, Transports."
-    );
+    expect(prompt).not.toContain("couverture_attendue");
     expect(prompt).toContain("[M1] Rouvrir des maternités de proximité.");
   });
 
-  it("asks a large programme to cover its five most represented themes", () => {
+  it("does not turn a large programme into a mandatory list of themes", () => {
     const themes = [
       "SANTE",
       "TRANSPORTS",
@@ -101,10 +99,8 @@ describe("buildCandidateSynthesisPrompt", () => {
       text: `Mesure ${index}.`,
     }));
     const prompt = buildCandidateSynthesisPrompt({ ...BASE, measures });
-    const coverage = prompt.match(/<couverture_attendue>\n(.+)\n<\/couverture_attendue>/)?.[1];
-
-    expect(coverage?.match(/,/g)).toHaveLength(4);
-    expect(coverage).not.toContain("Transports");
+    expect(prompt).not.toContain("couverture_attendue");
+    expect(prompt).toContain("<repartition_themes>");
   });
 
   it("presents every measure of a very large programme to the model", () => {
@@ -213,13 +209,17 @@ describe("screenCandidateSynthesis", () => {
     ).toMatchObject({ ok: false });
   });
 
-  it("refuse une synthèse qui omet un thème attendu", () => {
-    expect(
-      screenCandidateSynthesis(output([{ text: healthAxis, measureRefs: ["M1", "M2"] }]), BASE)
-    ).toMatchObject({
-      ok: false,
-      reason: "couverture_theme",
-    });
+  it("accepte une sélection éditoriale étayée sans imposer chaque thème", () => {
+    const result = screenCandidateSynthesis(
+      output([
+        {
+          text: `${healthAxis} Elles associent ainsi la réouverture de services de proximité au remboursement intégral des soins prescrits.`,
+          measureRefs: ["M1", "M2"],
+        },
+      ]),
+      BASE
+    );
+    expect(result).toMatchObject({ ok: true });
   });
 
   it("refuse une référence inconnue", () => {
@@ -237,6 +237,18 @@ describe("screenCandidateSynthesis", () => {
     });
   });
 
+  it("retire du texte public les marqueurs de preuve répétés par le modèle", () => {
+    const result = screenCandidateSynthesis(
+      output([
+        { text: `${healthAxis} (M1, M2)`, measureRefs: ["M1", "M2"] },
+        { text: `${transportAxis} M3.`, measureRefs: ["M3"] },
+      ]),
+      BASE
+    );
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).not.toMatch(/\bM[1-9][0-9]*\b/u);
+  });
+
   it("refuse une quantité absente des mesures citées", () => {
     expect(
       screenCandidateSynthesis(
@@ -250,6 +262,23 @@ describe("screenCandidateSynthesis", () => {
       ok: false,
       reason: "quantite",
     });
+  });
+
+  it("écarte un axe invalide quand les axes restants forment encore une synthèse", () => {
+    const result = screenCandidateSynthesis(
+      output([
+        { text: healthAxis, measureRefs: ["M1", "M2"] },
+        { text: transportAxis, measureRefs: ["M3"] },
+        {
+          text: "Une enveloppe supplémentaire de 90 millions financerait également ces politiques publiques.",
+          measureRefs: ["M1"],
+        },
+      ]),
+      BASE
+    );
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).not.toContain("90 millions");
+    expect(result.ok && result.programmeClaims).toHaveLength(2);
   });
 
   it("rend une phrase canonique quand le programme est vide", () => {

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -175,7 +175,6 @@ type ProgrammeReference = {
 
 type ProgrammePlan = {
   references: ProgrammeReference[];
-  expectedThemes: ThemeCategory[];
   themeCounts: Map<ThemeCategory, number>;
 };
 
@@ -273,7 +272,7 @@ Règles absolues :
 - Aucun jugement de valeur, aucun qualificatif d'appréciation. Ni « ambitieux », ni « radical », ni « crédible », ni « clivant ». Décris, ne commente pas.
 - Aucune comparaison avec un autre candidat.
 - Ne compte pas les mesures et ne dis pas combien il y en a : le chiffre est affiché à côté et il bougera.
-- Appuie-toi sur la répartition et la couverture attendue fournies avec le programme.
+- Appuie-toi sur la répartition fournie pour comprendre le corpus, sans énumérer mécaniquement ses thèmes.
 - Dégage les idées directrices et les moyens récurrents. Relie plusieurs mesures lorsqu'elles forment réellement un même axe.
 - Ne juxtapose pas les mesures et ne reproduis pas leur formulation l'une après l'autre.
 - Chaque affirmation sur le programme doit citer les références exactes des mesures qui l'étayent.
@@ -305,23 +304,11 @@ function buildProgrammePlan(input: CandidateSynthesisInput): ProgrammePlan {
   for (const reference of allReferences) {
     counts.set(reference.theme, (counts.get(reference.theme) ?? 0) + 1);
   }
-  const themes = [...counts.entries()].sort(
-    ([themeA, countA], [themeB, countB]) =>
-      countB - countA ||
-      THEME_CATEGORY_LABELS[themeA].localeCompare(THEME_CATEGORY_LABELS[themeB], "fr")
-  );
-  // Theme frequency is context, not an editorial ranking. It gives a stable, candidate-agnostic
-  // answer to “principal themes” while the explicit cap prevents the largest family swallowing the
-  // paragraph. Five examples fit the large 250-word format; three fit the standard one. A longer
-  // selection reads like an extraction dump rather than a summary, especially on mobile.
-  const coverageLimit = input.measures.length >= LARGE_PROGRAMME_MEASURES ? 5 : 3;
-  const expectedThemes = themes.slice(0, coverageLimit).map(([theme]) => theme);
   // Every published measure reaches the model. The earlier deterministic sample produced fluent
   // prose, but it was a synthesis of 24 examples rather than of a 70-measure programme.
   const references = allReferences;
   return {
     references,
-    expectedThemes,
     themeCounts: counts,
   };
 }
@@ -338,7 +325,6 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
       (programmePlan.themeCounts.get(themeB) ?? 0) - (programmePlan.themeCounts.get(themeA) ?? 0) ||
       THEME_CATEGORY_LABELS[themeA].localeCompare(THEME_CATEGORY_LABELS[themeB], "fr")
   );
-  const expectedThemes = programmePlan.expectedThemes.map((theme) => THEME_CATEGORY_LABELS[theme]);
   const measures =
     themes.length > 0
       ? themes
@@ -360,11 +346,6 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
           })
           .join("\n")
       : "Aucun thème représenté.";
-  const coverage =
-    expectedThemes.length > 0
-      ? `Représente au moins une mesure de chacun de ces thèmes : ${expectedThemes.join(", ")}.`
-      : "Aucun thème à représenter.";
-
   return `<candidature>
 <nom>${safe(input.candidateName)}</nom>
 <parti>${input.partyLabel ? safe(input.partyLabel) : "non renseigné"}</parti>
@@ -376,9 +357,6 @@ export function buildCandidateSynthesisPrompt(input: CandidateSynthesisInput): s
 <repartition_themes>
 ${distribution}
 </repartition_themes>
-<couverture_attendue>
-${coverage}
-</couverture_attendue>
 <mesures_par_theme>
 ${measures}
 </mesures_par_theme>
@@ -413,6 +391,15 @@ function isComparativeClaim(value: string): boolean {
   return /\b(?:contrairement aux|par rapport aux|plus que les autres|moins que les autres|les autres candidat(?:s|es)?)\b/iu.test(
     value
   );
+}
+
+/** Removes prompt-only evidence labels when the provider repeats them in reader-facing prose. */
+function stripEvidenceMarkers(value: string): string {
+  return value
+    .replace(/\s*[([]\s*M[1-9][0-9]*(?:\s*[,;]\s*M[1-9][0-9]*)*\s*[)\]]/gu, " ")
+    .replace(/\s+M[1-9][0-9]*(?:\s*[,;]\s*M[1-9][0-9]*)*(?=[,.;:!?]|$)/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 export function screenCandidateSynthesis(
@@ -469,32 +456,46 @@ export function screenCandidateSynthesis(
     };
   }
   const references = new Map(plan.references.map((reference) => [reference.ref, reference]));
-  const coveredThemes = new Set<ThemeCategory>();
   let hasGroupedAxis = false;
+  let firstClaimFailure: Extract<SynthesisScreen, { ok: false }> | undefined;
   const normalizedClaims: CandidateProgrammeClaim[] = [];
   for (const claim of claims) {
+    let claimFailure: Extract<SynthesisScreen, { ok: false }> | undefined;
     if (new Set(claim.measureRefs).size !== claim.measureRefs.length) {
-      return { ok: false, reason: "preuve_repetee", detail: "une référence est répétée" };
+      claimFailure = {
+        ok: false,
+        reason: "preuve_repetee",
+        detail: "une référence est répétée",
+      };
     }
     const cited = claim.measureRefs.flatMap((reference) => {
       const measure = references.get(reference);
       return measure ? [measure] : [];
     });
-    if (cited.length !== claim.measureRefs.length) {
-      return {
+    if (!claimFailure && cited.length !== claim.measureRefs.length) {
+      claimFailure = {
         ok: false,
         reason: "preuve_inconnue",
         detail: "une référence ne correspond à aucune mesure fournie",
       };
     }
-    if (isComparativeClaim(claim.text)) {
-      return { ok: false, reason: "comparaison", detail: "la synthèse compare des candidatures" };
+    const publicText = stripEvidenceMarkers(claim.text);
+    if (!claimFailure && isComparativeClaim(publicText)) {
+      claimFailure = {
+        ok: false,
+        reason: "comparaison",
+        detail: "la synthèse compare des candidatures",
+      };
     }
-    if (/[—–<>]/u.test(claim.text)) {
-      return { ok: false, reason: "style", detail: "la synthèse contient un caractère interdit" };
+    if (!claimFailure && /[—–<>]/u.test(publicText)) {
+      claimFailure = {
+        ok: false,
+        reason: "style",
+        detail: "la synthèse contient un caractère interdit",
+      };
     }
-    if (/(?:^|\W)M[1-9][0-9]*(?:\W|$)/u.test(claim.text)) {
-      return {
+    if (!claimFailure && /(?:^|\W)M[1-9][0-9]*(?:\W|$)/u.test(publicText)) {
+      claimFailure = {
         ok: false,
         reason: "style",
         detail: "les références de preuves doivent rester dans measureRefs",
@@ -502,27 +503,42 @@ export function screenCandidateSynthesis(
     }
     const evidence = cited.map((measure) => measure.text).join(" ");
     const allowedNumbers = new Set(numericTokens(evidence));
-    const unsupportedNumber = numericTokens(claim.text).find((token) => !allowedNumbers.has(token));
-    if (unsupportedNumber) {
-      return {
+    const unsupportedNumber = numericTokens(publicText).find((token) => !allowedNumbers.has(token));
+    if (!claimFailure && unsupportedNumber) {
+      claimFailure = {
         ok: false,
         reason: "quantite",
         detail: `la quantité ${unsupportedNumber} n'est pas présente dans les mesures citées`,
       };
     }
-    const normalizedText = claim.text.replace(/\s+/g, " ").trim();
-    if (cited.some((measure) => canonicalMeasureText(measure.text) === normalizedText)) {
-      return {
+    const normalizedText = publicText;
+    if (
+      !claimFailure &&
+      cited.some((measure) => canonicalMeasureText(measure.text) === normalizedText)
+    ) {
+      claimFailure = {
         ok: false,
         reason: "catalogue",
         detail: "un axe recopie une mesure au lieu de la synthétiser",
       };
     }
+    if (claimFailure) {
+      firstClaimFailure ??= claimFailure;
+      continue;
+    }
     if (claim.measureRefs.length >= 2) hasGroupedAxis = true;
-    cited.forEach((measure) => coveredThemes.add(measure.theme));
     normalizedClaims.push({ text: normalizedText, measureRefs: claim.measureRefs });
   }
 
+  if (normalizedClaims.length < minimumClaims) {
+    return (
+      firstClaimFailure ?? {
+        ok: false,
+        reason: "synthese_insuffisante",
+        detail: `le programme doit comporter au moins ${minimumClaims} axes synthétiques`,
+      }
+    );
+  }
   if (input.measures.length >= 6 && !hasGroupedAxis) {
     return {
       ok: false,
@@ -530,25 +546,17 @@ export function screenCandidateSynthesis(
       detail: "aucun axe ne regroupe plusieurs mesures",
     };
   }
-  for (const theme of plan.expectedThemes) {
-    if (!coveredThemes.has(theme)) {
-      return {
-        ok: false,
-        reason: "couverture_theme",
-        detail: `aucun axe étayé ne représente le thème ${THEME_CATEGORY_LABELS[theme]}`,
-      };
-    }
-  }
-
   const programmeText = normalizedClaims.map((claim) => claim.text).join("\n\n");
   const programmeWords = wordCount(programmeText);
   const programmeFloor = programmeSafetyFloor(input.measures.length);
   if (programmeWords < programmeFloor) {
-    return {
-      ok: false,
-      reason: "programme_trop_court",
-      detail: `${programmeWords} mots pour le programme, minimum ${programmeFloor}`,
-    };
+    return (
+      firstClaimFailure ?? {
+        ok: false,
+        reason: "programme_trop_court",
+        detail: `${programmeWords} mots pour le programme, minimum ${programmeFloor}`,
+      }
+    );
   }
 
   const screened = screenSynthesis({
@@ -568,6 +576,7 @@ const groundingResponseSchema = z
           index: z.number().int().nonnegative(),
           supported: z.boolean(),
           reason: z.string().trim().min(1).max(800),
+          correctedText: z.string().trim().max(900),
         })
         .strict()
     ),
@@ -599,37 +608,56 @@ Une affirmation est non étayée si elle ajoute un objectif, un effet, une causa
 ${claimsXml}
 </affirmations>
 
+Pour chaque affirmation refusée, correctedText doit proposer une version concise entièrement étayée par les preuves citées, sans ajouter de nouvelle référence. Pour une affirmation acceptée, correctedText doit être une chaîne vide.
+
 Réponds uniquement en JSON :
-{"claims":[{"index":0,"supported":true,"reason":"justification concise"}]}`;
+{"claims":[{"index":0,"supported":true,"reason":"justification concise","correctedText":""}]}`;
 }
 
 export function screenCandidateSynthesisGrounding(
   raw: unknown,
   expectedClaimCount: number
 ):
-  | { ok: true; supportedIndexes: number[] }
-  | { ok: false; detail: string; supportedIndexes: number[] } {
+  | { ok: true; supportedIndexes: number[]; corrections: Map<number, string> }
+  | {
+      ok: false;
+      detail: string;
+      supportedIndexes: number[];
+      corrections: Map<number, string>;
+    } {
   const parsed = groundingResponseSchema.safeParse(raw);
-  if (!parsed.success || parsed.data.claims.length !== expectedClaimCount) {
-    return { ok: false, detail: "le contrôle d'étayage est incomplet", supportedIndexes: [] };
+  if (!parsed.success) {
+    return {
+      ok: false,
+      detail: "le contrôle d'étayage est incomplet",
+      supportedIndexes: [],
+      corrections: new Map(),
+    };
   }
   const byIndex = new Map(parsed.data.claims.map((claim) => [claim.index, claim]));
   const failures: string[] = [];
   const supportedIndexes: number[] = [];
+  const corrections = new Map<number, string>();
   for (let index = 0; index < expectedClaimCount; index += 1) {
     const claim = byIndex.get(index);
     if (!claim || !claim.supported) {
       failures.push(`affirmation ${index + 1} : ${claim?.reason ?? "elle n'a pas été contrôlée"}`);
+      if (claim?.correctedText) corrections.set(index, claim.correctedText);
     } else {
       supportedIndexes.push(index);
     }
   }
   if (failures.length > 0) {
-    return { ok: false, detail: failures.join(" ; "), supportedIndexes };
+    return { ok: false, detail: failures.join(" ; "), supportedIndexes, corrections };
   }
   return byIndex.size === expectedClaimCount
-    ? { ok: true, supportedIndexes }
-    : { ok: false, detail: "le contrôle contient des index inattendus", supportedIndexes: [] };
+    ? { ok: true, supportedIndexes, corrections }
+    : {
+        ok: false,
+        detail: "le contrôle contient des index inattendus",
+        supportedIndexes: [],
+        corrections: new Map(),
+      };
 }
 
 /**

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -30,9 +30,16 @@ function providerOutput(over: Record<string, unknown> = {}): string {
   });
 }
 
-function groundingOutput(supported = true): string {
+function groundingOutput(supported = true, correctedText = ""): string {
   return JSON.stringify({
-    claims: [{ index: 0, supported, reason: supported ? "Étayer par M1 et M2." : "Ajout absent." }],
+    claims: [
+      {
+        index: 0,
+        supported,
+        reason: supported ? "Étayer par M1 et M2." : "Ajout absent.",
+        correctedText,
+      },
+    ],
   });
 }
 
@@ -116,7 +123,15 @@ describe("generateCandidateSynthesis", () => {
     expect(callMistralMock.mock.calls[0]![1]).toMatchObject({
       model: "mistral-large-latest",
       temperature: 0,
-      responseFormat: { type: "json_object" },
+      responseFormat: {
+        type: "json_schema",
+        json_schema: {
+          name: "candidate_synthesis",
+          schema: {
+            required: ["career", "programmeClaims"],
+          },
+        },
+      },
     });
   });
 
@@ -183,6 +198,58 @@ describe("generateCandidateSynthesis", () => {
     expect(callMistralMock).toHaveBeenCalledTimes(4);
     const retryMessages = callMistralMock.mock.calls[2]![0] as Array<{ content: string }>;
     expect(retryMessages.at(-1)?.content).toContain("contrôle d'étayage refusé");
+  });
+
+  it("recontrôle une correction proposée à partir des mêmes preuves", async () => {
+    const corrected =
+      "Les mesures associent la réouverture de maternités de proximité au rétablissement de trains de nuit sur six lignes.";
+    callMistralMock
+      .mockResolvedValueOnce({ text: providerOutput(), model: "mistral-large-latest" })
+      .mockResolvedValueOnce({
+        text: groundingOutput(false, corrected),
+        model: "mistral-large-latest",
+      })
+      .mockResolvedValueOnce({ text: groundingOutput(true), model: "mistral-large-latest" });
+    const { generateCandidateSynthesis } = await service();
+    const result = await generateCandidateSynthesis("cand-1", { persist: false });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain(corrected);
+    expect(callMistralMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("conserve en dernier recours les axes effectivement étayés", async () => {
+    const supported =
+      "La réouverture de maternités vise à rapprocher les soins des habitants dans les territoires concernés par leur fermeture.";
+    const unsupported =
+      "Les trains de nuit seraient rétablis afin de supprimer toutes les difficultés de déplacement sur le territoire.";
+    const generated = JSON.stringify({
+      career: `${CAREER}.`,
+      programmeClaims: [
+        { text: supported, measureRefs: ["M1"] },
+        { text: unsupported, measureRefs: ["M2"] },
+      ],
+    });
+    const checked = JSON.stringify({
+      claims: [
+        { index: 0, supported: true, reason: "Étayer par M1.", correctedText: "" },
+        { index: 1, supported: false, reason: "Effet absent.", correctedText: "" },
+      ],
+    });
+    callMistralMock
+      .mockResolvedValueOnce({ text: generated, model: "mistral-large-latest" })
+      .mockResolvedValueOnce({ text: checked, model: "mistral-large-latest" })
+      .mockResolvedValueOnce({ text: generated, model: "mistral-large-latest" })
+      .mockResolvedValueOnce({ text: checked, model: "mistral-large-latest" })
+      .mockResolvedValueOnce({ text: generated, model: "mistral-large-latest" })
+      .mockResolvedValueOnce({ text: checked, model: "mistral-large-latest" });
+
+    const { generateCandidateSynthesis } = await service();
+    const result = await generateCandidateSynthesis("cand-1", { persist: false });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).toContain(supported);
+    expect(result.ok && result.text).not.toContain(unsupported);
   });
 
   it("ne stocke rien quand deux réponses sont refusées", async () => {

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -13,7 +13,12 @@
  * No `server-only`: the script imports it under tsx.
  */
 
-import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
+import {
+  callMistral,
+  extractMistralText,
+  parseMistralJSON,
+  type MistralOptions,
+} from "@/lib/api/mistral";
 import { db } from "@/lib/db";
 import {
   buildCandidateSynthesisPrompt,
@@ -29,6 +34,69 @@ import {
 
 /** Mandates kept in the prompt, most recent first. Enough for a career, short of a list. */
 const MANDATE_LIMIT = 8;
+
+const SYNTHESIS_RESPONSE_FORMAT = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "candidate_synthesis",
+    strict: true,
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["career", "programmeClaims"],
+      properties: {
+        career: { type: "string", maxLength: 1_000 },
+        programmeClaims: {
+          type: "array",
+          maxItems: 5,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["text", "measureRefs"],
+            properties: {
+              text: { type: "string", maxLength: 700 },
+              measureRefs: {
+                type: "array",
+                minItems: 1,
+                maxItems: 12,
+                items: { type: "string", pattern: "^M[1-9][0-9]*$" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const GROUNDING_RESPONSE_FORMAT = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "candidate_synthesis_grounding",
+    strict: true,
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["claims"],
+      properties: {
+        claims: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["index", "supported", "reason"],
+            properties: {
+              index: { type: "integer", minimum: 0 },
+              supported: { type: "boolean" },
+              reason: { type: "string", maxLength: 500 },
+              correctedText: { type: "string", maxLength: 700 },
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
 /**
  * Why a refusal is a RETURNED value and never a throw.
@@ -65,13 +133,14 @@ export type SynthesisGenerationResult =
 async function generate(
   system: string,
   messages: Array<{ role: "user" | "assistant"; content: string }>,
-  maxTokens = 1_200
+  maxTokens = 2_400,
+  responseFormat: NonNullable<MistralOptions["responseFormat"]> = SYNTHESIS_RESPONSE_FORMAT
 ): Promise<{ text: string; provider: string }> {
   const response = await callMistral([{ role: "system", content: system }, ...messages], {
     model: "mistral-large-latest",
     maxTokens,
     temperature: 0,
-    responseFormat: { type: "json_object" },
+    responseFormat,
   });
   return { text: extractMistralText(response), provider: response.model?.trim() || "mistral" };
 }
@@ -192,6 +261,10 @@ export async function generateCandidateSynthesis(
   let expectedClaimCount: number | undefined;
   const preservedClaims = new Map<number, CandidateProgrammeClaim>();
   let lastGenerationError: string | undefined;
+  let pendingCorrectedOutput:
+    | { career: string; programmeClaims: CandidateProgrammeClaim[] }
+    | undefined;
+  let lastProvider = "mistral-large-latest";
   let accepted:
     | { text: string; provider: string; programmeClaims: CandidateProgrammeClaim[] }
     | undefined;
@@ -209,7 +282,11 @@ export async function generateCandidateSynthesis(
       : [{ role: "user" as const, content: prompt }];
 
     try {
-      const attempt = await generate(system, messages);
+      const attempt = pendingCorrectedOutput
+        ? { text: JSON.stringify(pendingCorrectedOutput), provider: lastProvider }
+        : await generate(system, messages);
+      pendingCorrectedOutput = undefined;
+      lastProvider = attempt.provider;
       previousResponseText = attempt.text;
       const parsed = parseMistralJSON<unknown>(attempt.text);
       const candidateOutput =
@@ -252,7 +329,8 @@ export async function generateCandidateSynthesis(
         const verification = await generate(
           "Tu contrôles strictement l'étayage d'une synthèse politique. N'utilise aucune connaissance extérieure.",
           [{ role: "user", content: buildCandidateSynthesisGroundingPrompt(claims, input) }],
-          700
+          1_800,
+          GROUNDING_RESPONSE_FORMAT
         );
         const grounding = screenCandidateSynthesisGrounding(
           parseMistralJSON<unknown>(verification.text),
@@ -264,6 +342,36 @@ export async function generateCandidateSynthesis(
             if (claim) preservedClaims.set(index, claim);
           }
           validationDetail = `contrôle d'étayage refusé : ${grounding.detail}`;
+          if (grounding.corrections.size > 0) {
+            const correctedClaims = claims.map((claim, index) => ({
+              ...claim,
+              text: grounding.corrections.get(index) ?? claim.text,
+            }));
+            const corrected = {
+              career: buildCanonicalCareer(input),
+              programmeClaims: correctedClaims,
+            };
+            const correctedScreen = screenCandidateSynthesis(corrected, input);
+            if (correctedScreen.ok) pendingCorrectedOutput = corrected;
+          }
+          if (attemptIndex === 2 && grounding.supportedIndexes.length > 0) {
+            const supportedOnly = {
+              career: buildCanonicalCareer(input),
+              programmeClaims: grounding.supportedIndexes.flatMap((index) => {
+                const claim = claims[index];
+                return claim ? [claim] : [];
+              }),
+            };
+            const supportedScreen = screenCandidateSynthesis(supportedOnly, input);
+            if (supportedScreen.ok) {
+              accepted = {
+                text: supportedScreen.text,
+                provider: attempt.provider,
+                programmeClaims: supportedScreen.programmeClaims ?? [],
+              };
+              break;
+            }
+          }
           continue;
         }
       }


### PR DESCRIPTION
## Problème

La génération de la synthèse de Juan Branco échouait successivement sur le format, la couverture forcée des thèmes et un contrôle partiel. Le mode JSON simple de Mistral garantit un objet JSON, mais pas son schéma.

## Correction

- impose un JSON Schema Mistral pour la génération et le contrôle d'étayage
- retire l'obligation d'énumérer les thèmes les plus représentés
- corrige puis recontrôle les axes non étayés
- conserve uniquement des axes effectivement validés lorsque le reste est refusé
- écarte individuellement les axes invalides si la synthèse restante demeure substantielle
- normalise les marqueurs techniques de preuves hors du texte public

## Vérifications

- 82 tests ciblés
- typecheck
- ESLint ciblé
- dry-run réel réussi sur Juan Branco, 1 176 mesures, sans écriture en base