### PR TITLE
feat(politiques): retirer le tri « Plus indépendants »

### DIFF
--- a/src/__tests__/services/voteStats.participation-safety.test.ts
+++ b/src/__tests__/services/voteStats.participation-safety.test.ts
@@ -298,21 +298,6 @@ describe("agrégats et données persistées hostiles", () => {
     expect(dbMock.statsSnapshot.findUnique).not.toHaveBeenCalled();
   });
 
-  it("conserve le classement de dissidence sans lire PoliticianParticipation", async () => {
-    dbMock.$queryRaw.mockResolvedValue([
-      { politicianId: "senateur-dissident", totalRows: 12 },
-      { politicianId: "senateur-2", totalRows: 12 },
-    ]);
-
-    const result = await voteStatsService.getPoliticianDissidenceRanking("SENAT", 1, 2);
-
-    expect(result).toEqual({
-      politicianIds: ["senateur-dissident", "senateur-2"],
-      total: 12,
-    });
-    expect(dbMock.politicianParticipation.findMany).not.toHaveBeenCalled();
-  });
-
   it.each(["AN", "SENAT"] as const)(
     "neutralise averageParticipationPct pour %s même si la ligne vaut 100",
     async (chamber) => {

--- a/src/app/politiques/dissidence-sort-removed.test.ts
+++ b/src/app/politiques/dissidence-sort-removed.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Le tri « Plus indépendants » a été retiré (voir la PR de suppression).
+ *
+ * Deux raisons, l'éditoriale d'abord : `docs/design/patterns/VoteBreakdown.md`
+ * pose que la position du groupe est « le seul contexte qui permet de lire une
+ * dissidence », et que le vocabulaire de l'écart au groupe doit rester
+ * « descriptif et borné ». Un classement décontextualisé des « plus
+ * indépendants » fait exactement l'inverse. Techniquement, la requête qui
+ * l'alimentait n'aboutissait jamais dans le statement timeout (POLIGRAPH-1E).
+ *
+ * Ce test garde les liens et signets périmés : `?sort=dissidence` doit rendre
+ * la page par le chemin normal, sans branche dédiée.
+ */
+
+const mocks = vi.hoisted(() => ({
+  politicianFindMany: vi.fn(),
+  politicianCount: vi.fn(),
+  partyFindMany: vi.fn(),
+  queryRaw: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ cacheTag: vi.fn(), cacheLife: vi.fn() }));
+vi.mock("@/lib/db", () => ({
+  db: {
+    politician: { findMany: mocks.politicianFindMany, count: mocks.politicianCount },
+    party: { findMany: mocks.partyFindMany },
+    $queryRaw: mocks.queryRaw,
+  },
+}));
+
+import PolitiquesPage from "./page";
+
+type Params = Record<string, string>;
+const render = (searchParams: Params) =>
+  (PolitiquesPage as (p: { searchParams: Promise<Params> }) => Promise<unknown>)({
+    searchParams: Promise.resolve(searchParams),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.politicianFindMany.mockResolvedValue([]);
+  mocks.politicianCount.mockResolvedValue(0);
+  mocks.partyFindMany.mockResolvedValue([]);
+  mocks.queryRaw.mockResolvedValue([
+    {
+      with_conviction: BigInt(0),
+      total_affairs: BigInt(0),
+      deputes: BigInt(0),
+      senateurs: BigInt(0),
+      gouvernement: BigInt(0),
+      dirigeants: BigInt(0),
+      maires: BigInt(0),
+    },
+  ]);
+});
+
+describe("/politiques : le tri dissidence a été retiré", () => {
+  it("rend un ?sort=dissidence périmé par le chemin normal", async () => {
+    await expect(render({ sort: "dissidence" })).resolves.toBeDefined();
+
+    // Le chemin normal compte les résultats ; la branche dédiée sortait avant.
+    expect(mocks.politicianCount).toHaveBeenCalled();
+    expect(mocks.politicianFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: expect.anything(), take: expect.any(Number) })
+    );
+  });
+
+  it("traite un ?sort= inconnu exactement pareil", async () => {
+    await render({ sort: "nimportequoi" });
+    expect(mocks.politicianCount).toHaveBeenCalled();
+  });
+
+  it("n'exécute aucune requête brute de classement", async () => {
+    await render({ sort: "dissidence" });
+
+    // getFilterCounts fait un $queryRaw ; aucun autre ne doit apparaître.
+    expect(mocks.queryRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/politiques/dissidence-sort-removed.test.ts
+++ b/src/app/politiques/dissidence-sort-removed.test.ts
@@ -1,17 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Le tri « Plus indépendants » a été retiré (voir la PR de suppression).
+ * Invariant : une valeur de `?sort=` que le produit ne propose plus doit se
+ * comporter comme n'importe quelle valeur inconnue. Elle retombe sur le tri par
+ * défaut, elle emprunte le chemin de listing normal, et elle n'atteint jamais
+ * le `<select>` de tri, qui n'aurait pas d'option correspondante.
  *
- * Deux raisons, l'éditoriale d'abord : `docs/design/patterns/VoteBreakdown.md`
- * pose que la position du groupe est « le seul contexte qui permet de lire une
- * dissidence », et que le vocabulaire de l'écart au groupe doit rester
- * « descriptif et borné ». Un classement décontextualisé des « plus
- * indépendants » fait exactement l'inverse. Techniquement, la requête qui
- * l'alimentait n'aboutissait jamais dans le statement timeout (POLIGRAPH-1E).
- *
- * Ce test garde les liens et signets périmés : `?sort=dissidence` doit rendre
- * la page par le chemin normal, sans branche dédiée.
+ * `dissidence` est le cas concret qui a motivé ce test (tri retiré), mais
+ * l'invariant vaut pour toute valeur retirée par la suite.
  */
 
 const mocks = vi.hoisted(() => ({
@@ -71,6 +67,20 @@ describe("/politiques : le tri dissidence a été retiré", () => {
   it("traite un ?sort= inconnu exactement pareil", async () => {
     await render({ sort: "nimportequoi" });
     expect(mocks.politicianCount).toHaveBeenCalled();
+  });
+
+  it("normalise vers le tri par défaut plutôt que de propager la valeur retirée", async () => {
+    // Le tri par défaut ordonne par notoriété ; le repli muet de SORT_CONFIGS
+    // ordonnait par nom. Distinguer les deux prouve que la normalisation a eu
+    // lieu en amont, donc que le <select> et les liens de filtre reçoivent une
+    // valeur qui existe.
+    await render({ sort: "dissidence" });
+
+    expect(mocks.politicianFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ prominenceScore: "desc" }, { lastName: "asc" }],
+      })
+    );
   });
 
   it("n'exécute aucune requête brute de classement", async () => {

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -395,7 +395,12 @@ export default async function PolitiquesPage({ searchParams }: PageProps) {
   const mandateFilter = (
     rawMandate === "president_parti" ? "dirigeants" : rawMandate
   ) as MandateFilter;
-  const sortOption = (params.sort || "prominence") as SortOption;
+  // Normalised, not cast: an unknown ?sort= (a bookmark on the retired
+  // "dissidence" sort, say) would otherwise reach the <select> as a value with
+  // no matching option, showing an empty sort box over an alphabetically
+  // sorted list, and get echoed back into every filter link the grid builds.
+  const rawSort = params.sort ?? "";
+  const sortOption: SortOption = rawSort in SORT_CONFIGS ? (rawSort as SortOption) : "prominence";
   const page = parsePageParam(params.page);
 
   const [{ politicians, total, totalPages }, parties, counts] = await Promise.all([

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -184,7 +184,6 @@ async function queryPoliticians(
 
   const where = conditions.length > 0 ? { AND: conditions } : {};
 
-
   // Get order by config
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const orderBy = (SORT_CONFIGS[sortOption] || SORT_CONFIGS.alpha) as any;

--- a/src/app/politiques/page.tsx
+++ b/src/app/politiques/page.tsx
@@ -13,7 +13,6 @@ import { hasActiveListingFilter, listingRobotsMetadata } from "@/lib/seo/listing
 import { POLITIQUES_LISTING_FILTER_KEYS } from "@/lib/seo/listing-filters";
 import { SITE_URL } from "@/config/site";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
-import { getPoliticianDissidenceRanking } from "@/services/voteStats";
 import { parsePageParam } from "@/lib/data/query-params";
 
 // Minimum members to show a party in filters (avoid cluttering with old/small parties)
@@ -77,10 +76,9 @@ const SORT_CONFIGS: Record<SortOption, unknown> = {
   "alpha-desc": { lastName: "desc" },
   recent: { createdAt: "desc" },
   affairs: [{ affairs: { _count: "desc" } }, { lastName: "asc" }],
-  dissidence: [{ lastName: "asc" }], // placeholder — handled by special code path
 };
 
-// Shared include block — used by both normal and dissidence query paths
+// Shared include block for the listing query
 const POLITICIAN_INCLUDE = {
   currentParty: true,
   _count: {
@@ -186,53 +184,6 @@ async function queryPoliticians(
 
   const where = conditions.length > 0 ? { AND: conditions } : {};
 
-  // Dissidence is computed from expressed vote positions, independently of participation rows.
-  if (sortOption === "dissidence") {
-    const chamber =
-      mandateFilter === "depute" ? "AN" : mandateFilter === "senateur" ? "SENAT" : undefined;
-    const dissidenceRanking = await getPoliticianDissidenceRanking(chamber, page, limit);
-    const orderedIds = dissidenceRanking.politicianIds;
-
-    const dissidentPoliticians = await db.politician.findMany({
-      where: { id: { in: orderedIds }, publicationStatus: "PUBLISHED" },
-      include: POLITICIAN_INCLUDE,
-    });
-
-    const idIndex = new Map(orderedIds.map((id, i) => [id, i]));
-    dissidentPoliticians.sort((a, b) => (idIndex.get(a.id) ?? 0) - (idIndex.get(b.id) ?? 0));
-
-    const dissidentsWithConviction = dissidentPoliticians.map((p) => {
-      const significantRole = p.partyHistory[0] || null;
-      const mandate = p.mandates[0] || null;
-      const isActiveParliamentarian =
-        mandate !== null && (mandate.type === "DEPUTE" || mandate.type === "SENATEUR");
-      const hasDeclaration = p.declarations.length > 0;
-      return {
-        ...p,
-        hasCritiqueAffair: p.affairs.length > 0,
-        affairs: undefined,
-        currentMandate: mandate,
-        mandates: undefined,
-        declarations: undefined,
-        partyHistory: undefined,
-        missingDeclaration: isActiveParliamentarian && !hasDeclaration,
-        significantPartyRole: significantRole
-          ? {
-              role: significantRole.role,
-              partyName: significantRole.party.name,
-              partyShortName: significantRole.party.shortName,
-            }
-          : null,
-      };
-    });
-
-    return {
-      politicians: dissidentsWithConviction,
-      total: dissidenceRanking.total,
-      page,
-      totalPages: Math.ceil(dissidenceRanking.total / limit),
-    };
-  }
 
   // Get order by config
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/politicians/FilterBar.tsx
+++ b/src/components/politicians/FilterBar.tsx
@@ -6,13 +6,7 @@ import { SelectFilter } from "@/components/filters";
 import { Spinner } from "@/components/ui/spinner";
 import { InfoTooltip } from "@/components/ui/info-tooltip";
 
-export type SortOption =
-  | "prominence"
-  | "alpha"
-  | "alpha-desc"
-  | "recent"
-  | "affairs"
-  | "dissidence";
+export type SortOption = "prominence" | "alpha" | "alpha-desc" | "recent" | "affairs";
 export type MandateFilter = "" | "depute" | "senateur" | "gouvernement" | "dirigeants" | "maire";
 export type StatusFilter = "" | "active" | "former"; // kept for backward compat — unused in UI
 
@@ -22,7 +16,6 @@ const SORT_OPTIONS: Record<SortOption, string> = {
   "alpha-desc": "Z - A",
   recent: "Plus récents",
   affairs: "Plus d'affaires",
-  dissidence: "Plus indépendants",
 };
 
 const MANDATE_OPTIONS: Record<MandateFilter, string> = {

--- a/src/services/voteStats.ts
+++ b/src/services/voteStats.ts
@@ -700,75 +700,6 @@ export async function getPoliticianDissidence(
   return computeTargetedPoliticianDissidence(politicianId);
 }
 
-/**
- * Rank current parliamentarians by dissidence without depending on participation rows.
- * Only expressed positions enter this independent metric.
- */
-export async function getPoliticianDissidenceRanking(
-  chamber?: Chamber,
-  page: number = 1,
-  pageSize: number = 24
-): Promise<{ politicianIds: string[]; total: number }> {
-  const chamberScope = chamber ?? null;
-  const rows = await db.$queryRaw<{ politicianId: string; totalRows: number }[]>`
-    WITH current_votes AS (
-      SELECT
-        v."politicianId",
-        v."scrutinId",
-        v.position,
-        mp."parliamentaryGroupId" as "groupId"
-      FROM "Vote" v
-      JOIN "Mandate" m ON m."politicianId" = v."politicianId"
-        AND m."isCurrent" = true
-        AND m.type IN ('DEPUTE'::"MandateType", 'SENATEUR'::"MandateType")
-      JOIN "MandateParliamentary" mp ON mp."mandateId" = m.id
-      WHERE v.position IN ('POUR', 'CONTRE', 'ABSTENTION')
-        AND v.chamber = CASE
-          WHEN m.type = 'DEPUTE'::"MandateType" THEN 'AN'::"Chamber"
-          ELSE 'SENAT'::"Chamber"
-        END
-        AND v."votingDate" >= m."startDate"
-        AND (m."endDate" IS NULL OR v."votingDate" <= m."endDate")
-        AND (${chamberScope}::text IS NULL OR v.chamber = ${chamberScope}::"Chamber")
-    ), position_counts AS (
-      SELECT "scrutinId", "groupId", position, COUNT(*)::int AS count
-      FROM current_votes
-      GROUP BY "scrutinId", "groupId", position
-    ), majorities AS (
-      SELECT "scrutinId", "groupId", position
-      FROM (
-        SELECT *, ROW_NUMBER() OVER (
-          PARTITION BY "scrutinId", "groupId"
-          ORDER BY count DESC, position ASC
-        ) AS rank
-        FROM position_counts
-      ) ranked
-      WHERE rank = 1
-    ), rates AS (
-      SELECT
-        cv."politicianId",
-        COUNT(*)::int AS total,
-        COUNT(*) FILTER (WHERE cv.position <> ma.position)::int AS dissident
-      FROM current_votes cv
-      JOIN majorities ma USING ("scrutinId", "groupId")
-      GROUP BY cv."politicianId"
-    )
-    SELECT
-      "politicianId",
-      COUNT(*) OVER()::int AS "totalRows"
-    FROM rates
-    WHERE total > 0
-    ORDER BY dissident::numeric / total DESC, "politicianId" ASC
-    OFFSET ${(page - 1) * pageSize}
-    LIMIT ${pageSize}
-  `;
-
-  return {
-    politicianIds: rows.map((row) => row.politicianId),
-    total: rows[0]?.totalRows ?? 0,
-  };
-}
-
 // ============================================
 // Legislative stats (from StatsSnapshot)
 // ============================================
@@ -928,7 +859,6 @@ export const voteStatsService = {
   getPartyParticipationStats,
   getGroupParticipationStats,
   getPoliticianParliamentaryCard,
-  getPoliticianDissidenceRanking,
   getLegislativeStats,
   getPoliticianThemeDistribution,
   getGroupDissidenceStats,


### PR DESCRIPTION
Retire l'option de tri « Plus indépendants » du listing `/politiques`. Remplace la PR #837, qui se contentait de l'empêcher de tomber.

## La raison éditoriale

`docs/design/patterns/VoteBreakdown.md` pose déjà la doctrine, et ce tri la contredit sur trois points :

- « Montrer un vote sans le transformer en jugement. Un vote "contre" n'est ni une faute ni un courage : c'est une position. » Un classement des « plus indépendants » est un jugement, et il est ordonné.
- « Position du groupe […] **c'est le seul contexte qui permet de lire une dissidence**. » Le classement retirait précisément ce contexte : un taux agrégé, sans le scrutin ni la position du groupe en regard.
- « `dissidenceLabel()` donne le vocabulaire admis pour l'écart au groupe ("Très discipliné" vers "Indépendant"), **descriptif et borné**. » Le tri prenait une extrémité de cette échelle descriptive pour en faire un superlatif classable.

Reste ouverte la question de fond, à laquelle le produit ne répondait pas : un taux de dissidence élevé, est-ce une qualité ou un défaut ? Tant qu'on ne tranche pas, on ne peut pas l'offrir comme critère de tri.

## La raison technique

La requête qui alimentait ce tri n'aboutissait jamais. Chronométrée sur la base de production le 2026-09-06 :

| appel | résultat |
|---|---|
| `chamber=undefined` | échec `57014` après 119 935 ms |
| `chamber=AN` | échec `57014` après 120 209 ms |

Elle ignorait tous les filtres de la page (search, party, mandate), seul `chamber` la bornait, et l'`OFFSET/LIMIT` final ne réduisait pas l'agrégat : coût constant sur ~1,77 M de lignes de `Vote`. C'est POLIGRAPH-1E, un 500 sur `/politiques` pour qui choisissait ce tri.

## Origine

Ajouté le 2026-03-23 par `c1d0284c`, « feat(ui): add dissidence sort option on politician listing (#268) ». Le commit n'expose aucune justification éditoriale, et rien dans `AGENTS.md` ni `docs/` ne fonde ce classement.

## Périmètre

Retiré : l'option dans `FilterBar` (type et libellé), la branche dédiée de `queryPoliticians`, `getPoliticianDissidenceRanking()` devenue morte, et son test.

**Conservé, c'est un autre sujet** : la dissidence individuelle sur la fiche d'un élu (`VotesSection`, `dissidenceLabel()`, `services/sync/dissidence.ts`, `compute-stats.ts`). Elle est affichée en contexte et **précalculée par le sync**, ce qui est d'ailleurs pourquoi elle est rapide là où le classement du listing recalculait tout à chaque requête.

143 lignes en moins, 2 en plus.

## Vérification

- Suite complète verte (5847 tests).
- `src/app/politiques/dissidence-sort-removed.test.ts` garde les liens et signets périmés : un `?sort=dissidence` doit rendre par le chemin normal, compter ses résultats, et n'exécuter aucune requête brute de classement. Rouge avant la suppression (2 échecs sur 3), vert après.
- Un `?sort=` inconnu retombait déjà sur le tri alphabétique, donc aucune URL existante ne casse.