### PR TITLE
fix(sentry): couper le session replay dans l'admin

### DIFF
--- a/src/instrumentation-client.test.ts
+++ b/src/instrumentation-client.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  init: vi.fn(),
+  replayIntegration: vi.fn(() => ({ name: "Replay" })),
+  captureRouterTransitionStart: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  init: mocks.init,
+  replayIntegration: mocks.replayIntegration,
+  captureRouterTransitionStart: mocks.captureRouterTransitionStart,
+}));
+
+/** Boots the client instrumentation as if the document had loaded at `pathname`. */
+async function bootAt(pathname: string) {
+  vi.resetModules();
+  mocks.init.mockClear();
+  mocks.replayIntegration.mockClear();
+  window.history.replaceState(null, "", pathname);
+  await import("./instrumentation-client");
+  return (mocks.init.mock.calls[0]?.[0] ?? {}) as { integrations?: unknown[] };
+}
+
+const hasReplay = (opts: { integrations?: unknown[] }) =>
+  (opts.integrations ?? []).some((i) => (i as { name?: string })?.name === "Replay");
+
+beforeEach(() => {
+  vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", "https://public@o1.ingest.de.sentry.io/1");
+  vi.stubEnv("NEXT_PUBLIC_SENTRY_ENABLED", "true");
+});
+
+describe("Session replay : périmètre d'enregistrement", () => {
+  it("enregistre sur les pages publiques", async () => {
+    expect(hasReplay(await bootAt("/elections/presidentielle-2027/themes/economie-budget"))).toBe(
+      true
+    );
+    expect(hasReplay(await bootAt("/"))).toBe(true);
+    expect(hasReplay(await bootAt("/statistiques"))).toBe(true);
+  });
+
+  // Les écrans de modération affichent des affaires non publiées, donc des données
+  // d'infractions rattachées à des personnes nommées (RGPD art. 10). Le replay
+  // enregistre le texte en clair (maskAllText: false) : il n'a rien à y faire.
+  it("n'enregistre jamais dans l'admin", async () => {
+    expect(hasReplay(await bootAt("/admin"))).toBe(false);
+    expect(hasReplay(await bootAt("/admin/affaires"))).toBe(false);
+    expect(hasReplay(await bootAt("/admin/affaires/123/edit"))).toBe(false);
+    expect(hasReplay(await bootAt("/admin/policy-titles?status=PENDING"))).toBe(false);
+  });
+
+  it("continue de remonter les erreurs dans l'admin, sans replay", async () => {
+    const opts = await bootAt("/admin/affaires");
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+    expect(hasReplay(opts)).toBe(false);
+  });
+
+  it("ne coupe pas une route publique dont le nom commence par admin", async () => {
+    expect(hasReplay(await bootAt("/administration-publique"))).toBe(true);
+  });
+});

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -3,6 +3,19 @@ import * as Sentry from "@sentry/nextjs";
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const SENTRY_ENABLED = Boolean(SENTRY_DSN) && process.env.NEXT_PUBLIC_SENTRY_ENABLED !== "false";
 
+// Session replay records page text verbatim (`maskAllText: false`), which is the
+// whole point on the public site: an error there is diagnosable from the
+// recording alone. Admin is the opposite trade-off. Moderation screens show
+// unpublished affairs, i.e. offence and conviction data tied to named people
+// (RGPD art. 10), and none of it is worth recording to diagnose a back-office
+// bug. Errors are still reported, only the recording is dropped.
+//
+// Gating at boot is enough: nothing on the public site links into /admin, so the
+// section is only ever entered by a full document load, which re-runs this file.
+// No replay session started on a public page can follow the visitor into admin.
+const IS_ADMIN_ROUTE =
+  typeof window !== "undefined" && /^\/admin(\/|$)/.test(window.location.pathname);
+
 if (SENTRY_ENABLED) {
   Sentry.init({
     dsn: SENTRY_DSN,
@@ -12,7 +25,9 @@ if (SENTRY_ENABLED) {
     replaysOnErrorSampleRate: 1.0,
     replaysSessionSampleRate: 0,
     sendDefaultPii: false,
-    integrations: [Sentry.replayIntegration({ maskAllText: false, blockAllMedia: true })],
+    integrations: IS_ADMIN_ROUTE
+      ? []
+      : [Sentry.replayIntegration({ maskAllText: false, blockAllMedia: true })],
     ignoreErrors: [
       "ResizeObserver loop limit exceeded",
       "ResizeObserver loop completed with undelivered notifications",


### PR DESCRIPTION
## Pourquoi

Le session replay tourne aujourd'hui sur tout le site, admin compris, avec `maskAllText: false`. Ce réglage enregistre le texte visible en clair : c'est voulu sur le site public, où une erreur devient diagnosticable à partir du seul enregistrement.

Dans l'admin le compromis s'inverse. Les écrans de modération affichent des affaires non publiées, donc des données relatives à des infractions et des condamnations rattachées à des personnes nommées. Dès qu'une erreur survient pendant une session de modération, l'écran part tel quel chez le sous-traitant. Il n'y a rien à diagnostiquer là qui justifie de l'enregistrer.

## Correctif

Une garde au démarrage dans `instrumentation-client.ts` : l'intégration replay n'est pas chargée quand le document a été ouvert sous `/admin`.

La garde au boot suffit, et c'est vérifié : aucun lien du site public ne pointe vers `/admin`, donc la section n'est atteinte que par un chargement complet, qui rejoue ce fichier. Aucune session de replay démarrée sur une page publique ne peut suivre le visiteur dans l'admin.

Les erreurs continuent d'être remontées depuis l'admin. `integrations: []` fusionne avec les intégrations par défaut (`[...defaultIntegrations, ...userIntegrations]` dans `getIntegrationsToSetup`), donc seuls les gestionnaires par défaut restent en place et c'est bien le replay, et lui seul, qui saute.

## Vérification

- Suite complète verte.
- `src/instrumentation-client.test.ts` monte le vrai module pour quatre chemins et vérifie les options passées à `Sentry.init` : replay présent sur les pages publiques, absent sur `/admin`, `/admin/...` et une route admin avec query string.
- Le prédicat est `/^\/admin(\/|$)/` et non un `startsWith`, pour qu'une future route publique commençant par « admin » ne perde pas son replay au passage. Un test couvre ce cas.

Pas de vérification navigateur bout en bout : le layout racine a besoin de la base, donc aucune page ne rend sans `DATABASE_URL` en local.

## Reste ouvert

Sentry n'apparaît toujours pas dans la liste des destinataires de la page confidentialité, qui en nomme cinq autres. Sujet distinct, à trancher séparément.