### PR TITLE
Survivre à une séquence de publicId en retard

### DIFF
--- a/src/lib/public-ids/__tests__/collision-retry.test.ts
+++ b/src/lib/public-ids/__tests__/collision-retry.test.ts
@@ -2,11 +2,33 @@ import { describe, it, expect, vi } from "vitest";
 import { Prisma } from "@/generated/prisma";
 import { createWithPublicId, isPublicIdCollision } from "../prisma-extension";
 
+/** Forme sans adaptateur : les colonnes sont dans meta.target. */
 function collisionSur(champ: string) {
   return new Prisma.PrismaClientKnownRequestError("dup", {
     code: "P2002",
     clientVersion: "7",
     meta: { target: [champ] },
+  });
+}
+
+/**
+ * Forme réelle sous PrismaPg, relevée en production : meta.target est absent
+ * et les colonnes arrivent entre guillemets sous driverAdapterError.
+ */
+function collisionAdaptateur(champ: string) {
+  return new Prisma.PrismaClientKnownRequestError("dup", {
+    code: "P2002",
+    clientVersion: "7",
+    meta: {
+      modelName: "Affair",
+      driverAdapterError: {
+        cause: {
+          originalCode: "23505",
+          kind: "UniqueConstraintViolation",
+          constraint: { fields: [`"${champ}"`] },
+        },
+      },
+    },
   });
 }
 
