### PR TITLE
fix(affaires): dériver AFFAIR_STATUSES de l'enum Prisma (#583)

### DIFF
--- a/src/lib/affairs/__tests__/status-enum-sync.test.ts
+++ b/src/lib/affairs/__tests__/status-enum-sync.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { AffairStatus } from "@/generated/prisma";
 import { COLORS } from "@/config/colors";
 import { VALID_STATUSES } from "@/lib/security/schemas/affair";
+import { AFFAIR_STATUSES } from "@/services/affair-moderation";
 import { getJudicialMaturity } from "@/config/judicial-maturity";
 import { getCertaintyLevel } from "@/config/certainty";
 
@@ -16,6 +17,14 @@ describe("les listes de statuts recopiées suivent l'enum Prisma", () => {
 
   it("VALID_STATUSES couvre tous les statuts", () => {
     expect([...VALID_STATUSES].sort()).toEqual(prismaValues);
+  });
+
+  // affair-moderation.ts:AFFAIR_STATUSES sert de seule garde avant d'écrire un
+  // corrected_status proposé par le modèle. Une liste recopiée à la main y a déjà
+  // omis POURVOI_EN_CASSATION (#583) ; elle est désormais dérivée de l'enum Prisma,
+  // ce test protège contre une régression vers une recopie manuelle.
+  it("AFFAIR_STATUSES (affair-moderation.ts) couvre tous les statuts", () => {
+    expect([...AFFAIR_STATUSES].sort()).toEqual(prismaValues);
   });
 });
 

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -13,6 +13,7 @@
 
 import { AI_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
+import { AffairStatus } from "@/generated/prisma";
 
 const MODEL = "claude-sonnet-4-5-20250929";
 const MAX_TOKENS = 2000;
@@ -74,22 +75,10 @@ export const SENSITIVE_CATEGORIES = new Set([
   "VIOLENCE",
 ]);
 
-export const AFFAIR_STATUSES = [
-  "ENQUETE_PRELIMINAIRE",
-  "INSTRUCTION",
-  "INSTRUCTION_CLOTUREE_SANS_MISE_EN_EXAMEN",
-  "MISE_EN_EXAMEN",
-  "RENVOI_TRIBUNAL",
-  "PROCES_EN_COURS",
-  "CONDAMNATION_PREMIERE_INSTANCE",
-  "APPEL_EN_COURS",
-  "CONDAMNATION_DEFINITIVE",
-  "RELAXE",
-  "ACQUITTEMENT",
-  "NON_LIEU",
-  "PRESCRIPTION",
-  "CLASSEMENT_SANS_SUITE",
-] as const;
+// Dérivée de l'enum Prisma pour ne jamais diverger (#583) : une liste recopiée à la
+// main a déjà omis POURVOI_EN_CASSATION, laissant une affaire non définitive sans
+// garde valide pour une correction de statut appliquée sans revue.
+export const AFFAIR_STATUSES = Object.values(AffairStatus);
 
 export const AFFAIR_CATEGORIES = [
   "CORRUPTION",

--- a/src/services/press-analysis.ts
+++ b/src/services/press-analysis.ts
@@ -14,6 +14,7 @@
 import { AI_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { callMistral, extractMistralText, parseMistralJSON } from "@/lib/api/mistral";
+import { AffairStatus } from "@/generated/prisma";
 
 const TIER_MODELS = {
   TIER_1: "mistral-large-latest",
@@ -96,21 +97,8 @@ const AFFAIR_CATEGORIES = [
   "AUTRE",
 ] as const;
 
-const AFFAIR_STATUSES = [
-  "ENQUETE_PRELIMINAIRE",
-  "INSTRUCTION",
-  "MISE_EN_EXAMEN",
-  "RENVOI_TRIBUNAL",
-  "PROCES_EN_COURS",
-  "CONDAMNATION_PREMIERE_INSTANCE",
-  "APPEL_EN_COURS",
-  "CONDAMNATION_DEFINITIVE",
-  "RELAXE",
-  "ACQUITTEMENT",
-  "NON_LIEU",
-  "PRESCRIPTION",
-  "CLASSEMENT_SANS_SUITE",
-] as const;
+// Dérivée de l'enum Prisma pour ne jamais diverger (#583).
+const AFFAIR_STATUSES = Object.values(AffairStatus);
 
 const SENSITIVE_CATEGORIES = new Set(["AGRESSION_SEXUELLE", "HARCELEMENT_SEXUEL"]);
 

--- a/src/services/wikipedia-affair-extraction.ts
+++ b/src/services/wikipedia-affair-extraction.ts
@@ -15,6 +15,7 @@
 import { AI_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
+import { AffairStatus } from "@/generated/prisma";
 
 const MODEL = "claude-sonnet-4-5-20250929";
 const MAX_TOKENS = 2000;
@@ -83,21 +84,8 @@ const AFFAIR_CATEGORIES = [
   "AUTRE",
 ] as const;
 
-const AFFAIR_STATUSES = [
-  "ENQUETE_PRELIMINAIRE",
-  "INSTRUCTION",
-  "MISE_EN_EXAMEN",
-  "RENVOI_TRIBUNAL",
-  "PROCES_EN_COURS",
-  "CONDAMNATION_PREMIERE_INSTANCE",
-  "APPEL_EN_COURS",
-  "CONDAMNATION_DEFINITIVE",
-  "RELAXE",
-  "ACQUITTEMENT",
-  "NON_LIEU",
-  "PRESCRIPTION",
-  "CLASSEMENT_SANS_SUITE",
-] as const;
+// Dérivée de l'enum Prisma pour ne jamais diverger (#583).
+const AFFAIR_STATUSES = Object.values(AffairStatus);
 
 // ============================================
 // TOOL DEFINITION (Anthropic tool_use)


### PR DESCRIPTION
## Résumé

- `AFFAIR_STATUSES` dans `affair-moderation.ts` recopiait à la main la liste des statuts judiciaires et omettait `POURVOI_EN_CASSATION`. Cette liste sert de seule garde avant d'écrire un `corrected_status` proposé par le modèle sur une affaire existante (`affair-enrichment.ts`) : un statut légitimement `POURVOI_EN_CASSATION` pouvait donc être reclassé sans que cette valeur ne soit reconnue comme valide.
- Le même défaut recopié existait dans `wikipedia-affair-extraction.ts` et `press-analysis.ts` (services d'extraction de nouvelles affaires).
- Les trois listes sont maintenant dérivées de `Object.values(AffairStatus)` (enum Prisma), comme le fait déjà `admin/affaires/route.ts`. Une divergence future devient structurellement impossible.
- Ajout d'un test de régression dans `status-enum-sync.test.ts` verrouillant `AFFAIR_STATUSES` contre l'enum Prisma.

## Hors périmètre

L'issue soulève aussi la question de fond : une correction de statut proposée par un modèle doit-elle être appliquée sans revue humaine, quel que soit le résultat de la validation ? Cette question est explicitement identifiée dans l'issue comme méritant d'être tranchée à part ; elle n'est pas traitée par cette PR.

## Test plan

- [x] `npx tsc --noEmit` (aucune nouvelle erreur introduite par le changement)
- [x] `npx vitest run` : 5794 tests passés, 0 échec
- [x] `npx prisma generate` régénéré (v7.9.1, conforme à `^7.9.0`)

Closes #583