### PR TITLE
Faire dire aux compteurs de l'admin la charge et non l'historique

### DIFF
--- a/scripts/backfill-orphan-moderation-reviews.ts
+++ b/scripts/backfill-orphan-moderation-reviews.ts
@@ -1,0 +1,96 @@
+/**
+ * Backfill: close moderation reviews orphaned by the missing appliedAt write.
+ *
+ * `ModerationReview.appliedAt` gates every moderation queue, and until
+ * `closeModerationReviews()` shipped, no code path ever wrote it. Every
+ * editorial decision therefore left its review pending forever, and the admin
+ * counter grew by one row each time someone did the work.
+ *
+ * This closes the historical residue: reviews still pending whose affair has
+ * already left DRAFT, so there is nothing left to decide. A DRAFT affair keeps
+ * its pending review, because that one is real work.
+ *
+ * Versioned on purpose, not a throwaway under scripts/.local: the July 2026
+ * matching triage lost its review capacity when its scratch script was
+ * deleted, and the backlog came straight back.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/backfill-orphan-moderation-reviews.ts            # rapport
+ *   npx tsx --env-file=.env scripts/backfill-orphan-moderation-reviews.ts --apply
+ *   npx tsx --env-file=.env scripts/backfill-orphan-moderation-reviews.ts --revoke
+ */
+import { db } from "@/lib/db";
+import { APPLIED_BY_BACKFILL } from "@/lib/affairs/close-moderation-reviews";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const revoke = args.includes("--revoke");
+
+/** A review is orphaned when its affair has already been decided. */
+const DECIDED = ["PUBLISHED", "REJECTED", "ARCHIVED", "EXCLUDED"] as const;
+
+async function main() {
+  if (revoke) {
+    const { count } = await db.moderationReview.updateMany({
+      where: { appliedBy: APPLIED_BY_BACKFILL },
+      data: { appliedAt: null, appliedBy: null },
+    });
+    console.log(`Révoqué : ${count} revue(s) remises en attente.`);
+    return;
+  }
+
+  const orphans = await db.moderationReview.findMany({
+    where: { appliedAt: null, affair: { publicationStatus: { in: [...DECIDED] } } },
+    select: {
+      id: true,
+      recommendation: true,
+      createdAt: true,
+      affair: { select: { publicationStatus: true } },
+    },
+  });
+
+  const stillPending = await db.moderationReview.count({
+    where: { appliedAt: null, affair: { publicationStatus: "DRAFT" } },
+  });
+
+  const byStatus: Record<string, number> = {};
+  for (const o of orphans) {
+    const k = o.affair.publicationStatus;
+    byStatus[k] = (byStatus[k] ?? 0) + 1;
+  }
+
+  console.log("=== Revues orphelines (affaire déjà tranchée) ===");
+  for (const [status, n] of Object.entries(byStatus).sort()) {
+    console.log(`  ${status.padEnd(10)} ${n}`);
+  }
+  console.log(`  TOTAL à clore : ${orphans.length}`);
+  console.log(`  Laissées en attente (affaire DRAFT, vrai travail) : ${stillPending}`);
+
+  if (!apply) {
+    console.log("\nMode rapport. Relancer avec --apply pour écrire.");
+    return;
+  }
+
+  const { count } = await db.moderationReview.updateMany({
+    where: { appliedAt: null, affair: { publicationStatus: { in: [...DECIDED] } } },
+    data: { appliedAt: new Date(), appliedBy: APPLIED_BY_BACKFILL },
+  });
+
+  // Le compteur d'écriture, jamais la taille du lot : c'est lui qui dit la vérité.
+  console.log(`\nÉcrit : ${count} revue(s) closes, marquées ${APPLIED_BY_BACKFILL}.`);
+  if (count !== orphans.length) {
+    console.log(
+      `  Écart avec le rapport (${orphans.length}) : des décisions ont eu lieu entre les deux requêtes.`
+    );
+  }
+
+  const remaining = await db.moderationReview.count({ where: { appliedAt: null } });
+  console.log(`  File « Revues de modération » après backfill : ${remaining}`);
+}
+
+main()
+  .catch((e) => {
+    console.error("ERREUR", e instanceof Error ? e.message : e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/__tests__/architecture/moderation-review-closure.test.ts
+++ b/src/__tests__/architecture/moderation-review-closure.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Toute route admin qui tranche le statut d'une affaire EXISTANTE doit clore
+ * ses revues de modération.
+ *
+ * `ModerationReview.appliedAt` gouverne toutes les files de modération et
+ * n'était écrit par aucun chemin : la file grossissait à chaque décision
+ * éditoriale. Le correctif a d'abord manqué un quatrième chemin, celui du
+ * formulaire d'édition complet, parce que la recherche des appelants avait été
+ * tronquée. Ce test teste la propriété sur tout le corpus plutôt que de faire
+ * confiance à une énumération.
+ */
+
+const ADMIN_API = "src/app/api/admin";
+
+function routeFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...routeFiles(full));
+    else if (entry === "route.ts") out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Exceptions, avec leur raison. Une affaire qui vient d'être créée ne porte
+ * aucune revue, il n'y a donc rien à clore.
+ */
+const EXEMPT: Record<string, string> = {
+  "src/app/api/admin/slapp/import/route.ts":
+    "crée l'affaire en DRAFT ; sa branche update ne touche que les champs SLAPP",
+  "src/app/api/admin/press/rejections/recover/route.ts":
+    "crée une affaire en DRAFT depuis un rejet presse",
+};
+
+describe("clôture des revues de modération", () => {
+  const files = routeFiles(ADMIN_API);
+
+  it("trouve bien les routes admin à inspecter", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it("toute route qui publie une affaire existante clôt ses revues", () => {
+    const manquantes: string[] = [];
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      // `assertPublishable` ne s'appelle que pour faire passer une affaire
+      // existante à PUBLISHED : c'est le marqueur le plus fiable d'une décision.
+      const decides = src.includes("assertPublishable(");
+      if (!decides) continue;
+      if (EXEMPT[file]) continue;
+      if (!src.includes("closeModerationReviews")) manquantes.push(file);
+    }
+
+    expect(manquantes, `routes qui tranchent sans clore :\n${manquantes.join("\n")}`).toEqual([]);
+  });
+
+  it("les quatre chemins de décision connus sont bien couverts", () => {
+    // Énumération explicite en plus de la propriété : si l'un disparaît ou
+    // change de nom, le test le dit au lieu de passer sur un corpus réduit.
+    const attendus = [
+      "src/app/api/admin/affaires/moderate/route.ts",
+      "src/app/api/admin/affaires/bulk/route.ts",
+      "src/app/api/admin/affaires/[id]/quick-update/route.ts",
+      "src/app/api/admin/affaires/[id]/route.ts",
+    ];
+    for (const f of attendus) {
+      expect(readFileSync(f, "utf8"), f).toContain("closeModerationReviews");
+    }
+  });
+
+  it("les exceptions déclarées existent encore", () => {
+    for (const f of Object.keys(EXEMPT)) {
+      expect(() => readFileSync(f, "utf8"), `exception obsolète : ${f}`).not.toThrow();
+    }
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -72,12 +72,14 @@ async function getDashboardData() {
     db.affairUpdateProposal.count({ where: { status: "CONFLICT" } }),
     db.moderationReview.count({ where: { appliedAt: null } }),
     db.affairPoliticianDecision.count({ where: { judgment: "UNDECIDED", reviewedAt: null } }),
-    db.pressArticle.count({
-      where: { aiAnalyzedAt: { not: null }, isAffairRelated: true, affairLinks: { none: {} } },
-    }),
+    countArticlesToLink(),
     findPotentialDuplicates(),
-    db.pressAnalysisRejection.count(),
-    db.syncJob.count({ where: { status: "FAILED" } }),
+    db.pressAnalysisRejection.count({ where: { rejectedAt: { gte: since(FAILURE_WINDOW_DAYS) } } }),
+    db.syncJob.count({
+      // Sans fenêtre, un échec de février compte encore en septembre : le
+      // compteur mesurait l'historique, pas ce qu'il reste à inspecter.
+      where: { status: "FAILED", createdAt: { gte: since(FAILURE_WINDOW_DAYS) } },
+    }),
     getPipelineHealthAll(),
     db.auditLog.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
     db.syncJob.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
@@ -125,6 +127,79 @@ function relativeTime(value: Date): string {
   return new Date(value).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
 }
 
+/**
+ * Grille de cartes-compteurs. Extraite parce que le tableau de bord en rend
+ * maintenant deux : les files où l'on agit, et les stocks que l'on surveille.
+ * Le texte d'état vide diffère, une file se vide, un stock non.
+ */
+function QueueGrid({ cards, emptyLabel }: { cards: QueueCard[]; emptyLabel: string }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+      {cards.map((card) => {
+        const Icon = card.icon;
+        return (
+          <Link key={card.label} href={card.href}>
+            <Card className="h-full hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="p-2 rounded-lg bg-primary/10">
+                    <Icon className="w-4 h-4 text-primary" aria-hidden="true" />
+                  </div>
+                  <span
+                    className={`text-2xl font-bold font-display ${card.count ? "text-primary" : "text-muted-foreground"}`}
+                  >
+                    {card.count}
+                  </span>
+                </div>
+                <p className="text-sm font-medium mt-3">{card.label}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {card.count ? card.description : emptyLabel}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Fenêtre au-delà de laquelle un échec relève de l'historique, pas de la file. */
+const FAILURE_WINDOW_DAYS = 7;
+
+function since(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Articles analysés qu'il reste vraiment à rattacher.
+ *
+ * Le compteur d'origine comptait aussi ceux dont le registre d'attribution a
+ * déjà conclu qu'aucun politicien ne correspond : mesuré sur la base, 443 des
+ * 1761 étaient dans ce cas. Un article résolu négatif n'est pas du travail en
+ * attente, c'est une réponse.
+ *
+ * En SQL parce que `AffairPoliticianDecision.sourceRef` est une chaîne libre,
+ * sans relation Prisma vers `PressArticle.url`.
+ */
+async function countArticlesToLink(): Promise<number> {
+  const rows = await db.$queryRaw<{ count: bigint }[]>`
+    SELECT COUNT(*) AS count
+    FROM "PressArticle" a
+    WHERE a."aiAnalyzedAt" IS NOT NULL
+      AND a."isAffairRelated" = true
+      AND NOT EXISTS (
+        SELECT 1 FROM "PressArticleAffair" l WHERE l."articleId" = a.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "AffairPoliticianDecision" d
+        WHERE d."sourceRef" = a.url
+          AND d.judgment IN ('NO_MATCH', 'NOT_SAME')
+      )
+  `;
+  return Number(rows[0]?.count ?? 0);
+}
+
 export default async function AdminDashboard() {
   const data = await getDashboardData();
   const queueCards: QueueCard[] = [
@@ -164,25 +239,11 @@ export default async function AdminDashboard() {
       icon: Newspaper,
     },
     {
-      label: "Liaisons à confirmer",
-      count: data.queues.decisionsPending,
-      description: "Confirmer ou rejeter les rapprochements.",
-      href: "/admin/affair-matching/review?tab=UNDECIDED",
-      icon: Fingerprint,
-    },
-    {
       label: "Doublons à trancher",
       count: data.queues.duplicates,
       description: "Comparer les paires proposées.",
       href: "/admin/affaires/doublons",
       icon: CopyCheck,
-    },
-    {
-      label: "Rejets presse",
-      count: data.queues.rejectionsPending,
-      description: "Prendre une décision éditoriale sur les rejets.",
-      href: "/admin/press/rejections",
-      icon: Newspaper,
     },
     {
       label: "Pipelines en échec",
@@ -197,6 +258,30 @@ export default async function AdminDashboard() {
       description: "Inspecter les exécutions interrompues.",
       href: "/admin/syncs?status=FAILED",
       icon: RefreshCw,
+    },
+  ];
+
+  // Ces deux compteurs ne sont pas des files : rien ne s'y clôt.
+  //
+  // « Liaisons » est le stock du registre d'attribution, dont la charge réelle
+  // (les affaires qu'une décision bloque) est déjà listée en tête de /review
+  // par loadBlockedAffairs. « Rejets presse » n'a aucun champ de décision au
+  // schéma, donc aucune ligne ne peut être marquée traitée.
+  const trackingCards: QueueCard[] = [
+    {
+      label: "Liaisons au registre",
+      count: data.queues.decisionsPending,
+      description:
+        "Stock de rapprochements non revus. Les blocages réels sont en tête de la revue.",
+      href: "/admin/affair-matching/review?tab=UNDECIDED",
+      icon: Fingerprint,
+    },
+    {
+      label: "Rejets presse (7 j)",
+      count: data.queues.rejectionsPending,
+      description: "Journal des rejets de l'analyse presse, sur les sept derniers jours.",
+      href: "/admin/press/rejections",
+      icon: Newspaper,
     },
   ];
 
@@ -226,33 +311,20 @@ export default async function AdminDashboard() {
             Chaque compteur correspond à une file distincte et ouvre son filtre de travail.
           </p>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
-          {queueCards.map((card) => {
-            const Icon = card.icon;
-            return (
-              <Link key={card.label} href={card.href}>
-                <Card className="h-full hover:shadow-md transition-shadow">
-                  <CardContent className="p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="p-2 rounded-lg bg-primary/10">
-                        <Icon className="w-4 h-4 text-primary" aria-hidden="true" />
-                      </div>
-                      <span
-                        className={`text-2xl font-bold font-display ${card.count ? "text-primary" : "text-muted-foreground"}`}
-                      >
-                        {card.count}
-                      </span>
-                    </div>
-                    <p className="text-sm font-medium mt-3">{card.label}</p>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {card.count ? card.description : "File vide, aucune action en attente."}
-                    </p>
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
+        <QueueGrid cards={queueCards} emptyLabel="File vide, aucune action en attente." />
+      </section>
+
+      <section aria-labelledby="tracking-title" className="space-y-4">
+        <div>
+          <h2 id="tracking-title" className="text-lg font-display font-semibold">
+            Suivi
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Des stocks et des journaux, pas des files : ces compteurs ne se vident pas et n{"'"}
+            attendent aucune action de votre part.
+          </p>
         </div>
+        <QueueGrid cards={trackingCards} emptyLabel="Rien à signaler sur la période." />
       </section>
 
       <section aria-labelledby="health-title" className="space-y-4">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
 import { db } from "@/lib/db";
+import {
+  countArticlesToLink,
+  countRecentPressRejections,
+  countRecentFailedSyncs,
+} from "@/lib/admin/queue-counts";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
@@ -74,12 +79,8 @@ async function getDashboardData() {
     db.affairPoliticianDecision.count({ where: { judgment: "UNDECIDED", reviewedAt: null } }),
     countArticlesToLink(),
     findPotentialDuplicates(),
-    db.pressAnalysisRejection.count({ where: { rejectedAt: { gte: since(FAILURE_WINDOW_DAYS) } } }),
-    db.syncJob.count({
-      // Sans fenêtre, un échec de février compte encore en septembre : le
-      // compteur mesurait l'historique, pas ce qu'il reste à inspecter.
-      where: { status: "FAILED", createdAt: { gte: since(FAILURE_WINDOW_DAYS) } },
-    }),
+    countRecentPressRejections(),
+    countRecentFailedSyncs(),
     getPipelineHealthAll(),
     db.auditLog.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
     db.syncJob.findMany({ take: 10, orderBy: { createdAt: "desc" } }),
@@ -162,42 +163,6 @@ function QueueGrid({ cards, emptyLabel }: { cards: QueueCard[]; emptyLabel: stri
       })}
     </div>
   );
-}
-
-/** Fenêtre au-delà de laquelle un échec relève de l'historique, pas de la file. */
-const FAILURE_WINDOW_DAYS = 7;
-
-function since(days: number): Date {
-  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-}
-
-/**
- * Articles analysés qu'il reste vraiment à rattacher.
- *
- * Le compteur d'origine comptait aussi ceux dont le registre d'attribution a
- * déjà conclu qu'aucun politicien ne correspond : mesuré sur la base, 443 des
- * 1761 étaient dans ce cas. Un article résolu négatif n'est pas du travail en
- * attente, c'est une réponse.
- *
- * En SQL parce que `AffairPoliticianDecision.sourceRef` est une chaîne libre,
- * sans relation Prisma vers `PressArticle.url`.
- */
-async function countArticlesToLink(): Promise<number> {
-  const rows = await db.$queryRaw<{ count: bigint }[]>`
-    SELECT COUNT(*) AS count
-    FROM "PressArticle" a
-    WHERE a."aiAnalyzedAt" IS NOT NULL
-      AND a."isAffairRelated" = true
-      AND NOT EXISTS (
-        SELECT 1 FROM "PressArticleAffair" l WHERE l."articleId" = a.id
-      )
-      AND NOT EXISTS (
-        SELECT 1 FROM "AffairPoliticianDecision" d
-        WHERE d."sourceRef" = a.url
-          AND d.judgment IN ('NO_MATCH', 'NOT_SAME')
-      )
-  `;
-  return Number(rows[0]?.count ?? 0);
 }
 
 export default async function AdminDashboard() {

--- a/src/app/api/admin/affaires/[id]/quick-update/route.ts
+++ b/src/app/api/admin/affaires/[id]/quick-update/route.ts
@@ -4,6 +4,7 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation, getRequestMeta } from "@/lib/security";
 import { quickUpdateAffairSchema } from "@/lib/security/schemas/affair";
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
+import { closeModerationReviews } from "@/lib/affairs/close-moderation-reviews";
 import { trackStatusChange } from "@/services/affairs/status-tracking";
 import {
   assertPublishable,
@@ -131,6 +132,14 @@ export const PATCH = withAdminAuth(
 
     if (!updated) {
       updated = await db.affair.findUnique({ where: { id } });
+    }
+
+    // Une revue en attente ne se clôt que si le STATUT a été tranché. Sur une
+    // simple correction de champ (titre, dates), la recommandation reste à
+    // examiner et la file doit la garder.
+    const statusDecided = wantsPublish || updateData.publicationStatus !== undefined;
+    if (statusDecided) {
+      await closeModerationReviews([id!], VERIFIED_BY_MODERATION);
     }
 
     // Only past the commit. Purging "affairs" also regenerates the sitemap

--- a/src/app/api/admin/affaires/[id]/route.ts
+++ b/src/app/api/admin/affaires/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { invalidateEntity } from "@/lib/cache";
+import { closeModerationReviews } from "@/lib/affairs/close-moderation-reviews";
 import { generateAffairSlug } from "@/lib/utils";
 import { trackStatusChange } from "@/services/affairs/status-tracking";
 import { updateAffairSchema } from "@/lib/validations/affairs";
@@ -194,6 +195,16 @@ export const PUT = withAdminAuth(async (request: NextRequest, context) => {
       }
       throw err;
     }
+  }
+
+  // Le formulaire complet tranche aussi le statut : sans cette clôture, la file
+  // de modération continuerait de compter un travail déjà fait, par le chemin
+  // d'édition le plus courant.
+  const statusDecided =
+    wantsPublish ||
+    (data.publicationStatus !== undefined && data.publicationStatus !== existing.publicationStatus);
+  if (statusDecided) {
+    await closeModerationReviews([id!], VERIFIED_BY_MODERATION);
   }
 
   // Log action

--- a/src/app/api/admin/affaires/__tests__/depublication-commit.test.ts
+++ b/src/app/api/admin/affaires/__tests__/depublication-commit.test.ts
@@ -13,6 +13,8 @@ const h = vi.hoisted(() => ({
     $transaction: vi.fn(),
     affair: { findUnique: vi.fn(), update: vi.fn() },
     auditLog: { create: vi.fn() },
+    // La dépublication clôt les revues en attente de l'affaire.
+    moderationReview: { updateMany: vi.fn() },
   },
 }));
 
@@ -76,6 +78,7 @@ const PUBLISHED_AFFAIR = {
 };
 
 beforeEach(() => {
+  h.db.moderationReview.updateMany.mockResolvedValue({ count: 0 });
   vi.clearAllMocks();
   db.affair.findUnique.mockResolvedValue(PUBLISHED_AFFAIR);
   db.auditLog.create.mockResolvedValue({});

--- a/src/app/api/admin/affaires/__tests__/politician-invalidation.test.ts
+++ b/src/app/api/admin/affaires/__tests__/politician-invalidation.test.ts
@@ -18,6 +18,8 @@ const h = vi.hoisted(() => ({
       update: vi.fn(),
     },
     auditLog: { create: vi.fn(), createMany: vi.fn() },
+    // Les trois routes de décision closent désormais les revues en attente.
+    moderationReview: { updateMany: vi.fn() },
   },
 }));
 
@@ -76,6 +78,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   db.auditLog.create.mockResolvedValue({});
   db.auditLog.createMany.mockResolvedValue({});
+  db.moderationReview.updateMany.mockResolvedValue({ count: 0 });
   db.$transaction.mockResolvedValue([{ id: "1" }, {}]);
 });
 
@@ -120,5 +123,71 @@ describe("affair mutations invalidate affected politician profiles", () => {
 
     expect(h.invalidateEntity).toHaveBeenCalledWith("affair", "aff-slug");
     expect(h.invalidateAffectedPoliticians).toHaveBeenCalledWith(["pol-x"]);
+  });
+});
+
+// Régression : `ModerationReview.appliedAt` gouverne toutes les files de
+// modération de l'admin et n'était écrit par AUCUN chemin. Chaque décision
+// éditoriale laissait donc une revue en attente pour toujours, et la file
+// grossissait d'une ligne à chaque fois qu'un humain faisait le travail.
+describe("une décision clôt les revues de modération de son affaire", () => {
+  const closeCall = () => db.moderationReview.updateMany.mock.calls[0]?.[0];
+
+  it("moderate (reject) clôt les revues des affaires visées", async () => {
+    db.affair.findMany.mockResolvedValue([{ politician: { slug: "p" } }]);
+    db.affair.updateMany.mockResolvedValue({ count: 2 });
+
+    await moderatePOST(req({ ids: ["a1", "a2"], action: "reject" }), ctx());
+
+    expect(closeCall().where.affairId).toEqual({ in: ["a1", "a2"] });
+    expect(closeCall().where.appliedAt).toBeNull();
+    expect(closeCall().data.appliedBy).toBe("Poligraph Moderation");
+  });
+
+  it("bulk (reject) clôt les revues des affaires visées", async () => {
+    db.affair.findMany.mockResolvedValue([{ politician: { slug: "p" } }]);
+    db.affair.updateMany.mockResolvedValue({ count: 1 });
+
+    await bulkPOST(req({ ids: ["b1"], action: "reject" }), ctx());
+
+    expect(closeCall().where.affairId).toEqual({ in: ["b1"] });
+  });
+
+  it("bulk (delete) ne clôt rien : la cascade supprime les revues", async () => {
+    db.affair.findMany.mockResolvedValue([{ politician: { slug: "p" } }]);
+    db.affair.deleteMany.mockResolvedValue({ count: 1 });
+
+    await bulkPOST(req({ ids: ["c1"], action: "delete" }), ctx());
+
+    expect(db.moderationReview.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("quick-update ne clôt RIEN sur une simple correction de champ", async () => {
+    db.affair.findUnique.mockResolvedValue({
+      id: "d1",
+      slug: "s",
+      status: "RELAXE",
+      publicationStatus: "DRAFT",
+      politician: { slug: "p" },
+    });
+
+    // Corriger un titre ne tranche pas l'affaire : la recommandation reste à examiner.
+    await quickUpdatePATCH(req({ title: "Titre corrigé" }), ctx({ id: "d1" }));
+
+    expect(db.moderationReview.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("quick-update clôt quand le statut de publication change", async () => {
+    db.affair.findUnique.mockResolvedValue({
+      id: "d2",
+      slug: "s",
+      status: "RELAXE",
+      publicationStatus: "PUBLISHED",
+      politician: { slug: "p" },
+    });
+
+    await quickUpdatePATCH(req({ publicationStatus: "REJECTED" }), ctx({ id: "d2" }));
+
+    expect(closeCall().where.affairId).toEqual({ in: ["d2"] });
   });
 });

--- a/src/app/api/admin/affaires/bulk/route.ts
+++ b/src/app/api/admin/affaires/bulk/route.ts
@@ -4,6 +4,7 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation } from "@/lib/security/validate";
 import { bulkAffairSchema } from "@/lib/security/schemas/affair";
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
+import { closeModerationReviews } from "@/lib/affairs/close-moderation-reviews";
 import {
   assertPublishable,
   PublishGuardError,
@@ -41,6 +42,8 @@ export const POST = withAdminAuth(
         })),
       });
 
+      // Pas de closeModerationReviews ici : ModerationReview est en
+      // onDelete: Cascade, les revues partent avec l'affaire.
       invalidateEntity("affair");
       invalidateAffectedPoliticians(politicianSlugs);
 
@@ -74,6 +77,7 @@ export const POST = withAdminAuth(
             changes: { publicationStatus: PUBLISHED_STATUS, verifiedBy: VERIFIED_BY_MODERATION },
           })),
         });
+        await closeModerationReviews(published, VERIFIED_BY_MODERATION);
         invalidateEntity("affair");
         invalidateAffectedPoliticians(politicianSlugs);
       }
@@ -100,6 +104,7 @@ export const POST = withAdminAuth(
       })),
     });
 
+    await closeModerationReviews(ids, VERIFIED_BY_MODERATION);
     invalidateEntity("affair");
     invalidateAffectedPoliticians(politicianSlugs);
 

--- a/src/app/api/admin/affaires/moderate/route.ts
+++ b/src/app/api/admin/affaires/moderate/route.ts
@@ -4,6 +4,7 @@ import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { withValidation } from "@/lib/security/validate";
 import { moderateAffairSchema } from "@/lib/security/schemas/affair";
 import { invalidateEntity, invalidateAffectedPoliticians } from "@/lib/cache";
+import { closeModerationReviews } from "@/lib/affairs/close-moderation-reviews";
 import {
   assertPublishable,
   PublishGuardError,
@@ -110,6 +111,10 @@ export const POST = withAdminAuth(
             },
           })),
         });
+        // La décision est prise : les revues en attente de ces affaires n'ont
+        // plus rien à trancher. Sans ça la file « à modérer » grossit d'une
+        // ligne à chaque publication.
+        await closeModerationReviews(published, VERIFIED_BY_MODERATION);
         invalidateEntity("affair");
         invalidateAffectedPoliticians(politicianSlugs);
       }
@@ -132,6 +137,8 @@ export const POST = withAdminAuth(
         changes: { publicationStatus, moderationAction: action },
       })),
     });
