### PR TITLE
Supprimer la colonne héritée Mandate.governmentName

### DIFF
--- a/prisma/migrations/manual/2026-09-10-drop-mandate-government-name.sql
+++ b/prisma/migrations/manual/2026-09-10-drop-mandate-government-name.sql
@@ -1,0 +1,18 @@
+-- Suppression de la colonne héritée Mandate."governmentName" (suivi #576).
+--
+-- Le nom du gouvernement vit dans MandateGovernment depuis que l'extension 1:1
+-- a été introduite. La colonne d'origine n'a jamais été supprimée, et le schéma
+-- Prisma ne la déclare plus : elle apparaît donc dans chaque diff comme un DROP
+-- en attente, ce qui fait échouer db:push et masque les vraies dérives.
+--
+-- Vérifié avant exécution, sur les 43 003 mandats de production :
+--   valeurs non nulles ................. 0
+--   lignes sans MandateGovernment ...... 0
+--   valeurs divergentes de la relation . 0
+-- La colonne est vide, la suppression ne perd aucune donnée.
+--
+-- Aucun code ne la lit : Prisma ne la déclare pas, donc aucune requête générée
+-- ne la sélectionne, et les lectures de `governmentName` dans src/ passent
+-- toutes par la relation `governmentData`.
+
+ALTER TABLE "Mandate" DROP COLUMN IF EXISTS "governmentName";


### PR DESCRIPTION
Refs #576

## Le problème

`Mandate."governmentName"` existe en base mais pas dans le schéma Prisma : le nom du gouvernement vit dans `MandateGovernment` depuis l'introduction de l'extension 1:1, et la colonne d'origine n'a jamais été supprimée.

Conséquence quotidienne : chaque `migrate diff` porte un `ALTER TABLE "Mandate" DROP COLUMN "governmentName"` en attente. Le garde-fou de dérive refuse donc `db:push` systématiquement, ce qui a deux effets. Toute évolution de schéma passe par du SQL écrit à la main, et surtout **une vraie dérive destructrice se noierait dans ce bruit permanent**, puisqu'on s'habitue à voir le garde refuser.

## La vérification avant suppression

Sur les 43 003 mandats de production :

| | |
|---|---|
| Valeurs non nulles dans la colonne | **0** |
| Lignes sans `MandateGovernment` correspondant | **0** |
| Valeurs divergentes de la relation | **0** |

La colonne est vide. La suppression ne perd aucune donnée.

Aucun code ne la lit non plus : Prisma ne la déclare pas, donc aucune requête générée ne la sélectionne, et les lectures de `governmentName` dans `src/` passent toutes par la relation `governmentData`. Vérifié après suppression, la lecture par la relation répond toujours.

## Application

SQL ciblé et idempotent dans `prisma/migrations/manual/`, selon la convention du dépôt, avec les chiffres de la vérification en commentaire. Déjà appliqué en production.

Après suppression, le garde de dérive ne signale plus que l'index HNSW, indéclarable par Prisma et exempté explicitement :

```
Toléré (non déclarable ou explicitement autorisé) : DROP INDEX "SearchEmbedding_embedding_hnsw_idx";
Aucune opération destructrice bloquante dans le diff.
```

`db:push` est utilisable de nouveau.

## Vérification

`tsc` à zéro. Suite complète : 5 999 tests passés. Deux tests d'architecture ont expiré au premier passage sous charge machine, puis passent isolément (73/73) : ce sont des scans de fichiers sensibles à la charge, sans rapport avec ce changement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)