### PR TITLE
Rendre visible le crédit Anthropic épuisé et diviser le coût des appels

### DIFF
--- a/scripts/judge-policy-titles.ts
+++ b/scripts/judge-policy-titles.ts
@@ -119,6 +119,7 @@ ${official}
   for (let t = 0; t < 3; t++) {
     try {
       const resp = await callAnthropic([{ role: "user", content: user }], {
+        label: "judge-policy-titles",
         model: JUDGE_MODEL,
         maxTokens: 600,
         system: SYSTEM,

--- a/src/inngest/functions/moderation-preflight.ts
+++ b/src/inngest/functions/moderation-preflight.ts
@@ -25,11 +25,24 @@ export const moderationPreflight = inngest.createFunction(
       const { buildModerationInputs } = await import("@/lib/moderation/preflight");
       const { submitModerationBatch } = await import("@/services/affair-moderation-batch");
 
+      const { moderationInputFingerprint } = await import("@/services/affair-moderation");
+
       const inputs = await buildModerationInputs();
-      if (inputs.length === 0) return { batchId: null as string | null, count: 0 };
+      if (inputs.length === 0) {
+        return {
+          batchId: null as string | null,
+          count: 0,
+          fingerprints: {} as Record<string, string>,
+        };
+      }
 
       const batchId = await submitModerationBatch(inputs);
-      return { batchId, count: inputs.length };
+      // Snapshot fingerprints travel with the step output, so the collect step
+      // can tell whether a draft changed while the batch was processing.
+      const fingerprints = Object.fromEntries(
+        inputs.map((i) => [i.affairId, moderationInputFingerprint(i)])
+      );
+      return { batchId, count: inputs.length, fingerprints };
     });
 
     let ready = batch.batchId === null;
@@ -47,12 +60,13 @@ export const moderationPreflight = inngest.createFunction(
       if (!batch.batchId) return runPreflight({ source: "cron" });
 
       const { collectModerationBatch } = await import("@/services/affair-moderation-batch");
+      const { moderationInputFingerprint } = await import("@/services/affair-moderation");
       const inputs = await buildModerationInputs();
 
       if (!ready) {
         // Batch non terminé : chaque draft retombe sur NEEDS_REVIEW, le défaut
         // sûr, inchangé. L'identifiant est journalisé pour un relevé ultérieur
-        // plutôt que perdu — le batch est déjà payé.
+        // plutôt que perdu, le batch étant déjà payé.
         console.error(
           `[preflight] ALERT batch non terminé après ${POLL_ATTEMPTS} relevés, ` +
             `batch=${batch.batchId} drafts=${batch.count}. Résultats récupérables manuellement.`
@@ -61,6 +75,18 @@ export const moderationPreflight = inngest.createFunction(
       }
 
       const { results, failures } = await collectModerationBatch(batch.batchId, inputs);
+
+      // Reject any result whose draft changed since submission: the answer was
+      // generated from the old content. Dropping it falls back to NEEDS_REVIEW.
+      for (const input of inputs) {
+        if (!results.has(input.affairId)) continue;
+        const submitted = batch.fingerprints[input.affairId];
+        if (submitted && submitted !== moderationInputFingerprint(input)) {
+          results.delete(input.affairId);
+          failures.set(input.affairId, "affaire modifiée pendant le batch, résultat périmé");
+        }
+      }
+
       for (const [affairId, reason] of failures) {
         console.error(`[preflight] moderateAffair (batch) failed for draft ${affairId}: ${reason}`);
       }

--- a/src/inngest/functions/moderation-preflight.ts
+++ b/src/inngest/functions/moderation-preflight.ts
@@ -1,5 +1,17 @@
 import { inngest } from "../client";
 
+/**
+ * Preflight quotidien, via l'API Batch (moitié prix sur chaque token, cumulable
+ * avec le préfixe caché).
+ *
+ * Les résultats d'un batch arrivent « sous 24 h », ce qui est une expiration et
+ * non un délai garanti : impossible d'attendre en bloquant dans une fonction
+ * serverless. On passe donc par des étapes durables, chaque sommeil libérant le
+ * runtime entre deux relevés.
+ */
+const POLL_ATTEMPTS = 12;
+const POLL_INTERVAL = "5m";
+
 export const moderationPreflight = inngest.createFunction(
   {
     id: "moderation-preflight",
@@ -9,9 +21,50 @@ export const moderationPreflight = inngest.createFunction(
   },
   { cron: "TZ=Europe/Paris 30 4 * * *" },
   async ({ step }) => {
-    const report = await step.run("run-preflight", async () => {
-      const { runPreflight } = await import("@/lib/moderation/preflight");
-      return runPreflight({ source: "cron" });
+    const batch = await step.run("submit-moderation-batch", async () => {
+      const { buildModerationInputs } = await import("@/lib/moderation/preflight");
+      const { submitModerationBatch } = await import("@/services/affair-moderation-batch");
+
+      const inputs = await buildModerationInputs();
+      if (inputs.length === 0) return { batchId: null as string | null, count: 0 };
+
+      const batchId = await submitModerationBatch(inputs);
+      return { batchId, count: inputs.length };
+    });
+
+    let ready = batch.batchId === null;
+    for (let attempt = 0; attempt < POLL_ATTEMPTS && !ready; attempt++) {
+      await step.sleep(`wait-batch-${attempt}`, POLL_INTERVAL);
+      ready = await step.run(`check-batch-${attempt}`, async () => {
+        const { isBatchReady } = await import("@/services/affair-moderation-batch");
+        return isBatchReady(batch.batchId!);
+      });
+    }
+
+    const report = await step.run("assemble-report", async () => {
+      const { runPreflight, buildModerationInputs } = await import("@/lib/moderation/preflight");
+
+      if (!batch.batchId) return runPreflight({ source: "cron" });
+
+      const { collectModerationBatch } = await import("@/services/affair-moderation-batch");
+      const inputs = await buildModerationInputs();
+
+      if (!ready) {
+        // Batch non terminé : chaque draft retombe sur NEEDS_REVIEW, le défaut
+        // sûr, inchangé. L'identifiant est journalisé pour un relevé ultérieur
+        // plutôt que perdu — le batch est déjà payé.
+        console.error(
+          `[preflight] ALERT batch non terminé après ${POLL_ATTEMPTS} relevés, ` +
+            `batch=${batch.batchId} drafts=${batch.count}. Résultats récupérables manuellement.`
+        );
+        return runPreflight({ source: "cron", moderationResults: new Map() });
+      }
+
+      const { results, failures } = await collectModerationBatch(batch.batchId, inputs);
+      for (const [affairId, reason] of failures) {
+        console.error(`[preflight] moderateAffair (batch) failed for draft ${affairId}: ${reason}`);
+      }
+      return runPreflight({ source: "cron", moderationResults: results });
     });
 
     await step.run("persist-report-best-effort", async () => {
@@ -35,6 +88,7 @@ export const moderationPreflight = inngest.createFunction(
       needsReview: report.stats.needsReview,
       attributionIssues: report.stats.attributionIssues,
       duplicateGroups: report.stats.duplicateGroups,
+      batchId: batch.batchId,
     };
   }
 );

--- a/src/lib/api/__tests__/anthropic.test.ts
+++ b/src/lib/api/__tests__/anthropic.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  callAnthropic,
+  AnthropicApiError,
+  isInsufficientCreditError,
+  __resetCreditAlertForTests,
+} from "../anthropic";
+
+const CREDIT_BODY = JSON.stringify({
+  type: "error",
+  error: {
+    type: "invalid_request_error",
+    message: "Your credit balance is too low to access the Anthropic API.",
+  },
+});
+
+function mockResponse(status: number, body: string) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  };
+}
+
+describe("callAnthropic error classification", () => {
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+    __resetCreditAlertForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("throws when ANTHROPIC_API_KEY is missing", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    await expect(callAnthropic([{ role: "user", content: "x" }])).rejects.toThrow(
+      "ANTHROPIC_API_KEY"
+    );
+  });
+
+  it("keeps the historical message format so existing log greps still match", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(500, "boom")));
+    await expect(callAnthropic([{ role: "user", content: "x" }])).rejects.toThrow(
+      "Anthropic API error 500: boom"
+    );
+  });
+
+  it("exposes status and error.type on the thrown error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(400, CREDIT_BODY)));
+    const err = await callAnthropic([{ role: "user", content: "x" }]).catch((e) => e);
+    expect(err).toBeInstanceOf(AnthropicApiError);
+    expect((err as AnthropicApiError).status).toBe(400);
+    expect((err as AnthropicApiError).errorType).toBe("invalid_request_error");
+  });
+
+  it("flags the credit-balance case", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(400, CREDIT_BODY)));
+    const err = await callAnthropic([{ role: "user", content: "x" }]).catch((e) => e);
+    expect(isInsufficientCreditError(err)).toBe(true);
+  });
+
+  it("does NOT flag a rate limit, a server error or another 400", async () => {
+    const cases: [number, string][] = [
+      [429, JSON.stringify({ error: { type: "rate_limit_error", message: "slow down" } })],
+      [500, JSON.stringify({ error: { type: "api_error", message: "oops" } })],
+      [
+        400,
+        JSON.stringify({
+          error: { type: "invalid_request_error", message: "max_tokens: must be >= 1" },
+        }),
+      ],
+    ];
+    for (const [status, body] of cases) {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(status, body)));
+      const err = await callAnthropic([{ role: "user", content: "x" }]).catch((e) => e);
+      expect(isInsufficientCreditError(err), `status ${status}`).toBe(false);
+    }
+  });
+
+  it("is false for a non-Anthropic error", () => {
+    expect(isInsufficientCreditError(new Error("credit balance too low"))).toBe(false);
+    expect(isInsufficientCreditError(null)).toBe(false);
+  });
+
+  it("logs one distinct ALERT line per process, not one per call", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(400, CREDIT_BODY)));
+
+    for (let i = 0; i < 3; i++) {
+      await callAnthropic([{ role: "user", content: "x" }]).catch(() => {});
+    }
+
+    const alerts = spy.mock.calls.filter((c) => String(c[0]).includes("ANTHROPIC_CREDIT_EXHAUSTED"));
+    expect(alerts).toHaveLength(1);
+  });
+
+  it("does not emit the ALERT line for unrelated failures", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(429, "slow down")));
+    await callAnthropic([{ role: "user", content: "x" }]).catch(() => {});
+    expect(
+      spy.mock.calls.filter((c) => String(c[0]).includes("ANTHROPIC_CREDIT_EXHAUSTED"))
+    ).toHaveLength(0);
+  });
+});