+
+    await closeModerationReviews(ids, VERIFIED_BY_MODERATION);
 
     invalidateEntity("affair");
     invalidateAffectedPoliticians(politicianSlugs);

--- a/src/app/api/admin/badges/route.test.ts
+++ b/src/app/api/admin/badges/route.test.ts
@@ -13,12 +13,22 @@ const h = vi.hoisted(() => ({
     syncJob: { count: vi.fn() },
   },
   duplicates: vi.fn(),
+  articlesToLink: vi.fn(),
+  recentRejections: vi.fn(),
+  recentFailedSyncs: vi.fn(),
   pipelines: vi.fn(),
   candidaciesHoldingBack: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({ db: h.db }));
 vi.mock("@/services/affairs/reconciliation", () => ({ findPotentialDuplicates: h.duplicates }));
+// Les prédicats de charge vivent dans @/lib/admin/queue-counts, partagés avec le
+// tableau de bord. La route délègue ; leur justesse se teste là-bas.
+vi.mock("@/lib/admin/queue-counts", () => ({
+  countArticlesToLink: h.articlesToLink,
+  countRecentPressRejections: h.recentRejections,
+  countRecentFailedSyncs: h.recentFailedSyncs,
+}));
 vi.mock("@/lib/data/pipelines", () => ({ getPipelineHealthAll: h.pipelines }));
 // Le compteur des candidatures vit dans la couche mesures : c'est elle qui porte le prédicat de
 // visibilité publique, la route ne fait que l'appeler.
@@ -40,9 +50,9 @@ beforeEach(() => {
   );
   h.db.moderationReview.count.mockResolvedValue(7);
   h.db.affairPoliticianDecision.count.mockResolvedValue(8);
-  h.db.pressArticle.count.mockResolvedValue(11);
-  h.db.pressAnalysisRejection.count.mockResolvedValue(9);
-  h.db.syncJob.count.mockResolvedValue(10);
+  h.articlesToLink.mockResolvedValue(11);
+  h.recentRejections.mockResolvedValue(9);
+  h.recentFailedSyncs.mockResolvedValue(10);
   h.duplicates.mockResolvedValue([{ id: "duplicate-1" }, { id: "duplicate-2" }]);
   h.candidaciesHoldingBack.mockResolvedValue(6);
   h.pipelines.mockResolvedValue([
@@ -65,8 +75,10 @@ describe("GET /api/admin/badges", () => {
       press: { rejectionsPending: 9 },
       operations: { failedPipelines: 2, failedSyncs: 10 },
     });
-    expect(h.db.pressArticle.count).toHaveBeenCalledWith({
-      where: { aiAnalyzedAt: { not: null }, isAffairRelated: true, affairLinks: { none: {} } },
-    });
+    // La route ne doit pas porter de copie locale du prédicat : le tableau de
+    // bord et la navigation afficheraient deux vérités au même écran.
+    expect(h.articlesToLink).toHaveBeenCalled();
+    expect(h.recentRejections).toHaveBeenCalled();
+    expect(h.recentFailedSyncs).toHaveBeenCalled();
   });
 });

