### PR TITLE
Précalculer le compteur de probité présidentiel

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "sync:dossier-summaries:force": "tsx -e \"import {generateDossierSummaries} from './src/services/sync/generate-dossier-summaries'; generateDossierSummaries({limit:20,force:true}).then(console.log)\"",
     "sync:compute-stats": "tsx scripts/compute-stats.ts",
     "sync:municipales-snapshots": "tsx scripts/compute-municipales-snapshots.ts",
+    "sync:presidential-snapshots": "tsx scripts/compute-presidential-snapshots.ts",
     "sync:senat:stats": "tsx scripts/sync-senat.ts --stats",
     "sync:gouvernement:stats": "tsx scripts/sync-gouvernement.ts --stats",
     "sync:wikidata-ids": "tsx scripts/sync-wikidata-ids.ts",

--- a/scripts/compute-presidential-snapshots.ts
+++ b/scripts/compute-presidential-snapshots.ts
@@ -3,17 +3,20 @@
  *
  * Usage:
  *   npm run sync:presidential-snapshots
+ *   npm run sync:presidential-snapshots -- --dry-run
  */
 
 import "dotenv/config";
 import { db } from "@/lib/db";
 import { computePresidentialSnapshots } from "@/services/sync/compute-presidential-snapshots";
 
+const DRY_RUN = process.argv.includes("--dry-run");
+
 async function main() {
-  console.log("Computing presidential snapshots...");
+  console.log(`Computing presidential snapshots${DRY_RUN ? " (DRY RUN)" : ""}...`);
   const t0 = Date.now();
   try {
-    const result = await computePresidentialSnapshots();
+    const result = await computePresidentialSnapshots(undefined, { dryRun: DRY_RUN });
     console.log(`\nDone in ${result.totalDurationMs}ms`);
     console.log(`Computed ${result.computed.length} snapshot(s):`);
     for (const s of result.computed) {

--- a/scripts/compute-presidential-snapshots.ts
+++ b/scripts/compute-presidential-snapshots.ts
@@ -1,0 +1,31 @@
+/**
+ * CLI runner for the presidential snapshot pre-computation.
+ *
+ * Usage:
+ *   npm run sync:presidential-snapshots
+ */
+
+import "dotenv/config";
+import { db } from "@/lib/db";
+import { computePresidentialSnapshots } from "@/services/sync/compute-presidential-snapshots";
+
+async function main() {
+  console.log("Computing presidential snapshots...");
+  const t0 = Date.now();
+  try {
+    const result = await computePresidentialSnapshots();
+    console.log(`\nDone in ${result.totalDurationMs}ms`);
+    console.log(`Computed ${result.computed.length} snapshot(s):`);
+    for (const s of result.computed) {
+      console.log(`  - ${s}`);
+    }
+  } catch (err) {
+    console.error("FAILED:", err);
+    process.exit(1);
+  } finally {
+    await db.$disconnect();
+  }
+  console.log(`\nTotal wall-clock: ${Date.now() - t0}ms`);
+}
+
+main();

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -150,7 +150,7 @@ const steps: SyncStep[] = [
     // 1.2M-row Candidacy table on the request path (POLIGRAPH-1H). Non-blocking: the page falls
     // back to computing it live, so a failure here costs speed, never accuracy.
     name: "Snapshots présidentielle",
-    command: `npx tsx scripts/compute-presidential-snapshots.ts`,
+    command: `npx tsx scripts/compute-presidential-snapshots.ts${dryRunFlag}`,
     allowFailure: true,
   },
   {

--- a/scripts/sync-daily.ts
+++ b/scripts/sync-daily.ts
@@ -146,6 +146,14 @@ const steps: SyncStep[] = [
     retries: 2,
   },
   {
+    // Pre-computes the presidential probity count so /statistiques stops running an EXISTS over the
+    // 1.2M-row Candidacy table on the request path (POLIGRAPH-1H). Non-blocking: the page falls
+    // back to computing it live, so a failure here costs speed, never accuracy.
+    name: "Snapshots présidentielle",
+    command: `npx tsx scripts/compute-presidential-snapshots.ts`,
+    allowFailure: true,
+  },
+  {
     name: "IndexNow",
     command: `npx tsx scripts/submit-indexnow.ts`,
   },

--- a/src/lib/data/__tests__/presidential-stats.test.ts
+++ b/src/lib/data/__tests__/presidential-stats.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   getField: vi.fn(),
   getContext: vi.fn(),
   groupBy: vi.fn(),
+  snapshotFindUnique: vi.fn(),
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
 }));
@@ -19,26 +20,30 @@ vi.mock("@/lib/data/hub", () => ({
 }));
 
 vi.mock("@/lib/db", () => ({
-  db: { affair: { groupBy: mocks.groupBy } },
+  db: {
+    affair: { groupBy: mocks.groupBy },
+    statsSnapshot: { findUnique: (...args: unknown[]) => mocks.snapshotFindUnique(...args) },
+  },
 }));
 
 import { getPresidentialOverviewStats } from "../presidential-stats";
 
-describe("getPresidentialOverviewStats", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.getField.mockResolvedValue([
-      { id: "c1", measureCount: 12 },
-      { id: "c2", measureCount: 0 },
-      { id: "c3", measureCount: 2 },
-    ]);
-    mocks.getContext.mockResolvedValue({
-      verifiedMeasureCount: 14,
-      publishableSubjectPageCount: 5,
-    });
-    mocks.groupBy.mockResolvedValue([{ politicianId: "p1" }, { politicianId: "p3" }]);
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getField.mockResolvedValue([
+    { id: "c1", measureCount: 12 },
+    { id: "c2", measureCount: 0 },
+    { id: "c3", measureCount: 2 },
+  ]);
+  mocks.getContext.mockResolvedValue({
+    verifiedMeasureCount: 14,
+    publishableSubjectPageCount: 5,
   });
+  mocks.groupBy.mockResolvedValue([{ politicianId: "p1" }, { politicianId: "p3" }]);
+  mocks.snapshotFindUnique.mockResolvedValue(null);
+});
 
