### PR TITLE
Corriger deux compteurs faux et borner les lectures de Candidacy

### DIFF
--- a/prisma/migrations/manual/2026-09-12-candidacy-drop-unused-indexes.sql
+++ b/prisma/migrations/manual/2026-09-12-candidacy-drop-unused-indexes.sql
@@ -1,0 +1,28 @@
+-- Suppression de deux index de Candidacy qui se paient sans servir.
+--
+-- Candidacy_electionId_listName_idx : 34 Mo pour 1 seul scan entre le 18 juin
+-- et le 12 septembre 2026. Le seul calcul qui pouvait s'y appuyer, le compteur
+-- de listes 2020, a été retiré de la page : il comptait des noms de personnes,
+-- l'import écrivant `listName: list.listName || candidateName`.
+--
+-- Candidacy_electoralListId_idx : 8,8 Mo sur une colonne entièrement à NULL.
+-- ElectoralList est vide, aucune candidature n'y est liée, et le modèle n'est
+-- référencé nulle part dans src/ hors code généré.
+--
+-- La table portait 512 Mo d'index pour 412 Mo de données, et chaque écriture du
+-- sync les entretenait tous.
+--
+-- CONCURRENTLY : la table est lue par les pages publiques élections. Ne pas
+-- envelopper dans une transaction, PostgreSQL le refuse.
+--
+-- À exécuter APRÈS le déploiement du schéma qui ne déclare plus ces @@index :
+-- tant que schema.prisma les déclare, un db:push les recrée.
+--
+-- Recréation, si une régression de plan l'imposait :
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "Candidacy_electionId_listName_idx"
+--     ON "Candidacy" ("electionId", "listName");
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "Candidacy_electoralListId_idx"
+--     ON "Candidacy" ("electoralListId");
+
+DROP INDEX CONCURRENTLY IF EXISTS "Candidacy_electionId_listName_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "Candidacy_electoralListId_idx";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1895,7 +1895,6 @@ model Candidacy {
 
   @@index([electionId])
   @@index([electionId, communeId])
-  @@index([electionId, listName])
   @@index([electionId, partyLabel])
   // Covering index for parity-outliers aggregation (index-only scan, no heap fetch).
   // Created in prod via CREATE INDEX CONCURRENTLY; declared here so db:push keeps it.
@@ -1905,7 +1904,6 @@ model Candidacy {
   @@index([constituencyCode])
   @@index([candidateId])
   @@index([communeId])
-  @@index([electoralListId])
   @@index([partyId])
 }
 

--- a/src/__tests__/architecture/candidacy-read-bounds.test.ts
+++ b/src/__tests__/architecture/candidacy-read-bounds.test.ts
@@ -20,6 +20,12 @@ const ROOT = process.cwd();
  *
  * What it does NOT guarantee: `take` bounds the rows returned, not the work a GROUP BY does, which
  * PostgreSQL runs in full before limiting the output. This is a transfer and memory guard.
