### PR TITLE
fix(votes): refuser une résolution vide des sénateurs (#768)

### DIFF
--- a/src/services/sync/__tests__/scrutins-senat.test.ts
+++ b/src/services/sync/__tests__/scrutins-senat.test.ts
@@ -6,6 +6,7 @@ import {
   getNextSenateCursor,
   parseScrutinMetadata,
   shouldSaveSenateCursor,
+  shouldRewriteSenateVotes,
 } from "@/services/sync/scrutins-senat";
 
 describe("import des scrutins publics du Sénat", () => {
@@ -46,6 +47,11 @@ describe("import des scrutins publics du Sénat", () => {
 
     expect(nextCursor).toBe(0);
     expect(shouldSaveSenateCursor(false, true, 0, nextCursor)).toBe(true);
+  });
+
+  it("refuse de réécrire les votes quand aucune identité de sénateur n'est résolue", () => {
+    expect(shouldRewriteSenateVotes(0)).toBe(false);
+    expect(shouldRewriteSenateVotes(1)).toBe(true);
   });
 
   it("extrait le total de contrôle officiel sans supposer 348 sièges", () => {

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -572,14 +572,23 @@ export async function syncScrutinsSenat(
             cursorOutcomes.push({ number: numInt, outcome: "PROCESSED" });
           } else {
             // Dry run: just count
-            stats.scrutinsCreated++;
             if (sourceAssessment.status === "COMPLETE") {
+              const resolvedVotes = votes.filter((vote) =>
+                matriculeToId.has(vote.matricule)
+              ).length;
               for (const vote of votes) {
                 if (!matriculeToId.has(vote.matricule)) {
                   stats.senatorsNotFound.add(vote.matricule);
-                } else {
-                  stats.votesCreated++;
                 }
+              }
+              if (!shouldRewriteSenateVotes(resolvedVotes)) {
+                stats.scrutinsSkipped++;
+                stats.errors.push(
+                  `Session ${currentSession} n°${number}: aucune identité de sénateur résolue`
+                );
+              } else {
+                stats.scrutinsCreated++;
+                stats.votesCreated += resolvedVotes;
               }
             } else {
               stats.scrutinsSkipped++;

--- a/src/services/sync/scrutins-senat.ts
+++ b/src/services/sync/scrutins-senat.ts
@@ -110,6 +110,10 @@ export function shouldSaveSenateCursor(
   return !dryRun && (force || nextCursor > currentCursor);
 }
 
+export function shouldRewriteSenateVotes(resolvedVotes: number): boolean {
+  return resolvedVotes > 0;
+}
+
 /**
  * Get list of scrutin numbers from a session page
  */
@@ -515,6 +519,23 @@ export async function syncScrutinsSenat(
               } else {
                 stats.senatorsNotFound.add(vote.matricule);
               }
+            }
+
+            if (!shouldRewriteSenateVotes(votesToCreate.length)) {
+              stats.scrutinsSkipped++;
+              stats.errors.push(
+                `Session ${currentSession} n°${number}: aucune identité de sénateur résolue`
+              );
+              await db.scrutinVoteImport.update({
+                where: { scrutinId: scrutin.id },
+                data: {
+                  status: "INCOMPLETE",
+                  statusReason: "no_resolved_senators",
+                },
+              });
+              cursorOutcomes.push({ number: numInt, outcome: "RETRY" });
+              progress.tick();
+              continue;
             }
 
             // Check votes hash to skip unchanged scrutins


### PR DESCRIPTION
## Problème

Si le JSON officiel est complet mais qu'aucun sénateur n'est résolu dans la base, la réécriture vide supprimait les votes existants, enregistrait un hash vide et faisait avancer le curseur.

## Correction

- refuse toute réécriture avec zéro identité résolue
- conserve l'import en statut `INCOMPLETE` avec la raison `no_resolved_senators`
- marque le scrutin en reprise afin qu'une exécution ultérieure puisse restaurer les votes
- ajoute un test de régression sur la garde de résolution

## Vérifications

- `npm run db:generate`
- `npm run typecheck`
- `npm run test:run -- src/services/sync/__tests__/scrutins-senat.test.ts` (7 tests réussis)
- lint ciblé des deux fichiers

Fixes #768
