### PR TITLE
fix(politiques): dégrader le classement de dissidence au lieu de tomber

### DIFF
--- a/src/app/politiques/dissidence-ranking-failure.test.ts
+++ b/src/app/politiques/dissidence-ranking-failure.test.ts
@@ -16,9 +16,11 @@ const mocks = vi.hoisted(() => ({
   politicianCount: vi.fn(),
   partyFindMany: vi.fn(),
   queryRaw: vi.fn(),
+  captureException: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
+vi.mock("@sentry/nextjs", () => ({ captureException: mocks.captureException }));
 vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
 vi.mock("@/services/voteStats", () => ({
   getPoliticianDissidenceRanking: mocks.getPoliticianDissidenceRanking,
@@ -68,6 +70,26 @@ beforeEach(() => {
 });
 
 describe("/politiques : le classement de dissidence échoue", () => {
+  it("signale l'échec à Sentry plutôt que de l'avaler", async () => {
+    const boom = statementTimeout();
+    mocks.getPoliticianDissidenceRanking.mockRejectedValue(boom);
+
+    await render({ sort: "dissidence" });
+
+    expect(mocks.captureException).toHaveBeenCalledWith(
+      boom,
+      expect.objectContaining({ tags: { feature: "dissidence-ranking" } })
+    );
+  });
+
+  it("laisse remonter une panne qui n'est pas le classement", async () => {
+    // Un échec du listing lui-même ne doit pas être maquillé en liste vide.
+    mocks.getPoliticianDissidenceRanking.mockResolvedValue({ politicianIds: ["p1"], total: 1 });
+    mocks.politicianFindMany.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(render({ sort: "dissidence" })).rejects.toThrow("connection terminated");
+  });
+
   it("rend la page malgré un statement timeout sur le classement", async () => {
     mocks.getPoliticianDissidenceRanking.mockRejectedValue(statementTimeout());
 

--- a/src/app/politiques/dissidence-ranking-failure.test.ts
+++ b/src/app/politiques/dissidence-ranking-failure.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression guard for POLIGRAPH-1E (2026-09-04).
+ *
+ * The "Plus indépendants" sort runs a raw aggregate over every vote of every
+ * sitting parliamentarian. Measured against production it cannot finish inside
+ * the statement timeout, so it raises 57014 and, being unguarded, took the
+ * whole /politiques Server Component down with it. A ranking that cannot be
+ * computed must degrade to an empty ranking, never to a 500.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getPoliticianDissidenceRanking: vi.fn(),
+  politicianFindMany: vi.fn(),
+  politicianCount: vi.fn(),
+  partyFindMany: vi.fn(),
+  queryRaw: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
+vi.mock("@/services/voteStats", () => ({
+  getPoliticianDissidenceRanking: mocks.getPoliticianDissidenceRanking,
+}));
+vi.mock("@/lib/db", () => ({
+  db: {
+    politician: { findMany: mocks.politicianFindMany, count: mocks.politicianCount },
+    party: { findMany: mocks.partyFindMany },
+    $queryRaw: mocks.queryRaw,
+  },
+}));
+
+import PolitiquesPage from "./page";
+
+type Params = Record<string, string>;
+const render = (searchParams: Params) =>
+  (PolitiquesPage as (p: { searchParams: Promise<Params> }) => Promise<unknown>)({
+    searchParams: Promise.resolve(searchParams),
+  });
+
+/** The exact shape Postgres returns when statement_timeout fires. */
+function statementTimeout() {
+  const e = new Error(
+    "Invalid `prisma.$queryRaw()` invocation: Raw query failed. Code: `57014`. " +
+      "Message: `canceling statement due to statement timeout`"
+  );
+  (e as unknown as { code: string }).code = "P2010";
+  return e;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.politicianFindMany.mockResolvedValue([]);
+  mocks.politicianCount.mockResolvedValue(0);
+  mocks.partyFindMany.mockResolvedValue([]);
+  mocks.queryRaw.mockResolvedValue([
+    {
+      with_conviction: BigInt(0),
+      total_affairs: BigInt(0),
+      deputes: BigInt(0),
+      senateurs: BigInt(0),
+      gouvernement: BigInt(0),
+      dirigeants: BigInt(0),
+      maires: BigInt(0),
+    },
+  ]);
+});
+
+describe("/politiques : le classement de dissidence échoue", () => {
+  it("rend la page malgré un statement timeout sur le classement", async () => {
+    mocks.getPoliticianDissidenceRanking.mockRejectedValue(statementTimeout());
+
+    await expect(render({ sort: "dissidence" })).resolves.toBeDefined();
+    expect(mocks.getPoliticianDissidenceRanking).toHaveBeenCalled();
+  });
+
+  it("rend la page quelle que soit la panne du classement", async () => {
+    mocks.getPoliticianDissidenceRanking.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(render({ sort: "dissidence" })).resolves.toBeDefined();
+  });
+
+  it("n'interroge pas les fiches quand le classement a échoué", async () => {
+    mocks.getPoliticianDissidenceRanking.mockRejectedValue(statementTimeout());
+
+    await render({ sort: "dissidence" });
+
+    // Un classement vide ne doit pas déclencher un findMany sur `id: { in: [] }`.
+    const dissidenceLookups = mocks.politicianFindMany.mock.calls.filter(
+      (c) => (c[0] as { where?: { id?: unknown } })?.where?.id !== undefined
+    );
+    expect(dissidenceLookups).toHaveLength(0);
+  });
+
+  it("laisse passer un classement qui fonctionne", async () => {
+    mocks.getPoliticianDissidenceRanking.mockResolvedValue({
+      politicianIds: ["p1", "p2"],
+      total: 2,
+    });
+
+    await expect(render({ sort: "dissidence" })).resolves.toBeDefined();
+    expect(mocks.politicianFindMany).toHaveBeenCalled();
+  });
+
+  it("ne touche pas au classement pour les autres tris", async () => {
+    await render({ sort: "prominence" });
+    expect(mocks.getPoliticianDissidenceRanking).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -123,6 +123,13 @@ const POLITICIAN_INCLUDE = {
   },
 } as const;
 
+/**
+ * Marker for "the dissidence ranking could not be computed". Carried in the
+ * message rather than by class identity so it survives any re-wrapping on the
+ * way out of the cached path.
+ */
+const DISSIDENCE_RANKING_UNAVAILABLE = "DISSIDENCE_RANKING_UNAVAILABLE";
+
 // Core query logic shared by cached and uncached paths
 async function queryPoliticians(
   search?: string,
@@ -194,14 +201,19 @@ async function queryPoliticians(
     // POLIGRAPH-1E: this ranking aggregates every expressed vote of every
     // sitting parliamentarian and cannot finish inside the statement timeout,
     // so Postgres cancels it with 57014. Unguarded, that took the whole
-    // listing down with a 500. A ranking we cannot compute degrades to an
-    // empty one, and the failure is reported rather than swallowed.
+    // listing down with a 500.
+    //
+    // Reported here, but NOT turned into an empty listing here: this runs
+    // inside `getPoliticiansFiltered`, whose "use cache" would store that empty
+    // listing under the `synced` profile and keep serving "0 representants" for
+    // a day after the database recovered. The fallback belongs to
+    // `getPoliticians`, outside the cache boundary.
     let dissidenceRanking: { politicianIds: string[]; total: number };
     try {
       dissidenceRanking = await getPoliticianDissidenceRanking(chamber, page, limit);
     } catch (error) {
       Sentry.captureException(error, { tags: { feature: "dissidence-ranking" } });
-      return { politicians: [], total: 0, page, totalPages: 0 };
+      throw new Error(DISSIDENCE_RANKING_UNAVAILABLE);
     }
 
     const orderedIds = dissidenceRanking.politicianIds;
@@ -331,10 +343,17 @@ async function getPoliticians(
   sortOption: SortOption = "alpha",
   page = 1
 ) {
-  if (search) {
-    return searchPoliticians(search, partyId, withConviction, mandateFilter, sortOption, page);
+  try {
+    return search
+      ? await searchPoliticians(search, partyId, withConviction, mandateFilter, sortOption, page)
+      : await getPoliticiansFiltered(partyId, withConviction, mandateFilter, sortOption, page);
+  } catch (error) {
+    // Only the dissidence ranking degrades; every other failure still surfaces.
+    if (!(error instanceof Error) || !error.message.includes(DISSIDENCE_RANKING_UNAVAILABLE)) {
+      throw error;
+    }
+    return { politicians: [], total: 0, page, totalPages: 0 };
   }
-  return getPoliticiansFiltered(partyId, withConviction, mandateFilter, sortOption, page);
 }
 
 async function getParties() {

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -13,6 +13,7 @@ import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing
 import { POLITIQUES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import * as Sentry from "@sentry/nextjs";
 import { getPoliticianDissidenceRanking } from "@/services/voteStats";
 import { parsePageParam } from "@/lib/data/query-params";
 
@@ -190,7 +191,19 @@ async function queryPoliticians(
   if (sortOption === "dissidence") {
     const chamber =
       mandateFilter === "depute" ? "AN" : mandateFilter === "senateur" ? "SENAT" : undefined;
-    const dissidenceRanking = await getPoliticianDissidenceRanking(chamber, page, limit);
+    // POLIGRAPH-1E: this ranking aggregates every expressed vote of every
+    // sitting parliamentarian and cannot finish inside the statement timeout,
+    // so Postgres cancels it with 57014. Unguarded, that took the whole
+    // listing down with a 500. A ranking we cannot compute degrades to an
+    // empty one, and the failure is reported rather than swallowed.
+    let dissidenceRanking: { politicianIds: string[]; total: number };
+    try {
+      dissidenceRanking = await getPoliticianDissidenceRanking(chamber, page, limit);
+    } catch (error) {
+      Sentry.captureException(error, { tags: { feature: "dissidence-ranking" } });
+      return { politicians: [], total: 0, page, totalPages: 0 };
+    }
+
     const orderedIds = dissidenceRanking.politicianIds;
 
     const dissidentPoliticians = await db.politician.findMany({

--- a/src/services/voteStats.ts
+++ b/src/services/voteStats.ts
@@ -701,6 +701,16 @@ export async function getPoliticianDissidence(
 }
 
 /**
+ * Duration past which the ranking query earns a line in the logs.
+ *
+ * A tripwire, not a limit anyone is near: measured against production on
+ * 2026-09-06 the aggregate below does not finish within the 120s statement
+ * timeout at all (POLIGRAPH-1E). The threshold is there so that whoever makes
+ * it fast enough to succeed still hears about it before it drifts back.
+ */
+const DISSIDENCE_RANKING_SLOW_MS = 5_000;
+
+/**
  * Rank current parliamentarians by dissidence without depending on participation rows.
  * Only expressed positions enter this independent metric.
  */
@@ -710,6 +720,7 @@ export async function getPoliticianDissidenceRanking(
   pageSize: number = 24
 ): Promise<{ politicianIds: string[]; total: number }> {
   const chamberScope = chamber ?? null;
+  const startedAt = Date.now();
   const rows = await db.$queryRaw<{ politicianId: string; totalRows: number }[]>`
     WITH current_votes AS (
       SELECT
@@ -761,7 +772,15 @@ export async function getPoliticianDissidenceRanking(
     ORDER BY dissident::numeric / total DESC, "politicianId" ASC
     OFFSET ${(page - 1) * pageSize}
     LIMIT ${pageSize}
-  `;
+  `.finally(() => {
+    // Timed on both outcomes: the interesting duration is usually the failing one.
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs > DISSIDENCE_RANKING_SLOW_MS) {
+      console.warn(
+        `[dissidence-ranking] ${elapsedMs}ms (chamber=${chamberScope ?? "all"}, page=${page}): heading for the statement timeout`
+      );
+    }
+  });
 
   return {
     politicianIds: rows.map((row) => row.politicianId),


### PR DESCRIPTION
Corrige POLIGRAPH-1E.

## Ce qui se passe

Le tri « Plus indépendants » de `/politiques` appelle `getPoliticianDissidenceRanking()`, une requête brute qui agrège **tous les votes exprimés de tous les parlementaires en exercice**. L'appel n'était ni caché ni gardé, et il a lieu pendant le rendu du Server Component : quand Postgres l'annule (`57014`), c'est la page entière qui part en 500.

## Ce que la mesure donne

Chronométré sur la base de production le 2026-09-06 :

| appel | résultat |
|---|---|
| `chamber=undefined` | échec `57014` après 119 935 ms |
| `chamber=AN` | échec `57014` après 120 209 ms |

Ce n'est donc pas une lenteur occasionnelle : la requête **n'aboutit jamais**. L'événement Sentry unique correspond à la seule fois où un visiteur a choisi ce tri. L'option est exposée dans l'UI (`FilterBar`, « Plus indépendants »), elle est atteignable par n'importe qui.

Deux causes au coût : la requête ignore complètement les filtres de la page (search, party, mandate), seul `chamber` la borne, et l'`OFFSET/LIMIT` final ne réduit pas l'agrégat. Coût constant, ~1,77 M de lignes de `Vote`.

## Ce que fait cette PR

Elle empêche la page de tomber, elle ne rend pas la requête rapide.

- `queryPoliticians` signale l'échec à Sentry (tag `dissidence-ranking`) et relance une erreur marquée.
- `getPoliticians`, qui n'est **pas** caché, traduit ce marqueur en classement vide. Le repli est volontairement hors de `getPoliticiansFiltered` : son `"use cache"` en profil `synced` (`revalidate: 86400`) figerait sinon « 0 représentants » pendant vingt-quatre heures après le rétablissement. Toute autre panne continue de remonter.
- `voteStats.ts` mesure la durée sur les deux issues via `.finally()` sur la `PrismaPromise`, avec un avertissement au-delà de 5 s. Fil-piège pour la suite, pas une limite dont on soit proche.

## Sur les index

Ce n'est pas le manque d'index. `Vote` et `Mandate` ont déjà ce qu'il faut, dont un index partiel `Mandate(politicianId, type) WHERE isCurrent AND type IN ('DEPUTE','SENATEUR')` qui colle à la jointure. Le problème est le volume agrégé, pas l'accès.

## À décider ensuite

Après cette PR, choisir « Plus indépendants » renvoie une liste vide. C'est mieux qu'un 500, mais ça reste un affichage qui affirme quelque chose de faux. Deux suites, hors périmètre ici :

1. précalculer le classement dans `StatsSnapshot`, le motif existe déjà dans ce fichier pour les stats législatives ;
2. retirer l'option du `FilterBar` tant que le point 1 n'est pas fait.

## Vérification

- Suite complète verte (5852 tests).
- `src/app/politiques/dissidence-ranking-failure.test.ts` : le classement est mocké pour rejeter avec la forme exacte d'un `57014`, la page doit rendre quand même, l'échec doit partir dans Sentry, et une panne qui n'est pas le classement doit toujours remonter. Rouge avant le correctif, vert après.
- Pas de test bout en bout contre un vrai timeout : il coûte deux minutes de requête lourde sur la base de production à chaque essai.