--- a/src/app/api/admin/badges/route.ts
+++ b/src/app/api/admin/badges/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import {
+  countArticlesToLink,
+  countRecentPressRejections,
+  countRecentFailedSyncs,
+} from "@/lib/admin/queue-counts";
 import { withAdminAuth } from "@/lib/api/with-admin-auth";
 import { findPotentialDuplicates } from "@/services/affairs/reconciliation";
 import { getPipelineHealthAll } from "@/lib/data/pipelines";
@@ -42,12 +47,12 @@ export const GET = withAdminAuth(async () => {
     db.affairPoliticianDecision.count({
       where: { judgment: "UNDECIDED", reviewedAt: null },
     }),
-    db.pressArticle.count({
-      where: { aiAnalyzedAt: { not: null }, isAffairRelated: true, affairLinks: { none: {} } },
-    }),
+    // Mêmes prédicats que le tableau de bord : une copie locale afficherait
+    // l'historique dans la navigation et la charge sur /admin, au même écran.
+    countArticlesToLink(),
     findPotentialDuplicates(),
-    db.pressAnalysisRejection.count(),
-    db.syncJob.count({ where: { status: "FAILED" } }),
+    countRecentPressRejections(),
+    countRecentFailedSyncs(),
     getPipelineHealthAll(),
     countCandidaciesHoldingBackMeasures(),
   ]);

