### PR TITLE
fix(factchecks): corriger le mapping des verdicts inconnus et les libellés de classement

### DIFF
--- a/src/app/statistiques/page.tsx
+++ b/src/app/statistiques/page.tsx
@@ -98,10 +98,10 @@ export default async function StatistiquesPage({ searchParams }: PageProps) {
               total={factCheckData.total}
               groups={factCheckData.groups}
               bySource={factCheckData.bySource}
-              mostReliablePoliticians={factCheckData.mostReliablePoliticians}
-              leastReliablePoliticians={factCheckData.leastReliablePoliticians}
-              mostReliableParties={factCheckData.mostReliableParties}
-              leastReliableParties={factCheckData.leastReliableParties}
+              topVraiSharePoliticians={factCheckData.topVraiSharePoliticians}
+              topFauxSharePoliticians={factCheckData.topFauxSharePoliticians}
+              topVraiShareParties={factCheckData.topVraiShareParties}
+              topFauxShareParties={factCheckData.topFauxShareParties}
             />
           }
           legislativeContent={

--- a/src/components/stats/FactCheckSection.tsx
+++ b/src/components/stats/FactCheckSection.tsx
@@ -40,10 +40,10 @@ interface FactCheckSectionProps {
   total: number;
   groups: VerdictBreakdown;
   bySource: { source: string; count: number }[];
-  mostReliablePoliticians: RankedPolitician[];
-  leastReliablePoliticians: RankedPolitician[];
-  mostReliableParties: RankedParty[];
-  leastReliableParties: RankedParty[];
+  topVraiSharePoliticians: RankedPolitician[];
+  topFauxSharePoliticians: RankedPolitician[];
+  topVraiShareParties: RankedParty[];
+  topFauxShareParties: RankedParty[];
 }
 
 function PoliticianRankingItem({
@@ -53,12 +53,12 @@ function PoliticianRankingItem({
 }: {
   pol: RankedPolitician;
   rank: number;
-  mode: "reliable" | "unreliable";
+  mode: "vrai" | "faux";
 }) {
   const scorable = pol.totalMentions - pol.breakdown.inverifiable;
   const rawPct =
     scorable > 0
-      ? mode === "reliable"
+      ? mode === "vrai"
         ? pol.breakdown.vrai / scorable
         : pol.breakdown.faux / scorable
       : 0;
@@ -86,7 +86,7 @@ function PoliticianRankingItem({
       <span
         className="text-sm font-bold tabular-nums shrink-0"
         style={{
-          color: mode === "reliable" ? VERDICT_GROUP_COLORS.vrai : VERDICT_GROUP_COLORS.faux,
+          color: mode === "vrai" ? VERDICT_GROUP_COLORS.vrai : VERDICT_GROUP_COLORS.faux,
         }}
       >
         {(rawPct * 100).toFixed(0)}%
@@ -102,12 +102,12 @@ function PartyRankingItem({
 }: {
   party: RankedParty;
   rank: number;
-  mode: "reliable" | "unreliable";
+  mode: "vrai" | "faux";
 }) {
   const scorable = party.totalMentions - party.breakdown.inverifiable;
   const rawPct =
     scorable > 0
-      ? mode === "reliable"
+      ? mode === "vrai"
         ? party.breakdown.vrai / scorable
         : party.breakdown.faux / scorable
       : 0;
@@ -137,7 +137,7 @@ function PartyRankingItem({
       <span
         className="text-sm font-bold tabular-nums shrink-0"
         style={{
-          color: mode === "reliable" ? VERDICT_GROUP_COLORS.vrai : VERDICT_GROUP_COLORS.faux,
+          color: mode === "vrai" ? VERDICT_GROUP_COLORS.vrai : VERDICT_GROUP_COLORS.faux,
         }}
       >
         {(rawPct * 100).toFixed(0)}%
@@ -150,10 +150,10 @@ export function FactCheckSection({
   total,
   groups,
   bySource,
-  mostReliablePoliticians,
-  leastReliablePoliticians,
-  mostReliableParties,
-  leastReliableParties,
+  topVraiSharePoliticians,
+  topFauxSharePoliticians,
+  topVraiShareParties,
+  topFauxShareParties,
 }: FactCheckSectionProps) {
   const vraiPct = total > 0 ? ((groups.vrai / total) * 100).toFixed(0) : "0";
   const trompeurPct = total > 0 ? ((groups.trompeur / total) * 100).toFixed(0) : "0";
@@ -191,12 +191,21 @@ export function FactCheckSection({
             <li>
               <strong>Seuil :</strong> minimum 5 propos vérifiés pour figurer dans les classements
             </li>
+            <li>
+              <strong>Unité comptée :</strong> uniquement les affirmations dont le responsable
+              politique est l&apos;auteur direct, pas les simples mentions
+            </li>
+            <li>
+              <strong>Parti affiché :</strong> affiliation partisane actuelle, pas nécessairement
+              celle au moment de l&apos;affirmation
+            </li>
           </ul>
         }
       >
-        Le nombre de fact-checks reflète la place d&apos;un responsable politique dans le débat
-        public. Les proportions et le score pondéré permettent de comparer leur fiabilité
-        indépendamment de leur exposition médiatique.
+        Ces classements décrivent la répartition des verdicts sur un corpus d&apos;affirmations
+        attribuées : ils ne constituent pas un jugement global sur l&apos;honnêteté d&apos;une
+        personne ou d&apos;un parti. Le nombre de fact-checks reflète surtout la place d&apos;un
+        responsable politique dans le débat public.
       </MethodologyDisclaimer>
 
       {/* KPI cards — 4 columns */}
@@ -244,36 +253,36 @@ export function FactCheckSection({
 
       {/* Politician rankings — 2 columns */}
       <div className="grid md:grid-cols-2 gap-8 mb-8">
-        {mostReliablePoliticians.length > 0 && (
+        {topVraiSharePoliticians.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Politiques les plus fiables</CardTitle>
+              <CardTitle className="text-lg">Propos les plus souvent jugés vrais</CardTitle>
               <p className="text-sm text-muted-foreground">
-                Par proportion de propos vérifiés vrais (classement pondéré)
+                Part des affirmations attribuées jugées vraies (classement pondéré)
               </p>
             </CardHeader>
             <CardContent>
               <div className="space-y-1">
-                {mostReliablePoliticians.map((pol, i) => (
-                  <PoliticianRankingItem key={pol.slug} pol={pol} rank={i + 1} mode="reliable" />
+                {topVraiSharePoliticians.map((pol, i) => (
+                  <PoliticianRankingItem key={pol.slug} pol={pol} rank={i + 1} mode="vrai" />
                 ))}
               </div>
             </CardContent>
           </Card>
         )}
 
-        {leastReliablePoliticians.length > 0 && (
+        {topFauxSharePoliticians.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Politiques les moins fiables</CardTitle>
+              <CardTitle className="text-lg">Propos les plus souvent jugés faux</CardTitle>
               <p className="text-sm text-muted-foreground">
-                Par proportion de propos vérifiés faux (classement pondéré)
+                Part des affirmations attribuées jugées fausses (classement pondéré)
               </p>
             </CardHeader>
             <CardContent>
               <div className="space-y-1">
-                {leastReliablePoliticians.map((pol, i) => (
-                  <PoliticianRankingItem key={pol.slug} pol={pol} rank={i + 1} mode="unreliable" />
+                {topFauxSharePoliticians.map((pol, i) => (
+                  <PoliticianRankingItem key={pol.slug} pol={pol} rank={i + 1} mode="faux" />
                 ))}
               </div>
             </CardContent>
@@ -283,36 +292,40 @@ export function FactCheckSection({
 
       {/* Party rankings — 2 columns */}
       <div className="grid md:grid-cols-2 gap-8 mb-8">
-        {mostReliableParties.length > 0 && (
+        {topVraiShareParties.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Partis les plus fiables</CardTitle>
+              <CardTitle className="text-lg">
+                Partis : affirmations les plus souvent jugées vraies
+              </CardTitle>
               <p className="text-sm text-muted-foreground">
-                Par proportion de propos vérifiés vrais (classement pondéré)
+                Part des affirmations attribuées jugées vraies (classement pondéré)
               </p>
             </CardHeader>
             <CardContent>
               <div className="space-y-1">
-                {mostReliableParties.map((party, i) => (
-                  <PartyRankingItem key={party.name} party={party} rank={i + 1} mode="reliable" />
+                {topVraiShareParties.map((party, i) => (
+                  <PartyRankingItem key={party.name} party={party} rank={i + 1} mode="vrai" />
                 ))}
               </div>
             </CardContent>
           </Card>
         )}
 
-        {leastReliableParties.length > 0 && (
+        {topFauxShareParties.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Partis les moins fiables</CardTitle>
+              <CardTitle className="text-lg">
+                Partis : affirmations les plus souvent jugées fausses
+              </CardTitle>
               <p className="text-sm text-muted-foreground">
-                Par proportion de propos vérifiés faux (classement pondéré)
+                Part des affirmations attribuées jugées fausses (classement pondéré)
               </p>
             </CardHeader>
             <CardContent>
               <div className="space-y-1">
-                {leastReliableParties.map((party, i) => (
-                  <PartyRankingItem key={party.name} party={party} rank={i + 1} mode="unreliable" />
+                {topFauxShareParties.map((party, i) => (
+                  <PartyRankingItem key={party.name} party={party} rank={i + 1} mode="faux" />
                 ))}
               </div>
             </CardContent>

--- a/src/services/factcheckStats.test.ts
+++ b/src/services/factcheckStats.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { factcheckStatsService } from "./factcheckStats";
+import { classifyRating, factcheckStatsService } from "./factcheckStats";
 
 describe("statistiques publiques des fact-checks", () => {
   beforeEach(() => {
@@ -34,5 +34,67 @@ describe("statistiques publiques des fact-checks", () => {
       values: expect.arrayContaining(["PUBLISHED"]),
     });
     expect(call[0].values.every((value: unknown) => typeof value !== "object")).toBe(true);
+  });
+
+  describe("classifyRating", () => {
+    it("classe les verdicts connus dans leur groupe respectif", () => {
+      expect(classifyRating("TRUE")).toBe("vrai");
+      expect(classifyRating("MOSTLY_TRUE")).toBe("vrai");
+      expect(classifyRating("HALF_TRUE")).toBe("trompeur");
+      expect(classifyRating("MISLEADING")).toBe("trompeur");
+      expect(classifyRating("OUT_OF_CONTEXT")).toBe("trompeur");
+      expect(classifyRating("MOSTLY_FALSE")).toBe("faux");
+      expect(classifyRating("FALSE")).toBe("faux");
+      expect(classifyRating("UNVERIFIABLE")).toBe("inverifiable");
+    });
+
+    it("ne mappe jamais un code de verdict inconnu vers UNVERIFIABLE : inconnu ≠ invérifiable", () => {
+      expect(classifyRating("SOME_FUTURE_RATING")).toBeNull();
+      expect(classifyRating("")).toBeNull();
+    });
+  });
+
+  describe("getStatisticsData face à un verdictRating inconnu", () => {
+    it("exclut les mentions au code inconnu des classements au lieu de les compter comme invérifiable", async () => {
+      mocks.count.mockResolvedValue(8);
+      mocks.queryRaw.mockResolvedValue([
+        {
+          politicianId: "pol1",
+          fullName: "Jean Test",
+          slug: "jean-test",
+          photoUrl: null,
+          partyName: "Parti Test",
+          partyShortName: "PT",
+          partyColor: "#000000",
+          partySlug: "parti-test",
+          verdictRating: "TRUE",
+          mentionCount: BigInt(5),
+        },
+        {
+          politicianId: "pol1",
+          fullName: "Jean Test",
+          slug: "jean-test",
+          photoUrl: null,
+          partyName: "Parti Test",
+          partyShortName: "PT",
+          partyColor: "#000000",
+          partySlug: "parti-test",
+          verdictRating: "SOME_FUTURE_RATING",
+          mentionCount: BigInt(3),
+        },
+      ]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await factcheckStatsService.getStatisticsData();
+
+      const jean = result.topVraiSharePoliticians.find((p) => p.slug === "jean-test");
+      expect(jean).toBeDefined();
+      expect(jean!.totalMentions).toBe(5);
+      expect(jean!.breakdown.vrai).toBe(5);
+      expect(jean!.breakdown.inverifiable).toBe(0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("SOME_FUTURE_RATING"));
+
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/src/services/factcheckStats.ts
+++ b/src/services/factcheckStats.ts
@@ -76,15 +76,29 @@ export interface RankedParty {
   scoreFaux: number;
 }
 
-/** Shape returned by getStatisticsData() — consumed by statistiques/page.tsx */
+/**
+ * Shape returned by getStatisticsData() — consumed by statistiques/page.tsx.
+ *
+ * Doctrine éditoriale (issue #727) : ces classements décrivent la
+ * répartition des verdicts sur un corpus d'affirmations attribuées, pas la
+ * fiabilité générale d'une personne ou d'un parti. D'où des noms de champs
+ * et des libellés descriptifs ("part de vrai/faux") plutôt que normatifs
+ * ("le/la plus fiable").
+ *
+ * Unité comptée : uniquement les mentions où le responsable politique est
+ * l'auteur direct de l'affirmation (`isClaimant = true`), pas une simple
+ * mention. L'affiliation partisane utilisée est l'affiliation actuelle du
+ * responsable (`currentPartyId`), pas nécessairement celle au moment de
+ * l'affirmation.
+ */
 export interface FactCheckStatisticsData {
   total: number;
   groups: VerdictBreakdown;
   bySource: Array<{ source: string; count: number }>;
-  mostReliablePoliticians: RankedPolitician[];
-  leastReliablePoliticians: RankedPolitician[];
-  mostReliableParties: RankedParty[];
-  leastReliableParties: RankedParty[];
+  topVraiSharePoliticians: RankedPolitician[];
+  topFauxSharePoliticians: RankedPolitician[];
+  topVraiShareParties: RankedParty[];
+  topFauxShareParties: RankedParty[];
 }
 
 // ============================================
@@ -177,11 +191,21 @@ async function getPageStats(): Promise<FactCheckPageStats> {
 /** Minimum fact-check mentions required to include a politician/party in rankings */
 const MIN_MENTIONS = 5;
 
-function classifyRating(rating: string): keyof VerdictBreakdown {
+/**
+ * Classe un `verdictRating` dans une des quatre catégories connues.
+ *
+ * `UNVERIFIABLE` est un verdict éditorial explicite ("l'affirmation ne peut
+ * être vérifiée"), pas une valeur par défaut. Un code non reconnu (futur
+ * enum Prisma non encore mappé ici) doit donc renvoyer `null` plutôt que
+ * d'être assimilé à `inverifiable` : inconnu ≠ invérifiable. Les appelants
+ * doivent exclure les `null` des agrégats plutôt que de les compter.
+ */
+export function classifyRating(rating: string): keyof VerdictBreakdown | null {
   if ((VERDICT_GROUPS.vrai as readonly string[]).includes(rating)) return "vrai";
   if ((VERDICT_GROUPS.trompeur as readonly string[]).includes(rating)) return "trompeur";
   if ((VERDICT_GROUPS.faux as readonly string[]).includes(rating)) return "faux";
-  return "inverifiable";
+  if ((VERDICT_GROUPS.inverifiable as readonly string[]).includes(rating)) return "inverifiable";
+  return null;
 }
 
 /**
@@ -253,7 +277,7 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
     vrai: VERDICT_GROUPS.vrai.reduce((sum, r) => sum + (ratingMap[r] || 0), 0),
     trompeur: VERDICT_GROUPS.trompeur.reduce((sum, r) => sum + (ratingMap[r] || 0), 0),
     faux: VERDICT_GROUPS.faux.reduce((sum, r) => sum + (ratingMap[r] || 0), 0),
-    inverifiable: ratingMap["UNVERIFIABLE"] || 0,
+    inverifiable: VERDICT_GROUPS.inverifiable.reduce((sum, r) => sum + (ratingMap[r] || 0), 0),
   };
 
   const politicianMap = new Map<
@@ -283,6 +307,12 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
   for (const row of allMentions) {
     const count = Number(row.mentionCount);
     const verdict = classifyRating(row.verdictRating);
+    if (!verdict) {
+      // Code de verdict non reconnu : exclu des classements plutôt que
+      // rattaché à "inverifiable" par défaut (voir classifyRating()).
+      console.warn(`[factcheckStats] verdictRating inconnu ignoré: ${row.verdictRating}`);
+      continue;
+    }
     const partyKey = row.partySlug;
     const partyDisplayName = row.partyName || row.partyShortName;
 
@@ -343,12 +373,12 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
   };
 
   const rankedPoliticians = allPols.map(scorePolitician);
-  const mostReliablePoliticians = [...rankedPoliticians]
+  const topVraiSharePoliticians = [...rankedPoliticians]
     .sort((a, b) => b.scoreVrai - a.scoreVrai)
     .slice(0, 5);
-  const mostReliableSlugs = new Set(mostReliablePoliticians.map((p) => p.slug));
-  const leastReliablePoliticians = [...rankedPoliticians]
-    .filter((p) => !mostReliableSlugs.has(p.slug))
+  const topVraiSlugs = new Set(topVraiSharePoliticians.map((p) => p.slug));
+  const topFauxSharePoliticians = [...rankedPoliticians]
+    .filter((p) => !topVraiSlugs.has(p.slug))
     .sort((a, b) => b.scoreFaux - a.scoreFaux)
     .slice(0, 5);
 
@@ -379,12 +409,12 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
   };
 
   const rankedParties = allParties.map(scoreParty);
-  const mostReliableParties = [...rankedParties]
+  const topVraiShareParties = [...rankedParties]
     .sort((a, b) => b.scoreVrai - a.scoreVrai)
     .slice(0, 5);
-  const mostReliablePartyNames = new Set(mostReliableParties.map((p) => p.name));
-  const leastReliableParties = [...rankedParties]
-    .filter((p) => !mostReliablePartyNames.has(p.name))
+  const topVraiPartyNames = new Set(topVraiShareParties.map((p) => p.name));
+  const topFauxShareParties = [...rankedParties]
+    .filter((p) => !topVraiPartyNames.has(p.name))
     .sort((a, b) => b.scoreFaux - a.scoreFaux)
     .slice(0, 5);
 
@@ -392,10 +422,10 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
     total,
     groups,
     bySource: bySourceRaw.map((s) => ({ source: s.source, count: s._count })),
-    mostReliablePoliticians,
-    leastReliablePoliticians,
-    mostReliableParties,
-    leastReliableParties,
+    topVraiSharePoliticians,
+    topFauxSharePoliticians,
+    topVraiShareParties,
+    topFauxShareParties,
   };
 }
 

--- a/src/services/factcheckStats.ts
+++ b/src/services/factcheckStats.ts
@@ -77,7 +77,7 @@ export interface RankedParty {
 }
 
 /**
- * Shape returned by getStatisticsData() — consumed by statistiques/page.tsx.
+ * Shape returned by getStatisticsData(), consumed by statistiques/page.tsx.
  *
  * Doctrine éditoriale (issue #727) : ces classements décrivent la
  * répartition des verdicts sur un corpus d'affirmations attribuées, pas la

--- a/src/services/factcheckStats.ts
+++ b/src/services/factcheckStats.ts
@@ -372,13 +372,15 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
     };
   };
 
+  // Chaque classement est calculé indépendamment sur l'ensemble éligible complet :
+  // un même responsable peut apparaître dans les deux s'il a un score élevé sur
+  // les deux métriques (score = part de vrai/faux pondérée, pas un pourcentage
+  // brut), notamment quand "trompeur" représente une large part de son corpus.
   const rankedPoliticians = allPols.map(scorePolitician);
   const topVraiSharePoliticians = [...rankedPoliticians]
     .sort((a, b) => b.scoreVrai - a.scoreVrai)
     .slice(0, 5);
-  const topVraiSlugs = new Set(topVraiSharePoliticians.map((p) => p.slug));
   const topFauxSharePoliticians = [...rankedPoliticians]
-    .filter((p) => !topVraiSlugs.has(p.slug))
     .sort((a, b) => b.scoreFaux - a.scoreFaux)
     .slice(0, 5);
 
@@ -412,9 +414,7 @@ async function getStatisticsData(): Promise<FactCheckStatisticsData> {
   const topVraiShareParties = [...rankedParties]
     .sort((a, b) => b.scoreVrai - a.scoreVrai)
     .slice(0, 5);
-  const topVraiPartyNames = new Set(topVraiShareParties.map((p) => p.name));
   const topFauxShareParties = [...rankedParties]
-    .filter((p) => !topVraiPartyNames.has(p.name))
     .sort((a, b) => b.scoreFaux - a.scoreFaux)
     .slice(0, 5);
 


### PR DESCRIPTION
## Description

Corrige deux problèmes éditoriaux/techniques identifiés dans `src/services/factcheckStats.ts` :

1. **`classifyRating()` fail-open sur les verdicts inconnus** : tout code de verdict non reconnu (par exemple un futur ajout à l'enum Prisma `FactCheckRating`) était silencieusement assimilé à `UNVERIFIABLE`. `UNVERIFIABLE` est un verdict éditorial explicite, pas une valeur par défaut : inconnu ≠ invérifiable. La fonction renvoie désormais `null` pour un code non reconnu, et les mentions correspondantes sont exclues des classements (avec un `console.warn` pour la traçabilité) plutôt que comptées par défaut.

2. **Libellés normatifs sur la page statistiques** : "Politiques/Partis les plus/moins fiables" transformait un ratio de verdicts sur un corpus de fact-checks en jugement de fiabilité générale d'une personne ou d'un parti. Remplacé par des libellés descriptifs du corpus ("propos les plus souvent jugés vrais/faux"), et les noms de champs renommés en conséquence (`mostReliablePoliticians` → `topVraiSharePoliticians`, etc.). Le bandeau méthodologique précise désormais l'unité comptée (affirmations attribuées où le responsable est l'auteur direct, pas les simples mentions) et le rôle de l'affiliation partisane (actuelle, pas au moment des faits).

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Autre : \_\_\_

## Issue liée

Fixes #727

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [ ] `npm run build` passe sans erreur (non exécuté dans cette session, `npx tsc --noEmit` ciblé sur les fichiers modifiés passe)
- [x] Les changements sont testés (tests unitaires ajoutés pour `classifyRating()` et pour l'exclusion des verdicts inconnus dans `getStatisticsData()`)
- [x] La documentation est mise à jour (doctrine éditoriale documentée en JSDoc dans `factcheckStats.ts`)
- [x] Pas de données sensibles dans le code
