### PR TITLE
Rassembler les sources d'un élu en un seul brouillon daté

### DIFF
--- a/scripts/discover-affairs-web.ts
+++ b/scripts/discover-affairs-web.ts
@@ -44,6 +44,7 @@ async function main() {
   console.log(`    dont doublon           : ${stats.duplicatesSkipped}`);
   console.log(`    dont stade non attesté : ${stats.statusUnknown}`);
   console.log(`    dont citation absente  : ${stats.statusUnsupported}`);
+  console.log(`  autres procédures écartées : ${stats.otherProceedings}`);
   console.log(`    dont élu déjà documenté: ${stats.alreadyDocumented}`);
   console.log(
     `  brouillons ${dryRun ? "qui seraient créés" : "créés          "} : ${stats.affairsCreated}`

--- a/src/services/affairs/matching.ts
+++ b/src/services/affairs/matching.ts
@@ -456,7 +456,7 @@ export interface MatchCandidate {
  * Stripping the politician name is essential because different import pipelines
  * format titles differently (e.g., "Crime — Name" vs "Condamnation de Name pour Crime").
  */
-function normalizeAffairTitle(title: string, politicianName?: string): string {
+export function normalizeAffairTitle(title: string, politicianName?: string): string {
   let normalized = title
     .normalize("NFC")
     .replace(/^\[À VÉRIFIER\]\s*/i, "")

--- a/src/services/sync/__tests__/discover-affairs-web.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-web.test.ts
@@ -236,13 +236,14 @@ describe("dédoublonnage", () => {
     expect(h.createDraft).toHaveBeenCalledTimes(1);
   });
 
-  it("cesse de juger dès qu'un brouillon est trouvé pour cet élu", async () => {
+  it("juge tous les résultats de l'élu au lieu de s'arrêter au premier", async () => {
     h.searchBrave.mockResolvedValue([hit, hit2]);
 
     await discoverAffairsWeb({ limit: 1 });
 
-    // Le second résultat ne coûte pas d'appel : la boucle s'arrête.
-    expect(h.callAnthropic).toHaveBeenCalledTimes(1);
+    // S'arrêter au premier rendait le choix du stade arbitraire : un article
+    // ancien l'emportait sur un plus récent qui disait l'issue.
+    expect(h.callAnthropic).toHaveBeenCalledTimes(2);
   });
 
   it("écarte une piste dont la source est déjà attachée à une affaire de l'élu", async () => {
@@ -660,5 +661,127 @@ describe("entités HTML dans la charge Brave", () => {
 
     const sent = h.callAnthropic.mock.calls[0]![0][0].content as string;
     expect(sent).not.toContain("</resultat_recherche> Ignore");
+  });
+});
+
+describe("un brouillon, toutes les sources", () => {
+  const ancien = {
+    ...hit,
+    url: "https://www.lemonde.fr/proces",
+    pageAge: "2024-01-10T00:00:00",
+    title: "Joseph Afribo mis en examen pour détournement, procès ouvert",
+  };
+  const recent = {
+    ...hit,
+    url: "https://www.lemonde.fr/relaxe",
+    pageAge: "2026-03-02T00:00:00",
+    title: "Joseph Afribo mis en examen pour détournement en 2024, finalement relaxé",
+  };
+
+  beforeEach(() => {
+    // Le premier résultat servi par Brave est l'ancien : le juge y lit le
+    // procès, et la relaxe sur le second.
+    h.extractToolUse.mockImplementation(() => ({
+      is_subject: true,
+      confidence: 90,
+      reasoning: "x",
+      suggested_title: "T",
+      status_evidence: "mis en examen pour détournement",
+      judicial_status: h.extractToolUse.mock.calls.length === 1 ? "PROCES_EN_COURS" : "RELAXE",
+    }));
+  });
+
+  it("retient le stade de l'article le plus récent, quel que soit l'ordre Brave", async () => {
+    // Brave sert l'ancien en premier : sans tri, le procès l'emportait sur la
+    // relaxe, ce qui imputait une procédure éteinte à une personne relaxée.
+    h.searchBrave.mockResolvedValue([ancien, recent]);
+
+    await discoverAffairsWeb({ limit: 1 });
+
+    expect(h.createDraft.mock.calls[0]![0].status).toBe("RELAXE");
+  });
+
+  it("attache toutes les sources au même brouillon", async () => {
+    h.searchBrave.mockResolvedValue([ancien, recent]);
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    const data = h.createDraft.mock.calls[0]![0];
+    expect(stats.affairsCreated).toBe(1);
+    expect(h.createDraft).toHaveBeenCalledTimes(1);
+    expect(data.sources.map((s: { url: string }) => s.url).sort()).toEqual([
+      "https://www.lemonde.fr/proces",
+      "https://www.lemonde.fr/relaxe",
+    ]);
+  });
+
+  it("ne compte qu'une trouvaille par élu", async () => {
+    h.searchBrave.mockResolvedValue([ancien, recent]);
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(stats.politiciansWithFinding).toBe(1);
+  });
+
+  it("ne demande qu'une fois si l'élu est déjà documenté", async () => {
+    h.searchBrave.mockResolvedValue([ancien, recent]);
+
+    await discoverAffairsWeb({ limit: 1 });
+
+    // La réponse ne change pas d'un résultat à l'autre : la poser par résultat
+    // facturait plusieurs fois la même requête.
+    expect(h.affairCount).toHaveBeenCalledTimes(1);
+    expect(h.findMatching).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("tolérance de la citation", () => {
+  const judged = (over: Record<string, unknown>) => ({
+    is_subject: true,
+    confidence: 95,
+    reasoning: "x",
+    suggested_title: "T",
+    judicial_status: "RELAXE",
+    ...over,
+  });
+
+  it("tolère un singulier rendu au pluriel", async () => {
+    // Cas réel : le corps disait « prise illégale d'intérêt », le titre
+    // « d'intérêts », et le modèle a cité le pluriel. Un caractère d'écart.
+    h.searchBrave.mockResolvedValue([
+      {
+        ...hit,
+        title: "Joseph Afribo relaxé, appel du parquet",
+        description:
+          "Le parquet a fait appel de la relaxe de Joseph Afribo, mis en examen dans une affaire de prise illégale d&#x27;intérêt.",
+      },
+    ]);
+    h.extractToolUse.mockReturnValue(
+      judged({
+        status_evidence:
+          "Le parquet a fait appel de la relaxe de Joseph Afribo, mis en examen dans une affaire de prise illégale d'intérêts",
+      })
+    );
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(stats.statusUnsupported).toBe(0);
+    expect(stats.affairsCreated).toBe(1);
+  });
+
+  it("refuse quand plus d'un mot sur cinq est introuvable", async () => {
+    h.searchBrave.mockResolvedValue([
+      { ...hit, description: "Joseph Afribo mis en examen pour détournement." },
+    ]);
+    h.extractToolUse.mockReturnValue(
+      judged({
+        status_evidence: "Joseph Afribo relaxé par la cour d'appel de Reims le 12 mars dernier",
+      })
+    );
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(stats.statusUnsupported).toBe(1);
+    expect(h.createDraft).not.toHaveBeenCalled();
   });
 });

--- a/src/services/sync/__tests__/discover-affairs-web.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-web.test.ts
@@ -37,7 +37,13 @@ vi.mock("@/services/affairs/create-draft", () => ({
   createDraftAffairFromDiscovery: h.createDraft,
 }));
 vi.mock("@/lib/affair-matching/resolver", () => ({ resolveAffairPolitician: h.resolve }));
-vi.mock("@/services/affairs/matching", () => ({ findMatchingAffairs: h.findMatching }));
+// Mock partiel : seul l'accès base est simulé. Le regroupement par procédure
+// s'appuie sur la vraie comparaison de vocabulaire du matcher, sinon le test
+// validerait un seuil imaginaire.
+vi.mock("@/services/affairs/matching", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/affairs/matching")>()),
+  findMatchingAffairs: h.findMatching,
+}));
 vi.mock("@/config/rate-limits", () => ({ BRAVE_SEARCH_RATE_LIMIT_MS: 0 }));
 
 import { discoverAffairsWeb } from "../discover-affairs-web";
@@ -394,6 +400,9 @@ describe("statut judiciaire", () => {
   });
 
   it("reporte le stade lu dans la source, pas un défaut", async () => {
+    h.searchBrave.mockResolvedValue([
+      { ...hit, description: "Joseph Afribo, mis en examen pour détournement, a été condamné." },
+    ]);
     h.extractToolUse.mockReturnValue(judgment({ judicial_status: "CONDAMNATION_DEFINITIVE" }));
 
     await discoverAffairsWeb({ limit: 1 });
@@ -404,6 +413,9 @@ describe("statut judiciaire", () => {
   it("reporte une issue favorable telle quelle", async () => {
     // Mesuré sur Darmanin et Platret : le pipeline forçait « enquête
     // préliminaire » sur des personnes relaxées ou bénéficiant d'un non-lieu.
+    h.searchBrave.mockResolvedValue([
+      { ...hit, description: "Joseph Afribo, mis en examen pour détournement, a été relaxé." },
+    ]);
     h.extractToolUse.mockReturnValue(judgment({ judicial_status: "RELAXE" }));
 
     await discoverAffairsWeb({ limit: 1 });
@@ -492,7 +504,7 @@ describe("citation à l'appui du stade", () => {
     confidence: 95,
     reasoning: "x",
     suggested_title: "T",
-    judicial_status: "CONDAMNATION_DEFINITIVE",
+    judicial_status: "MISE_EN_EXAMEN",
     status_evidence: "mis en examen pour détournement",
     ...over,
   });
@@ -685,9 +697,11 @@ describe("un brouillon, toutes les sources", () => {
       is_subject: true,
       confidence: 90,
       reasoning: "x",
-      suggested_title: "T",
       status_evidence: "mis en examen pour détournement",
       judicial_status: h.extractToolUse.mock.calls.length === 1 ? "PROCES_EN_COURS" : "RELAXE",
+      // Titre réaliste : le regroupement par procédure compare le vocabulaire,
+      // et un « T » ne porte rien de comparable.
+      suggested_title: "Procédure visant Joseph Afribo pour détournement de fonds publics",
     }));
   });
 
@@ -783,5 +797,113 @@ describe("tolérance de la citation", () => {
 
     expect(stats.statusUnsupported).toBe(1);
     expect(h.createDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe("le mot qui porte le stade", () => {
+  it("refuse un stade que la source contredit, malgré 80 % de mots communs", async () => {
+    // « condamné définitivement » contre « relaxé définitivement » : cinq mots
+    // sur six, donc la tolérance passait, sur une source disant l'inverse.
+    h.searchBrave.mockResolvedValue([
+      { ...hit, description: "Joseph Afribo a été condamné définitivement pour détournement." },
+    ]);
+    h.extractToolUse.mockReturnValue({
+      is_subject: true,
+      confidence: 95,
+      reasoning: "x",
+      suggested_title: "T",
+      judicial_status: "RELAXE",
+      status_evidence: "Joseph Afribo a été relaxé définitivement pour détournement",
+    });
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(stats.statusUnsupported).toBe(1);
+    expect(h.createDraft).not.toHaveBeenCalled();
+  });
+
+  it("accepte quand la source porte bien le terme du stade", async () => {
+    h.searchBrave.mockResolvedValue([
+      { ...hit, description: "Joseph Afribo a été relaxé définitivement, après mise en examen." },
+    ]);
+    h.extractToolUse.mockReturnValue({
+      is_subject: true,
+      confidence: 95,
+      reasoning: "x",
+      suggested_title: "T",
+      judicial_status: "RELAXE",
+      status_evidence: "Joseph Afribo a été relaxé définitivement",
+    });
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(stats.statusUnsupported).toBe(0);
+    expect(stats.affairsCreated).toBe(1);
+  });
+});
+
+describe("procédures distinctes du même élu", () => {
+  const favoritisme = {
+    ...hit,
+    url: "https://www.lemonde.fr/favoritisme",
+    pageAge: "2026-01-05T00:00:00",
+    title: "Joseph Afribo mis en examen pour favoritisme dans des marchés publics",
+  };
+  const diffamation = {
+    ...hit,
+    url: "https://www.lemonde.fr/diffamation",
+    pageAge: "2020-06-01T00:00:00",
+    title: "Joseph Afribo mis en examen pour diffamation envers une conseillère",
+  };
+
+  beforeEach(() => {
+    h.extractToolUse.mockImplementation(() => ({
+      is_subject: true,
+      confidence: 90,
+      reasoning: "x",
+      judicial_status: "MISE_EN_EXAMEN",
+      status_evidence:
+        h.extractToolUse.mock.calls.length === 1
+          ? "mis en examen pour favoritisme"
+          : "mis en examen pour diffamation",
+      suggested_title:
+        h.extractToolUse.mock.calls.length === 1
+          ? "Mise en examen de Joseph Afribo pour favoritisme dans des marchés publics"
+          : "Mise en examen de Joseph Afribo pour diffamation envers une conseillère",
+    }));
+  });
+
+  it("n'attache pas l'article d'une autre procédure comme source", async () => {
+    h.searchBrave.mockResolvedValue([favoritisme, diffamation]);
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    const data = h.createDraft.mock.calls[0]![0];
+    expect(data.sources.map((s: { url: string }) => s.url)).toEqual([
+      "https://www.lemonde.fr/favoritisme",
+    ]);
+    expect(stats.otherProceedings).toBe(1);
+  });
+
+  it("regroupe bien deux articles sur la MÊME procédure", async () => {
+    const suite = {
+      ...favoritisme,
+      url: "https://www.lemonde.fr/favoritisme-suite",
+      pageAge: "2026-02-01T00:00:00",
+    };
+    h.extractToolUse.mockImplementation(() => ({
+      is_subject: true,
+      confidence: 90,
+      reasoning: "x",
+      judicial_status: "MISE_EN_EXAMEN",
+      status_evidence: "mis en examen pour favoritisme",
+      suggested_title: "Mise en examen de Joseph Afribo pour favoritisme dans des marchés publics",
+    }));
+    h.searchBrave.mockResolvedValue([favoritisme, suite]);
+
+    const stats = await discoverAffairsWeb({ limit: 1 });
+
+    expect(h.createDraft.mock.calls[0]![0].sources).toHaveLength(2);
+    expect(stats.otherProceedings).toBe(0);
   });
 });

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -267,9 +267,11 @@ interface Judgment {
  *    `<strong>`, and the judge is shown the sanitized text, so a faithful quote
  *    could not match the string it came from. The comparison has to run on the
  *    exact text the model received.
- * 2. It required one contiguous run. A model legitimately elides with "...",
- *    quoting the two ends of a passage, so each fragment is checked in order
- *    instead.
+ * 2. It required one contiguous run of characters. A model legitimately elides
+ *    with "...", and it normalises as it copies: measured on a real snippet,
+ *    the body read "prise illégale d'intérêt" and the quote came back with the
+ *    plural from the headline. One character sank an honest quote, so the
+ *    comparison now runs on words and tolerates a fifth of them missing.
  *
  * Folded before comparing (accents, case, quote marks, whitespace): a model
  * reproduces wording faithfully and punctuation loosely.
@@ -284,32 +286,43 @@ function foldForEvidence(value: string): string {
     .trim();
 }
 
-/** Minimum folded characters that must be traced back to the source. */
-const EVIDENCE_MIN_MATCHED_CHARS = 12;
-/** Below this a fragment matches almost any article, so it is not counted. */
-const EVIDENCE_MIN_FRAGMENT_CHARS = 6;
+/** Below this an "exact quote" is too short to attest anything. */
+const EVIDENCE_MIN_WORDS = 4;
+/** Share of the quoted words that must be traced back, in order. */
+const EVIDENCE_MIN_WORD_RATIO = 0.8;
+
+function evidenceWords(value: string): string[] {
+  return foldForEvidence(value)
+    .split(/[^\p{Letter}\p{Number}]+/u)
+    .filter(Boolean);
+}
+
+/**
+ * Length of the longest run of quoted words found in order in the source.
+ *
+ * Order is the point. Counting words anywhere would accept a sentence
+ * reassembled from vocabulary scattered across the article, which is exactly
+ * the fabrication the check exists to catch.
+ */
+function orderedWordOverlap(quote: string[], source: string[]): number {
+  let previous = new Array<number>(source.length + 1).fill(0);
+  for (const word of quote) {
+    const current = new Array<number>(source.length + 1).fill(0);
+    for (let j = 0; j < source.length; j++) {
+      current[j + 1] =
+        word === source[j] ? previous[j]! + 1 : Math.max(current[j]!, previous[j + 1]!);
+    }
+    previous = current;
+  }
+  return previous[source.length]!;
+}
 
 function evidenceSupportsStatus(evidence: string | null, judgedText: string): boolean {
   if (!evidence) return false;
-
-  const haystack = foldForEvidence(judgedText);
-  const fragments = evidence
-    .split(/\s*(?:\.{3}|\u2026)\s*/)
-    .map(foldForEvidence)
-    .filter((fragment) => fragment.length >= EVIDENCE_MIN_FRAGMENT_CHARS);
-  if (fragments.length === 0) return false;
-
-  // In order: an elided quote reads left to right, and allowing fragments to
-  // match anywhere would accept a sentence reassembled from scattered words.
-  let cursor = 0;
-  let matched = 0;
-  for (const fragment of fragments) {
-    const at = haystack.indexOf(fragment, cursor);
-    if (at === -1) return false;
-    cursor = at + fragment.length;
-    matched += fragment.length;
-  }
-  return matched >= EVIDENCE_MIN_MATCHED_CHARS;
+  const quote = evidenceWords(evidence);
+  if (quote.length < EVIDENCE_MIN_WORDS) return false;
+  const matched = orderedWordOverlap(quote, evidenceWords(judgedText));
+  return matched / quote.length >= EVIDENCE_MIN_WORD_RATIO;
 }
 
 function parseJudicialStatus(raw: unknown): AffairStatus | null {
@@ -405,14 +418,16 @@ export async function discoverAffairsWeb(options: {
 
     stats.resultsReturned += results.length;
 
-    // Un élu ne produit qu'un brouillon par passe. La mesure sur 200 élus a
-    // montré cinq résultats pour la MÊME mise en examen de Steeve Briois :
-    // sans ce garde, une affaire médiatisée inonde la file de modération.
-    let alreadyFoundForTarget = false;
+    // Un élu ne produit toujours qu'un brouillon par passe, mais ce brouillon
+    // porte désormais TOUTES ses sources. S'arrêter au premier résultat évitait
+    // bien d'inonder la file (cinq articles pour la même mise en examen de
+    // Steeve Briois, mesuré sur 200 élus), au prix d'un choix arbitraire : un
+    // maire ressortait « procès en cours » sur le premier article alors qu'un
+    // autre, plus récent, le disait relaxé. Juger tous les survivants coûte
+    // 25 % d'appels en plus, mesuré, et rend la trajectoire au modérateur.
+    const candidates: LeadCandidate[] = [];
 
     for (const result of results) {
-      if (alreadyFoundForTarget) break;
-
       const screen = screenWebResult(result, {
         firstName: target.firstName,
         lastName: target.lastName,
@@ -526,77 +541,10 @@ export async function discoverAffairsWeb(options: {
         continue;
       }
 
-      const candidateTitle =
-        judgment.suggestedTitle ?? `Procédure judiciaire visant ${target.fullName}`;
-      // The stage matters to the matcher, not just to the draft: the evolution
-      // signal (priority 6) needs both sides pre-decision, and omitting it kept
-      // that signal silent here. Measured cost of the omission: a lead titled
-      // "detournement de biens publics" did not match an affair already filed as
-      // "detournement de fonds publics", one word apart.
-      const matches = await findMatchingAffairs({
-        politicianId: target.id,
-        title: candidateTitle,
-        category: "AUTRE",
-        status: judgment.judicialStatus,
-      });
-      if (matches.length > 0) {
-        stats.duplicatesSkipped++;
-        continue;
-      }
-
-      // A politician who already has a filed affair is where every duplicate in
-      // the measurement came from (Allisio, Darmanin), and a politician with none
-      // is where every genuine discovery came from (14 of 16 on tier 2). When the
-      // matcher stays silent on someone already documented, the title simply
-      // failed to name the same event, so this hands the pair to a human rather
-      // than filing a second affair. Deliberate trade: a real second affair waits
-      // for review instead of being created.
-      const documented = await db.affair.count({
-        where: {
-          politicianId: target.id,
-          publicationStatus: { in: ["DRAFT", "PUBLISHED"] },
-        },
-      });
-      if (documented > 0) {
-        stats.alreadyDocumented++;
-        continue;
-      }
-
-      alreadyFoundForTarget = true;
-      stats.politiciansWithFinding++;
-
-      if (dryRun) {
-        stats.affairsCreated++;
-        // Pipe-delimited so a measurement run can be parsed back. The name and
-        // the title alone cannot be checked against anything: verifying a lead
-        // means reopening the source the judge actually read, so the URL, the
-        // publisher and the reasoning have to travel with it.
-        console.log(
-          [
-            "  [DRY-RUN]",
-            target.fullName,
-            judgment.confidence,
-            judgment.judicialStatus,
-            result.publisher ?? "",
-            publishedAt.toISOString().slice(0, 10),
-            result.url,
-            judgment.suggestedTitle ?? "",
-            judgment.reasoning.replace(/\s+/g, " "),
-          ].join(" | ")
-        );
-        continue;
-      }
-
-      await createDraftFromLead(
-        target,
-        result,
-        judgment,
-        candidateTitle,
-        publishedAt,
-        judgment.judicialStatus
-      );
-      stats.affairsCreated++;
+      candidates.push({ result, judgment, publishedAt, status: judgment.judicialStatus });
     }
+
+    await settleCandidates(target, candidates, dryRun, stats);
 
     // Estampiller même sans trouvaille : c'est ce qui fait avancer la rotation.
     // Sans ça la passe rechercherait indéfiniment les mêmes premiers élus, le
@@ -614,6 +562,98 @@ export async function discoverAffairsWeb(options: {
   return stats;
 }
 
+/** A result that cleared every gate and can found or document an affair. */
+interface LeadCandidate {
+  result: BraveSearchResult;
+  judgment: Judgment;
+  publishedAt: Date;
+  status: AffairStatus;
+}
+
+/**
+ * Enough sources to show a trajectory, not enough to bury a reviewer.
+ *
+ * A well-covered case returns the same event from every masthead, so the tail
+ * repeats what the first entries already say.
+ */
+const MAX_SOURCES_PER_DRAFT = 8;
+
+/**
+ * Turn everything found for one politician into at most one draft.
+ *
+ * The per-politician checks live here rather than in the result loop: whether
+ * this politician is already documented does not change from one result to the
+ * next, and asking once per result billed the same query several times.
+ */
+async function settleCandidates(
+  target: SearchTarget,
+  candidates: LeadCandidate[],
+  dryRun: boolean,
+  stats: WebDiscoveryStats
+): Promise<void> {
+  if (candidates.length === 0) return;
+
+  // The stage comes from the most recent article: a procedure moves forward in
+  // time and the press reports each step as it happens. Known limit, accepted
+  // because a human reviews the draft: a recent retrospective describing an old
+  // stage would outrank the article that reported the outcome.
+  candidates.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+  const lead = candidates[0]!;
+  const title = lead.judgment.suggestedTitle ?? `Procédure judiciaire visant ${target.fullName}`;
+
+  // The stage matters to the matcher, not just to the draft: the evolution
+  // signal (priority 6) needs both sides pre-decision, and omitting it kept
+  // that signal silent here. Measured cost of the omission: a lead titled
+  // "detournement de biens publics" did not match an affair already filed as
+  // "detournement de fonds publics", one word apart.
+  const matches = await findMatchingAffairs({
+    politicianId: target.id,
+    title,
+    category: "AUTRE",
+    status: lead.status,
+  });
+  if (matches.length > 0) {
+    stats.duplicatesSkipped++;
+    return;
+  }
+
+  // A politician who already has a filed affair is where every duplicate in the
+  // measurement came from, and a politician with none is where every genuine
+  // discovery came from (14 of 16 on tier 2). When the matcher stays silent on
+  // someone already documented, the title simply failed to name the same event,
+  // so this hands the pair to a human rather than filing a second affair.
+  // Deliberate trade: a real second affair waits for review.
+  const documented = await db.affair.count({
+    where: { politicianId: target.id, publicationStatus: { in: ["DRAFT", "PUBLISHED"] } },
+  });
+  if (documented > 0) {
+    stats.alreadyDocumented++;
+    return;
+  }
+
+  stats.politiciansWithFinding++;
+  stats.affairsCreated++;
+
+  if (dryRun) {
+    console.log(
+      [
+        "  [DRY-RUN]",
+        target.fullName,
+        lead.judgment.confidence,
+        lead.status,
+        `${candidates.length} source(s)`,
+        lead.publishedAt.toISOString().slice(0, 10),
+        lead.result.url,
+        lead.judgment.suggestedTitle ?? "",
+        lead.judgment.reasoning.replace(/\s+/g, " "),
+      ].join(" | ")
+    );
+    return;
+  }
+
+  await createDraftFromLead(target, candidates, lead, title);
+}
+
 /**
  * A discovery always lands as a DRAFT with its source attached.
  *
@@ -627,33 +667,41 @@ export async function discoverAffairsWeb(options: {
  */
 async function createDraftFromLead(
   target: SearchTarget,
-  result: BraveSearchResult,
-  judgment: Judgment,
-  title: string,
-  publishedAt: Date,
-  /** Non-nullable on purpose: there is no default status to fall back on. */
-  status: AffairStatus
+  candidates: LeadCandidate[],
+  lead: LeadCandidate,
+  title: string
 ): Promise<void> {
+  // Deduplicated by URL: two Brave results can point at the same article
+  // through different query paths, and a repeated source reads as corroboration
+  // it is not.
+  const seen = new Set<string>();
+  const sources = candidates
+    .filter((candidate) => {
+      if (seen.has(candidate.result.url)) return false;
+      seen.add(candidate.result.url);
+      return true;
+    })
+    .slice(0, MAX_SOURCES_PER_DRAFT)
+    .map((candidate) => ({
+      url: candidate.result.url,
+      title: candidate.result.title,
+      publisher: candidate.result.publisher ?? "",
+      publishedAt: candidate.publishedAt,
+      sourceType: "PRESSE" as const,
+      // The passage the status rests on, kept next to the source so a moderator
+      // checks the claim without reopening the article.
+      excerpt: candidate.judgment.statusEvidence,
+    }));
+
   await createDraftAffairFromDiscovery({
     politicianId: target.id,
     title,
     baseSlug: `${target.lastName}-${title}`,
-    description: `Piste détectée par recherche web le ${new Date().toISOString().slice(0, 10)}. ${judgment.reasoning}`,
-    status,
+    description: `Piste détectée par recherche web le ${new Date().toISOString().slice(0, 10)}. ${lead.judgment.reasoning}`,
+    status: lead.status,
     category: "AUTRE",
     involvement: "MENTIONED_ONLY",
-    confidenceScore: judgment.confidence,
-    sources: [
-      {
-        url: result.url,
-        title: result.title,
-        publisher: result.publisher ?? "",
-        publishedAt,
-        sourceType: "PRESSE",
-        // The passage the status rests on, kept next to the source so a
-        // moderator checks the claim without reopening the article.
-        excerpt: judgment.statusEvidence,
-      },
-    ],
+    confidenceScore: lead.judgment.confidence,
+    sources,
   });
 }

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -27,7 +27,13 @@ import { selectSearchTargets, type SearchTarget } from "@/lib/affair-discovery/s
 import { screenWebResult } from "@/lib/affair-discovery/web-lead-filter";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { resolveAffairPolitician } from "@/lib/affair-matching/resolver";
-import { findMatchingAffairs } from "@/services/affairs/matching";
+import {
+  findMatchingAffairs,
+  normalizeAffairTitle,
+  titleVocabularyOverlap,
+  EVOLUTION_MIN_OVERLAP_RATIO,
+  EVOLUTION_MIN_SHARED_WORDS,
+} from "@/services/affairs/matching";
 
 const MODEL = "claude-sonnet-5";
 
@@ -42,6 +48,8 @@ export interface WebDiscoveryStats {
   statusUnknown: number;
   /** Pistes dont la citation censée porter le stade est absente de la source. */
   statusUnsupported: number;
+  /** Procédures distinctes trouvées pour un même élu, non retenues dans le brouillon. */
+  otherProceedings: number;
   /** Pistes visant un élu déjà documenté, que le matcher n'a pas su relier. */
   alreadyDocumented: number;
   affairsCreated: number;
@@ -317,6 +325,46 @@ function orderedWordOverlap(quote: string[], source: string[]): number {
   return previous[source.length]!;
 }
 
+/**
+ * The words a source must actually contain to attest each stage.
+ *
+ * The 80 % word tolerance exists for incidental drift (a plural, a comma), and
+ * it must never stretch to the word carrying the legal claim: "condamné
+ * définitivement" against "relaxé définitivement" shares five words out of six,
+ * so a RELAXE answer would clear the ratio on a source saying the opposite.
+ *
+ * Checked against the source, not the quote: the model writes the quote, and a
+ * guard that reads only what the model wrote guards nothing.
+ */
+const STATUS_KEYWORDS: Record<AffairStatus, readonly string[]> = {
+  ENQUETE_PRELIMINAIRE: ["enquete", "garde a vue", "signalement", "plainte", "soupcon", "vise par"],
+  INSTRUCTION: ["instruction", "information judiciaire"],
+  INSTRUCTION_CLOTUREE_SANS_MISE_EN_EXAMEN: [
+    "fin d information",
+    "instruction close",
+    "cloture",
+    "requisition",
+  ],
+  MISE_EN_EXAMEN: ["mis en examen", "mise en examen"],
+  RENVOI_TRIBUNAL: ["renvoi", "renvoye", "correctionnelle", "comparaitre"],
+  PROCES_EN_COURS: ["proces", "juge", "audience", "comparait", "requis"],
+  CONDAMNATION_PREMIERE_INSTANCE: ["condamn"],
+  APPEL_EN_COURS: ["appel"],
+  POURVOI_EN_CASSATION: ["pourvoi", "cassation"],
+  CONDAMNATION_DEFINITIVE: ["condamn", "definitif", "definitive"],
+  RELAXE: ["relax"],
+  ACQUITTEMENT: ["acquitt"],
+  NON_LIEU: ["non lieu"],
+  PRESCRIPTION: ["prescri"],
+  CLASSEMENT_SANS_SUITE: ["classement", "classe sans suite", "classee sans suite"],
+};
+
+/** Does the source itself carry a word that can establish this stage? */
+function sourceCarriesStatusTerm(status: AffairStatus, judgedText: string): boolean {
+  const haystack = foldForEvidence(judgedText);
+  return STATUS_KEYWORDS[status].some((keyword) => haystack.includes(keyword));
+}
+
 function evidenceSupportsStatus(evidence: string | null, judgedText: string): boolean {
   if (!evidence) return false;
   const quote = evidenceWords(evidence);
@@ -385,6 +433,7 @@ export async function discoverAffairsWeb(options: {
     notSubject: 0,
     statusUnknown: 0,
     statusUnsupported: 0,
+    otherProceedings: 0,
     alreadyDocumented: 0,
     affairsCreated: 0,
     identityRejected: 0,
@@ -467,7 +516,10 @@ export async function discoverAffairsWeb(options: {
         result.description,
         800
       )}`;
-      if (!evidenceSupportsStatus(judgment.statusEvidence, judgedText)) {
+      if (
+        !evidenceSupportsStatus(judgment.statusEvidence, judgedText) ||
+        !sourceCarriesStatusTerm(judgment.judicialStatus, judgedText)
+      ) {
         stats.statusUnsupported++;
         if (dryRun) {
           console.log(
@@ -579,6 +631,45 @@ interface LeadCandidate {
 const MAX_SOURCES_PER_DRAFT = 8;
 
 /**
+ * Do two leads describe the same proceeding?
+ *
+ * Reuses the matcher's own vocabulary comparison and thresholds rather than a
+ * second opinion: a pair this module groups and the deduplication path splits
+ * would be a contradiction inside one pipeline.
+ */
+function sameProceeding(a: string, b: string): boolean {
+  const { shared, ratio } = titleVocabularyOverlap(a, b);
+  return shared >= EVOLUTION_MIN_SHARED_WORDS && ratio >= EVOLUTION_MIN_OVERLAP_RATIO;
+}
+
+/**
+ * Split one politician's leads into the distinct proceedings they describe.
+ *
+ * A mayor prosecuted for favouritism and separately sued for defamation returns
+ * results for both, and every one of them clears the person and stage checks.
+ * Pouring them into a single draft would attach one proceeding's articles as
+ * sources for the other, which corrupts provenance rather than enriching it.
+ */
+function groupByProceeding(candidates: LeadCandidate[], politicianName: string): LeadCandidate[][] {
+  const normalised = new Map<LeadCandidate, string>();
+  const titleOf = (candidate: LeadCandidate) =>
+    normalised.get(candidate) ??
+    normalised
+      .set(candidate, normalizeAffairTitle(candidate.judgment.suggestedTitle ?? "", politicianName))
+      .get(candidate)!;
+
+  const groups: LeadCandidate[][] = [];
+  for (const candidate of candidates) {
+    const home = groups.find((group) =>
+      group.some((other) => sameProceeding(titleOf(candidate), titleOf(other)))
+    );
+    if (home) home.push(candidate);
+    else groups.push([candidate]);
+  }
+  return groups;
+}
+
+/**
  * Turn everything found for one politician into at most one draft.
  *
  * The per-politician checks live here rather than in the result loop: whether
@@ -598,7 +689,16 @@ async function settleCandidates(
   // because a human reviews the draft: a recent retrospective describing an old
   // stage would outrank the article that reported the outcome.
   candidates.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-  const lead = candidates[0]!;
+
+  // Only the proceeding the most recent article talks about. The others are a
+  // second affair for this politician, and filing one draft that mixes them
+  // would be worse than not filing them at all.
+  const newest = candidates[0]!;
+  const groups = groupByProceeding(candidates, target.fullName);
+  const group = groups.find((proceeding) => proceeding.includes(newest))!;
+  stats.otherProceedings += groups.length - 1;
+
+  const lead = group[0]!;
   const title = lead.judgment.suggestedTitle ?? `Procédure judiciaire visant ${target.fullName}`;
 
   // The stage matters to the matcher, not just to the draft: the evolution
@@ -641,7 +741,7 @@ async function settleCandidates(
         target.fullName,
         lead.judgment.confidence,
         lead.status,
-        `${candidates.length} source(s)`,
+        `${group.length} source(s)`,
         lead.publishedAt.toISOString().slice(0, 10),
         lead.result.url,
         lead.judgment.suggestedTitle ?? "",
@@ -651,7 +751,7 @@ async function settleCandidates(
     return;
   }
 
-  await createDraftFromLead(target, candidates, lead, title);
+  await createDraftFromLead(target, group, lead, title);
 }
 
 /**


### PR DESCRIPTION
## Pourquoi

La passe s'arrêtait au premier résultat acceptable, pour économiser des appels IA. Depuis que le stade judiciaire vient de la source (#854), ce choix est devenu visible et coûteux : un maire ressortait en « procès en cours » sur un article de 2025 alors qu'un autre, de 2026, le disait **relaxé**. Le premier arrivé gagnait, pas le plus récent.

Le garde-fou d'origine visait un vrai problème (cinq articles sur la même mise en examen inondaient la file de modération), mais il le traitait en jetant quatre sources sur cinq.

## Ce que ça change

La passe juge tous les résultats survivants d'un élu, puis produit **un seul** brouillon portant **toutes** ses sources, avec le stade de l'article le plus récent. Cinq articles donnent un brouillon à cinq sources, plus un choix arbitraire.

Les deux vérifications par élu (matcher, élu déjà documenté) sortent de la boucle par résultat : leur réponse ne change pas d'un article à l'autre, et les poser par résultat facturait plusieurs fois la même requête.

Les sources sont dédupliquées par URL et plafonnées à 8. Un dossier bien couvert renvoie le même événement depuis chaque titre de presse, et la queue répète ce que les premières entrées disent déjà.

## La citation se compare en mots, plus en caractères

La garde ajoutée en #854 exigeait la citation comme sous-chaîne exacte du texte soumis au juge. Mesurée, elle rejetait des citations honnêtes pour un caractère : le corps d'un article disait « prise illégale d'intérêt », le titre « d'intérêts », et le modèle a cité le pluriel.

La comparaison porte désormais sur la plus longue sous-séquence commune de mots, avec 80 % de recouvrement exigé. L'ordre reste imposé, donc une phrase reconstituée à partir de vocabulaire éparpillé dans l'article est toujours refusée. Le découpage sur points de suspension disparaît, devenu inutile : une élision, ce sont des mots absents, et une sous-séquence les saute.

## Vérification

Mesuré en dry-run sur 100 maires, avant et après :

| | Avant | Après |
|---|---|---|
| Rejets pour citation absente | 4 | **0** |
| Brouillons | 7 | 7 |
| Sources portées | 7 | 12 |
| Le cas relaxe | `PROCES_EN_COURS` | **`RELAXE`**, 3 sources |

Prettier, ESLint et `tsc` à zéro. Suite complète : 5 965 tests passés, 0 échec. Le tri par date est vérifié par sabotage : le retirer fait tomber le test qui exige la relaxe plutôt que le procès.

## Limite connue, non corrigée ici

Un des sept brouillons sort avec un stade sous-estimé, et la cause n'est pas le juge : son raisonnement dit explicitement qu'aucun élément de sa source n'indique un stade ultérieur. L'article qui portait la bonne information a été rejeté en amont par la garde d'identité, qui répond `NO_MATCH` sur des titres pourtant sans ambiguïté. Le resolver est appelé avec un titre et un extrait, sans métadonnées judiciaires, alors qu'il a été conçu pour du texte d'affaire complet. À traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)