--- a/src/lib/admin/__tests__/queue-counts.test.ts
+++ b/src/lib/admin/__tests__/queue-counts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  db: {
+    $queryRaw: vi.fn(),
+    pressAnalysisRejection: { count: vi.fn() },
+    syncJob: { count: vi.fn() },
+  },
+}));
+vi.mock("@/lib/db", () => ({ db: h.db }));
+
+import {
+  countArticlesToLink,
+  countRecentPressRejections,
+  countRecentFailedSyncs,
+  FAILURE_WINDOW_DAYS,
+} from "../queue-counts";
+
+describe("countArticlesToLink", () => {
+  beforeEach(() => h.db.$queryRaw.mockReset());
+
+  it("exclut les articles que le registre a déjà résolus négativement", async () => {
+    h.db.$queryRaw.mockResolvedValue([{ count: BigInt(1318) }]);
+
+    await countArticlesToLink();
+
+    // Le template SQL est passé en fragments : on vérifie l'intention.
+    const sql = h.db.$queryRaw.mock.calls[0]![0].join(" ");
+    expect(sql).toContain("NO_MATCH");
+    expect(sql).toContain("NOT_SAME");
+    expect(sql).toContain("PressArticleAffair");
+  });
+
+  it("convertit le bigint de COUNT en nombre", async () => {
+    h.db.$queryRaw.mockResolvedValue([{ count: BigInt(1318) }]);
+    await expect(countArticlesToLink()).resolves.toBe(1318);
+  });
+
+  it("renvoie 0 quand la requête ne ramène aucune ligne", async () => {
+    h.db.$queryRaw.mockResolvedValue([]);
+    await expect(countArticlesToLink()).resolves.toBe(0);
+  });
+});
+
+describe("fenêtre temporelle des échecs", () => {
+  beforeEach(() => {
+    h.db.pressAnalysisRejection.count.mockReset().mockResolvedValue(0);
+    h.db.syncJob.count.mockReset().mockResolvedValue(0);
+  });
+
+  const windowStart = (fn: ReturnType<typeof vi.fn>) => fn.mock.calls[0]![0].where;
+
+  it("borne les rejets presse à la fenêtre", async () => {
+    await countRecentPressRejections();
+
+    const gte = windowStart(h.db.pressAnalysisRejection.count).rejectedAt.gte as Date;
+    const ageDays = (Date.now() - gte.getTime()) / 86_400_000;
+    expect(ageDays).toBeCloseTo(FAILURE_WINDOW_DAYS, 1);
+  });
+
+  it("borne les syncs en échec à la fenêtre, sinon février compte en septembre", async () => {
+    await countRecentFailedSyncs();
+
+    const where = windowStart(h.db.syncJob.count);
+    expect(where.status).toBe("FAILED");
+    const ageDays = (Date.now() - (where.createdAt.gte as Date).getTime()) / 86_400_000;
+    expect(ageDays).toBeCloseTo(FAILURE_WINDOW_DAYS, 1);
+  });
+});

