### PR TITLE
fix(listings): valider page et filtres avant Prisma

### DIFF
--- a/src/app/__tests__/listing-malformed-params.test.ts
+++ b/src/app/__tests__/listing-malformed-params.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ElectionType } from "@/generated/prisma";
+
+/**
+ * Regression guard for the production incident of 2026-09-01: an automated
+ * scanner walked the listing pages with junk filter and pagination values, and
+ * every one of them answered with an unhandled 500 raised by Prisma rather
+ * than a listing with defaults applied.
+ *
+ * The loaders here are mocked to refuse the same arguments Prisma refuses, so
+ * a page that lets a bad value through fails this suite instead of production.
+ */
+
+// Payloads lifted verbatim from the production access log.
+const SQLI_PROBE = 'SENATORIALES") AND UPDATEXML(6619,CONCAT(0x2e),1)-- -';
+const AFFAIRS_PAGE_SIZE = 20;
+
+const mocks = vi.hoisted(() => ({
+  getElections: vi.fn(),
+  getTypeCounts: vi.fn(),
+  getAffairs: vi.fn(),
+  getPartiesWithAffairs: vi.fn(),
+  getPublicPartyMetadataBySlug: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("@/lib/data/elections", () => ({
+  getElections: mocks.getElections,
+  getTypeCounts: mocks.getTypeCounts,
+}));
+vi.mock("@/lib/data/affairs", () => ({
+  getAffairs: mocks.getAffairs,
+  getSuperCategoryCounts: vi.fn().mockResolvedValue({}),
+  getCertaintyCounts: vi.fn().mockResolvedValue({}),
+  getPartiesWithAffairs: mocks.getPartiesWithAffairs,
+  getPublicPartyMetadataBySlug: mocks.getPublicPartyMetadataBySlug,
+}));
+vi.mock("next/navigation", () => ({ notFound: mocks.notFound }));
+
+import ElectionsPage from "../elections/page";
+import AffairesPage from "../affaires/page";
+
+type Params = Record<string, string>;
+const render = (page: unknown, searchParams: Params) =>
+  (page as (p: { searchParams: Promise<Params> }) => Promise<unknown>)({
+    searchParams: Promise.resolve(searchParams),
+  });
+
+/** Reproduces `Invalid value for argument \`type\`. Expected ElectionType.` */
+function assertElectionType(value: unknown) {
+  if (value === undefined) return;
+  if (!(Object.values(ElectionType) as unknown[]).includes(value)) {
+    throw new Error("PrismaClientValidationError: Expected ElectionType.");
+  }
+}
+
+/** Reproduces `Argument \`skip\` is missing.`: Prisma drops a NaN argument. */
+function assertUsableSkip(page: unknown) {
+  const skip = ((page as number) - 1) * AFFAIRS_PAGE_SIZE;
+  if (!Number.isSafeInteger(skip) || skip < 0) {
+    throw new Error("PrismaClientValidationError: Argument `skip` is missing.");
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getElections.mockImplementation(async (type?: unknown) => {
+    assertElectionType(type);
+    return [];
+  });
+  mocks.getTypeCounts.mockResolvedValue([]);
+  mocks.getAffairs.mockImplementation(async (...args: unknown[]) => {
+    assertUsableSkip(args[5]);
+    return { affairs: [], total: 0, totalPages: 0 };
+  });
+  mocks.getPartiesWithAffairs.mockResolvedValue([]);
+  mocks.getPublicPartyMetadataBySlug.mockResolvedValue(null);
+});
+
+describe("/elections : un ?type= hors enum", () => {
+  it("rend la page au lieu de faire lever Prisma", async () => {
+    await expect(render(ElectionsPage, { type: SQLI_PROBE })).resolves.toBeDefined();
+  });
+
+  it("ignore le filtre plutôt que de le transmettre", async () => {
+    await render(ElectionsPage, { type: SQLI_PROBE });
+    expect(mocks.getElections).toHaveBeenCalledWith(undefined);
+  });
+
+  it("conserve un type valide", async () => {
+    await render(ElectionsPage, { type: "MUNICIPALES" });
+    expect(mocks.getElections).toHaveBeenCalledWith("MUNICIPALES");
+  });
+
+  it("ne filtre pas quand le paramètre est absent", async () => {
+    await render(ElectionsPage, {});
+    expect(mocks.getElections).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe("/affaires : un ?page= inexploitable", () => {
+  it.each(["abc", "", "0", "-3", SQLI_PROBE])("rend la page pour page=%j", async (page) => {
+    await expect(render(AffairesPage, { page })).resolves.toBeDefined();
+  });
+
+  it("retombe sur la première page", async () => {
+    await render(AffairesPage, { page: "abc" });
+    expect(mocks.getAffairs.mock.calls[0]?.[5]).toBe(1);
+  });
+
+  it("conserve une page valide", async () => {
+    await render(AffairesPage, { page: "3" });
+    expect(mocks.getAffairs.mock.calls[0]?.[5]).toBe(3);
+  });
+});

--- a/src/app/__tests__/listing-malformed-params.test.ts
+++ b/src/app/__tests__/listing-malformed-params.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ElectionType } from "@/generated/prisma";
+import { ElectionType, PoliticalPosition } from "@/generated/prisma";
 
 /**
  * Regression guard for the production incident of 2026-09-01: an automated
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getElections: vi.fn(),
   getTypeCounts: vi.fn(),
   getAffairs: vi.fn(),
+  getParties: vi.fn(),
   getPartiesWithAffairs: vi.fn(),
   getPublicPartyMetadataBySlug: vi.fn(),
   notFound: vi.fn(() => {
@@ -37,10 +38,15 @@ vi.mock("@/lib/data/affairs", () => ({
   getPartiesWithAffairs: mocks.getPartiesWithAffairs,
   getPublicPartyMetadataBySlug: mocks.getPublicPartyMetadataBySlug,
 }));
+vi.mock("@/lib/data/partis", () => ({
+  getParties: mocks.getParties,
+  getPartiesStats: vi.fn().mockResolvedValue({}),
+}));
 vi.mock("next/navigation", () => ({ notFound: mocks.notFound }));
 
 import ElectionsPage from "../elections/page";
 import AffairesPage from "../affaires/page";
+import PartisPage from "../partis/page";
 
 type Params = Record<string, string>;
 const render = (page: unknown, searchParams: Params) =>
@@ -77,6 +83,15 @@ beforeEach(() => {
   });
   mocks.getPartiesWithAffairs.mockResolvedValue([]);
   mocks.getPublicPartyMetadataBySlug.mockResolvedValue(null);
+  mocks.getParties.mockImplementation(async (_search?: unknown, position?: unknown) => {
+    if (
+      position !== undefined &&
+      !(Object.values(PoliticalPosition) as unknown[]).includes(position)
+    ) {
+      throw new Error("PrismaClientValidationError: Expected PoliticalPosition.");
+    }
+    return [];
+  });
 });
 
 describe("/elections : un ?type= hors enum", () => {
@@ -113,5 +128,21 @@ describe("/affaires : un ?page= inexploitable", () => {
   it("conserve une page valide", async () => {
     await render(AffairesPage, { page: "3" });
     expect(mocks.getAffairs.mock.calls[0]?.[5]).toBe(3);
+  });
+});
+
+describe("/partis : un ?position= hors enum", () => {
+  it("rend la page au lieu de faire lever Prisma", async () => {
+    await expect(render(PartisPage, { position: SQLI_PROBE })).resolves.toBeDefined();
+  });
+
+  it("ignore le filtre plutôt que de le transmettre", async () => {
+    await render(PartisPage, { position: SQLI_PROBE });
+    expect(mocks.getParties.mock.calls[0]?.[1]).toBeUndefined();
+  });
+
+  it("conserve une position valide", async () => {
+    await render(PartisPage, { position: "CENTER_LEFT" });
+    expect(mocks.getParties.mock.calls[0]?.[1]).toBe("CENTER_LEFT");
   });
 });

--- a/src/app/affaires/page.tsx
+++ b/src/app/affaires/page.tsx
@@ -30,6 +30,7 @@ import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing
 import { AFFAIRES_DEFAULT_TITLE, AFFAIRES_DEFAULT_DESCRIPTION } from "@/lib/seo/affaires-metadata";
 import { AFFAIRES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
 import { buildRetourParam } from "@/lib/affairs/listing-return";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
 
@@ -112,7 +113,7 @@ export default async function AffairesPage({ searchParams }: PageProps) {
   const categoryFilter = params.category || "";
   const certaintyFilter = (params.certainty || "") as CertaintyLevel | "";
   const partiFilter = params.parti || "";
-  const page = parseInt(params.page || "1", 10);
+  const page = parsePageParam(params.page);
   const mode = (params.mode === "victime" ? "victime" : "mise-en-cause") as
     | "mise-en-cause"
     | "victime";

--- a/src/app/api/elections/route.ts
+++ b/src/app/api/elections/route.ts
@@ -4,6 +4,7 @@ import { ElectionType, ElectionStatus } from "@/generated/prisma";
 import { withCache } from "@/lib/cache";
 import { parsePagination, buildPaginationMeta } from "@/lib/api/pagination";
 import { withPublicRoute } from "@/lib/api/with-public-route";
+import { pickEnumValue } from "@/lib/data/enum-guards";
 
 /**
  * @openapi
@@ -76,9 +77,14 @@ export const GET = withPublicRoute(async (request) => {
 
   const year = yearStr ? parseInt(yearStr, 10) : null;
 
+  // An out-of-enum ?type=/?status= is dropped rather than cast: Prisma answers
+  // a bad enum with a validation error, i.e. an unhandled 500 on a public route.
+  const safeType = pickEnumValue(type, ElectionType);
+  const safeStatus = pickEnumValue(status, ElectionStatus);
+
   const where = {
-    ...(type && { type: type as ElectionType }),
-    ...(status && { status: status as ElectionStatus }),
+    ...(safeType && { type: safeType }),
+    ...(safeStatus && { status: safeStatus }),
     ...(year && {
       round1Date: {
         gte: new Date(year, 0, 1),

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { withCache } from "@/lib/cache";
 import { parsePagination, buildPaginationMeta } from "@/lib/api/pagination";
 import { withPublicRoute } from "@/lib/api/with-public-route";
+import { parseIntFilter } from "@/lib/data/query-params";
 
 /**
  * @openapi
@@ -79,12 +80,16 @@ export const GET = withPublicRoute(async (request) => {
       ? (result as (typeof ALLOWED_RESULTS)[number])
       : undefined;
 
+  // `parseInt("abc")` is NaN, and a NaN in a `where` makes Prisma throw rather
+  // than match nothing, so an unparseable legislature drops the filter.
+  const safeLegislature = parseIntFilter(legislature);
+
   const where = {
     ...(search && {
       title: { contains: search, mode: "insensitive" as const },
     }),
     ...(validResult && { result: validResult }),
-    ...(legislature && { legislature: parseInt(legislature, 10) }),
+    ...(safeLegislature !== undefined && { legislature: safeLegislature }),
   };
 
   const [scrutins, total] = await Promise.all([

--- a/src/app/comparer/votes/page.tsx
+++ b/src/app/comparer/votes/page.tsx
@@ -11,6 +11,7 @@ import { VoteComparisonFilters } from "@/components/compare/VoteComparisonFilter
 import { COMPARE_CATEGORIES, COMPARE_CATEGORY_LABELS, type CompareCategory } from "@/types/compare";
 import { buildComparerVotesCanonical } from "@/lib/seo/comparer-votes-metadata";
 import type { VotePosition } from "@/types";
+import { parsePageParam } from "@/lib/data/query-params";
 
 interface PageProps {
   searchParams: Promise<{
@@ -283,7 +284,7 @@ export default async function VotesComparisonPage({ searchParams }: PageProps) {
   const slugA = params.a;
   const slugB = params.b;
   const { search, filter } = params;
-  const page = Math.max(1, parseInt(params.page || "1", 10));
+  const page = parsePageParam(params.page);
 
   if (!slugA || !slugB) {
     notFound();

--- a/src/app/declarations-et-patrimoine/page.tsx
+++ b/src/app/declarations-et-patrimoine/page.tsx
@@ -24,6 +24,7 @@ import {
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 300;
 
@@ -60,7 +61,7 @@ export default async function DeclarationsPage({ searchParams }: PageProps) {
   const search = params.search || "";
   const partyFilter = params.party || "";
   const sortOption = (params.sort || "portfolio") as DeclarationSortOption;
-  const page = parseInt(params.page || "1", 10);
+  const page = parsePageParam(params.page);
 
   const [stats, topPortfolios, topCompanies, tableData, parties, transparency] = await Promise.all([
     getDeclarationStats(),

--- a/src/app/elections/page.tsx
+++ b/src/app/elections/page.tsx
@@ -5,10 +5,11 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ElectionCountdown, ElectionTimeline } from "@/components/elections";
 import { ELECTION_TYPE_LABELS, ELECTION_TYPE_ICONS } from "@/config/labels";
 import { getElections, getTypeCounts } from "@/lib/data/elections";
+import { pickEnumValue } from "@/lib/data/enum-guards";
+import { ElectionType } from "@/generated/prisma";
 import { resolveElectionStatus } from "@/lib/elections/status";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
-import type { ElectionType } from "@/types";
 
 export const revalidate = 300; // ISR: revalidate every 5 minutes
 
@@ -27,7 +28,11 @@ interface PageProps {
 
 export default async function ElectionsPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const typeFilter = params.type as ElectionType | undefined;
+  // A ?type= that is not an ElectionType is dropped, not forwarded: Prisma
+  // rejects an out-of-enum value with a validation error, which surfaces as an
+  // unhandled 500. An unknown filter means "no filter", so the calendar still
+  // renders for a stale bookmark or a scanner payload alike.
+  const typeFilter = pickEnumValue(params.type, ElectionType);
 
   const [rawElections, typeCounts] = await Promise.all([getElections(typeFilter), getTypeCounts()]);
 
@@ -44,7 +49,7 @@ export default async function ElectionsPage({ searchParams }: PageProps) {
   // Build filter URL helper
   const buildUrl = (newParams: Record<string, string | undefined>) => {
     const current = new URLSearchParams();
-    if (params.type) current.set("type", params.type);
+    if (typeFilter) current.set("type", typeFilter);
 
     for (const [key, value] of Object.entries(newParams)) {
       if (value) {

--- a/src/app/factchecks/page.tsx
+++ b/src/app/factchecks/page.tsx
@@ -22,6 +22,7 @@ import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import type { FactCheckRating } from "@/types";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 300; // 5 minutes — CDN edge cache with ISR
 
@@ -88,7 +89,7 @@ const VERDICT_GROUP_LABELS: Record<string, string> = {
 
 export default async function FactChecksPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const page = Math.max(1, parseInt(params.page || "1", 10));
+  const page = parsePageParam(params.page);
   const limit = 12;
   const source = params.source;
   const verdict = params.verdict;

--- a/src/app/parlement/dossiers/page.tsx
+++ b/src/app/parlement/dossiers/page.tsx
@@ -27,6 +27,7 @@ import { SeoIntro } from "@/components/seo/SeoIntro";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import { DOSSIERS_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 300; // ISR: re-check feature flag every 5 minutes
 
@@ -132,7 +133,7 @@ export default async function AssembleePage({ searchParams }: PageProps) {
   const statusFilter = params.status || "";
   const themeFilter = params.theme || "";
   const sortFilter = params.sort || "";
-  const page = parseInt(params.page || "1", 10);
+  const page = parsePageParam(params.page);
 
   const [{ dossiers, total, totalPages }, statusCounts, themeCounts, pplStats] = await Promise.all([
     getDossiers(statusFilter, themeFilter, sortFilter, page),

--- a/src/app/parlement/votes/themes/[theme]/page.tsx
+++ b/src/app/parlement/votes/themes/[theme]/page.tsx
@@ -21,6 +21,7 @@ import { formatDate } from "@/lib/utils";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 3600;
 
@@ -99,7 +100,7 @@ export default async function ThemePage({
   const theme = legacyThemeFromSlug(slug);
   if (!theme) notFound();
 
-  const page = Math.max(1, parseInt(pageParam || "1", 10));
+  const page = parsePageParam(pageParam);
   const skip = (page - 1) * PAGE_SIZE;
   const label = THEME_CATEGORY_LABELS[theme];
   const icon = THEME_CATEGORY_ICONS[theme];

--- a/src/app/partis/page.tsx
+++ b/src/app/partis/page.tsx
@@ -11,7 +11,8 @@ import { SITE_URL } from "@/config/site";
 import { getParties, getPartiesStats } from "@/lib/data/partis";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
 import type { SortOption, StatusFilter } from "@/lib/data/partis";
-import type { PoliticalPosition } from "@/types";
+import { PoliticalPosition } from "@/generated/prisma";
+import { pickEnumValue } from "@/lib/data/enum-guards";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 
 export const revalidate = 300; // 5 minutes, cohérent avec l'API
@@ -41,7 +42,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
 export default async function PartiesPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const search = params.search || "";
-  const position = (params.position || "") as PoliticalPosition | "";
+  const position = pickEnumValue(params.position, PoliticalPosition);
   const statusFilter = (params.status || "actifs") as StatusFilter;
   const sort = (params.sort || "members") as SortOption;
 

--- a/src/app/politiques/[slug]/votes/page.tsx
+++ b/src/app/politiques/[slug]/votes/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/seo/politician-votes-metadata";
 import type { ScrutinType } from "@/generated/prisma";
 import type { Prisma } from "@/generated/prisma";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 86400; // ISR: 24h backstop; real changes propagate on-demand via revalidateTag (pagination is client-side)
 
@@ -167,7 +168,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function PoliticianVotesPage({ params, searchParams }: PageProps) {
   const { slug } = await params;
   const sp = await searchParams;
-  const page = Math.max(1, parseInt(sp.page || "1", 10));
+  const page = parsePageParam(sp.page);
   const limit = 20;
   const typeTab = sp.type || "votes";
 

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -14,6 +14,7 @@ import { POLITIQUES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { getPoliticianDissidenceRanking } from "@/services/voteStats";
+import { parsePageParam } from "@/lib/data/query-params";
 
 // Minimum members to show a party in filters (avoid cluttering with old/small parties)
 const MIN_PARTY_MEMBERS = 2;
@@ -445,7 +446,7 @@ export default async function PolitiquesPage({ searchParams }: PageProps) {
     rawMandate === "president_parti" ? "dirigeants" : rawMandate
   ) as MandateFilter;
   const sortOption = (params.sort || "prominence") as SortOption;
-  const page = parseInt(params.page || "1", 10);
+  const page = parsePageParam(params.page);
 
   const [{ politicians, total, totalPages }, parties, counts] = await Promise.all([
     getPoliticians(search, partyFilter, convictionFilter, mandateFilter, sortOption, page),

--- a/src/app/presse/page.tsx
+++ b/src/app/presse/page.tsx
@@ -10,6 +10,7 @@ import { isFeatureEnabled } from "@/lib/feature-flags";
 import { getPress, getPressStats, getPartiesWithPressMentions } from "@/lib/data/press";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { listingRobotsMetadata, hasActiveListingFilter } from "@/lib/seo/listing-robots";
+import { parsePageParam } from "@/lib/data/query-params";
 
 export const revalidate = 300; // ISR: re-check feature flag every 5 minutes
 
@@ -45,7 +46,7 @@ export default async function PressePage({ searchParams }: PageProps) {
   if (!(await isFeatureEnabled("PRESS_SECTION"))) notFound();
 
   const params = await searchParams;
-  const page = Math.max(1, parseInt(params.page || "1", 10));
+  const page = parsePageParam(params.page);
   const limit = 12;
   const source = params.source;
   const partyId = params.party;

--- a/src/components/parlement/ScrutinsListing.tsx
+++ b/src/components/parlement/ScrutinsListing.tsx
@@ -19,6 +19,7 @@ import { themeSeoPhrase } from "@/lib/seo/theme-metadata";
 import { SITE_URL } from "@/config/site";
 import { statsHref } from "@/config/routes";
 import type { VotingResult, Chamber, ThemeCategory, ScrutinType } from "@/types";
+import { parsePageParam, parseIntFilter } from "@/lib/data/query-params";
 
 // Map URL param values to data layer params
 const TYPE_TAB_MAP: Record<string, { type?: ScrutinType; excludeType?: ScrutinType }> = {
@@ -41,10 +42,10 @@ interface ScrutinsListingProps {
 }
 
 export async function ScrutinsListing({ searchParams: params, sort }: ScrutinsListingProps) {
-  const page = Math.max(1, parseInt(params.page || "1", 10));
+  const page = parsePageParam(params.page);
   const limit = 20;
   const result = (params.result || undefined) as VotingResult | undefined;
-  const legislature = params.legislature ? parseInt(params.legislature, 10) : undefined;
+  const legislature = parseIntFilter(params.legislature);
   const chamber = (params.chamber || undefined) as Chamber | undefined;
   const theme = (params.theme || undefined) as ThemeCategory | undefined;
   const search = params.search || undefined;

--- a/src/lib/data/__tests__/query-params.test.ts
+++ b/src/lib/data/__tests__/query-params.test.ts
@@ -31,6 +31,17 @@ describe("parsePageParam", () => {
     expect(parsePageParam("-4")).toBe(1);
   });
 
+  it("retombe sur 1 sur une page absurde", () => {
+    // Une page entière sûre peut donner un offset qui ne l'est plus :
+    // (MAX_SAFE_INTEGER - 1) * 20 est un flottant imprécis.
+    expect(Number.isSafeInteger(Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(Number.isSafeInteger((Number.MAX_SAFE_INTEGER - 1) * 20)).toBe(false);
+    expect(parsePageParam(String(Number.MAX_SAFE_INTEGER))).toBe(1);
+    expect(parsePageParam("9007199254740991")).toBe(1);
+    expect(parsePageParam("1000001")).toBe(1);
+    expect(parsePageParam("1000000")).toBe(1000000);
+  });
+
   it("prend la première valeur d'un paramètre répété", () => {
     expect(parsePageParam(["3", "abc"])).toBe(3);
     expect(parsePageParam(["abc", "3"])).toBe(1);
@@ -38,11 +49,15 @@ describe("parsePageParam", () => {
   });
 
   it("rend toujours un entier utilisable comme skip", () => {
-    for (const raw of [undefined, "", "abc", "0", "-4", SQLI_PROBE, "2.9"]) {
+    const absurd = String(Number.MAX_SAFE_INTEGER);
+    for (const raw of [undefined, "", "abc", "0", "-4", SQLI_PROBE, "2.9", absurd, "1000000"]) {
       const page = parsePageParam(raw);
       expect(Number.isSafeInteger(page)).toBe(true);
       expect(page).toBeGreaterThanOrEqual(1);
-      expect(Number.isSafeInteger((page - 1) * 20)).toBe(true);
+      // Le contrat qui compte : l'offset calculé par les loaders reste exact.
+      for (const limit of [12, 20, 24, 1000]) {
+        expect(Number.isSafeInteger((page - 1) * limit)).toBe(true);
+      }
     }
   });
 });

--- a/src/lib/data/__tests__/query-params.test.ts
+++ b/src/lib/data/__tests__/query-params.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parsePageParam, parseIntFilter } from "@/lib/data/query-params";
+
+// Real payload lifted from the production scan of 2026-09-01.
+const SQLI_PROBE = 'SENATORIALES") AND UPDATEXML(6619,CONCAT(0x2e),1)-- -';
+
+describe("parsePageParam", () => {
+  it("lit une page valide", () => {
+    expect(parsePageParam("1")).toBe(1);
+    expect(parsePageParam("7")).toBe(7);
+    expect(parsePageParam("  7  ")).toBe(7);
+  });
+
+  it("retombe sur 1 quand le paramètre est absent", () => {
+    expect(parsePageParam(undefined)).toBe(1);
+    expect(parsePageParam(null)).toBe(1);
+    expect(parsePageParam("")).toBe(1);
+  });
+
+  it("retombe sur 1 sur une saisie non numérique", () => {
+    // Le piège corrigé ici : Math.max(1, parseInt("abc", 10)) vaut NaN, pas 1.
+    expect(Math.max(1, parseInt("abc", 10))).toBeNaN();
+    expect(parsePageParam("abc")).toBe(1);
+    expect(parsePageParam(SQLI_PROBE)).toBe(1);
+    expect(parsePageParam("NaN")).toBe(1);
+    expect(parsePageParam("Infinity")).toBe(1);
+  });
+
+  it("retombe sur 1 sur une page nulle ou négative", () => {
+    expect(parsePageParam("0")).toBe(1);
+    expect(parsePageParam("-4")).toBe(1);
+  });
+
+  it("prend la première valeur d'un paramètre répété", () => {
+    expect(parsePageParam(["3", "abc"])).toBe(3);
+    expect(parsePageParam(["abc", "3"])).toBe(1);
+    expect(parsePageParam([])).toBe(1);
+  });
+
+  it("rend toujours un entier utilisable comme skip", () => {
+    for (const raw of [undefined, "", "abc", "0", "-4", SQLI_PROBE, "2.9"]) {
+      const page = parsePageParam(raw);
+      expect(Number.isSafeInteger(page)).toBe(true);
+      expect(page).toBeGreaterThanOrEqual(1);
+      expect(Number.isSafeInteger((page - 1) * 20)).toBe(true);
+    }
+  });
+});
+
+describe("parseIntFilter", () => {
+  it("lit un entier valide", () => {
+    expect(parseIntFilter("17")).toBe(17);
+    expect(parseIntFilter("0")).toBe(0);
+    expect(parseIntFilter("-2")).toBe(-2);
+  });
+
+  it("rend undefined plutôt qu'un NaN qui ferait lever Prisma", () => {
+    expect(parseIntFilter("abc")).toBeUndefined();
+    expect(parseIntFilter(SQLI_PROBE)).toBeUndefined();
+    expect(parseIntFilter("")).toBeUndefined();
+    expect(parseIntFilter(undefined)).toBeUndefined();
+    expect(parseIntFilter(null)).toBeUndefined();
+  });
+});

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { cacheTag, cacheLife } from "next/cache";
-import { Prisma } from "@/generated/prisma";
+import { Prisma, ElectionType as ElectionTypeEnum } from "@/generated/prisma";
+import { pickEnumValue } from "@/lib/data/enum-guards";
 import { db } from "@/lib/db";
 import type { ElectionType } from "@/types";
 import type { ElectionRoundScore } from "@/lib/elections/banner-state";
@@ -693,7 +694,11 @@ export async function getElections(typeFilter?: ElectionType) {
   cacheTag("elections");
   cacheLife("synced");
 
-  const where = typeFilter ? { type: typeFilter } : {};
+  // Defense-in-depth: the page already whitelists `type`, but this is a cached
+  // boundary reachable from anywhere, and an out-of-enum value would both throw
+  // in Prisma and mint a cache entry per payload.
+  const safeType = pickEnumValue(typeFilter, ElectionTypeEnum);
+  const where = safeType ? { type: safeType } : {};
 
   return db.election.findMany({
     where,

--- a/src/lib/data/partis.ts
+++ b/src/lib/data/partis.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { cacheTag, cacheLife } from "next/cache";
-import { Prisma } from "@/generated/prisma";
+import { Prisma, PoliticalPosition as PoliticalPositionEnum } from "@/generated/prisma";
+import { pickEnumValue } from "@/lib/data/enum-guards";
 import { db } from "@/lib/db";
 import { CONVICTION_BADGE_WHERE } from "@/config/labels";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
@@ -162,8 +163,11 @@ async function queryParties(
     });
   }
 
-  if (position) {
-    conditions.push({ politicalPosition: position });
+  // An out-of-enum ?position= is dropped rather than filtered on: Prisma
+  // rejects a bad enum with a validation error, which kills the listing.
+  const safePosition = pickEnumValue(position, PoliticalPositionEnum);
+  if (safePosition) {
+    conditions.push({ politicalPosition: safePosition });
   }
 
   if (status === "actifs") {

--- a/src/lib/data/query-params.ts
+++ b/src/lib/data/query-params.ts
@@ -1,0 +1,42 @@
+/**
+ * Safe parsing for numbers that arrive straight from a query string.
+ *
+ * The idiom this replaces looks like a guard and is not one:
+ * `Math.max(1, parseInt("abc", 10))` evaluates to NaN, because Math.max
+ * propagates NaN rather than discarding it. The NaN then travels into
+ * `skip: (page - 1) * limit`, and Prisma serialises a NaN argument as an
+ * absent one, so the page dies on "Argument `skip` is missing", an
+ * unhandled 500 whose message points nowhere near the query string.
+ *
+ * Same intent as `pickEnumValue` in `@/lib/data/enum-guards`, for the numeric
+ * half of the listing parameters: an unusable value means "use the default",
+ * never "hand it to Prisma and hope".
+ */
+
+/** Query params are `string | string[]` once a key is repeated in the URL. */
+type RawParam = string | string[] | null | undefined;
+
+function firstValue(value: RawParam): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value ?? undefined;
+}
+
+/**
+ * Page number for a listing, clamped to a usable page. Anything unparseable,
+ * absent, zero or negative reads as page 1 rather than crashing the listing.
+ */
+export function parsePageParam(value: RawParam): number {
+  const parsed = parseInt(firstValue(value) ?? "", 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
+/**
+ * Integer filter (legislature, year…) for a Prisma `where`. An unusable value
+ * yields `undefined` so the caller drops the filter instead of narrowing on a
+ * NaN that Prisma refuses.
+ */
+export function parseIntFilter(value: RawParam): number | undefined {
+  const parsed = parseInt(firstValue(value) ?? "", 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}

--- a/src/lib/data/query-params.ts
+++ b/src/lib/data/query-params.ts
@@ -22,12 +22,23 @@ function firstValue(value: RawParam): string | undefined {
 }
 
 /**
+ * Upper bound on a page number. Callers turn a page into an offset with
+ * `(page - 1) * limit`, so a page that is itself a safe integer can still
+ * produce an offset past Number.MAX_SAFE_INTEGER, i.e. an imprecise float
+ * handed to the database as an OFFSET. The bound sits far above any real
+ * listing here (the largest table is under 30k pages) while keeping the
+ * product exact for any page size up to 1000.
+ */
+const MAX_PAGE = 1_000_000;
+
+/**
  * Page number for a listing, clamped to a usable page. Anything unparseable,
- * absent, zero or negative reads as page 1 rather than crashing the listing.
+ * absent, zero, negative or absurdly large reads as page 1 rather than
+ * crashing the listing.
  */
 export function parsePageParam(value: RawParam): number {
   const parsed = parseInt(firstValue(value) ?? "", 10);
-  if (!Number.isSafeInteger(parsed) || parsed < 1) return 1;
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_PAGE) return 1;
   return parsed;
 }
 


### PR DESCRIPTION
## Problème

Les listings publics tombaient en erreur de validation Prisma sur des valeurs de `page` ou de filtre inattendues.

Deux causes :

- `Math.max(1, parseInt("abc", 10))` vaut **NaN**, pas 1, parce que `Math.max` propage NaN. Le NaN arrivait dans `skip: (page - 1) * limit` et Prisma sérialise un argument NaN comme absent, d'où le message trompeur `Argument \`skip\` is missing`. Les pages qui semblaient borner leur pagination étaient donc aussi cassées que celles sans garde.
- `/elections` et `/partis` castaient `?type=` / `?position=` sans contrôle avant de les passer au `where`.

Côté visiteur, la réponse RSC étant streamée, le statut restait 200 mais le corps était tronqué (122 Ko au lieu de 229 Ko sur `/elections`). Les routes `/api/*` renvoyaient de vraies 500.

## Correctif

`src/lib/data/query-params.ts`, pendant numérique de `pickEnumValue` :

- `parsePageParam()` : absent, illisible, nul, négatif ou absurde se lisent comme la page 1.
- `parseIntFilter()` : une valeur illisible rend `undefined`, le filtre saute au lieu de porter un NaN.

Appliqué aux pages publiques concernées, plus `pickEnumValue` sur `/elections`, `/partis` et `/api/elections`. Pour `/elections` et `/partis` la garde est posée à la fois sur la page et sur le loader, ce dernier étant un `"use cache"` où chaque valeur créait son entrée.

## Vérification

- Suite complète verte.
- Test de non-régression `src/app/__tests__/listing-malformed-params.test.ts` : les loaders y sont mockés pour refuser exactement ce que Prisma refuse, sinon un mock avalerait `page: NaN` et le test serait vert sur le code cassé.
- Vérifié en local avant/après sur chaque route concernée.

## Reste à faire

Les pages `/admin/*` portent le même idiome `Math.max(1, parseInt(...))`. Elles sont derrière authentification, donc hors périmètre ici, mais elles tomberont pareil.