+ *
+ * Scope: this guard only sees direct `db.candidacy.findMany` / `.groupBy` (and `tx.candidacy.*`)
+ * call sites. It is blind to relation loads, e.g. `db.election.findUnique({ include: { candidacies:
+ * true } })`, which read the same unbounded rows without ever writing `db.candidacy.*`. A known
+ * unguarded site of that shape is tracked in the task 5 report rather than here, since fixing it is
+ * a public API contract decision, not a mechanical bound.
  */
 const ALLOWED_UNBOUNDED = new Map<string, { count: number; reason: string }>([
   [
@@ -92,6 +98,14 @@ const ALLOWED_UNBOUNDED = new Map<string, { count: number; reason: string }>([
       count: 1,
       reason:
         "liste de filtre de la file de modération : une borne masquerait des candidatures existantes sans signal pour l'utilisateur",
+    },
+  ],
+  [
+    "src/app/admin/mesures/_data/candidacies-query.ts",
+    {
+      count: 1,
+      reason:
+        "déjà borné par la constante MAX_CANDIDACIES (200) ; le détecteur n'accepte qu'un littéral, jamais une constante nommée",
     },
   ],
 ]);

--- a/src/__tests__/architecture/candidacy-read-bounds.test.ts
+++ b/src/__tests__/architecture/candidacy-read-bounds.test.ts
@@ -1,0 +1,295 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+/**
+ * Unbounded reads of `Candidacy` outside the sync services.
+ *
+ * A findMany without a bound has already produced a 19 MB page, and a groupBy without one shipped
+ * 375 368 rows to Node to read its length. The rule is not "always add a take": in
+ * `src/app/api/admin/partis/[id]/route.ts` every presidential candidacy of the party must be
+ * locked before the mutation, and a bound there would leave some unlocked.
+ *
+ * So this guard proves only what static analysis can prove: a positive integer `take` literal that
+ * no later spread can overwrite, or an explicit entry below. It deliberately does not try to infer a bound from a `where` clause, which cannot be done
+ * reliably: an `id: { in: [...] }` may sit inside a relation or one branch of an OR and bound
+ * nothing.
+ *
+ * What it does NOT guarantee: `take` bounds the rows returned, not the work a GROUP BY does, which
+ * PostgreSQL runs in full before limiting the output. This is a transfer and memory guard.
+ */
+const ALLOWED_UNBOUNDED = new Map<string, { count: number; reason: string }>([
+  [
+    "src/app/api/admin/partis/[id]/route.ts",
+    {
+      count: 1,
+      reason:
+        "verrouillage avant mutation : toutes les candidatures présidentielles du parti doivent être prises",
+    },
+  ],
+  [
+    "src/app/api/admin/politiques/[id]/route.ts",
+    {
+      count: 1,
+      reason:
+        "verrouillage avant mutation : toutes les candidatures présidentielles du politique doivent être prises",
+    },
+  ],
+  [
+    "src/lib/data/elections.ts",
+    {
+      count: 2,
+      reason:
+        "fiches commune 2020 et 2014 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+    },
+  ],
+  [
+    "src/lib/data/municipales.ts",
+    {
+      count: 2,
+      reason:
+        "fiche commune (toutes les candidatures) et page cumul des mandats (tous les cumulards) : listes exhaustives par nature, une borne en tronquerait certaines",
+    },
+  ],
+  [
+    "src/lib/data/candidates.ts",
+    {
+      count: 2,
+      reason:
+        "modération d'une seule élection présidentielle et historique cross-cycle d'un seul politique : ensembles déjà bornés par le réel, l'exhaustivité conditionne leur exactitude",
+    },
+  ],
+  [
+    "src/lib/data/presidential-candidacy-field.ts",
+    {
+      count: 1,
+      reason:
+        "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+    },
+  ],
+  [
+    "src/lib/data/presidential-candidates-public.ts",
+    {
+      count: 1,
+      reason:
+        "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+    },
+  ],
+  [
+    "src/lib/data/presidentielle-2027.ts",
+    {
+      count: 1,
+      reason:
+        "champ admin complet d'une élection présidentielle : une borne en tronquerait des candidats",
+    },
+  ],
+  [
+    "src/app/admin/mesures/_data/queue-query.ts",
+    {
+      count: 1,
+      reason:
+        "liste de filtre de la file de modération : une borne masquerait des candidatures existantes sans signal pour l'utilisateur",
+    },
+  ],
+]);
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(join(ROOT, directory), { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")
+      ? [relative(ROOT, join(ROOT, path))]
+      : [];
+  });
+}
+
+const MAX_ALLOWED_TAKE = 10_000;
+
+/**
+ * The only bound this guard can actually prove: `take` set to a positive integer literal, with
+ * nothing after it that could overwrite the property.
+ *
+ * `take: limit` is rejected even when `limit` holds a number at run time. Static analysis cannot
+ * tell, and `take: undefined` is written exactly the same way here. `{ take: 50, ...options }` is
+ * rejected too, since a later spread can replace the value; `{ ...options, take: 50 }` is accepted,
+ * the literal winning. Dynamic bounds go through ALLOWED_UNBOUNDED, where a human states why they
+ * are safe, which is the point: an unprovable bound becomes a written decision instead of an
+ * assumption.
+ */
+function hasLiteralTake(argument: ts.ObjectLiteralExpression, file: ts.SourceFile): boolean {
+  const index = argument.properties.findIndex(
+    (property) => ts.isPropertyAssignment(property) && property.name.getText(file) === "take"
+  );
+  if (index === -1) return false;
+
+  // `noUncheckedIndexedAccess` is on in tsconfig.json, so an indexed access is `T | undefined`
+  // whatever the preceding bounds check says.
+  const property = argument.properties[index];
+  if (
+    !property ||
+    !ts.isPropertyAssignment(property) ||
+    !ts.isNumericLiteral(property.initializer)
+  ) {
+    return false;
+  }
+
+  const value = Number(property.initializer.text);
+  if (!Number.isInteger(value) || value <= 0 || value > MAX_ALLOWED_TAKE) return false;
+
+  return !argument.properties.slice(index + 1).some(ts.isSpreadAssignment);
+}
+
+export function unboundedCandidacyReads(path: string, code: string): number[] {
+  const file = ts.createSourceFile(path, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const lines: number[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ["findMany", "groupBy"].includes(node.expression.name.text) &&
+      ts.isPropertyAccessExpression(node.expression.expression) &&
+      node.expression.expression.name.text === "candidacy"
+    ) {
+      const [argument] = node.arguments;
+      const bounded =
+        argument !== undefined &&
+        ts.isObjectLiteralExpression(argument) &&
+        hasLiteralTake(argument, file);
+
+      if (!bounded) {
+        lines.push(file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(file);
+  return lines;
+}
+
+describe("détecteur de lectures non bornées", () => {
+  const wrap = (call: string) => `declare const db: any;\nasync function f() { ${call} }`;
+
+  it("accepte un take littéral", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await db.candidacy.findMany({ take: 50 });"))
+    ).toEqual([]);
+  });
+
+  it("refuse take: undefined", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await db.candidacy.findMany({ take: undefined });"))
+    ).toHaveLength(1);
+  });
+
+  it("refuse un take non littéral, qui peut valoir undefined à l'exécution", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await db.candidacy.findMany({ take: limit });"))
+    ).toHaveLength(1);
+  });
+
+  it("refuse un take qu'un spread postérieur peut écraser", () => {
+    expect(
+      unboundedCandidacyReads(
+        "a.ts",
+        wrap("await db.candidacy.findMany({ take: 50, ...options });")
+      )
+    ).toHaveLength(1);
+  });
+
+  it("accepte un take littéral placé après le spread", () => {
+    expect(
+      unboundedCandidacyReads(
+        "a.ts",
+        wrap("await db.candidacy.findMany({ ...options, take: 50 });")
+      )
+    ).toEqual([]);
+  });
+
+  it("refuse un take littéral hors plage", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await db.candidacy.findMany({ take: 500000 });"))
+    ).toHaveLength(1);
+  });
+
+  it("refuse un id: { in } qui ne borne rien, placé dans une relation", () => {
+    expect(
+      unboundedCandidacyReads(
+        "a.ts",
+        wrap("await db.candidacy.findMany({ where: { election: { id: { in: ids } } } });")
+      )
+    ).toHaveLength(1);
+  });
+
+  it("refuse un id: { in } dans une seule branche d'un OR", () => {
+    expect(
+      unboundedCandidacyReads(
+        "a.ts",
+        wrap(
+          "await db.candidacy.findMany({ where: { OR: [{ id: { in: ids } }, { isElected: true }] } });"
+        )
+      )
+    ).toHaveLength(1);
+  });
+
+  it("ne se laisse pas tromper par un commentaire", () => {
+    expect(
+      unboundedCandidacyReads(
+        "a.ts",
+        wrap("// id: { in: ids }\n await db.candidacy.groupBy({ by: ['communeId'] });")
+      )
+    ).toHaveLength(1);
+  });
+
+  it("attrape aussi un appel transactionnel", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await tx.candidacy.findMany({ where: { partyId } });"))
+    ).toHaveLength(1);
+  });
+
+  it("ignore les lectures d'autres modèles", () => {
+    expect(
+      unboundedCandidacyReads("a.ts", wrap("await db.measure.findMany({ where: { id } });"))
+    ).toEqual([]);
+  });
+});
+
+describe("bornes des lectures de Candidacy", () => {
+  const files = [...sourceFiles("src/lib/data"), ...sourceFiles("src/app")].filter(
+    (path) =>
+      !path.includes("__tests__") && !path.endsWith(".test.ts") && !path.endsWith(".test.tsx")
+  );
+
+  it("lit bien un ensemble de fichiers non vide", () => {
+    // Guards the read: an empty list would make every assertion below vacuously true.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("n'a pas de lecture non bornée en dehors des exceptions déclarées", () => {
+    const unexpected = files.flatMap((path) => {
+      const lines = unboundedCandidacyReads(path, readFileSync(join(ROOT, path), "utf8"));
+      const allowed = ALLOWED_UNBOUNDED.get(path)?.count ?? 0;
+      return lines.length > allowed
+        ? [`${path} : ${lines.length} non bornée(s), ${allowed} autorisée(s)`]
+        : [];
+    });
+
+    expect(unexpected).toEqual([]);
+  });
+
+  it("ne garde pas d'exception périmée", () => {
+    // An allowlist nobody prunes stops being a list of decisions and becomes noise.
+    const stale = [...ALLOWED_UNBOUNDED.entries()].flatMap(([path, entry]) => {
+      const lines = unboundedCandidacyReads(path, readFileSync(join(ROOT, path), "utf8"));
+      return lines.length < entry.count
+        ? [`${path} : ${entry.count} déclarée(s), ${lines.length} trouvée(s)`]
+        : [];
+    });
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/src/__tests__/architecture/candidacy-read-bounds.test.ts
+++ b/src/__tests__/architecture/candidacy-read-bounds.test.ts
@@ -26,87 +26,117 @@ const ROOT = process.cwd();
  * true } })`, which read the same unbounded rows without ever writing `db.candidacy.*`. A known
  * unguarded site of that shape is tracked in the task 5 report rather than here, since fixing it is
  * a public API contract decision, not a mechanical bound.
+ *
+ * An entry earns its place in ALLOWED_UNBOUNDED only by falling into one of three families:
+ * bounded by reality (one commune, one election, one politician — at most a few dozen rows);
+ * exhaustiveness required by the correctness of the code, typically a lock taken before a
+ * mutation, where a `take` would leave rows unlocked; or bounded by a named constant, which this
+ * detector cannot see since it only accepts a literal. A display read that could simply take a
+ * `take` — a dropdown, a paginable listing — falls into none of these and has no place here: bound
+ * it instead.
  */
-const ALLOWED_UNBOUNDED = new Map<string, { count: number; reason: string }>([
+const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
   [
     "src/app/api/admin/partis/[id]/route.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "PUT",
         "verrouillage avant mutation : toutes les candidatures présidentielles du parti doivent être prises",
-    },
+      ],
+    ]),
   ],
   [
     "src/app/api/admin/politiques/[id]/route.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "PUT",
         "verrouillage avant mutation : toutes les candidatures présidentielles du politique doivent être prises",
-    },
+      ],
+    ]),
   ],
   [
     "src/lib/data/elections.ts",
-    {
-      count: 2,
-      reason:
-        "fiches commune 2020 et 2014 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
-    },
+    new Map([
+      [
+        "getCommuneResults2020",
+        "fiche commune 2020 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+      ],
+      [
+        "getCommuneResults2014",
+        "fiche commune 2014 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+      ],
+    ]),
   ],
   [
     "src/lib/data/municipales.ts",
-    {
-      count: 2,
-      reason:
-        "fiche commune (toutes les candidatures) et page cumul des mandats (tous les cumulards) : listes exhaustives par nature, une borne en tronquerait certaines",
-    },
+    new Map([
+      [
+        "getCommune",
+        "fiche commune : toutes les candidatures doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+      ],
+      [
+        "getCumulCandidates",
+        "page cumul des mandats : tous les cumulards doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+      ],
+    ]),
   ],
   [
     "src/lib/data/candidates.ts",
-    {
-      count: 2,
-      reason:
-        "modération d'une seule élection présidentielle et historique cross-cycle d'un seul politique : ensembles déjà bornés par le réel, l'exhaustivité conditionne leur exactitude",
-    },
+    new Map([
+      [
+        "getCandidates2027ForModeration",
+        "modération d'une seule élection présidentielle : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+      ],
+      [
+        "getCandidateCrossCycle",
+        "historique cross-cycle d'un seul politique : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+      ],
+    ]),
   ],
   [
     "src/lib/data/presidential-candidacy-field.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "getPublicPresidentialCandidacyField",
         "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
-    },
+      ],
+    ]),
   ],
   [
     "src/lib/data/presidential-candidates-public.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "getPublicPresidentialCandidates",
         "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
-    },
+      ],
+    ]),
   ],
   [
     "src/lib/data/presidentielle-2027.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "getPresidentielle2027Candidates",
         "champ admin complet d'une élection présidentielle : une borne en tronquerait des candidats",
-    },
+      ],
+    ]),
   ],
   [
     "src/app/admin/mesures/_data/queue-query.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "listMeasureQueueCandidates",
         "liste de filtre de la file de modération : une borne masquerait des candidatures existantes sans signal pour l'utilisateur",
-    },
+      ],
+    ]),
   ],
   [
     "src/app/admin/mesures/_data/candidacies-query.ts",
-    {
-      count: 1,
-      reason:
+    new Map([
+      [
+        "listPresidentialCandidacies",
         "déjà borné par la constante MAX_CANDIDACIES (200) ; le détecteur n'accepte qu'un littéral, jamais une constante nommée",
-    },
+      ],
+    ]),
   ],
 ]);
 
@@ -118,6 +148,24 @@ function sourceFiles(directory: string): string[] {
       ? [relative(ROOT, join(ROOT, path))]
       : [];
   });
+}
+
+/**
+ * Reads a source file for the guard, turning a raw `ENOENT` into a message that names the file and
+ * says why it matters here: an `ALLOWED_UNBOUNDED` entry pointing at it is stale (the file was
+ * renamed or removed), not a generic filesystem failure in the middle of a test run.
+ */
+function readSourceFile(path: string): string {
+  try {
+    return readFileSync(join(ROOT, path), "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      throw new Error(
+        `${path} est introuvable : l'entrée d'exception dans ALLOWED_UNBOUNDED est périmée (fichier renommé ou supprimé).`
+      );
+    }
+    throw error;
+  }
 }
 
 const MAX_ALLOWED_TAKE = 10_000;
@@ -156,9 +204,70 @@ function hasLiteralTake(argument: ts.ObjectLiteralExpression, file: ts.SourceFil
   return !argument.properties.slice(index + 1).some(ts.isSpreadAssignment);
 }
 
-export function unboundedCandidacyReads(path: string, code: string): number[] {
+/**
+ * Nearest top-level module binding enclosing `node` (`export const NAME = ...`), used only when
+ * `node` sits inside nothing but anonymous callbacks — a HOC-composed route handler such as
+ * `export const PUT = withAdminAuth(withValidation(schema, async (req) => {...}))`, where neither
+ * callback has a name of its own. `PUT` is the only stable label left for that shape.
+ */
+function topLevelBindingName(node: ts.Node, file: ts.SourceFile): string | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (
+      ts.isVariableDeclaration(current) &&
+      ts.isIdentifier(current.name) &&
+      ts.isVariableDeclarationList(current.parent) &&
+      ts.isVariableStatement(current.parent.parent) &&
+      current.parent.parent.parent === file
+    ) {
+      return current.name.text;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
+ * Name of the function enclosing `node`, the stable location an `ALLOWED_UNBOUNDED` entry is
+ * anchored to instead of a raw count: a file exempted by count can bound the one reviewed read and
+ * add an unrelated unbounded one for free, since the total never changes. Anchoring to the
+ * enclosing function name closes that hole.
+ *
+ * Walks up looking for a `FunctionDeclaration`, a `MethodDeclaration`, a named function
+ * expression, or an arrow/anonymous function expression directly assigned to a variable
+ * (`const f = async () => {}`). When the nearest enclosing function is itself anonymous — a
+ * callback passed straight to a call, with no binding of its own — the search continues outward
+ * to the nearest top-level exported binding, per `topLevelBindingName`.
+ */
+function enclosingFunctionName(node: ts.Node, file: ts.SourceFile): string | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isFunctionDeclaration(current) && current.name) {
+      return current.name.text;
+    }
+    if (ts.isMethodDeclaration(current) && ts.isIdentifier(current.name)) {
+      return current.name.text;
+    }
+    if (ts.isFunctionExpression(current) && current.name) {
+      return current.name.text;
+    }
+    if (
+      (ts.isFunctionExpression(current) || ts.isArrowFunction(current)) &&
+      ts.isVariableDeclaration(current.parent) &&
+      ts.isIdentifier(current.parent.name)
+    ) {
+      return current.parent.name.text;
+    }
+    current = current.parent;
+  }
+  return topLevelBindingName(node, file);
+}
+
+export type UnboundedRead = { line: number; functionName: string };
+
+export function unboundedCandidacyReads(path: string, code: string): UnboundedRead[] {
   const file = ts.createSourceFile(path, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  const lines: number[] = [];
+  const reads: UnboundedRead[] = [];
 
   const visit = (node: ts.Node) => {
     if (
@@ -175,14 +284,55 @@ export function unboundedCandidacyReads(path: string, code: string): number[] {
         hasLiteralTake(argument, file);
 
       if (!bounded) {
-        lines.push(file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1);
+        const line = file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1;
+        const functionName = enclosingFunctionName(node, file);
+        if (functionName === undefined) {
+          throw new Error(
+            `${path}:${line} — lecture non bornée de Candidacy hors de toute fonction nommée ; ` +
+              "impossible de construire une clé d'exception stable (voir ALLOWED_UNBOUNDED dans candidacy-read-bounds.test.ts)."
+          );
+        }
+        reads.push({ line, functionName });
       }
     }
     ts.forEachChild(node, visit);
   };
 
   visit(file);
-  return lines;
+  return reads;
+}
+
+/** Unbounded reads not covered by any declared exception for their file and function. */
+function findUnexpectedReads(
+  files: string[],
+  allowed: Map<string, Map<string, string>>,
+  readFile: (path: string) => string
+): string[] {
+  return files.flatMap((path) => {
+    const reads = unboundedCandidacyReads(path, readFile(path));
+    const allowedFunctions = allowed.get(path);
+    return reads.flatMap((read) =>
+      allowedFunctions?.has(read.functionName)
+        ? []
+        : [`${path}:${read.line} dans ${read.functionName} : lecture non bornée non déclarée`]
+    );
+  });
+}
+
+/** Declared exceptions whose function no longer exists, or no longer contains an unbounded read. */
+function findStaleExceptions(
+  allowed: Map<string, Map<string, string>>,
+  readFile: (path: string) => string
+): string[] {
+  return [...allowed.entries()].flatMap(([path, functions]) => {
+    const reads = unboundedCandidacyReads(path, readFile(path));
+    const foundNames = new Set(reads.map((read) => read.functionName));
+    return [...functions.keys()].flatMap((functionName) =>
+      foundNames.has(functionName)
+        ? []
+        : [`${path} : ${functionName} déclarée, aucune lecture non bornée trouvée`]
+    );
+  });
 }
 
 describe("détecteur de lectures non bornées", () => {
@@ -272,6 +422,65 @@ describe("détecteur de lectures non bornées", () => {
   });
 });
 
+describe("allowlist ancrée par fonction (pas par compte)", () => {
+  it("signale une lecture non déclarée même si le fichier a d'autres exceptions", () => {
+    const code = [
+      "declare const db: any;",
+      "async function fonctionDeclaree() {",
+      "  await db.candidacy.findMany({ where: { id } });",
+      "}",
+      "async function fonctionNonDeclaree() {",
+      "  await db.candidacy.findMany({ where: { id } });",
+      "}",
+    ].join("\n");
+    const allowed = new Map([["fake.ts", new Map([["fonctionDeclaree", "raison de test"]])]]);
+
+    const unexpected = findUnexpectedReads(["fake.ts"], allowed, () => code);
+
+    expect(unexpected).toHaveLength(1);
+    expect(unexpected[0]).toContain("fonctionNonDeclaree");
+  });
+
+  it("signale une exception périmée dont la fonction n'existe plus", () => {
+    const code =
+      "declare const db: any;\nasync function fonctionActuelle() { await db.candidacy.findMany({ take: 50 }); }";
+    const allowed = new Map([["fake.ts", new Map([["fonctionRenommee", "raison de test"]])]]);
+
+    const stale = findStaleExceptions(allowed, () => code);
+
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain("fonctionRenommee");
+  });
+
+  it("signale une exception périmée dont la fonction est redevenue bornée", () => {
+    const code =
+      "declare const db: any;\nasync function fonctionCorrigee() { await db.candidacy.findMany({ take: 50 }); }";
+    const allowed = new Map([["fake.ts", new Map([["fonctionCorrigee", "raison de test"]])]]);
+
+    const stale = findStaleExceptions(allowed, () => code);
+
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain("fonctionCorrigee");
+  });
+
+  it("produit un message clair pour un appel hors de toute fonction nommée", () => {
+    expect(() =>
+      unboundedCandidacyReads(
+        "a.ts",
+        "declare const db: any;\nvoid db.candidacy.findMany({ where: { id } });"
+      )
+    ).toThrow(/hors de toute fonction nommée/);
+  });
+
+  it("signale clairement une entrée d'exception dont le fichier a disparu", () => {
+    const missing = new Map([
+      ["src/lib/data/ce-fichier-n-existe-plus.ts", new Map([["x", "raison de test"]])],
+    ]);
+
+    expect(() => findStaleExceptions(missing, readSourceFile)).toThrow(/introuvable/);
+  });
+});
+
 describe("bornes des lectures de Candidacy", () => {
   const files = [...sourceFiles("src/lib/data"), ...sourceFiles("src/app")].filter(
     (path) =>
@@ -284,25 +493,14 @@ describe("bornes des lectures de Candidacy", () => {
   });
 
   it("n'a pas de lecture non bornée en dehors des exceptions déclarées", () => {
-    const unexpected = files.flatMap((path) => {
-      const lines = unboundedCandidacyReads(path, readFileSync(join(ROOT, path), "utf8"));
-      const allowed = ALLOWED_UNBOUNDED.get(path)?.count ?? 0;
-      return lines.length > allowed
-        ? [`${path} : ${lines.length} non bornée(s), ${allowed} autorisée(s)`]
-        : [];
-    });
+    const unexpected = findUnexpectedReads(files, ALLOWED_UNBOUNDED, readSourceFile);
 
     expect(unexpected).toEqual([]);
   });
 
   it("ne garde pas d'exception périmée", () => {
     // An allowlist nobody prunes stops being a list of decisions and becomes noise.
-    const stale = [...ALLOWED_UNBOUNDED.entries()].flatMap(([path, entry]) => {
-      const lines = unboundedCandidacyReads(path, readFileSync(join(ROOT, path), "utf8"));
-      return lines.length < entry.count
-        ? [`${path} : ${entry.count} déclarée(s), ${lines.length} trouvée(s)`]
-        : [];
-    });
+    const stale = findStaleExceptions(ALLOWED_UNBOUNDED, readSourceFile);
 
     expect(stale).toEqual([]);
   });

--- a/src/__tests__/architecture/candidacy-read-bounds.test.ts
+++ b/src/__tests__/architecture/candidacy-read-bounds.test.ts
@@ -35,13 +35,20 @@ const ROOT = process.cwd();
  * `take` — a dropdown, a paginable listing — falls into none of these and has no place here: bound
  * it instead.
  */
-const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
+type AllowedEntry = { count: number; reason: string };
+type AllowedUnbounded = Map<string, Map<string, AllowedEntry>>;
+
+const ALLOWED_UNBOUNDED: AllowedUnbounded = new Map([
   [
     "src/app/api/admin/partis/[id]/route.ts",
     new Map([
       [
         "PUT",
-        "verrouillage avant mutation : toutes les candidatures présidentielles du parti doivent être prises",
+        {
+          count: 1,
+          reason:
+            "verrouillage avant mutation : toutes les candidatures présidentielles du parti doivent être prises",
+        },
       ],
     ]),
   ],
@@ -50,7 +57,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "PUT",
-        "verrouillage avant mutation : toutes les candidatures présidentielles du politique doivent être prises",
+        {
+          count: 1,
+          reason:
+            "verrouillage avant mutation : toutes les candidatures présidentielles du politique doivent être prises",
+        },
       ],
     ]),
   ],
@@ -59,11 +70,19 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getCommuneResults2020",
-        "fiche commune 2020 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+        {
+          count: 1,
+          reason:
+            "fiche commune 2020 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+        },
       ],
       [
         "getCommuneResults2014",
-        "fiche commune 2014 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+        {
+          count: 1,
+          reason:
+            "fiche commune 2014 : toutes les listes/candidatures de la commune doivent apparaître, une borne en tronquerait certaines",
+        },
       ],
     ]),
   ],
@@ -72,11 +91,19 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getCommune",
-        "fiche commune : toutes les candidatures doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+        {
+          count: 1,
+          reason:
+            "fiche commune : toutes les candidatures doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+        },
       ],
       [
         "getCumulCandidates",
-        "page cumul des mandats : tous les cumulards doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+        {
+          count: 1,
+          reason:
+            "page cumul des mandats : tous les cumulards doivent apparaître, liste exhaustive par nature, une borne en tronquerait certaines",
+        },
       ],
     ]),
   ],
@@ -85,11 +112,19 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getCandidates2027ForModeration",
-        "modération d'une seule élection présidentielle : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+        {
+          count: 1,
+          reason:
+            "modération d'une seule élection présidentielle : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+        },
       ],
       [
         "getCandidateCrossCycle",
-        "historique cross-cycle d'un seul politique : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+        {
+          count: 1,
+          reason:
+            "historique cross-cycle d'un seul politique : ensemble déjà borné par le réel, l'exhaustivité conditionne son exactitude",
+        },
       ],
     ]),
   ],
@@ -98,7 +133,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getPublicPresidentialCandidacyField",
-        "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        {
+          count: 1,
+          reason:
+            "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        },
       ],
     ]),
   ],
@@ -107,7 +146,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getPublicPresidentialCandidates",
-        "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        {
+          count: 1,
+          reason:
+            "champ public complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        },
       ],
     ]),
   ],
@@ -116,7 +159,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "getPresidentielle2027Candidates",
-        "champ admin complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        {
+          count: 1,
+          reason:
+            "champ admin complet d'une élection présidentielle : une borne en tronquerait des candidats",
+        },
       ],
     ]),
   ],
@@ -125,7 +172,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "listMeasureQueueCandidates",
-        "liste de filtre de la file de modération : une borne masquerait des candidatures existantes sans signal pour l'utilisateur",
+        {
+          count: 1,
+          reason:
+            "liste de filtre de la file de modération : une borne masquerait des candidatures existantes sans signal pour l'utilisateur",
+        },
       ],
     ]),
   ],
@@ -134,7 +185,11 @@ const ALLOWED_UNBOUNDED = new Map<string, Map<string, string>>([
     new Map([
       [
         "listPresidentialCandidacies",
-        "déjà borné par la constante MAX_CANDIDACIES (200) ; le détecteur n'accepte qu'un littéral, jamais une constante nommée",
+        {
+          count: 1,
+          reason:
+            "déjà borné par la constante MAX_CANDIDACIES (200) ; le détecteur n'accepte qu'un littéral, jamais une constante nommée",
+        },
       ],
     ]),
   ],
@@ -302,36 +357,55 @@ export function unboundedCandidacyReads(path: string, code: string): UnboundedRe
   return reads;
 }
 
-/** Unbounded reads not covered by any declared exception for their file and function. */
+/** Number of unbounded reads found per function, for one file. */
+function unboundedCountsByFunction(
+  path: string,
+  readFile: (path: string) => string
+): Map<string, number> {
+  const reads = unboundedCandidacyReads(path, readFile(path));
+  const counts = new Map<string, number>();
+  for (const read of reads) {
+    counts.set(read.functionName, (counts.get(read.functionName) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Functions with more unbounded reads than their declared count — either a function absent from
+ * the allowlist entirely, or one already declared whose count no longer matches. A presence check
+ * alone (`Map.has`) would let a declared function accumulate any number of unreviewed reads behind
+ * a single approved name; comparing counts closes that.
+ */
 function findUnexpectedReads(
   files: string[],
-  allowed: Map<string, Map<string, string>>,
+  allowed: AllowedUnbounded,
   readFile: (path: string) => string
 ): string[] {
   return files.flatMap((path) => {
-    const reads = unboundedCandidacyReads(path, readFile(path));
+    const counts = unboundedCountsByFunction(path, readFile);
     const allowedFunctions = allowed.get(path);
-    return reads.flatMap((read) =>
-      allowedFunctions?.has(read.functionName)
-        ? []
-        : [`${path}:${read.line} dans ${read.functionName} : lecture non bornée non déclarée`]
-    );
+    return [...counts.entries()].flatMap(([functionName, count]) => {
+      const allowedCount = allowedFunctions?.get(functionName)?.count ?? 0;
+      return count > allowedCount
+        ? [`${path} dans ${functionName} : ${count} non bornée(s), ${allowedCount} autorisée(s)`]
+        : [];
+    });
   });
 }
 
-/** Declared exceptions whose function no longer exists, or no longer contains an unbounded read. */
+/** Declared exceptions whose function no longer exists, or now contains fewer unbounded reads than declared. */
 function findStaleExceptions(
-  allowed: Map<string, Map<string, string>>,
+  allowed: AllowedUnbounded,
   readFile: (path: string) => string
 ): string[] {
   return [...allowed.entries()].flatMap(([path, functions]) => {
-    const reads = unboundedCandidacyReads(path, readFile(path));
-    const foundNames = new Set(reads.map((read) => read.functionName));
-    return [...functions.keys()].flatMap((functionName) =>
-      foundNames.has(functionName)
-        ? []
-        : [`${path} : ${functionName} déclarée, aucune lecture non bornée trouvée`]
-    );
+    const counts = unboundedCountsByFunction(path, readFile);
+    return [...functions.entries()].flatMap(([functionName, { count: allowedCount }]) => {
+      const observed = counts.get(functionName) ?? 0;
+      return observed < allowedCount
+        ? [`${path} : ${functionName} déclare ${allowedCount}, ${observed} trouvée(s)`]
+        : [];
+    });
   });
 }
 
@@ -433,7 +507,9 @@ describe("allowlist ancrée par fonction (pas par compte)", () => {
       "  await db.candidacy.findMany({ where: { id } });",
       "}",
     ].join("\n");
-    const allowed = new Map([["fake.ts", new Map([["fonctionDeclaree", "raison de test"]])]]);
+    const allowed: AllowedUnbounded = new Map([
+      ["fake.ts", new Map([["fonctionDeclaree", { count: 1, reason: "raison de test" }]])],
+    ]);
 
     const unexpected = findUnexpectedReads(["fake.ts"], allowed, () => code);
 
@@ -444,7 +520,9 @@ describe("allowlist ancrée par fonction (pas par compte)", () => {
   it("signale une exception périmée dont la fonction n'existe plus", () => {
     const code =
       "declare const db: any;\nasync function fonctionActuelle() { await db.candidacy.findMany({ take: 50 }); }";
-    const allowed = new Map([["fake.ts", new Map([["fonctionRenommee", "raison de test"]])]]);
+    const allowed: AllowedUnbounded = new Map([
+      ["fake.ts", new Map([["fonctionRenommee", { count: 1, reason: "raison de test" }]])],
+    ]);
 
     const stale = findStaleExceptions(allowed, () => code);
 
@@ -455,7 +533,9 @@ describe("allowlist ancrée par fonction (pas par compte)", () => {
   it("signale une exception périmée dont la fonction est redevenue bornée", () => {
     const code =
       "declare const db: any;\nasync function fonctionCorrigee() { await db.candidacy.findMany({ take: 50 }); }";
-    const allowed = new Map([["fake.ts", new Map([["fonctionCorrigee", "raison de test"]])]]);
+    const allowed: AllowedUnbounded = new Map([
+      ["fake.ts", new Map([["fonctionCorrigee", { count: 1, reason: "raison de test" }]])],
+    ]);
 
     const stale = findStaleExceptions(allowed, () => code);
 
@@ -473,11 +553,55 @@ describe("allowlist ancrée par fonction (pas par compte)", () => {
   });
 
   it("signale clairement une entrée d'exception dont le fichier a disparu", () => {
-    const missing = new Map([
-      ["src/lib/data/ce-fichier-n-existe-plus.ts", new Map([["x", "raison de test"]])],
+    const missing: AllowedUnbounded = new Map([
+      [
+        "src/lib/data/ce-fichier-n-existe-plus.ts",
+        new Map([["x", { count: 1, reason: "raison de test" }]]),
+      ],
     ]);
 
     expect(() => findStaleExceptions(missing, readSourceFile)).toThrow(/introuvable/);
+  });
+
+  // Handlers composed by higher-order functions (`export const PUT = withAdminAuth(withValidation(
+  // schema, async (req, ctx, body) => {...}))`) resolve every call inside them to the same
+  // top-level name (`PUT`, see `topLevelBindingName`). A presence check on that name would let any
+  // number of unreviewed reads hide behind one approved handler; only a count comparison catches it.
+  const hocHandlerCode = (readCount: number) =>
+    [
+      "declare const db: any;",
+      "declare function withAdminAuth(fn: unknown): unknown;",
+      "declare function withValidation(schema: unknown, fn: unknown): unknown;",
+      "declare const schema: unknown;",
+      "export const PUT = withAdminAuth(",
+      "  withValidation(schema, async (req: unknown, ctx: unknown, body: unknown) => {",
+      ...Array.from(
+        { length: readCount },
+        () => "    await db.candidacy.findMany({ where: { id } });"
+      ),
+      "  })",
+      ");",
+    ].join("\n");
+
+  it("un handler composé par HOC déclaré à 1 lecture qui en contient 2 échoue", () => {
+    const allowed: AllowedUnbounded = new Map([
+      ["fake-route.ts", new Map([["PUT", { count: 1, reason: "raison de test" }]])],
+    ]);
+
+    const unexpected = findUnexpectedReads(["fake-route.ts"], allowed, () => hocHandlerCode(2));
+
+    expect(unexpected).toHaveLength(1);
+    expect(unexpected[0]).toContain("PUT");
+  });
+
+  it("un handler composé par HOC déclaré à 1 lecture qui en contient 1 passe", () => {
+    const allowed: AllowedUnbounded = new Map([
+      ["fake-route.ts", new Map([["PUT", { count: 1, reason: "raison de test" }]])],
+    ]);
+
+    const unexpected = findUnexpectedReads(["fake-route.ts"], allowed, () => hocHandlerCode(1));
+
+    expect(unexpected).toEqual([]);
   });
 });
 

--- a/src/app/admin/mesures/_data/candidacies-query.ts
+++ b/src/app/admin/mesures/_data/candidacies-query.ts
@@ -19,7 +19,6 @@ import { db } from "@/lib/db";
  * `Candidacy` also holds municipal rows and loading it whole has already produced a 19 MB page.
  */
 const HUB_ELECTION_SLUG = "presidentielle-2027";
-const MAX_CANDIDACIES = 200;
 
 export type CandidacyOption = {
   id: string;
@@ -47,7 +46,9 @@ export async function listPresidentialCandidacies(): Promise<CandidacyOption[]> 
     },
     // Alphabetical, and the page says so: any other order on a list of candidates is a ranking.
     orderBy: [{ candidateName: "asc" }],
-    take: MAX_CANDIDACIES,
+    // Literal, not `MAX_CANDIDACIES`: the read-bounds guard only proves a numeric literal, since
+    // a named constant could hold anything at run time as far as static analysis is concerned.
+    take: 200,
   });
 
   return rows.flatMap((row) =>

--- a/src/app/admin/mesures/_data/candidacies-query.ts
+++ b/src/app/admin/mesures/_data/candidacies-query.ts
@@ -19,6 +19,7 @@ import { db } from "@/lib/db";
  * `Candidacy` also holds municipal rows and loading it whole has already produced a 19 MB page.
  */
 const HUB_ELECTION_SLUG = "presidentielle-2027";
+const MAX_CANDIDACIES = 200;
 
 export type CandidacyOption = {
   id: string;
@@ -46,9 +47,10 @@ export async function listPresidentialCandidacies(): Promise<CandidacyOption[]> 
     },
     // Alphabetical, and the page says so: any other order on a list of candidates is a ranking.
     orderBy: [{ candidateName: "asc" }],
-    // Literal, not `MAX_CANDIDACIES`: the read-bounds guard only proves a numeric literal, since
-    // a named constant could hold anything at run time as far as static analysis is concerned.
-    take: 200,
+    // Bounded by MAX_CANDIDACIES (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the
+    // read-bounds guard only proves a numeric literal, so a named constant reads as unbounded to
+    // it even though this call is already correctly bounded at run time.
+    take: MAX_CANDIDACIES,
   });
 
   return rows.flatMap((row) =>

--- a/src/app/admin/mesures/_data/queue-query.ts
+++ b/src/app/admin/mesures/_data/queue-query.ts
@@ -164,6 +164,8 @@ export type MeasureQueueCandidateOption = {
 
 /** Only offers candidacies that already own at least one measure in the moderation queue. */
 export async function listMeasureQueueCandidates(): Promise<MeasureQueueCandidateOption[]> {
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): this is a
+  // filter dropdown, and a take would silently hide candidacies from it without any signal.
   const rows = await db.candidacy.findMany({
     where: { measures: { some: {} } },
     select: {

--- a/src/app/api/admin/partis/[id]/route.ts
+++ b/src/app/api/admin/partis/[id]/route.ts
@@ -88,6 +88,9 @@ export const PUT = withAdminAuth(
     }
 
     const { updatedParty, presidentialElectionIds } = await db.$transaction(async (tx) => {
+      // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): every
+      // presidential candidacy of this party must be locked before the mutation, and a take
+      // would leave some unlocked.
       const candidacies = await tx.candidacy.findMany({
         where: { partyId: id, election: { type: "PRESIDENTIELLE" } },
         select: { id: true },

--- a/src/app/api/admin/politiques/[id]/route.ts
+++ b/src/app/api/admin/politiques/[id]/route.ts
@@ -66,6 +66,9 @@ export const PUT = withAdminAuth(
 
     // Update politician
     const { politician, presidentialElectionIds } = await db.$transaction(async (tx) => {
+      // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): every
+      // presidential candidacy of this politician must be locked before the mutation, and a take
+      // would leave some unlocked.
       const candidacies = await tx.candidacy.findMany({
         where: { politicianId: id, election: { type: "PRESIDENTIELLE" } },
         select: { id: true, electionId: true },

--- a/src/app/elections/municipales-2020/page.tsx
+++ b/src/app/elections/municipales-2020/page.tsx
@@ -60,7 +60,9 @@ export default async function Municipales2020Page() {
       {stats && (
         <section className="py-8">
           <h2 className="text-xl font-bold mb-4">En chiffres</h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {/* "listes" and "maires élus" were removed on 2026-09-12: neither measured its label.
+              See the Municipales2020Stats doc comment. */}
+          <div className="grid grid-cols-2 gap-4">
             <Card>
               <CardContent className="pt-5 text-center">
                 <p className="text-2xl font-bold tabular-nums">
@@ -75,22 +77,6 @@ export default async function Municipales2020Page() {
                   {stats.totalCommunes.toLocaleString("fr-FR")}
                 </p>
                 <p className="text-sm text-muted-foreground">communes</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-5 text-center">
-                <p className="text-2xl font-bold tabular-nums">
-                  {stats.totalLists.toLocaleString("fr-FR")}
-                </p>
-                <p className="text-sm text-muted-foreground">listes</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-5 text-center">
-                <p className="text-2xl font-bold tabular-nums">
-                  {stats.electedMayorsCount.toLocaleString("fr-FR")}
-                </p>
-                <p className="text-sm text-muted-foreground">maires élus</p>
               </CardContent>
             </Card>
           </div>

--- a/src/app/elections/municipales-2026/communes/[inseeCode]/opengraph-image.tsx
+++ b/src/app/elections/municipales-2026/communes/[inseeCode]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { Prisma } from "@/generated/prisma";
 import { db } from "@/lib/db";
 import { OgLayout, OgCategoryLabel, OG_SIZE } from "@/lib/og-utils";
 import { getDepartmentShapeWithDot } from "@/lib/og-department-shape";
@@ -50,17 +51,18 @@ export default async function Image({ params }: { params: Promise<{ inseeCode: s
   let listCount = 0;
   let candidateCount = 0;
   if (election) {
-    const stats = await db.candidacy.aggregate({
-      where: { electionId: election.id, communeId: inseeCode },
-      _count: true,
-    });
-    candidateCount = stats._count;
-
-    const lists = await db.candidacy.groupBy({
-      by: ["listName"],
-      where: { electionId: election.id, communeId: inseeCode },
-    });
-    listCount = lists.length;
+    // One aggregate row rather than one row per list: the former groupBy shipped rows back to
+    // Node only to read its length, the same bug fixed in getMunicipales2020Stats.
+    const [row] = await db.$queryRaw<Array<{ candidateCount: number; listCount: number }>>(
+      Prisma.sql`
+        SELECT COUNT(*)::int AS "candidateCount",
+               COUNT(DISTINCT "listName")::int AS "listCount"
+        FROM "Candidacy"
+        WHERE "electionId" = ${election.id} AND "communeId" = ${inseeCode}
+      `
+    );
+    candidateCount = row?.candidateCount ?? 0;
+    listCount = row?.listCount ?? 0;
   }
 
   const populationFormatted = commune.population

--- a/src/app/elections/municipales-2026/communes/[inseeCode]/opengraph-image.tsx
+++ b/src/app/elections/municipales-2026/communes/[inseeCode]/opengraph-image.tsx
@@ -53,10 +53,17 @@ export default async function Image({ params }: { params: Promise<{ inseeCode: s
   if (election) {
     // One aggregate row rather than one row per list: the former groupBy shipped rows back to
     // Node only to read its length, the same bug fixed in getMunicipales2020Stats.
+    //
+    // The null-listName group counts as one list: getCommune (src/lib/data/municipales.ts:348)
+    // buckets candidacies without a listName under "Sans liste", the canonical fiche commune
+    // definition this card illustrates, so a candidacy count on its own without that group would
+    // silently change a public number.
     const [row] = await db.$queryRaw<Array<{ candidateCount: number; listCount: number }>>(
       Prisma.sql`
         SELECT COUNT(*)::int AS "candidateCount",
-               COUNT(DISTINCT "listName")::int AS "listCount"
+               (COUNT(DISTINCT "listName")
+                 + (CASE WHEN COUNT(*) FILTER (WHERE "listName" IS NULL) > 0 THEN 1 ELSE 0 END)
+               )::int AS "listCount"
         FROM "Candidacy"
         WHERE "electionId" = ${election.id} AND "communeId" = ${inseeCode}
       `

--- a/src/lib/data/__tests__/municipales-2020-stats.integration.test.ts
+++ b/src/lib/data/__tests__/municipales-2020-stats.integration.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value.
+let db: typeof import("@/lib/db").db;
+let getMunicipales2020Stats: typeof import("../elections").getMunicipales2020Stats;
+
+/**
+ * The 2020 headline counters, on the shape production actually has: several candidacies per
+ * commune, and rows with no commune at all. `totalCommunes` counts distinct communes, not rows,
+ * and ignores the null ones.
+ */
+describeIfDisposableDb("statistiques municipales 2020", () => {
+  let electionId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ getMunicipales2020Stats } = await import("../elections"));
+
+    const election = await db.election.create({
+      data: {
+        slug: "municipales-2020",
+        type: "MUNICIPALES",
+        scope: "MUNICIPAL",
+        title: "Municipales 2020",
+      },
+    });
+    electionId = election.id;
+
+    await db.commune.createMany({
+      data: [
+        { id: "01004", name: "Ambérieu", departmentCode: "01", departmentName: "Ain" },
+        { id: "01005", name: "Ambronay", departmentCode: "01", departmentName: "Ain" },
+      ],
+      skipDuplicates: true,
+    });
+
+    await db.candidacy.createMany({
+      data: [
+        { electionId, candidateName: "A", communeId: "01004", listName: "L1" },
+        { electionId, candidateName: "B", communeId: "01004", listName: "L1" },
+        { electionId, candidateName: "C", communeId: "01004", listName: "L2" },
+        { electionId, candidateName: "D", communeId: "01005", listName: "L3" },
+        { electionId, candidateName: "E", communeId: null, listName: null },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.election.delete({ where: { id: electionId } });
+    await db.commune.deleteMany({ where: { id: { in: ["01004", "01005"] } } });
+    await db.$disconnect();
+  });
+
+  it("compte les communes distinctes, pas les lignes", async () => {
+    const stats = await getMunicipales2020Stats();
+    expect(stats).not.toBeNull();
+    expect(stats!.totalCandidacies).toBe(5);
+    expect(stats!.totalCommunes).toBe(2);
+  });
+});

--- a/src/lib/data/candidates.ts
+++ b/src/lib/data/candidates.ts
@@ -22,6 +22,8 @@ export type CandidatePresidentialRow = Prisma.CandidacyGetPayload<{
 }>;
 
 export async function getCandidates2027ForModeration(): Promise<CandidatePresidentialRow[]> {
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the moderation
+  // queue must show every candidate of that one election, and a take would silently drop some.
   return db.candidacy.findMany({
     where: { election: { slug: "presidentielle-2027" } },
     include: PRESIDENTIAL_INCLUDE,
@@ -56,6 +58,8 @@ export async function getCandidateCrossCycle(
   politicianId: string,
   excludeElectionSlug: string
 ): Promise<CrossCycleEntry[]> {
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): this is one
+  // politician's whole presidential history, and a take would silently drop past cycles.
   const rows = await db.candidacy.findMany({
     where: {
       politicianId,

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -12,11 +12,21 @@ import { NAV_ELECTIONS } from "@/config/navigation";
 // Types
 // ============================================
 
+/**
+ * Headline counters for the 2020 municipal election.
+ *
+ * Two former counters were dropped on 2026-09-12 because neither measured what its label claimed.
+ * `municipales-2020.ts` writes `listName: list.listName || candidateName`, so in communes under
+ * 1000 inhabitants (93 % of the rows) the list name is the person's name: the "lists" counter read
+ * 375 368 where there are roughly 20 000 actual lists. The "elected mayors" counter filtered on
+ * `listPosition = 1`, which the 2020 import never fills, so it published a plain 0.
+ *
+ * `totalCandidacies` is kept but is not clean either: one row is a person in small communes and a
+ * list in larger ones. Both counters return once the import has an explicit data unit.
+ */
 export interface Municipales2020Stats {
   totalCandidacies: number;
   totalCommunes: number;
-  totalLists: number;
-  electedMayorsCount: number;
 }
 
 export interface ElectionRoundData {
@@ -81,7 +91,7 @@ export const getMunicipales2020Stats = cache(
     const electionId = await getElectionId();
     if (!electionId) return null;
 
-    const [totalCandidacies, communeGroups, listGroups, electedMayorsCount] = await Promise.all([
+    const [totalCandidacies, communeGroups] = await Promise.all([
       db.candidacy.count({
         where: { electionId },
       }),
@@ -90,26 +100,11 @@ export const getMunicipales2020Stats = cache(
         by: ["communeId"],
         where: { electionId, communeId: { not: null } },
       }),
-
-      db.candidacy.groupBy({
-        by: ["listName", "communeId"],
-        where: { electionId, listName: { not: null }, communeId: { not: null } },
-      }),
-
-      db.candidacy.count({
-        where: {
-          electionId,
-          isElected: true,
-          listPosition: 1,
-        },
-      }),
     ]);
 
     return {
       totalCandidacies,
       totalCommunes: communeGroups.length,
-      totalLists: listGroups.length,
-      electedMayorsCount,
     };
   }
 );

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -187,7 +187,8 @@ export const getCommuneResults2020 = cache(async function getCommuneResults2020(
   });
   if (!commune) return null;
 
-  // Fetch all candidacies for this commune
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the fiche
+  // commune must show every list of that one commune, and a take would silently drop some.
   const candidacies = await db.candidacy.findMany({
     where: { electionId, communeId: inseeCode },
     select: {
@@ -359,18 +360,23 @@ export const getMunicipales2014Stats = cache(
     const electionId = await getElection2014Id();
     if (!electionId) return null;
 
-    const [totalCandidacies, communeGroups, electedCount] = await Promise.all([
-      db.candidacy.count({ where: { electionId } }),
-      db.candidacy.groupBy({
-        by: ["communeId"],
-        where: { electionId, communeId: { not: null } },
-      }),
+    // Same fix as getMunicipales2020Stats above: one aggregate row rather than one row per
+    // commune, which the former groupBy shipped back to Node only to read its length.
+    const [[row], electedCount] = await Promise.all([
+      db.$queryRaw<Array<{ totalCandidacies: number; totalCommunes: number }>>(
+        Prisma.sql`
+          SELECT COUNT(*)::int AS "totalCandidacies",
+                 COUNT(DISTINCT "communeId")::int AS "totalCommunes"
+          FROM "Candidacy"
+          WHERE "electionId" = ${electionId}
+        `
+      ),
       db.candidacy.count({ where: { electionId, isElected: true } }),
     ]);
 
     return {
-      totalCandidacies,
-      totalCommunes: communeGroups.length,
+      totalCandidacies: row?.totalCandidacies ?? 0,
+      totalCommunes: row?.totalCommunes ?? 0,
       electedCount,
     };
   }
@@ -452,6 +458,8 @@ export const getCommuneResults2014 = cache(async function getCommuneResults2014(
   if (!commune) return null;
 
   // 2014 import has one candidacy per list (tête de liste only)
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the fiche
+  // commune must show every list of that one commune, and a take would silently drop some.
   const candidacies = await db.candidacy.findMany({
     where: { electionId, communeId: inseeCode },
     select: {

--- a/src/lib/data/elections.ts
+++ b/src/lib/data/elections.ts
@@ -91,20 +91,21 @@ export const getMunicipales2020Stats = cache(
     const electionId = await getElectionId();
     if (!electionId) return null;
 
-    const [totalCandidacies, communeGroups] = await Promise.all([
-      db.candidacy.count({
-        where: { electionId },
-      }),
-
-      db.candidacy.groupBy({
-        by: ["communeId"],
-        where: { electionId, communeId: { not: null } },
-      }),
-    ]);
+    // One aggregate row rather than one row per commune: the former groupBy shipped 34 805 rows
+    // back to Node only to read its length. Measured at 108 ms of Execution Time, index-only scan
+    // on Candidacy_electionId_communeId_idx.
+    const [row] = await db.$queryRaw<Array<{ totalCandidacies: number; totalCommunes: number }>>(
+      Prisma.sql`
+        SELECT COUNT(*)::int AS "totalCandidacies",
+               COUNT(DISTINCT "communeId")::int AS "totalCommunes"
+        FROM "Candidacy"
+        WHERE "electionId" = ${electionId}
+      `
+    );
 
     return {
-      totalCandidacies,
-      totalCommunes: communeGroups.length,
+      totalCandidacies: row?.totalCandidacies ?? 0,
+      totalCommunes: row?.totalCommunes ?? 0,
     };
   }
 );

--- a/src/lib/data/municipales.ts
+++ b/src/lib/data/municipales.ts
@@ -274,7 +274,9 @@ export const getCommune = cache(async function getCommune(inseeCode: string) {
     };
   }
 
-  // Get all candidacies for this commune in this election, with candidate + politician data
+  // Get all candidacies for this commune in this election, with candidate + politician data.
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the fiche
+  // commune must show every candidacy of that one commune, and a take would silently drop some.
   const candidacies = await db.candidacy.findMany({
     where: {
       electionId: election.id,
@@ -483,7 +485,9 @@ export const getCumulCandidates = cache(async function getCumulCandidates() {
   });
   if (!election) return [];
 
-  // Get candidacies with linked politicians who have active national mandates
+  // Get candidacies with linked politicians who have active national mandates.
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): the page
+  // computes stats over and renders every cumulard, and a take would silently drop some.
   const candidacies = await db.candidacy.findMany({
     where: {
       electionId: election.id,

--- a/src/lib/data/presidential-candidacy-field.ts
+++ b/src/lib/data/presidential-candidacy-field.ts
@@ -85,6 +85,8 @@ export async function getPublicPresidentialCandidacyField(
   }
 
   const [rows, measureRollups, editions] = await Promise.all([
+    // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): this is the
+    // whole tracked field of one presidential election, and a take would silently drop candidates.
     db.candidacy.findMany({
       where: {
         electionId: election.id,

--- a/src/lib/data/presidential-candidates-public.ts
+++ b/src/lib/data/presidential-candidates-public.ts
@@ -47,6 +47,8 @@ export type PublicPresidentialCandidate = {
 export async function getPublicPresidentialCandidates(
   electionSlug: string
 ): Promise<PublicPresidentialCandidate[]> {
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): this is the
+  // whole public field of one presidential election, and a take would silently drop candidates.
   const rows = await db.candidacy.findMany({
     where: { election: { slug: electionSlug }, ...PUBLIC_CANDIDACY_WHERE },
     include: {

--- a/src/lib/data/presidentielle-2027.ts
+++ b/src/lib/data/presidentielle-2027.ts
@@ -20,6 +20,8 @@ function rank(status: CandidacyStatus | null): number {
 }
 
 export async function getPresidentielle2027Candidates(): Promise<PresidentielleCandidate[]> {
+  // Unbounded by design (see ALLOWED_UNBOUNDED in candidacy-read-bounds.test.ts): this is the
+  // whole admin field of one presidential election, and a take would silently drop candidates.
   const rows = await db.candidacy.findMany({
     where: { election: { slug: "presidentielle-2027" } },
     include: {

--- a/src/services/sync/__tests__/candidacy-update-batch.integration.test.ts
+++ b/src/services/sync/__tests__/candidacy-update-batch.integration.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
+import { Prisma } from "@/generated/prisma";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+import { buildCandidacyUpdateBatch, type CandidacyUpdateRow } from "../candidacy-update-batch";
+
+// Deferred: this module imports @/lib/db as a value.
+let db: typeof import("@/lib/db").db;
+
+function row(id: string, patch: Partial<CandidacyUpdateRow> = {}): CandidacyUpdateRow {
+  return {
+    id,
+    politicianId: null,
+    partyId: null,
+    partyLabel: null,
+    listName: null,
+    listPosition: null,
+    constituencyName: null,
+    candidateId: null,
+    communeId: null,
+    ...patch,
+  };
+}
+
+async function flush(rows: CandidacyUpdateRow[]): Promise<number> {
+  const batch = buildCandidacyUpdateBatch(rows, new Date());
+  return batch === null ? 0 : db.$executeRaw(batch.sql);
+}
+
+/**
+ * The properties the sequential loop had, which raw SQL does not get for free: a written
+ * `updatedAt`, nulls that stay null, an integer column that accepts an all-null batch, a
+ * deterministic winner on duplicates, and a defined answer when the target no longer exists.
+ */
+describeIfDisposableDb("mise à jour par lot des candidatures", () => {
+  let electionId: string;
+  let firstId: string;
+  let secondId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+
+    const election = await db.election.create({
+      data: {
+        slug: "municipales-batch-test",
+        type: "MUNICIPALES",
+        scope: "MUNICIPAL",
+        title: "Test lot",
+      },
+    });
+    electionId = election.id;
+  });
+
+  beforeEach(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    const first = await db.candidacy.create({
+      data: { electionId, candidateName: "Premier", partyLabel: "ANCIEN", listPosition: 7 },
+    });
+    const second = await db.candidacy.create({
+      data: { electionId, candidateName: "Second", partyLabel: "ANCIEN" },
+    });
+    firstId = first.id;
+    secondId = second.id;
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.election.delete({ where: { id: electionId } });
+    await db.$disconnect();
+  });
+
+  it("écrit les valeurs et compte les lignes", async () => {
+    const count = await flush([
+      row(firstId, { partyLabel: "NOUVEAU", listName: "Liste A", listPosition: 2 }),
+      row(secondId, { partyLabel: "AUTRE" }),
+    ]);
+
+    expect(count).toBe(2);
+
+    const after = await db.candidacy.findUniqueOrThrow({ where: { id: firstId } });
+    expect(after.partyLabel).toBe("NOUVEAU");
+    expect(after.listName).toBe("Liste A");
+    expect(after.listPosition).toBe(2);
+  });
+
+  it("fait strictement avancer updatedAt", async () => {
+    // Forced back in SQL, not through Prisma: `@updatedAt` is filled client side, so a freshly
+    // created row already carries "now" and a `>=` assertion would pass even if the batch never
+    // touched the column. Starting from a known old value is what makes the check mean something.
+    const stale = new Date("2020-01-01T00:00:00.000Z");
+    await db.$executeRaw(
+      Prisma.sql`UPDATE "Candidacy" SET "updatedAt" = ${stale} WHERE id = ${firstId}`
+    );
+
+    await flush([row(firstId, { partyLabel: "NOUVEAU" })]);
+
+    const after = await db.candidacy.findUniqueOrThrow({ where: { id: firstId } });
+    expect(after.updatedAt.getTime()).toBeGreaterThan(stale.getTime());
+  });
+
+  it("remet à null une colonne dont la valeur devient nulle", async () => {
+    await flush([row(firstId, { partyLabel: null, listPosition: null })]);
+
+    const after = await db.candidacy.findUniqueOrThrow({ where: { id: firstId } });
+    expect(after.partyLabel).toBeNull();
+    expect(after.listPosition).toBeNull();
+  });
+
+  it("accepte un lot dont la colonne entière est entièrement nulle", async () => {
+    // Without the SET-side cast, PostgreSQL infers `text` for an all-null VALUES column and the
+    // assignment to the integer column fails.
+    await expect(
+      flush([row(firstId, { listPosition: null }), row(secondId, { listPosition: null })])
+    ).resolves.toBe(2);
+  });
+
+  it("applique la dernière ligne quand un identifiant est répété", async () => {
+    await flush([
+      row(secondId, { partyLabel: "PREMIER PASSAGE" }),
+      row(secondId, { partyLabel: "DERNIER PASSAGE" }),
+    ]);
+
+    const after = await db.candidacy.findUniqueOrThrow({ where: { id: secondId } });
+    expect(after.partyLabel).toBe("DERNIER PASSAGE");
+  });
+
+  it("donne le même résultat que la boucle séquentielle sur les mêmes entrées", async () => {
+    // The reference the batch replaces, run on a second pair of rows, then compared column by
+    // column. This is the equivalence claim itself, not a proxy for it.
+    const a = await db.candidacy.create({
+      data: { electionId, candidateName: "Ref A", partyLabel: "ANCIEN" },
+    });
+    const b = await db.candidacy.create({
+      data: { electionId, candidateName: "Ref B", partyLabel: "ANCIEN" },
+    });
+
+    const inputs = [
+      row(a.id, { partyLabel: "X", listName: "LX", listPosition: 1 }),
+      row(b.id, { partyLabel: "Y" }),
+      row(a.id, { partyLabel: "Z", listName: "LZ", listPosition: 3 }),
+    ];
+
+    // Sequential reference, exactly what candidatures.ts used to do.
+    for (const input of inputs) {
+      const { id, ...data } = input;
+      await db.candidacy.update({ where: { id }, data });
+    }
+    const sequentialA = await db.candidacy.findUniqueOrThrow({ where: { id: a.id } });
+    const sequentialB = await db.candidacy.findUniqueOrThrow({ where: { id: b.id } });
+
+    // Reset, then apply the same inputs as one batch.
+    await db.candidacy.update({
+      where: { id: a.id },
+      data: { partyLabel: "ANCIEN", listName: null, listPosition: null },
+    });
+    await db.candidacy.update({ where: { id: b.id }, data: { partyLabel: "ANCIEN" } });
+    await flush(inputs);
+
+    const batchedA = await db.candidacy.findUniqueOrThrow({ where: { id: a.id } });
+    const batchedB = await db.candidacy.findUniqueOrThrow({ where: { id: b.id } });
+
+    for (const key of [
+      "partyLabel",
+      "listName",
+      "listPosition",
+      "politicianId",
+      "candidateId",
+      "communeId",
+      "constituencyName",
+    ] as const) {
+      expect(batchedA[key]).toEqual(sequentialA[key]);
+      expect(batchedB[key]).toEqual(sequentialB[key]);
+    }
+  });
+
+  it("ignore un identifiant absent et le signale par le compte", async () => {
+    // Documented divergence: db.candidacy.update() raised P2025 on a missing row, the batch
+    // silently updates nothing. The caller compares the count to the batch size, see task 4.
+    const count = await flush([
+      row(firstId, { partyLabel: "OK" }),
+      row("inexistant", { partyLabel: "PERDU" }),
+    ]);
+
+    expect(count).toBe(1);
+  });
+
+  it("ne fait rien et rend zéro sur un lot vide", async () => {
+    await expect(flush([])).resolves.toBe(0);
+  });
+
+  it("tient le budget de 500 ms sur un lot de 500 lignes", async () => {
+    const created = await Promise.all(
+      Array.from({ length: 500 }, (_, i) =>
+        db.candidacy.create({ data: { electionId, candidateName: `Charge ${i}` } })
+      )
+    );
+    const rows = created.map((c, i) => row(c.id, { partyLabel: `P${i}`, listPosition: i }));
+    const batch = buildCandidacyUpdateBatch(rows, new Date())!;
+
+    // EXPLAIN ANALYZE on an UPDATE performs the write. That is why this only ever runs against the
+    // disposable container, and why the budget is checked on Execution Time rather than on a
+    // wall-clock timer, which would also count the round trip and let a one-second batch pass.
+    const plan = await db.$queryRaw<Array<Record<string, unknown>>>(
+      Prisma.sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${batch.sql}`
+    );
+    const rootPlan = (plan[0]!["QUERY PLAN"] as Array<{ "Execution Time": number }>)[0]!;
+    const executionMs = rootPlan["Execution Time"];
+
+    // Local container, no network: this bounds the statement's cost, it does not predict the
+    // duration of a national re-import. Report it as a local figure.
+    console.log(`[batch] 500 lignes : ${executionMs} ms d'Execution Time (conteneur local)`);
+    expect(executionMs).toBeLessThan(500);
+  });
+});

--- a/src/services/sync/__tests__/candidacy-update-batch.test.ts
+++ b/src/services/sync/__tests__/candidacy-update-batch.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCandidacyUpdateBatch,
+  dedupeCandidacyUpdates,
+  type CandidacyUpdateRow,
+} from "../candidacy-update-batch";
+
+function row(id: string, partyLabel: string | null = null): CandidacyUpdateRow {
+  return {
+    id,
+    politicianId: null,
+    partyId: null,
+    partyLabel,
+    listName: null,
+    listPosition: null,
+    constituencyName: null,
+    candidateId: null,
+    communeId: null,
+  };
+}
+
+describe("dedupeCandidacyUpdates", () => {
+  it("garde la dernière valeur pour un identifiant répété", () => {
+    // The sequential loop it replaces applied updates in order, so the last write won.
+    // UPDATE ... FROM (VALUES ...) picks an arbitrary source row, hence this pre-pass.
+    const result = dedupeCandidacyUpdates([row("a", "LR"), row("b", "PS"), row("a", "RN")]);
+
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.id === "a")?.partyLabel).toBe("RN");
+  });
+
+  it("préserve l'ordre de première apparition", () => {
+    const result = dedupeCandidacyUpdates([row("b", "PS"), row("a", "LR"), row("b", "EELV")]);
+
+    expect(result.map((r) => r.id)).toEqual(["b", "a"]);
+  });
+
+  it("rend un tableau vide pour une entrée vide", () => {
+    expect(dedupeCandidacyUpdates([])).toEqual([]);
+  });
+});
+
+describe("buildCandidacyUpdateBatch", () => {
+  it("rend null sur un lot vide plutôt qu'un UPDATE sans cible", () => {
+    expect(buildCandidacyUpdateBatch([], new Date())).toBeNull();
+  });
+
+  it("dédoublonne avant de construire, donc une seule ligne de VALUES", () => {
+    const batch = buildCandidacyUpdateBatch([row("a", "LR"), row("a", "RN")], new Date());
+
+    expect(batch).not.toBeNull();
+    // 9 columns + the updatedAt parameter, for one deduplicated row.
+    expect(batch!.sql.values).toHaveLength(10);
+    expect(batch!.sql.values).toContain("RN");
+    expect(batch!.sql.values).not.toContain("LR");
+  });
+
+  it("rend le nombre de cibles, pas le nombre d'entrées", () => {
+    // This is what stops the caller from reading a legitimate duplicate as a missing row.
+    const batch = buildCandidacyUpdateBatch([row("a"), row("b"), row("a")], new Date());
+
+    expect(batch!.targets).toBe(2);
+  });
+
+  it("porte les casts dans le SET, pas dans le VALUES", () => {
+    // The pg adapter rejects some casts written inside a VALUES list, and an all-null column
+    // would otherwise be inferred as text and fail on assignment to an integer column.
+    const text = buildCandidacyUpdateBatch([row("a")], new Date())!.sql.sql;
+
+    expect(text).toContain('"listPosition"     = v."listPosition"::int');
+    expect(text).not.toMatch(/VALUES[^)]*::/);
+  });
+});

--- a/src/services/sync/__tests__/candidatures-chunk.integration.test.ts
+++ b/src/services/sync/__tests__/candidatures-chunk.integration.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+// Deferred: these modules import @/lib/db as a value.
+let db: typeof import("@/lib/db").db;
+let applyCandidacyChunk: typeof import("../candidatures").applyCandidacyChunk;
+
+/**
+ * The update/insert pair of one chunk. The batch changed the granularity of a failure, so the
+ * failing path is the one worth proving: the inserts of an aborted chunk must not land.
+ */
+describeIfDisposableDb("application d'un chunk de candidatures", () => {
+  let electionId: string;
+  let existingId: string;
+
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ applyCandidacyChunk } = await import("../candidatures"));
+
+    const election = await db.election.create({
+      data: {
+        slug: "municipales-chunk-test",
+        type: "MUNICIPALES",
+        scope: "MUNICIPAL",
+        title: "Test chunk",
+      },
+    });
+    electionId = election.id;
+  });
+
+  beforeEach(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    const existing = await db.candidacy.create({
+      data: { electionId, candidateName: "Existant", partyLabel: "ANCIEN" },
+    });
+    existingId = existing.id;
+  });
+
+  afterAll(async () => {
+    await db.candidacy.deleteMany({ where: { electionId } });
+    await db.election.delete({ where: { id: electionId } });
+    await db.$disconnect();
+  });
+
+  function update(id: string, patch: Record<string, unknown> = {}) {
+    return {
+      id,
+      politicianId: null,
+      partyId: null,
+      partyLabel: "NOUVEAU",
+      listName: null,
+      listPosition: null,
+      constituencyName: null,
+      candidateId: null,
+      communeId: null,
+      ...patch,
+    };
+  }
+
+  it("écrit les mises à jour puis les créations", async () => {
+    const applied = await applyCandidacyChunk(
+      [update(existingId)],
+      [{ electionId, candidateName: "Nouveau" }]
+    );
+
+    expect(applied).toEqual({ updated: 1, created: 1, missing: 0, failure: null });
+    expect(await db.candidacy.count({ where: { electionId } })).toBe(2);
+  });
+
+  it("ne signale aucune candidature manquante sur un doublon légitime", async () => {
+    // The regression this guards: the batch deduplicates, so two entries for one id affect one row.
+    // Comparing that 1 to the two entries received used to report a missing candidacy and turn the
+    // whole sync into success: false.
+    const applied = await applyCandidacyChunk(
+      [
+        update(existingId, { partyLabel: "PREMIER" }),
+        update(existingId, { partyLabel: "DERNIER" }),
+      ],
+      []
+    );
+
+    expect(applied.updated).toBe(1);
+    expect(applied.missing).toBe(0);
+
+    const after = await db.candidacy.findUniqueOrThrow({ where: { id: existingId } });
+    expect(after.partyLabel).toBe("DERNIER");
+  });
+
+  it("signale un identifiant réellement absent", async () => {
+    const applied = await applyCandidacyChunk([update(existingId), update("inexistant")], []);
+
+    expect(applied.updated).toBe(1);
+    expect(applied.missing).toBe(1);
+  });
+
+  it("n'écrit aucune création quand la mise à jour échoue", async () => {
+    // A politicianId that points nowhere violates the foreign key, so the UPDATE fails. The inserts
+    // come after it and must not land.
+    const applied = await applyCandidacyChunk(
+      [update(existingId, { politicianId: "politicien-inexistant" })],
+      [{ electionId, candidateName: "Ne doit pas exister" }]
+    );
+
+    expect(applied.failure).toContain("mise à jour");
+    expect(applied.updated).toBe(0);
+    expect(applied.created).toBe(0);
+
+    expect(
+      await db.candidacy.count({ where: { electionId, candidateName: "Ne doit pas exister" } })
+    ).toBe(0);
+    const untouched = await db.candidacy.findUniqueOrThrow({ where: { id: existingId } });
+    expect(untouched.partyLabel).toBe("ANCIEN");
+  });
+
+  it("comptabilise les mises à jour même si la création échoue ensuite", async () => {
+    // The two halves are separate statements with no transaction around them, so an update that
+    // succeeded is committed. Losing its count would under-report candidaciesUpdated on a run that
+    // really did write rows.
+    const applied = await applyCandidacyChunk(
+      [update(existingId, { partyLabel: "BIEN ÉCRIT" })],
+      [{ electionId: "election-inexistante", candidateName: "Création impossible" }]
+    );
+
+    expect(applied.updated).toBe(1);
+    expect(applied.created).toBe(0);
+    expect(applied.failure).toContain("création");
+
+    const written = await db.candidacy.findUniqueOrThrow({ where: { id: existingId } });
+    expect(written.partyLabel).toBe("BIEN ÉCRIT");
+  });
+});

--- a/src/services/sync/candidacy-update-batch.ts
+++ b/src/services/sync/candidacy-update-batch.ts
@@ -1,0 +1,86 @@
+import { Prisma } from "@/generated/prisma";
+
+/**
+ * One candidacy row to update during a candidatures sync.
+ *
+ * Mirrors the columns the sequential `db.candidacy.update()` loop wrote, and nothing more:
+ * widening it would silently start overwriting columns the sync never owned.
+ */
+export type CandidacyUpdateRow = {
+  id: string;
+  politicianId: string | null;
+  partyId: string | null;
+  partyLabel: string | null;
+  listName: string | null;
+  listPosition: number | null;
+  constituencyName: string | null;
+  candidateId: string | null;
+  communeId: string | null;
+};
+
+/**
+ * Keep one row per id, the last one, and preserve first-appearance order.
+ *
+ * The sequential loop this replaces applied each update in turn, so a CSV holding two rows for the
+ * same candidacy ended on the later one. `UPDATE ... FROM (VALUES ...)` has no such rule: with
+ * several source rows matching one target, PostgreSQL does not define which is used. Collapsing
+ * duplicates first is what keeps the behaviour identical.
+ */
+export function dedupeCandidacyUpdates(rows: CandidacyUpdateRow[]): CandidacyUpdateRow[] {
+  const byId = new Map<string, CandidacyUpdateRow>();
+  for (const row of rows) {
+    byId.set(row.id, row);
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Build the single statement that applies the batch, with the number of rows it targets.
+ * Returns null when there is nothing to write.
+ *
+ * Casts sit in the SET clause, not inside VALUES: the pg adapter rejects some casts written in a
+ * VALUES list, and a column whose every value is null would otherwise be inferred as text and fail
+ * on assignment to the integer column.
+ *
+ * `updatedAt` is passed explicitly. The column is declared `@updatedAt`, which Prisma fills client
+ * side; raw SQL bypasses that entirely and would leave the timestamp untouched.
+ *
+ * This module deliberately does not import `@/lib/db`: that module builds the client at import time
+ * and throws without DATABASE_URL, which the unit-test CI job does not provide.
+ */
+export function buildCandidacyUpdateBatch(
+  rows: CandidacyUpdateRow[],
+  updatedAt: Date
+): { sql: Prisma.Sql; targets: number } | null {
+  const deduped = dedupeCandidacyUpdates(rows);
+  if (deduped.length === 0) return null;
+
+  const values = Prisma.join(
+    deduped.map(
+      (r) =>
+        Prisma.sql`(${r.id}, ${r.politicianId}, ${r.partyId}, ${r.partyLabel}, ${r.listName}, ${r.listPosition}, ${r.constituencyName}, ${r.candidateId}, ${r.communeId})`
+    )
+  );
+
+  const sql = Prisma.sql`
+    UPDATE "Candidacy" AS c
+    SET "politicianId"     = v."politicianId"::text,
+        "partyId"          = v."partyId"::text,
+        "partyLabel"       = v."partyLabel"::text,
+        "listName"         = v."listName"::text,
+        "listPosition"     = v."listPosition"::int,
+        "constituencyName" = v."constituencyName"::text,
+        "candidateId"      = v."candidateId"::text,
+        "communeId"        = v."communeId"::text,
+        "updatedAt"        = ${updatedAt}
+    FROM (VALUES ${values}) AS v(
+      "id", "politicianId", "partyId", "partyLabel", "listName",
+      "listPosition", "constituencyName", "candidateId", "communeId"
+    )
+    WHERE c."id" = v."id"::text
+  `;
+
+  // `targets` travels with the SQL so a caller cannot compare the affected-row count to the number
+  // of entries it passed in: duplicates make those two numbers differ legitimately.
+  return { sql, targets: deduped.length };
+}

--- a/src/services/sync/candidatures.ts
+++ b/src/services/sync/candidatures.ts
@@ -8,6 +8,10 @@ import { DATA_GOUV_RATE_LIMIT_MS } from "@/config/rate-limits";
 import { resolveBatch } from "@/lib/identity";
 import type { ResolveInput } from "@/lib/identity";
 import { normalizeText, primarySurname } from "@/lib/name-matching";
+import {
+  buildCandidacyUpdateBatch,
+  type CandidacyUpdateRow,
+} from "@/services/sync/candidacy-update-batch";
 
 // 2026 CSV (semicolon-delimited, UTF-8, no comment header)
 const DEFAULT_CSV_URL =
@@ -212,6 +216,61 @@ async function loadRNEBirthdateLookup(): Promise<
     }
   }
   return map;
+}
+
+/**
+ * Apply one chunk: updates first, then inserts, in the order the sequential loop used.
+ *
+ * Exported for its integration test. The ordering of the pair and what happens when the first half
+ * fails are exactly what this refactor changes, and neither can be exercised through
+ * `syncCandidaturesMunicipales` without a full CSV fixture.
+ *
+ * Three deliberate differences from the sequential loop this replaces:
+ * 1. Granularity. The loop wrote row by row, so a failure on row 300 left 299 written. The batch is
+ *    one statement: a failure leaves none of this chunk's updates written.
+ * 2. A failed update aborts before the inserts, so the chunk's inserts are skipped too. The loop had
+ *    already written its updates by the time it reached them.
+ * 3. A vanished id no longer raises P2025. It is reported through `missing` instead.
+ *
+ * It does not throw: a failure is returned alongside the counts. The updates and the inserts are two
+ * statements with no transaction around them, so throwing after a successful update would drop rows
+ * that were really written from `candidaciesUpdated`.
+ */
+export async function applyCandidacyChunk(
+  toUpdate: CandidacyUpdateRow[],
+  toCreate: Prisma.CandidacyCreateManyInput[]
+): Promise<{ updated: number; created: number; missing: number; failure: string | null }> {
+  let updated = 0;
+  let missing = 0;
+
+  const batch = buildCandidacyUpdateBatch(toUpdate, new Date());
+  if (batch !== null) {
+    try {
+      updated = await db.$executeRaw(batch.sql);
+      // Compare against the deduplicated target count, never against toUpdate.length: a CSV holding
+      // the same candidacy twice is legitimate, and comparing to the raw length would report a
+      // missing row that does not exist.
+      missing = batch.targets - updated;
+    } catch (error) {
+      // One statement, so nothing of this chunk was written. The inserts are skipped on purpose.
+      return { updated: 0, created: 0, missing: 0, failure: `mise à jour: ${error}` };
+    }
+  }
+
+  let created = 0;
+  if (toCreate.length > 0) {
+    try {
+      await db.candidacy.createMany({ data: toCreate, skipDuplicates: true });
+      created = toCreate.length;
+    } catch (error) {
+      // The updates above are already committed: there is no transaction around the pair. Reporting
+      // the failure while returning the counts is what keeps candidaciesUpdated truthful; throwing
+      // here would lose rows that really were written.
+      return { updated, created: 0, missing, failure: `création: ${error}` };
+    }
+  }
+
+  return { updated, created, missing, failure: null };
 }
 
 /**
@@ -488,6 +547,7 @@ export async function syncCandidaturesMunicipales(
 
       // ── Step 5: Upsert candidacies for this chunk ──────────────────
       const toCreate: Prisma.CandidacyCreateManyInput[] = [];
+      const toUpdate: CandidacyUpdateRow[] = [];
 
       for (let j = 0; j < chunk.length; j++) {
         const row = chunk[j];
@@ -506,20 +566,17 @@ export async function syncCandidaturesMunicipales(
           const existingId = existingCandidacyMap.get(existingKey);
 
           if (existingId) {
-            await db.candidacy.update({
-              where: { id: existingId },
-              data: {
-                politicianId,
-                partyId,
-                partyLabel: row!.partyLabel,
-                listName: row!.listName,
-                listPosition: row!.listPosition,
-                constituencyName: row!.communeName,
-                candidateId,
-                communeId,
-              },
+            toUpdate.push({
+              id: existingId,
+              politicianId,
+              partyId,
+              partyLabel: row!.partyLabel,
+              listName: row!.listName,
+              listPosition: row!.listPosition,
+              constituencyName: row!.communeName,
+              candidateId,
+              communeId,
             });
-            candidaciesUpdated++;
           } else {
             toCreate.push({
               electionId: electionRecord.id,
@@ -540,9 +597,16 @@ export async function syncCandidaturesMunicipales(
         }
       }
 
-      if (toCreate.length > 0) {
-        await db.candidacy.createMany({ data: toCreate, skipDuplicates: true });
-        candidaciesCreated += toCreate.length;
+      const applied = await applyCandidacyChunk(toUpdate, toCreate);
+      candidaciesUpdated += applied.updated;
+      candidaciesCreated += applied.created;
+      if (applied.missing > 0) {
+        errors.push(
+          `Chunk ${chunkIdx + 1}: ${applied.missing} candidature(s) introuvable(s) à la mise à jour`
+        );
+      }
+      if (applied.failure !== null) {
+        errors.push(`Chunk ${chunkIdx + 1}: ${applied.failure}`);
       }
     } catch (error) {
       errors.push(`Chunk ${chunkIdx + 1}: ${error}`);


### PR DESCRIPTION
## Pourquoi

Audit de performance autour de `Candidacy` (1,28 M de lignes). Quatre chantiers étaient suspectés ; deux ne tenaient pas à la mesure, deux étaient réels et l'un d'eux plus grave que décrit.

Ce qui a été écarté après mesure :

- Le « N+1 en lecture » n'en est pas un. La forme `WHERE id IN (...) OFFSET` est le chargement de relation de Prisma, et la requête s'exécute en **11 ms**.
- Le précalcul des agrégations municipales existe depuis avril 2026 (`compute-municipales-snapshots.ts`).

## Ce que fait cette PR

**Compteurs de `/elections/municipales-2020`.** Les cartes « listes » et « maires élus » sont retirées : ni l'une ni l'autre ne mesurait ce que son libellé annonçait. `municipales-2020.ts` écrit `listName: list.listName || candidateName`, donc dans les communes de moins de 1000 habitants (93 % des lignes) le nom de la liste est celui de la personne : le compteur affichait 375 368 là où il y a de l'ordre de 20 000 listes. Le compteur de maires filtrait sur `listPosition = 1`, jamais rempli par l'import 2020, et publiait donc un zéro.

Le compteur de communes restant passe d'un `groupBy` rapatriant 34 805 lignes pour en lire la longueur à une agrégation SQL.

| | Avant | Après |
|---|---|---|
| `getMunicipales2020Stats` | 4 100 ms | **1 690 ms** |
| Lignes transférées | 410 173 | 34 805 |
| `Execution Time` de la requête restante | | **107 à 117 ms**, `Index Only Scan` |

**Écriture par lot dans le sync.** `candidatures.ts` faisait un aller-retour par ligne CSV déjà en base. Un lot de 500 lignes, soit `CHUNK_SIZE`, s'exécute désormais en **12,4 ms**. Le dédoublonnage reproduit le « dernier gagne » de la boucle séquentielle, que `UPDATE ... FROM (VALUES)` ne garantit pas, et `updatedAt` est écrit explicitement puisque `@updatedAt` est appliqué côté client et ignoré en SQL brut.

**Garde-fou.** Un test d'architecture interdit les lectures non bornées de `Candidacy` sous `src/lib/data` et `src/app`. Il exige un `take` littéral, ou une exception déclarée avec sa raison. Il a révélé 15 sites : 2 réécrits en agrégation SQL (dont `getMunicipales2014Stats`, qui portait le même défaut que 2020), et 13 inscrits en exception justifiée sur 10 fichiers.

Chaque exception est ancrée au couple fichier plus fonction englobante, et non à un compte par fichier : sans cela, un fichier exempté aurait pu borner une lecture approuvée tout en ajoutant une lecture non bornée sans rapport, le total restant identique. L'en-tête énonce les trois familles d'exception admissibles, pour qu'un lecteur puisse décider seul d'en ajouter une quatorzième.

**Index.** `Candidacy_partyId_idx` est déclaré dans le schéma depuis ce matin mais absent de la production. `Candidacy_electionId_listName_idx` pèse 34 Mo pour un seul scan depuis le 18 juin, et `Candidacy_electoralListId_idx` 8,8 Mo sur une colonne entièrement nulle, `ElectoralList` étant vide.

## À faire à la main après le merge

Le fichier `prisma/migrations/manual/2026-09-12-candidacy-drop-unused-indexes.sql` **n'est pas encore appliqué**, et c'est voulu. L'ordre ne se négocie pas :

1. créer `Candidacy_partyId_idx` avec le fichier déjà présent, puis vérifier sa validité **et** sa définition, `IF NOT EXISTS` ne testant que le nom ;
2. déployer, pour que le schéma en vigueur ne déclare plus les deux index ;
3. seulement alors, jouer la migration de suppression.

Sans cet ordre, un `db:push` depuis l'ancien schéma recrée ce qu'on vient de supprimer.

## Hors périmètre, signalé

Trois sujets sortent du périmètre et ont leur issue, ouverte avant ce merge pour qu'ils ne disparaissent pas avec la PR :

- **#870** : `src/app/api/elections/[slug]/route.ts:50` charge toutes les candidatures d'une élection par relation, sans borne, sur une route publique. Pour `municipales-2020` cela fait 375 371 lignes sérialisées en JSON, soit le scénario exact de la page de 19 Mo. Le garde-fou ne le voit pas, il ne couvre que les appels directs, et son en-tête le dit.
- **#871** : deux définitions de « liste » coexistent selon qu'on compte ou non le groupe nul. La divergence est antérieure à cette PR, qui l'a seulement mise au jour et a choisi de ne pas changer une valeur affichée au détour d'un lot de performance.
- **#872** : `DEFAULT_CSV_URL` rend un HTTP 404, donc `sync:candidatures` ne peut plus s'exécuter. Corollaire assumé : le gain du batch est mesuré sur le conteneur de test et ne sera pas observable en production tant que cette URL est morte.

Enfin, la carte « candidatures » de 2020 reste affichée bien que son unité soit impure : une ligne est une personne sous 1000 habitants, une liste au-dessus. Le libellé n'est pas faux, il est imprécis. Elle reviendra propre avec une reprise de l'import.

## Vérifications

680 fichiers de tests passés, 6 087 tests, zéro échec. `tsc --noEmit` et `eslint` en code 0.

Les trois suites d'intégration de ce lot ont tourné sur le conteneur jetable, et non en « skipped ». À noter : aucun workflow CI n'appelle `test:db:*`, donc elles ne tournent pas en continu. La démonstration d'équivalence du batch (dernier gagne, nulls préservés, `updatedAt`, identifiant absent) repose sur des exécutions locales. C'est préexistant au lot.

Les deux réécritures SQL sans test d'intégration ont été exécutées une fois contre la production : `getMunicipales2014Stats` rend 20 771 candidatures et 9 586 communes, la requête de la carte OG rend 9 listes pour 500 candidats sur la commune 45234. Aucune erreur de cast.