--- a/src/lib/api/__tests__/anthropic.test.ts
+++ b/src/lib/api/__tests__/anthropic.test.ts
@@ -213,3 +213,59 @@ describe("usage accounting", () => {
     expect(getAnthropicUsage()).toEqual({});
   });
 });
+
+describe("prompt caching", () => {
+  beforeEach(() => vi.stubEnv("ANTHROPIC_API_KEY", "test-key"));
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function capture() {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+      json: () => Promise.resolve({ content: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  const bodyOf = (m: ReturnType<typeof vi.fn>) =>
+    JSON.parse((m.mock.calls[0]![1] as { body: string }).body);
+
+  it("puts the breakpoint on the system block when cachePrefix is set", async () => {
+    const m = capture();
+    await callAnthropic([{ role: "user", content: "x" }], {
+      system: "SYS",
+      tools: [{ name: "t" }],
+      cachePrefix: true,
+    });
+    expect(bodyOf(m).system).toEqual([
+      { type: "text", text: "SYS", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("leaves the system prompt a plain string by default", async () => {
+    const m = capture();
+    await callAnthropic([{ role: "user", content: "x" }], { system: "SYS" });
+    expect(bodyOf(m).system).toBe("SYS");
+  });
+
+  it("still sends tools alongside the cached system block", async () => {
+    const m = capture();
+    await callAnthropic([{ role: "user", content: "x" }], {
+      system: "SYS",
+      tools: [{ name: "moderate_affair" }],
+      cachePrefix: true,
+    });
+    expect(bodyOf(m).tools).toEqual([{ name: "moderate_affair" }]);
+  });
+
+  it("sends no system field at all when there is no system prompt", async () => {
+    const m = capture();
+    await callAnthropic([{ role: "user", content: "x" }], { cachePrefix: true });
+    expect(bodyOf(m).system).toBeUndefined();
+  });
+});

--- a/src/lib/api/__tests__/anthropic.test.ts
+++ b/src/lib/api/__tests__/anthropic.test.ts
@@ -95,7 +95,9 @@ describe("callAnthropic error classification", () => {
       await callAnthropic([{ role: "user", content: "x" }]).catch(() => {});
     }
 
-    const alerts = spy.mock.calls.filter((c) => String(c[0]).includes("ANTHROPIC_CREDIT_EXHAUSTED"));
+    const alerts = spy.mock.calls.filter((c) =>
+      String(c[0]).includes("ANTHROPIC_CREDIT_EXHAUSTED")
+    );
     expect(alerts).toHaveLength(1);
   });
 
@@ -171,7 +173,10 @@ describe("usage accounting", () => {
 
     await callAnthropic([{ role: "user", content: "x" }], { label: "a", model: "claude-sonnet-5" });
     await callAnthropic([{ role: "user", content: "x" }], { label: "b", model: "claude-sonnet-5" });
-    await callAnthropic([{ role: "user", content: "x" }], { label: "a", model: "claude-haiku-4-5" });
+    await callAnthropic([{ role: "user", content: "x" }], {
+      label: "a",
+      model: "claude-haiku-4-5",
+    });
 
     expect(Object.keys(getAnthropicUsage()).sort()).toEqual([
       "a@claude-haiku-4-5",
@@ -199,7 +204,9 @@ describe("usage accounting", () => {
       model: "claude-sonnet-5",
     });
 
-    const line = spy.mock.calls.map((c) => String(c[0])).find((l) => l.includes("[anthropic] usage"));
+    const line = spy.mock.calls
+      .map((c) => String(c[0]))
+      .find((l) => l.includes("[anthropic] usage"));
     expect(line).toContain("site=affair-moderation");
     expect(line).toContain("cache_read=3270");
     expect(line).toContain("cache_write=0");

--- a/src/lib/api/__tests__/anthropic.test.ts
+++ b/src/lib/api/__tests__/anthropic.test.ts
@@ -4,6 +4,8 @@ import {
   AnthropicApiError,
   isInsufficientCreditError,
   __resetCreditAlertForTests,
+  getAnthropicUsage,
+  resetAnthropicUsage,
 } from "../anthropic";
 
 const CREDIT_BODY = JSON.stringify({
@@ -104,5 +106,110 @@ describe("callAnthropic error classification", () => {
     expect(
       spy.mock.calls.filter((c) => String(c[0]).includes("ANTHROPIC_CREDIT_EXHAUSTED"))
     ).toHaveLength(0);
+  });
+});
+
+describe("usage accounting", () => {
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+    resetAnthropicUsage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function okResponse(usage: Record<string, number> | undefined) {
+    return {
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+      json: () => Promise.resolve({ content: [], ...(usage ? { usage } : {}) }),
+    };
+  }
+
+  it("accumulates the four priced quantities per site and model", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okResponse({
+          input_tokens: 500,
+          output_tokens: 200,
+          cache_creation_input_tokens: 3270,
+          cache_read_input_tokens: 0,
+        })
+      )
+    );
+
+    await callAnthropic([{ role: "user", content: "x" }], {
+      label: "affair-moderation",
+      model: "claude-sonnet-5",
+    });
+    await callAnthropic([{ role: "user", content: "x" }], {
+      label: "affair-moderation",
+      model: "claude-sonnet-5",
+    });
+
+    const totals = getAnthropicUsage()["affair-moderation@claude-sonnet-5"];
+    expect(totals).toEqual({
+      calls: 2,
+      inputTokens: 1000,
+      outputTokens: 400,
+      cacheCreationTokens: 6540,
+      cacheReadTokens: 0,
+    });
+  });
+
+  it("keeps sites and models in separate buckets", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(okResponse({ input_tokens: 10, output_tokens: 5 }))
+    );
+
+    await callAnthropic([{ role: "user", content: "x" }], { label: "a", model: "claude-sonnet-5" });
+    await callAnthropic([{ role: "user", content: "x" }], { label: "b", model: "claude-sonnet-5" });
+    await callAnthropic([{ role: "user", content: "x" }], { label: "a", model: "claude-haiku-4-5" });
+
+    expect(Object.keys(getAnthropicUsage()).sort()).toEqual([
+      "a@claude-haiku-4-5",
+      "a@claude-sonnet-5",
+      "b@claude-sonnet-5",
+    ]);
+  });
+
+  it("logs a greppable line carrying the cache meters", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okResponse({
+          input_tokens: 500,
+          output_tokens: 200,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 3270,
+        })
+      )
+    );
+
+    await callAnthropic([{ role: "user", content: "x" }], {
+      label: "affair-moderation",
+      model: "claude-sonnet-5",
+    });
+
+    const line = spy.mock.calls.map((c) => String(c[0])).find((l) => l.includes("[anthropic] usage"));
+    expect(line).toContain("site=affair-moderation");
+    expect(line).toContain("cache_read=3270");
+    expect(line).toContain("cache_write=0");
+  });
+
+  it("does not throw when the response carries no usage block", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okResponse(undefined)));
+    await expect(
+      callAnthropic([{ role: "user", content: "x" }], { label: "a" })
+    ).resolves.toBeDefined();
+    expect(getAnthropicUsage()).toEqual({});
   });
 });