@@ -28,9 +50,30 @@ describe("isPublicIdCollision", () => {
   it("ignore une erreur qui n'est pas une violation d'unicité", () => {
     expect(isPublicIdCollision(new Error("boom"))).toBe(false);
   });
+
+  it("reconnaît la forme de l'adaptateur pg, celle que la prod produit", () => {
+    // meta.target est undefined avec PrismaPg : ne lire que lui rendait la
+    // garde inerte là précisément où elle devait servir.
+    expect(isPublicIdCollision(collisionAdaptateur("publicId"))).toBe(true);
+  });
+
+  it("ignore un autre champ dans la forme de l'adaptateur", () => {
+    expect(isPublicIdCollision(collisionAdaptateur("slug"))).toBe(false);
+  });
 });
 
 describe("createWithPublicId", () => {
+  it("réessaie sur la forme de l'adaptateur, celle de la production", async () => {
+    const query = vi
+      .fn()
+      .mockRejectedValueOnce(collisionAdaptateur("publicId"))
+      .mockResolvedValueOnce({ id: "a1" });
+    const args = { data: {} as { publicId?: string | null } };
+
+    await expect(createWithPublicId(args, query, allocateur(576))).resolves.toEqual({ id: "a1" });
+    expect(args.data.publicId).toBe("AF-000577");
+  });
+
   it("réessaie et franchit une valeur déjà prise", async () => {
     // Vécu : séquence à 575 pour un maximum réel de 576, donc le premier
     // nextval rend une valeur existante. Deux passes de production tuées.

--- a/src/lib/public-ids/__tests__/collision-retry.test.ts
+++ b/src/lib/public-ids/__tests__/collision-retry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { Prisma } from "@/generated/prisma";
+import { createWithPublicId, isPublicIdCollision } from "../prisma-extension";
+
+function collisionSur(champ: string) {
+  return new Prisma.PrismaClientKnownRequestError("dup", {
+    code: "P2002",
+    clientVersion: "7",
+    meta: { target: [champ] },
+  });
+}
+
+/** Alloue en suivant la séquence, comme le fait `nextval`. */
+function allocateur(depart: number) {
+  let n = depart;
+  return async () => `AF-${String(n++).padStart(6, "0")}`;
+}
+
+describe("isPublicIdCollision", () => {
+  it("reconnaît une violation d'unicité sur publicId", () => {
+    expect(isPublicIdCollision(collisionSur("publicId"))).toBe(true);
+  });
+
+  it("ignore une violation sur un autre champ", () => {
+    expect(isPublicIdCollision(collisionSur("slug"))).toBe(false);
+  });
+
+  it("ignore une erreur qui n'est pas une violation d'unicité", () => {
+    expect(isPublicIdCollision(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("createWithPublicId", () => {
+  it("réessaie et franchit une valeur déjà prise", async () => {
+    // Vécu : séquence à 575 pour un maximum réel de 576, donc le premier
+    // nextval rend une valeur existante. Deux passes de production tuées.
+    const query = vi
+      .fn()
+      .mockRejectedValueOnce(collisionSur("publicId"))
+      .mockResolvedValueOnce({ id: "a1" });
+    const args = { data: {} as { publicId?: string | null } };
+
+    await expect(createWithPublicId(args, query, allocateur(576))).resolves.toEqual({ id: "a1" });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(args.data.publicId).toBe("AF-000577");
+  });
+
+  it("laisse remonter une violation sur un autre champ, sans réessayer", async () => {
+    // Un slug en double ne se résout pas en avançant la séquence : réessayer
+    // boucle sur une erreur permanente.
+    const query = vi.fn().mockRejectedValue(collisionSur("slug"));
+
+    await expect(createWithPublicId({ data: {} }, query, allocateur(1))).rejects.toThrow();
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandonne après la série bornée au lieu de boucler", async () => {
+    const query = vi.fn().mockRejectedValue(collisionSur("publicId"));
+
+    await expect(createWithPublicId({ data: {} }, query, allocateur(1), 3)).rejects.toThrow();
+    expect(query).toHaveBeenCalledTimes(4);
+  });
+
+  it("respecte un publicId fourni explicitement, sans allouer", async () => {
+    const query = vi.fn().mockResolvedValue({ id: "a1" });
+    const allocate = vi.fn();
+    const args = { data: { publicId: "AF-000042" } };
+
+    await createWithPublicId(args, query, allocate);
+
+    expect(allocate).not.toHaveBeenCalled();
+    expect(args.data.publicId).toBe("AF-000042");
+  });
+});

--- a/src/lib/public-ids/prisma-extension.ts
+++ b/src/lib/public-ids/prisma-extension.ts
@@ -17,6 +17,62 @@ import { Prisma, type PrismaClient } from "@/generated/prisma";
  * The factory takes the raw (unextended) client so the hooks can call
  * `$queryRaw` without recursing back through the extension.
  */
+/**
+ * Combien de valeurs déjà prises la séquence peut franchir avant d'abandonner.
+ *
+ * Une séquence peut se retrouver derrière les identifiants réellement
+ * attribués : un backfill qui écrit `MAX + 1` sans appeler `setval`, une
+ * restauration, un import. `nextval` rend alors une valeur existante et la
+ * création échoue sur la contrainte d'unicité.
+ *
+ * Sans repli, ça a tué deux passes de production : l'import des maires
+ * d'arrondissement (une fiche perdue) puis un balayage de 1 000 maires, arrêté
+ * net au troisième élu. Chaque tentative avance la séquence, donc réessayer la
+ * fait franchir le trou ; la borne évite de boucler si la collision vient
+ * d'autre chose que du retard de séquence.
+ */
+export const ID_COLLISION_RETRIES = 5;
+
+/** Une violation d'unicité qui porte précisément sur `publicId`. */
+export function isPublicIdCollision(error: unknown): boolean {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError)) return false;
+  if (error.code !== "P2002") return false;
+  const target = error.meta?.target;
+  const fields = Array.isArray(target) ? target.map(String) : [String(target ?? "")];
+  return fields.some((field) => field.includes("publicId"));
+}
+
+/**
+ * Crée en réallouant l'identifiant tant qu'il tombe sur une valeur prise.
+ *
+ * Ne rattrape QUE la collision sur `publicId` : toute autre violation
+ * d'unicité, un slug en double par exemple, doit remonter telle quelle, sinon
+ * on boucle sur une erreur qui ne se résoudra jamais.
+ *
+ * Exporté pour être testable : `defineExtension` rend une fonction qui attend
+ * un client, donc les hooks ne sont pas atteignables depuis un test.
+ */
+export async function createWithPublicId<A extends { data: { publicId?: string | null } }, R>(
+  args: A,
+  query: (args: A) => Promise<R>,
+  allocate: () => Promise<string>,
+  retries = ID_COLLISION_RETRIES
+): Promise<R> {
+  if (args.data.publicId) return query(args);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    args.data.publicId = await allocate();
+    try {
+      return await query(args);
+    } catch (error) {
+      if (!isPublicIdCollision(error)) throw error;
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 export function createPoligraphIdExtension(rawClient: PrismaClient) {
   async function allocate(sequenceSql: Prisma.Sql, prefix: string): Promise<string> {
     const rows = await rawClient.$queryRaw<{ nextval: bigint }[]>(sequenceSql);
@@ -32,112 +88,72 @@ export function createPoligraphIdExtension(rawClient: PrismaClient) {
     query: {
       politician: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_politician_seq') AS nextval`,
-              "PG"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_politician_seq') AS nextval`, "PG")
+          );
         },
       },
       affair: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_affair_seq') AS nextval`,
-              "AF"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_affair_seq') AS nextval`, "AF")
+          );
         },
       },
       factCheck: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_factcheck_seq') AS nextval`,
-              "FC"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_factcheck_seq') AS nextval`, "FC")
+          );
         },
       },
       scrutin: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_scrutin_seq') AS nextval`,
-              "SC"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_scrutin_seq') AS nextval`, "SC")
+          );
         },
       },
       party: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_party_seq') AS nextval`,
-              "PT"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_party_seq') AS nextval`, "PT")
+          );
         },
       },
       election: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_election_seq') AS nextval`,
