### PR TITLE
Écarter un parti sans slug des paramètres statiques

### DIFF
--- a/src/app/partis/[slug]/__tests__/static-params.test.ts
+++ b/src/app/partis/[slug]/__tests__/static-params.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * `Party.slug` is nullable, and a party is public as soon as one of its politicians is published,
  * with no condition on the slug. A slugless row therefore reaches generateStaticParams, which
  * hands Next `{ slug: null }` and fails the whole build with "a required parameter (slug) was not
- * provided as a string received object" — typeof null being "object".
+ * provided as a string received object", typeof null being "object".
  *
  * Measured on production data 2026-09-10: one such row, created two days earlier, broke
  * `next build` at page collection while CI stayed green, since CI builds without the database.

--- a/src/app/partis/[slug]/__tests__/static-params.test.ts
+++ b/src/app/partis/[slug]/__tests__/static-params.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * `Party.slug` is nullable, and a party is public as soon as one of its politicians is published,
+ * with no condition on the slug. A slugless row therefore reaches generateStaticParams, which
+ * hands Next `{ slug: null }` and fails the whole build with "a required parameter (slug) was not
+ * provided as a string received object" — typeof null being "object".
+ *
+ * Measured on production data 2026-09-10: one such row, created two days earlier, broke
+ * `next build` at page collection while CI stayed green, since CI builds without the database.
+ * The sitemap and /affaires/parti/[slug] already filter on the slug; this route did not.
+ */
+
+const findMany = vi.fn();
+vi.mock("@/lib/db", () => ({ db: { party: { findMany: (args: unknown) => findMany(args) } } }));
+vi.mock("@/lib/data/partis", () => ({
+  getParty: vi.fn(),
+  getPartyLeadership: vi.fn(async () => []),
+  getPartyRoles: vi.fn(async () => []),
+}));
+vi.mock("@/lib/data/platforms", () => ({ getPartyPlatform: vi.fn(async () => null) }));
+
+import { generateStaticParams } from "@/app/partis/[slug]/page";
+
+beforeEach(() => findMany.mockReset());
+
+describe("/partis/[slug] generateStaticParams", () => {
+  it("écarte un parti sans slug au lieu de casser la collecte des pages", async () => {
+    findMany.mockResolvedValue([
+      { slug: "renaissance" },
+      { slug: null },
+      { slug: "parti-socialiste" },
+    ]);
+    await expect(generateStaticParams()).resolves.toEqual([
+      { slug: "renaissance" },
+      { slug: "parti-socialiste" },
+    ]);
+  });
+
+  it("n'émet que des chaînes non vides", async () => {
+    findMany.mockResolvedValue([{ slug: null }, { slug: "" }, { slug: "horizons" }]);
+    const params = await generateStaticParams();
+    for (const p of params) expect(typeof p.slug).toBe("string");
+    expect(params).toEqual([{ slug: "horizons" }]);
+  });
+
+  it("garde les partis avec slug quand aucun n'est nul", async () => {
+    // Guards the assertions above: a filter that dropped everything would pass them too.
+    findMany.mockResolvedValue([{ slug: "les-ecologistes" }]);
+    await expect(generateStaticParams()).resolves.toEqual([{ slug: "les-ecologistes" }]);
+  });
+});

--- a/src/app/partis/[slug]/page.tsx
+++ b/src/app/partis/[slug]/page.tsx
@@ -32,7 +32,10 @@ export async function generateStaticParams() {
     orderBy: { name: "asc" },
     take: 50,
   });
-  return parties.map((p) => ({ slug: p.slug }));
+  // Party.slug is nullable and a slugless party has no URL, so it cannot be a static param:
+  // Next rejects `{ slug: null }` and fails the whole build. Same filter as the sitemap and
+  // /affaires/parti/[slug].
+  return parties.filter((p) => p.slug).map((p) => ({ slug: p.slug as string }));
 }
 
 interface PageProps {


### PR DESCRIPTION
## Le build de production échoue depuis le 09/09

```
Error: A required parameter (slug) was not provided as a string received object
       in generateStaticParams for /partis/[slug]
> Build error occurred
Error: Failed to collect page data for /partis/[slug]
```

`Party.slug` est `String?`, et `PUBLIC_PARTY_WHERE` ne demande qu'un politicien
publié, sans rien exiger du slug. Une ligne sans slug entre donc dans
`generateStaticParams`, qui rend `{ slug: null }` ; `typeof null === "object"`,
et Next fait échouer la collecte des pages, donc tout le build.

La ligne en cause : « Parti progressiste martiniquais » (PPM), créée le
2026-09-09 à 05:11 UTC, sans slug, avec un politicien publié. Le dernier
déploiement réussi (`2c79b79a`, 08/09 à 19:45) lui est antérieur, donc le
prochain déploiement aurait échoué, cinq minutes après son lancement, sur une
erreur qui ne nomme pas la cause.

La CI ne pouvait pas le voir : elle build sans la base, donc
`generateStaticParams` y renvoie un tableau vide.

## Le correctif

Le dépôt avait déjà ce garde à trois endroits, cette route l'avait manqué :

| Site | État avant |
|---|---|
| `affaires/parti/[slug]:202` | `parties.filter((p) => p.slug)` |
| `factchecks/[slug]:26` | `factChecks.filter((fc) => fc.slug !== null)` |
| `sitemap.ts:445` et `:454` | `.filter((p) => p.slug)` |
| `partis/[slug]:35` | aucun filtre |

Périmètre vérifié : `Politician.slug` et `Affair.slug` ne sont pas nullables,
`FactCheck.slug` l'est mais sa route filtre déjà. Ce site était le seul exposé.

## Vérifications

- `npx next build` sur les données de production : **exit 0**, aucune erreur de
  collecte (il échouait avant le correctif, même commande, même base)
- 3 tests sur `generateStaticParams`, dont un qui échouerait aussi si le filtre
  devenait trop gourmand
- `npx vitest run` : 5994 tests passés (un timeout de scan sous charge sur
  `SEC-02`, qui repasse isolé en 2 s)
- `tsc --noEmit`, `eslint`, `prettier` propres

## Reste à faire, hors code

Le PPM devrait recevoir son slug (`parti-progressiste-martiniquais`), sinon sa
fiche reste inaccessible. C'est une écriture en base de production, laissée à
part : ce correctif rend le build insensible à la donnée, les deux sont
indépendants.

Je n'ai pas identifié l'écriture fautive. Tous les chemins audités
(`services/sync/partis.ts`, `president.ts`, `scripts/sync-partis.ts`,
`import-wikidata-parties.ts`) posent `slug: generateSlug(name)`, et
`generateSlug("Parti progressiste martiniquais")` renvoie bien un slug valide.