### PR TITLE
Retirer le statement_timeout que la base ignore

### DIFF
--- a/docs/engineering/db-statement-timeout.md
+++ b/docs/engineering/db-statement-timeout.md
@@ -1,0 +1,103 @@
+# Capping query duration on the request path
+
+A runaway query holds one of the two pool slots of its lambda until the server cancels it. With
+`max: 2` in `src/lib/db.ts`, two of them starve that lambda, and every other request it is handling
+fails with `timeout exceeded when trying to connect` once `connectionTimeoutMillis` elapses. That is
+the shape behind the connection-timeout issues tracked as POLIGRAPH-V and POLIGRAPH-1C.
+
+The obvious remedy, capping statement duration from the client, does not work here. This document
+records what was measured, so the next reader does not repeat it, and describes the one path that
+would work.
+
+Do not paste connection strings, host names, keys, or role passwords into this document, a pull
+request, an issue, or CI output.
+
+## What was measured
+
+All figures come from production on 2026-09-10, from sessions opened by the same pool the
+application uses.
+
+| Mechanism                                            | Effect on `SHOW statement_timeout` |
+| ---------------------------------------------------- | ---------------------------------- |
+| `statement_timeout` in the `pg.Pool` config          | none, server default stands        |
+| `options=-c statement_timeout=...` startup parameter | none, server default stands        |
+| both together                                        | none, server default stands        |
+| `SET statement_timeout` in session                   | applied                            |
+
+The server default is two minutes, not the thirty seconds the pool config used to claim. That claim
+has been removed and `src/lib/__tests__/db-pool-config.test.ts` fails if the option comes back.
+
+## Why a session SET cannot be used from the pool
+
+The pooler reuses physical backends across unrelated clients and does not reset session state
+between them. Measured: one pool sets a distinctive `statement_timeout`, disconnects, and a second
+pool built from scratch reads that same value on the same backend. Thirty consecutive connections
+from fresh pools landed on a single backend.
+
+Two consequences:
+
+1. A cap applied on connect would leak onto whatever reuses that backend next, including the batch
+   jobs in `src/services/sync/` that legitimately run for minutes. The daily sync tolerates a failed
+   step, so the failure would be survivable but silent in intent and hard to attribute.
+2. Any diagnostic session that issues `SET` pollutes a backend serving live traffic. Always `RESET`
+   afterwards and confirm from fresh connections with `current_setting()`.
+
+`SET LOCAL` inside an explicit transaction is the only leak-free variant, because its scope ends
+with the transaction. It would force a transaction and an extra round trip on every page read across
+the data layer, which is why it is not the recommended path.
+
+## Recommended path: a dedicated role for the request path
+
+Give the application's read path its own PostgreSQL role carrying its own `statement_timeout`, and
+leave the batch jobs on the current role. The cap then lives on the server, where the pooler cannot
+strip it and session reuse cannot leak it, because it is a property of the role rather than of the
+session.
+
+### Preconditions
+
+1. Confirm the current server default and the role in use, recording only the values, in the private
+   change record.
+2. Decide the cap from measured page-query durations, not from intuition. The three heaviest queries
+   in the codebase belong to `src/services/sync/compute-municipales-snapshots.ts` and average ten,
+   six and three seconds; they must stay on the batch role.
+3. Identify the operator and the rollback owner.
+
+### Steps
+
+1. Create the role in the Supabase Dashboard, grant it exactly the privileges the request path needs
+   and no more, and set its `statement_timeout`.
+2. Add a separate connection string for the request path to the hosted environment variables. Keep
+   the existing variable pointing at the batch role so scripts, crons and Inngest functions are
+   untouched.
+3. Teach `src/lib/db.ts` to select the request-path connection string when one is present, falling
+   back to the existing variable so local development and scripts keep working unchanged.
+4. Deploy, then verify.
+
+### Verification
+
+1. From a request-path session, `SHOW statement_timeout` returns the new cap.
+2. From a script session, it still returns the server default.
+3. A deliberately slow read on the request path is cancelled with SQLSTATE `57014` at the cap, and
+   the page renders an error rather than holding a pool slot.
+4. The daily sync completes with the same step results as before the change.
+
+### Rollback
+
+Remove the request-path connection string from the hosted environment and redeploy. The fallback in
+step 3 restores the previous behaviour without a code change.
+
+## Still unknown
+
+What consumed the connections during the 2026-09-03 incident window is not established. Deploys, the
+Inngest schedule and a database restart were each checked and ruled out. The remaining candidates,
+a traffic surge and a heavy script run by hand against production, need the hosted observability for
+that window, including the pooler's own client metrics.
+
+Alerting on the connection-timeout rate should come before any further change, so the next
+occurrence is caught while that observability still covers it.
+
+## References
+
+- `src/lib/db.ts` for the pool configuration and the reason the option is absent
+- `src/lib/__tests__/db-pool-config.test.ts` for the guard
+- `src/inngest/functions/sync-daily.ts` for the step-level failure tolerance relied on above

