### PR TITLE
fix(votes): conserver les scrutins rejetés derrière le curseur (#769)

### DIFF
--- a/src/services/sync/__tests__/scrutins-senat.test.ts
+++ b/src/services/sync/__tests__/scrutins-senat.test.ts
@@ -2,9 +2,41 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({ db: {} }));
 
-import { parseScrutinMetadata } from "@/services/sync/scrutins-senat";
+import { getNextSenateCursor, parseScrutinMetadata } from "@/services/sync/scrutins-senat";
 
 describe("import des scrutins publics du Sénat", () => {
+  it("garde le curseur derrière un scrutin rejeté au milieu d'une liste descendante", () => {
+    expect(
+      getNextSenateCursor(100, [
+        { number: 105, outcome: "PROCESSED" },
+        { number: 104, outcome: "RETRY" },
+        { number: 103, outcome: "PROCESSED" },
+        { number: 102, outcome: "PROCESSED" },
+        { number: 101, outcome: "PROCESSED" },
+      ])
+    ).toBe(103);
+  });
+
+  it("avance au plus grand scrutin quand aucun numéro ne doit être retenté", () => {
+    expect(
+      getNextSenateCursor(100, [
+        { number: 103, outcome: "PROCESSED" },
+        { number: 102, outcome: "PROCESSED" },
+        { number: 101, outcome: "PROCESSED" },
+      ])
+    ).toBe(103);
+  });
+
+  it("conserve le curseur courant si le prochain scrutin doit être retenté", () => {
+    expect(
+      getNextSenateCursor(100, [
+        { number: 103, outcome: "PROCESSED" },
+        { number: 102, outcome: "PROCESSED" },
+        { number: 101, outcome: "RETRY" },
+      ])
+    ).toBe(100);
+  });
+
   it("extrait le total de contrôle officiel sans supposer 348 sièges", () => {
     const html = `
       <p class="page-lead">Projet de loi de test</p>

--- a/src/services/sync/__tests__/scrutins-senat.test.ts
+++ b/src/services/sync/__tests__/scrutins-senat.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({ db: {} }));
 
-import { getNextSenateCursor, parseScrutinMetadata } from "@/services/sync/scrutins-senat";
+import {
+  getNextSenateCursor,
+  parseScrutinMetadata,
+  shouldSaveSenateCursor,
+} from "@/services/sync/scrutins-senat";
 
 describe("import des scrutins publics du Sénat", () => {
   it("garde le curseur derrière un scrutin rejeté au milieu d'une liste descendante", () => {
@@ -35,6 +39,13 @@ describe("import des scrutins publics du Sénat", () => {
         { number: 101, outcome: "RETRY" },
       ])
     ).toBe(100);
+  });
+
+  it("réinitialise un ancien curseur quand un import forcé échoue dès le numéro 1", () => {
+    const nextCursor = getNextSenateCursor(0, [{ number: 1, outcome: "RETRY" }]);
+
+    expect(nextCursor).toBe(0);
+    expect(shouldSaveSenateCursor(false, true, 0, nextCursor)).toBe(true);
   });
 
   it("extrait le total de contrôle officiel sans supposer 348 sièges", () => {

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -101,6 +101,15 @@ export function getNextSenateCursor(
   return lowestRetry === null ? highestProcessed : Math.min(highestProcessed, lowestRetry - 1);
 }
 
+export function shouldSaveSenateCursor(
+  dryRun: boolean,
+  force: boolean,
+  currentCursor: number,
+  nextCursor: number
+): boolean {
+  return !dryRun && (force || nextCursor > currentCursor);
+}
+
 /**
  * Get list of scrutin numbers from a session page
  */
@@ -580,7 +589,7 @@ export async function syncScrutinsSenat(
 
       // Update cursor for this session
       const nextCursor = getNextSenateCursor(cursorNum, cursorOutcomes);
-      if (!dryRun && nextCursor > cursorNum) {
+      if (shouldSaveSenateCursor(dryRun, force, cursorNum, nextCursor)) {
         await syncMetadata.markCompleted(sessionKey, {
           cursor: String(nextCursor),
           itemCount: stats.scrutinsProcessed,

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -73,6 +73,34 @@ export interface ScrutinsSenatSyncStats {
 // Helpers
 // ---------------------------------------------------------------------------
 
+export interface SenateCursorOutcome {
+  number: number;
+  outcome: "PROCESSED" | "RETRY";
+}
+
+export function getNextSenateCursor(
+  currentCursor: number,
+  outcomes: SenateCursorOutcome[]
+): number {
+  const highestProcessed = outcomes.reduce(
+    (highest, result) =>
+      result.outcome === "PROCESSED" ? Math.max(highest, result.number) : highest,
+    currentCursor
+  );
+  const lowestRetry = outcomes.reduce<number | null>(
+    (lowest, result) =>
+      result.outcome === "RETRY" && result.number > currentCursor
+        ? Math.min(lowest ?? result.number, result.number)
+        : lowest,
+    null
+  );
+
+  // The cursor skips every lower or equal number on later incremental runs.
+  // Keep it immediately behind the first rejected scrutin so temporary source
+  // gaps are retried, while already completed lower numbers can still advance it.
+  return lowestRetry === null ? highestProcessed : Math.min(highestProcessed, lowestRetry - 1);
+}
+
 /**
  * Get list of scrutin numbers from a session page
  */
@@ -318,8 +346,9 @@ export async function syncScrutinsSenat(
         }
       }
 
-      // Process each scrutin
-      let maxProcessedNumber = cursorNum;
+      // Process each scrutin. The final cursor must retain every hole that
+      // needs another attempt, even though the source list is descending.
+      const cursorOutcomes: SenateCursorOutcome[] = [];
 
       const progress = new ProgressTracker({
         total: scrutinNumbers.length,
@@ -349,6 +378,7 @@ export async function syncScrutinsSenat(
           const metadata = parseScrutinMetadata(html, currentSession, number!);
           if (!metadata) {
             stats.scrutinsSkipped++;
+            cursorOutcomes.push({ number: numInt, outcome: "RETRY" });
             progress.tick();
             continue;
           }
@@ -458,6 +488,7 @@ export async function syncScrutinsSenat(
               stats.errors.push(
                 `Session ${currentSession} n°${number}: source nominative ${sourceAssessment.status.toLowerCase()} (${sourceAssessment.reason})`
               );
+              cursorOutcomes.push({ number: numInt, outcome: "RETRY" });
               progress.tick();
               continue;
             }
@@ -508,10 +539,7 @@ export async function syncScrutinsSenat(
               data: { votesHash: newHash },
             });
 
-            // Track max processed number for cursor
-            if (numInt > maxProcessedNumber) {
-              maxProcessedNumber = numInt;
-            }
+            cursorOutcomes.push({ number: numInt, outcome: "PROCESSED" });
           } else {
             // Dry run: just count
             stats.scrutinsCreated++;
@@ -536,6 +564,7 @@ export async function syncScrutinsSenat(
           stats.errors.push(
             `Session ${currentSession} n°${number}: ${err instanceof Error ? err.message : String(err)}`
           );
+          cursorOutcomes.push({ number: numInt, outcome: "RETRY" });
         }
 
         progress.update({
@@ -550,9 +579,10 @@ export async function syncScrutinsSenat(
       progress.finish();
 
       // Update cursor for this session
-      if (!dryRun && maxProcessedNumber > cursorNum) {
+      const nextCursor = getNextSenateCursor(cursorNum, cursorOutcomes);
+      if (!dryRun && nextCursor > cursorNum) {
         await syncMetadata.markCompleted(sessionKey, {
-          cursor: String(maxProcessedNumber),
+          cursor: String(nextCursor),
           itemCount: stats.scrutinsProcessed,
         });
       }


### PR DESCRIPTION
## Problème

La liste des scrutins du Sénat est traitée par numéro décroissant. Le curseur retenait pourtant le plus grand numéro traité avec succès, même lorsqu'un scrutin de numéro inférieur avait été rejeté temporairement. Les exécutions suivantes ignoraient alors définitivement ce scrutin.

## Correction

- enregistre l'issue de chaque tentative (`PROCESSED` ou `RETRY`)
- borne le curseur juste avant le plus petit numéro à retenter
- traite aussi les erreurs de récupération et de parsing comme des tentatives à reprendre
- ajoute des tests de régression pour une liste descendante avec et sans rejet

## Vérifications

- `npm run typecheck`
- `npm run lint` (0 erreur, 57 avertissements préexistants)
- `npm run test:run` (5 766 tests réussis, 409 ignorés)

Fixes #769
