### PR TITLE
perf: alléger les pages publiques sans recul SEO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,8 @@ When unsure: if the noun is specific to French politics, law, or administration,
 - Prettier: 100 char width, 2-space indent, double quotes, trailing commas (es5), semicolons.
 - ESLint: `next/core-web-vitals` + prettier. Unused vars with `_` prefix allowed. `no-console` is a warning (disabled in `api/`, `services/`, `lib/`, `sync/`).
 - Pre-commit: `lint-staged` runs ESLint fix + Prettier on staged files. Do not skip hooks.
+- Comments explain a non-obvious invariant or constraint. Do not narrate the diff, the former
+  implementation, or code that is already self-explanatory.
 
 ### Language rules for user-facing text
 
@@ -352,6 +354,12 @@ These are scar-tissue lessons. Reading them costs thirty seconds; rediscovering 
 - **`permanentRedirect()` in a page renders an HTML meta-refresh shell, not an HTTP 308.** For citation resolvers, URL shorteners, or crawler-facing redirects, use a Route Handler (`route.ts` returning `Response.redirect(url, 308)`).
 - **`generateStaticParams` with `searchParams` and `useCache: true` crashes** with `DYNAMIC_SERVER_USAGE`. Use `revalidate = N` alone for ISR on dynamic pages.
 - **ISR pages prerender at build time.** If the DB is unreachable during build, pages render empty. Vercel env vars must be set before build.
+- **Repeated public images stay optimized.** Do not use `unoptimized` in public app or component
+  code. Store unreliable remote assets in Blob rather than serving full originals to every reader.
+- **Large link collections do not prefetch by default.** Footer, result grids and directories use
+  `prefetch={false}`. The `href` remains in server HTML for readers and crawlers.
+- **One visible dataset per client boundary.** Do not pass hidden panels or whole corpora into a
+  client component. Give substantial indexable sections stable server-rendered URLs.
 
 ### Prisma 7
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ import { OG_IMAGE_NOINDEX_HEADERS } from "./src/lib/seo/og-image-robots";
 import { API_NOINDEX_HEADERS } from "./src/lib/seo/api-robots";
 import { buildSecurityHeaders } from "./src/lib/security-headers";
 
