### PR TITLE
chore(git): ignorer la configuration Codex locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ Thumbs.db
 CLAUDE.md
 .claude/
 
+# Codex local configuration
+/.codex/
+
 # database backups (sensitive data)
 /backups
 job-logs.txt


### PR DESCRIPTION
## Modification

- ignore le dossier local `.codex/` pour tous les contributeurs
- conserve les workflows Codex présents sur chaque poste sans les publier

## Vérification

- `git check-ignore` confirme que le workflow local est exclu
- aucun fichier sous `.codex/` n'est actuellement suivi