### PR TITLE
Repasser la synthèse présidentielle en cacheLife synced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,13 @@ Two distinct resolver systems:
 ### Caching strategy
 
 - `"use cache"` directive: only for functions with bounded params, never with free-text search.
-- `cacheLife("minutes")` default; `cacheLife("hours")` for election or reshuffle data only.
+- `cacheLife("synced")` everywhere (custom profile in `next.config.ts`, revalidate 24 h). A route's
+  effective ISR revalidate is the MIN of its own and of every `"use cache"` boundary it reads, so a
+  single short profile re-blocks the whole route: that is what produced 8.7M ISR writes in July 2026.
+  Freshness comes from `revalidateTag`, not from the timer. Two documented exceptions carry a shorter
+  profile: the admin pipeline dashboard, and election data that flips on the clock rather than on a
+  write. Enforced by `src/__tests__/architecture/cachelife-profiles.test.ts`, which also checks that
+  each exemption still matches reality.
 - `cacheTag()` uses entity-based tags (`politicians`, `affairs`, `parties`, `elections`) for targeted invalidation.
 - `export const revalidate = N` (ISR) for listing pages with search.
 - `React.cache()` to deduplicate between `generateMetadata()` and `page()`.

--- a/src/__tests__/architecture/cachelife-profiles.test.ts
+++ b/src/__tests__/architecture/cachelife-profiles.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * The ISR revalidate a route actually gets is
+ * MIN(`export const revalidate`, `cacheLife.revalidate` of EVERY `"use cache"`
+ * boundary it consumes). The built-in `minutes` profile revalidates every 60 s,
+ * so a single boundary using it drags every route that reads it back to 60 s
+ * whatever the page declares.
+ *
+ * That is not theoretical: it is what produced 8.7M ISR writes on the July 2026
+ * Vercel bill, and the remedy was replacing 106 `minutes`/`hours` boundaries
+ * with the custom `synced` profile (revalidate 86400) declared in
+ * `next.config.ts`. Freshness does not depend on that timer: everything is
+ * invalidated on demand by `revalidateTag`, from the daily sync and from admin
+ * edits. The timer is only a backstop.
+ *
+ * The rule the July fix wrote down is exhaustiveness, because one forgotten
+ * boundary re-blocks a whole route. `getPresidentialOverviewStats` was added
+ * afterwards with `cacheLife("minutes")` and re-blocked /statistiques at 60 s,
+ * which is what this guard exists to catch.
+ */
+
+const SRC_DIR = join(process.cwd(), "src");
+
+/**
+ * Boundaries allowed to keep a shorter profile, with the reason each one is a
+ * deliberate trade-off rather than an oversight. Both are documented in the
+ * file that carries them.
+ */
+const SHORTER_PROFILE_ALLOWED = new Map([
+  ["lib/data/pipelines.ts", "admin pipeline dashboard: staleness is the thing being diagnosed"],
+  ["lib/data/elections.ts", "flips on the clock on polling day, and no tag purge happens that day"],
+]);
+
+/** Every source file, tests and generated Prisma client aside. */
+function sourceFiles(dir = SRC_DIR): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "generated" || entry.name === "__tests__") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** Drop block and line comments so the predicates below read code, not prose. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function cacheLifeProfiles(file: string): string[] {
+  const src = stripComments(readFileSync(file, "utf8"));
+  return [...src.matchAll(/cacheLife\("([a-z]+)"\)/g)].map((m) => m[1]!);
+}
+
+describe("profils cacheLife et revalidate ISR effectif", () => {
+  it("trouve bien des frontières cacheLife à inspecter", () => {
+    // Guards the walk itself: finding nothing would make the assertion below
+    // vacuously true.
+    const total = sourceFiles().reduce((n, f) => n + cacheLifeProfiles(f).length, 0);
+    expect(total).toBeGreaterThan(100);
+  });
+
+  it("toute frontière utilise le profil synced, hors exceptions documentées", () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles()) {
+      const rel = relative(SRC_DIR, file);
+      if (SHORTER_PROFILE_ALLOWED.has(rel)) continue;
+      for (const profile of cacheLifeProfiles(file)) {
+        if (profile !== "synced") offenders.push(`${rel}: cacheLife("${profile}")`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("les exceptions autorisées existent encore et portent bien un profil court", () => {
+    // An allowlist entry that no longer matches reality is a stale exemption:
+    // it would silently permit a future `minutes` boundary in that file.
+    for (const [rel] of SHORTER_PROFILE_ALLOWED) {
+      const profiles = cacheLifeProfiles(join(SRC_DIR, rel));
+      expect(profiles.length, `${rel} ne déclare plus de cacheLife`).toBeGreaterThan(0);
+      expect(
+        profiles.some((p) => p !== "synced"),
+        `${rel} est passé à synced`
+      ).toBe(true);
+    }
+  });
+
+  it("ne se laisse pas berner par une mention en commentaire", () => {
+    const commentOnly = `
+      // cacheLife("minutes") is only named here.
+      /* cacheLife("hours") */
+      cacheLife("synced");
+    `;
+    expect(
+      [...stripComments(commentOnly).matchAll(/cacheLife\("([a-z]+)"\)/g)].map((m) => m[1])
+    ).toEqual(["synced"]);
+  });
+});

--- a/src/__tests__/architecture/cachelife-profiles.test.ts
+++ b/src/__tests__/architecture/cachelife-profiles.test.ts
@@ -30,9 +30,31 @@ const SRC_DIR = join(process.cwd(), "src");
  * file that carries them.
  */
 const SHORTER_PROFILE_ALLOWED = new Map([
-  ["lib/data/pipelines.ts", "admin pipeline dashboard: staleness is the thing being diagnosed"],
-  ["lib/data/elections.ts", "flips on the clock on polling day, and no tag purge happens that day"],
+  [
+    "lib/data/pipelines.ts",
+    {
+      profile: "minutes",
+      reason: "admin pipeline dashboard: staleness is the thing being diagnosed",
+    },
+  ],
+  [
+    "lib/data/elections.ts",
+    {
+      profile: "hours",
+      reason: "flips on the clock on polling day, and no tag purge happens that day",
+    },
+  ],
 ]);
+
+/**
+ * The offending profiles of one file. An exemption covers a single named profile, not the file:
+ * `elections.ts` legitimately carries one `hours` next to four `synced`, and skipping the whole
+ * file would let a `minutes` land there unnoticed.
+ */
+function offendingProfiles(relativePath: string, profiles: string[]): string[] {
+  const exemption = SHORTER_PROFILE_ALLOWED.get(relativePath);
+  return profiles.filter((profile) => profile !== "synced" && profile !== exemption?.profile);
+}
 
 /** Every source file, tests and generated Prisma client aside. */
 function sourceFiles(dir = SRC_DIR): string[] {
@@ -69,26 +91,29 @@ describe("profils cacheLife et revalidate ISR effectif", () => {
 
     for (const file of sourceFiles()) {
       const rel = relative(SRC_DIR, file);
-      if (SHORTER_PROFILE_ALLOWED.has(rel)) continue;
-      for (const profile of cacheLifeProfiles(file)) {
-        if (profile !== "synced") offenders.push(`${rel}: cacheLife("${profile}")`);
+      for (const profile of offendingProfiles(rel, cacheLifeProfiles(file))) {
+        offenders.push(`${rel}: cacheLife("${profile}")`);
       }
     }
 
     expect(offenders).toEqual([]);
   });
 
-  it("les exceptions autorisées existent encore et portent bien un profil court", () => {
-    // An allowlist entry that no longer matches reality is a stale exemption:
-    // it would silently permit a future `minutes` boundary in that file.
-    for (const [rel] of SHORTER_PROFILE_ALLOWED) {
+  it("les exceptions autorisées portent encore exactement le profil exempté", () => {
+    // An allowlist entry that no longer matches reality is a stale exemption: it would keep
+    // tolerating a shorter profile in that file after the reason for it disappeared.
+    for (const [rel, { profile }] of SHORTER_PROFILE_ALLOWED) {
       const profiles = cacheLifeProfiles(join(SRC_DIR, rel));
-      expect(profiles.length, `${rel} ne déclare plus de cacheLife`).toBeGreaterThan(0);
-      expect(
-        profiles.some((p) => p !== "synced"),
-        `${rel} est passé à synced`
-      ).toBe(true);
+      expect(profiles, `${rel} ne déclare plus cacheLife("${profile}")`).toContain(profile);
     }
+  });
+
+  it("n'exempte que la frontière nommée, pas tout le fichier", () => {
+    expect(offendingProfiles("lib/data/elections.ts", ["hours", "synced", "synced"])).toEqual([]);
+    expect(offendingProfiles("lib/data/elections.ts", ["hours", "minutes"])).toEqual(["minutes"]);
+    expect(offendingProfiles("lib/data/pipelines.ts", ["minutes"])).toEqual([]);
+    expect(offendingProfiles("lib/data/pipelines.ts", ["hours"])).toEqual(["hours"]);
+    expect(offendingProfiles("lib/data/statistics.ts", ["minutes"])).toEqual(["minutes"]);
   });
 
   it("ne se laisse pas berner par une mention en commentaire", () => {

--- a/src/lib/data/__tests__/presidential-stats.test.ts
+++ b/src/lib/data/__tests__/presidential-stats.test.ts
@@ -48,7 +48,9 @@ describe("getPresidentialOverviewStats", () => {
       probityCandidateCount: 2,
     });
     expect(mocks.cacheTag).toHaveBeenCalledWith("statistics", "affairs", "elections");
-    expect(mocks.cacheLife).toHaveBeenCalledWith("minutes");
+    // `synced` and not a shorter profile: a route's effective ISR revalidate is the MIN of its own
+    // and of every boundary it reads, so `minutes` here held /statistiques at 60 s.
+    expect(mocks.cacheLife).toHaveBeenCalledWith("synced");
   });
 
   it("limite la probité aux condamnations publiées des personnalités suivies", async () => {

--- a/src/lib/data/presidential-stats.ts
+++ b/src/lib/data/presidential-stats.ts
@@ -28,7 +28,12 @@ export async function getPresidentialOverviewStats(
   cacheTag("statistics", "affairs", "elections");
   // The overview joins several independently cached authorities and a judicial aggregation.
   // Cache the assembled result so every page view does not repeat that expensive cross-domain read.
-  cacheLife("minutes");
+  //
+  // `synced`, like every other boundary: the effective ISR revalidate of a route is the MIN of its
+  // own and of every boundary it reads, so `minutes` here re-blocked /statistiques at 60 s. The
+  // judicial aggregation below is the expensive one, an EXISTS over the 1.2M-row Candidacy table,
+  // and it was paying that toll every minute. Freshness comes from the tags above, not the timer.
+  cacheLife("synced");
 
   const [field, context, probityCandidates] = await Promise.all([
     getHubCandidacyField(electionSlug),


### PR DESCRIPTION
## Contexte

`POLIGRAPH-1H` remonte une « Slow DB Query » sur `GET /statistiques`, avec des
pics à plusieurs secondes.

Le ticket désignait les deux `findMany({ distinct })` de `getJudicialData()`.
Ce n'est pas la bonne requête : le SQL du span Sentry contient un
`LEFT JOIN "Politician"`, un filtre sur 8 catégories, un `GROUP BY "politicianId"`
et un `EXISTS` corrélé sur `Candidacy`. C'est
`getPresidentialOverviewStats` (`src/lib/data/presidential-stats.ts:36`).

## Mesures

| Objet | Mesure |
|---|---|
| Table `Affair` | 506 lignes, 1,6 Mo |
| Table `Candidacy` | 1 285 101 lignes, 924 Mo |
| Requêtes désignées par le ticket | `EXPLAIN ANALYZE` 0,250 ms, index utilisé |
| Requête réellement lente, à chaud | 0,606 ms, 1542 buffers, 0 lecture disque |
| Même requête, cache froid | 4483 ms |

Les trois pistes du ticket sont donc écartées : la forme de la requête ne pèse
rien sur 506 lignes, l'index composite est bien utilisé (pas de stats
obsolètes), et élargir le pool de 2 à 5 est *plus lent* (chaque connexion neuve
coûte un handshake TLS). Inverser le sens de la requête pour partir des affaires
a aussi été mesuré : 70-91 ms contre 48 ms, donc plus lent.

## Cause

Le `revalidate` ISR effectif d'une route est le **MIN** du sien et du
`cacheLife.revalidate` de chaque frontière `"use cache"` qu'elle lit. Cette
fonction déclarait `cacheLife("minutes")`, soit 60 s, ce qui ramenait
`/statistiques` de 300 s à 60 s : cinq fois plus de régénérations, chacune
payant l'`EXISTS` sur une table de 924 Mo dont les pages sortent du cache.

Une PR de juillet 2026 avait remplacé 106 frontières `minutes`/`hours` par le
profil `synced` après 8,7 M d'écritures ISR sur la facture Vercel, en posant la
règle d'exhaustivité. Cette fonction a été ajoutée le 30 août, après.

## Vérification du avant/après

Prod actuelle, sondée toutes les 15 s : `HIT` à 35 s, `HIT` à 50 s,
**`STALE` à 65 s**, puis `HIT` à 7 s. La page se régénère bien toutes les 60 s
malgré `export const revalidate = 300`.

Après correctif, `.next/prerender-manifest.json` :
`/statistiques` → `initialRevalidateSeconds: 300`, et **aucune route ne reste à
60 s**.

## Contenu

- `cacheLife("minutes")` → `cacheLife("synced")`, avec le pourquoi en commentaire.
- Un garde d'architecture, écrit avant le correctif, qui exige `synced` partout
  sauf deux exceptions documentées (`pipelines.ts`, dashboard admin ;
  `elections.ts`, bascule à l'horloge le jour d'un scrutin). Il vérifie aussi
  que ces exemptions correspondent encore à la réalité, pour qu'une allowlist
  périmée ne couvre pas une régression.
- L'assertion unitaire qui verrouillait `"minutes"` suit le nouveau choix.

## À part, non traité ici

Le `cacheLife("hours")` de `getPastElectionSlugs` est lu par `Header`, donc par
le layout racine, donc par **toutes** les routes : 524 routes prérendues sont à
3600 s au lieu des 86400 s visés en juillet. C'est un arbitrage assumé et
documenté, mais son effet est global. À trancher séparément.

## Vérifications

- `npx vitest run` : 5884 tests passés, 0 échec
- `npx next build` : exit 0
- `tsc --noEmit`, `eslint`, `prettier` propres

Ref POLIGRAPH-1H