-              "EL"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_election_seq') AS nextval`, "EL")
+          );
         },
       },
       mandate: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_mandate_seq') AS nextval`,
-              "MA"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_mandate_seq') AS nextval`, "MA")
+          );
         },
       },
       legislativeDossier: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_dossier_seq') AS nextval`,
-              "DO"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_dossier_seq') AS nextval`, "DO")
+          );
         },
       },
       parliamentaryGroup: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_group_seq') AS nextval`,
-              "GP"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_group_seq') AS nextval`, "GP")
+          );
         },
       },
       electoralList: {
         async create({ args, query }) {
-          if (!args.data.publicId) {
-            args.data.publicId = await allocate(
-              Prisma.sql`SELECT nextval('poligraph_electoral_list_seq') AS nextval`,
-              "LM"
-            );
-          }
-          return query(args);
+          return createWithPublicId(args, query, () =>
+            allocate(Prisma.sql`SELECT nextval('poligraph_electoral_list_seq') AS nextval`, "LM")
+          );
         },
       },
     },

--- a/src/lib/public-ids/prisma-extension.ts
+++ b/src/lib/public-ids/prisma-extension.ts
@@ -33,13 +33,36 @@ import { Prisma, type PrismaClient } from "@/generated/prisma";
  */
 export const ID_COLLISION_RETRIES = 5;
 
