### PR TITLE
Regrouper le bruit des scripts de streaming React dans Sentry

### DIFF
--- a/src/instrumentation-client.test.ts
+++ b/src/instrumentation-client.test.ts
@@ -1,5 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type SentryEvent = {
+  exception?: { values?: { type?: string; value?: string; stacktrace?: { frames?: unknown[] } }[] };
+  fingerprint?: string[];
+};
+
+/** Builds an event whose stack sits in a React inline script, as Sentry receives it. */
+function reactStreamingEvent(fn: string, value: string): SentryEvent {
+  return {
+    exception: {
+      values: [
+        {
+          type: "TypeError",
+          value,
+          stacktrace: {
+            frames: [
+              { function: null, filename: "app:///affaires/condamnations", in_app: true },
+              { function: fn, filename: "app:///affaires/condamnations", in_app: true },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
 const mocks = vi.hoisted(() => ({
   init: vi.fn(),
   replayIntegration: vi.fn(() => ({ name: "Replay" })),
@@ -19,7 +44,10 @@ async function bootAt(pathname: string) {
   mocks.replayIntegration.mockClear();
   window.history.replaceState(null, "", pathname);
   await import("./instrumentation-client");
-  return (mocks.init.mock.calls[0]?.[0] ?? {}) as { integrations?: unknown[] };
+  return (mocks.init.mock.calls[0]?.[0] ?? {}) as {
+    integrations?: unknown[];
+    beforeSend?: (event: SentryEvent) => SentryEvent | null;
+  };
 }
 
 const hasReplay = (opts: { integrations?: unknown[] }) =>
@@ -57,5 +85,80 @@ describe("Session replay : périmètre d'enregistrement", () => {
 
   it("ne coupe pas une route publique dont le nom commence par admin", async () => {
     expect(hasReplay(await bootAt("/administration-publique"))).toBe(true);
+  });
+});
+
+describe("Scripts de streaming React : bruit non actionnable", () => {
+  // $RS/$RC/$RV sont les scripts inline que React injecte dans le HTML pour
+  // révéler une frontière Suspense. Ils déréférencent getElementById sans
+  // null-check : le nombre d'events égale le nombre de frontières de la page,
+  // et aucun frame applicatif n'est en cause.
+  it("regroupe la famille sous une empreinte unique", async () => {
+    const { beforeSend } = await bootAt("/affaires/condamnations");
+    const kept = beforeSend!(
+      reactStreamingEvent("$RS", "Cannot read properties of null (reading 'parentNode')")
+    );
+    expect(kept).not.toBeNull();
+    expect(kept!.fingerprint).toEqual(["react-streaming-reveal-script"]);
+  });
+
+  it("ne garde qu'un event par chargement de page", async () => {
+    const { beforeSend } = await bootAt("/affaires/condamnations");
+    const first = beforeSend!(
+      reactStreamingEvent("$RS", "Cannot read properties of null (reading 'parentNode')")
+    );
+    const second = beforeSend!(
+      reactStreamingEvent("$RS", "Cannot read properties of null (reading 'parentNode')")
+    );
+    const third = beforeSend!(
+      reactStreamingEvent("$RC", "Cannot read properties of null (reading 'tagName')")
+    );
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(third).toBeNull();
+  });
+
+  it("laisse passer une vraie erreur applicative qui touche parentNode", async () => {
+    const { beforeSend } = await bootAt("/affaires/condamnations");
+    const appError: SentryEvent = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Cannot read properties of null (reading 'parentNode')",
+            stacktrace: {
+              frames: [
+                {
+                  function: "closeDropdown",
+                  filename: "app:///_next/static/chunks/8409-8295dd6356804e56.js",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const kept = beforeSend!(appError);
+    expect(kept).toBe(appError);
+    expect(kept!.fingerprint).toBeUndefined();
+  });
+
+  // POLIGRAPH-M est la cible réelle de l'investigation : la filtrer avec le
+  // bruit qu'elle produit reviendrait à masquer la cause.
+  it("laisse passer une erreur d'hydratation", async () => {
+    const { beforeSend } = await bootAt("/");
+    const hydration: SentryEvent = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Hydration failed because the server rendered HTML didn't match the client.",
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    };
+    expect(beforeSend!(hydration)).toBe(hydration);
   });
 });

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -16,6 +16,29 @@ const SENTRY_ENABLED = Boolean(SENTRY_DSN) && process.env.NEXT_PUBLIC_SENTRY_ENA
 const IS_ADMIN_ROUTE =
   typeof window !== "undefined" && /^\/admin(\/|$)/.test(window.location.pathname);
 
+// React's streaming renderer injects these inline scripts into the HTML document
+// to reveal a Suspense boundary ($RS), complete one ($RC) or reveal viewport
+// content ($RV). They dereference `document.getElementById(...)` with no null
+// check, so once the hidden template nodes are gone from the document every
+// remaining call throws. One page load therefore produces one TypeError per
+// Suspense boundary: the event count measures the page's boundary count, not
+// severity, and there is no application frame to fix. Collapse the family into a
+// single issue and keep one event per page load so a burst cannot read as an
+// escalating regression. Hydration errors are deliberately left untouched:
+// they are the actual signal these bursts sit downstream of.
+const REACT_STREAMING_SCRIPTS = new Set(["$RS", "$RC", "$RV"]);
+const REACT_STREAMING_FINGERPRINT = "react-streaming-reveal-script";
+
+let reactStreamingReported = false;
+
+function isReactStreamingScriptError(event: Sentry.ErrorEvent): boolean {
+  return (event.exception?.values ?? []).some((value) =>
+    (value.stacktrace?.frames ?? []).some(
+      (frame) => frame.function != null && REACT_STREAMING_SCRIPTS.has(frame.function)
+    )
+  );
+}
+
 if (SENTRY_ENABLED) {
   Sentry.init({
     dsn: SENTRY_DSN,
@@ -28,6 +51,12 @@ if (SENTRY_ENABLED) {
     integrations: IS_ADMIN_ROUTE
       ? []
       : [Sentry.replayIntegration({ maskAllText: false, blockAllMedia: true })],
+    beforeSend(event) {
+      if (!isReactStreamingScriptError(event)) return event;
+      if (reactStreamingReported) return null;
+      reactStreamingReported = true;
+      return { ...event, fingerprint: [REACT_STREAMING_FINGERPRINT] };
+    },
     ignoreErrors: [
       "ResizeObserver loop limit exceeded",
       "ResizeObserver loop completed with undelivered notifications",


### PR DESCRIPTION
## Contexte

Trois issues Sentry (`POLIGRAPH-1K`, `POLIGRAPH-1D`, `POLIGRAPH-1J`) remontaient
un `TypeError: Cannot read properties of null (reading 'parentNode')` lu comme un
crash récurrent. L'investigation dit autre chose : sur 3 mois, 7 routes et
150 events, mais seulement **9 sessions distinctes**, et `userCount: 0` partout.

Le frame fautif est `$RS`, le script inline que React injecte dans le HTML pour
révéler une frontière Suspense. Il déréférence `document.getElementById(...)`
sans null-check. Il n'appartient pas à notre code et vit dans le document, pas
dans un chunk : il n'existe aucune ligne applicative à corriger.

Surtout, le nombre d'events par page **égale le nombre d'appels `$RS(` de son
HTML** : 31 pour 31 sur `/comparer`, 1 pour 1 sur `/politiques`. Le classement
« 31 events escalating » contre « 1 event » ne mesurait donc que le poids des
pages, jamais la gravité.

## Ce que fait cette PR

Un `beforeSend` qui regroupe la famille `$RS`/`$RC`/`$RV` sous une empreinte
unique et ne garde qu'un event par chargement de page. Le prédicat porte sur le
nom de fonction du frame, pas sur le message : une vraie `TypeError` applicative
touchant `parentNode` continue de remonter normalement.

## Ce que cette PR ne fait pas

Elle ne corrige pas la cause. `POLIGRAPH-M` (« Hydration failed », 42 events,
apparue le même jour que toute la famille) reste le suspect, et elle est
**volontairement laissée non filtrée**, avec un test qui verrouille ce point.

La repro n'a pas abouti : chromium et webkit, timezones `Europe/Paris` et
`Europe/Lisbon`, 16 cas sur 16 propres. Le dev en est de toute façon incapable,
il sert 1 frontière Suspense là où la prod en sert 34.

## Vérifications

- `npx vitest run` : 5886 tests passés, 0 échec
- `npx tsc --noEmit --incremental false` : propre
- `eslint` et `prettier` propres sur les deux fichiers
- Détecteur d'hydratation validé sur un mismatch volontaire avant de conclure au négatif

Ref POLIGRAPH-1K, POLIGRAPH-1D, POLIGRAPH-1J