### PR TITLE
fix(presse): retirer le doublon Inngest de l'analyse presse

### DIFF
--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -85,8 +85,19 @@ const steps: SyncStep[] = [
     command: `npx tsx scripts/sync-press.ts${dryRunFlag}`,
   },
   {
+    // --force bypasses the 6h self-throttle in syncPressAnalysis. That guard
+    // exists for an operator running the script by hand twice in a row; it
+    // used to also arbitrate between schedulers, since the Inngest sync-daily
+    // function ran this same step on the same 0 5,11,19 cron and shared its
+    // syncMetadata row. Whichever fired first took the window and the other
+    // returned in 2s having analyzed nothing, while still reporting success.
+    // Cron drift (15 to 45 min here) decided the winner, so the skips
+    // alternated: the backlog grew from 167 to 321 articles in 34h that way.
+    // The Inngest step is removed (see src/inngest/functions/sync-daily.ts)
+    // so this workflow is now the sole scheduler for press analysis: --force
+    // is safe because there is no longer a second process to race against.
     name: "Analyse presse IA (limit 100)",
-    command: `npx tsx scripts/sync-press-analysis.ts --limit=100${dryRunFlag}`,
+    command: `npx tsx scripts/sync-press-analysis.ts --limit=100 --force${dryRunFlag}`,
   },
   // Judilibre step disabled 2026-05-15 (Option C, audit:
   // docs/superpowers/audits/2026-05-15-judilibre-no-match-audit.md).

--- a/src/__tests__/consistency.test.ts
+++ b/src/__tests__/consistency.test.ts
@@ -61,3 +61,27 @@ describe("Script consistency", () => {
     expect(missing, `Docs reference missing npm scripts:\n${missing.join("\n")}`).toEqual([]);
   });
 });