+/**
+ * Les colonnes en conflit d'une P2002, quelle que soit la forme du message.
+ *
+ * Deux formes coexistent, et le projet reçoit la seconde. Sans adaptateur,
+ * Prisma remplit `meta.target`. Avec `PrismaPg`, que `src/lib/db.ts` configure,
+ * `meta.target` est **undefined** et les colonnes vivent sous
+ * `meta.driverAdapterError.cause.constraint.fields`, entourées de guillemets :
+ * `["\"publicId\""]`. Relevé sur une vraie erreur de production.
+ *
+ * Ne lire que `meta.target` rendait la garde inerte là où elle devait servir.
+ */
+function conflictingFields(error: Prisma.PrismaClientKnownRequestError): string[] {
+  const meta = error.meta as
+    | {
+        target?: unknown;
+        driverAdapterError?: { cause?: { constraint?: { fields?: unknown } } };
+      }
+    | undefined;
+
+  const adapterFields = meta?.driverAdapterError?.cause?.constraint?.fields;
+  const raw = Array.isArray(adapterFields) ? adapterFields : (meta?.target ?? []);
+  const list = Array.isArray(raw) ? raw : [raw];
+  return list.map((field) => String(field).replace(/"/g, ""));
+}
+
 /** Une violation d'unicité qui porte précisément sur `publicId`. */
 export function isPublicIdCollision(error: unknown): boolean {
   if (!(error instanceof Prisma.PrismaClientKnownRequestError)) return false;
   if (error.code !== "P2002") return false;
-  const target = error.meta?.target;
-  const fields = Array.isArray(target) ? target.map(String) : [String(target ?? "")];
-  return fields.some((field) => field.includes("publicId"));
+  return conflictingFields(error).includes("publicId");
 }
 
 /**

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -745,10 +745,9 @@ async function settleCandidates(
     return;
   }
 
-  stats.politiciansWithFinding++;
-  stats.affairsCreated++;
-
   if (dryRun) {
+    stats.politiciansWithFinding++;
+    stats.affairsCreated++;
     console.log(
       [
         "  [DRY-RUN]",
@@ -766,6 +765,10 @@ async function settleCandidates(
   }
 
   await createDraftFromLead(target, group, lead, title);
+  // Comptés après l'écriture : la garde par élu transforme un échec en retour
+  // normal, donc compter avant ferait annoncer une création qui n'a pas eu lieu.
+  stats.politiciansWithFinding++;
+  stats.affairsCreated++;
 }
 
 /**

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -600,7 +600,17 @@ export async function discoverAffairsWeb(options: {
       candidates.push({ result, judgment, publishedAt, status: judgment.judicialStatus });
     }
 
-    await settleCandidates(target, candidates, dryRun, stats);
+    // Un échec sur un élu ne doit pas emporter la passe entière. Vécu : une
+    // collision de publicId sur la troisième création a tué un balayage de
+    // 1 000 maires, après deux élus traités. L'estampille suit quand même, pour
+    // que la rotation avance et ne rejoue pas indéfiniment le même échec.
+    try {
+      await settleCandidates(target, candidates, dryRun, stats);
+    } catch (err) {
+      stats.errors.push(
+        `création ${target.fullName} : ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
 
     // Estampiller même sans trouvaille : c'est ce qui fait avancer la rotation.
     // Sans ça la passe rechercherait indéfiniment les mêmes premiers élus, le


### PR DESCRIPTION
## Ce qui s'est passé

Une passe réelle de découverte web sur 1 000 maires s'est arrêtée **au troisième élu**, sur `Unique constraint failed on the fields: ("publicId")`. Deux politiciens estampillés, zéro affaire créée.

La cause est en base, pas dans la passe :

```
poligraph_affair_seq.last_value = 575
MAX(publicId) réellement utilisé = 576
```

La séquence était derrière les identifiants attribués, donc `nextval` rendait une valeur existante. Dans cet état, **aucune création d'affaire n'était possible**, d'où qu'elle vienne. Une séquence peut se retrouver en retard après un backfill qui écrit `MAX + 1` sans appeler `setval`, une restauration, ou un import.

La séquence a été resynchronisée en production (`setval` sur le maximum réel). Ce correctif porte sur le fait que ça n'aurait pas dû suffire à tout arrêter.

## Deux défauts, deux niveaux

**L'allocateur n'avait aucun repli.** Une collision remontait telle quelle. Ce n'est pas le premier dégât : l'import des maires d'arrondissement avait déjà perdu une fiche de la même façon, signalée à l'époque sans être corrigée. L'allocation réessaie désormais, ce qui fait mécaniquement franchir le trou puisque chaque tentative avance la séquence.

Le réessai est **borné** et ne rattrape **que** `publicId` : une violation d'unicité sur un slug doit remonter, sinon on boucle sur une erreur qui ne se résoudra jamais.

**La boucle de découverte n'avait pas de garde par élu.** `settleCandidates` était appelé hors de tout `try`, si bien qu'un seul échec emportait les 999 élus restants. Chaque élu est maintenant isolé, l'erreur est collectée dans les stats, et l'estampille suit quand même pour que la rotation avance au lieu de rejouer indéfiniment le même échec.

## Vérification

Le helper de réessai a été sorti du closure pour être testable : `Prisma.defineExtension` rend une fonction attendant un client, donc les hooks sont inatteignables depuis un test. Sept tests couvrent le franchissement d'une valeur prise, le refus de réessayer sur un autre champ, la borne, et le respect d'un `publicId` fourni.

Les dix hooks d'entités passent par le même chemin, donc le correctif vaut pour tous les types qui portent un `publicId`, pas seulement les affaires.

Prettier, ESLint et `tsc` à zéro. Suite complète sous `TZ=UTC` : 6 013 tests passés, 0 échec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)