### PR TITLE
fix(presidentielle): compacter les sources des synthèses

### DIFF
--- a/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/__tests__/CandidateThemes.test.tsx
@@ -147,8 +147,50 @@ describe("CandidateThemes", () => {
     ).toBeTruthy();
     expect(screen.getByText(/puis relue par Poligraph/)).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /Voir la mesure et sa source : Rouvrir/ })
+      screen.getByRole("link", { name: /Voir la mesure citée et sa source : Rouvrir/ })
     ).toHaveAttribute("href", "/elections/presidentielle-2027/mesures/rouvrir-des-maternites");
+  });
+
+  it("regroupe les références nombreuses derrière un seul contrôle lisible", () => {
+    const citedMeasures = Array.from({ length: 4 }, (_, index) => ({
+      id: `m${index + 1}`,
+      slug: `mesure-${index + 1}`,
+      text: `Mesure citée ${index + 1}.`,
+      sourceUrl: "https://example.org/programme.pdf",
+    }));
+    render(
+      <CandidateThemes
+        themes={[
+          theme({
+            measureCount: 4,
+            measures: citedMeasures,
+            synthesis: {
+              claims: [
+                {
+                  text: "La synthèse rassemble plusieurs engagements institutionnels.",
+                  measures: citedMeasures,
+                },
+              ],
+            },
+          }),
+        ]}
+        electionSlug="presidentielle-2027"
+        candidateSlug="camille-riviere"
+        measureCount={16}
+        lastReviewedAt={null}
+      />
+    );
+
+    expect(screen.getByText("Voir les 4 mesures citées")).toBeInTheDocument();
+    expect(screen.queryByText("Voir la mesure et sa source")).not.toBeInTheDocument();
+    const evidence = screen.getByRole("list", {
+      name: "Mesures qui étayent l’affirmation 1",
+    });
+    expect(within(evidence).getAllByRole("link")).toHaveLength(4);
+    expect(within(evidence).getByRole("link", { name: "Mesure citée 1." })).toHaveAttribute(
+      "href",
+      "/elections/presidentielle-2027/mesures/mesure-1"
+    );
   });
 
   it("n'affiche aucun extrait arbitraire pour un grand programme", () => {

--- a/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
+++ b/src/app/elections/presidentielle-2027/candidats/[slug]/_components/CandidateFicheBlocks.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ExternalLink } from "lucide-react";
+import { ArrowRight, ChevronDown, ExternalLink } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { THEME_ACCENT_BAR, THEME_CATEGORY_LABELS, VOTE_POSITION_LABELS } from "@/config/labels";
 import type { CandidateFicheDetail } from "@/lib/data/politician-candidacy";
@@ -230,23 +230,42 @@ export function CandidateThemes({
                         <p className="text-[0.9375rem] leading-relaxed text-foreground">
                           {claim.text}
                         </p>
-                        <ul
-                          aria-label={`Mesures qui étayent l’affirmation ${index + 1}`}
-                          className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs"
-                        >
-                          {claim.measures.map((measure) => (
-                            <li key={measure.id}>
-                              <Link
-                                href={`/elections/${electionSlug}/mesures/${measure.slug}`}
-                                prefetch={false}
-                                className="inline-flex min-h-11 items-center font-semibold underline underline-offset-2"
-                                aria-label={`Voir la mesure et sa source : ${measure.text}`}
-                              >
-                                Voir la mesure et sa source
-                              </Link>
-                            </li>
-                          ))}
-                        </ul>
+                        {claim.measures.length === 1 ? (
+                          <Link
+                            href={`/elections/${electionSlug}/mesures/${claim.measures[0]!.slug}`}
+                            prefetch={false}
+                            className="inline-flex min-h-11 items-center text-xs font-semibold underline underline-offset-2"
+                            aria-label={`Voir la mesure citée et sa source : ${claim.measures[0]!.text}`}
+                          >
+                            Voir la mesure citée
+                          </Link>
+                        ) : (
+                          <details className="group mt-1 text-xs">
+                            <summary className="inline-flex min-h-11 cursor-pointer list-none items-center gap-1 font-semibold underline underline-offset-2 [&::-webkit-details-marker]:hidden">
+                              <span>Voir les {claim.measures.length} mesures citées</span>
+                              <ChevronDown
+                                aria-hidden="true"
+                                className="size-4 group-open:rotate-180"
+                              />
+                            </summary>
+                            <ul
+                              aria-label={`Mesures qui étayent l’affirmation ${index + 1}`}
+                              className="ml-5 list-disc space-y-1 pb-2"
+                            >
+                              {claim.measures.map((measure) => (
+                                <li key={measure.id}>
+                                  <Link
+                                    href={`/elections/${electionSlug}/mesures/${measure.slug}`}
+                                    prefetch={false}
+                                    className="inline-flex min-h-11 items-center font-semibold underline underline-offset-2"
+                                  >
+                                    {measure.text}
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        )}
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## Résultat

- conserve une référence directe lorsqu’une affirmation repose sur une seule mesure
- regroupe les références multiples dans un volet fermé par défaut
- affiche les titres précis des mesures dans le volet ouvert
- préserve la traçabilité vers chaque mesure et sa source

## Vérifications

- test ciblé CandidateThemes : 12 tests réussis
- ESLint ciblé : réussi
- Prettier et git diff --check : réussis

Aucun changement de données et aucun déploiement.