### PR TITLE
fix(sync): éviter les faux échecs du sync des élus

### DIFF
--- a/.github/workflows/sync-politicians.yml
+++ b/.github/workflows/sync-politicians.yml
@@ -16,7 +16,10 @@ env:
 jobs:
   sync-politicians:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    # The full refresh can legitimately exceed an hour when official sources
+    # throttle requests. Keep a generous job bound while retaining per-step
+    # limits so a permanently hung source still unblocks the remaining syncs.
+    timeout-minutes: 90
     environment: production
 
     steps:
@@ -41,13 +44,13 @@ jobs:
       - name: Sync Assemblée Nationale (Deputies)
         id: sync-assemblee
         run: npm run sync:assemblee
-        timeout-minutes: 15
+        timeout-minutes: 20
         continue-on-error: true
 
       - name: Sync Sénat (Senators)
         id: sync-senat
         run: npm run sync:senat
-        timeout-minutes: 10
+        timeout-minutes: 15
         continue-on-error: true
 
       - name: Sync Gouvernement (Ministers)
@@ -62,19 +65,19 @@ jobs:
       - name: Sync Careers (Wikidata P39/P488/P112)
         id: sync-careers
         run: npm run sync:careers -- --limit=3000
-        timeout-minutes: 10
+        timeout-minutes: 15
         continue-on-error: true
 
       - name: Sync Photos
         id: sync-photos
         run: npm run sync:photos -- --limit=2000
-        timeout-minutes: 10
+        timeout-minutes: 15
         continue-on-error: true
 
       - name: Sync Deceased (from Wikidata)
         id: sync-deceased
         run: npm run sync:deceased
-        timeout-minutes: 5
+        timeout-minutes: 10
         continue-on-error: true
 
       - name: Show sync stats


### PR DESCRIPTION
## Résumé

Les synchronisations hebdomadaires des élus atteignaient régulièrement les timeouts de 10 à 15 minutes malgré la fin des traitements en amont. Cela déclenchait des issues automatisées pour des erreurs réseau ou des réponses Wikidata ralenties.

Cette PR augmente les timeouts individuels et le plafond du job, tout en conservant des bornes strictes pour qu’une source réellement bloquée ne monopolise pas le workflow.

## Vérifications

- `git diff --check`
- `prettier --check .github/workflows/sync-politicians.yml`
- Run manuel avant correction : https://github.com/ironlam/poligraph/actions/runs/33653153519

Fixes #730