+describe("getPresidentialOverviewStats", () => {
   it("compte les personnalités, les programmes documentés et les thèmes comparables", async () => {
     await expect(getPresidentialOverviewStats("presidentielle-2027")).resolves.toEqual({
       trackedCandidacyCount: 3,
@@ -73,5 +78,44 @@ describe("getPresidentialOverviewStats", () => {
     mocks.getContext.mockResolvedValue(null);
 
     await expect(getPresidentialOverviewStats("inconnue")).resolves.toBeNull();
+  });
+});
+
+/**
+ * The probity count used to run an EXISTS over the 1.2M-row Candidacy table on the request path,
+ * which Sentry flagged as POLIGRAPH-1H: 0.6 ms warm but 4.5 s on a cold buffer cache. The count is
+ * now pre-computed by the daily sync, and the live computation stays as the fallback so a missing
+ * snapshot degrades speed rather than correctness.
+ */
+describe("compteur de probité pré-calculé", () => {
+  it("lit le snapshot sans interroger Affair", async () => {
+    mocks.snapshotFindUnique.mockResolvedValue({
+      data: { electionSlug: "presidentielle-2027", count: 7 },
+    });
+
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
+
+    expect(stats?.probityCandidateCount).toBe(7);
+    expect(mocks.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("retombe sur le calcul direct quand le snapshot est absent", async () => {
+    mocks.snapshotFindUnique.mockResolvedValue(null);
+
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
+
+    // Two rows in the default groupBy mock, so the fallback must report 2, not 0.
+    expect(stats?.probityCandidateCount).toBe(2);
+    expect(mocks.groupBy).toHaveBeenCalled();
+  });
+
+  it("retombe aussi sur le calcul direct si le snapshot est illisible", async () => {
+    // A row whose JSON drifted must not be served as a silent zero.
+    mocks.snapshotFindUnique.mockResolvedValue({ data: { count: "sept" } });
+
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
+
+    expect(stats?.probityCandidateCount).toBe(2);
+    expect(mocks.groupBy).toHaveBeenCalled();
   });
 });

--- a/src/lib/data/__tests__/presidential-stats.test.ts
+++ b/src/lib/data/__tests__/presidential-stats.test.ts
@@ -91,6 +91,7 @@ describe("compteur de probité pré-calculé", () => {
   it("lit le snapshot sans interroger Affair", async () => {
     mocks.snapshotFindUnique.mockResolvedValue({
       data: { electionSlug: "presidentielle-2027", count: 7 },
+      computedAt: new Date(),
     });
 
     const stats = await getPresidentialOverviewStats("presidentielle-2027");
@@ -115,6 +116,42 @@ describe("compteur de probité pré-calculé", () => {
 
     const stats = await getPresidentialOverviewStats("presidentielle-2027");
 
+    expect(stats?.probityCandidateCount).toBe(2);
+    expect(mocks.groupBy).toHaveBeenCalled();
+  });
+});
+
+describe("fraîcheur du snapshot", () => {
+  it("sert un snapshot récent", async () => {
+    mocks.snapshotFindUnique.mockResolvedValue({
+      data: { electionSlug: "presidentielle-2027", count: 7 },
+      computedAt: new Date(),
+    });
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
+    expect(stats?.probityCandidateCount).toBe(7);
+    expect(mocks.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("refuse un snapshot abandonné et recalcule", async () => {
+    // The daily step is allowFailure, so a broken job leaves the previous row in place. Serving a
+    // months-old conviction count as current would be a false claim, not a slow page.
+    mocks.snapshotFindUnique.mockResolvedValue({
+      data: { electionSlug: "presidentielle-2027", count: 7 },
+      computedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
+    expect(stats?.probityCandidateCount).toBe(2);
+    expect(mocks.groupBy).toHaveBeenCalled();
+  });
+});
+
+describe("snapshot sans horodatage", () => {
+  it("ne fait pas confiance à une ligne sans computedAt", async () => {
+    // Prisma always writes computedAt, so its absence means the row did not come from the job.
+    mocks.snapshotFindUnique.mockResolvedValue({
+      data: { electionSlug: "presidentielle-2027", count: 7 },
+    });
+    const stats = await getPresidentialOverviewStats("presidentielle-2027");
     expect(stats?.probityCandidateCount).toBe(2);
     expect(mocks.groupBy).toHaveBeenCalled();
   });

--- a/src/lib/data/presidential-stats.ts
+++ b/src/lib/data/presidential-stats.ts
@@ -1,10 +1,9 @@
 import "server-only";
 
 import { cacheLife, cacheTag } from "next/cache";
-import { getCategoriesForSuper } from "@/config/labels";
-import { getConvictionOnlyWhere } from "@/lib/affairs/public-filters";
 import { db } from "@/lib/db";
-import { PUBLIC_HUB_CANDIDACY_WHERE } from "@/lib/presidentielle/publication";
+import { computeProbityCandidateCountLive } from "@/services/sync/compute-presidential-snapshots";
+import { ProbityCandidateCountSchema, probityCandidateCountKey } from "@/types/stats-snapshots";
 import { getHubCandidacyField, getHubMeasureContext } from "./hub";
 
 export type PresidentialOverviewStats = {
@@ -35,26 +34,10 @@ export async function getPresidentialOverviewStats(
   // and it was paying that toll every minute. Freshness comes from the tags above, not the timer.
   cacheLife("synced");
 
-  const [field, context, probityCandidates] = await Promise.all([
+  const [field, context, probityCandidateCount] = await Promise.all([
     getHubCandidacyField(electionSlug),
     getHubMeasureContext(electionSlug),
-    db.affair.groupBy({
-      by: ["politicianId"],
-      where: {
-        ...getConvictionOnlyWhere(),
-        category: { in: getCategoriesForSuper("PROBITE") },
-        politician: {
-          is: {
-            candidacies: {
-              some: {
-                election: { slug: electionSlug },
-                ...PUBLIC_HUB_CANDIDACY_WHERE,
-              },
-            },
-          },
-        },
-      },
-    }),
+    readProbityCandidateCount(electionSlug),
   ]);
 
   if (context === null) return null;
@@ -64,6 +47,24 @@ export async function getPresidentialOverviewStats(
     documentedCandidacyCount: field.filter((candidacy) => candidacy.measureCount > 0).length,
     verifiedMeasureCount: context.verifiedMeasureCount,
     comparableThemeCount: context.publishableSubjectPageCount,
-    probityCandidateCount: probityCandidates.length,
+    probityCandidateCount,
   };
+}
+
+/**
+ * The probity count comes from the daily snapshot. Its live form is an EXISTS over the 1.2M-row
+ * Candidacy table, sub-millisecond warm but several seconds on a cold buffer cache, which is what
+ * Sentry flagged as POLIGRAPH-1H on this page.
+ *
+ * A missing or malformed row falls back to computing it, so the number is never silently wrong:
+ * the snapshot buys speed, it is not the authority on the value. The trade-off is freshness, the
+ * count trails a newly published affair until the next daily run.
+ */
+async function readProbityCandidateCount(electionSlug: string): Promise<number> {
+  const snapshot = await db.statsSnapshot.findUnique({
+    where: { key: probityCandidateCountKey(electionSlug) },
+  });
+  const parsed = ProbityCandidateCountSchema.safeParse(snapshot?.data);
+  if (parsed.success) return parsed.data.count;
+  return computeProbityCandidateCountLive(electionSlug);
 }

--- a/src/lib/data/presidential-stats.ts
+++ b/src/lib/data/presidential-stats.ts
@@ -60,11 +60,17 @@ export async function getPresidentialOverviewStats(
  * the snapshot buys speed, it is not the authority on the value. The trade-off is freshness, the
  * count trails a newly published affair until the next daily run.
  */
+const SNAPSHOT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
 async function readProbityCandidateCount(electionSlug: string): Promise<number> {
   const snapshot = await db.statsSnapshot.findUnique({
     where: { key: probityCandidateCountKey(electionSlug) },
   });
   const parsed = ProbityCandidateCountSchema.safeParse(snapshot?.data);
-  if (parsed.success) return parsed.data.count;
+  const age = snapshot ? Date.now() - new Date(snapshot.computedAt).getTime() : Infinity;
+  // The daily step is allowFailure, so a broken job leaves the previous row in place. A few failed
+  // runs are worth absorbing rather than falling back to the slow query; a month of them is not,
+  // because serving a stale conviction count as current is a false claim, not a slow page.
+  if (parsed.success && age <= SNAPSHOT_MAX_AGE_MS) return parsed.data.count;
   return computeProbityCandidateCountLive(electionSlug);
 }

--- a/src/services/sync/__tests__/compute-presidential-snapshots.test.ts
+++ b/src/services/sync/__tests__/compute-presidential-snapshots.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({ groupBy: vi.fn(), upsert: vi.fn() }));
+
+vi.mock("@/lib/db", () => ({
+  db: { affair: { groupBy: mocks.groupBy }, statsSnapshot: { upsert: mocks.upsert } },
+}));
+
+import { computePresidentialSnapshots } from "../compute-presidential-snapshots";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.groupBy.mockResolvedValue([{ politicianId: "p1" }, { politicianId: "p2" }]);
+});
+
+describe("computePresidentialSnapshots", () => {
+  it("écrit le compteur en mode normal", async () => {
+    const result = await computePresidentialSnapshots("presidentielle-2027");
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(result.computed).toHaveLength(1);
+  });
+
+  it("n'écrit rien en dry-run", async () => {
+    // `.env` points at production on this project, so a preview run must not mutate it.
+    const result = await computePresidentialSnapshots("presidentielle-2027", { dryRun: true });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+    expect(result.computed).toHaveLength(1);
+  });
+});

--- a/src/services/sync/compute-presidential-snapshots.ts
+++ b/src/services/sync/compute-presidential-snapshots.ts
@@ -18,8 +18,10 @@ import { probityCandidateCountKey, type ProbityCandidateCount } from "@/types/st
  * Idempotent. Safe to run concurrently, the upsert key prevents duplicates.
  */
 export async function computePresidentialSnapshots(
-  electionSlug = "presidentielle-2027"
+  electionSlug = "presidentielle-2027",
+  options: { dryRun?: boolean } = {}
 ): Promise<{ ok: true; computed: string[]; totalDurationMs: number }> {
+  const { dryRun = false } = options;
   const t0 = Date.now();
   const computed: string[] = [];
 
@@ -29,17 +31,22 @@ export async function computePresidentialSnapshots(
   const durationMs = Date.now() - t1;
 
   const data: ProbityCandidateCount = { electionSlug, count };
-  await db.statsSnapshot.upsert({
-    where: { key },
-    create: { key, data: data as unknown as Prisma.InputJsonValue, durationMs },
-    update: {
-      data: data as unknown as Prisma.InputJsonValue,
-      durationMs,
-      computedAt: new Date(),
-    },
-  });
+  if (dryRun) {
+    // `.env` points at production on this project, so a preview run must not write.
+    console.log(`  [DRY RUN] would upsert ${key} -> ${count} (${durationMs}ms)`);
+  } else {
+    await db.statsSnapshot.upsert({
+      where: { key },
+      create: { key, data: data as unknown as Prisma.InputJsonValue, durationMs },
+      update: {
+        data: data as unknown as Prisma.InputJsonValue,
+        durationMs,
+        computedAt: new Date(),
+      },
+    });
+    console.log(`  [snapshot] ${key} -> ${count} in ${durationMs}ms`);
+  }
   computed.push(`${key} = ${count} (${durationMs}ms)`);
-  console.log(`  [snapshot] ${key} -> ${count} in ${durationMs}ms`);
 
   return { ok: true, computed, totalDurationMs: Date.now() - t0 };
 }

--- a/src/services/sync/compute-presidential-snapshots.ts
+++ b/src/services/sync/compute-presidential-snapshots.ts
@@ -1,0 +1,71 @@
+import { Prisma } from "@/generated/prisma";
+import { getCategoriesForSuper } from "@/config/labels";
+import { db } from "@/lib/db";
+import { getConvictionOnlyWhere } from "@/lib/affairs/public-filters";
+import { PUBLIC_HUB_CANDIDACY_WHERE } from "@/lib/presidentielle/publication";
+import { probityCandidateCountKey, type ProbityCandidateCount } from "@/types/stats-snapshots";
+
+/**
+ * Pre-compute the presidential aggregations that are too heavy for the request path.
+ *
+ * Called by:
+ *   - npm run sync:presidential-snapshots (CLI)
+ *   - the GitHub Actions daily sync (scripts/sync-daily.ts)
+ *
+ * It runs in GitHub Actions rather than Inngest on purpose: Inngest is served by Next, so a heavy
+ * query there holds one of the two connection-pool slots of a lambda that also serves pages.
+ *
+ * Idempotent. Safe to run concurrently, the upsert key prevents duplicates.
+ */
+export async function computePresidentialSnapshots(
+  electionSlug = "presidentielle-2027"
+): Promise<{ ok: true; computed: string[]; totalDurationMs: number }> {
+  const t0 = Date.now();
+  const computed: string[] = [];
+
+  const key = probityCandidateCountKey(electionSlug);
+  const t1 = Date.now();
+  const count = await computeProbityCandidateCountLive(electionSlug);
+  const durationMs = Date.now() - t1;
+
+  const data: ProbityCandidateCount = { electionSlug, count };
+  await db.statsSnapshot.upsert({
+    where: { key },
+    create: { key, data: data as unknown as Prisma.InputJsonValue, durationMs },
+    update: {
+      data: data as unknown as Prisma.InputJsonValue,
+      durationMs,
+      computedAt: new Date(),
+    },
+  });
+  computed.push(`${key} = ${count} (${durationMs}ms)`);
+  console.log(`  [snapshot] ${key} -> ${count} in ${durationMs}ms`);
+
+  return { ok: true, computed, totalDurationMs: Date.now() - t0 };
+}
+
+/**
+ * The live form, kept as the read-time fallback so a missing snapshot costs speed, never accuracy.
+ * The predicate is the single source of truth for both paths: it must stay identical to what the
+ * candidate fiches use, so an investigation or a favourable outcome can never enter the count.
+ */
+export async function computeProbityCandidateCountLive(electionSlug: string): Promise<number> {
+  const rows = await db.affair.groupBy({
+    by: ["politicianId"],
+    where: {
+      ...getConvictionOnlyWhere(),
+      category: { in: getCategoriesForSuper("PROBITE") },
+      politician: {
+        is: {
+          candidacies: {
+            some: {
+              election: { slug: electionSlug },
+              ...PUBLIC_HUB_CANDIDACY_WHERE,
+            },
+          },
+        },
+      },
+    },
+  });
+  return rows.length;
+}

--- a/src/types/stats-snapshots.ts
+++ b/src/types/stats-snapshots.ts
@@ -95,6 +95,25 @@ export const OutgoingSenateCompositionSchema = z.object({
 });
 export type OutgoingSenateComposition = z.infer<typeof OutgoingSenateCompositionSchema>;
 
+// ─── <slug>-probity-candidates ────────────────────────────
+/**
+ * Number of tracked candidates in one presidential election carrying a probity conviction.
+ *
+ * Pre-computed because the live form is an EXISTS over the 1.2M-row Candidacy table, 99 % of which
+ * is municipal data, to answer a question about a few dozen presidential candidacies. Sub-millisecond
+ * warm, several seconds on a cold buffer cache, which is what Sentry flagged as POLIGRAPH-1H.
+ */
+export const ProbityCandidateCountSchema = z.object({
+  electionSlug: z.string(),
+  count: z.number().int().nonnegative(),
+});
+export type ProbityCandidateCount = z.infer<typeof ProbityCandidateCountSchema>;
+
+/** Snapshot key for one election's probity count. */
+export function probityCandidateCountKey(electionSlug: string): string {
+  return `${electionSlug}-probity-candidates`;
+}
+
 // ─── Key registry ─────────────────────────────────────────
 export const MUNICIPALES_SNAPSHOT_KEYS = {
   parityOutliers: "municipales-2026-parite-outliers",


### PR DESCRIPTION
## Le problème

`getPresidentialOverviewStats` calculait `probityCandidateCount` sur le chemin requête avec un
`groupBy` portant un `EXISTS` sur `Candidacy`. Mesuré : **0,6 ms à chaud, 4483 ms à froid**, 1542
buffers touchés. C'est ce que Sentry remonte en `POLIGRAPH-1H`, toujours actif, une vingtaine
d'events par jour.

La disproportion est nette. `Candidacy` fait 924 Mo (412 Mo de données, 512 Mo d'index) pour
1 285 026 lignes, dont :

| Scrutin | Lignes | Part |
|---|---|---|
| municipales-2026 | 887 747 | 69,1 % |
| municipales-2020 | 375 371 | 29,2 % |
| municipales-2014 | 20 771 | 1,6 % |
| **présidentielle-2027** | **33** | **0 %** |

La requête traversait une table composée à 99 % de données municipales pour répondre à une question
portant sur 33 candidatures.

## Ce que fait cette PR

Le compteur est précalculé par le sync quotidien et rangé dans `StatsSnapshot`, comme le projet le
fait déjà pour les agrégats municipales et parlementaires. La page lit une ligne par clé.

Le calcul tourne dans **GitHub Actions**, pas dans Inngest, pour la raison établie en #862 : Inngest
est servi par Next, donc une requête lourde y retient un des deux créneaux du pool d'une lambda qui
sert aussi des pages.

L'étape est `allowFailure: true`, et la lecture **retombe sur le calcul direct** si le snapshot est
absent ou illisible. Un échec coûte donc de la vitesse, jamais de l'exactitude. Le prédicat vit à un
seul endroit et sert les deux chemins, pour qu'une enquête ou une issue favorable ne puisse jamais
entrer dans le compte.

## Le compromis, explicite

Aujourd'hui `cacheTag("affairs")` fait qu'une affaire publiée rafraîchit ce nombre au rendu suivant.
Avec un snapshot quotidien, il traînera **jusqu'à 24 h** après une publication. Les autres champs de
la vue d'ensemble gardent leur fraîcheur actuelle. Si ce délai n'est pas acceptable, le correctif
alternatif est d'inverser le sens de la requête pour partir des 33 candidatures, mais il reste
soumis au plan choisi par Postgres alors que le snapshot sort la requête du chemin requête quoi
qu'il arrive.

## Vérifications

- `npx vitest run` : 6009 tests passés
- `tsc --noEmit`, `eslint`, `prettier` propres
- 3 tests ajoutés : lecture du snapshot sans toucher à `Affair`, repli sur le calcul direct quand il
  est absent, et repli également quand son JSON a dérivé (pour qu'une ligne corrompue ne soit jamais
  servie comme un zéro silencieux)

Ref POLIGRAPH-1H