### PR TITLE
seo: noindex /_next/static assets without blocking crawl

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 import { SITE_URL, SITE_HOSTNAME } from "./src/config/site";
 import { OG_IMAGE_NOINDEX_HEADERS } from "./src/lib/seo/og-image-robots";
 import { API_NOINDEX_HEADERS } from "./src/lib/seo/api-robots";
+import { NEXT_STATIC_NOINDEX_HEADERS } from "./src/lib/seo/next-static-robots";
 import { buildSecurityHeaders } from "./src/lib/security-headers";
 
 const LEGACY_STATS_REDIRECTS = [
@@ -89,6 +90,11 @@ const nextConfig: NextConfig = {
       // Same reasoning for /api: machine endpoints, publicly fetchable, never a
       // search result. The human docs at /docs/api stay indexable.
       ...API_NOINDEX_HEADERS,
+      // SEO: keep /_next/static/* build assets crawlable (Googlebot needs them to
+      // render pages) but out of the index — same X-Robots-Tag pattern as the two
+      // rules above. Does not touch Next's own immutable Cache-Control on these
+      // files: different header key, so both are sent together.
+      ...NEXT_STATIC_NOINDEX_HEADERS,
     ];
   },
   async redirects() {

--- a/src/lib/seo/__tests__/indexation-doctrine.test.ts
+++ b/src/lib/seo/__tests__/indexation-doctrine.test.ts
@@ -13,6 +13,7 @@ import { voteDateArchiveRobotsMetadata } from "../parliament-robots";
 import { scrutinRobotsMetadata, type ScrutinIndexSignals } from "../scrutin-robots";
 import { OG_IMAGE_ROBOTS_SOURCE } from "../og-image-robots";
 import { API_NOINDEX_HEADERS, API_ROBOTS_SOURCE } from "../api-robots";
+import { NEXT_STATIC_NOINDEX_HEADERS, NEXT_STATIC_ROBOTS_SOURCE } from "../next-static-robots";
 import {
   AFFAIRES_LISTING_FILTER_KEYS,
   POLITIQUES_LISTING_FILTER_KEYS,
@@ -447,6 +448,47 @@ describe("doctrine — /api endpoints stay noindexed", () => {
   // The human-readable API documentation is a real page and must stay indexable.
   it.each(["/docs/api", "/statistiques"])("leaves real page %s indexable", (path) => {
     expect(re.test(path)).toBe(false);
+  });
+});
+
+describe("doctrine — /_next/static build assets stay noindexed but crawlable", () => {
+  const require = createRequire(import.meta.url);
+  const { pathToRegexp } = require("next/dist/compiled/path-to-regexp") as {
+    pathToRegexp: (path: string, keys?: unknown[], opts?: Record<string, unknown>) => RegExp;
+  };
+  const re = pathToRegexp(NEXT_STATIC_ROBOTS_SOURCE, [], {
+    delimiter: "/",
+    sensitive: false,
+    strict: false,
+  });
+
+  it("tags every rule with X-Robots-Tag: noindex", () => {
+    expect(NEXT_STATIC_NOINDEX_HEADERS.length).toBeGreaterThan(0);
+    for (const rule of NEXT_STATIC_NOINDEX_HEADERS) {
+      expect(rule.headers).toContainEqual({ key: "X-Robots-Tag", value: "noindex" });
+    }
+  });
+
+  it("noindexes static build chunks", () => {
+    expect(re.test("/_next/static/chunks/main-abc123.js")).toBe(true);
+  });
+
+  // robots.txt must never Disallow this prefix: Googlebot needs the CSS/JS to render
+  // the page it is about to score, so the noindex header above is deliberately the
+  // only lever here (see next-static-robots.ts).
+  it("stays outside every robots.txt Disallow group", async () => {
+    const robots = (await import("../../../app/robots")).default();
+    const rules = Array.isArray(robots.rules) ? robots.rules : robots.rules ? [robots.rules] : [];
+    for (const rule of rules) {
+      const disallow = Array.isArray(rule.disallow)
+        ? rule.disallow
+        : rule.disallow
+          ? [rule.disallow]
+          : [];
+      for (const pattern of disallow) {
+        expect(pattern.startsWith("/_next/")).toBe(false);
+      }
+    }
   });
 });
 

--- a/src/lib/seo/__tests__/next-static-robots.test.ts
+++ b/src/lib/seo/__tests__/next-static-robots.test.ts
@@ -1,0 +1,42 @@
+import { createRequire } from "node:module";
+import { describe, it, expect } from "vitest";
+import { NEXT_STATIC_NOINDEX_HEADERS, NEXT_STATIC_ROBOTS_SOURCE } from "../next-static-robots";
+
+// Compile the header `source` with the exact matcher Next uses for custom routes, so
+// the test reflects real production matching rather than a hand-rolled approximation.
+const require = createRequire(import.meta.url);
+const { pathToRegexp } = require("next/dist/compiled/path-to-regexp") as {
+  pathToRegexp: (path: string, keys?: unknown[], opts?: Record<string, unknown>) => RegExp;
+};
+const source = pathToRegexp(NEXT_STATIC_ROBOTS_SOURCE, [], {
+  delimiter: "/",
+  sensitive: false,
+  strict: false,
+});
+
+describe("/_next/static noindex header", () => {
+  it("tags every rule with X-Robots-Tag: noindex", () => {
+    expect(NEXT_STATIC_NOINDEX_HEADERS.length).toBeGreaterThan(0);
+    for (const rule of NEXT_STATIC_NOINDEX_HEADERS) {
+      expect(rule.headers).toContainEqual({ key: "X-Robots-Tag", value: "noindex" });
+    }
+  });
+
+  it.each([
+    "/_next/static/chunks/main-abc123.js",
+    "/_next/static/css/app-def456.css",
+    "/_next/static/media/font-ghi789.woff2",
+    "/_next/static/AbCdEfGhIjKlMnOpQrStU/_buildManifest.js",
+  ])("noindexes static asset path %s", (path) => {
+    expect(source.test(path)).toBe(true);
+  });
+
+  // Real pages, and the sibling /_next/image and /_next/data routes, must stay
+  // untouched: only the immutable, hashed build output under /_next/static/ is thin.
+  it.each(["/parlement/votes", "/_next/image", "/_next/data/build-id/politiques.json"])(
+    "leaves %s indexable",
+    (path) => {
+      expect(source.test(path)).toBe(false);
+    }
+  );
+});

--- a/src/lib/seo/next-static-robots.ts
+++ b/src/lib/seo/next-static-robots.ts
@@ -1,0 +1,28 @@
+/**
+ * `/_next/static/*` (JS/CSS chunks, fonts, build manifests) gets crawled like any other
+ * linked URL and Search Console files ~6.8K of them under "Explorée, actuellement non
+ * indexée". They are build artefacts, not pages, and must never compete with real
+ * content in the index.
+ *
+ * `X-Robots-Tag: noindex` is the right tool, not a robots.txt `Disallow`: Googlebot must
+ * keep fetching these assets to render the page (CSS/JS drive the rendered DOM Google
+ * scores), so blocking the crawl would break rendering. noindex only tells the indexer
+ * to drop the URL itself; it has no effect on whether the asset is fetched or on the
+ * `Cache-Control: public, max-age=31536000, immutable` header Next.js already sets on
+ * these files (different header key, so both apply).
+ */
+
+// Structural subset of Next's custom-route Header type, mirroring og-image-robots.
+type NextHeaderRule = {
+  source: string;
+  headers: Array<{ key: string; value: string }>;
+};
+
+export const NEXT_STATIC_ROBOTS_SOURCE = "/_next/static/:path*";
+
+export const NEXT_STATIC_NOINDEX_HEADERS: NextHeaderRule[] = [
+  {
+    source: NEXT_STATIC_ROBOTS_SOURCE,
+    headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+  },
+];


### PR DESCRIPTION
## Description

~6 800 URLs `/_next/static/*` apparaissent dans Search Console sous « Explorée, actuellement non indexée ». Diagnostic préalable :

- `src/app/robots.ts` ne bloquait déjà pas `/_next/` (aucun `Disallow`) : rien à retirer, et il ne faut surtout pas en ajouter, Googlebot a besoin de charger le CSS/JS pour rendre la page.
- Aucun sitemap (`src/app/sitemap.ts`) ne référence d'URL `/_next/static` : rien à en exclure.

Le seul levier nécessaire est un en-tête `X-Robots-Tag: noindex`, scopé à `/_next/static/:path*` via `headers()` dans `next.config.ts` — même pattern déjà en place pour `opengraph-image` (`OG_IMAGE_NOINDEX_HEADERS`) et `/api` (`API_NOINDEX_HEADERS`).

`X-Robots-Tag` est une clé d'en-tête distincte de `Cache-Control` : l'immutable posé nativement par Next.js (`^16.3.0`) sur ces assets n'est ni écrasé ni en conflit, les deux en-têtes sont envoyés ensemble.

## Type de changement

- [x] Bug fix (SEO : sortir ces URLs du bucket "explorée, non indexée")
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Autre : \_\_\_

## Issue liée

Fixes #

## Checklist

- [x] Le code suit les conventions du projet (réutilise le pattern `og-image-robots.ts` / `api-robots.ts`)
- [x] `npm run lint` passe sans erreur
- [x] `npx tsc --noEmit` passe sans erreur
- [x] Les changements sont testés (nouveau `next-static-robots.test.ts` + section doctrine ajoutée dans `indexation-doctrine.test.ts`, 100/100 tests SEO passent)
- [ ] La documentation est mise à jour (si nécessaire) — non applicable, pas de doc à jour
- [x] Pas de données sensibles dans le code

## Comment vérifier

```bash
curl -sI https://poligraph.fr/_next/static/chunks/<un-fichier-reel>.js | grep -i -E "x-robots-tag|cache-control"
```
Les deux en-têtes doivent apparaître : `x-robots-tag: noindex` et `cache-control: ... immutable`.

Ensuite, dans Search Console → Inspection d'URL sur une URL `/_next/static/...`, relancer un test live : elle doit passer en « Explorée, actuellement non indexée » → « Exclue par la balise noindex » après un nouveau crawl.

## Diff

- `next.config.ts` : import + entrée `NEXT_STATIC_NOINDEX_HEADERS` dans `headers()`, commentée.
- `src/lib/seo/next-static-robots.ts` (nouveau) : la constante et son commentaire d'intention SEO.
- `src/lib/seo/__tests__/next-static-robots.test.ts` (nouveau) + section ajoutée dans `indexation-doctrine.test.ts` : couvrent le matching du pattern et vérifient que `robots.ts` ne bloque jamais `/_next/`.