--- a/src/lib/__tests__/db-pool-config.test.ts
+++ b/src/lib/__tests__/db-pool-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * `statement_timeout` in the pg.Pool config is silently ignored on this database, so declaring it
+ * buys nothing and tells the next reader that queries are capped when they are not.
+ *
+ * Measured against production on 2026-09-10, from a session opened by this very pool:
+ * `SHOW statement_timeout` returns the server default whether the option is set, whether the
+ * PostgreSQL startup parameter `options=-c statement_timeout=…` is passed, or both. Only a session
+ * `SET` takes effect, and a `SET` cannot be used here: the pooler hands the same physical backend
+ * to unrelated clients without resetting session state, so a cap set for a page request leaks onto
+ * the batch jobs that legitimately need minutes.
+ *
+ * See docs/engineering/db-statement-timeout.md for the measurements and for the dedicated-role
+ * path that would give the request path its own cap.
+ */
+
+const capturedConfigs: Record<string, unknown>[] = [];
+
+vi.mock("pg", () => ({
+  Pool: class {
+    constructor(config: Record<string, unknown>) {
+      capturedConfigs.push(config);
+    }
+    on() {}
+  },
+}));
+vi.mock("@prisma/adapter-pg", () => ({ PrismaPg: class {} }));
+vi.mock("@/generated/prisma", () => ({
+  PrismaClient: class {
+    $extends() {
+      return this;
+    }
+  },
+}));
+vi.mock("@/lib/public-ids/prisma-extension", () => ({
+  createPoligraphIdExtension: () => () => ({}),
+}));
+
+/**
+ * `db.ts` caches the client on globalThis so a lambda reuses one pool. Clearing that cache is what
+ * makes the module rebuild a pool on re-import; without it only the first call captures a config
+ * and every later assertion runs against an empty object, which passes for the wrong reason.
+ */
+async function poolConfig(): Promise<Record<string, unknown>> {
+  capturedConfigs.length = 0;
+  const g = globalThis as unknown as {
+    prisma?: unknown;
+    pool?: unknown;
+    shutdownRegistered?: unknown;
+  };
+  delete g.prisma;
+  delete g.pool;
+  delete g.shutdownRegistered;
+  vi.resetModules();
+  vi.stubEnv("DATABASE_URL", "postgresql://user@example.invalid:5432/db");
+  await import("../db");
+  expect(capturedConfigs, "aucun pool construit : le harnais ne mesure rien").toHaveLength(1);
+  return capturedConfigs[0]!;
+}
+
+describe("configuration du pool Postgres", () => {
+  it("construit bien un pool à inspecter", async () => {
+    // Guards the harness: capturing nothing would make the assertions below vacuously true.
+    expect(Object.keys(await poolConfig())).toContain("connectionString");
+  });
+
+  it("ne déclare pas de statement_timeout, qui serait silencieusement ignoré", async () => {
+    expect(await poolConfig()).not.toHaveProperty("statement_timeout");
+  });
+
+  it("garde les réglages qui, eux, sont appliqués", async () => {
+    const config = await poolConfig();
+    expect(config.max).toBe(2);
+    expect(config.connectionTimeoutMillis).toBe(15_000);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -33,7 +33,16 @@ function buildExtendedClient() {
     connectionTimeoutMillis: 15_000,
     ssl: useSsl ? { rejectUnauthorized: false } : false,
     allowExitOnIdle: true, // Release idle connections faster in serverless
-    statement_timeout: 30_000, // Kill queries after 30s to prevent pool starvation
+    // No statement_timeout here on purpose. It is silently ignored on this database, and declaring
+    // it claimed a cap that never existed: a runaway query holds one of the two pool slots for the
+    // server default (2 min), not for 30 s. Measured 2026-09-10 from a session opened by this pool,
+    // where `SHOW statement_timeout` returns the server default with the option set, with the
+    // PostgreSQL startup parameter `options=-c statement_timeout=...`, and with both.
+    //
+    // A session `SET` is the only mechanism that works, and it cannot be used from here: the pooler
+    // hands the same physical backend to unrelated clients without resetting session state, so a cap
+    // meant for a page request leaks onto the batch jobs that legitimately run for minutes.
+    // docs/engineering/db-statement-timeout.md records the measurements and the dedicated-role path.
   });
   globalForPrisma.pool = pool;
 


### PR DESCRIPTION
## Le problème

`src/lib/db.ts` déclarait `statement_timeout: 30_000` avec le commentaire « Kill queries after 30s
to prevent pool starvation ». Cette protection n'existe pas.

Mesuré sur la production le 2026-09-10, depuis des sessions ouvertes par ce pool :

| Mécanisme | Effet sur `SHOW statement_timeout` |
|---|---|
| `statement_timeout` en config `pg.Pool` | aucun, le défaut serveur tient |
| paramètre de démarrage `options=-c statement_timeout=...` | aucun |
| les deux ensemble | aucun |
| `SET statement_timeout` en session | appliqué |

Le défaut serveur est de **2 minutes**, pas 30 s. Une requête qui dérape tient donc un des deux
créneaux du pool (`max: 2`) pendant deux minutes, ce qui est la forme derrière les
`timeout exceeded when trying to connect` de POLIGRAPH-V et POLIGRAPH-1C.

## Pourquoi on ne peut pas simplement faire un SET

Un hook `on('connect')` fonctionne techniquement, `pg` sérialisant la file du client, et je l'avais
écrit avant de le jeter. Mais le pooler réutilise les mêmes backends physiques entre clients sans
réinitialiser l'état de session : un pool pose une valeur distinctive, se déconnecte, et un pool
neuf la relit sur le même backend. Trente connexions successives depuis des pools distincts
atterrissent sur un seul backend.

Un plafond posé pour une requête de page fuirait donc vers les jobs de `src/services/sync/` qui ont
légitimement besoin de minutes. Le correctif qui « marche » est nuisible.

## Cette PR

Retire l'option morte, remplace le commentaire par ce qui a été mesuré, et ajoute un garde qui
échoue si l'option revient. Aucun changement de comportement : l'option n'avait aucun effet.

`docs/engineering/db-statement-timeout.md` consigne les mesures et décrit le chemin qui
fonctionnerait, un rôle Postgres dédié au chemin requête portant son propre `statement_timeout`, les
jobs restant sur le rôle actuel. Le cap vit alors sur le serveur, là où le pooler ne peut ni le
dépouiller ni le faire fuir.

## Note d'hygiène, apprise à mes dépens

Une sonde qui fait `SET` sur cette base pollue une session partagée qui sert la production. La
mienne a laissé un plafond de 17 s sur un backend dont la requête précédente était un
`SELECT "FeatureFlag"` du site. Remis par `RESET` et vérifié depuis des connexions neuves. Le
document le note comme règle.

## Vérifications

- `npx vitest run` : 6002 tests passés
- `tsc --noEmit`, `eslint`, `prettier` propres
- Le garde a d'abord été faussement vert (le cache `globalThis` de `db.ts` faisait que seul le
  premier import construisait un pool, les suivants assertaient sur un objet vide). Le harnais vide
  ce cache et échoue s'il ne capture aucun pool.

Ref POLIGRAPH-V