### PR TITLE
Améliorer la génération et la relecture des synthèses candidates

### DIFF
--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { CandidacyStatus, PublicationStatus } from "@/generated/prisma";
 import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
 import { PUBLICATION_STATUS_LABELS, PUBLICATION_STATUS_STYLES } from "@/config/labels";
 import { formatDate } from "@/lib/utils";
 import type { CandidacyMeasureReadiness } from "@/lib/data/measures";
@@ -67,6 +68,7 @@ export type CandidateRowView = {
   rank: number | null;
   readiness: CandidacyMeasureReadiness;
   synthesisState: SynthesisState;
+  synthesis: string | null;
   synthesisGeneratedAt: Date | null;
   editions: ProgramEditionView[];
 };
@@ -81,6 +83,11 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [synthesisEditor, setSynthesisEditor] = useState<{
+    candidacyId: string;
+    candidateName: string;
+    text: string;
+  } | null>(null);
   const [statusDrafts, setStatusDrafts] = useState(() =>
     Object.fromEntries(
       rows.map((row) => [
@@ -129,6 +136,55 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
       setBusy(null);
       router.refresh();
     });
+  }
+
+  async function generateSynthesisProposal(row: CandidateRowView) {
+    const key = `synthese:${row.candidacyId}`;
+    setBusy(key);
+    setError(null);
+    try {
+      const result = await regenerateCandidateSynthesisAction({ candidacyId: row.candidacyId });
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setSynthesisEditor({
+        candidacyId: row.candidacyId,
+        candidateName: row.candidateName,
+        text: result.text ?? "",
+      });
+    } catch (err) {
+      setError(`Erreur : ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function saveSynthesis() {
+    if (!synthesisEditor) return;
+    const key = `synthese-save:${synthesisEditor.candidacyId}`;
+    setBusy(key);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/admin/candidats/${synthesisEditor.candidacyId}/synthesis`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ synthesis: synthesisEditor.text }),
+        }
+      );
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error ?? "L'enregistrement a échoué.");
+      }
+      setSynthesisEditor(null);
+      router.refresh();
+    } catch (err) {
+      setError(`Erreur : ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(null);
+    }
   }
 
   return (
@@ -201,314 +257,404 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
         </p>
       )}
 
-      <div className="rounded-lg border overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead className="bg-muted/50">
-            <tr>
-              <th className="text-left px-3 py-2">Rang</th>
-              <th className="text-left px-3 py-2">Candidat</th>
-              <th className="text-left px-3 py-2">Parti</th>
-              <th className="text-left px-3 py-2">Statut</th>
-              <th className="text-left px-3 py-2">Mesures prêtes</th>
-              <th className="text-left px-3 py-2">Fiche publique</th>
-              <th className="text-left px-3 py-2">Programme</th>
-              <th className="text-left px-3 py-2">Synthèse</th>
-              <th className="text-left px-3 py-2">Slogan</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => {
-              const publicationKey = `publication:${row.candidacyId}`;
-              const statusKey = `statut:${row.candidacyId}`;
-              const synthesisKey = `synthese:${row.candidacyId}`;
-              const published = row.publicationStatus === "PUBLISHED";
-              const locked = busy !== null || pending;
-              const statusDraft = statusDrafts[row.candidacyId] ?? {
-                status: row.status ?? "",
-                sourceUrl: row.sourceUrl ?? "",
-                sourceLabel: row.sourceLabel ?? "",
-              };
-              const updateStatusDraft = (patch: Partial<typeof statusDraft>) =>
-                setStatusDrafts((current) => ({
-                  ...current,
-                  [row.candidacyId]: { ...statusDraft, ...patch },
-                }));
-              return (
-                <tr key={row.candidacyId} className="border-t align-top">
-                  <td className="px-3 py-2 w-12">
-                    <input
-                      type="number"
-                      min={0}
-                      defaultValue={row.rank ?? ""}
-                      onBlur={(e) => {
-                        const value = e.target.value ? Number(e.target.value) : null;
-                        if (row.presidentialId)
-                          patchPresidential(row.presidentialId, { rank: value });
-                      }}
-                      className="w-12 rounded border px-1 py-0.5 text-sm dark:bg-slate-800"
-                      aria-label={`Rang de ${row.candidateName}`}
-                      disabled={locked || !row.presidentialId}
-                    />
-                  </td>
-                  <td className="px-3 py-2 whitespace-nowrap">
+      <div className="space-y-4">
+        {rows.map((row) => {
+          const publicationKey = `publication:${row.candidacyId}`;
+          const statusKey = `statut:${row.candidacyId}`;
+          const synthesisKey = `synthese:${row.candidacyId}`;
+          const saveKey = `synthese-save:${row.candidacyId}`;
+          const published = row.publicationStatus === "PUBLISHED";
+          const locked = busy !== null || pending;
+          const statusDraft = statusDrafts[row.candidacyId] ?? {
+            status: row.status ?? "",
+            sourceUrl: row.sourceUrl ?? "",
+            sourceLabel: row.sourceLabel ?? "",
+          };
+          const updateStatusDraft = (patch: Partial<typeof statusDraft>) =>
+            setStatusDrafts((current) => ({
+              ...current,
+              [row.candidacyId]: { ...statusDraft, ...patch },
+            }));
+          const editorOpen = synthesisEditor?.candidacyId === row.candidacyId;
+
+          return (
+            <article
+              key={row.candidacyId}
+              aria-labelledby={`candidat-${row.candidacyId}`}
+              className="rounded-xl border bg-card p-4 shadow-sm sm:p-5"
+            >
+              <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 id={`candidat-${row.candidacyId}`} className="font-display text-xl font-bold">
                     {row.politicianSlug ? (
                       <Link
                         href={`/admin/candidats/${row.politicianSlug}`}
-                        className="text-primary hover:underline"
+                        className="hover:underline"
                       >
                         {row.candidateName}
                       </Link>
                     ) : (
-                      <span>{row.candidateName}</span>
+                      row.candidateName
                     )}
-                    {row.politicianId && row.politicianPublicationStatus !== "PUBLISHED" && (
-                      <Link
-                        href={`/admin/politiques/${row.politicianId}`}
-                        className="mt-1 inline-flex min-h-11 items-center rounded px-2 text-xs font-semibold text-primary underline underline-offset-2"
-                      >
-                        Publier la personnalité
-                      </Link>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 whitespace-nowrap">{row.partyLabel ?? "Sans parti"}</td>
-                  <td className="px-3 py-2 whitespace-nowrap">
-                    <label className="sr-only" htmlFor={statusKey}>
-                      Statut de {row.candidateName}
-                    </label>
-                    <div className="flex min-w-64 flex-col gap-2">
-                      <select
-                        id={statusKey}
-                        value={statusDraft.status}
-                        onChange={(event) => updateStatusDraft({ status: event.target.value })}
-                        disabled={locked}
-                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
-                        aria-label={`Statut de ${row.candidateName}`}
-                      >
-                        {!row.status && <option value="">Statut non renseigné</option>}
-                        {Object.entries(STATUS_LABELS).map(([value, label]) => (
-                          <option key={value} value={value}>
-                            {label}
-                          </option>
-                        ))}
-                      </select>
-                      <input
-                        type="url"
-                        value={statusDraft.sourceUrl}
-                        onChange={(event) => updateStatusDraft({ sourceUrl: event.target.value })}
-                        disabled={locked}
-                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
-                        aria-label={`URL source du statut de ${row.candidateName}`}
-                        placeholder="https://site-officiel.fr/annonce"
-                      />
-                      <input
-                        type="text"
-                        value={statusDraft.sourceLabel}
-                        onChange={(event) => updateStatusDraft({ sourceLabel: event.target.value })}
-                        disabled={locked}
-                        className="min-h-11 rounded border bg-background px-2 text-sm md:min-h-[36px]"
-                        aria-label={`Libellé source du statut de ${row.candidateName}`}
-                        placeholder="Annonce officielle, date"
-                      />
-                      <button
-                        type="button"
-                        onClick={() =>
-                          runAction(statusKey, () =>
-                            setCandidacyStatusAction({
-                              candidacyId: row.candidacyId,
-                              status: statusDraft.status as CandidacyStatus,
-                              sourceUrl: statusDraft.sourceUrl.trim(),
-                              sourceLabel: statusDraft.sourceLabel.trim(),
-                            })
-                          )
-                        }
-                        disabled={
-                          locked ||
-                          !statusDraft.status ||
-                          !statusDraft.sourceUrl.trim() ||
-                          !statusDraft.sourceLabel.trim()
-                        }
-                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
-                      >
-                        {busy === statusKey ? "Enregistrement..." : "Enregistrer le statut"}
-                      </button>
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 whitespace-nowrap">
-                    {row.readiness.measureCount === 0 ? (
-                      <span className="text-muted-foreground">Aucune</span>
-                    ) : (
-                      <>
-                        <span className="font-semibold">{row.readiness.measureCount}</span>
-                        <span className="text-muted-foreground">
-                          {" "}
-                          · {row.readiness.themesCoveredCount} thèmes ·{" "}
-                          {row.readiness.primarySourceMeasureCount} sourcées 1re main
-                        </span>
-                      </>
-                    )}
-                  </td>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-col gap-1.5">
-                      <Badge
-                        variant="outline"
-                        className={
-                          row.publicationStatus
-                            ? PUBLICATION_STATUS_STYLES[row.publicationStatus]
-                            : ""
-                        }
-                      >
-                        {row.publicationStatus
-                          ? PUBLICATION_STATUS_LABELS[row.publicationStatus]
-                          : "Métadonnées absentes"}
-                      </Badge>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          runAction(publicationKey, () =>
-                            setCandidacyPublicationAction({
-                              candidacyId: row.candidacyId,
-                              status: published ? "DRAFT" : "PUBLISHED",
-                            })
-                          )
-                        }
-                        disabled={locked || (!published && !row.sourced)}
-                        title={
-                          !published && !row.sourced
-                            ? "Renseigner le statut et la source de la candidature avant publication"
+                  </h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {row.partyLabel ?? "Sans parti"} ·{" "}
+                    {STATUS_LABELS[row.status ?? ""] ?? "Statut non renseigné"}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={
+                      row.publicationStatus ? PUBLICATION_STATUS_STYLES[row.publicationStatus] : ""
+                    }
+                  >
+                    {row.publicationStatus === "PUBLISHED"
+                      ? "Fiche publiée"
+                      : row.publicationStatus === "DRAFT"
+                        ? "Fiche en brouillon"
+                        : row.publicationStatus
+                          ? `Fiche ${PUBLICATION_STATUS_LABELS[row.publicationStatus].toLowerCase()}`
+                          : "Fiche sans métadonnées"}
+                  </Badge>
+                  {row.politicianSlug && (
+                    <Link
+                      href={`/elections/presidentielle-2027/candidats/${row.politicianSlug}`}
+                      className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-primary underline underline-offset-2"
+                    >
+                      Voir la fiche publique
+                    </Link>
+                  )}
+                </div>
+              </header>
+
+              <div className="grid gap-6 py-5 xl:grid-cols-[minmax(18rem,1.15fr)_minmax(16rem,0.9fr)_minmax(18rem,1fr)]">
+                <section aria-labelledby={`${statusKey}-titre`} className="space-y-3">
+                  <div>
+                    <h3 id={`${statusKey}-titre`} className="font-semibold">
+                      Statut et source
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      La source justifie le statut public de la candidature.
+                    </p>
+                  </div>
+                  <label className="sr-only" htmlFor={statusKey}>
+                    Statut de {row.candidateName}
+                  </label>
+                  <select
+                    id={statusKey}
+                    value={statusDraft.status}
+                    onChange={(event) => updateStatusDraft({ status: event.target.value })}
+                    disabled={locked}
+                    className="min-h-11 w-full rounded-md border bg-background px-3 text-sm"
+                  >
+                    {!row.status && <option value="">Statut non renseigné</option>}
+                    {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="url"
+                    value={statusDraft.sourceUrl}
+                    onChange={(event) => updateStatusDraft({ sourceUrl: event.target.value })}
+                    disabled={locked}
+                    className="min-h-11 w-full rounded-md border bg-background px-3 text-sm"
+                    aria-label={`URL source du statut de ${row.candidateName}`}
+                    placeholder="https://site-officiel.fr/annonce"
+                  />
+                  <input
+                    type="text"
+                    value={statusDraft.sourceLabel}
+                    onChange={(event) => updateStatusDraft({ sourceLabel: event.target.value })}
+                    disabled={locked}
+                    className="min-h-11 w-full rounded-md border bg-background px-3 text-sm"
+                    aria-label={`Libellé source du statut de ${row.candidateName}`}
+                    placeholder="Annonce officielle, date"
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      runAction(statusKey, () =>
+                        setCandidacyStatusAction({
+                          candidacyId: row.candidacyId,
+                          status: statusDraft.status as CandidacyStatus,
+                          sourceUrl: statusDraft.sourceUrl.trim(),
+                          sourceLabel: statusDraft.sourceLabel.trim(),
+                        })
+                      )
+                    }
+                    disabled={
+                      locked ||
+                      !statusDraft.status ||
+                      !statusDraft.sourceUrl.trim() ||
+                      !statusDraft.sourceLabel.trim()
+                    }
+                    className="inline-flex min-h-11 w-full items-center justify-center rounded-md border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50"
+                  >
+                    {busy === statusKey ? "Enregistrement..." : "Enregistrer le statut"}
+                  </button>
+                </section>
+
+                <section aria-labelledby={`${publicationKey}-titre`} className="space-y-3">
+                  <div>
+                    <h3 id={`${publicationKey}-titre`} className="font-semibold">
+                      Publication et programme
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {row.readiness.measureCount === 0
+                        ? "Aucune mesure prête"
+                        : `${row.readiness.measureCount} mesures · ${row.readiness.themesCoveredCount} thèmes · ${row.readiness.primarySourceMeasureCount} sourcées en première main`}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      runAction(publicationKey, () =>
+                        setCandidacyPublicationAction({
+                          candidacyId: row.candidacyId,
+                          status: published ? "DRAFT" : "PUBLISHED",
+                        })
+                      )
+                    }
+                    disabled={locked || (!published && !row.sourced)}
+                    title={
+                      !published && !row.sourced
+                        ? "Renseigner le statut et la source avant publication"
+                        : undefined
+                    }
+                    className="inline-flex min-h-11 w-full items-center justify-center rounded-md border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50"
+                  >
+                    {busy === publicationKey
+                      ? "En cours..."
+                      : published
+                        ? "Dépublier la fiche"
+                        : "Publier la fiche"}
+                  </button>
+                  {!published && !row.sourced && (
+                    <p className="text-xs text-muted-foreground">Statut et source obligatoires</p>
+                  )}
+                  {row.editions.length === 0 ? (
+                    <p className="rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+                      Aucune édition de programme.
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {row.editions.map((edition) => {
+                        const editionKey = `edition:${edition.id}`;
+                        const editionPublished = edition.publicationStatus === "PUBLISHED";
+                        return (
+                          <li key={edition.id} className="rounded-md border p-3 text-sm">
+                            <p className="font-medium">
+                              {edition.label}{" "}
+                              <span className="text-muted-foreground">(v{edition.version})</span>
+                            </p>
+                            <div className="mt-2 flex flex-wrap items-center gap-2">
+                              <Badge
+                                variant="outline"
+                                className={PUBLICATION_STATUS_STYLES[edition.publicationStatus]}
+                              >
+                                {PUBLICATION_STATUS_LABELS[edition.publicationStatus]}
+                              </Badge>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  runAction(editionKey, () =>
+                                    setProgramEditionPublicationAction({
+                                      programEditionId: edition.id,
+                                      status: editionPublished ? "DRAFT" : "PUBLISHED",
+                                    })
+                                  )
+                                }
+                                disabled={locked}
+                                aria-label={`${editionPublished ? "Dépublier" : "Publier"} l'édition ${edition.label} de ${row.candidateName}`}
+                                className="inline-flex min-h-11 items-center rounded-md px-3 text-xs font-semibold text-primary underline underline-offset-2 disabled:opacity-50"
+                              >
+                                {busy === editionKey
+                                  ? "En cours..."
+                                  : editionPublished
+                                    ? "Dépublier"
+                                    : "Publier"}
+                              </button>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </section>
+
+                <section aria-labelledby={`${synthesisKey}-titre`} className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 id={`${synthesisKey}-titre`} className="font-semibold">
+                      Synthèse générale
+                    </h3>
+                    <Badge variant="outline" className={SYNTHESIS_STYLES[row.synthesisState]}>
+                      {SYNTHESIS_LABELS[row.synthesisState]}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    La génération crée une proposition. Elle ne remplace le texte public qu’après
+                    ton enregistrement.
+                  </p>
+                  <div className="flex flex-col gap-2 sm:flex-row xl:flex-col 2xl:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => generateSynthesisProposal(row)}
+                      disabled={locked || row.status !== "DECLARE" || !row.presidentialId}
+                      title={
+                        row.status !== "DECLARE"
+                          ? "Seule une candidature déclarée porte une synthèse"
+                          : !row.presidentialId
+                            ? "Publier la fiche crée les métadonnées nécessaires"
                             : undefined
-                        }
-                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
-                      >
-                        {busy === publicationKey
-                          ? "En cours..."
-                          : published
-                            ? "Dépublier"
-                            : "Publier la fiche"}
-                      </button>
-                      {!published && !row.sourced && (
-                        <span className="text-xs text-muted-foreground">
-                          Statut et source obligatoires
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 max-w-xs">
-                    {row.editions.length === 0 ? (
-                      <span className="text-muted-foreground">Aucune édition</span>
-                    ) : (
-                      <ul className="space-y-2">
-                        {row.editions.map((edition) => {
-                          const editionKey = `edition:${edition.id}`;
-                          const editionPublished = edition.publicationStatus === "PUBLISHED";
-                          return (
-                            <li key={edition.id} className="space-y-1">
-                              <p className="line-clamp-2">
-                                {edition.label}{" "}
-                                <span className="text-muted-foreground">(v{edition.version})</span>
-                              </p>
-                              <div className="flex flex-wrap items-center gap-2">
-                                <Badge
-                                  variant="outline"
-                                  className={PUBLICATION_STATUS_STYLES[edition.publicationStatus]}
-                                >
-                                  {PUBLICATION_STATUS_LABELS[edition.publicationStatus]}
-                                </Badge>
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    runAction(editionKey, () =>
-                                      setProgramEditionPublicationAction({
-                                        programEditionId: edition.id,
-                                        status: editionPublished ? "DRAFT" : "PUBLISHED",
-                                      })
-                                    )
-                                  }
-                                  disabled={locked}
-                                  aria-label={`${editionPublished ? "Dépublier" : "Publier"} l'édition ${edition.label} de ${row.candidateName}`}
-                                  className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
-                                >
-                                  {busy === editionKey
-                                    ? "En cours..."
-                                    : editionPublished
-                                      ? "Dépublier"
-                                      : "Publier"}
-                                </button>
-                              </div>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    )}
-                  </td>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-col gap-1.5">
-                      <Badge variant="outline" className={SYNTHESIS_STYLES[row.synthesisState]}>
-                        {SYNTHESIS_LABELS[row.synthesisState]}
-                      </Badge>
+                      }
+                      className="inline-flex min-h-11 flex-1 items-center justify-center rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      {busy === synthesisKey ? "Génération..." : "Générer une proposition"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSynthesisEditor({
+                          candidacyId: row.candidacyId,
+                          candidateName: row.candidateName,
+                          text: row.synthesis ?? "",
+                        })
+                      }
+                      disabled={locked || !row.synthesis}
+                      className="inline-flex min-h-11 items-center justify-center rounded-md border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50"
+                    >
+                      Modifier le texte
+                    </button>
+                  </div>
+                  {row.synthesisGeneratedAt !== null && (
+                    <p className="text-xs text-muted-foreground">
+                      Dernière version : {formatDate(row.synthesisGeneratedAt)}
+                    </p>
+                  )}
+                  {row.politicianSlug && (
+                    <Link
+                      href={`/admin/candidats/${row.politicianSlug}/syntheses-thematiques`}
+                      className="inline-flex min-h-11 items-center text-sm font-semibold text-primary underline underline-offset-2"
+                    >
+                      Gérer les synthèses par thème
+                    </Link>
+                  )}
+                </section>
+              </div>
+
+              {editorOpen && synthesisEditor && (
+                <section
+                  aria-labelledby={`editeur-${row.candidacyId}`}
+                  className="mb-5 rounded-lg border border-primary/30 bg-muted/40 p-4"
+                >
+                  <h3 id={`editeur-${row.candidacyId}`} className="font-display text-lg font-bold">
+                    Relire la synthèse de {synthesisEditor.candidateName}
+                  </h3>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Corrige librement la proposition. Rien n’est publié avant « Enregistrer la
+                    synthèse ».
+                  </p>
+                  <label
+                    htmlFor={`texte-synthese-${row.candidacyId}`}
+                    className="mt-4 block text-sm font-semibold"
+                  >
+                    Texte public
+                  </label>
+                  <Textarea
+                    id={`texte-synthese-${row.candidacyId}`}
+                    value={synthesisEditor.text}
+                    onChange={(event) =>
+                      setSynthesisEditor((current) =>
+                        current ? { ...current, text: event.target.value } : current
+                      )
+                    }
+                    rows={10}
+                    className="mt-2 text-base leading-7"
+                  />
+                  <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-xs text-muted-foreground">
+                      {synthesisEditor.text.trim().split(/\s+/).filter(Boolean).length} mots
+                    </p>
+                    <div className="flex flex-wrap gap-2">
                       <button
                         type="button"
-                        onClick={() =>
-                          runAction(synthesisKey, () =>
-                            regenerateCandidateSynthesisAction({ candidacyId: row.candidacyId })
-                          )
-                        }
-                        disabled={locked || row.status !== "DECLARE" || !row.presidentialId}
-                        title={
-                          row.status !== "DECLARE"
-                            ? "Seule une candidature déclarée porte une synthèse"
-                            : !row.presidentialId
-                              ? "Publier la fiche crée les métadonnées où la synthèse est écrite"
-                              : undefined
-                        }
-                        aria-label={`Régénérer la synthèse de ${row.candidateName}`}
-                        className="inline-flex min-h-11 items-center justify-center rounded border px-3 text-sm font-semibold hover:bg-muted disabled:opacity-50 md:min-h-[36px]"
+                        onClick={() => setSynthesisEditor(null)}
+                        disabled={locked}
+                        className="inline-flex min-h-11 items-center justify-center rounded-md border px-4 text-sm font-semibold hover:bg-muted disabled:opacity-50"
                       >
-                        {busy === synthesisKey ? "Génération..." : "Régénérer"}
+                        Annuler
                       </button>
-                      {row.synthesisGeneratedAt !== null && (
-                        <span className="text-xs text-muted-foreground">
-                          {formatDate(row.synthesisGeneratedAt)}
-                        </span>
-                      )}
-                      {row.politicianSlug && (
-                        <Link
-                          href={`/admin/candidats/${row.politicianSlug}/syntheses-thematiques`}
-                          className="inline-flex min-h-11 items-center text-xs font-semibold text-primary hover:underline md:min-h-[36px]"
-                        >
-                          Gérer les synthèses par thème
-                        </Link>
-                      )}
+                      <button
+                        type="button"
+                        onClick={saveSynthesis}
+                        disabled={locked || synthesisEditor.text.trim().length < 20}
+                        className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        {busy === saveKey ? "Enregistrement..." : "Enregistrer la synthèse"}
+                      </button>
                     </div>
-                  </td>
-                  <td className="px-3 py-2 max-w-md">
+                  </div>
+                </section>
+              )}
+
+              <details className="border-t pt-4">
+                <summary className="min-h-11 cursor-pointer text-sm font-semibold text-primary">
+                  Paramètres secondaires
+                </summary>
+                <div className="grid gap-4 pt-3 sm:grid-cols-[8rem_1fr]">
+                  <label className="space-y-1 text-sm">
+                    <span className="font-medium">Rang</span>
+                    <input
+                      type="number"
+                      min={0}
+                      defaultValue={row.rank ?? ""}
+                      onBlur={(event) => {
+                        const value = event.target.value ? Number(event.target.value) : null;
+                        if (row.presidentialId)
+                          patchPresidential(row.presidentialId, { rank: value });
+                      }}
+                      className="min-h-11 w-full rounded-md border bg-background px-3 text-sm"
+                      disabled={locked || !row.presidentialId}
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="font-medium">Slogan</span>
                     <input
                       type="text"
                       defaultValue={row.slogan ?? ""}
-                      onBlur={(e) => {
-                        const value = e.target.value.trim() || null;
+                      onBlur={(event) => {
+                        const value = event.target.value.trim() || null;
                         if (row.presidentialId)
                           patchPresidential(row.presidentialId, { slogan: value });
                       }}
-                      className="w-full rounded border px-2 py-0.5 text-sm dark:bg-slate-800"
-                      aria-label={`Slogan de ${row.candidateName}`}
+                      className="min-h-11 w-full rounded-md border bg-background px-3 text-sm"
                       disabled={locked || !row.presidentialId}
                       placeholder={
-                        row.presidentialId ? "ex : Vous protéger" : "Métadonnées absentes"
+                        row.presidentialId ? "Ex. : Vous protéger" : "Métadonnées absentes"
                       }
                     />
-                  </td>
-                </tr>
-              );
-            })}
-            {rows.length === 0 && (
-              <tr>
-                <td colSpan={9} className="px-3 py-6 text-center text-muted-foreground">
-                  Aucune candidature enregistrée.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+                  </label>
+                </div>
+                {row.politicianId && row.politicianPublicationStatus !== "PUBLISHED" && (
+                  <Link
+                    href={`/admin/politiques/${row.politicianId}`}
+                    className="mt-3 inline-flex min-h-11 items-center text-sm font-semibold text-primary underline underline-offset-2"
+                  >
+                    Publier la personnalité
+                  </Link>
+                )}
+              </details>
+            </article>
+          );
+        })}
+        {rows.length === 0 && (
+          <p className="rounded-lg border p-6 text-center text-muted-foreground">
+            Aucune candidature enregistrée.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/candidats/CandidatesListClient.tsx
+++ b/src/app/admin/candidats/CandidatesListClient.tsx
@@ -87,6 +87,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
     candidacyId: string;
     candidateName: string;
     text: string;
+    reviewWarning?: string;
   } | null>(null);
   const [statusDrafts, setStatusDrafts] = useState(() =>
     Object.fromEntries(
@@ -152,6 +153,7 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
         candidacyId: row.candidacyId,
         candidateName: row.candidateName,
         text: result.text ?? "",
+        reviewWarning: result.reviewWarning,
       });
     } catch (err) {
       setError(`Erreur : ${err instanceof Error ? err.message : String(err)}`);
@@ -557,6 +559,14 @@ export function CandidatesListClient({ rows }: { rows: CandidateRowView[] }) {
                     Corrige librement la proposition. Rien n’est publié avant « Enregistrer la
                     synthèse ».
                   </p>
+                  {synthesisEditor.reviewWarning && (
+                    <p
+                      role="alert"
+                      className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950"
+                    >
+                      {synthesisEditor.reviewWarning}
+                    </p>
+                  )}
                   <label
                     htmlFor={`texte-synthese-${row.candidacyId}`}
                     className="mt-4 block text-sm font-semibold"

--- a/src/app/admin/candidats/[slug]/page.tsx
+++ b/src/app/admin/candidats/[slug]/page.tsx
@@ -55,6 +55,7 @@ export default async function AdminCandidacyPage({ params }: PageProps) {
           })
         ? "CONTRADICTED"
         : "CURRENT",
+    synthesis: candidacy.presidentialData?.synthesis ?? null,
     synthesisGeneratedAt: candidacy.presidentialData?.synthesisGeneratedAt ?? null,
     editions: editions.map((edition) => ({
       id: edition.id,

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CandidatesListClient, type CandidateRowView } from "../CandidatesListClient";
 
-type ActionResult = { ok: true } | { ok: false; message: string };
+type ActionResult = { ok: true; text?: string } | { ok: false; message: string };
 
 const setCandidacyPublicationMock = vi.fn<(input: unknown) => Promise<ActionResult>>(async () => ({
   ok: true,
@@ -12,11 +12,12 @@ const setProgramEditionPublicationMock = vi.fn<(input: unknown) => Promise<Actio
   async () => ({ ok: true })
 );
 const regenerateCandidateSynthesisMock = vi.fn<(input: unknown) => Promise<ActionResult>>(
-  async () => ({ ok: true })
+  async () => ({ ok: true, text: "Une proposition de synthèse suffisamment développée." })
 );
 const setCandidacyStatusMock = vi.fn<(input: unknown) => Promise<ActionResult>>(async () => ({
   ok: true,
 }));
+const fetchMock = vi.fn();
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 vi.mock("../actions", () => ({
@@ -49,6 +50,7 @@ function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
       firstPublishedAt: new Date("2026-08-01T00:00:00.000Z"),
     },
     synthesisState: "CURRENT",
+    synthesis: "Une synthèse existante relue par la rédaction.",
     synthesisGeneratedAt: new Date("2026-08-07T00:00:00.000Z"),
     editions: [
       { id: "ed-1", label: "Premiers engagements", version: 1, publicationStatus: "DRAFT" },
@@ -59,6 +61,8 @@ function row(over: Partial<CandidateRowView> = {}): CandidateRowView {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
 });
 
 describe("CandidatesListClient", () => {
@@ -77,7 +81,7 @@ describe("CandidatesListClient", () => {
     render(<CandidatesListClient rows={[row({ publicationStatus: "PUBLISHED" })]} />);
 
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Dépublier" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dépublier la fiche" })).toBeInTheDocument();
   });
 
   it("signale une candidature publiée dont la personnalité reste masquée", () => {
@@ -195,6 +199,7 @@ describe("CandidatesListClient", () => {
               firstPublishedAt: null,
             },
             synthesisState: "MISSING",
+            synthesis: null,
             synthesisGeneratedAt: null,
             editions: [],
           }),
@@ -202,21 +207,47 @@ describe("CandidatesListClient", () => {
       />
     );
 
-    expect(screen.getByText("Aucune")).toBeInTheDocument();
-    expect(screen.getByText("Métadonnées absentes")).toBeInTheDocument();
-    expect(screen.getByText("Aucune édition")).toBeInTheDocument();
+    expect(screen.getByText("Aucune mesure prête")).toBeInTheDocument();
+    expect(screen.getByText("Fiche sans métadonnées")).toBeInTheDocument();
+    expect(screen.getByText("Aucune édition de programme.")).toBeInTheDocument();
     expect(screen.getByText("Absente")).toBeInTheDocument();
   });
 
-  it("régénère la synthèse d'une candidature depuis la liste", async () => {
+  it("ouvre la proposition générée sans la publier", async () => {
     const user = userEvent.setup();
     render(<CandidatesListClient rows={[row()]} />);
 
-    await user.click(
-      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
-    );
+    await user.click(screen.getByRole("button", { name: "Générer une proposition" }));
 
     expect(regenerateCandidateSynthesisMock).toHaveBeenCalledWith({ candidacyId: "cand-1" });
+    expect(await screen.findByLabelText("Texte public")).toHaveValue(
+      "Une proposition de synthèse suffisamment développée."
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("permet de modifier puis d'enregistrer la synthèse existante", async () => {
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Modifier le texte" }));
+    const editor = screen.getByLabelText("Texte public");
+    expect(editor).toHaveValue("Une synthèse existante relue par la rédaction.");
+    await user.clear(editor);
+    await user.type(
+      editor,
+      "Cette synthèse corrigée présente les principaux axes du programme documenté et leurs moyens."
+    );
+    await user.click(screen.getByRole("button", { name: "Enregistrer la synthèse" }));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/admin/candidats/cand-1/synthesis", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        synthesis:
+          "Cette synthèse corrigée présente les principaux axes du programme documenté et leurs moyens.",
+      }),
+    });
   });
 
   // Le bug d'origine : la synthèse d'Arthaud, écrite sur une candidature vide, niait les cinq
@@ -240,9 +271,7 @@ describe("CandidatesListClient", () => {
     // son programme. Le bouton la porte aussi, plutôt que de laisser l'action répondre par un refus.
     render(<CandidatesListClient rows={[row({ status: "PRESSENTI" })]} />);
 
-    expect(
-      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Générer une proposition" })).toBeDisabled();
   });
 
   it("affiche l'échec d'une régénération au lieu de le taire", async () => {
@@ -253,9 +282,7 @@ describe("CandidatesListClient", () => {
     const user = userEvent.setup();
     render(<CandidatesListClient rows={[row()]} />);
 
-    await user.click(
-      screen.getByRole("button", { name: "Régénérer la synthèse de Alix Démonstration" })
-    );
+    await user.click(screen.getByRole("button", { name: "Générer une proposition" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Texte refusé par le contrôle : tiret_long."

--- a/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
+++ b/src/app/admin/candidats/__tests__/CandidatesListClient.test.tsx
@@ -3,7 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CandidatesListClient, type CandidateRowView } from "../CandidatesListClient";
 
-type ActionResult = { ok: true; text?: string } | { ok: false; message: string };
+type ActionResult =
+  | { ok: true; text?: string; reviewWarning?: string }
+  | { ok: false; message: string };
 
 const setCandidacyPublicationMock = vi.fn<(input: unknown) => Promise<ActionResult>>(async () => ({
   ok: true,
@@ -222,6 +224,26 @@ describe("CandidatesListClient", () => {
     expect(regenerateCandidateSynthesisMock).toHaveBeenCalledWith({ candidacyId: "cand-1" });
     expect(await screen.findByLabelText("Texte public")).toHaveValue(
       "Une proposition de synthèse suffisamment développée."
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ouvre aussi une proposition refusée avec le motif à corriger", async () => {
+    regenerateCandidateSynthesisMock.mockResolvedValueOnce({
+      ok: true,
+      text: "Une proposition lisible qui doit encore être corrigée avant publication.",
+      reviewWarning: "Cette proposition n'a pas passé le contrôle automatique : mention parquet.",
+    });
+    const user = userEvent.setup();
+    render(<CandidatesListClient rows={[row()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Générer une proposition" }));
+
+    expect(await screen.findByLabelText("Texte public")).toHaveValue(
+      "Une proposition lisible qui doit encore être corrigée avant publication."
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Cette proposition n'a pas passé le contrôle automatique : mention parquet."
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -341,9 +341,33 @@ describe("génération d'une proposition de synthèse", () => {
     const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
 
     expect(result).toEqual({ ok: true, text: "Une synthèse." });
-    expect(generateSynthesisMock).toHaveBeenCalledWith("cand-1", { persist: false });
+    expect(generateSynthesisMock).toHaveBeenCalledWith("cand-1", {
+      persist: false,
+      returnRejectedProposal: true,
+    });
     expect(invalidateCandidacyTagsMock).not.toHaveBeenCalled();
     expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it("transmet à l'éditeur l'avertissement du contrôle automatique", async () => {
+    generateSynthesisMock.mockResolvedValue({
+      ok: true,
+      text: "Une proposition à corriger.",
+      provider: "mistral-large-latest",
+      measureCount: 5,
+      mandateCount: 0,
+      persisted: false,
+      reviewWarning: "Cette proposition n'a pas passé le contrôle automatique.",
+    });
+    const { regenerateCandidateSynthesisAction } = await actions();
+
+    const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
+
+    expect(result).toEqual({
+      ok: true,
+      text: "Une proposition à corriger.",
+      reviewWarning: "Cette proposition n'a pas passé le contrôle automatique.",
+    });
   });
 
   it("rend le refus du service au lieu de le traduire en échec générique", async () => {

--- a/src/app/admin/candidats/__tests__/actions.test.ts
+++ b/src/app/admin/candidats/__tests__/actions.test.ts
@@ -79,10 +79,10 @@ beforeEach(() => {
   generateSynthesisMock.mockResolvedValue({
     ok: true,
     text: "Une synthèse.",
-    provider: "anthropic",
+    provider: "mistral-large-latest",
     measureCount: 5,
     mandateCount: 0,
-    persisted: true,
+    persisted: false,
   });
 });
 
@@ -326,7 +326,7 @@ describe("statut politique d'une candidature", () => {
  * Same doctrine as the two switches above: the action is a network endpoint, so an unauthenticated
  * call must reach neither the provider nor the database.
  */
-describe("régénération de la synthèse d'une candidature", () => {
+describe("génération d'une proposition de synthèse", () => {
   it("n'appelle pas le générateur sans session", async () => {
     isAuthenticatedMock.mockResolvedValue(false);
     const { regenerateCandidateSynthesisAction } = await actions();
@@ -335,16 +335,15 @@ describe("régénération de la synthèse d'une candidature", () => {
     expect(generateSynthesisMock).not.toHaveBeenCalled();
   });
 
-  it("écrit la synthèse et purge le tag des surfaces présidentielles", async () => {
+  it("renvoie une proposition sans écrire ni purger les surfaces publiques", async () => {
     const { regenerateCandidateSynthesisAction } = await actions();
 
     const result = await regenerateCandidateSynthesisAction({ candidacyId: "cand-1" });
 
-    expect(result).toEqual({ ok: true });
-    expect(generateSynthesisMock).toHaveBeenCalledWith("cand-1", { persist: true });
-    // Sans cette purge, la fiche sert l'ancien texte jusqu'au filet ISR de 24 h.
-    expect(invalidateCandidacyTagsMock).toHaveBeenCalledWith("elec-1");
-    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/candidats");
+    expect(result).toEqual({ ok: true, text: "Une synthèse." });
+    expect(generateSynthesisMock).toHaveBeenCalledWith("cand-1", { persist: false });
+    expect(invalidateCandidacyTagsMock).not.toHaveBeenCalled();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
   });
 
   it("rend le refus du service au lieu de le traduire en échec générique", async () => {

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -27,7 +27,9 @@ import { generateCandidateSynthesis } from "@/services/candidate-synthesis";
  */
 
 /** Business errors are returned so the moderator reads the reason on screen; auth failures throw. */
-export type CandidacyActionResult = { ok: true; text?: string } | { ok: false; message: string };
+export type CandidacyActionResult =
+  | { ok: true; text?: string; reviewWarning?: string }
+  | { ok: false; message: string };
 
 const publicationStatusSchema = z.enum(["DRAFT", "PUBLISHED", "ARCHIVED", "EXCLUDED", "REJECTED"]);
 
@@ -313,7 +315,10 @@ export async function regenerateCandidateSynthesisAction(input: {
     return { ok: false, message: "Candidature introuvable." };
   }
 
-  const result = await generateCandidateSynthesis(candidacyId, { persist: false });
+  const result = await generateCandidateSynthesis(candidacyId, {
+    persist: false,
+    returnRejectedProposal: true,
+  });
   if (!result.ok) {
     return { ok: false, message: result.message };
   }
@@ -321,5 +326,9 @@ export async function regenerateCandidateSynthesisAction(input: {
   // Nothing is written here. The moderator receives a proposal, edits it if needed, then saves it
   // through the reviewed-synthesis endpoint. This prevents a provider response from becoming
   // public solely because somebody clicked "Générer".
-  return { ok: true, text: result.text };
+  return {
+    ok: true,
+    text: result.text,
+    ...(result.reviewWarning ? { reviewWarning: result.reviewWarning } : {}),
+  };
 }

--- a/src/app/admin/candidats/actions.ts
+++ b/src/app/admin/candidats/actions.ts
@@ -27,7 +27,7 @@ import { generateCandidateSynthesis } from "@/services/candidate-synthesis";
  */
 
 /** Business errors are returned so the moderator reads the reason on screen; auth failures throw. */
-export type CandidacyActionResult = { ok: true } | { ok: false; message: string };
+export type CandidacyActionResult = { ok: true; text?: string } | { ok: false; message: string };
 
 const publicationStatusSchema = z.enum(["DRAFT", "PUBLISHED", "ARCHIVED", "EXCLUDED", "REJECTED"]);
 
@@ -282,7 +282,7 @@ export async function setProgramEditionPublicationAction(input: {
 }
 
 /**
- * Regenerates the synthesis of one candidacy, inline, on the moderator's click.
+ * Generates a synthesis proposal for one candidacy, inline, on the moderator's click.
  *
  * Inline and not queued, following `regenerateScrutinPolicyTitle`: one candidacy is one or two
  * provider calls, the moderator is watching the row, and a queue would put a job board between them
@@ -291,7 +291,8 @@ export async function setProgramEditionPublicationAction(input: {
  *
  * The generation itself, including the rule that only a DECLARED candidacy carries a synthesis,
  * belongs to `@/services/candidate-synthesis`. This action adds what an admin surface owes: the
- * session check, the input validation, the cache purge, and a refusal the moderator can read.
+ * session check, input validation, and a refusal the moderator can read. Cache invalidation only
+ * happens later, when the moderator explicitly saves the reviewed proposal.
  */
 export async function regenerateCandidateSynthesisAction(input: {
   candidacyId: string;
@@ -312,15 +313,13 @@ export async function regenerateCandidateSynthesisAction(input: {
     return { ok: false, message: "Candidature introuvable." };
   }
 
-  const result = await generateCandidateSynthesis(candidacyId, { persist: true });
+  const result = await generateCandidateSynthesis(candidacyId, { persist: false });
   if (!result.ok) {
     return { ok: false, message: result.message };
   }
 
-  // The fiche reads the synthesis through `getPoliticianPresidentialCandidacy`, which carries this
-  // tag: without the purge the new text waits out the 24h ISR backstop behind the old one.
-  invalidatePresidentialCandidacyTags(candidacy.electionId);
-  revalidate();
-
-  return { ok: true };
+  // Nothing is written here. The moderator receives a proposal, edits it if needed, then saves it
+  // through the reviewed-synthesis endpoint. This prevents a provider response from becoming
+  // public solely because somebody clicked "Générer".
+  return { ok: true, text: result.text };
 }

--- a/src/app/admin/candidats/page.tsx
+++ b/src/app/admin/candidats/page.tsx
@@ -60,6 +60,7 @@ export default async function AdminCandidatsPage() {
             })
           ? "CONTRADICTED"
           : "CURRENT",
+      synthesis: candidacy.presidentialData?.synthesis ?? null,
       synthesisGeneratedAt: candidacy.presidentialData?.synthesisGeneratedAt ?? null,
       editions: editions
         .filter((edition) => edition.candidacyId === candidacy.id)

--- a/src/app/api/admin/candidats/[id]/synthesis/route.ts
+++ b/src/app/api/admin/candidats/[id]/synthesis/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/api/with-admin-auth";
+import { invalidatePresidentialCandidacyTags } from "@/lib/presidentielle/candidacy-cache";
+import { getRequestMeta } from "@/lib/security/audit";
+import { reviewCandidateSynthesisSchema } from "@/lib/security/schemas";
+import { withValidation } from "@/lib/security/validate";
+import { saveReviewedCandidateSynthesis } from "@/services/candidate-synthesis";
+
+export const PATCH = withAdminAuth(
+  withValidation(reviewCandidateSynthesisSchema, async (request, context, body) => {
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json({ error: "Candidature introuvable." }, { status: 404 });
+    }
+
+    const { ip, userAgent } = getRequestMeta(request);
+    const result = await saveReviewedCandidateSynthesis(id, body.synthesis, {
+      ipAddress: ip ?? undefined,
+      userAgent: userAgent ?? undefined,
+    });
+    if (!result.ok) {
+      return NextResponse.json({ error: result.message }, { status: 400 });
+    }
+
+    invalidatePresidentialCandidacyTags(result.electionId);
+    return NextResponse.json({ success: true });
+  })
+);

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -4,6 +4,7 @@ import {
   buildCandidateSynthesisGroundingPrompt,
   buildCanonicalCareer,
   buildSynthesisSystemPrompt,
+  formatCandidateSynthesisProposal,
   isSynthesisContradictedByMeasures,
   screenCandidateSynthesis,
   screenSynthesis as screenSynthesisSegments,
@@ -279,6 +280,29 @@ describe("buildCandidateSynthesisPrompt", () => {
       measures: [{ theme: "SANTE", text: "a".repeat(1000) }],
     });
     expect(prompt).toContain("a".repeat(1000));
+  });
+});
+
+describe("formatCandidateSynthesisProposal", () => {
+  it("conserve un brouillon éditable sans reprendre un parcours inventé", () => {
+    const proposal = formatCandidateSynthesisProposal(
+      {
+        career: "Jeanne Martin a exercé une fonction absente des données.",
+        programmeClaims: [
+          {
+            text: "Les mesures rapprochent les soins de proximité et les dessertes ferroviaires. (M1, M3)",
+          },
+        ],
+      },
+      BASE
+    );
+
+    expect(proposal).toContain(buildCanonicalCareer(BASE));
+    expect(proposal).toContain(
+      "Les mesures rapprochent les soins de proximité et les dessertes ferroviaires."
+    );
+    expect(proposal).not.toContain("fonction absente");
+    expect(proposal).not.toContain("M1");
   });
 });
 

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -33,8 +33,20 @@ const BASE: CandidateSynthesisInput = {
   candidateName: "Jeanne Martin",
   partyLabel: "Parti fictif",
   mandates: [
-    { role: "Députée", institution: "Assemblée nationale", startYear: 2017, endYear: null },
-    { role: "Maire", institution: "Villeneuve", startYear: 2008, endYear: 2017 },
+    {
+      role: "Députée",
+      institution: "Assemblée nationale",
+      startYear: 2017,
+      endYear: null,
+      isCurrent: true,
+    },
+    {
+      role: "Maire",
+      institution: "Villeneuve",
+      startYear: 2008,
+      endYear: 2017,
+      isCurrent: false,
+    },
   ],
   voteCount: 421,
   measures: [
@@ -75,36 +87,42 @@ describe("buildCandidateSynthesisPrompt", () => {
           institution: "Assemblée nationale",
           startYear: 2024,
           endYear: null,
+          isCurrent: true,
         },
         {
           role: "député français",
           institution: "Assemblée nationale",
           startYear: 2022,
           endYear: 2024,
+          isCurrent: false,
         },
         {
           role: "député français",
           institution: "Assemblée nationale",
           startYear: 2017,
           endYear: 2022,
+          isCurrent: false,
         },
         {
           role: "Députée de la 2e circonscription",
           institution: "Assemblée nationale",
           startYear: 2013,
           endYear: 2017,
+          isCurrent: false,
         },
         {
           role: "Ministre de l'Écologie",
           institution: "Gouvernement Jean-Marc Ayrault n°2",
           startYear: 2012,
           endYear: 2013,
+          isCurrent: false,
         },
         {
           role: "député français",
           institution: "Assemblée nationale",
           startYear: 2007,
           endYear: 2012,
+          isCurrent: false,
         },
       ],
     });
@@ -113,6 +131,50 @@ describe("buildCandidateSynthesisPrompt", () => {
       "Delphine Batho est actuellement députée de la 2e circonscription (Assemblée nationale), avec des mandats enregistrés depuis 2007. Delphine Batho a également été ministre de l'Écologie (Gouvernement Jean-Marc Ayrault n°2) de 2012 à 2013."
     );
     expect(career.match(/Assemblée nationale/g)).toHaveLength(1);
+  });
+
+  it("utilise isCurrent même quand une fin de mandat importée n'a pas de date", () => {
+    const career = buildCanonicalCareer({
+      ...BASE,
+      mandates: [
+        {
+          role: "Député français",
+          institution: "Assemblée nationale",
+          startYear: 2022,
+          endYear: null,
+          isCurrent: false,
+        },
+      ],
+    });
+
+    expect(career).not.toContain("actuellement");
+    expect(career).not.toContain("depuis 2022");
+    expect(career).toContain("à partir de 2022");
+  });
+
+  it("fusionne aussi les mandats successifs d'une sénatrice", () => {
+    const career = buildCanonicalCareer({
+      ...BASE,
+      mandates: [
+        {
+          role: "Sénatrice",
+          institution: "Sénat",
+          startYear: 2023,
+          endYear: null,
+          isCurrent: true,
+        },
+        {
+          role: "Sénatrice",
+          institution: "Sénat",
+          startYear: 2017,
+          endYear: 2023,
+          isCurrent: false,
+        },
+      ],
+    });
+
+    expect(career.match(/Sénat/g)).toHaveLength(1);
+    expect(career).toContain("mandats enregistrés depuis 2017");
   });
 
   it("groups measures by theme under their French label", () => {
@@ -590,6 +652,22 @@ describe("screenSynthesis", () => {
     // "procession" contains "procès" only if the pattern forgets its word boundaries.
     const result = screenSynthesis(`Elle a ouvert la procession du 14 juillet. ${words(120)}`);
     expect(result.ok).toBe(true);
+  });
+
+  it("refuse chaque famille judiciaire absente des sources", () => {
+    const result = screenSynthesisSegments({
+      text: `Le programme prévoit un parquet spécialisé sans évoquer de condamnation individuelle. ${words(40)}`,
+      generatedText:
+        "Le programme prévoit un parquet spécialisé sans évoquer de condamnation individuelle.",
+      exemptSourceTexts: [],
+      allowedJudicialSourceTexts: ["Créer un parquet financier spécialisé."],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "judiciaire",
+      detail: "mention « condamnation »",
+    });
   });
 
   it.each(["—", "–"])("rejects the long dash %s", (dash) => {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -61,8 +61,58 @@ function screenSynthesis(raw: string, material?: SynthesisMaterial) {
 describe("buildCandidateSynthesisPrompt", () => {
   it("construit le parcours uniquement avec les mandats enregistrés", () => {
     expect(buildCanonicalCareer(BASE)).toBe(
-      "Jeanne Martin a exercé les fonctions suivantes : Députée (Assemblée nationale) depuis 2017 et Maire (Villeneuve) de 2008 à 2017."
+      "Jeanne Martin est actuellement députée (Assemblée nationale) depuis 2017. Jeanne Martin a également été maire (Villeneuve) de 2008 à 2017."
     );
+  });
+
+  it("fusionne les mandats parlementaires découpés par législature", () => {
+    const career = buildCanonicalCareer({
+      ...BASE,
+      candidateName: "Delphine Batho",
+      mandates: [
+        {
+          role: "Députée de la 2ème circonscription",
+          institution: "Assemblée nationale",
+          startYear: 2024,
+          endYear: null,
+        },
+        {
+          role: "député français",
+          institution: "Assemblée nationale",
+          startYear: 2022,
+          endYear: 2024,
+        },
+        {
+          role: "député français",
+          institution: "Assemblée nationale",
+          startYear: 2017,
+          endYear: 2022,
+        },
+        {
+          role: "Députée de la 2e circonscription",
+          institution: "Assemblée nationale",
+          startYear: 2013,
+          endYear: 2017,
+        },
+        {
+          role: "Ministre de l'Écologie",
+          institution: "Gouvernement Jean-Marc Ayrault n°2",
+          startYear: 2012,
+          endYear: 2013,
+        },
+        {
+          role: "député français",
+          institution: "Assemblée nationale",
+          startYear: 2007,
+          endYear: 2012,
+        },
+      ],
+    });
+
+    expect(career).toBe(
+      "Delphine Batho est actuellement députée de la 2e circonscription (Assemblée nationale), avec des mandats enregistrés depuis 2007. Delphine Batho a également été ministre de l'Écologie (Gouvernement Jean-Marc Ayrault n°2) de 2012 à 2013."
+    );
+    expect(career.match(/Assemblée nationale/g)).toHaveLength(1);
   });
 
   it("groups measures by theme under their French label", () => {
@@ -193,6 +243,21 @@ describe("screenCandidateSynthesis", () => {
     expect(result.ok && result.text).toContain("les engagements rapprochent");
     expect(result.ok && result.text).toContain("dessertes ferroviaires");
     expect(result.ok && result.text).not.toContain("thèmes suivants");
+  });
+
+  it("retire les espaces laissés devant la ponctuation par les marqueurs de preuve", () => {
+    const raw = output([
+      {
+        text: `${healthAxis} M1 .`,
+        measureRefs: ["M1", "M2"],
+      },
+      { text: `${transportAxis} M3 .`, measureRefs: ["M3"] },
+    ]);
+
+    const result = screenCandidateSynthesis(raw, BASE);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(result.ok && result.text).not.toMatch(/\s+[.,;:!?]/u);
   });
 
   it("accepte le vocabulaire judiciaire lorsqu'il provient d'une mesure citée", () => {
@@ -404,6 +469,13 @@ describe("buildSynthesisSystemPrompt", () => {
         "Recopie sans la modifier la phrase de parcours"
       );
     }
+  });
+
+  it("demande de hiérarchiser les axes sans couvrir chaque thème", () => {
+    const prompt = buildSynthesisSystemPrompt(FULL);
+
+    expect(prompt).toContain("Ne cherche pas à couvrir chaque thème");
+    expect(prompt).toContain("Hiérarchise");
   });
 
   it("accorde cent mots au plus à un parcours entièrement documenté", () => {

--- a/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidate-synthesis.test.ts
@@ -195,6 +195,29 @@ describe("screenCandidateSynthesis", () => {
     expect(result.ok && result.text).not.toContain("thèmes suivants");
   });
 
+  it("accepte le vocabulaire judiciaire lorsqu'il provient d'une mesure citée", () => {
+    const input: CandidateSynthesisInput = {
+      ...BASE,
+      measures: [
+        {
+          theme: "SECURITE_JUSTICE",
+          text: "Créer des parquets financiers européens aux compétences élargies.",
+        },
+      ],
+    };
+    const result = screenCandidateSynthesis(
+      output([
+        {
+          text: "Sur la justice, le programme propose de créer un parquet financier européen aux compétences élargies pour traiter les dossiers concernés.",
+          measureRefs: ["M1"],
+        },
+      ]),
+      input
+    );
+
+    expect(result).toMatchObject({ ok: true });
+  });
+
   it("refuse l'ancien sommaire de thèmes", () => {
     expect(
       screenCandidateSynthesis(
@@ -428,7 +451,8 @@ describe("buildSynthesisSystemPrompt", () => {
 
   it("garde les règles absolues quelle que soit la matière", () => {
     const prompt = buildSynthesisSystemPrompt(BARE);
-    expect(prompt).toContain("Ne mentionne AUCUNE affaire judiciaire");
+    expect(prompt).toContain("Ne mentionne AUCUNE affaire judiciaire concernant la personne");
+    expect(prompt).toContain("vocabulaire de la justice");
     expect(prompt).toContain("Aucun tiret cadratin");
   });
 });

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -169,6 +169,15 @@ const generatedCandidateSynthesisSchema = z
   })
   .strict();
 
+/** Wider than the publication schema, but still bounded, for a moderator-editable JSON draft. */
+const reviewableCandidateSynthesisSchema = z
+  .object({
+    programmeClaims: z
+      .array(z.object({ text: z.string().trim().min(1).max(2_000) }).passthrough())
+      .max(12),
+  })
+  .passthrough();
+
 type ProgrammeReference = {
   ref: string;
   theme: ThemeCategory;
@@ -547,6 +556,32 @@ function stripEvidenceMarkers(value: string): string {
     .replace(/\s+/g, " ")
     .replace(/\s+([,.;:!?])/gu, "$1")
     .trim();
+}
+
+/**
+ * Turns a structurally usable provider response into an admin-review proposal.
+ *
+ * This deliberately does not make the text publishable: the strict screen and grounding pass may
+ * still reject it. Its sole purpose is to avoid throwing away readable work when a moderator can
+ * correct the precise defect in the editor. The career remains deterministic even in that draft,
+ * so an invented office never reaches the review surface.
+ */
+export function formatCandidateSynthesisProposal(
+  raw: unknown,
+  input: CandidateSynthesisInput
+): string | null {
+  const parsed = reviewableCandidateSynthesisSchema.safeParse(raw);
+  if (!parsed.success) return null;
+
+  const claims = parsed.data.programmeClaims
+    .map((claim) => stripEvidenceMarkers(claim.text))
+    .filter(Boolean);
+  if (input.measures.length > 0 && claims.length === 0) return null;
+
+  return [
+    buildCanonicalCareer(input),
+    ...(input.measures.length === 0 ? [EMPTY_PROGRAMME_SENTENCE] : claims),
+  ].join("\n\n");
 }
 
 export function screenCandidateSynthesis(

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -46,7 +46,7 @@ const FIELD_LIMIT = 240;
  * the tightest margin being 27 words against a floor of 25.
  */
 export const SYNTHESIS_MAX_WORDS = 200;
-/** Five programme themes plus a career paragraph fit without turning into a catalogue. */
+/** Four programme axes plus a career paragraph fit without turning into a catalogue. */
 export const LARGE_SYNTHESIS_MAX_WORDS = 250;
 /**
  * Safety ceiling, deliberately distinct from the editorial target.
@@ -61,7 +61,7 @@ export const SYNTHESIS_HARD_MAX_WORDS = 350;
 /** Below one hundred measures, the existing 200-word format already carries the material. */
 export const LARGE_PROGRAMME_MEASURES = 100;
 /** Enough alternatives for the model to choose without sending an entire manifesto. */
-export const MAX_PROGRAMME_CLAIMS = 5;
+export const MAX_PROGRAMME_CLAIMS = 4;
 
 /** The provider writes the career and a bounded set of programme axes. */
 export const TARGET_EMPTY_CAREER_MIN = 8;
@@ -220,12 +220,102 @@ function safeCorpus(value: string): string {
 
 /** Reader-facing measure wording, changed only where the house style already requires it. */
 function canonicalMeasureText(value: string): string {
-  return value.replace(/[—–]/g, "-").replace(/\s+/g, " ").trim();
+  return value
+    .replace(/[—–]/g, "-")
+    .replace(/\b1(?:er|ère|eme|ème)\b/giu, "1re")
+    .replace(/\b([2-9]|[1-9][0-9]+)(?:eme|ème)\b/giu, "$1e")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function joinFrench(items: string[]): string {
   if (items.length <= 1) return items[0] ?? "";
   return `${items.slice(0, -1).join(", ")} et ${items.at(-1)}`;
+}
+
+type CanonicalMandate = SynthesisMandate & { occurrences: number };
+
+function mandateFamily(role: string, institution: string | null): string | null {
+  const plainRole = role.normalize("NFD").replace(/\p{M}/gu, "").toLowerCase();
+  const plainInstitution = (institution ?? "")
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase();
+  if (/depute/u.test(plainRole) && /assemblee nationale/u.test(plainInstitution)) {
+    return "depute-assemblee-nationale";
+  }
+  if (/senateur/u.test(plainRole) && /senat/u.test(plainInstitution)) {
+    return "senateur-senat";
+  }
+  if (/(?:depute europeen|parlement europeen)/u.test(`${plainRole} ${plainInstitution}`)) {
+    return "depute-parlement-europeen";
+  }
+  return null;
+}
+
+/** Legislative imports split one parliamentary function into one row per legislature. */
+function compactMandates(mandates: SynthesisMandate[]): CanonicalMandate[] {
+  const compacted: CanonicalMandate[] = [];
+  const families = new Map<string, number>();
+  for (const mandate of mandates) {
+    const normalized = {
+      ...mandate,
+      role: canonicalMeasureText(mandate.role),
+      institution: mandate.institution ? canonicalMeasureText(mandate.institution) : null,
+    };
+    const family = mandateFamily(normalized.role, normalized.institution);
+    const existingIndex = family ? families.get(family) : undefined;
+    if (existingIndex === undefined) {
+      compacted.push({ ...normalized, occurrences: 1 });
+      if (family) families.set(family, compacted.length - 1);
+      continue;
+    }
+
+    const existing = compacted[existingIndex]!;
+    existing.occurrences += 1;
+    if (normalized.role.length > existing.role.length) existing.role = normalized.role;
+    if (normalized.startYear !== null) {
+      existing.startYear =
+        existing.startYear === null
+          ? normalized.startYear
+          : Math.min(existing.startYear, normalized.startYear);
+    }
+    existing.endYear =
+      existing.endYear === null || normalized.endYear === null
+        ? null
+        : Math.max(existing.endYear, normalized.endYear);
+  }
+  return compacted;
+}
+
+function lowercaseInitial(value: string): string {
+  return value.length === 0 ? value : `${value[0]!.toLocaleLowerCase("fr")}${value.slice(1)}`;
+}
+
+function formatCanonicalMandate(mandate: CanonicalMandate): string {
+  const institution = mandate.institution ? canonicalMeasureText(mandate.institution) : null;
+  let role = canonicalMeasureText(mandate.role);
+  if (institution && role.endsWith(` - ${institution}`)) {
+    role = role.slice(0, -` - ${institution}`.length);
+  }
+  if (/^Dirigeant\(e\)$/iu.test(role) && institution) {
+    role = `Direction de ${institution}`;
+  }
+  const where = institution && !role.includes(institution) ? ` (${institution})` : "";
+  if (mandate.occurrences > 1 && mandate.startYear) {
+    const dates = mandate.endYear
+      ? `, à plusieurs reprises de ${mandate.startYear} à ${mandate.endYear}`
+      : `, avec des mandats enregistrés depuis ${mandate.startYear}`;
+    return `${role}${where}${dates}`;
+  }
+  const dates = mandate.startYear
+    ? mandate.endYear
+      ? mandate.startYear === mandate.endYear
+        ? ` en ${mandate.startYear}`
+        : ` de ${mandate.startYear} à ${mandate.endYear}`
+      : ` depuis ${mandate.startYear}`
+    : "";
+  return `${role}${where}${dates}`;
 }
 
 /** Career wording is deterministic: the model cannot add a plausible but unrecorded office. */
@@ -234,24 +324,27 @@ export function buildCanonicalCareer(input: CandidateSynthesisInput): string {
   if (input.mandates.length === 0) {
     return `${name} ne dispose d'aucun mandat enregistré sur le site.`;
   }
-  const mandates = input.mandates.map((mandate) => {
-    const institution = mandate.institution ? canonicalMeasureText(mandate.institution) : null;
-    let role = canonicalMeasureText(mandate.role);
-    if (institution && role.endsWith(` - ${institution}`)) {
-      role = role.slice(0, -` - ${institution}`.length);
-    }
-    if (/^Dirigeant\(e\)$/iu.test(role) && institution) {
-      role = `Direction de ${institution}`;
-    }
-    const where = institution && !role.includes(institution) ? ` (${institution})` : "";
-    const dates = mandate.startYear
-      ? mandate.endYear
-        ? ` de ${mandate.startYear} à ${mandate.endYear}`
-        : ` depuis ${mandate.startYear}`
-      : "";
-    return `${role}${where}${dates}`;
-  });
-  return `${name} a exercé les fonctions suivantes : ${joinFrench(mandates)}.`;
+  const mandates = compactMandates(input.mandates).map((mandate) => ({
+    ...mandate,
+    text: formatCanonicalMandate(mandate),
+  }));
+  const current = mandates.filter((mandate) => mandate.endYear === null);
+  const previous = mandates.filter((mandate) => mandate.endYear !== null);
+  const sentences: string[] = [];
+  if (current.length > 0) {
+    const roles = current.map((mandate) => {
+      const text = lowercaseInitial(mandate.text);
+      return text.startsWith("direction de ") ? `à la ${text}` : text;
+    });
+    sentences.push(`${name} est actuellement ${joinFrench(roles)}.`);
+  }
+  if (previous.length > 0) {
+    const roles = previous.map((mandate) => lowercaseInitial(mandate.text));
+    sentences.push(
+      `${name} ${current.length > 0 ? "a également" : "a notamment"} été ${joinFrench(roles)}.`
+    );
+  }
+  return sentences.join(" ");
 }
 
 /**
@@ -273,6 +366,8 @@ Règles absolues :
 - Aucune comparaison avec un autre candidat.
 - Ne compte pas les mesures et ne dis pas combien il y en a : le chiffre est affiché à côté et il bougera.
 - Appuie-toi sur la répartition fournie pour comprendre le corpus, sans énumérer mécaniquement ses thèmes.
+- Ne cherche pas à couvrir chaque thème. Hiérarchise les idées selon leur place dans le corpus et ne retiens une mesure isolée que si elle apporte un axe distinct.
+- Ne transforme pas les intitulés de thèmes en débuts de paragraphes administratifs comme « Les institutions... », « La justice... » ou « En matière de... ».
 - Dégage les idées directrices et les moyens récurrents. Relie plusieurs mesures lorsqu'elles forment réellement un même axe.
 - Ne juxtapose pas les mesures et ne reproduis pas leur formulation l'une après l'autre.
 - Chaque affirmation sur le programme doit citer les références exactes des mesures qui l'étayent.
@@ -429,8 +524,9 @@ function isComparativeClaim(value: string): boolean {
 function stripEvidenceMarkers(value: string): string {
   return value
     .replace(/\s*[([]\s*M[1-9][0-9]*(?:\s*[,;]\s*M[1-9][0-9]*)*\s*[)\]]/gu, " ")
-    .replace(/\s+M[1-9][0-9]*(?:\s*[,;]\s*M[1-9][0-9]*)*(?=[,.;:!?]|$)/gu, "")
+    .replace(/\s+M[1-9][0-9]*(?:\s*[,;]\s*M[1-9][0-9]*)*(?=\s*[,.;:!?]|$)/gu, "")
     .replace(/\s+/g, " ")
+    .replace(/\s+([,.;:!?])/gu, "$1")
     .trim();
 }
 

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -132,6 +132,8 @@ export type SynthesisMandate = {
   institution: string | null;
   startYear: number | null;
   endYear: number | null;
+  /** The domain flag is authoritative; a closed imported row may still have no end date. */
+  isCurrent: boolean;
 };
 
 export type CandidateSynthesisInput = {
@@ -244,7 +246,7 @@ function mandateFamily(role: string, institution: string | null): string | null 
   if (/depute/u.test(plainRole) && /assemblee nationale/u.test(plainInstitution)) {
     return "depute-assemblee-nationale";
   }
-  if (/senateur/u.test(plainRole) && /senat/u.test(plainInstitution)) {
+  if (/(?:senateur|senatrice)/u.test(plainRole) && /senat/u.test(plainInstitution)) {
     return "senateur-senat";
   }
   if (/(?:depute europeen|parlement europeen)/u.test(`${plainRole} ${plainInstitution}`)) {
@@ -281,15 +283,27 @@ function compactMandates(mandates: SynthesisMandate[]): CanonicalMandate[] {
           : Math.min(existing.startYear, normalized.startYear);
     }
     existing.endYear =
-      existing.endYear === null || normalized.endYear === null
+      existing.isCurrent || normalized.isCurrent
         ? null
-        : Math.max(existing.endYear, normalized.endYear);
+        : Math.max(existing.endYear ?? 0, normalized.endYear ?? 0) || null;
+    existing.isCurrent ||= normalized.isCurrent;
   }
   return compacted;
 }
 
 function lowercaseInitial(value: string): string {
   return value.length === 0 ? value : `${value[0]!.toLocaleLowerCase("fr")}${value.slice(1)}`;
+}
+
+function containsWholePhrase(value: string, phrase: string): boolean {
+  let offset = value.indexOf(phrase);
+  while (offset >= 0) {
+    const before = value[offset - 1];
+    const after = value[offset + phrase.length];
+    if ((!before || !/\p{L}/u.test(before)) && (!after || !/\p{L}/u.test(after))) return true;
+    offset = value.indexOf(phrase, offset + 1);
+  }
+  return false;
 }
 
 function formatCanonicalMandate(mandate: CanonicalMandate): string {
@@ -301,19 +315,23 @@ function formatCanonicalMandate(mandate: CanonicalMandate): string {
   if (/^Dirigeant\(e\)$/iu.test(role) && institution) {
     role = `Direction de ${institution}`;
   }
-  const where = institution && !role.includes(institution) ? ` (${institution})` : "";
+  const where = institution && !containsWholePhrase(role, institution) ? ` (${institution})` : "";
   if (mandate.occurrences > 1 && mandate.startYear) {
-    const dates = mandate.endYear
-      ? `, à plusieurs reprises de ${mandate.startYear} à ${mandate.endYear}`
-      : `, avec des mandats enregistrés depuis ${mandate.startYear}`;
+    const dates = mandate.isCurrent
+      ? `, avec des mandats enregistrés depuis ${mandate.startYear}`
+      : mandate.endYear
+        ? `, à plusieurs reprises de ${mandate.startYear} à ${mandate.endYear}`
+        : `, avec des mandats enregistrés à partir de ${mandate.startYear}`;
     return `${role}${where}${dates}`;
   }
   const dates = mandate.startYear
-    ? mandate.endYear
-      ? mandate.startYear === mandate.endYear
-        ? ` en ${mandate.startYear}`
-        : ` de ${mandate.startYear} à ${mandate.endYear}`
-      : ` depuis ${mandate.startYear}`
+    ? mandate.isCurrent
+      ? ` depuis ${mandate.startYear}`
+      : mandate.endYear
+        ? mandate.startYear === mandate.endYear
+          ? ` en ${mandate.startYear}`
+          : ` de ${mandate.startYear} à ${mandate.endYear}`
+        : ` à partir de ${mandate.startYear}`
     : "";
   return `${role}${where}${dates}`;
 }
@@ -328,8 +346,8 @@ export function buildCanonicalCareer(input: CandidateSynthesisInput): string {
     ...mandate,
     text: formatCanonicalMandate(mandate),
   }));
-  const current = mandates.filter((mandate) => mandate.endYear === null);
-  const previous = mandates.filter((mandate) => mandate.endYear !== null);
+  const current = mandates.filter((mandate) => mandate.isCurrent);
+  const previous = mandates.filter((mandate) => !mandate.isCurrent);
   const sentences: string[] = [];
   if (current.length > 0) {
     const roles = current.map((mandate) => {
@@ -494,12 +512,13 @@ const JUDICIAL_TERMS = [
   { family: "ineligibilite", pattern: /(?<!\p{L})inéligibilité(?!\p{L})/iu },
 ] as const;
 
-function findJudicialTerm(text: string) {
+function findJudicialTerms(text: string) {
+  const matches: Array<{ family: string; match: string }> = [];
   for (const term of JUDICIAL_TERMS) {
     const match = term.pattern.exec(text);
-    if (match) return { family: term.family, match: match[0] };
+    if (match) matches.push({ family: term.family, match: match[0] });
   }
-  return null;
+  return matches;
 }
 
 function sourceCarriesJudicialFamily(sourceTexts: readonly string[], family: string): boolean {
@@ -842,9 +861,15 @@ export function screenSynthesis({
   // non-word character. `\binéligibilité\b` therefore fails to match the very word it
   // names, which is how this pattern first shipped. Every term here is accented or
   // followed by one, so the whole family was affected.
-  const judicial = findJudicialTerm(generatedText);
-  if (judicial && !sourceCarriesJudicialFamily(allowedJudicialSourceTexts, judicial.family)) {
-    return { ok: false, reason: "judiciaire", detail: `mention « ${judicial.match} »` };
+  const unsupportedJudicial = findJudicialTerms(generatedText).find(
+    (judicial) => !sourceCarriesJudicialFamily(allowedJudicialSourceTexts, judicial.family)
+  );
+  if (unsupportedJudicial) {
+    return {
+      ok: false,
+      reason: "judiciaire",
+      detail: `mention « ${unsupportedJudicial.match} »`,
+    };
   }
 
   const words = wordCount(text);

--- a/src/lib/presidentielle/candidate-synthesis.ts
+++ b/src/lib/presidentielle/candidate-synthesis.ts
@@ -268,7 +268,7 @@ export function buildSynthesisSystemPrompt(_material: SynthesisMaterial): string
 
 Règles absolues :
 - N'écris RIEN qui ne figure pas dans les données fournies. Aucune connaissance extérieure, aucune inférence sur les intentions, aucune prévision.
-- Ne mentionne AUCUNE affaire judiciaire, enquête, mise en examen ou condamnation, même si tu en connais. Ce n'est pas le sujet de ce texte et c'est traité ailleurs sur le site.
+- Ne mentionne AUCUNE affaire judiciaire concernant la personne, même si tu en connais. Tu peux employer le vocabulaire de la justice lorsqu'il décrit explicitement une mesure du programme fourni.
 - Aucun jugement de valeur, aucun qualificatif d'appréciation. Ni « ambitieux », ni « radical », ni « crédible », ni « clivant ». Décris, ne commente pas.
 - Aucune comparaison avec un autre candidat.
 - Ne compte pas les mesures et ne dis pas combien il y en a : le chiffre est affiché à côté et il bougera.
@@ -378,6 +378,38 @@ function wordCount(value: string): number {
 
 function numericTokens(value: string): string[] {
   return value.match(/\b[0-9]+(?:[.,][0-9]+)?(?:\s*%)?/gu) ?? [];
+}
+
+const JUDICIAL_TERMS = [
+  { family: "mise_en_examen", pattern: /(?<!\p{L})mises? en examen(?!\p{L})/iu },
+  {
+    family: "condamnation",
+    pattern: /(?<!\p{L})condamn(?:é|ée|és|ées|ation|ations)(?!\p{L})/iu,
+  },
+  { family: "proces", pattern: /(?<!\p{L})procès(?!\p{L})/iu },
+  { family: "enquete", pattern: /(?<!\p{L})enquête judiciaire(?!\p{L})/iu },
+  { family: "garde_a_vue", pattern: /(?<!\p{L})garde à vue(?!\p{L})/iu },
+  {
+    family: "instruction",
+    pattern: /(?<!\p{L})instruction judiciaire(?!\p{L})/iu,
+  },
+  { family: "tribunal", pattern: /(?<!\p{L})(?:tribunal|tribunaux)(?!\p{L})/iu },
+  { family: "cour_appel", pattern: /(?<!\p{L})cour d['’]appel(?!\p{L})/iu },
+  { family: "parquet", pattern: /(?<!\p{L})parquets?(?!\p{L})/iu },
+  { family: "ineligibilite", pattern: /(?<!\p{L})inéligibilité(?!\p{L})/iu },
+] as const;
+
+function findJudicialTerm(text: string) {
+  for (const term of JUDICIAL_TERMS) {
+    const match = term.pattern.exec(text);
+    if (match) return { family: term.family, match: match[0] };
+  }
+  return null;
+}
+
+function sourceCarriesJudicialFamily(sourceTexts: readonly string[], family: string): boolean {
+  const term = JUDICIAL_TERMS.find((candidate) => candidate.family === family);
+  return Boolean(term && sourceTexts.some((source) => term.pattern.test(source)));
 }
 
 function programmeSafetyFloor(measureCount: number): number {
@@ -563,6 +595,10 @@ export function screenCandidateSynthesis(
     text: `${career}\n\n${programmeText}`,
     generatedText: `${career}\n\n${programmeText}`,
     exemptSourceTexts: [],
+    allowedJudicialSourceTexts: [
+      ...input.measures.map((measure) => measure.text),
+      ...input.mandates.flatMap((mandate) => [mandate.role, mandate.institution ?? ""]),
+    ],
     material: synthesisMaterial(input),
   });
   return screened.ok ? { ...screened, programmeClaims: normalizedClaims } : screened;
@@ -672,6 +708,7 @@ export function screenSynthesis({
   text: raw,
   generatedText,
   exemptSourceTexts,
+  allowedJudicialSourceTexts = [],
   material = {
     mandateCount: SUBSTANTIAL_MANDATES,
     voteCount: SUBSTANTIAL_VOTES,
@@ -684,6 +721,8 @@ export function screenSynthesis({
   generatedText: string;
   /** One canonical source formulation per mandatory theme, excluded from the flexible maximum. */
   exemptSourceTexts: string[];
+  /** Prompt sources allowed to supply institutional judicial vocabulary. */
+  allowedJudicialSourceTexts?: readonly string[];
   /** Omitted, the strictest ordinary floor applies. */
   material?: SynthesisMaterial;
 }): SynthesisScreen {
@@ -707,12 +746,9 @@ export function screenSynthesis({
   // non-word character. `\binéligibilité\b` therefore fails to match the very word it
   // names, which is how this pattern first shipped. Every term here is accented or
   // followed by one, so the whole family was affected.
-  const judicial =
-    /(?<!\p{L})(mises? en examen|condamn(?:é|ée|és|ées|ation|ations)|procès|enquête judiciaire|garde à vue|instruction judiciaire|tribunal|cour d'appel|parquet|inéligibilité)(?!\p{L})/iu.exec(
-      generatedText
-    );
-  if (judicial) {
-    return { ok: false, reason: "judiciaire", detail: `mention « ${judicial[0]} »` };
+  const judicial = findJudicialTerm(generatedText);
+  if (judicial && !sourceCarriesJudicialFamily(allowedJudicialSourceTexts, judicial.family)) {
+    return { ok: false, reason: "judiciaire", detail: `mention « ${judicial.match} »` };
   }
 
   const words = wordCount(text);

--- a/src/lib/security/schemas/__tests__/candidate.test.ts
+++ b/src/lib/security/schemas/__tests__/candidate.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createCandidacyPresidentialFromPickerSchema } from "../candidate";
+import {
+  createCandidacyPresidentialFromPickerSchema,
+  reviewCandidateSynthesisSchema,
+} from "../candidate";
 
 const declare = {
   politicianId: "p1",
@@ -92,6 +95,25 @@ describe("createCandidacyPresidentialFromPickerSchema : declaredAt facultatif (c
       createCandidacyPresidentialFromPickerSchema.safeParse({
         ...declare,
         declaredAt: "2026-03-01T10:00:00.000Z",
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("reviewCandidateSynthesisSchema", () => {
+  it("accepte un texte relu et refuse une valeur trop courte ou un champ imprévu", () => {
+    expect(
+      reviewCandidateSynthesisSchema.safeParse({
+        synthesis: "Une synthèse éditoriale relue et suffisamment développée.",
+      }).success
+    ).toBe(true);
+    expect(reviewCandidateSynthesisSchema.safeParse({ synthesis: "Trop court." }).success).toBe(
+      false
+    );
+    expect(
+      reviewCandidateSynthesisSchema.safeParse({
+        synthesis: "Une synthèse éditoriale relue et suffisamment développée.",
+        publicationStatus: "PUBLISHED",
       }).success
     ).toBe(false);
   });

--- a/src/lib/security/schemas/candidate.ts
+++ b/src/lib/security/schemas/candidate.ts
@@ -8,6 +8,7 @@ const WITHDREW_REASON_MAX = 1000;
 const NOTES_MAX = 2000;
 const RANK_MAX = 999;
 const SOURCE_LABEL_MAX = 300;
+const SYNTHESIS_MAX = 5_000;
 
 export const createCandidatePresidentialSchema = z.object({
   candidacyId: z.string().min(1),
@@ -30,6 +31,10 @@ export const updateCandidatePresidentialSchema = z.object({
   notes: z.string().max(NOTES_MAX).nullable().optional(),
   publicationStatus: z.enum(["DRAFT", "PUBLISHED", "ARCHIVED", "EXCLUDED", "REJECTED"]).optional(),
 });
+
+export const reviewCandidateSynthesisSchema = z
+  .object({ synthesis: z.string().trim().min(20).max(SYNTHESIS_MAX) })
+  .strict();
 
 // Schéma combiné pour POST /api/admin/candidats : crée la Candidacy (via picker)
 // ET les métadonnées CandidacyPresidential dans une seule transaction.

--- a/src/lib/security/schemas/index.ts
+++ b/src/lib/security/schemas/index.ts
@@ -30,4 +30,5 @@ export {
   createCandidatePresidentialSchema,
   updateCandidatePresidentialSchema,
   createCandidacyPresidentialFromPickerSchema,
+  reviewCandidateSynthesisSchema,
 } from "./candidate";

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -129,6 +129,9 @@ describe("generateCandidateSynthesis", () => {
           name: "candidate_synthesis",
           schema: {
             required: ["career", "programmeClaims"],
+            properties: {
+              programmeClaims: { maxItems: 4 },
+            },
           },
         },
       },

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -300,6 +300,50 @@ describe("generateCandidateSynthesis", () => {
     expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
   });
 
+  it("rend à l'admin un brouillon exploitable que l'étayage a refusé", async () => {
+    callMistralMock.mockImplementation((messages: Array<{ content: string }>) => {
+      const grounding = messages.some((message) =>
+        message.content.includes("Vérifie si chaque affirmation")
+      );
+      return Promise.resolve({
+        text: grounding ? groundingOutput(false) : providerOutput(),
+        model: "mistral-large-latest",
+      });
+    });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", {
+      persist: false,
+      returnRejectedProposal: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      persisted: false,
+      reviewWarning: expect.stringContaining("contrôle d'étayage refusé"),
+    });
+    expect(result.ok && result.text).toContain(PROGRAMME_AXIS);
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+    expect(dbMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("ne persiste jamais un brouillon refusé même si l'option de relecture est demandée", async () => {
+    callMistralMock.mockResolvedValue({
+      text: JSON.stringify({ career: `${CAREER}.`, programmeClaims: [] }),
+      model: "mistral-large-latest",
+    });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", {
+      persist: true,
+      returnRejectedProposal: true,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "refuse" });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+    expect(dbMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
   it("gère un programme vide sans lancer de contrôle d'étayage", async () => {
     dbMock.measure.findMany.mockResolvedValue([]);
     callMistralMock.mockResolvedValue({

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -313,3 +313,58 @@ describe("generateCandidateSynthesis", () => {
     );
   });
 });
+
+describe("saveReviewedCandidateSynthesis", () => {
+  it("enregistre explicitement le texte relu et son audit", async () => {
+    const { saveReviewedCandidateSynthesis } = await service();
+    const text = `${CAREER}.\n\n${PROGRAMME_AXIS}`;
+
+    const result = await saveReviewedCandidateSynthesis("cand-1", text, {
+      ipAddress: "203.0.113.10",
+      userAgent: "Poligraph test",
+    });
+
+    expect(result).toEqual({ ok: true, electionId: "elec-1" });
+    expect(dbMock.candidacyPresidential.update).toHaveBeenCalledWith({
+      where: { id: "pres-1" },
+      data: { synthesis: text, synthesisGeneratedAt: expect.any(Date) },
+    });
+    expect(dbMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          changes: expect.objectContaining({ synthesis: text, reviewedManually: true }),
+          ipAddress: "203.0.113.10",
+          userAgent: "Poligraph test",
+        }),
+      })
+    );
+  });
+
+  it("accepte un parquet lorsque le terme figure dans les mesures publiées", async () => {
+    dbMock.measure.findMany.mockResolvedValue([
+      {
+        publishedRevision: {
+          text: "Créer un parquet financier européen aux compétences élargies.",
+        },
+      },
+    ]);
+    const { saveReviewedCandidateSynthesis } = await service();
+    const text = `${CAREER}. Le programme propose de créer un parquet financier européen aux compétences élargies pour les dossiers concernés.`;
+
+    const result = await saveReviewedCandidateSynthesis("cand-1", text);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(dbMock.candidacyPresidential.update).toHaveBeenCalledOnce();
+  });
+
+  it("refuse une mention judiciaire absente du corpus", async () => {
+    const { saveReviewedCandidateSynthesis } = await service();
+    const text = `${CAREER}. Le parquet a ouvert une enquête judiciaire concernant la candidature et ses responsables.`;
+
+    const result = await saveReviewedCandidateSynthesis("cand-1", text);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(dbMock.candidacyPresidential.update).not.toHaveBeenCalled();
+    expect(dbMock.auditLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/candidate-synthesis/__tests__/index.test.ts
+++ b/src/services/candidate-synthesis/__tests__/index.test.ts
@@ -135,6 +135,38 @@ describe("generateCandidateSynthesis", () => {
     });
   });
 
+  it("accepte le vocabulaire judiciaire lorsqu'il provient d'une mesure publiée", async () => {
+    const judicialAxis =
+      "Sur la justice, le programme propose de créer un parquet financier européen aux compétences élargies pour traiter les dossiers concernés.";
+    dbMock.measure.findMany.mockResolvedValue([
+      {
+        theme: "SECURITE_JUSTICE",
+        publishedRevision: {
+          text: "Créer des parquets financiers européens aux compétences élargies.",
+        },
+      },
+    ]);
+    callMistralMock.mockImplementation((messages: Array<{ content: string }>) => {
+      const grounding = messages.some((message) =>
+        message.content.includes("Vérifie si chaque affirmation")
+      );
+      return Promise.resolve({
+        text: grounding
+          ? groundingOutput()
+          : providerOutput({
+              programmeClaims: [{ text: judicialAxis, measureRefs: ["M1"] }],
+            }),
+        model: "mistral-large-latest",
+      });
+    });
+    const { generateCandidateSynthesis } = await service();
+
+    const result = await generateCandidateSynthesis("cand-1", { persist: true });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(dbMock.candidacyPresidential.update).toHaveBeenCalledOnce();
+  });
+
   it("refuse une candidature qui n'est pas déclarée", async () => {
     dbMock.candidacy.findUnique.mockResolvedValue({ ...CANDIDACY, status: "PRESSENTI" });
     const { generateCandidateSynthesis } = await service();

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -25,6 +25,7 @@ import {
   buildCandidateSynthesisGroundingPrompt,
   buildCanonicalCareer,
   buildSynthesisSystemPrompt,
+  MAX_PROGRAMME_CLAIMS,
   screenCandidateSynthesis,
   screenCandidateSynthesisGrounding,
   screenSynthesis,
@@ -49,7 +50,7 @@ const SYNTHESIS_RESPONSE_FORMAT = {
         career: { type: "string", maxLength: 1_000 },
         programmeClaims: {
           type: "array",
-          maxItems: 5,
+          maxItems: MAX_PROGRAMME_CLAIMS,
           items: {
             type: "object",
             additionalProperties: false,
@@ -221,7 +222,14 @@ export async function generateCandidateSynthesis(
   const [mandates, voteCount, measures] = await Promise.all([
     db.mandate.findMany({
       where: { politicianId },
-      select: { role: true, title: true, institution: true, startDate: true, endDate: true },
+      select: {
+        role: true,
+        title: true,
+        institution: true,
+        startDate: true,
+        endDate: true,
+        isCurrent: true,
+      },
       orderBy: { startDate: "desc" },
       take: MANDATE_LIMIT,
     }),
@@ -247,6 +255,7 @@ export async function generateCandidateSynthesis(
       institution: m.institution,
       startYear: m.startDate.getUTCFullYear(),
       endYear: m.endDate?.getUTCFullYear() ?? null,
+      isCurrent: m.isCurrent,
     })),
     voteCount,
     measures: measures.flatMap((m) =>

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -25,6 +25,7 @@ import {
   buildCandidateSynthesisGroundingPrompt,
   buildCanonicalCareer,
   buildSynthesisSystemPrompt,
+  formatCandidateSynthesisProposal,
   MAX_PROGRAMME_CLAIMS,
   screenCandidateSynthesis,
   screenCandidateSynthesisGrounding,
@@ -127,8 +128,10 @@ export type SynthesisGenerationResult =
       /** What the prompt was built from, for the script's log and the action's message. */
       measureCount: number;
       mandateCount: number;
-      /** False on a dry run: the text was produced and screened, nothing was written. */
+      /** False on a dry run or admin-review proposal: nothing was written. */
       persisted: boolean;
+      /** Present only for an admin-review draft that did not pass the automatic controls. */
+      reviewWarning?: string;
     }
   | { ok: false; reason: SynthesisRefusal; message: string };
 
@@ -180,9 +183,15 @@ async function loadInput(candidacyId: string) {
 export type GenerateCandidateSynthesisOptions = {
   /**
    * Write the result on the candidacy's presidential extension. False is the script's dry run: the
-   * text is produced and screened so the operator can read what WOULD be stored.
+   * text is produced and screened so the operator can read what WOULD be stored. An admin caller
+   * may separately request a rejected but structurally usable proposal for manual correction.
    */
   persist: boolean;
+  /**
+   * Return the best structurally usable draft when automatic controls reject it. This is only
+   * honored when `persist` is false: a rejected provider response must never be stored directly.
+   */
+  returnRejectedProposal?: boolean;
 };
 
 /**
@@ -282,6 +291,7 @@ export async function generateCandidateSynthesis(
   let accepted:
     | { text: string; provider: string; programmeClaims: CandidateProgrammeClaim[] }
     | undefined;
+  let bestProposal: { text: string; provider: string } | undefined;
 
   for (let attemptIndex = 0; attemptIndex < 3; attemptIndex += 1) {
     const messages = previousResponseText
@@ -307,11 +317,14 @@ export async function generateCandidateSynthesis(
         parsed && typeof parsed === "object"
           ? { ...parsed, career: buildCanonicalCareer(input) }
           : parsed;
+      const proposal = formatCandidateSynthesisProposal(candidateOutput, input);
+      if (proposal) bestProposal = { text: proposal, provider: attempt.provider };
       let screened = screenCandidateSynthesis(candidateOutput, input);
       if (!screened.ok) {
         validationDetail = screened.detail;
         continue;
       }
+      bestProposal = { text: screened.text, provider: attempt.provider };
 
       const parsedOutput = candidateOutput as {
         career: string;
@@ -402,6 +415,19 @@ export async function generateCandidateSynthesis(
   }
 
   if (!accepted) {
+    if (!options.persist && options.returnRejectedProposal && bestProposal) {
+      return {
+        ok: true,
+        text: bestProposal.text,
+        provider: bestProposal.provider,
+        measureCount: input.measures.length,
+        mandateCount: mandates.length,
+        persisted: false,
+        reviewWarning:
+          "Cette proposition n'a pas passé le contrôle automatique : " +
+          `${validationDetail}. Corrigez-la avant de l'enregistrer.`,
+      };
+    }
     if (lastGenerationError) {
       return {
         ok: false,

--- a/src/services/candidate-synthesis/index.ts
+++ b/src/services/candidate-synthesis/index.ts
@@ -27,6 +27,7 @@ import {
   buildSynthesisSystemPrompt,
   screenCandidateSynthesis,
   screenCandidateSynthesisGrounding,
+  screenSynthesis,
   synthesisMaterial,
   type CandidateProgrammeClaim,
   type CandidateSynthesisInput,
@@ -129,6 +130,10 @@ export type SynthesisGenerationResult =
       persisted: boolean;
     }
   | { ok: false; reason: SynthesisRefusal; message: string };
+
+export type CandidateSynthesisReviewResult =
+  | { ok: true; electionId: string }
+  | { ok: false; message: string };
 
 async function generate(
   system: string,
@@ -448,4 +453,103 @@ export async function generateCandidateSynthesis(
   });
 
   return { ...base, persisted: true };
+}
+
+/**
+ * Stores the text a moderator has actually read and edited.
+ *
+ * Generation and publication are deliberately separate operations: a provider response is a
+ * proposal, while this function is the explicit human decision that makes the text public. The
+ * same mechanical style and length checks still apply, but institutional judicial vocabulary is
+ * accepted when it is present in the programme or career material supplied on the fiche.
+ */
+export async function saveReviewedCandidateSynthesis(
+  candidacyId: string,
+  rawText: string,
+  auditMeta: { ipAddress?: string; userAgent?: string } = {}
+): Promise<CandidateSynthesisReviewResult> {
+  const candidacy = await db.candidacy.findUnique({
+    where: { id: candidacyId },
+    select: {
+      id: true,
+      electionId: true,
+      politicianId: true,
+      status: true,
+      presidentialData: { select: { id: true, synthesis: true } },
+    },
+  });
+  if (!candidacy) return { ok: false, message: "Candidature introuvable." };
+  if (candidacy.status !== "DECLARE") {
+    return { ok: false, message: "Seule une candidature déclarée porte une synthèse." };
+  }
+  if (!candidacy.politicianId) {
+    return { ok: false, message: "Aucune personnalité n'est rattachée à cette candidature." };
+  }
+  if (!candidacy.presidentialData) {
+    return { ok: false, message: "Les métadonnées présidentielles sont absentes." };
+  }
+
+  const [mandates, voteCount, measures] = await Promise.all([
+    db.mandate.findMany({
+      where: { politicianId: candidacy.politicianId },
+      select: { role: true, title: true, institution: true },
+      take: MANDATE_LIMIT,
+    }),
+    db.vote.count({ where: { politicianId: candidacy.politicianId } }),
+    db.measure.findMany({
+      where: {
+        candidacyId,
+        publicationStatus: "PUBLISHED",
+        withdrawnAt: null,
+        publishedRevision: { reviewedAt: { not: null } },
+      },
+      select: { publishedRevision: { select: { text: true } } },
+    }),
+  ]);
+  const measureTexts = measures.flatMap((measure) =>
+    measure.publishedRevision ? [measure.publishedRevision.text] : []
+  );
+  const reviewed = screenSynthesis({
+    text: rawText,
+    generatedText: rawText,
+    exemptSourceTexts: [],
+    allowedJudicialSourceTexts: [
+      ...measureTexts,
+      ...mandates.flatMap((mandate) => [mandate.role ?? mandate.title, mandate.institution ?? ""]),
+    ],
+    material: {
+      mandateCount: mandates.length,
+      voteCount,
+      measureCount: measureTexts.length,
+    },
+  });
+  if (!reviewed.ok) {
+    return {
+      ok: false,
+      message: `La synthèse ne peut pas être enregistrée : ${reviewed.detail}.`,
+    };
+  }
+
+  const reviewedAt = new Date();
+  await db.candidacyPresidential.update({
+    where: { id: candidacy.presidentialData.id },
+    data: { synthesis: reviewed.text, synthesisGeneratedAt: reviewedAt },
+  });
+  await db.auditLog.create({
+    data: {
+      action: "UPDATE",
+      entityType: "CandidacyPresidential",
+      entityId: candidacy.presidentialData.id,
+      changes: {
+        synthesis: reviewed.text,
+        previousSynthesis: candidacy.presidentialData.synthesis,
+        reviewedManually: true,
+        synthesisGeneratedAt: reviewedAt.toISOString(),
+      },
+      ipAddress: auditMeta.ipAddress,
+      userAgent: auditMeta.userAgent,
+    },
+  });
+
+  return { ok: true, electionId: candidacy.electionId };
 }


### PR DESCRIPTION
## Résultat

Cette PR rend la génération des synthèses candidates plus fiable et leur validation éditoriale plus simple.

- le vocabulaire judiciaire est accepté uniquement lorsqu'il provient réellement des mesures ou du parcours fourni ;
- la génération produit une proposition sans écriture automatique ;
- l'administration permet de relire, modifier et enregistrer explicitement le texte ;
- l'enregistrement est validé, audité et invalide les caches concernés ;
- les mandats parlementaires découpés par législature sont regroupés ;
- les synthèses sont limitées à quatre axes hiérarchisés au lieu de couvrir mécaniquement chaque thème ;
- la ponctuation est normalisée après retrait des références de preuve.

## Vérifications locales

- 125 tests ciblés passent ;
- typecheck passe ;
- lint des fichiers concernés passe ;
- flux de génération et d'enregistrement vérifié sur l'administration locale.

Aucune migration et aucune écriture de production ne sont nécessaires.