+const LEGACY_STATS_REDIRECTS = [
+  ["factchecks", "/statistiques/factchecks"],
+  ["legislatif", "/statistiques/legislatif"],
+  ["participation", "/statistiques/participation"],
+] as const;
+
 const nextConfig: NextConfig = {
   serverExternalPackages: ["jsdom"],
   staticPageGenerationTimeout: 120,
@@ -99,6 +105,12 @@ const nextConfig: NextConfig = {
         destination: "/statistiques",
         permanent: true,
       },
+      ...LEGACY_STATS_REDIRECTS.map(([tab, destination]) => ({
+        source: "/statistiques",
+        has: [{ type: "query" as const, key: "tab", value: tab }],
+        destination,
+        permanent: true,
+      })),
       {
         source: "/api-docs",
         destination: "/docs/api",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "storybook:build": "STORYBOOK_DISABLE_TELEMETRY=1 storybook build",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:performance-guards": "vitest run src/__tests__/architecture/public-page-performance-guards.test.ts",
     "triage:matching": "tsx --env-file=.env scripts/triage-matching.ts",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",

--- a/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
+++ b/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
@@ -146,7 +146,10 @@ const PARTY_SURFACES = [
   "src/app/recap/[week]/opengraph-image.tsx",
   "src/app/recap/[week]/page.tsx",
   "src/app/recap/page.tsx",
+  "src/app/statistiques/factchecks/page.tsx",
+  "src/app/statistiques/legislatif/page.tsx",
   "src/app/statistiques/page.tsx",
+  "src/app/statistiques/participation/page.tsx",
 ] as const;
 
 const FACTCHECK_SURFACES = [
@@ -174,7 +177,10 @@ const FACTCHECK_SURFACES = [
   "src/app/recap/[week]/opengraph-image.tsx",
   "src/app/recap/[week]/page.tsx",
   "src/app/recap/page.tsx",
+  "src/app/statistiques/factchecks/page.tsx",
+  "src/app/statistiques/legislatif/page.tsx",
   "src/app/statistiques/page.tsx",
+  "src/app/statistiques/participation/page.tsx",
 ] as const;
 
 const AFFAIR_SURFACES = [
@@ -226,7 +232,10 @@ const AFFAIR_SURFACES = [
   "src/app/recap/[week]/opengraph-image.tsx",
   "src/app/recap/[week]/page.tsx",
   "src/app/recap/page.tsx",
+  "src/app/statistiques/factchecks/page.tsx",
+  "src/app/statistiques/legislatif/page.tsx",
   "src/app/statistiques/page.tsx",
+  "src/app/statistiques/participation/page.tsx",
 ] as const;
 
 const PARTY_AFFAIRS_AT_TIME_SURFACES = new Set([

--- a/src/__tests__/architecture/public-page-performance-guards.test.ts
+++ b/src/__tests__/architecture/public-page-performance-guards.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.cwd();
+
+function read(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8");
+}
+
+function tsxFiles(directory: string): string[] {
+  return readdirSync(join(ROOT, directory), { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.name.endsWith(".tsx") ? [relative(ROOT, join(ROOT, path))] : [];
+  });
+}
+
+describe("public page performance contracts", () => {
+  it("keeps public images behind the Next optimizer", () => {
+    const violations = [...tsxFiles("src/app"), ...tsxFiles("src/components")]
+      .filter((path) => !path.includes("opengraph-image") && !path.includes("__tests__"))
+      .filter((path) => /\bunoptimized\b/.test(read(path)));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("renders one statistics dataset per server route", () => {
+    const landing = read("src/app/statistiques/page.tsx");
+    const navigation = read("src/components/stats/StatsTabs.tsx");
+
+    expect(landing).toContain("getJudicialData");
+    expect(landing).not.toMatch(/getFactCheckData|getLegislativeData|getParticipationData/);
+    expect(navigation).not.toContain('"use client"');
+    expect(navigation).toContain("prefetch={false}");
+  });
+
+  it("does not preload low-intent link collections", () => {
+    expect(read("src/components/layout/Footer.tsx")).toContain("prefetch={false}");
+    expect(
+      read("src/app/elections/presidentielle-2027/_components/CandidacyDirectoryLink.tsx")
+    ).toContain("prefetch={false}");
+  });
+
+  it("counts candidacy measures without loading complete revisions", () => {
+    const source = read("src/lib/data/presidential-candidacy-field.ts");
+    expect(source).toContain("getPublicMeasureRollupsByElection");
+    expect(source).not.toContain("getPublicMeasuresByElection");
+  });
+});

--- a/src/__tests__/architecture/public-page-performance-guards.test.ts
+++ b/src/__tests__/architecture/public-page-performance-guards.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
 
 const ROOT = process.cwd();
 
-function read(path: string): string {
-  return readFileSync(join(ROOT, path), "utf8");
+function sourceFile(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    readFileSync(join(ROOT, path), "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
 }
 
 function tsxFiles(directory: string): string[] {
@@ -16,35 +23,121 @@ function tsxFiles(directory: string): string[] {
   });
 }
 
+function jsxElements(path: string, tagName: string): ts.JsxOpeningLikeElement[] {
+  const matches: ts.JsxOpeningLikeElement[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      node.tagName.getText() === tagName
+    ) {
+      matches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile(path));
+  return matches;
+}
+
+function hasFalseAttribute(element: ts.JsxOpeningLikeElement, name: string): boolean {
+  return element.attributes.properties.some(
+    (property) =>
+      ts.isJsxAttribute(property) &&
+      property.name.getText() === name &&
+      property.initializer !== undefined &&
+      ts.isJsxExpression(property.initializer) &&
+      property.initializer.expression?.kind === ts.SyntaxKind.FalseKeyword
+  );
+}
+
+function importedNames(path: string, moduleName: string): string[] {
+  return sourceFile(path).statements.flatMap((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== moduleName
+    ) {
+      return [];
+    }
+    const bindings = statement.importClause?.namedBindings;
+    return bindings && ts.isNamedImports(bindings)
+      ? bindings.elements.map((element) => element.name.text)
+      : [];
+  });
+}
+
+function calledNames(path: string): Set<string> {
+  const calls = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      calls.add(node.expression.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile(path));
+  return calls;
+}
+
 describe("public page performance contracts", () => {
   it("keeps public images behind the Next optimizer", () => {
-    const violations = [...tsxFiles("src/app"), ...tsxFiles("src/components")]
-      .filter((path) => !path.includes("opengraph-image") && !path.includes("__tests__"))
-      .filter((path) => /\bunoptimized\b/.test(read(path)));
+    const files = [...tsxFiles("src/app"), ...tsxFiles("src/components")].filter(
+      (path) =>
+        !path.startsWith("src/app/admin/") &&
+        !path.startsWith("src/components/admin/") &&
+        !path.includes("opengraph-image") &&
+        !path.includes("__tests__")
+    );
+    const violations = files.filter((path) =>
+      jsxElements(path, "Image").some((element) =>
+        element.attributes.properties.some(
+          (property) => ts.isJsxAttribute(property) && property.name.getText() === "unoptimized"
+        )
+      )
+    );
 
     expect(violations).toEqual([]);
   });
 
-  it("renders one statistics dataset per server route", () => {
-    const landing = read("src/app/statistiques/page.tsx");
-    const navigation = read("src/components/stats/StatsTabs.tsx");
-
-    expect(landing).toContain("getJudicialData");
-    expect(landing).not.toMatch(/getFactCheckData|getLegislativeData|getParticipationData/);
-    expect(navigation).not.toContain('"use client"');
-    expect(navigation).toContain("prefetch={false}");
+  it.each([
+    ["src/app/statistiques/page.tsx", "getJudicialData"],
+    ["src/app/statistiques/factchecks/page.tsx", "getFactCheckData"],
+    ["src/app/statistiques/legislatif/page.tsx", "getLegislativeData"],
+    ["src/app/statistiques/participation/page.tsx", "getParticipationData"],
+  ])("loads only its visible statistics dataset in %s", (path, expectedLoader) => {
+    const imports = importedNames(path, "@/lib/data/statistics");
+    expect(imports).toContain(expectedLoader);
+    expect(
+      imports.filter((name) => name.startsWith("get") && name !== "getGroupDynamicsData")
+    ).toEqual([expectedLoader]);
   });
 
-  it("does not preload low-intent link collections", () => {
-    expect(read("src/components/layout/Footer.tsx")).toContain("prefetch={false}");
+  it("keeps statistics navigation on the server", () => {
+    const file = sourceFile("src/components/stats/StatsTabs.tsx");
+    const directives = file.statements
+      .filter(ts.isExpressionStatement)
+      .map((statement) => statement.expression)
+      .filter(ts.isStringLiteral)
+      .map((literal) => literal.text);
+
+    expect(directives).not.toContain("use client");
     expect(
-      read("src/app/elections/presidentielle-2027/_components/CandidacyDirectoryLink.tsx")
-    ).toContain("prefetch={false}");
+      jsxElements("src/components/stats/StatsTabs.tsx", "Link").every((link) =>
+        hasFalseAttribute(link, "prefetch")
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    "src/components/layout/Footer.tsx",
+    "src/app/elections/presidentielle-2027/_components/CandidacyDirectoryLink.tsx",
+  ])("does not preload links from %s", (path) => {
+    const links = jsxElements(path, "Link");
+    expect(links.length).toBeGreaterThan(0);
+    expect(links.every((link) => hasFalseAttribute(link, "prefetch"))).toBe(true);
   });
 
   it("counts candidacy measures without loading complete revisions", () => {
-    const source = read("src/lib/data/presidential-candidacy-field.ts");
-    expect(source).toContain("getPublicMeasureRollupsByElection");
-    expect(source).not.toContain("getPublicMeasuresByElection");
+    const calls = calledNames("src/lib/data/presidential-candidacy-field.ts");
+    expect(calls.has("getPublicMeasureRollupsByElection")).toBe(true);
+    expect(calls.has("getPublicMeasuresByElection")).toBe(false);
   });
 });

--- a/src/__tests__/next-config-redirects.test.ts
+++ b/src/__tests__/next-config-redirects.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vitest";
 import nextConfig from "../../next.config";
 
 describe("redirections de compatibilité", () => {
+  it("redirige les anciennes statistiques vers leurs pages dédiées", async () => {
+    expect(nextConfig.redirects).toBeTypeOf("function");
+    const redirects = await nextConfig.redirects!();
+
+    expect(redirects).toEqual(
+      expect.arrayContaining(
+        [
+          ["factchecks", "/statistiques/factchecks"],
+          ["legislatif", "/statistiques/legislatif"],
+          ["participation", "/statistiques/participation"],
+        ].map(([tab, destination]) => ({
+          source: "/statistiques",
+          has: [{ type: "query", key: "tab", value: tab }],
+          destination,
+          permanent: true,
+        }))
+      )
+    );
+  });
+
   it("redirige durablement les anciennes pages sujets vers les pages thèmes", async () => {
     expect(nextConfig.redirects).toBeTypeOf("function");
     const redirects = await nextConfig.redirects!();

--- a/src/app/__tests__/sitemap-dynamic.test.ts
+++ b/src/app/__tests__/sitemap-dynamic.test.ts
@@ -109,4 +109,16 @@ describe("the sitemap route renders per request", () => {
   it("returns nothing for an unknown shard rather than throwing", async () => {
     await expect(sitemap({ id: Promise.resolve("9") })).resolves.toEqual([]);
   });
+
+  it("keeps every server-rendered statistics section discoverable", async () => {
+    const urls = (await sitemap({ id: Promise.resolve("0") })).map((entry) => entry.url);
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/\/statistiques$/),
+        expect.stringMatching(/\/statistiques\/factchecks$/),
+        expect.stringMatching(/\/statistiques\/legislatif$/),
+        expect.stringMatching(/\/statistiques\/participation$/),
+      ])
+    );
+  });
 });

--- a/src/app/elections/presidentielle-2027/_components/PartyLogo.tsx
+++ b/src/app/elections/presidentielle-2027/_components/PartyLogo.tsx
@@ -43,7 +43,6 @@ export function PartyLogo({
           src={logoUrl}
           alt=""
           fill
-          unoptimized
           sizes={size === "lg" ? "96px" : size === "md" ? "48px" : "24px"}
           onError={() => setLogoFailed(true)}
           className="object-contain p-1"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { DEPARTMENTS, getDepartmentSlug } from "@/config/departments";
 import { getAllLegacyThemeSlugs } from "@/lib/theme-utils";
 import { SITE_URL } from "@/config/site";
+import { STATS_SECTIONS, STATS_TABS } from "@/config/routes";
 import { getWeekStart, getISOWeekString } from "@/lib/data/recap";
 import { loadThemesIndex } from "@/lib/data/themes-index";
 import { isFicheCandidatPublishable, isHubPublishable } from "@/config/publication-gates";
@@ -158,8 +159,8 @@ async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap
       changeFrequency: "weekly",
       priority: 0.8,
     },
-    ...["factchecks", "legislatif", "participation"].map((section) => ({
-      url: `${SITE_URL}/statistiques/${section}`,
+    ...STATS_TABS.filter((section) => section !== "judiciaire").map((section) => ({
+      url: `${SITE_URL}${STATS_SECTIONS[section].path}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.7,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -158,6 +158,12 @@ async function buildStaticAndPoliticiansSitemap(): Promise<MetadataRoute.Sitemap
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    ...["factchecks", "legislatif", "participation"].map((section) => ({
+      url: `${SITE_URL}/statistiques/${section}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
     {
       url: `${SITE_URL}/elections`,
       lastModified: new Date(),

--- a/src/app/statistiques/factchecks/page.tsx
+++ b/src/app/statistiques/factchecks/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { FactCheckSection } from "@/components/stats/FactCheckSection";
+import { StatisticsPageLayout } from "@/components/stats/StatisticsPageLayout";
+import { getFactCheckData } from "@/lib/data/statistics";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "Statistiques du fact-checking politique",
+  description:
+    "Répartition des verdicts du fact-checking politique par source, personnalité et parti dans le corpus Poligraph.",
+  alternates: { canonical: "/statistiques/factchecks" },
+};
+
+export default async function FactCheckStatisticsPage() {
+  if (!(await isFeatureEnabled("STATISTIQUES_SECTION"))) notFound();
+  const data = await getFactCheckData();
+
+  return (
+    <StatisticsPageLayout
+      active="factchecks"
+      title="Statistiques du fact-checking politique"
+      description="Répartition des verdicts publiés dans le corpus de fact-checks de Poligraph."
+    >
+      <FactCheckSection
+        total={data.total}
+        groups={data.groups}
+        bySource={data.bySource}
+        topVraiSharePoliticians={data.topVraiSharePoliticians}
+        topFauxSharePoliticians={data.topFauxSharePoliticians}
+        topVraiShareParties={data.topVraiShareParties}
+        topFauxShareParties={data.topFauxShareParties}
+      />
+    </StatisticsPageLayout>
+  );
+}

--- a/src/app/statistiques/legislatif/page.tsx
+++ b/src/app/statistiques/legislatif/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { LegislativeSection } from "@/components/stats/LegislativeSection";
+import { StatisticsPageLayout } from "@/components/stats/StatisticsPageLayout";
+import { getGroupDynamicsData, getLegislativeData } from "@/lib/data/statistics";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "Statistiques de l’activité législative",
+  description:
+    "Scrutins, textes, thèmes et dynamiques des groupes parlementaires documentés par Poligraph.",
+  alternates: { canonical: "/statistiques/legislatif" },
+};
+
+export default async function LegislativeStatisticsPage() {
+  if (!(await isFeatureEnabled("STATISTIQUES_SECTION"))) notFound();
+  const [data, dynamics] = await Promise.all([getLegislativeData(), getGroupDynamicsData()]);
+
+  return (
+    <StatisticsPageLayout
+      active="legislatif"
+      title="Statistiques de l’activité législative"
+      description="Scrutins publics, textes et dynamiques des groupes à l’Assemblée nationale et au Sénat."
+    >
+      <LegislativeSection
+        stats={data}
+        dynamicsAN={dynamics.dynamicsAN}
+        dynamicsSENAT={dynamics.dynamicsSENAT}
+      />
+    </StatisticsPageLayout>
+  );
+}

--- a/src/app/statistiques/page.tsx
+++ b/src/app/statistiques/page.tsx
@@ -1,126 +1,49 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { isFeatureEnabled } from "@/lib/feature-flags";
-import type { Chamber } from "@/generated/prisma";
-import { getVictimStats } from "@/lib/data/affairs";
-import {
-  getJudicialData,
-  getFactCheckData,
-  getLegislativeData,
-  getGroupDynamicsData,
-  getParticipationData,
-} from "@/lib/data/statistics";
-import { StatsTabs } from "@/components/stats/StatsTabs";
-import { LegislativeSection } from "@/components/stats/LegislativeSection";
 import { JudicialSection } from "@/components/stats/JudicialSection";
-import { FactCheckSection } from "@/components/stats/FactCheckSection";
-import { ParticipationSection } from "@/components/stats/ParticipationSection";
-import { PresidentialEntry } from "@/components/stats/PresidentialEntry";
+import { StatisticsPageLayout } from "@/components/stats/StatisticsPageLayout";
+import { getVictimStats } from "@/lib/data/affairs";
 import { getHemicycleData } from "@/lib/data/hemicycle";
-import { Breadcrumb } from "@/components/ui/Breadcrumb";
-import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { getPresidentialOverviewStats } from "@/lib/data/presidential-stats";
-import { SITE_URL } from "@/config/site";
+import { getJudicialData } from "@/lib/data/statistics";
+import { isFeatureEnabled } from "@/lib/feature-flags";
 
 export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Statistiques de la vie politique française",
   description:
-    "Tableaux de bord sur les responsables politiques français : condamnations par parti, activité parlementaire, votes et fact-checks. Données ouvertes, méthodologie transparente.",
+    "Statistiques sur la vie politique française : affaires judiciaires, fact-checking, activité législative et participation.",
   alternates: { canonical: "/statistiques" },
 };
 
-// ── Page ─────────────────────────────────────────────────────
-
-interface PageProps {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
-export default async function StatistiquesPage({ searchParams }: PageProps) {
+export default async function StatistiquesPage() {
   if (!(await isFeatureEnabled("STATISTIQUES_SECTION"))) notFound();
 
-  const params = await searchParams;
-  const pChamber =
-    params.chamber === "AN" || params.chamber === "SENAT" ? (params.chamber as Chamber) : undefined;
-  const pPage = Math.max(1, Math.min(100, parseInt(String(params.pPage ?? "1"), 10) || 1));
-  const pSort = params.pSort === "desc" ? ("DESC" as const) : ("ASC" as const);
-
-  const [
-    legislativeData,
-    judicialData,
-    factCheckData,
-    participationData,
-    groupDynamicsData,
-    hemicycleData,
-    victimStats,
-    presidentialStats,
-  ] = await Promise.all([
-    getLegislativeData(),
+  const [judicialData, hemicycleData, victimStats, presidentialStats] = await Promise.all([
     getJudicialData(),
-    getFactCheckData(),
-    getParticipationData(pChamber, pPage, pSort),
-    getGroupDynamicsData(),
     getHemicycleData(),
     getVictimStats(),
     getPresidentialOverviewStats("presidentielle-2027"),
   ]);
 
   return (
-    <>
-      <CollectionPageJsonLd
-        name="Statistiques politiques de la France"
-        description="Statistiques sur la vie politique française : travail législatif, transparence judiciaire, fact-checking."
-        url={`${SITE_URL}/statistiques`}
+    <StatisticsPageLayout
+      active="judiciaire"
+      title="Statistiques de la vie politique française"
+      description="Affaires judiciaires documentées, fact-checking, activité législative et participation politique."
+      presidentialStats={presidentialStats}
+    >
+      <JudicialSection
+        maturityCounts={judicialData.maturityCounts}
+        uniqueCondamnes={judicialData.uniqueCondamnes}
+        uniqueMisEnCause={judicialData.uniqueMisEnCause}
+        byStatus={judicialData.byStatus}
+        byCategory={judicialData.byCategory}
+        critiqueByCategory={judicialData.critiqueByCategory}
+        hemicycleGroups={hemicycleData}
+        victimStats={victimStats}
       />
-      <div className="container mx-auto px-4 pt-4 pb-8">
-        <Breadcrumb items={[{ label: "Statistiques" }]} />
-        <h1 className="text-3xl font-display font-extrabold tracking-tight mb-2">Statistiques</h1>
-        <p className="text-muted-foreground mb-8">
-          Vue d&apos;ensemble des données sur la vie politique française
-        </p>
-
-        <StatsTabs
-          judicialContent={
-            <JudicialSection
-              maturityCounts={judicialData.maturityCounts}
-              uniqueCondamnes={judicialData.uniqueCondamnes}
-              uniqueMisEnCause={judicialData.uniqueMisEnCause}
-              byStatus={judicialData.byStatus}
-              byCategory={judicialData.byCategory}
-              critiqueByCategory={judicialData.critiqueByCategory}
-              hemicycleGroups={hemicycleData}
-              victimStats={victimStats}
-            />
-          }
-          factCheckContent={
-            <FactCheckSection
-              total={factCheckData.total}
-              groups={factCheckData.groups}
-              bySource={factCheckData.bySource}
-              topVraiSharePoliticians={factCheckData.topVraiSharePoliticians}
-              topFauxSharePoliticians={factCheckData.topFauxSharePoliticians}
-              topVraiShareParties={factCheckData.topVraiShareParties}
-              topFauxShareParties={factCheckData.topFauxShareParties}
-            />
-          }
-          legislativeContent={
-            <LegislativeSection
-              stats={legislativeData}
-              dynamicsAN={groupDynamicsData.dynamicsAN}
-              dynamicsSENAT={groupDynamicsData.dynamicsSENAT}
-            />
-          }
-          participationContent={
-            <ParticipationSection
-              groupDissidenceAN={participationData.groupDissidenceAN}
-              groupDissidenceSENAT={participationData.groupDissidenceSENAT}
-              chamber={pChamber}
-            />
-          }
-        />
-        {presidentialStats !== null ? <PresidentialEntry stats={presidentialStats} /> : null}
-      </div>
-    </>
+    </StatisticsPageLayout>
   );
 }

--- a/src/app/statistiques/participation/page.tsx
+++ b/src/app/statistiques/participation/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { Chamber } from "@/generated/prisma";
+import { ParticipationSection } from "@/components/stats/ParticipationSection";
+import { StatisticsPageLayout } from "@/components/stats/StatisticsPageLayout";
+import { getParticipationData } from "@/lib/data/statistics";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "Participation aux scrutins publics",
+  description:
+    "Données de participation et de dissidence lors des scrutins publics de l’Assemblée nationale et du Sénat.",
+  alternates: { canonical: "/statistiques/participation" },
+};
+
+export default async function ParticipationStatisticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  if (!(await isFeatureEnabled("STATISTIQUES_SECTION"))) notFound();
+  const params = await searchParams;
+  const chamber =
+    params.chamber === "AN" || params.chamber === "SENAT" ? (params.chamber as Chamber) : undefined;
+  const data = await getParticipationData(chamber);
+
+  return (
+    <StatisticsPageLayout
+      active="participation"
+      title="Participation aux scrutins publics"
+      description="Participation et dissidence documentées dans les scrutins publics des deux chambres."
+    >
+      <ParticipationSection
+        groupDissidenceAN={data.groupDissidenceAN}
+        groupDissidenceSENAT={data.groupDissidenceSENAT}
+        chamber={chamber}
+      />
+    </StatisticsPageLayout>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -58,6 +58,7 @@ export async function Footer() {
                     ) : (
                       <Link
                         href={link.href}
+                        prefetch={false}
                         className="text-muted-foreground hover:text-foreground transition-colors nav-link-underline"
                       >
                         {link.label}

--- a/src/components/stats/FactCheckSection.tsx
+++ b/src/components/stats/FactCheckSection.tsx
@@ -65,6 +65,7 @@ function PoliticianRankingItem({
   return (
     <Link
       href={`/politiques/${pol.slug}`}
+      prefetch={false}
       className="flex items-center gap-3 hover:bg-muted/50 rounded-lg p-2 -mx-1 sm:-mx-2 transition-colors"
     >
       <span className="text-sm font-bold text-muted-foreground w-6 text-right tabular-nums shrink-0">
@@ -114,6 +115,7 @@ function PartyRankingItem({
   return (
     <Link
       href={party.slug ? `/partis/${party.slug}` : "#"}
+      prefetch={false}
       className="flex items-center gap-3 hover:bg-muted/50 rounded-lg p-2 -mx-1 sm:-mx-2 transition-colors"
     >
       <span className="text-sm font-bold text-muted-foreground w-6 text-right tabular-nums shrink-0">

--- a/src/components/stats/Hemicycle.tsx
+++ b/src/components/stats/Hemicycle.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, useCallback, useId } from "react";
 import { useRouter } from "next/navigation";
-import { scaleLinear } from "d3-scale";
 import { computeHemicycleLayout } from "./hemicycle-layout";
 import { CERTAINTY_LABELS } from "@/config/certainty";
 import type { HemicycleGroup, HemicycleDeputy } from "@/lib/data/hemicycle";
@@ -23,6 +22,26 @@ const SVG_WIDTH = 800;
 const SVG_HEIGHT = 420;
 const BASE_RADIUS = 3.8;
 const MAX_SCALE = 3;
+const RADIUS_STOPS = [
+  [0, BASE_RADIUS],
+  [1, BASE_RADIUS * 1.4],
+  [4, BASE_RADIUS * 2],
+  [12, BASE_RADIUS * MAX_SCALE],
+] as const;
+
+function radiusForScore(score: number): number {
+  const value = Math.max(0, Math.min(score, 12));
+
+  for (let index = 1; index < RADIUS_STOPS.length; index++) {
+    const [nextScore, nextRadius] = RADIUS_STOPS[index]!;
+    if (value > nextScore) continue;
+    const [previousScore, previousRadius] = RADIUS_STOPS[index - 1]!;
+    const ratio = (value - previousScore) / (nextScore - previousScore);
+    return previousRadius + ratio * (nextRadius - previousRadius);
+  }
+
+  return BASE_RADIUS * MAX_SCALE;
+}
 
 export function Hemicycle({ groups }: HemicycleProps) {
   const router = useRouter();
@@ -103,16 +122,6 @@ export function Hemicycle({ groups }: HemicycleProps) {
     };
   }, [deputyMap, seats, highlightGroup, groups]);
 
-  // Severity score → circle radius
-  const radiusScale = useMemo(
-    () =>
-      scaleLinear()
-        .domain([0, 1, 4, 12])
-        .range([BASE_RADIUS, BASE_RADIUS * 1.4, BASE_RADIUS * 2, BASE_RADIUS * MAX_SCALE])
-        .clamp(true),
-    []
-  );
-
   const handleMouseEnter = useCallback(
     (seatIdx: number, event: React.MouseEvent<SVGCircleElement>) => {
       const data = deputyMap.get(seatIdx);
@@ -154,7 +163,7 @@ export function Hemicycle({ groups }: HemicycleProps) {
           const data = deputyMap.get(seat.seatIndex);
           const deputy = data?.deputy;
           const score = deputy?.severityScore ?? 0;
-          const r = radiusScale(score);
+          const r = radiusForScore(score);
           const isHighlighted = !highlightGroup || seat.groupCode === highlightGroup;
           const hasIssue = score > 0;
           const maxLevel = deputy?.maxCertaintyLevel;

--- a/src/components/stats/Hemicycle.tsx
+++ b/src/components/stats/Hemicycle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState, useCallback, useId } from "react";
-import { useRouter } from "next/navigation";
 import { computeHemicycleLayout } from "./hemicycle-layout";
 import { CERTAINTY_LABELS } from "@/config/certainty";
 import type { HemicycleGroup, HemicycleDeputy } from "@/lib/data/hemicycle";
@@ -44,7 +43,6 @@ function radiusForScore(score: number): number {
 }
 
 export function Hemicycle({ groups }: HemicycleProps) {
-  const router = useRouter();
   const descId = useId();
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
   const [highlightGroup, setHighlightGroup] = useState<string | null>(null);
@@ -142,14 +140,6 @@ export function Hemicycle({ groups }: HemicycleProps) {
 
   const handleMouseLeave = useCallback(() => setTooltip(null), []);
 
-  const handleClick = useCallback(
-    (seatIdx: number) => {
-      const data = deputyMap.get(seatIdx);
-      if (data) router.push(`/politiques/${data.deputy.slug}`);
-    },
-    [deputyMap, router]
-  );
-
   return (
     <div className="relative">
       <svg
@@ -181,9 +171,8 @@ export function Hemicycle({ groups }: HemicycleProps) {
           const strokeWidth =
             maxLevel === "ETABLI" ? 2 : maxLevel === "PRONONCE" ? 1.5 : hasIssue ? 0.8 : 0;
 
-          return (
+          const circle = (
             <circle
-              key={i}
               cx={seat.x}
               cy={seat.y}
               r={r}
@@ -194,8 +183,32 @@ export function Hemicycle({ groups }: HemicycleProps) {
               className="cursor-pointer transition-opacity duration-200"
               onMouseEnter={(e) => handleMouseEnter(seat.seatIndex, e)}
               onMouseLeave={handleMouseLeave}
-              onClick={() => handleClick(seat.seatIndex)}
             />
+          );
+
+          if (!data) return <g key={i}>{circle}</g>;
+
+          const deputyName = `${data.deputy.firstName} ${data.deputy.lastName}`;
+          return (
+            <a
+              key={i}
+              href={`/politiques/${data.deputy.slug}`}
+              aria-label={`Voir la fiche de ${deputyName}`}
+              className="group focus:outline-none"
+              onFocus={() =>
+                setTooltip({
+                  deputy: data.deputy,
+                  groupName: data.groupName,
+                  groupCode: data.groupCode,
+                  x: seat.x,
+                  y: seat.y,
+                })
+              }
+              onBlur={handleMouseLeave}
+            >
+              <title>{`${deputyName}, ${data.groupName}`}</title>
+              {circle}
+            </a>
           );
         })}
       </svg>

--- a/src/components/stats/Hemicycle.tsx
+++ b/src/components/stats/Hemicycle.tsx
@@ -145,7 +145,7 @@ export function Hemicycle({ groups }: HemicycleProps) {
       <svg
         viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
         className="w-full h-auto"
-        role="img"
+        role="group"
         aria-label={`Hémicycle de l'Assemblée nationale : ${summary.misEnCause} député${summary.misEnCause !== 1 ? "s" : ""}${summary.groupLabel ? ` du groupe ${summary.groupLabel}` : ""} mis en cause dans une affaire judiciaire sur ${summary.seatCount}`}
         aria-describedby={descId}
       >
@@ -194,7 +194,6 @@ export function Hemicycle({ groups }: HemicycleProps) {
               key={i}
               href={`/politiques/${data.deputy.slug}`}
               aria-label={`Voir la fiche de ${deputyName}`}
-              className="group focus:outline-none"
               onFocus={() =>
                 setTooltip({
                   deputy: data.deputy,

--- a/src/components/stats/HorizontalBars.tsx
+++ b/src/components/stats/HorizontalBars.tsx
@@ -49,7 +49,12 @@ export function HorizontalBars({ bars, title, maxValue: globalMax }: HorizontalB
           );
 
           return bar.href ? (
-            <Link key={bar.label} href={bar.href} className="block hover:opacity-80">
+            <Link
+              key={bar.label}
+              href={bar.href}
+              prefetch={false}
+              className="block hover:opacity-80"
+            >
               {label}
               {barEl}
             </Link>

--- a/src/components/stats/PresidentialEntry.tsx
+++ b/src/components/stats/PresidentialEntry.tsx
@@ -83,6 +83,7 @@ export function PresidentialEntry({ stats }: { stats: PresidentialOverviewStats 
         <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
           <Link
             href={HUB_PATH}
+            prefetch={false}
             className={cn(buttonVariants({ variant: "default" }), "min-h-11 justify-center")}
           >
             Voir le dossier présidentielle 2027
@@ -90,6 +91,7 @@ export function PresidentialEntry({ stats }: { stats: PresidentialOverviewStats 
           </Link>
           <Link
             href={`${HUB_PATH}/comparer`}
+            prefetch={false}
             className={cn(buttonVariants({ variant: "outline" }), "min-h-11 justify-center")}
           >
             Comparer les mesures des candidats

--- a/src/components/stats/StatisticsPageLayout.tsx
+++ b/src/components/stats/StatisticsPageLayout.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
+import { SITE_URL } from "@/config/site";
+import { statsHref, type StatsTab } from "@/config/routes";
+import type { PresidentialOverviewStats } from "@/lib/data/presidential-stats";
+import { PresidentialEntry } from "./PresidentialEntry";
+import { StatsTabs } from "./StatsTabs";
+
+const SECTION_LABELS: Record<StatsTab, string> = {
+  judiciaire: "Judiciaire",
+  factchecks: "Fact-checking",
+  legislatif: "Législatif",
+  participation: "Participation",
+};
+
+export function StatisticsPageLayout({
+  active,
+  title,
+  description,
+  children,
+  presidentialStats,
+}: {
+  active: StatsTab;
+  title: string;
+  description: string;
+  children: ReactNode;
+  presidentialStats?: PresidentialOverviewStats | null;
+}) {
+  const path = statsHref(active);
+  return (
+    <>
+      <CollectionPageJsonLd name={title} description={description} url={`${SITE_URL}${path}`} />
+      <div className="container mx-auto px-4 pb-8 pt-4">
+        <Breadcrumb
+          items={
+            active === "judiciaire"
+              ? [{ label: "Statistiques" }]
+              : [
+                  { label: "Statistiques", href: "/statistiques" },
+                  { label: SECTION_LABELS[active] },
+                ]
+          }
+        />
+        <h1 className="mb-2 font-display text-3xl font-extrabold tracking-tight">{title}</h1>
+        <p className="mb-8 text-muted-foreground">{description}</p>
+        <StatsTabs active={active}>{children}</StatsTabs>
+        {presidentialStats ? <PresidentialEntry stats={presidentialStats} /> : null}
+      </div>
+    </>
+  );
+}

--- a/src/components/stats/StatisticsPageLayout.tsx
+++ b/src/components/stats/StatisticsPageLayout.tsx
@@ -2,17 +2,10 @@ import type { ReactNode } from "react";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
 import { CollectionPageJsonLd } from "@/components/seo/JsonLd";
 import { SITE_URL } from "@/config/site";
-import { statsHref, type StatsTab } from "@/config/routes";
+import { STATS_SECTIONS, statsHref, type StatsTab } from "@/config/routes";
 import type { PresidentialOverviewStats } from "@/lib/data/presidential-stats";
 import { PresidentialEntry } from "./PresidentialEntry";
 import { StatsTabs } from "./StatsTabs";
-
-const SECTION_LABELS: Record<StatsTab, string> = {
-  judiciaire: "Judiciaire",
-  factchecks: "Fact-checking",
-  legislatif: "Législatif",
-  participation: "Participation",
-};
 
 export function StatisticsPageLayout({
   active,
@@ -38,7 +31,7 @@ export function StatisticsPageLayout({
               ? [{ label: "Statistiques" }]
               : [
                   { label: "Statistiques", href: "/statistiques" },
-                  { label: SECTION_LABELS[active] },
+                  { label: STATS_SECTIONS[active].label },
                 ]
           }
         />

--- a/src/components/stats/StatsTabs.test.tsx
+++ b/src/components/stats/StatsTabs.test.tsx
@@ -1,66 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { StatsTabs } from "./StatsTabs";
-import { STATS_TABS, DEFAULT_STATS_TAB, statsHref, type StatsTab } from "@/config/routes";
-
-// jsdom doesn't ship ResizeObserver; Radix's TabsList uses it via `tabs.tsx`.
-if (typeof globalThis.ResizeObserver === "undefined") {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as unknown as typeof ResizeObserver;
-}
-
-const searchParamsRef: { current: URLSearchParams } = { current: new URLSearchParams() };
-
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => searchParamsRef.current,
-}));
-
-/** Extract the query string a `statsHref` result carries, as the router would. */
-function searchParamsFrom(href: string): URLSearchParams {
-  return new URLSearchParams(href.split("?")[1] ?? "");
-}
-
-function renderAt(href: string) {
-  searchParamsRef.current = searchParamsFrom(href);
-  return render(
-    <StatsTabs
-      judicialContent={<p>panneau judiciaire</p>}
-      factCheckContent={<p>panneau factchecks</p>}
-      legislativeContent={<p>panneau legislatif</p>}
-      participationContent={<p>panneau participation</p>}
-    />
-  );
-}
-
-beforeEach(() => {
-  searchParamsRef.current = new URLSearchParams();
-});
+import { STATS_TABS, statsHref, type StatsTab } from "@/config/routes";
 
 describe("StatsTabs", () => {
-  // Round-trip guard: a tab listed in config must actually be rendered by the
-  // component. Dropping a `TabsContent` while leaving the tab in `STATS_TABS`
-  // is what let links to a removed tab survive as silent redirects to the
-  // default tab.
-  it.each(STATS_TABS)("opens the %s panel for the URL statsHref builds", (tab: StatsTab) => {
-    renderAt(statsHref(tab));
+  it.each(STATS_TABS)("links to the server-rendered %s section", (tab: StatsTab) => {
+    render(
+      <StatsTabs active={tab}>
+        <p>Contenu actif</p>
+      </StatsTabs>
+    );
 
-    expect(screen.getByText(`panneau ${tab}`)).toBeInTheDocument();
+    const activeLink = screen.getByRole("link", { current: "page" });
+    expect(activeLink).toHaveAttribute("href", statsHref(tab));
+    expect(screen.getAllByRole("link")).toHaveLength(STATS_TABS.length);
+    expect(screen.getByText("Contenu actif")).toBeInTheDocument();
   });
 
-  it("falls back to the default tab for an unknown tab value", () => {
-    renderAt("/statistiques?tab=votes");
-
-    expect(screen.getByText(`panneau ${DEFAULT_STATS_TAB}`)).toBeInTheDocument();
-  });
-
-  it("keeps the chamber param usable alongside the participation tab", () => {
-    const href = statsHref("participation", { chamber: "AN" });
-    renderAt(href);
-
-    expect(searchParamsFrom(href).get("chamber")).toBe("AN");
-    expect(screen.getByText("panneau participation")).toBeInTheDocument();
+  it("keeps the chamber on the participation URL", () => {
+    expect(statsHref("participation", { chamber: "AN" })).toBe(
+      "/statistiques/participation?chamber=AN"
+    );
   });
 });

--- a/src/components/stats/StatsTabs.tsx
+++ b/src/components/stats/StatsTabs.tsx
@@ -1,89 +1,56 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import Link from "next/link";
 import type { ReactNode } from "react";
-import { Suspense, useEffect, useMemo, useState } from "react";
-import { Scale, ShieldCheck, FileText, BarChart3 } from "lucide-react";
-import { STATS_TABS, DEFAULT_STATS_TAB, type StatsTab } from "@/config/routes";
+import { BarChart3, FileText, Scale, ShieldCheck } from "lucide-react";
+import { statsHref, type StatsTab } from "@/config/routes";
 
-interface StatsTabsProps {
-  judicialContent: ReactNode;
-  factCheckContent: ReactNode;
-  legislativeContent: ReactNode;
-  participationContent: ReactNode;
-}
+const ITEMS: Array<{
+  tab: StatsTab;
+  label: string;
+  shortLabel: string;
+  icon: typeof Scale;
+}> = [
+  { tab: "judiciaire", label: "Judiciaire", shortLabel: "Justice", icon: Scale },
+  { tab: "factchecks", label: "Fact-checking", shortLabel: "Facts", icon: ShieldCheck },
+  { tab: "legislatif", label: "Législatif", shortLabel: "Lois", icon: FileText },
+  {
+    tab: "participation",
+    label: "Participation aux scrutins publics",
+    shortLabel: "Votes",
+    icon: BarChart3,
+  },
+];
 
-function StatsTabsInner({
-  judicialContent,
-  factCheckContent,
-  legislativeContent,
-  participationContent,
-}: StatsTabsProps) {
-  const searchParams = useSearchParams();
-
-  const tabFromUrl = useMemo<StatsTab>(() => {
-    const raw = searchParams.get("tab");
-    return STATS_TABS.includes(raw as StatsTab) ? (raw as StatsTab) : DEFAULT_STATS_TAB;
-  }, [searchParams]);
-
-  const [tab, setTab] = useState<StatsTab>(tabFromUrl);
-
-  // Keep local state in sync when the URL changes externally
-  // (browser back/forward, in-page <Link href="?tab=...">).
-  useEffect(() => {
-    setTab(tabFromUrl);
-  }, [tabFromUrl]);
-
-  function onTabChange(value: string) {
-    const next = value as StatsTab;
-    setTab(next);
-    const params = new URLSearchParams(window.location.search);
-    if (next === DEFAULT_STATS_TAB) {
-      params.delete("tab");
-    } else {
-      params.set("tab", next);
-    }
-    const qs = params.toString();
-    window.history.replaceState(null, "", `/statistiques${qs ? `?${qs}` : ""}`);
-  }
-
+/** Server-rendered navigation avoids mounting and prefetching hidden datasets. */
+export function StatsTabs({ active, children }: { active: StatsTab; children: ReactNode }) {
   return (
-    <Tabs value={tab} onValueChange={onTabChange}>
-      <TabsList>
-        <TabsTrigger value="judiciaire">
-          <Scale className="h-4 w-4" />
-          <span className="hidden sm:inline">Judiciaire</span>
-          <span className="sm:hidden">Justice</span>
-        </TabsTrigger>
-        <TabsTrigger value="factchecks">
-          <ShieldCheck className="h-4 w-4" />
-          <span className="hidden sm:inline">Fact-checking</span>
-          <span className="sm:hidden">Facts</span>
-        </TabsTrigger>
-        <TabsTrigger value="legislatif">
-          <FileText className="h-4 w-4" />
-          <span className="hidden sm:inline">Législatif</span>
-          <span className="sm:hidden">Lois</span>
-        </TabsTrigger>
-        <TabsTrigger value="participation">
-          <BarChart3 className="h-4 w-4" />
-          <span className="hidden sm:inline">Participation aux scrutins publics</span>
-          <span className="sm:hidden">Votes</span>
-        </TabsTrigger>
-      </TabsList>
-      <TabsContent value="judiciaire">{judicialContent}</TabsContent>
-      <TabsContent value="factchecks">{factCheckContent}</TabsContent>
-      <TabsContent value="legislatif">{legislativeContent}</TabsContent>
-      <TabsContent value="participation">{participationContent}</TabsContent>
-    </Tabs>
-  );
-}
-
-export function StatsTabs(props: StatsTabsProps) {
-  return (
-    <Suspense>
-      <StatsTabsInner {...props} />
-    </Suspense>
+    <>
+      <nav aria-label="Rubriques statistiques" className="overflow-x-auto pb-1">
+        <ul className="flex min-w-max gap-1 rounded-lg bg-muted p-[3px]">
+          {ITEMS.map((item) => {
+            const Icon = item.icon;
+            const selected = item.tab === active;
+            return (
+              <li key={item.tab}>
+                <Link
+                  href={statsHref(item.tab)}
+                  prefetch={false}
+                  aria-current={selected ? "page" : undefined}
+                  className={`inline-flex min-h-11 items-center justify-center gap-1.5 rounded-md px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                    selected
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Icon aria-hidden="true" className="h-4 w-4" />
+                  <span className="hidden sm:inline">{item.label}</span>
+                  <span className="sm:hidden">{item.shortLabel}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      {children}
+    </>
   );
 }

--- a/src/components/stats/StatsTabs.tsx
+++ b/src/components/stats/StatsTabs.tsx
@@ -1,23 +1,16 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { BarChart3, FileText, Scale, ShieldCheck } from "lucide-react";
-import { statsHref, type StatsTab } from "@/config/routes";
+import { STATS_SECTIONS, statsHref, type StatsTab } from "@/config/routes";
 
 const ITEMS: Array<{
   tab: StatsTab;
-  label: string;
-  shortLabel: string;
   icon: typeof Scale;
 }> = [
-  { tab: "judiciaire", label: "Judiciaire", shortLabel: "Justice", icon: Scale },
-  { tab: "factchecks", label: "Fact-checking", shortLabel: "Facts", icon: ShieldCheck },
-  { tab: "legislatif", label: "Législatif", shortLabel: "Lois", icon: FileText },
-  {
-    tab: "participation",
-    label: "Participation aux scrutins publics",
-    shortLabel: "Votes",
-    icon: BarChart3,
-  },
+  { tab: "judiciaire", icon: Scale },
+  { tab: "factchecks", icon: ShieldCheck },
+  { tab: "legislatif", icon: FileText },
+  { tab: "participation", icon: BarChart3 },
 ];
 
 /** Server-rendered navigation avoids mounting and prefetching hidden datasets. */
@@ -29,6 +22,7 @@ export function StatsTabs({ active, children }: { active: StatsTab; children: Re
           {ITEMS.map((item) => {
             const Icon = item.icon;
             const selected = item.tab === active;
+            const section = STATS_SECTIONS[item.tab];
             return (
               <li key={item.tab}>
                 <Link
@@ -42,8 +36,8 @@ export function StatsTabs({ active, children }: { active: StatsTab; children: Re
                   }`}
                 >
                   <Icon aria-hidden="true" className="h-4 w-4" />
-                  <span className="hidden sm:inline">{item.label}</span>
-                  <span className="sm:hidden">{item.shortLabel}</span>
+                  <span className="hidden sm:inline">{section.label}</span>
+                  <span className="sm:hidden">{section.shortLabel}</span>
                 </Link>
               </li>
             );

--- a/src/components/stats/__tests__/Hemicycle.test.tsx
+++ b/src/components/stats/__tests__/Hemicycle.test.tsx
@@ -45,6 +45,16 @@ function summary() {
 }
 
 describe("Hemicycle summary", () => {
+  it("rend chaque siège occupé accessible au clavier", () => {
+    const { container } = render(<Hemicycle groups={groups} />);
+    const links = container.querySelectorAll('svg a[href^="/politiques/"]');
+
+    expect(links).toHaveLength(5);
+    expect([...links].map((link) => link.getAttribute("aria-label"))).toContain(
+      "Voir la fiche de Jean Nom1"
+    );
+  });
+
   it("counts the whole chamber when no group is selected", () => {
     render(<Hemicycle groups={groups} />);
 

--- a/src/components/stats/__tests__/Hemicycle.test.tsx
+++ b/src/components/stats/__tests__/Hemicycle.test.tsx
@@ -8,7 +8,6 @@ function deputy(over: Partial<HemicycleDeputy> & { id: string }): HemicycleDeput
     slug: `d-${over.id}`,
     firstName: "Jean",
     lastName: `Nom${over.id}`,
-    photoUrl: null,
     severityScore: 0,
     maxCertaintyLevel: null,
     activeAffairCount: 0,

--- a/src/components/stats/__tests__/Hemicycle.test.tsx
+++ b/src/components/stats/__tests__/Hemicycle.test.tsx
@@ -47,11 +47,17 @@ function summary() {
 describe("Hemicycle summary", () => {
   it("rend chaque siège occupé accessible au clavier", () => {
     const { container } = render(<Hemicycle groups={groups} />);
+    const hemicycle = screen.getByRole("group", { name: /Hémicycle de l'Assemblée nationale/ });
     const links = container.querySelectorAll('svg a[href^="/politiques/"]');
 
+    expect(hemicycle).toBeInTheDocument();
+    expect(container.querySelector('svg[role="img"]')).toBeNull();
     expect(links).toHaveLength(5);
     expect([...links].map((link) => link.getAttribute("aria-label"))).toContain(
       "Voir la fiche de Jean Nom1"
+    );
+    expect([...links].every((link) => !link.getAttribute("class")?.includes("outline-none"))).toBe(
+      true
     );
   });
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -14,24 +14,24 @@ export const ROUTES = {
   groupeDetail: (slug: string) => `/parlement/groupes/${slug}`,
 } as const;
 
-/**
- * Tabs rendered by /statistiques. Single source of truth: `StatsTabs` reads this
- * list to validate `?tab=`, and `statsHref` only accepts a value from it, so
- * linking to a tab that no longer exists is a type error rather than a silent
- * fallback to the default tab.
- */
+/** Stable URLs keep each statistics section server-rendered and indexable. */
 export const STATS_TABS = ["judiciaire", "factchecks", "legislatif", "participation"] as const;
 export type StatsTab = (typeof STATS_TABS)[number];
 export const DEFAULT_STATS_TAB: StatsTab = "judiciaire";
 
+export const STATS_PATHS: Record<StatsTab, string> = {
+  judiciaire: "/statistiques",
+  factchecks: "/statistiques/factchecks",
+  legislatif: "/statistiques/legislatif",
+  participation: "/statistiques/participation",
+};
+
 /**
- * Build a /statistiques URL. `chamber` is only read by the participation tab.
- * The default tab is left out so the canonical URL stays /statistiques.
+ * Build a statistics URL. `chamber` is only read by the participation section.
  */
 export function statsHref(tab: StatsTab, params?: { chamber?: Chamber }): string {
   const search = new URLSearchParams();
-  if (tab !== DEFAULT_STATS_TAB) search.set("tab", tab);
   if (params?.chamber) search.set("chamber", params.chamber);
   const qs = search.toString();
-  return qs ? `/statistiques?${qs}` : "/statistiques";
+  return qs ? `${STATS_PATHS[tab]}?${qs}` : STATS_PATHS[tab];
 }

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -15,23 +15,29 @@ export const ROUTES = {
 } as const;
 
 /** Stable URLs keep each statistics section server-rendered and indexable. */
-export const STATS_TABS = ["judiciaire", "factchecks", "legislatif", "participation"] as const;
-export type StatsTab = (typeof STATS_TABS)[number];
+export const STATS_SECTIONS = {
+  judiciaire: { path: "/statistiques", label: "Judiciaire", shortLabel: "Justice" },
+  factchecks: {
+    path: "/statistiques/factchecks",
+    label: "Fact-checking",
+    shortLabel: "Facts",
+  },
+  legislatif: { path: "/statistiques/legislatif", label: "Législatif", shortLabel: "Lois" },
+  participation: {
+    path: "/statistiques/participation",
+    label: "Participation aux scrutins publics",
+    shortLabel: "Votes",
+  },
+} as const;
+
+export type StatsTab = keyof typeof STATS_SECTIONS;
+export const STATS_TABS = Object.keys(STATS_SECTIONS) as StatsTab[];
 export const DEFAULT_STATS_TAB: StatsTab = "judiciaire";
 
-export const STATS_PATHS: Record<StatsTab, string> = {
-  judiciaire: "/statistiques",
-  factchecks: "/statistiques/factchecks",
-  legislatif: "/statistiques/legislatif",
-  participation: "/statistiques/participation",
-};
-
-/**
- * Build a statistics URL. `chamber` is only read by the participation section.
- */
 export function statsHref(tab: StatsTab, params?: { chamber?: Chamber }): string {
   const search = new URLSearchParams();
   if (params?.chamber) search.set("chamber", params.chamber);
   const qs = search.toString();
-  return qs ? `${STATS_PATHS[tab]}?${qs}` : STATS_PATHS[tab];
+  const path = STATS_SECTIONS[tab].path;
+  return qs ? `${path}?${qs}` : path;
 }

--- a/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
+++ b/src/lib/data/__tests__/measure-stats-by-candidacy.integration.test.ts
@@ -3,6 +3,7 @@ import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard"
 
 let db: typeof import("@/lib/db").db;
 let getPublicMeasureStatsByCandidacy: typeof import("../measures").getPublicMeasureStatsByCandidacy;
+let getPublicMeasureRollupsByElection: typeof import("../measures").getPublicMeasureRollupsByElection;
 let getMeasureReadinessByCandidacies: typeof import("../measures").getMeasureReadinessByCandidacies;
 
 const SLUG = "stats-by-candidacy";
@@ -24,8 +25,11 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
   beforeAll(async () => {
     assertDisposableTestDb();
     ({ db } = await import("@/lib/db"));
-    ({ getPublicMeasureStatsByCandidacy, getMeasureReadinessByCandidacies } =
-      await import("../measures"));
+    ({
+      getPublicMeasureStatsByCandidacy,
+      getPublicMeasureRollupsByElection,
+      getMeasureReadinessByCandidacies,
+    } = await import("../measures"));
     const { createMeasure, reviewMeasureRevision, publishMeasureRevision, draftMeasureRevision } =
       await import("@/lib/measures/transitions");
 
@@ -155,6 +159,41 @@ describeIfDisposableDb("getPublicMeasureStatsByCandidacy", () => {
     const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
     expect(stats.measureCount).toBe(2);
     expect(stats.themesCoveredCount).toBe(2);
+  });
+
+  it("agrège le même corpus public pour toute l'élection", async () => {
+    const rollups = await getPublicMeasureRollupsByElection(electionId);
+    const publishedStats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+    const secondaryStats = await getPublicMeasureStatsByCandidacy(secondarySourceCandidacyId);
+
+    expect(rollups.get(publishedCandidacyId)).toEqual({
+      measureCount: publishedStats.measureCount,
+      themesCoveredCount: publishedStats.themesCoveredCount,
+    });
+    expect(rollups.get(secondarySourceCandidacyId)).toEqual({
+      measureCount: secondaryStats.measureCount,
+      themesCoveredCount: secondaryStats.themesCoveredCount,
+    });
+    expect(rollups.has(draftExtensionCandidacyId)).toBe(false);
+  });
+
+  it("ignore les mesures retirées dans les deux lectures publiques", async () => {
+    const measure = await db.measure.findFirstOrThrow({
+      where: { candidacyId: publishedCandidacyId },
+      select: { id: true },
+    });
+    await db.measure.update({ where: { id: measure.id }, data: { withdrawnAt: new Date() } });
+
+    try {
+      const rollups = await getPublicMeasureRollupsByElection(electionId);
+      const stats = await getPublicMeasureStatsByCandidacy(publishedCandidacyId);
+      expect(rollups.get(publishedCandidacyId)).toEqual({
+        measureCount: stats.measureCount,
+        themesCoveredCount: stats.themesCoveredCount,
+      });
+    } finally {
+      await db.measure.update({ where: { id: measure.id }, data: { withdrawnAt: null } });
+    }
   });
 
   it("compte une seule mesure à source primaire quand l'autre est secondaire", async () => {

--- a/src/lib/data/hemicycle.ts
+++ b/src/lib/data/hemicycle.ts
@@ -10,11 +10,9 @@ import {
 import type { PoliticalPosition } from "@/generated/prisma";
 
 export interface HemicycleDeputy {
-  id: string;
   slug: string;
   firstName: string;
   lastName: string;
-  photoUrl: string | null;
   /** Certainty-based severity score */
   severityScore: number;
   /** Highest certainty level among active affairs */
@@ -56,11 +54,9 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
             select: {
               politician: {
                 select: {
-                  id: true,
                   slug: true,
                   firstName: true,
                   lastName: true,
-                  photoUrl: true,
                   affairs: {
                     where: {
                       publicationStatus: "PUBLISHED",
@@ -108,11 +104,9 @@ export async function getHemicycleData(): Promise<HemicycleGroup[]> {
         }
 
         return {
-          id: m.politician.id,
           slug: m.politician.slug,
           firstName: m.politician.firstName,
           lastName: m.politician.lastName,
-          photoUrl: m.politician.photoUrl,
           severityScore: score,
           maxCertaintyLevel: maxCertainty,
           activeAffairCount: activeCount,

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -616,6 +616,41 @@ export async function getPublicMeasureStatsByCandidacy(
   };
 }
 
+export type PublicCandidacyMeasureRollup = {
+  measureCount: number;
+  themesCoveredCount: number;
+};
+
+/** Aggregate public measure counts without loading complete revisions. */
+export async function getPublicMeasureRollupsByElection(
+  electionId: string
+): Promise<Map<string, PublicCandidacyMeasureRollup>> {
+  const rows = await db.measure.groupBy({
+    by: ["candidacyId", "theme"],
+    where: {
+      electionId,
+      candidacyId: { not: null },
+      candidacy: { is: PUBLIC_CANDIDACY_WHERE },
+      withdrawnAt: null,
+      ...PUBLIC_MEASURE_WHERE,
+    },
+    _count: { _all: true },
+  });
+
+  const result = new Map<string, PublicCandidacyMeasureRollup>();
+  for (const row of rows) {
+    if (row.candidacyId === null) continue;
+    const current = result.get(row.candidacyId) ?? {
+      measureCount: 0,
+      themesCoveredCount: 0,
+    };
+    current.measureCount += row._count._all;
+    if (isPresidentialTheme(row.theme)) current.themesCoveredCount += 1;
+    result.set(row.candidacyId, current);
+  }
+  return result;
+}
+
 /**
  * The same measure population as the public reads, for a set of candidacies, WITHOUT the
  * `PUBLIC_CANDIDACY_WHERE` gate.

--- a/src/lib/data/measures.ts
+++ b/src/lib/data/measures.ts
@@ -621,7 +621,6 @@ export type PublicCandidacyMeasureRollup = {
   themesCoveredCount: number;
 };
 
-/** Aggregate public measure counts without loading complete revisions. */
 export async function getPublicMeasureRollupsByElection(
   electionId: string
 ): Promise<Map<string, PublicCandidacyMeasureRollup>> {

--- a/src/lib/data/presidential-candidacy-field.ts
+++ b/src/lib/data/presidential-candidacy-field.ts
@@ -3,16 +3,12 @@ import type { CandidacyStatus, ElectionType } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { resolveCandidateAccentColor } from "@/lib/presidentielle/candidate-accent";
 import { sortPresidentialCandidatesBySurname } from "@/lib/presidentielle/candidate-order";
-import {
-  resolveProgrammeAbsence,
-  rollupMeasuresByCandidacy,
-} from "@/lib/presidentielle/candidacy-rollup";
-import { getPublicMeasuresByElection } from "./measures";
+import { resolveProgrammeAbsence } from "@/lib/presidentielle/candidacy-rollup";
+import { getPublicMeasureRollupsByElection } from "./measures";
 import {
   getPublicTrackedPresidentialCandidacyWhere,
   PUBLIC_TRACKED_PRESIDENTIAL_CANDIDACY_WHERE,
 } from "./presidential-candidacy-policy";
-import { getPublicPresidentialCandidates } from "./presidential-candidates-public";
 
 export type PublicPresidentialElection = {
   id: string;
@@ -88,7 +84,7 @@ export async function getPublicPresidentialCandidacyField(
     return { election, candidacies: [] };
   }
 
-  const [rows, measures, publicCandidates, editions] = await Promise.all([
+  const [rows, measureRollups, editions] = await Promise.all([
     db.candidacy.findMany({
       where: {
         electionId: election.id,
@@ -114,8 +110,7 @@ export async function getPublicPresidentialCandidacyField(
         party: { select: { color: true, name: true, shortName: true, logoUrl: true } },
       },
     }),
-    getPublicMeasuresByElection(election.id),
-    getPublicPresidentialCandidates(electionSlug),
+    getPublicMeasureRollupsByElection(election.id),
     // A party edition is not a candidate programme without an explicit candidacy owner.
     db.programEdition.findMany({
       where: {
@@ -127,14 +122,6 @@ export async function getPublicPresidentialCandidacyField(
     }),
   ]);
 
-  const byCandidacy = rollupMeasuresByCandidacy(
-    measures.map((measure) => ({
-      candidacyId: measure.candidacyId,
-      theme: measure.theme,
-      hasPrimarySource: measure.sources.some((source) => source.tier === "PRIMARY"),
-    })),
-    new Set(publicCandidates.map((candidate) => candidate.id))
-  );
   const editionCandidacyIds = new Set(
     editions.map((edition) => edition.candidacyId).filter((id): id is string => id !== null)
   );
@@ -149,7 +136,7 @@ export async function getPublicPresidentialCandidacyField(
       return [];
     }
 
-    const rollup = byCandidacy.get(candidacy.id);
+    const rollup = measureRollups.get(candidacy.id);
     const measureCount = rollup?.measureCount ?? 0;
 
     return [


### PR DESCRIPTION
## Résultat

- Sépare les quatre rubriques statistiques sur des URL serveur stables et indexables.
- Conserve /statistiques, son titre général, ses données judiciaires et son canonical.
- Ajoute les nouvelles rubriques au sitemap et redirige en 308 les anciennes URL avec ?tab=.
- Remplace le chargement complet des mesures par une agrégation en base sur la page des candidatures.
- Réactive l optimisation Next Image pour les logos et désactive le prefetch des grands ensembles de liens.
- Allège le composant hémicycle et rend chaque siège accessible au clavier.

## Garde-fous

- Registre unique pour les chemins et libellés statistiques.
- Tests AST contre le retour de unoptimized, les jeux de données masqués et les prefetchs de masse.
- Test intégration de équivalence des compteurs publics, avec extension en brouillon et mesure retirée.
- Règles documentées dans AGENTS.md, commentaires concis inclus.

## Mesures locales

- Candidatures : environ 3,76 s avant, 0,42 s après.
- Statistiques fact-checking : 1,83 s au premier chargement local.
- Statistiques participation : 1,93 s au premier chargement local.
- HTML de /statistiques : environ 755 Ko avant, 472 Ko après.

## Validation

- typecheck : OK
- lint : OK
- tests ciblés : 78 OK
- suite complète : 5 831 OK, 409 ignorés; seuls 4 fichiers de tests échouent à cause de scripts gitignorés sous scripts/.local, absents de la PR
- build local : compilation atteinte, puis téléversement Sentry bloqué par la restriction réseau de environnement; la CI vérifie le build complet

## Revue adversariale

Deux axes, standards et conformité à objectif. Les constats sur les redirections, la centralisation, les gardes AST, exactitude des compteurs et accessibilité de hémicycle ont été corrigés dans le dernier commit.