### PR TITLE
Retirer compute-stats du pipeline Inngest

### DIFF
--- a/src/__tests__/architecture/compute-stats-single-owner.test.ts
+++ b/src/__tests__/architecture/compute-stats-single-owner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * `computeStats()` must run once per cycle, from GitHub Actions.
+ *
+ * Both daily pipelines fire on the same `0 5,11,19` schedule, and both used to call it: the
+ * workflow through `scripts/compute-stats.ts`, and the Inngest function inside the Next runtime.
+ * Its first step is the heaviest query in the codebase, averaging 54 s against a two minute server
+ * timeout, so the Inngest copy held one of the two pool slots of a lambda that also serves page
+ * requests. The workflow copy is also the sturdier one: two retries with a backoff, added for the
+ * transient Supabase drops of #442.
+ *
+ * Keeping it out of the Next runtime is what makes a capped role viable for the request path, see
+ * docs/engineering/db-statement-timeout.md.
+ */
+
+/** Drop block and line comments so the predicates below read code, not prose. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+const inngestPipeline = stripComments(readFileSync("src/inngest/functions/sync-daily.ts", "utf8"));
+const workflowPipeline = stripComments(readFileSync("scripts/sync-daily.ts", "utf8"));
+
+describe("computeStats n'a qu'un seul propriétaire", () => {
+  it("lit bien les deux pipelines", () => {
+    // Guards the reads: an empty source would make every assertion below vacuously true.
+    expect(inngestPipeline).toContain("compute-municipales-snapshots");
+    expect(workflowPipeline).toContain("scripts/compute-stats.ts");
+  });
+
+  it("le pipeline Inngest n'appelle plus computeStats", () => {
+    expect(inngestPipeline).not.toContain("computeStats");
+    expect(inngestPipeline).not.toContain("compute-stats");
+  });
+
+  it("le workflow GitHub Actions le lance toujours", () => {
+    // The complement matters as much as the removal: dropping it here too would silently stop
+    // producing PoliticianParticipation and StatsSnapshot rows.
+    expect(workflowPipeline).toContain("scripts/compute-stats.ts");
+  });
+
+  it("laisse les snapshots municipales à Inngest, qui en est le seul propriétaire", () => {
+    // They exist nowhere else, so they must stay, and their queries average ten seconds or less.
+    expect(inngestPipeline).toContain("computeMunicipalesSnapshots");
+    expect(workflowPipeline).not.toContain("municipales-snapshots");
+  });
+});

--- a/src/__tests__/architecture/compute-stats-single-owner.test.ts
+++ b/src/__tests__/architecture/compute-stats-single-owner.test.ts
@@ -21,13 +21,17 @@ function stripComments(source: string): string {
 }
 
 const inngestPipeline = stripComments(readFileSync("src/inngest/functions/sync-daily.ts", "utf8"));
-const workflowPipeline = stripComments(readFileSync("scripts/sync-daily.ts", "utf8"));
+const dailyScript = stripComments(readFileSync("scripts/sync-daily.ts", "utf8"));
+const workflow = readFileSync(".github/workflows/sync-daily.yml", "utf8");
+const packageJson = readFileSync("package.json", "utf8");
 
 describe("computeStats n'a qu'un seul propriétaire", () => {
-  it("lit bien les deux pipelines", () => {
+  it("lit bien les quatre sources", () => {
     // Guards the reads: an empty source would make every assertion below vacuously true.
     expect(inngestPipeline).toContain("compute-municipales-snapshots");
-    expect(workflowPipeline).toContain("scripts/compute-stats.ts");
+    expect(dailyScript).toContain("scripts/compute-stats.ts");
+    expect(workflow).toContain("Daily Sync");
+    expect(packageJson).toContain('"sync:daily"');
   });
 
   it("le pipeline Inngest n'appelle plus computeStats", () => {
@@ -35,15 +39,20 @@ describe("computeStats n'a qu'un seul propriétaire", () => {
     expect(inngestPipeline).not.toContain("compute-stats");
   });
 
-  it("le workflow GitHub Actions le lance toujours", () => {
-    // The complement matters as much as the removal: dropping it here too would silently stop
-    // producing PoliticianParticipation and StatsSnapshot rows.
-    expect(workflowPipeline).toContain("scripts/compute-stats.ts");
+  it("la chaîne GitHub Actions le lance toujours, de bout en bout", () => {
+    // The complement matters as much as the removal: losing it here too would silently stop
+    // producing PoliticianParticipation and StatsSnapshot rows. Asserting on the script alone left
+    // the first link unchecked, so the workflow could drop the call and this guard stay green.
+    expect(workflow).toMatch(/run:\s*npm run sync:daily/);
+    expect(workflow).toMatch(/schedule:/);
+    expect(packageJson).toMatch(/"sync:daily":\s*"tsx scripts\/sync-daily\.ts"/);
+    expect(dailyScript).toContain("scripts/compute-stats.ts");
+    expect(packageJson).toMatch(/"sync:compute-stats":\s*"tsx scripts\/compute-stats\.ts"/);
   });
 
   it("laisse les snapshots municipales à Inngest, qui en est le seul propriétaire", () => {
     // They exist nowhere else, so they must stay, and their queries average ten seconds or less.
     expect(inngestPipeline).toContain("computeMunicipalesSnapshots");
-    expect(workflowPipeline).not.toContain("municipales-snapshots");
+    expect(dailyScript).not.toContain("municipales-snapshots");
   });
 });

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -368,13 +368,12 @@ const DAILY_STEPS: DailyStep[] = [
       return assignPublicationStatus();
     },
   },
-  {
-    name: "compute-stats",
-    run: async () => {
-      const { computeStats } = await import("@/services/sync/compute-stats");
-      return computeStats();
-    },
-  },
+  // computeStats() is deliberately absent. The GitHub Actions daily sync runs it on the same
+  // schedule through scripts/compute-stats.ts, with two retries and a backoff for the transient
+  // Supabase drops of #442, so running it here only duplicated the work. Its first step is the
+  // heaviest query in the codebase, averaging 54 s, and it held one of the two pool slots of a
+  // lambda that also serves page requests. src/__tests__/architecture/compute-stats-single-owner.test.ts
+  // fails if it comes back, or if the workflow stops running it.
   {
     name: "compute-municipales-snapshots",
     run: async () => {


### PR DESCRIPTION
## Le doublon

Deux pipelines quotidiens tirent sur le cron `0 5,11,19` et appelaient tous les deux le **même**
`computeStats()` :

| Pipeline | Chemin | Robustesse |
|---|---|---|
| GitHub Actions (`sync-daily.yml`) | `scripts/compute-stats.ts` | 2 retries + backoff, ajoutés pour les coupures Supabase de #442 |
| Inngest (`src/inngest/functions/sync-daily.ts`) | `computeStats()` direct | aucune |

Vérifié : les deux passent par `@/services/sync/compute-stats`, donc retirer la copie Inngest ne
perd aucune donnée, et laisse la version la plus solide des deux.

## Pourquoi ça compte au-delà du doublon

La première étape de `computeStats()` est la requête la plus lourde du dépôt. Mesuré dans
`pg_stat_statements` : **54 s de moyenne**, 78 s de pic, sur 182 appels, contre un
`statement_timeout` serveur de deux minutes. Le commentaire du code l'annonce à « ~20s ».

Comme Inngest est servi par Next, cette requête tournait dans une lambda et tenait un des deux
créneaux de `max: 2`, celui-là même que les requêtes de page attendent. C'est la forme derrière les
`timeout exceeded when trying to connect` de POLIGRAPH-V et POLIGRAPH-1C.

Et c'est le prérequis du chantier suivant : tant que cette requête tourne dans le runtime Next, on
ne peut pas plafonner le rôle Postgres du chemin requête sans la casser. Avec elle partie, la plus
lourde qui reste côté Next est celle des snapshots municipales, à 10,4 s de moyenne, largement sous
un plafond raisonnable. Voir `docs/engineering/db-statement-timeout.md`.

## Le garde

`src/__tests__/architecture/compute-stats-single-owner.test.ts` échoue si l'étape revient dans
Inngest **et** si le workflow cesse de la lancer. Le second volet compte autant que le premier :
supprimer aussi la version GitHub Actions arrêterait silencieusement de produire les lignes
`PoliticianParticipation` et `StatsSnapshot`.

Il vérifie également que les snapshots municipales restent chez Inngest, qui en est le seul
propriétaire (elles n'existent pas dans le workflow).

## Ce que cette PR ne fait pas

Les deux pipelines se recouvrent sur une dizaine d'autres étapes (scrutins AN et Sénat, législation,
presse RSS, réconciliation d'affaires, fact-checks, classification thématique, embeddings) et tirent
aux mêmes heures. Je n'ai traité que `compute-stats`, la seule qui bloquait le chantier du rôle
plafonné. Le reste est un sujet à part, à instruire avant de toucher quoi que ce soit.

## Vérifications

- `npx vitest run` : 6006 tests passés
- `tsc --noEmit`, `eslint`, `prettier` propres (les 3 avertissements `no-console` du fichier sont
  préexistants et hors du diff)

Ref POLIGRAPH-V