### PR TITLE
feat(presidentielle): fiabiliser les synthèses thématiques

### DIFF
--- a/src/lib/presidentielle/__tests__/candidacy-theme-synthesis-review.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-theme-synthesis-review.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   findCandidacy: vi.fn(),
   findMeasures: vi.fn(),
   updateSynthesis: vi.fn(),
+  upsertSynthesis: vi.fn(),
   createAudit: vi.fn(),
   lockCandidacy: vi.fn(),
 }));
@@ -32,6 +33,7 @@ vi.mock("@/lib/db", () => ({
         candidacyThemeSynthesis: {
           findUnique: mocks.findSynthesis,
           update: mocks.updateSynthesis,
+          upsert: mocks.upsertSynthesis,
         },
         candidacy: { findUnique: mocks.findCandidacy },
         measure: { findMany: mocks.findMeasures },
@@ -68,7 +70,150 @@ beforeEach(() => {
     },
   ]);
   mocks.updateSynthesis.mockResolvedValue({ id: "synthesis-1" });
+  mocks.upsertSynthesis.mockResolvedValue({ id: "synthesis-1" });
   mocks.createAudit.mockResolvedValue({ id: "audit-1" });
+});
+
+describe("saveReviewedCandidacyThemeSynthesisDraft", () => {
+  it("enregistre une correction éditoriale comme brouillon sans la publier", async () => {
+    mocks.findSynthesis.mockResolvedValue(null);
+    const { computeThemeCorpusFingerprint } = await import("../candidacy-theme-synthesis");
+    const corpusFingerprint = computeThemeCorpusFingerprint({
+      theme: "SANTE",
+      measures: [
+        {
+          id: "measure-1",
+          revisionId: "revision-1",
+          text: "Rouvrir des maternités.",
+          details: null,
+        },
+      ],
+    });
+    const { saveReviewedCandidacyThemeSynthesisDraft } =
+      await import("../candidacy-theme-synthesis-review");
+
+    const result = await saveReviewedCandidacyThemeSynthesisDraft({
+      candidacyId: "cand-1",
+      theme: "SANTE",
+      claims: [{ text: "Le programme propose de rouvrir des maternités.", measureRefs: ["M1"] }],
+      expectedCorpusFingerprint: corpusFingerprint,
+      model: "mistral-large-latest",
+      promptVersion: "candidacy-theme-synthesis-v3",
+      actor: { id: "admin", ipAddress: "127.0.0.1", userAgent: "vitest" },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      electionId: "election-1",
+      synthesisId: "synthesis-1",
+      contentFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(mocks.upsertSynthesis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ status: "PENDING_REVIEW" }),
+        update: expect.objectContaining({
+          status: "PENDING_REVIEW",
+          validatedAt: null,
+          publishedAt: null,
+        }),
+      })
+    );
+    expect(mocks.createAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "SAVE_REVIEWED_THEME_SYNTHESIS_DRAFT",
+          changes: expect.objectContaining({ reviewedManually: true }),
+        }),
+      })
+    );
+  });
+
+  it("refuse une correction lorsque le corpus a changé", async () => {
+    const { saveReviewedCandidacyThemeSynthesisDraft } =
+      await import("../candidacy-theme-synthesis-review");
+
+    const result = await saveReviewedCandidacyThemeSynthesisDraft({
+      candidacyId: "cand-1",
+      theme: "SANTE",
+      claims: [{ text: "Le programme propose de rouvrir des maternités.", measureRefs: ["M1"] }],
+      expectedCorpusFingerprint: "old",
+      model: "mistral-large-latest",
+      promptVersion: "candidacy-theme-synthesis-v3",
+      actor: { id: "admin", ipAddress: "127.0.0.1", userAgent: "vitest" },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "OBSOLETE" });
+    expect(mocks.upsertSynthesis).not.toHaveBeenCalled();
+    expect(mocks.createAudit).not.toHaveBeenCalled();
+  });
+
+  it("préserve une synthèse déjà publiée", async () => {
+    mocks.findSynthesis.mockResolvedValue({
+      id: "synthesis-1",
+      status: "PUBLISHED",
+      text: "Synthèse publiée.",
+      corpusFingerprint: "current",
+    });
+    const { computeThemeCorpusFingerprint } = await import("../candidacy-theme-synthesis");
+    const corpusFingerprint = computeThemeCorpusFingerprint({
+      theme: "SANTE",
+      measures: [
+        {
+          id: "measure-1",
+          revisionId: "revision-1",
+          text: "Rouvrir des maternités.",
+          details: null,
+        },
+      ],
+    });
+    const { saveReviewedCandidacyThemeSynthesisDraft } =
+      await import("../candidacy-theme-synthesis-review");
+
+    const result = await saveReviewedCandidacyThemeSynthesisDraft({
+      candidacyId: "cand-1",
+      theme: "SANTE",
+      claims: [{ text: "Le programme propose de rouvrir des maternités.", measureRefs: ["M1"] }],
+      expectedCorpusFingerprint: corpusFingerprint,
+      model: "mistral-large-latest",
+      promptVersion: "candidacy-theme-synthesis-v4",
+      actor: { id: "admin", ipAddress: "127.0.0.1", userAgent: "vitest" },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "NOT_REVIEWABLE" });
+    expect(mocks.upsertSynthesis).not.toHaveBeenCalled();
+    expect(mocks.createAudit).not.toHaveBeenCalled();
+  });
+
+  it("refuse une quantité absente de la mesure citée", async () => {
+    const { computeThemeCorpusFingerprint } = await import("../candidacy-theme-synthesis");
+    const corpusFingerprint = computeThemeCorpusFingerprint({
+      theme: "SANTE",
+      measures: [
+        {
+          id: "measure-1",
+          revisionId: "revision-1",
+          text: "Rouvrir des maternités.",
+          details: null,
+        },
+      ],
+    });
+    const { saveReviewedCandidacyThemeSynthesisDraft } =
+      await import("../candidacy-theme-synthesis-review");
+
+    const result = await saveReviewedCandidacyThemeSynthesisDraft({
+      candidacyId: "cand-1",
+      theme: "SANTE",
+      claims: [{ text: "Le programme propose de rouvrir 500 maternités.", measureRefs: ["M1"] }],
+      expectedCorpusFingerprint: corpusFingerprint,
+      model: "mistral-large-latest",
+      promptVersion: "candidacy-theme-synthesis-v3",
+      actor: { id: "admin", ipAddress: "127.0.0.1", userAgent: "vitest" },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "INVALID" });
+    expect(mocks.upsertSynthesis).not.toHaveBeenCalled();
+    expect(mocks.createAudit).not.toHaveBeenCalled();
+  });
 });
 
 describe("publishCandidacyThemeSynthesis", () => {

--- a/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
@@ -171,17 +171,44 @@ describe("synthèse thématique d'une candidature", () => {
     expect(result).toMatchObject({ ok: false, reason: "style" });
   });
 
-  it("refuse un axe qui reprend une mesure à l'infinitif", () => {
+  it.each([
+    "Le programme applique l'art. 3 et rouvre des maternités.",
+    "Le programme rouvre des maternités, etc. puis développe les soins de proximité.",
+  ])("ne confond pas une abréviation avec une fin de phrase : %s", (text) => {
     const result = screenThemeSynthesis(
       {
         theme: "SANTE",
-        claims: [{ text: "Créer 100 centres de santé publics.", measureRefs: ["M2"] }],
+        claims: [{ text, measureRefs: ["M1"] }],
       },
-      input()
+      input({
+        measures: [
+          {
+            id: "measure-1",
+            revisionId: "revision-1",
+            text: "Le programme applique l'art. 3, rouvre des maternités et développe les soins de proximité, etc.",
+            details: null,
+          },
+        ],
+      })
     );
 
-    expect(result).toMatchObject({ ok: false, reason: "style" });
+    expect(result.ok).toBe(true);
   });
+
+  it.each(["Créer", "Rouvrir", "Développer", "Baisser"])(
+    "refuse un axe qui commence par l'infinitif %s",
+    (verb) => {
+      const result = screenThemeSynthesis(
+        {
+          theme: "SANTE",
+          claims: [{ text: `${verb} les centres de santé publics.`, measureRefs: ["M2"] }],
+        },
+        input()
+      );
+
+      expect(result).toMatchObject({ ok: false, reason: "style" });
+    }
+  );
 
   it("refuse une reprise anaphorique artificielle", () => {
     const result = screenThemeSynthesis(
@@ -437,7 +464,10 @@ describe("synthèse thématique d'une candidature", () => {
       {
         theme: "SANTE",
         claims: [
-          { text: "Rouvrir partout les maternités de proximité rapidement.", measureRefs: ["M1"] },
+          {
+            text: "Le programme rouvrirait partout les maternités de proximité rapidement.",
+            measureRefs: ["M1"],
+          },
         ],
       },
       input()

--- a/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
+++ b/src/lib/presidentielle/__tests__/candidacy-theme-synthesis.test.ts
@@ -154,6 +154,92 @@ describe("synthèse thématique d'une candidature", () => {
     });
   });
 
+  it("refuse un axe rédigé comme une succession de phrases", () => {
+    const result = screenThemeSynthesis(
+      {
+        theme: "SANTE",
+        claims: [
+          {
+            text: "Des maternités seraient rouvertes. Des centres de santé seraient créés.",
+            measureRefs: ["M1", "M2"],
+          },
+        ],
+      },
+      input()
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "style" });
+  });
+
+  it("refuse un axe qui reprend une mesure à l'infinitif", () => {
+    const result = screenThemeSynthesis(
+      {
+        theme: "SANTE",
+        claims: [{ text: "Créer 100 centres de santé publics.", measureRefs: ["M2"] }],
+      },
+      input()
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "style" });
+  });
+
+  it("refuse une reprise anaphorique artificielle", () => {
+    const result = screenThemeSynthesis(
+      {
+        theme: "SANTE",
+        claims: [
+          {
+            text: "Les urgences le seraient également.",
+            measureRefs: ["M1"],
+          },
+        ],
+      },
+      input()
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "style" });
+  });
+
+  it("ne force pas une synthèse à dépasser la matière disponible dans un corpus très bref", () => {
+    const sparse = input({
+      measures: [
+        {
+          id: "measure-1",
+          revisionId: "revision-1",
+          text: "Redonner du pouvoir d'achat.",
+          details: null,
+        },
+        {
+          id: "measure-2",
+          revisionId: "revision-2",
+          text: "Relancer l'activité économique.",
+          details: null,
+        },
+        {
+          id: "measure-3",
+          revisionId: "revision-3",
+          text: "Baisser les taxes sur l'énergie.",
+          details: null,
+        },
+      ],
+    });
+
+    expect(
+      screenThemeSynthesis(
+        {
+          theme: "SANTE",
+          claims: [
+            {
+              text: "Le programme propose de redonner du pouvoir d'achat, de relancer l'activité économique et de baisser les taxes sur l'énergie.",
+              measureRefs: ["M1", "M2", "M3"],
+            },
+          ],
+        },
+        sparse
+      ).ok
+    ).toBe(true);
+  });
+
   it.each([
     [
       "un autre thème",

--- a/src/lib/presidentielle/candidacy-theme-synthesis-review.ts
+++ b/src/lib/presidentielle/candidacy-theme-synthesis-review.ts
@@ -1,10 +1,12 @@
-import type { Prisma } from "@/generated/prisma";
+import type { Prisma, ThemeCategory } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { lockMeasureCandidacy } from "@/lib/measures/lock";
 import {
   computeThemeCorpusFingerprint,
   computeThemeSynthesisContentFingerprint,
   readThemeSynthesisClaims,
+  screenThemeSynthesis,
+  type ThemeSynthesisClaim,
 } from "./candidacy-theme-synthesis";
 import { loadCandidacyThemeSynthesisCorpus } from "./candidacy-theme-synthesis-corpus";
 
@@ -21,6 +23,162 @@ export type PublishThemeSynthesisResult =
       reason: "NOT_FOUND" | "NOT_REVIEWABLE" | "OBSOLETE";
       message: string;
     };
+
+export type SaveReviewedThemeSynthesisDraftResult =
+  | { ok: true; electionId: string; synthesisId: string; contentFingerprint: string }
+  | {
+      ok: false;
+      reason: "NOT_FOUND" | "NOT_REVIEWABLE" | "INVALID" | "OBSOLETE";
+      message: string;
+    };
+
+/**
+ * Stores an editorially corrected draft without publishing it.
+ *
+ * Generation cannot own this transition: provider text is only a proposal, while these claims
+ * are the version a moderator actually checked against the cited measures. The candidacy lock and
+ * corpus fingerprint prevent a review from being attached to measures that changed meanwhile.
+ */
+export async function saveReviewedCandidacyThemeSynthesisDraft(input: {
+  candidacyId: string;
+  theme: ThemeCategory;
+  claims: ThemeSynthesisClaim[];
+  expectedCorpusFingerprint: string;
+  model: string;
+  promptVersion: string;
+  actor: ReviewActor;
+}): Promise<SaveReviewedThemeSynthesisDraftResult> {
+  if (!input.model.trim() || !input.promptVersion.trim()) {
+    return { ok: false, reason: "INVALID", message: "La provenance du brouillon est absente." };
+  }
+
+  return db.$transaction(async (extendedTx) => {
+    const tx = extendedTx as unknown as Prisma.TransactionClient;
+    await lockMeasureCandidacy(extendedTx, input.candidacyId);
+    const loaded = await loadCandidacyThemeSynthesisCorpus(tx, input.candidacyId, input.theme);
+    if (!loaded.ok) {
+      return {
+        ok: false,
+        reason: "NOT_FOUND",
+        message: "Le corpus publié de cette candidature et de ce thème est introuvable.",
+      };
+    }
+
+    const currentCorpusFingerprint = computeThemeCorpusFingerprint({
+      theme: loaded.corpus.input.theme,
+      measures: loaded.corpus.input.measures,
+    });
+    if (currentCorpusFingerprint !== input.expectedCorpusFingerprint) {
+      return {
+        ok: false,
+        reason: "OBSOLETE",
+        message: "Les mesures publiées ont changé depuis la relecture.",
+      };
+    }
+
+    const screened = screenThemeSynthesis(
+      { theme: input.theme, claims: input.claims },
+      loaded.corpus.input
+    );
+    if (!screened.ok) {
+      return {
+        ok: false,
+        reason: "INVALID",
+        message: `La synthèse relue est refusée : ${screened.detail}`,
+      };
+    }
+
+    const previous = await tx.candidacyThemeSynthesis.findUnique({
+      where: {
+        candidacyPresidentialId_theme: {
+          candidacyPresidentialId: loaded.corpus.presidentialId,
+          theme: input.theme,
+        },
+      },
+      select: { id: true, status: true, text: true, corpusFingerprint: true },
+    });
+    if (previous?.status === "PUBLISHED") {
+      return {
+        ok: false,
+        reason: "NOT_REVIEWABLE",
+        message: "Une synthèse publiée ne peut pas être remplacée par un brouillon.",
+      };
+    }
+    const generatedAt = new Date();
+    const synthesis = await tx.candidacyThemeSynthesis.upsert({
+      where: {
+        candidacyPresidentialId_theme: {
+          candidacyPresidentialId: loaded.corpus.presidentialId,
+          theme: input.theme,
+        },
+      },
+      create: {
+        candidacyPresidentialId: loaded.corpus.presidentialId,
+        theme: input.theme,
+        text: screened.text,
+        evidence: { claims: screened.claims },
+        corpusFingerprint: currentCorpusFingerprint,
+        sourceMeasureCount: loaded.corpus.input.measures.length,
+        model: input.model.trim(),
+        promptVersion: input.promptVersion.trim(),
+        status: "PENDING_REVIEW",
+        generatedAt,
+      },
+      update: {
+        text: screened.text,
+        evidence: { claims: screened.claims },
+        corpusFingerprint: currentCorpusFingerprint,
+        sourceMeasureCount: loaded.corpus.input.measures.length,
+        model: input.model.trim(),
+        promptVersion: input.promptVersion.trim(),
+        status: "PENDING_REVIEW",
+        generatedAt,
+        validatedAt: null,
+        validatedBy: null,
+        publishedAt: null,
+      },
+      select: { id: true },
+    });
+    const contentFingerprint = computeThemeSynthesisContentFingerprint({
+      text: screened.text,
+      claims: screened.claims,
+      model: input.model.trim(),
+      promptVersion: input.promptVersion.trim(),
+    });
+    await tx.auditLog.create({
+      data: {
+        action: "SAVE_REVIEWED_THEME_SYNTHESIS_DRAFT",
+        entityType: "CandidacyThemeSynthesis",
+        entityId: synthesis.id,
+        changes: {
+          candidacyId: input.candidacyId,
+          theme: input.theme,
+          text: screened.text,
+          claims: screened.claims,
+          corpusFingerprint: currentCorpusFingerprint,
+          contentFingerprint,
+          sourceMeasureCount: loaded.corpus.input.measures.length,
+          model: input.model.trim(),
+          promptVersion: input.promptVersion.trim(),
+          reviewedManually: true,
+          previousStatus: previous?.status ?? null,
+          previousText: previous?.text ?? null,
+          previousCorpusFingerprint: previous?.corpusFingerprint ?? null,
+        },
+        userId: input.actor.id,
+        ipAddress: input.actor.ipAddress,
+        userAgent: input.actor.userAgent,
+      },
+    });
+
+    return {
+      ok: true,
+      electionId: loaded.corpus.electionId,
+      synthesisId: synthesis.id,
+      contentFingerprint,
+    };
+  });
+}
 
 /**
  * Human publication gate for a generated thematic synthesis.

--- a/src/lib/presidentielle/candidacy-theme-synthesis.ts
+++ b/src/lib/presidentielle/candidacy-theme-synthesis.ts
@@ -5,7 +5,7 @@ import { THEME_CATEGORY_LABELS } from "@/config/labels";
 
 const PROMPT_FIELD_LIMIT = 2_000;
 export const THEME_SYNTHESIS_HARD_MAX_WORDS = 260;
-export const THEME_SYNTHESIS_PROMPT_VERSION = "candidacy-theme-synthesis-v3";
+export const THEME_SYNTHESIS_PROMPT_VERSION = "candidacy-theme-synthesis-v4";
 
 export type ThemeSynthesisMeasure = {
   id: string;
@@ -171,6 +171,8 @@ Règles absolues :
 - n'invente aucune finalité avec « pour », « afin de » ou « vise à » si elle n'est pas écrite dans les mesures citées ;
 - ne transfère jamais la cible, la condition ou la modalité d'une mesure vers une autre mesure, même lorsqu'elles portent sur un axe proche ;
 - retiens les orientations principales et organise-les en ${maxAxes} axes cohérents au maximum ;
+- chaque axe doit tenir dans une seule phrase grammaticale avec un verbe conjugué ;
+- ne commence pas un axe par un infinitif et n'enchaîne pas « propose », « prévoit », « souhaite » ou « envisage » pour énumérer les mesures ;
 - une suite de reformulations n'est pas une synthèse, ne rédige pas une phrase pour chaque mesure ;
 - regroupe seulement les mesures qui expriment réellement une orientation commune. Une mesure peut former un axe à elle seule si aucun regroupement fidèle n'est possible ;
 - conserve les conditions, limites et nuances importantes ;
@@ -322,6 +324,31 @@ export function screenThemeSynthesis(
   );
 
   for (const claim of parsed.data.claims) {
+    if (/[.!?]\s+\S/u.test(claim.text)) {
+      return {
+        ok: false,
+        reason: "style",
+        detail: "Un axe contient plusieurs phrases au lieu d'une affirmation synthétique.",
+      };
+    }
+    if (
+      /^(?:Créer|Engager|Favoriser|Lutter|Mettre|Proposer|Ramener|Réorganiser|Renforcer|Valoriser)\b/u.test(
+        claim.text
+      )
+    ) {
+      return {
+        ok: false,
+        reason: "style",
+        detail: "Un axe commence par un infinitif au lieu d'une phrase rédigée.",
+      };
+    }
+    if (/\b(?:le|la|les) (?:serait|seraient|sera|seront) également\b/iu.test(claim.text)) {
+      return {
+        ok: false,
+        reason: "style",
+        detail: "Un axe contient une reprise anaphorique ambiguë.",
+      };
+    }
     if (new Set(claim.measureRefs).size !== claim.measureRefs.length) {
       return { ok: false, reason: "preuves", detail: "Une référence est répétée." };
     }
@@ -375,7 +402,15 @@ export function screenThemeSynthesis(
   }
   const text = claims.map((claim) => claim.text).join(" ");
   const wordCount = text.split(/\s+/u).filter(Boolean).length;
-  const safetyFloor = themeSynthesisSafetyFloor(input.measures.length);
+  // A refusal floor cannot demand more prose than the source corpus contains. Sparse
+  // programmes sometimes publish several one-line commitments; padding them to the
+  // count-based floor would force the synthesis to invent context or repeat itself.
+  const corpusWordCount = measures
+    .map((measure) => `${measure.text} ${measure.details ?? ""}`)
+    .join(" ")
+    .split(/\s+/u)
+    .filter(Boolean).length;
+  const safetyFloor = Math.min(themeSynthesisSafetyFloor(input.measures.length), corpusWordCount);
   if (wordCount < safetyFloor) {
     return {
       ok: false,

--- a/src/lib/presidentielle/candidacy-theme-synthesis.ts
+++ b/src/lib/presidentielle/candidacy-theme-synthesis.ts
@@ -306,6 +306,93 @@ function isComparativeClaim(value: string): boolean {
   );
 }
 
+const SENTENCE_ABBREVIATIONS = new Set([
+  "al",
+  "art",
+  "av",
+  "bd",
+  "cf",
+  "chap",
+  "dr",
+  "etc",
+  "ex",
+  "fig",
+  "m",
+  "mme",
+  "mmes",
+  "n",
+  "no",
+  "p",
+  "pp",
+  "pr",
+  "st",
+  "ste",
+]);
+
+const IRREGULAR_FRENCH_INFINITIVES = new Set([
+  "accroître",
+  "asseoir",
+  "avoir",
+  "conduire",
+  "construire",
+  "couvrir",
+  "croire",
+  "devenir",
+  "devoir",
+  "dire",
+  "découvrir",
+  "faire",
+  "interdire",
+  "lire",
+  "mettre",
+  "obtenir",
+  "offrir",
+  "ouvrir",
+  "permettre",
+  "prendre",
+  "recevoir",
+  "réduire",
+  "savoir",
+  "suivre",
+  "tenir",
+  "traduire",
+  "venir",
+  "vivre",
+  "voir",
+  "écrire",
+  "élire",
+  "être",
+]);
+
+function containsMultipleSentences(value: string): boolean {
+  for (const match of value.matchAll(/[.!?](?=\s+\S)/gu)) {
+    const punctuation = match[0];
+    const offset = match.index ?? 0;
+    const remainder = value.slice(offset + punctuation.length).trimStart();
+    if (!remainder) continue;
+    if (punctuation !== ".") return true;
+
+    const previousWord = value
+      .slice(0, offset)
+      .match(/([\p{L}]+)$/u)?.[1]
+      ?.toLowerCase();
+    if (previousWord && (previousWord.length === 1 || SENTENCE_ABBREVIATIONS.has(previousWord))) {
+      continue;
+    }
+    if (/^[A-ZÀ-ÖØ-Þ]/u.test(remainder)) return true;
+  }
+  return false;
+}
+
+function startsWithFrenchInfinitive(value: string): boolean {
+  const firstWord = value.match(/^([\p{L}]+)/u)?.[1]?.toLowerCase();
+  if (!firstWord) return false;
+  return (
+    IRREGULAR_FRENCH_INFINITIVES.has(firstWord) ||
+    (firstWord.length >= 5 && /(?:er|ir|re|oir)$/u.test(firstWord))
+  );
+}
+
 export function screenThemeSynthesis(
   raw: unknown,
   input: ThemeSynthesisInput
@@ -324,18 +411,14 @@ export function screenThemeSynthesis(
   );
 
   for (const claim of parsed.data.claims) {
-    if (/[.!?]\s+\S/u.test(claim.text)) {
+    if (containsMultipleSentences(claim.text)) {
       return {
         ok: false,
         reason: "style",
         detail: "Un axe contient plusieurs phrases au lieu d'une affirmation synthétique.",
       };
     }
-    if (
-      /^(?:Créer|Engager|Favoriser|Lutter|Mettre|Proposer|Ramener|Réorganiser|Renforcer|Valoriser)\b/u.test(
-        claim.text
-      )
-    ) {
+    if (startsWithFrenchInfinitive(claim.text)) {
       return {
         ok: false,
         reason: "style",

--- a/src/services/candidacy-theme-synthesis/__tests__/generation.test.ts
+++ b/src/services/candidacy-theme-synthesis/__tests__/generation.test.ts
@@ -37,7 +37,7 @@ const validOutput = JSON.stringify({
   theme: "SANTE",
   claims: [
     {
-      text: "Les mesures prévoient de rouvrir des maternités et de développer les soins de proximité. Elles mentionnent les maternités, les soins et leur proximité.",
+      text: "Les mesures prévoient de rouvrir des maternités et de développer les soins de proximité.",
       measureRefs: ["M1", "M2"],
     },
   ],
@@ -121,7 +121,7 @@ describe("generateCandidacyThemeSynthesis", () => {
           status: "PENDING_REVIEW",
           evidence: expect.objectContaining({ claims: expect.any(Array) }),
           corpusFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
-          promptVersion: "candidacy-theme-synthesis-v3",
+          promptVersion: "candidacy-theme-synthesis-v4",
         }),
         update: expect.objectContaining({
           status: "PENDING_REVIEW",


### PR DESCRIPTION
## Résumé

- améliore la rédaction des synthèses thématiques et refuse les catalogues de mesures
- ajoute un service audité pour enregistrer les corrections éditoriales sans publier
- protège explicitement les synthèses déjà publiées contre un retour en brouillon
- adapte la longueur minimale aux corpus courts

## Vérifications

- 39 tests ciblés
- ESLint ciblé sur les 5 fichiers modifiés
- git diff --check

Aucun déploiement Vercel n'est lancé depuis cette session.