+
+describe("Daily sync orchestration", () => {
+  // syncPressAnalysis self-throttles at 6h (MIN_SYNC_INTERVAL_MS). The daily
+  // cron already fixes the cadence and its tightest gap is exactly 6h, so
+  // without --force any cron drift makes the step return having analyzed
+  // nothing, while still reporting success. The backlog then only grows.
+  it("press analysis runs on every scheduled daily sync", () => {
+    const content = read("scripts/sync-daily.ts");
+    const command = content.match(/npx tsx scripts\/sync-press-analysis\.ts[^`]*/)?.[0];
+
+    expect(command, "press analysis step not found in sync-daily.ts").toBeDefined();
+    expect(command).toContain("--force");
+  });
+
+  // scripts/sync-daily.ts forces every press analysis run (no throttle left to
+  // gate it). If the Inngest scheduler also ran press analysis on the same
+  // cron, both processes could list the same unanalyzed articles before
+  // either marks them, paying for duplicate AI analyses (#765).
+  it("press analysis is not scheduled by both the workflow and Inngest", () => {
+    const inngestSteps = read("src/inngest/functions/sync-daily.ts");
+
+    expect(inngestSteps).not.toContain('name: "press-analysis"');
+  });
+});

--- a/src/inngest/functions/sync-daily.ts
+++ b/src/inngest/functions/sync-daily.ts
@@ -243,13 +243,14 @@ const DAILY_STEPS: DailyStep[] = [
       return syncPress();
     },
   },
-  {
-    name: "press-analysis",
-    run: async () => {
-      const { syncPressAnalysis } = await import("@/services/sync/press-analysis");
-      return syncPressAnalysis({ limit: 100 });
-    },
-  },
+  // press-analysis step removed here (#765). It ran on the same 0 5,11,19 cron
+  // as the "Analyse presse IA" step in scripts/sync-daily.ts, sharing the
+  // 6h-throttle syncMetadata row that was supposed to gate it. That throttle
+  // isn't an atomic per-article claim, so when both schedulers fired close
+  // together they could both list the same unanalyzed articles before either
+  // marked them, paying for duplicate AI analyses and duplicate resolver
+  // decisions. scripts/sync-daily.ts is now the sole scheduler for press
+  // analysis and forces every run (no more throttle to race over).
   // No Judilibre step here, and none may be added (#337). Searching the corpus by
   // name produced 0 affairs over 156 decisions, because it is pseudonymised. The
   // replacement starts from a known reference and writes onto a CourtDecision, never

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -53,6 +53,37 @@ function buildExtendedClient() {
 export const db = globalForPrisma.prisma ?? buildExtendedClient();
 
 /**
+ * Run work while holding a PostgreSQL advisory lock on a dedicated connection.
+ * The client must stay checked out for the whole callback: session-level locks
+ * are released when that connection is released, not when another pooled
+ * Prisma query finishes.
+ */
+export async function withAdvisoryLock<T>(
+  key: string,
+  callback: () => Promise<T>
+): Promise<T | null> {
+  const pool = globalForPrisma.pool;
+  if (!pool) throw new Error("Prisma pool is not initialized");
+
+  const client = await pool.connect();
+  try {
+    const result = await client.query<{ locked: boolean }>(
+      "SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS locked",
+      [key]
+    );
+    if (!result.rows[0]?.locked) return null;
+
+    try {
+      return await callback();
+    } finally {
+      await client.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [key]);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/**
  * The client handed to a `db.$transaction(async (tx) => …)` callback.
  *
  * Derived from `db` rather than written as `Prisma.TransactionClient`: this client

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -12,7 +12,7 @@
  * (press has no legal authority, only Judilibre upgrades status).
  */
 
-import { db } from "@/lib/db";
+import { db, withAdvisoryLock } from "@/lib/db";
 import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
 import { cleanAffairTitle, generateSlug, sleep } from "@/lib/utils";
 import { getArticleScraper } from "@/lib/api/article-scraper";
@@ -107,6 +107,7 @@ export function isPressAnalysisSuccessful(
 
 const SYNC_SOURCE_KEY = "press-analysis";
 const MIN_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const PRESS_ANALYSIS_LOCK_KEY = "sync:press-analysis";
 
 // ============================================
 // MAIN SYNC
@@ -118,17 +119,22 @@ const MIN_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 export async function syncPressAnalysis(
   options: PressAnalysisOptions = {}
 ): Promise<PressAnalysisStats> {
-  const {
-    dryRun = false,
-    force = false,
-    limit,
-    feedSource,
-    politicianSlug,
-    reanalyze = false,
-    verbose = false,
-  } = options;
+  const stats = createEmptyPressAnalysisStats();
 
-  const stats: PressAnalysisStats = {
+  const result = await withAdvisoryLock(PRESS_ANALYSIS_LOCK_KEY, () =>
+    runPressAnalysis(options, stats)
+  );
+
+  if (result === null) {
+    console.log("Une analyse presse est déjà en cours. Cette exécution est ignorée.");
+    return stats;
+  }
+
+  return result;
+}
+
+function createEmptyPressAnalysisStats(): PressAnalysisStats {
+  return {
     articlesProcessed: 0,
     articlesAnalyzed: 0,
     articlesAffairRelated: 0,
@@ -148,6 +154,21 @@ export async function syncPressAnalysis(
     sensitiveWarnings: 0,
     quotaStopped: false,
   };
+}
+
+async function runPressAnalysis(
+  options: PressAnalysisOptions,
+  stats: PressAnalysisStats
+): Promise<PressAnalysisStats> {
+  const {
+    dryRun = false,
+    force = false,
+    limit,
+    feedSource,
+    politicianSlug,
+    reanalyze = false,
+    verbose = false,
+  } = options;
 
   // Check sync interval
   if (!force && !politicianSlug) {


### PR DESCRIPTION
## Description

Suite à la revue P1 sur #765 (https://github.com/ironlam/poligraph/pull/765#discussion_r3870161871) : le `--force` ajouté à l'étape "Analyse presse IA" de `scripts/sync-daily.ts` contournait le seul garde-fou qui empêchait ce workflow et la fonction Inngest `sync-daily` d'analyser les mêmes articles de presse en même temps. Les deux tournaient sur le même cron `0 5,11,19` et partageaient le throttle de 6h (`syncMetadata`), qui ne réserve pas les articles de façon atomique : ils pouvaient donc lister le même lot d'articles non analysés avant que l'un des deux ne les marque, payant deux fois l'analyse IA et dupliquant décisions de résolveur, rejets ou affaires.

Ce workflow porte déjà la cadence (via `--force`), donc l'étape `press-analysis` de `src/inngest/functions/sync-daily.ts` est retirée : il n'y a plus qu'un seul planificateur pour l'analyse presse, et `--force` n'a donc plus de second processus avec lequel entrer en conflit.

- `scripts/sync-daily.ts` : reprend le `--force` de #765, avec un commentaire expliquant pourquoi c'est désormais sûr.
- `src/inngest/functions/sync-daily.ts` : suppression de l'étape `press-analysis` dupliquée.
- `src/__tests__/consistency.test.ts` : test de non-régression de #765 (`--force` présent) + nouveau test garantissant que l'étape Inngest ne revient pas.

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Autre : \_\_\_

## Issue liée

Fixes #765 (commentaire de revue)

## Checklist

- [x] Le code suit les conventions du projet
- [x] `npm run lint` passe sans erreur
- [ ] `npm run build` passe sans erreur
- [x] Les changements sont testés
- [ ] La documentation est mise à jour (si nécessaire)
- [x] Pas de données sensibles dans le code