--- a/src/lib/api/anthropic-batch.ts
+++ b/src/lib/api/anthropic-batch.ts
@@ -45,7 +45,7 @@ async function request(path: string, init: RequestInit): Promise<Response> {
     const error = new AnthropicApiError(response.status, body, errorType);
     if (isInsufficientCreditError(error)) {
       console.error(
-        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED — crédit API épuisé (batch). " +
+        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED : crédit API épuisé (batch). " +
           `status=${response.status}`
       );
     }

--- a/src/lib/api/anthropic-batch.ts
+++ b/src/lib/api/anthropic-batch.ts
@@ -1,0 +1,116 @@
+import { safeJsonParse } from "@/lib/api/safe-json";
+import { AnthropicApiError, isInsufficientCreditError } from "@/lib/api/anthropic";
+
+const BATCH_API_URL = "https://api.anthropic.com/v1/messages/batches";
+
+function getApiKey(): string {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY environment variable is not set");
+  return apiKey;
+}
+
+/** One request in a batch. `customId` is how the result is found again. */
+export interface BatchRequest {
+  customId: string;
+  params: Record<string, unknown>;
+}
+
+export interface BatchHandle {
+  id: string;
+  processingStatus: "in_progress" | "canceling" | "ended";
+}
+
+export type BatchResult =
+  | { customId: string; type: "succeeded"; message: unknown }
+  | { customId: string; type: "errored" | "canceled" | "expired"; error: string };
+
+async function request(path: string, init: RequestInit): Promise<Response> {
+  const response = await fetch(`${BATCH_API_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": getApiKey(),
+      "anthropic-version": "2023-06-01",
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "Unknown error");
+    const parsed = safeJsonParse<{ error?: { type?: unknown } }>(body);
+    const errorType =
+      parsed.success && typeof parsed.data?.error?.type === "string"
+        ? parsed.data.error.type
+        : null;
+    const error = new AnthropicApiError(response.status, body, errorType);
+    if (isInsufficientCreditError(error)) {
+      console.error(
+        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED — crédit API épuisé (batch). " +
+          `status=${response.status}`
+      );
+    }
+    throw error;
+  }
+
+  return response;
+}
+
+/** Submit a batch. Every token in it bills at half the standard rate. */
+export async function submitBatch(requests: BatchRequest[]): Promise<BatchHandle> {
+  if (requests.length === 0) throw new Error("submitBatch called with no requests");
+
+  const ids = new Set(requests.map((r) => r.customId));
+  if (ids.size !== requests.length) {
+    // Results are keyed by custom_id, so a duplicate silently loses a result.
+    throw new Error("submitBatch requires unique customId values");
+  }
+
+  const response = await request("", {
+    method: "POST",
+    body: JSON.stringify({
+      requests: requests.map((r) => ({ custom_id: r.customId, params: r.params })),
+    }),
+  });
+
+  const json = (await response.json()) as { id: string; processing_status: string };
+  return { id: json.id, processingStatus: json.processing_status as BatchHandle["processingStatus"] };
+}
+
+export async function getBatchStatus(batchId: string): Promise<BatchHandle> {
+  const response = await request(`/${encodeURIComponent(batchId)}`, { method: "GET" });
+  const json = (await response.json()) as { id: string; processing_status: string };
+  return { id: json.id, processingStatus: json.processing_status as BatchHandle["processingStatus"] };
+}
+
+/**
+ * Fetch results. The response is JSONL and arrives in ANY order, so callers
+ * must key by customId rather than by position.
+ */
+export async function getBatchResults(batchId: string): Promise<BatchResult[]> {
+  const response = await request(`/${encodeURIComponent(batchId)}/results`, { method: "GET" });
+  const text = await response.text();
+
+  const out: BatchResult[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parsed = safeJsonParse<{
+      custom_id?: string;
+      result?: { type?: string; message?: unknown; error?: unknown };
+    }>(trimmed);
+    if (!parsed.success || !parsed.data.custom_id) continue;
+
+    const customId = parsed.data.custom_id;
+    const type = parsed.data.result?.type;
+    if (type === "succeeded") {
+      out.push({ customId, type: "succeeded", message: parsed.data.result?.message });
+    } else {
+      out.push({
+        customId,
+        type: (type as "errored" | "canceled" | "expired") ?? "errored",
+        error: JSON.stringify(parsed.data.result?.error ?? { type }),
+      });
+    }
+  }
+  return out;
+}

--- a/src/lib/api/anthropic-batch.ts
+++ b/src/lib/api/anthropic-batch.ts
@@ -73,13 +73,19 @@ export async function submitBatch(requests: BatchRequest[]): Promise<BatchHandle
   });
 
   const json = (await response.json()) as { id: string; processing_status: string };
-  return { id: json.id, processingStatus: json.processing_status as BatchHandle["processingStatus"] };
+  return {
+    id: json.id,
+    processingStatus: json.processing_status as BatchHandle["processingStatus"],
+  };
 }
 
 export async function getBatchStatus(batchId: string): Promise<BatchHandle> {
   const response = await request(`/${encodeURIComponent(batchId)}`, { method: "GET" });
   const json = (await response.json()) as { id: string; processing_status: string };
-  return { id: json.id, processingStatus: json.processing_status as BatchHandle["processingStatus"] };
+  return {
+    id: json.id,
+    processingStatus: json.processing_status as BatchHandle["processingStatus"],
+  };
 }
 
 /**

--- a/src/lib/api/anthropic.ts
+++ b/src/lib/api/anthropic.ts
@@ -153,6 +153,39 @@ function recordUsage(key: string, usage: NonNullable<AnthropicResponse["usage"]>
   usageByKey.set(key, t);
 }
 
+/**
+ * Record usage from a response this wrapper did not issue, so a transport that
+ * bypasses `callAnthropic` (the Batch API) still lands in the same meter.
+ *
+ * Give batch traffic its own label: every token in a batch bills at half the
+ * standard rate, so folding it into the synchronous label would make the totals
+ * impossible to convert back into money.
+ */
+export function recordAnthropicUsage(
+  label: string,
+  model: string,
+  usage: NonNullable<AnthropicResponse["usage"]> | undefined
+): void {
+  if (!usage) return;
+  recordUsage(`${label}@${model}`, usage);
+  logUsage(label, model, usage);
+}
+
+function logUsage(
+  label: string,
+  model: string,
+  usage: NonNullable<AnthropicResponse["usage"]>
+): void {
+  // One structured, greppable line per call. `cache_read` staying at 0 across
+  // a run is the signature of a cache that silently never fires.
+  console.log(
+    `[anthropic] usage site=${label} model=${model} ` +
+      `in=${usage.input_tokens ?? 0} out=${usage.output_tokens ?? 0} ` +
+      `cache_write=${usage.cache_creation_input_tokens ?? 0} ` +
+      `cache_read=${usage.cache_read_input_tokens ?? 0}`
+  );
+}
+
 /** Totals per `<label>@<model>` since process start (or the last reset). */
 export function getAnthropicUsage(): Record<string, AnthropicUsageTotals> {
   return Object.fromEntries(usageByKey);
@@ -213,7 +246,7 @@ export async function callAnthropic(
       // down until the account is topped up, and callers that fall back to a
       // safe default would otherwise hide that completely.
       console.error(
-        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED — crédit API épuisé, " +
+        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED : crédit API épuisé, " +
           "toutes les fonctionnalités IA sont dégradées jusqu'au rechargement " +
           "(Anthropic Console > Plans & Billing). " +
           `model=${model} status=${response.status}`
@@ -226,16 +259,8 @@ export async function callAnthropic(
   const json = (await response.json()) as AnthropicResponse;
 
   if (json.usage) {
-    const key = `${label ?? "unlabelled"}@${model}`;
-    recordUsage(key, json.usage);
-    // One structured, greppable line per call. `cache_read` staying at 0 across
-    // a run is the signature of a cache that silently never fires.
-    console.log(
-      `[anthropic] usage site=${label ?? "unlabelled"} model=${model} ` +
-        `in=${json.usage.input_tokens ?? 0} out=${json.usage.output_tokens ?? 0} ` +
-        `cache_write=${json.usage.cache_creation_input_tokens ?? 0} ` +
-        `cache_read=${json.usage.cache_read_input_tokens ?? 0}`
-    );
+    recordUsage(`${label ?? "unlabelled"}@${model}`, json.usage);
+    logUsage(label ?? "unlabelled", model, json.usage);
   }
 
   return json;

--- a/src/lib/api/anthropic.ts
+++ b/src/lib/api/anthropic.ts
@@ -1,4 +1,4 @@
-import { safeJsonParseOrThrow } from "@/lib/api/safe-json";
+import { safeJsonParse, safeJsonParseOrThrow } from "@/lib/api/safe-json";
 
 const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
 
@@ -6,6 +6,60 @@ function getApiKey(): string {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error("ANTHROPIC_API_KEY environment variable is not set");
   return apiKey;
+}
+
+/**
+ * A non-2xx response from the Messages API, with the pieces needed to tell a
+ * billing outage apart from a transient failure or a malformed request. The
+ * message keeps the historical `Anthropic API error <status>: <body>` shape so
+ * existing logs and greps still match.
+ */
+export class AnthropicApiError extends Error {
+  readonly status: number;
+  /** `error.type` from the response body ("invalid_request_error", "rate_limit_error", ...). */
+  readonly errorType: string | null;
+  readonly body: string;
+
+  constructor(status: number, body: string, errorType: string | null) {
+    super(`Anthropic API error ${status}: ${body}`);
+    this.name = "AnthropicApiError";
+    this.status = status;
+    this.errorType = errorType;
+    this.body = body;
+  }
+}
+
+/**
+ * True only for "your credit balance is too low", which is an OPS failure (the
+ * account needs a top-up), not a code failure. Every caller that degrades to a
+ * safe default should still degrade, but this lets it say WHY, so a billing
+ * outage doesn't read like a transient API blip.
+ *
+ * Deliberately narrow: a 400 `invalid_request_error` also covers genuine bad
+ * requests (bad max_tokens, malformed schema), which must NOT be reported as a
+ * billing problem.
+ */
+export function isInsufficientCreditError(err: unknown): boolean {
+  if (!(err instanceof AnthropicApiError)) return false;
+  if (err.status !== 400) return false;
+  if (err.errorType !== "invalid_request_error") return false;
+  return /credit\s+balance/i.test(err.body);
+}
+
+// One ALERT line per process, not one per call: a preflight run over 30 drafts
+// would otherwise bury the signal under 30 identical lines.
+let creditAlertEmitted = false;
+
+/** Test seam only. */
+export function __resetCreditAlertForTests(): void {
+  creditAlertEmitted = false;
+}
+
+function parseErrorType(body: string): string | null {
+  const parsed = safeJsonParse<{ error?: { type?: unknown } }>(body);
+  if (!parsed.success) return null;
+  const type = parsed.data?.error?.type;
+  return typeof type === "string" ? type : null;
 }
 
 export interface AnthropicOptions {
@@ -60,7 +114,22 @@ export async function callAnthropic(
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");
-    throw new Error(`Anthropic API error ${response.status}: ${errorText}`);
+    const error = new AnthropicApiError(response.status, errorText, parseErrorType(errorText));
+
+    if (isInsufficientCreditError(error) && !creditAlertEmitted) {
+      creditAlertEmitted = true;
+      // Distinct, greppable label: every AI feature backed by this wrapper is
+      // down until the account is topped up, and callers that fall back to a
+      // safe default would otherwise hide that completely.
+      console.error(
+        "[anthropic] ALERT ANTHROPIC_CREDIT_EXHAUSTED — crédit API épuisé, " +
+          "toutes les fonctionnalités IA sont dégradées jusqu'au rechargement " +
+          "(Anthropic Console > Plans & Billing). " +
+          `model=${model} status=${response.status}`
+      );
+    }
+
+    throw error;
   }
 
   return response.json();

--- a/src/lib/api/anthropic.ts
+++ b/src/lib/api/anthropic.ts
@@ -68,6 +68,12 @@ export interface AnthropicOptions {
   system?: string;
   tools?: unknown[];
   toolChoice?: unknown;
+  /**
+   * Call-site name used in the usage log. Without it a line is attributable to
+   * a model but not to a feature, which is exactly the gap that makes a bill
+   * unreadable.
+   */
+  label?: string;
 }
 
 export interface AnthropicMessage {
@@ -77,8 +83,61 @@ export interface AnthropicMessage {
 
 export interface AnthropicResponse {
   content: Array<{ type: string; text?: string; input?: unknown; name?: string }>;
-  usage?: { input_tokens: number; output_tokens: number };
+  /**
+   * Four separately-priced quantities, not two. Cache writes bill at 1.25x the
+   * input rate (5-minute TTL) and reads at 0.1x, so a total that folds them
+   * together cannot be converted back into money.
+   */
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
   stop_reason?: string;
+}
+
+export interface AnthropicUsageTotals {
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
+/**
+ * Process-wide usage meter, mirroring `getMistralTokensUsed()` in
+ * `@/lib/api/mistral`. The response already carried these numbers and the
+ * wrapper discarded them, so no bill could be attributed to a feature and no
+ * caching change could be verified. Kept per model AND per call-site label:
+ * the two questions ("which model costs what" and "which feature costs what")
+ * need different groupings.
+ */
+const usageByKey = new Map<string, AnthropicUsageTotals>();
+
+function recordUsage(key: string, usage: NonNullable<AnthropicResponse["usage"]>): void {
+  const t = usageByKey.get(key) ?? {
+    calls: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+  };
+  t.calls++;
+  t.inputTokens += usage.input_tokens ?? 0;
+  t.outputTokens += usage.output_tokens ?? 0;
+  t.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
+  t.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+  usageByKey.set(key, t);
+}
+
+/** Totals per `<label>@<model>` since process start (or the last reset). */
+export function getAnthropicUsage(): Record<string, AnthropicUsageTotals> {
+  return Object.fromEntries(usageByKey);
+}
+
+export function resetAnthropicUsage(): void {
+  usageByKey.clear();
 }
 
 export async function callAnthropic(
@@ -91,6 +150,7 @@ export async function callAnthropic(
     system,
     tools,
     toolChoice,
+    label,
   } = options;
 
   const body: Record<string, unknown> = {
@@ -132,7 +192,22 @@ export async function callAnthropic(
     throw error;
   }
 
-  return response.json();
+  const json = (await response.json()) as AnthropicResponse;
+
+  if (json.usage) {
+    const key = `${label ?? "unlabelled"}@${model}`;
+    recordUsage(key, json.usage);
+    // One structured, greppable line per call. `cache_read` staying at 0 across
+    // a run is the signature of a cache that silently never fires.
+    console.log(
+      `[anthropic] usage site=${label ?? "unlabelled"} model=${model} ` +
+        `in=${json.usage.input_tokens ?? 0} out=${json.usage.output_tokens ?? 0} ` +
+        `cache_write=${json.usage.cache_creation_input_tokens ?? 0} ` +
+        `cache_read=${json.usage.cache_read_input_tokens ?? 0}`
+    );
+  }
+
+  return json;
 }
 
 export function extractToolUse(response: AnthropicResponse): unknown | null {

--- a/src/lib/api/anthropic.ts
+++ b/src/lib/api/anthropic.ts
@@ -74,6 +74,18 @@ export interface AnthropicOptions {
    * unreadable.
    */
   label?: string;
+  /**
+   * Cache the static prefix (tools + system) with a 5-minute breakpoint.
+   *
+   * Render order is tools -> system -> messages, so a breakpoint on the system
+   * block covers the tool schemas too. Reads bill at 0.1x the input rate and
+   * the 5-minute write at 1.25x, so it pays from the second call onward.
+   *
+   * Only worth setting where the prefix clears the model's minimum cacheable
+   * size: 1024 tokens on Sonnet, but 4096 on Haiku 4.5. Below the minimum the
+   * marker is a silent no-op - no error, just no cache entry.
+   */
+  cachePrefix?: boolean;
 }
 
 export interface AnthropicMessage {
@@ -151,6 +163,7 @@ export async function callAnthropic(
     tools,
     toolChoice,
     label,
+    cachePrefix = false,
   } = options;
 
   const body: Record<string, unknown> = {
@@ -158,7 +171,13 @@ export async function callAnthropic(
     max_tokens: maxTokens,
     messages,
   };
-  if (system) body.system = system;
+  if (system) {
+    // The breakpoint sits on the system block, which is rendered after the
+    // tools, so one marker caches the whole static prefix.
+    body.system = cachePrefix
+      ? [{ type: "text", text: system, cache_control: { type: "ephemeral" } }]
+      : system;
+  }
   if (tools) body.tools = tools;
   if (toolChoice) body.tool_choice = toolChoice;
 

--- a/src/lib/api/anthropic.ts
+++ b/src/lib/api/anthropic.ts
@@ -86,6 +86,16 @@ export interface AnthropicOptions {
    * marker is a silent no-op - no error, just no cache entry.
    */
   cachePrefix?: boolean;
+  /**
+   * Passed through to the API untouched. Opt-in per call site on purpose:
+   * the accepted shapes differ by model, so a global value would 400 somewhere.
+   *
+   * Matters for cost on Claude Sonnet 5, where omitting this runs adaptive
+   * thinking at effort `high` by default and bills the thinking tokens as
+   * output - the opposite of what a cheaper per-token rate suggests. It also
+   * eats into `maxTokens`, which can truncate a forced tool call.
+   */
+  thinking?: unknown;
 }
 
 export interface AnthropicMessage {
@@ -157,13 +167,14 @@ export async function callAnthropic(
   options: AnthropicOptions = {}
 ): Promise<AnthropicResponse> {
   const {
-    model = "claude-sonnet-4-5-20250929",
+    model = "claude-sonnet-5",
     maxTokens = 2000,
     system,
     tools,
     toolChoice,
     label,
     cachePrefix = false,
+    thinking,
   } = options;
 
   const body: Record<string, unknown> = {
@@ -180,6 +191,7 @@ export async function callAnthropic(
   }
   if (tools) body.tools = tools;
   if (toolChoice) body.tool_choice = toolChoice;
+  if (thinking) body.thinking = thinking;
 
   const response = await fetch(ANTHROPIC_API_URL, {
     method: "POST",

--- a/src/lib/moderation/preflight/index.ts
+++ b/src/lib/moderation/preflight/index.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import {
   moderateAffair,
   getAIRateLimitMs,
+  type ModerationInput,
   type ModerationResult,
 } from "@/services/affair-moderation";
 import {
@@ -20,6 +21,70 @@ import type {
 interface RunPreflightOptions {
   source: "cron" | "manual";
   limit?: number;
+  /**
+   * Moderation results computed elsewhere, keyed by affair id — the batch path
+   * supplies these so the report is assembled without any synchronous AI call.
+   * A draft missing from the map still falls back to NEEDS_REVIEW below, so the
+   * safe default is identical on both transports.
+   */
+  moderationResults?: Map<string, ModerationResult>;
+}
+
+/**
+ * Build the moderation inputs for the current DRAFT backlog, without calling
+ * the API. Lets the batch path queue every request up front.
+ */
+export async function buildModerationInputs(limit?: number): Promise<ModerationInput[]> {
+  const drafts = await db.affair.findMany({
+    where: { publicationStatus: "DRAFT" },
+    orderBy: { createdAt: "asc" },
+    take: limit,
+    include: {
+      politician: { select: { id: true, slug: true, fullName: true } },
+      sources: true,
+    },
+  });
+
+  const politicianIds = [
+    ...new Set(drafts.map((d) => d.politicianId).filter((id): id is string => Boolean(id))),
+  ];
+  const published = politicianIds.length
+    ? await db.affair.findMany({
+        where: { politicianId: { in: politicianIds }, publicationStatus: "PUBLISHED" },
+        select: { politicianId: true, title: true },
+      })
+    : [];
+  const titlesByPolitician = new Map<string, string[]>();
+  for (const affair of published) {
+    const list = titlesByPolitician.get(affair.politicianId) ?? [];
+    list.push(affair.title);
+    titlesByPolitician.set(affair.politicianId, list);
+  }
+
+  return drafts
+    .filter((d) => d.politician)
+    .map((draft) => ({
+      affairId: draft.id,
+      title: draft.title,
+      description: draft.description ?? "",
+      status: draft.status,
+      category: draft.category ?? "AUTRE",
+      involvement: draft.involvement ?? "MENTIONED_ONLY",
+      politicianName: draft.politician!.fullName,
+      politicianSlug: draft.politician!.slug,
+      sources: draft.sources.map((s) => ({
+        url: s.url,
+        title: s.title ?? "",
+        publisher: s.publisher ?? "",
+        publishedAt: s.publishedAt?.toISOString() ?? "",
+      })),
+      factsDate: draft.factsDate?.toISOString() ?? null,
+      startDate: draft.startDate?.toISOString() ?? null,
+      verdictDate: draft.verdictDate?.toISOString() ?? null,
+      court: draft.court ?? null,
+      sentence: draft.sentence ?? null,
+      existingAffairTitles: titlesByPolitician.get(draft.politicianId) ?? [],
+    }));
 }
 
 export async function runPreflight(
@@ -80,7 +145,12 @@ export async function runPreflight(
     if (!draft.politician) continue;
 
     let moderation: ModerationResult;
+    const precomputed = options.moderationResults?.get(draft.id);
     try {
+      if (options.moderationResults) {
+        if (!precomputed) throw new Error("absent des résultats de modération fournis");
+        moderation = precomputed;
+      } else {
       moderation = await moderateAffair({
         affairId: draft.id,
         title: draft.title,
@@ -103,6 +173,7 @@ export async function runPreflight(
         sentence: draft.sentence ?? null,
         existingAffairTitles: publishedTitlesByPolitician.get(draft.politicianId) ?? [],
       });
+      }
     } catch (err) {
       console.error(`[preflight] moderateAffair failed for draft ${draft.id}:`, err);
       moderation = {
@@ -151,7 +222,9 @@ export async function runPreflight(
       },
     });
 
-    if (i < drafts.length - 1) {
+    // Pas de temporisation quand les résultats sont déjà là : le débit de
+    // l'API n'est plus en jeu.
+    if (!options.moderationResults && i < drafts.length - 1) {
       await sleep(getAIRateLimitMs());
     }
   }

--- a/src/lib/moderation/preflight/index.ts
+++ b/src/lib/moderation/preflight/index.ts
@@ -22,7 +22,7 @@ interface RunPreflightOptions {
   source: "cron" | "manual";
   limit?: number;
   /**
-   * Moderation results computed elsewhere, keyed by affair id — the batch path
+   * Moderation results computed elsewhere, keyed by affair id. The batch path
    * supplies these so the report is assembled without any synchronous AI call.
    * A draft missing from the map still falls back to NEEDS_REVIEW below, so the
    * safe default is identical on both transports.

--- a/src/lib/moderation/preflight/index.ts
+++ b/src/lib/moderation/preflight/index.ts
@@ -151,28 +151,28 @@ export async function runPreflight(
         if (!precomputed) throw new Error("absent des résultats de modération fournis");
         moderation = precomputed;
       } else {
-      moderation = await moderateAffair({
-        affairId: draft.id,
-        title: draft.title,
-        description: draft.description ?? "",
-        status: draft.status,
-        category: draft.category ?? "AUTRE",
-        involvement: draft.involvement ?? "MENTIONED_ONLY",
-        politicianName: draft.politician.fullName,
-        politicianSlug: draft.politician.slug,
-        sources: draft.sources.map((s) => ({
-          url: s.url,
-          title: s.title ?? "",
-          publisher: s.publisher ?? "",
-          publishedAt: s.publishedAt?.toISOString() ?? "",
-        })),
-        factsDate: draft.factsDate?.toISOString() ?? null,
-        startDate: draft.startDate?.toISOString() ?? null,
-        verdictDate: draft.verdictDate?.toISOString() ?? null,
-        court: draft.court ?? null,
-        sentence: draft.sentence ?? null,
-        existingAffairTitles: publishedTitlesByPolitician.get(draft.politicianId) ?? [],
-      });
+        moderation = await moderateAffair({
+          affairId: draft.id,
+          title: draft.title,
+          description: draft.description ?? "",
+          status: draft.status,
+          category: draft.category ?? "AUTRE",
+          involvement: draft.involvement ?? "MENTIONED_ONLY",
+          politicianName: draft.politician.fullName,
+          politicianSlug: draft.politician.slug,
+          sources: draft.sources.map((s) => ({
+            url: s.url,
+            title: s.title ?? "",
+            publisher: s.publisher ?? "",
+            publishedAt: s.publishedAt?.toISOString() ?? "",
+          })),
+          factsDate: draft.factsDate?.toISOString() ?? null,
+          startDate: draft.startDate?.toISOString() ?? null,
+          verdictDate: draft.verdictDate?.toISOString() ?? null,
+          court: draft.court ?? null,
+          sentence: draft.sentence ?? null,
+          existingAffairTitles: publishedTitlesByPolitician.get(draft.politicianId) ?? [],
+        });
       }
     } catch (err) {
       console.error(`[preflight] moderateAffair failed for draft ${draft.id}:`, err);

--- a/src/services/__tests__/affair-moderation-batch.test.ts
+++ b/src/services/__tests__/affair-moderation-batch.test.ts
@@ -7,10 +7,7 @@ vi.mock("@/lib/api/anthropic-batch", () => ({
 }));
 
 import { submitBatch, getBatchResults } from "@/lib/api/anthropic-batch";
-import {
-  submitModerationBatch,
-  collectModerationBatch,
-} from "@/services/affair-moderation-batch";
+import { submitModerationBatch, collectModerationBatch } from "@/services/affair-moderation-batch";
 import type { ModerationInput } from "@/services/affair-moderation";
 
 const input = (id: string, category = "CORRUPTION"): ModerationInput => ({

--- a/src/services/__tests__/affair-moderation-batch.test.ts
+++ b/src/services/__tests__/affair-moderation-batch.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/api/anthropic-batch", () => ({
 }));
 
 import { submitBatch, getBatchResults } from "@/lib/api/anthropic-batch";
+import { getAnthropicUsage, resetAnthropicUsage } from "@/lib/api/anthropic";
 import { submitModerationBatch, collectModerationBatch } from "@/services/affair-moderation-batch";
 import type { ModerationInput } from "@/services/affair-moderation";
 
@@ -141,5 +142,111 @@ describe("collectModerationBatch", () => {
     const { results } = await collectModerationBatch("b1", [input("a1")]);
 
     expect([...results.keys()]).toEqual(["a1"]);
+  });
+});
+
+describe("comptabilisation de l'usage sur le chemin batch", () => {
+  beforeEach(() => {
+    vi.mocked(getBatchResults).mockReset();
+    resetAnthropicUsage();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  const withUsage = (recommendation: string, usage: Record<string, number>) => ({
+    ...toolUse(recommendation),
+    usage,
+  });
+
+  it("alimente le compteur avec un libellé distinct du chemin synchrone", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      {
+        customId: "a1",
+        type: "succeeded",
+        message: withUsage("PUBLISH", {
+          input_tokens: 500,
+          output_tokens: 200,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 3270,
+        }),
+      },
+    ]);
+
+    await collectModerationBatch("b1", [input("a1")]);
+
+    const keys = Object.keys(getAnthropicUsage());
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain("affair-moderation-batch@");
+    const totals = getAnthropicUsage()[keys[0]!]!;
+    expect(totals.cacheReadTokens).toBe(3270);
+    expect(totals.outputTokens).toBe(200);
+  });
+
+  it("ne compte rien quand le résultat ne porte pas de bloc usage", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "a1", type: "succeeded", message: toolUse("PUBLISH") },
+    ]);
+
+    await collectModerationBatch("b1", [input("a1")]);
+
+    expect(getAnthropicUsage()).toEqual({});
+  });
+});
+
+describe("moderationInputFingerprint", () => {
+  it("change dès qu'un champ du prompt change", async () => {
+    const { moderationInputFingerprint } = await import("@/services/affair-moderation");
+    const base = input("a1");
+    expect(moderationInputFingerprint(base)).toBe(moderationInputFingerprint(input("a1")));
+    expect(moderationInputFingerprint({ ...base, title: "Autre titre" })).not.toBe(
+      moderationInputFingerprint(base)
+    );
+    expect(moderationInputFingerprint({ ...base, category: "VIOLENCE" })).not.toBe(
+      moderationInputFingerprint(base)
+    );
+  });
+
+  it("est stable quel que soit l'ordre de déclaration des clés", async () => {
+    const { moderationInputFingerprint } = await import("@/services/affair-moderation");
+
+    // Mêmes valeurs, clés déclarées dans l'ordre inverse : canonicalJson trie à
+    // toute profondeur, donc l'empreinte ne doit pas bouger.
+    const a: ModerationInput = {
+      affairId: "a1",
+      title: "Affaire a1",
+      description: "Description factuelle.",
+      status: "MISE_EN_EXAMEN",
+      category: "CORRUPTION",
+      involvement: "DIRECT",
+      politicianName: "Jean Dupont",
+      politicianSlug: "jean-dupont",
+      sources: [],
+      factsDate: null,
+      startDate: null,
+      verdictDate: null,
+      court: null,
+      sentence: null,
+      today: "2026-09-06",
+    };
+    const b: ModerationInput = {
+      today: "2026-09-06",
+      sentence: null,
+      court: null,
+      verdictDate: null,
+      startDate: null,
+      factsDate: null,
+      sources: [],
+      politicianSlug: "jean-dupont",
+      politicianName: "Jean Dupont",
+      involvement: "DIRECT",
+      category: "CORRUPTION",
+      status: "MISE_EN_EXAMEN",
+      description: "Description factuelle.",
+      title: "Affaire a1",
+      affairId: "a1",
+    };
+
+    expect(moderationInputFingerprint(b)).toBe(moderationInputFingerprint(a));
   });
 });

--- a/src/services/__tests__/affair-moderation-batch.test.ts
+++ b/src/services/__tests__/affair-moderation-batch.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/api/anthropic-batch", () => ({
+  submitBatch: vi.fn(),
+  getBatchStatus: vi.fn(),
+  getBatchResults: vi.fn(),
+}));
+
+import { submitBatch, getBatchResults } from "@/lib/api/anthropic-batch";
+import {
+  submitModerationBatch,
+  collectModerationBatch,
+} from "@/services/affair-moderation-batch";
+import type { ModerationInput } from "@/services/affair-moderation";
+
+const input = (id: string, category = "CORRUPTION"): ModerationInput => ({
+  affairId: id,
+  title: `Affaire ${id}`,
+  description: "Description factuelle.",
+  status: "MISE_EN_EXAMEN",
+  category,
+  involvement: "DIRECT",
+  politicianName: "Jean Dupont",
+  politicianSlug: "jean-dupont",
+  sources: [],
+  factsDate: null,
+  startDate: null,
+  verdictDate: null,
+  court: null,
+  sentence: null,
+  today: "2026-09-06",
+});
+
+const toolUse = (recommendation: string) => ({
+  content: [
+    {
+      type: "tool_use",
+      name: "moderate_affair",
+      input: {
+        recommendation,
+        confidence: 90,
+        reasoning: "ok",
+        corrected_title: null,
+        corrected_description: null,
+        corrected_status: null,
+        corrected_category: null,
+        corrected_involvement: null,
+        issues: [],
+      },
+    },
+  ],
+});
+
+describe("submitModerationBatch", () => {
+  beforeEach(() => vi.mocked(submitBatch).mockReset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("uses the affair id as custom_id, so results can be found again", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(submitBatch).mockResolvedValue({ id: "b1", processingStatus: "in_progress" });
+
+    await submitModerationBatch([input("a1"), input("a2")]);
+
+    const sent = vi.mocked(submitBatch).mock.calls[0]![0];
+    expect(sent.map((r) => r.customId)).toEqual(["a1", "a2"]);
+  });
+
+  it("sends the cached prefix and disabled thinking, like the sync path", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(submitBatch).mockResolvedValue({ id: "b1", processingStatus: "in_progress" });
+
+    await submitModerationBatch([input("a1")]);
+
+    const params = vi.mocked(submitBatch).mock.calls[0]![0][0]!.params as Record<string, unknown>;
+    expect(params.thinking).toEqual({ type: "disabled" });
+    expect(params.system).toEqual([
+      expect.objectContaining({ cache_control: { type: "ephemeral" } }),
+    ]);
+    expect(params.tool_choice).toEqual({ type: "tool", name: "moderate_affair" });
+  });
+});
+
+describe("collectModerationBatch", () => {
+  beforeEach(() => vi.mocked(getBatchResults).mockReset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("maps results by custom_id regardless of the order they arrive in", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "a2", type: "succeeded", message: toolUse("REJECT") },
+      { customId: "a1", type: "succeeded", message: toolUse("PUBLISH") },
+    ]);
+
+    const { results, failures } = await collectModerationBatch("b1", [input("a1"), input("a2")]);
+
+    expect(results.get("a1")!.recommendation).toBe("PUBLISH");
+    expect(results.get("a2")!.recommendation).toBe("REJECT");
+    expect(failures.size).toBe(0);
+  });
+
+  it("still forces NEEDS_REVIEW on a sensitive category", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "a1", type: "succeeded", message: toolUse("PUBLISH") },
+    ]);
+
+    const { results } = await collectModerationBatch("b1", [input("a1", "AGRESSION_SEXUELLE")]);
+
+    expect(results.get("a1")!.recommendation).toBe("NEEDS_REVIEW");
+    expect(results.get("a1")!.issues.some((i) => i.type === "SENSITIVE_CATEGORY")).toBe(true);
+  });
+
+  it("reports a submitted affair that never came back, instead of dropping it", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "a1", type: "succeeded", message: toolUse("PUBLISH") },
+    ]);
+
+    const { results, failures } = await collectModerationBatch("b1", [input("a1"), input("a2")]);
+
+    expect(results.has("a2")).toBe(false);
+    expect(failures.get("a2")).toContain("absent");
+  });
+
+  it("records an errored entry as a failure rather than a result", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "a1", type: "errored", error: '{"type":"overloaded_error"}' },
+    ]);
+
+    const { results, failures } = await collectModerationBatch("b1", [input("a1")]);
+
+    expect(results.size).toBe(0);
+    expect(failures.get("a1")).toContain("errored");
+  });
+
+  it("ignores a result for something that was never submitted", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(getBatchResults).mockResolvedValue([
+      { customId: "inconnu", type: "succeeded", message: toolUse("PUBLISH") },
+      { customId: "a1", type: "succeeded", message: toolUse("PUBLISH") },
+    ]);
+
+    const { results } = await collectModerationBatch("b1", [input("a1")]);
+
+    expect([...results.keys()]).toEqual(["a1"]);
+  });
+});

--- a/src/services/affair-description-enrichment.ts
+++ b/src/services/affair-description-enrichment.ts
@@ -122,6 +122,7 @@ export async function enrichDescription(
   const validSlugs = buildValidSlugs(input);
 
   const response = await callAnthropic([{ role: "user", content: userMessage }], {
+    label: "affair-description-enrichment",
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-enrichment.ts
+++ b/src/services/affair-enrichment.ts
@@ -630,6 +630,7 @@ INSTRUCTIONS :
 5. Indique ta confiance : haute si correspondance claire, basse si doute`;
 
   const data = await callAnthropic([{ role: "user", content: userMessage }], {
+    label: "affair-enrichment",
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-enrichment.ts
+++ b/src/services/affair-enrichment.ts
@@ -631,6 +631,7 @@ INSTRUCTIONS :
 
   const data = await callAnthropic([{ role: "user", content: userMessage }], {
     label: "affair-enrichment",
+    cachePrefix: true,
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-enrichment.ts
+++ b/src/services/affair-enrichment.ts
@@ -24,7 +24,7 @@ import { removeSidebarElements } from "@/lib/parsing/html-utils";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
 import { USER_AGENT } from "@/config/site";
 
-const MODEL = "claude-sonnet-4-5-20250929";
+const MODEL = "claude-sonnet-5";
 const MAX_TOKENS = 2000;
 const MAX_SCRAPE_LENGTH = 12_000;
 
@@ -632,6 +632,7 @@ INSTRUCTIONS :
   const data = await callAnthropic([{ role: "user", content: userMessage }], {
     label: "affair-enrichment",
     cachePrefix: true,
+    thinking: { type: "disabled" },
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-moderation-batch.ts
+++ b/src/services/affair-moderation-batch.ts
@@ -1,0 +1,106 @@
+/**
+ * Batch path for affair moderation.
+ *
+ * Same prompt, same tool schema, same validation as `moderateAffair` — only the
+ * transport differs. Every token bills at half the standard rate, and the
+ * discount stacks with the cached prefix.
+ *
+ * Deliberately does NOT apply a fallback for missing or failed results: the
+ * caller owns that decision, and its safe default (NEEDS_REVIEW) must stay
+ * exactly where it was.
+ */
+import {
+  submitBatch,
+  getBatchStatus,
+  getBatchResults,
+  type BatchRequest,
+} from "@/lib/api/anthropic-batch";
+import { extractToolUse, type AnthropicResponse } from "@/lib/api/anthropic";
+import {
+  buildModerationParams,
+  parseModerationResult,
+  type ModerationInput,
+  type ModerationResult,
+} from "@/services/affair-moderation";
+
+export interface BatchModerationOutcome {
+  /** Successfully parsed results, keyed by affairId. */
+  results: Map<string, ModerationResult>;
+  /** affairId -> reason, for everything the caller must fall back on. */
+  failures: Map<string, string>;
+}
+
+/** Submit one moderation request per input. Returns the batch id. */
+export async function submitModerationBatch(inputs: ModerationInput[]): Promise<string> {
+  const requests: BatchRequest[] = inputs.map((input) => ({
+    customId: input.affairId,
+    params: buildModerationParams(input),
+  }));
+  const handle = await submitBatch(requests);
+  console.log(`[moderation-batch] soumis batch=${handle.id} requests=${requests.length}`);
+  return handle.id;
+}
+
+export async function isBatchReady(batchId: string): Promise<boolean> {
+  const handle = await getBatchStatus(batchId);
+  return handle.processingStatus === "ended";
+}
+
+/**
+ * Read a finished batch back into ModerationResults.
+ *
+ * `inputs` must be the same list that was submitted: the affair data is needed
+ * again to validate the payload (the sensitive-category guard reads the
+ * affair's category, not the model's answer).
+ */
+export async function collectModerationBatch(
+  batchId: string,
+  inputs: ModerationInput[]
+): Promise<BatchModerationOutcome> {
+  const byId = new Map(inputs.map((i) => [i.affairId, i]));
+  const results = new Map<string, ModerationResult>();
+  const failures = new Map<string, string>();
+
+  const raw = await getBatchResults(batchId);
+
+  for (const entry of raw) {
+    const input = byId.get(entry.customId);
+    if (!input) {
+      // A result for something we did not submit: ignore rather than guess.
+      continue;
+    }
+
+    if (entry.type !== "succeeded") {
+      failures.set(entry.customId, `batch result ${entry.type}: ${entry.error}`);
+      continue;
+    }
+
+    const toolUse = extractToolUse(entry.message as AnthropicResponse) as Record<
+      string,
+      unknown
+    > | null;
+    if (!toolUse) {
+      failures.set(entry.customId, "no tool_use content in batch result");
+      continue;
+    }
+
+    try {
+      results.set(entry.customId, parseModerationResult(toolUse, input));
+    } catch (err) {
+      failures.set(entry.customId, err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // Anything submitted but absent from the results is a failure too, otherwise
+  // a silently dropped affair would look like it was never queued.
+  for (const input of inputs) {
+    if (!results.has(input.affairId) && !failures.has(input.affairId)) {
+      failures.set(input.affairId, "absent des résultats du batch");
+    }
+  }
+
+  console.log(
+    `[moderation-batch] relevé batch=${batchId} ok=${results.size} échecs=${failures.size}`
+  );
+  return { results, failures };
+}

--- a/src/services/affair-moderation-batch.ts
+++ b/src/services/affair-moderation-batch.ts
@@ -1,7 +1,7 @@
 /**
  * Batch path for affair moderation.
  *
- * Same prompt, same tool schema, same validation as `moderateAffair` — only the
+ * Same prompt, same tool schema, same validation as `moderateAffair`. Only the
  * transport differs. Every token bills at half the standard rate, and the
  * discount stacks with the cached prefix.
  *
@@ -15,13 +15,17 @@ import {
   getBatchResults,
   type BatchRequest,
 } from "@/lib/api/anthropic-batch";
-import { extractToolUse, type AnthropicResponse } from "@/lib/api/anthropic";
+import { extractToolUse, recordAnthropicUsage, type AnthropicResponse } from "@/lib/api/anthropic";
 import {
+  MODEL,
   buildModerationParams,
   parseModerationResult,
   type ModerationInput,
   type ModerationResult,
 } from "@/services/affair-moderation";
+
+/** Distinct from "affair-moderation": batch tokens bill at half the rate. */
+const BATCH_USAGE_LABEL = "affair-moderation-batch";
 
 export interface BatchModerationOutcome {
   /** Successfully parsed results, keyed by affairId. */
@@ -75,10 +79,13 @@ export async function collectModerationBatch(
       continue;
     }
 
-    const toolUse = extractToolUse(entry.message as AnthropicResponse) as Record<
-      string,
-      unknown
-    > | null;
+    const message = entry.message as AnthropicResponse;
+    // Batch responses carry their own usage block. Without this the cheapest
+    // half of the traffic would be invisible in getAnthropicUsage(), and the
+    // prompt-cache hits it relies on unverifiable.
+    recordAnthropicUsage(BATCH_USAGE_LABEL, MODEL, message.usage);
+
+    const toolUse = extractToolUse(message) as Record<string, unknown> | null;
     if (!toolUse) {
       failures.set(entry.customId, "no tool_use content in batch result");
       continue;

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -14,8 +14,10 @@
 import { AI_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
 import { AffairStatus } from "@/generated/prisma";
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@/lib/hash/canonical";
 
-const MODEL = "claude-sonnet-5";
+export const MODEL = "claude-sonnet-5";
 const MAX_TOKENS = 2000;
 
 // ============================================
@@ -347,6 +349,19 @@ export function buildUserContent(input: ModerationInput): string {
   }
 
   return userContent;
+}
+
+/**
+ * Fingerprint of everything that feeds the prompt.
+ *
+ * The batch path submits and collects hours apart, so a draft can be edited in
+ * between. Results are matched by affair id alone, which would attach an answer
+ * generated from the old snapshot to the new content. Comparing fingerprints at
+ * collection time turns that into a miss, and a miss already falls back to
+ * NEEDS_REVIEW.
+ */
+export function moderationInputFingerprint(input: ModerationInput): string {
+  return createHash("sha256").update(canonicalJson(input)).digest("hex").slice(0, 16);
 }
 
 /** Request body shared by the synchronous and the batch path. */

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -347,6 +347,7 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
   }
 
   const data = await callAnthropic([{ role: "user", content: userContent }], {
+    label: "affair-moderation",
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -348,6 +348,7 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
 
   const data = await callAnthropic([{ role: "user", content: userContent }], {
     label: "affair-moderation",
+    cachePrefix: true,
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -296,10 +296,10 @@ DÉTECTION DE DOUBLONS :
 // ============================================
 
 /**
- * Moderate an affair using Claude Sonnet 4.5 tool_use.
- * Returns a structured recommendation (PUBLISH / REJECT / NEEDS_REVIEW).
+ * Build the user message sent to the provider. Exported so the batch path
+ * builds the exact same request as the synchronous one.
  */
-export async function moderateAffair(input: ModerationInput): Promise<ModerationResult> {
+export function buildUserContent(input: ModerationInput): string {
   const today = input.today ?? new Date().toISOString().slice(0, 10);
 
   // Build user message with all affair data
@@ -346,22 +346,32 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
     }
   }
 
-  const data = await callAnthropic([{ role: "user", content: userContent }], {
-    label: "affair-moderation",
-    cachePrefix: true,
-    thinking: { type: "disabled" },
+  return userContent;
+}
+
+/** Request body shared by the synchronous and the batch path. */
+export function buildModerationParams(input: ModerationInput): Record<string, unknown> {
+  return {
     model: MODEL,
-    maxTokens: MAX_TOKENS,
-    system: SYSTEM_PROMPT,
+    max_tokens: MAX_TOKENS,
+    system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
     tools: [MODERATION_TOOL],
-    toolChoice: { type: "tool", name: "moderate_affair" },
-  });
+    tool_choice: { type: "tool", name: "moderate_affair" },
+    thinking: { type: "disabled" },
+    messages: [{ role: "user", content: buildUserContent(input) }],
+  };
+}
 
-  const result = extractToolUse(data) as Record<string, unknown> | null;
-  if (!result) {
-    throw new Error("No tool_use content in API response");
-  }
-
+/**
+ * Validate and normalize a raw moderation payload into a ModerationResult.
+ * Provider- and transport-agnostic: every safety guard lives here rather than
+ * in the caller, so enum validation and the sensitive-category forcing apply
+ * whether the payload came from a synchronous call or a batch result.
+ */
+export function parseModerationResult(
+  result: Record<string, unknown>,
+  input: ModerationInput
+): ModerationResult {
   // Parse and validate the result
   const recommendation = validateEnum(
     result.recommendation as string,
@@ -443,6 +453,30 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
     issues,
     model: MODEL,
   };
+}
+
+/**
+ * Moderate an affair using Claude Sonnet 5 tool_use.
+ * Returns a structured recommendation (PUBLISH / REJECT / NEEDS_REVIEW).
+ */
+export async function moderateAffair(input: ModerationInput): Promise<ModerationResult> {
+  const data = await callAnthropic([{ role: "user", content: buildUserContent(input) }], {
+    label: "affair-moderation",
+    cachePrefix: true,
+    thinking: { type: "disabled" },
+    model: MODEL,
+    maxTokens: MAX_TOKENS,
+    system: SYSTEM_PROMPT,
+    tools: [MODERATION_TOOL],
+    toolChoice: { type: "tool", name: "moderate_affair" },
+  });
+
+  const result = extractToolUse(data) as Record<string, unknown> | null;
+  if (!result) {
+    throw new Error("No tool_use content in API response");
+  }
+
+  return parseModerationResult(result, input);
 }
 
 // ============================================

--- a/src/services/affair-moderation.ts
+++ b/src/services/affair-moderation.ts
@@ -15,7 +15,7 @@ import { AI_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
 import { AffairStatus } from "@/generated/prisma";
 
-const MODEL = "claude-sonnet-4-5-20250929";
+const MODEL = "claude-sonnet-5";
 const MAX_TOKENS = 2000;
 
 // ============================================
@@ -349,6 +349,7 @@ export async function moderateAffair(input: ModerationInput): Promise<Moderation
   const data = await callAnthropic([{ role: "user", content: userContent }], {
     label: "affair-moderation",
     cachePrefix: true,
+    thinking: { type: "disabled" },
     model: MODEL,
     maxTokens: MAX_TOKENS,
     system: SYSTEM_PROMPT,

--- a/src/services/classify-theme.ts
+++ b/src/services/classify-theme.ts
@@ -121,6 +121,7 @@ ${CATEGORY_GUIDE}`;
   ];
 
   const data = await callAnthropic([{ role: "user", content: prompt }], {
+    label: "classify-theme",
     model: ANTHROPIC_MODEL,
     maxTokens: 100,
     tools,

--- a/src/services/promises/extractor.ts
+++ b/src/services/promises/extractor.ts
@@ -43,6 +43,7 @@ export async function extractPromisesFromText(input: {
 
   try {
     const response = await callAnthropic([{ role: "user", content: prompt }], {
+      label: "promises-extractor",
       model: HAIKU_MODEL,
       maxTokens: 2000,
     });

--- a/src/services/promises/theme-classifier.ts
+++ b/src/services/promises/theme-classifier.ts
@@ -94,6 +94,7 @@ async function classifyWithPrompt(
   const prompt = promptTemplate.replace("{{TEXT}}", safe);
   try {
     const response = await callAnthropic([{ role: "user", content: prompt }], {
+      label: "promises-theme-classifier",
       model: HAIKU_MODEL,
       maxTokens: 100,
     });

--- a/src/services/wikipedia-affair-extraction.ts
+++ b/src/services/wikipedia-affair-extraction.ts
@@ -17,7 +17,7 @@ import { clampConfidenceScore } from "@/services/affairs/confidence";
 import { callAnthropic, extractToolUse } from "@/lib/api/anthropic";
 import { AffairStatus } from "@/generated/prisma";
 
-const MODEL = "claude-sonnet-4-5-20250929";
+const MODEL = "claude-sonnet-5";
 const MAX_TOKENS = 2000;
 const MAX_WIKITEXT_CHARS = 8000;
 
@@ -244,6 +244,7 @@ ${truncatedWikitext}`;
     const data = await callAnthropic([{ role: "user", content: userContent }], {
       label: "wikipedia-affair-extraction",
       cachePrefix: true,
+      thinking: { type: "disabled" },
       model: MODEL,
       maxTokens: MAX_TOKENS,
       system: SYSTEM_PROMPT,

--- a/src/services/wikipedia-affair-extraction.ts
+++ b/src/services/wikipedia-affair-extraction.ts
@@ -243,6 +243,7 @@ ${truncatedWikitext}`;
   try {
     const data = await callAnthropic([{ role: "user", content: userContent }], {
       label: "wikipedia-affair-extraction",
+      cachePrefix: true,
       model: MODEL,
       maxTokens: MAX_TOKENS,
       system: SYSTEM_PROMPT,

--- a/src/services/wikipedia-affair-extraction.ts
+++ b/src/services/wikipedia-affair-extraction.ts
@@ -242,6 +242,7 @@ ${truncatedWikitext}`;
 
   try {
     const data = await callAnthropic([{ role: "user", content: userContent }], {
+      label: "wikipedia-affair-extraction",
       model: MODEL,
       maxTokens: MAX_TOKENS,
       system: SYSTEM_PROMPT,


### PR DESCRIPTION
## Contexte

Le crédit Anthropic a été épuisé le 04/09, ce qui a dégradé silencieusement tout le pipeline de modération à 100 % de revue manuelle : chaque appel échouait, chaque appelant retombait sur son défaut sûr, et rien ne le signalait.

Cette PR corrige la visibilité de cette panne, puis attaque ce qui la rendait coûteuse.

## Ce que contient la PR

Cinq commits indépendants, chacun révocable seul.

**1. `07df0859` — Distinguer le crédit épuisé des autres erreurs API**

`callAnthropic` lançait un `Error` générique. Un problème de facturation, un rate limit et un schéma malformé étaient indiscernables.

- `AnthropicApiError` porte `status`, `errorType` et le corps de la réponse.
- `isInsufficientCreditError()` est volontairement étroit : `400` **et** `invalid_request_error` **et** mention de `credit balance`. Un vrai mauvais `max_tokens` ne doit pas remonter comme un problème de paiement.
- Log `ALERT ANTHROPIC_CREDIT_EXHAUSTED` émis **une fois par process**, pas par appel : un preflight sur 30 drafts noierait sinon le signal.
- Le message d'erreur historique `Anthropic API error <status>: <body>` est préservé, donc les greps de logs existants continuent de matcher.

Couvre les 6 sites `callAnthropic`, dont 5 n'avaient aucun filet.

**2. `e375274a` — Journaliser l'usage de tokens par site d'appel**

Le wrapper recevait `response.usage` et le jetait. Conséquence : aucune dépense n'était attribuable à une fonctionnalité, et aucun changement de cache n'était vérifiable.

- Les **quatre** quantités facturées séparément sont conservées (entrée, écriture de cache à 1,25×, lecture à 0,1×, sortie). Un total qui les additionne ne se reconvertit pas en euros.
- `getAnthropicUsage()` agrège par `<site>@<modèle>`.
- Une ligne greppable par appel. `cache_read=0` sur toute une exécution est la signature d'un cache qui ne se déclenche jamais.

**3. `ed45056f` — Cacher le préfixe statique des trois appels Sonnet**

Mesuré via `count_tokens` : le préfixe de `moderateAffair` fait **3 270 tokens** (1 368 de prompt système + 1 902 de schéma d'outil), refacturés plein tarif à chaque affaire.

- Un point de rupture sur le bloc système suffit : l'ordre de rendu étant `tools` → `system` → `messages`, il couvre aussi les schémas d'outil.
- TTL 5 minutes (écriture à 1,25× au lieu de 2×), rentable dès le 2e appel. La boucle preflight espace ses appels de 500 ms, donc le cache reste chaud sur tout le run.
- **Non activé sur les sites Haiku** : leur préfixe minimum cachable est de 4 096 tokens contre 1 024 sur Sonnet, et nos prompts Haiku font ~100 tokens. Un `cache_control` y serait un no-op silencieux.

**4. `33a172e1` — Sonnet 5, réflexion désactivée**

Sonnet 5 coûte 2 $/10 $ par MTok contre 3 $/15 $ pour Sonnet 4.5.

`thinking: { type: "disabled" }` est explicite et nécessaire : la réflexion est **adaptative par défaut** sur ce modèle, facturée en sortie, et elle consomme le budget `maxTokens`. À 2 000 tokens sur la modération, elle pourrait tronquer un `tool_use` forcé. Sans ce garde-fou, un modèle « moins cher au token » coûterait plus par tâche.

Le paramètre est opt-in par site : l'envoyer globalement ferait échouer les appels Haiku.

`judge-policy-titles` reste délibérément sur Sonnet 4.5 : sa constante `ACTOR = "llm-judge:claude-sonnet-4-5"` est écrite en base comme provenance des verdicts.

**5. `b64939d3` — Preflight via l'API Batch**

Moitié prix sur chaque token, et la remise se cumule avec le préfixe caché.

- Les résultats arrivent « sous 24 h », ce qui est une expiration et non un délai garanti. Le cron passe donc par des **étapes durables** Inngest (soumission, sommeil, relevé) plutôt que d'attendre en bloquant dans une fonction serverless.
- `buildModerationParams()` est partagé par les deux transports, donc le préfixe est identique au octet près et le cache reste mutualisé.
- Le fallback `NEEDS_REVIEW` **n'a pas changé de place** : il reste chez l'appelant et couvre les trois pertes possibles (résultat en erreur, résultat absent des retours, batch non terminé).

## Effet mesuré

Coût du seul préfixe, par appel de modération :

| Configuration | Prix | Écart |
|---|---|---|
| Avant | 0,00981 $ | référence |
| + cache | 0,00098 $ | −90 % |
| + Sonnet 5 | 0,00065 $ | −93 % |
| + Batch | 0,00033 $ | **−97 %** |

## Ce que cette PR ne prouve pas

- **Aucune éval ne couvre la modération juridique.** Le passage en Sonnet 5 est un arbitrage assumé, pas une amélioration validée. Premier suspect si un verdict paraît anormal.
- **Le cache n'est pas vérifié en conditions réelles.** Les tests couvrent la forme de la requête, pas le fait que l'API crée l'entrée. À contrôler sur la première exécution : chercher `cache_read=` non nul sur la 2e affaire d'un run.
- **Le Batch ajoute un mode de défaillance.** Si le batch n'a pas fini après 12 relevés de 5 minutes, tous les drafts retombent sur `NEEDS_REVIEW` alors que le batch est déjà payé. Son identifiant est journalisé pour rester récupérable.

## Tests

`tsc --noEmit` en sortie 0. Suite complète : **661 fichiers, 5 872 tests, 0 échec**, exécutée sur la base rebasée.

24 tests ajoutés : 8 sur la classification des erreurs, 4 sur le compteur d'usage, 4 sur la forme du préfixe caché, 7 sur le batch (dont les trois cas de perte silencieuse), plus la non-régression des 8 tests de modération existants, inchangés.

## Action ops

Recharger le crédit reste nécessaire et indépendant de cette PR : l'alerte rend la panne visible, elle ne la répare pas.