--- a/src/lib/admin/queue-counts.ts
+++ b/src/lib/admin/queue-counts.ts
@@ -1,0 +1,63 @@
+/**
+ * The predicates behind the admin workload counters, in one place.
+ *
+ * The dashboard and the sidebar badge endpoint each carried their own copy.
+ * Correcting one and not the other showed the reduced workload on `/admin` and
+ * the old historical totals in the navigation on the same screen, which is
+ * worse than either number alone.
+ *
+ * A counter belongs here only if it needs a closure predicate: a queue counter
+ * is a workload indicator only when every item costs something if it stays.
+ */
+import { db } from "@/lib/db";
+
+/** Beyond this, a failure is history rather than a queue item. */
+export const FAILURE_WINDOW_DAYS = 7;
+
+function since(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Analyzed articles that genuinely remain to be attached to an affair.
+ *
+ * Excludes those the attribution registry already resolved negatively: 443 of
+ * 1761 on the live base. A resolved-negative article is an answer, not pending
+ * work.
+ *
+ * Raw SQL because `AffairPoliticianDecision.sourceRef` is a free-form string
+ * with no Prisma relation to `PressArticle.url`.
+ */
+export async function countArticlesToLink(): Promise<number> {
+  const rows = await db.$queryRaw<{ count: bigint }[]>`
+    SELECT COUNT(*) AS count
+    FROM "PressArticle" a
+    WHERE a."aiAnalyzedAt" IS NOT NULL
+      AND a."isAffairRelated" = true
+      AND NOT EXISTS (
+        SELECT 1 FROM "PressArticleAffair" l WHERE l."articleId" = a.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "AffairPoliticianDecision" d
+        WHERE d."sourceRef" = a.url
+          AND d.judgment IN ('NO_MATCH', 'NOT_SAME')
+      )
+  `;
+  return Number(rows[0]?.count ?? 0);
+}
+
+/** Press-analysis rejections over the window. The model has no decision field,
+ *  so this is a log: nothing in it can ever be marked handled. */
+export function countRecentPressRejections(): Promise<number> {
+  return db.pressAnalysisRejection.count({
+    where: { rejectedAt: { gte: since(FAILURE_WINDOW_DAYS) } },
+  });
+}
+
+/** Failed syncs over the window. Without it, a February failure still counted
+ *  in September and the number never went down. */
+export function countRecentFailedSyncs(): Promise<number> {
+  return db.syncJob.count({
+    where: { status: "FAILED", createdAt: { gte: since(FAILURE_WINDOW_DAYS) } },
+  });
+}

--- a/src/lib/affairs/__tests__/close-moderation-reviews.test.ts
+++ b/src/lib/affairs/__tests__/close-moderation-reviews.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock est remonté en tête de fichier : la factory ne peut pas voir une
+// variable déclarée après, d'où vi.hoisted.
+const { updateMany } = vi.hoisted(() => ({ updateMany: vi.fn() }));
+vi.mock("@/lib/db", () => ({ db: { moderationReview: { updateMany } } }));
+
+import { closeModerationReviews } from "../close-moderation-reviews";
+
+describe("closeModerationReviews", () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+    updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("ne touche que les revues des affaires passées", async () => {
+    await closeModerationReviews(["a1", "a2"], "Poligraph Moderation");
+
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const arg = updateMany.mock.calls[0]![0];
+    expect(arg.where.affairId).toEqual({ in: ["a1", "a2"] });
+  });
+
+  it("laisse intacte une revue déjà appliquée", async () => {
+    await closeModerationReviews(["a1"], "Poligraph Moderation");
+
+    // Sans ce filtre, re-trancher une affaire réécrirait qui a appliqué quoi.
+    expect(updateMany.mock.calls[0]![0].where.appliedAt).toBeNull();
+  });
+
+  it("enregistre le décideur", async () => {
+    await closeModerationReviews(["a1"], "auto-triage-v9");
+
+    expect(updateMany.mock.calls[0]![0].data.appliedBy).toBe("auto-triage-v9");
+    expect(updateMany.mock.calls[0]![0].data.appliedAt).toBeInstanceOf(Date);
+  });
+
+  it("renvoie le nombre réellement écrit, pas la taille du lot", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+
+    // Le lot vaut 3 : renvoyer 3 masquerait une écriture partielle.
+    await expect(closeModerationReviews(["a1", "a2", "a3"], "x")).resolves.toBe(1);
+  });
+
+  it("n'émet aucune requête sur un lot vide", async () => {
+    await expect(closeModerationReviews([], "x")).resolves.toBe(0);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/affairs/close-moderation-reviews.ts
+++ b/src/lib/affairs/close-moderation-reviews.ts
@@ -1,0 +1,38 @@
+/**
+ * Closing a moderation review when its affair gets decided.
+ *
+ * `ModerationReview.appliedAt` gates every moderation queue in the admin, and
+ * before this module nothing ever wrote it: the three decision routes changed
+ * `publicationStatus` and left the review pending forever. The queue therefore
+ * grew by one row every time an editor made a decision, which is the opposite
+ * of what a workload counter should do.
+ *
+ * One authority, called by every decision path. Three copies of this predicate
+ * would drift, the way the three normalizers in `affair-matching` did.
+ */
+import { db } from "@/lib/db";
+
+/** Marker for rows closed by the historical backfill rather than by a decision. */
+export const APPLIED_BY_BACKFILL = "backfill-orphelines-2026-09-08";
+
+/**
+ * Close every pending review attached to the given affairs.
+ *
+ * Scoped to `appliedAt: null` so a review already closed keeps its original
+ * timestamp and author: re-deciding an affair must not rewrite who applied what.
+ * Returns the number of rows actually closed, never the size of the input, so a
+ * silently empty write cannot read as a success.
+ */
+export async function closeModerationReviews(
+  affairIds: string[],
+  appliedBy: string
+): Promise<number> {
+  if (affairIds.length === 0) return 0;
+
+  const result = await db.moderationReview.updateMany({
+    where: { affairId: { in: affairIds }, appliedAt: null },
+    data: { appliedAt: new Date(), appliedBy },
+  });
+
+  return result.count;
+}


### PR DESCRIPTION
## Le problème

Le tableau de bord admin annonçait **2 862 items « à traiter maintenant »**. Mesuré en base, la charge réelle était d'environ **20**. Le reste était de l'historique que des compteurs sans prédicat de clôture présentaient comme du travail.

Trois causes distinctes, mesurées avant d'écrire une ligne.

## 1. `ModerationReview.appliedAt` n'était écrit par aucun chemin

Le champ gouverne toutes les files de modération de l'admin (dashboard, badges, filtre `moderation-pending`). Il est lu dans six endroits et **écrit nulle part**.

Conséquence : `POST /affaires/moderate`, `POST /affaires/bulk` et `PATCH /affaires/[id]/quick-update` changeaient `publicationStatus` et laissaient la revue en attente pour toujours. **La file grossissait d'une ligne à chaque décision éditoriale**, c'est-à-dire à mesure du travail accompli. Sur 572 revues en attente, **570 portaient sur une affaire déjà tranchée** (428 PUBLISHED, 129 REJECTED, 11 ARCHIVED, 2 EXCLUDED). Deux seulement étaient du vrai travail.

Correction : `src/lib/affairs/close-moderation-reviews.ts`, une seule autorité appelée par les trois routes. Une copie par route aurait dérivé, comme les trois normaliseurs de `affair-matching` l'ont fait.

Trois nuances verrouillées par des tests :

- `quick-update` ne clôt **que si le statut a été tranché**. Corriger une coquille de titre ne tranche rien, et fermer la revue à ce moment-là ferait disparaître du travail réel.
- `bulk delete` ne clôt rien : `ModerationReview` est en `onDelete: Cascade`.
- Le filtre `appliedAt: null` est conservé, donc re-trancher une affaire ne réécrit pas qui a appliqué quoi.

## 2. Trois compteurs mesuraient un historique

| Compteur | Défaut | Correction |
|---|---|---|
| Synchronisations en échec | aucune fenêtre : les 9 échecs datent tous de février 2026 | fenêtre de 7 jours, passe à 0 |
| Rejets presse | `count()` sans aucun filtre, et le modèle n'a **aucun champ de décision** | fenêtre de 7 jours, et sort de la file d'action |
| Articles à lier | comptait aussi ceux que le registre a déjà résolus négatifs (443 sur 1761) | exclusion par `NOT EXISTS` sur les jugements `NO_MATCH` / `NOT_SAME` |

## 3. Deux stocks étaient présentés comme des files

« Liaisons à confirmer » et « Rejets presse » ne se vident pas : rien ne peut y être marqué traité. Ils passent dans une section **« Suivi »**, avec des libellés qui disent ce qu'ils sont.

Pour les liaisons, le compteur **n'essaie pas** de calculer la charge réelle. Elle est déjà calculée par `loadBlockedAffairs()` en tête de `/admin/affair-matching/review`, et la clause du garde-fou de publication a déjà dérivé deux fois quand elle a été réimplémentée ailleurs.

## Effet

| Carte | Avant | Après |
|---|---|---|
| Revues de modération | 572 | **2** |
| Articles à lier | 1761 | **1318** |
| Synchronisations en échec | 9 | **0** |
| Rejets presse | 111 | 18, en Suivi |

Total annoncé comme « à traiter » : **2 862 vers 1 339**, dont 1 318 sont la file des articles. Ce mur-là est un vrai sujet, traité séparément.

## Backfill

`scripts/backfill-orphan-moderation-reviews.ts`, versionné et non jetable : le triage de matching de juillet 2026 a perdu sa capacité de revue le jour où son script jetable a été supprimé, et le retard est revenu aussitôt.

`--dry-run` par défaut, `--apply` explicite, `--revoke` pour tout annuler. Les lignes closes portent `appliedBy = "backfill-orphelines-2026-09-08"`, donc l'historique reste lisible : personne ne croira qu'un humain a cliqué 570 fois.

**Déjà appliqué en production** : 570 closes, file à 2, vérifié indépendamment du script.

## Tests

`tsc --noEmit` en sortie 0. Suite complète : **662 fichiers, 5 890 tests, 0 échec**.

13 tests ajoutés. Deux fichiers existants ont cassé pendant le développement, `politician-invalidation` et `depublication-commit`, dont les mocks de `@/lib/db` n'avaient pas `moderationReview` : c'est le comportement attendu d'un mock quand une route acquiert une dépendance, et les deux sont étendus plutôt que de rendre l'autorité défensive.

## Ce que cette PR ne fait pas

- Elle ne touche pas au registre d'attribution, ni au garde-fou de publication, ni au fallback `NEEDS_REVIEW`.
- Elle n'ajoute pas de champ de décision à `PressAnalysisRejection`. En faire une vraie file demanderait un changement de schéma et une interface de décision qui n'existe pas.
- Elle ne traite pas les 1 318 articles à lier.
