### PR TITLE
perf(affair-matching): mutualiser le contexte du resolver

### DIFF
--- a/src/lib/affair-matching/__tests__/context.test.ts
+++ b/src/lib/affair-matching/__tests__/context.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AffairCandidateRecord, AffairScoringInput } from "../signals/types";
+import type { AffairResolverContext } from "../persistence";
+import type { SurnameVocabulary } from "../surname-ambiguity";
+import { CandidatePrefilter } from "../candidate-prefilter";
+
+const persistence = vi.hoisted(() => ({
+  computeTextHash: vi.fn(() => "hash"),
+  loadAffairResolverContext: vi.fn(),
+  loadBlocklist: vi.fn(),
+  persistDecision: vi.fn(),
+}));
+
+vi.mock("../persistence", () => persistence);
+
+import { previewAffairPolitician, resolveAffairPolitician } from "../resolver";
+
+const input: AffairScoringInput = {
+  text: "Jean Martin est cité dans cette affaire.",
+  metadata: { source: "PRESSE", sourceRef: "article-1" },
+};
+
+const candidate: AffairCandidateRecord = {
+  id: "pol-1",
+  firstName: "Jean",
+  lastName: "Martin",
+  fullName: "Jean Martin",
+  normalizedLastName: "martin",
+  birthDate: null,
+  deathDate: null,
+  civility: null,
+  departments: [],
+  mandates: [],
+  parties: [],
+  externalIds: {},
+};
+
+const vocabulary = { lookup: () => null } as unknown as SurnameVocabulary;
+
+function makeContext(): AffairResolverContext {
+  return { candidatePool: [candidate], vocabulary, prefilter: new CandidatePrefilter([candidate]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  persistence.loadAffairResolverContext.mockResolvedValue(makeContext());
+  persistence.loadBlocklist.mockResolvedValue(new Set<string>());
+  persistence.persistDecision.mockResolvedValue({ decisionId: "decision-1", created: true });
+});
+
+describe("resolver context", () => {
+  it("réutilise le contexte chargé une fois pour 100 affaires", async () => {
+    const context = await persistence.loadAffairResolverContext();
+
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        resolveAffairPolitician(
+          { ...input, metadata: { ...input.metadata, sourceRef: `${index}` } },
+          context
+        )
+      )
+    );
+
+    expect(persistence.loadAffairResolverContext).toHaveBeenCalledOnce();
+    expect(persistence.loadBlocklist).toHaveBeenCalledTimes(100);
+    expect(persistence.persistDecision).toHaveBeenCalledTimes(100);
+  });
+
+  it("relit la blocklist pour chaque affaire et exclut une exclusion enregistrée", async () => {
+    const context = makeContext();
+    persistence.loadBlocklist.mockResolvedValue(new Set(["pol-1"]));
+
+    const result = await previewAffairPolitician(input, context);
+
+    expect(result.judgment).toBe("NO_MATCH");
+    expect(result.topCandidateId).toBeNull();
+    expect(persistence.persistDecision).not.toHaveBeenCalled();
+  });
+
+  it("ne transforme pas un échec de chargement en NO_MATCH", async () => {
+    persistence.loadAffairResolverContext.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(resolveAffairPolitician(input)).rejects.toThrow("database unavailable");
+    expect(persistence.persistDecision).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/affair-matching/__tests__/context.test.ts
+++ b/src/lib/affair-matching/__tests__/context.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AffairCandidateRecord, AffairScoringInput } from "../signals/types";
+import type { AffairResolverContext } from "../persistence";
+import type { SurnameVocabulary } from "../surname-ambiguity";
+import { CandidatePrefilter } from "../candidate-prefilter";
+
+const persistence = vi.hoisted(() => ({
+  computeTextHash: vi.fn(() => "hash"),
+  loadAffairResolverContext: vi.fn(),
+  loadBlocklist: vi.fn(),
+  persistDecision: vi.fn(),
+}));
+
+vi.mock("../persistence", () => persistence);
+
+import { previewAffairPolitician, resolveAffairPolitician } from "../resolver";
+
+const input: AffairScoringInput = {
+  text: "Jean Martin est cité dans cette affaire.",
+  metadata: {
+    source: "PRESSE",
+    sourceRef: "article-1",
+    externalIds: { wikidataQId: "Q1" },
+  },
+};
+
+const candidate: AffairCandidateRecord = {
+  id: "pol-1",
+  firstName: "Jean",
+  lastName: "Martin",
+  fullName: "Jean Martin",
+  normalizedLastName: "martin",
+  birthDate: null,
+  deathDate: null,
+  civility: null,
+  departments: [],
+  mandates: [],
+  parties: [],
+  externalIds: { WIKIDATA: "Q1" },
+};
+
+const vocabulary = { lookup: () => null } as unknown as SurnameVocabulary;
+
+function makeContext(): AffairResolverContext {
+  return { candidatePool: [candidate], vocabulary, prefilter: new CandidatePrefilter([candidate]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  persistence.loadAffairResolverContext.mockResolvedValue(makeContext());
+  persistence.loadBlocklist.mockResolvedValue(new Set<string>());
+  persistence.persistDecision.mockResolvedValue({ decisionId: "decision-1", created: true });
+});
+
+describe("resolver context", () => {
+  it("réutilise le contexte chargé une fois pour 100 affaires", async () => {
+    const context = await persistence.loadAffairResolverContext();
+
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        resolveAffairPolitician(
+          { ...input, metadata: { ...input.metadata, sourceRef: `${index}` } },
+          context
+        )
+      )
+    );
+
+    expect(persistence.loadAffairResolverContext).toHaveBeenCalledOnce();
+    expect(persistence.loadBlocklist).toHaveBeenCalledTimes(100);
+    expect(persistence.persistDecision).toHaveBeenCalledTimes(100);
+  });
+
+  it("relit la blocklist pour chaque affaire et exclut une exclusion enregistrée", async () => {
+    const context = makeContext();
+    persistence.loadBlocklist
+      .mockResolvedValueOnce(new Set<string>())
+      .mockResolvedValueOnce(new Set(["pol-1"]));
+
+    const first = await previewAffairPolitician(input, context);
+    const second = await previewAffairPolitician(input, context);
+
+    expect(first.topCandidateId).toBe("pol-1");
+    expect(second.judgment).toBe("NO_MATCH");
+    expect(second.topCandidateId).toBeNull();
+    expect(persistence.persistDecision).not.toHaveBeenCalled();
+  });
+
+  it("conserve les mêmes décision et scores avec ou sans contexte partagé", async () => {
+    const shared = makeContext();
+
+    const withContext = await resolveAffairPolitician(input, shared);
+    const withoutContext = await resolveAffairPolitician(input);
+
+    expect(withContext).toMatchObject({
+      judgment: withoutContext.judgment,
+      topCandidateId: withoutContext.topCandidateId,
+      topScore: withoutContext.topScore,
+      gap: withoutContext.gap,
+      topCandidates: withoutContext.topCandidates,
+    });
+  });
+
+  it("ne transforme pas un échec de chargement en NO_MATCH", async () => {
+    persistence.loadAffairResolverContext.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(resolveAffairPolitician(input)).rejects.toThrow("database unavailable");
+    expect(persistence.persistDecision).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/affair-matching/__tests__/persistence.test.ts
+++ b/src/lib/affair-matching/__tests__/persistence.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/db", () => ({
   db: {
     politician: { findMany: vi.fn() },
+    commune: { findMany: vi.fn() },
     affairPoliticianDecision: {
       findUnique: vi.fn(),
       create: vi.fn(),
@@ -11,7 +12,13 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { computeTextHash, persistDecision, loadBlocklist } from "../persistence";
+import {
+  computeTextHash,
+  createAffairResolverContextLoader,
+  loadAffairResolverContext,
+  persistDecision,
+  loadBlocklist,
+} from "../persistence";
 import type { CombinerDecision } from "../combiner";
 import { db } from "@/lib/db";
 import { SourceType } from "@/generated/prisma";
@@ -20,6 +27,8 @@ import type { Mock } from "vitest";
 const mockDecisionCreate = db.affairPoliticianDecision.create as Mock;
 const mockDecisionFindUnique = db.affairPoliticianDecision.findUnique as Mock;
 const mockDecisionFindMany = db.affairPoliticianDecision.findMany as Mock;
+const mockPoliticianFindMany = db.politician.findMany as Mock;
+const mockCommuneFindMany = db.commune.findMany as Mock;
 
 describe("computeTextHash", () => {
   it("produces a stable sha256 hex digest", () => {
@@ -131,5 +140,45 @@ describe("loadBlocklist", () => {
     expect(result.has("pol-a")).toBe(true);
     expect(result.has("pol-b")).toBe(true);
     expect(result.size).toBe(2);
+  });
+});
+
+describe("loadAffairResolverContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("charge le pool et le vocabulaire une seule fois dans un contexte explicite", async () => {
+    mockPoliticianFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ firstName: "Jeanne", lastName: "Martin" }]);
+    mockCommuneFindMany.mockResolvedValue([]);
+    mockDecisionFindMany.mockResolvedValue([]);
+
+    const context = await loadAffairResolverContext();
+
+    expect(context.candidatePool).toEqual([]);
+    expect(context.prefilter.filter("Jeanne Martin")).toEqual([]);
+    expect(mockPoliticianFindMany).toHaveBeenCalledTimes(2);
+    expect(mockCommuneFindMany).toHaveBeenCalledOnce();
+    expect(mockDecisionFindMany).toHaveBeenCalledOnce();
+  });
+
+  it("ne charge rien avant le premier besoin et partage la même promesse", async () => {
+    mockPoliticianFindMany.mockResolvedValue([]);
+    mockCommuneFindMany.mockResolvedValue([]);
+    mockDecisionFindMany.mockResolvedValue([]);
+
+    const getContext = createAffairResolverContextLoader();
+    expect(mockPoliticianFindMany).not.toHaveBeenCalled();
+
+    const first = getContext();
+    const second = getContext();
+
+    expect(first).toBe(second);
+    await first;
+    expect(mockPoliticianFindMany).toHaveBeenCalledTimes(2);
+    expect(mockCommuneFindMany).toHaveBeenCalledOnce();
+    expect(mockDecisionFindMany).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/affair-matching/__tests__/persistence.test.ts
+++ b/src/lib/affair-matching/__tests__/persistence.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/db", () => ({
   db: {
     politician: { findMany: vi.fn() },
+    commune: { findMany: vi.fn() },
     affairPoliticianDecision: {
       findUnique: vi.fn(),
       create: vi.fn(),
@@ -11,7 +12,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { computeTextHash, persistDecision, loadBlocklist } from "../persistence";
+import {
+  computeTextHash,
+  loadAffairResolverContext,
+  persistDecision,
+  loadBlocklist,
+} from "../persistence";
 import type { CombinerDecision } from "../combiner";
 import { db } from "@/lib/db";
 import { SourceType } from "@/generated/prisma";
@@ -20,6 +26,8 @@ import type { Mock } from "vitest";
 const mockDecisionCreate = db.affairPoliticianDecision.create as Mock;
 const mockDecisionFindUnique = db.affairPoliticianDecision.findUnique as Mock;
 const mockDecisionFindMany = db.affairPoliticianDecision.findMany as Mock;
+const mockPoliticianFindMany = db.politician.findMany as Mock;
+const mockCommuneFindMany = db.commune.findMany as Mock;
 
 describe("computeTextHash", () => {
   it("produces a stable sha256 hex digest", () => {
@@ -131,5 +139,27 @@ describe("loadBlocklist", () => {
     expect(result.has("pol-a")).toBe(true);
     expect(result.has("pol-b")).toBe(true);
     expect(result.size).toBe(2);
+  });
+});
+
+describe("loadAffairResolverContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("charge le pool et le vocabulaire une seule fois dans un contexte explicite", async () => {
+    mockPoliticianFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ firstName: "Jeanne", lastName: "Martin" }]);
+    mockCommuneFindMany.mockResolvedValue([]);
+    mockDecisionFindMany.mockResolvedValue([]);
+
+    const context = await loadAffairResolverContext();
+
+    expect(context.candidatePool).toEqual([]);
+    expect(context.prefilter.filter("Jeanne Martin")).toEqual([]);
+    expect(mockPoliticianFindMany).toHaveBeenCalledTimes(2);
+    expect(mockCommuneFindMany).toHaveBeenCalledOnce();
+    expect(mockDecisionFindMany).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/affair-matching/index.ts
+++ b/src/lib/affair-matching/index.ts
@@ -6,6 +6,8 @@ export {
 export {
   computeTextHash,
   loadCandidatePool,
+  loadAffairResolverContext,
+  type AffairResolverContext,
   loadBlocklist,
   persistDecision,
   type PersistInput,

--- a/src/lib/affair-matching/index.ts
+++ b/src/lib/affair-matching/index.ts
@@ -6,6 +6,9 @@ export {
 export {
   computeTextHash,
   loadCandidatePool,
+  loadAffairResolverContext,
+  createAffairResolverContextLoader,
+  type AffairResolverContext,
   loadBlocklist,
   persistDecision,
   type PersistInput,

--- a/src/lib/affair-matching/persistence.ts
+++ b/src/lib/affair-matching/persistence.ts
@@ -4,7 +4,7 @@ import { type Prisma } from "@/generated/prisma";
 import type { AffairCandidateRecord, AffairScoringInput } from "./signals/types";
 import type { CombinerDecision } from "./combiner";
 import { RESOLVER_VERSION } from "./signals/constants";
-import { normalizeText } from "./candidate-prefilter";
+import { CandidatePrefilter, normalizeText } from "./candidate-prefilter";
 import { buildSurnameVocabulary, type SurnameVocabulary } from "./surname-ambiguity";
 
 /** SHA256 hex digest of a text input, used as the idempotency key. */
@@ -148,6 +148,42 @@ export async function loadSurnameVocabulary(): Promise<SurnameVocabulary> {
     politicianNames,
     corpus: decisions.map((d) => d.candidateText),
   });
+}
+
+export interface AffairResolverContext {
+  candidatePool: AffairCandidateRecord[];
+  vocabulary: SurnameVocabulary;
+  prefilter: CandidatePrefilter;
+}
+
+/**
+ * Loads the immutable scoring context for one bounded resolver execution.
+ * Callers processing a batch must keep this value in that execution only.
+ */
+export async function loadAffairResolverContext(): Promise<AffairResolverContext> {
+  const [candidatePool, vocabulary] = await Promise.all([
+    loadCandidatePool(),
+    loadSurnameVocabulary(),
+  ]);
+
+  return {
+    candidatePool,
+    vocabulary,
+    prefilter: new CandidatePrefilter(candidatePool),
+  };
+}
+
+/**
+ * Creates a loader for one bounded execution. The promise is created only by
+ * the first resolver that needs it, then shared by the remaining resolvers.
+ */
+export function createAffairResolverContextLoader(): () => Promise<AffairResolverContext> {
+  let contextPromise: Promise<AffairResolverContext> | undefined;
+
+  return () => {
+    contextPromise ??= loadAffairResolverContext();
+    return contextPromise;
+  };
 }
 
 export interface PersistInput {

--- a/src/lib/affair-matching/persistence.ts
+++ b/src/lib/affair-matching/persistence.ts
@@ -181,7 +181,10 @@ export function createAffairResolverContextLoader(): () => Promise<AffairResolve
   let contextPromise: Promise<AffairResolverContext> | undefined;
 
   return () => {
-    contextPromise ??= loadAffairResolverContext();
+    contextPromise ??= loadAffairResolverContext().catch((error) => {
+      contextPromise = undefined;
+      throw error;
+    });
     return contextPromise;
   };
 }

--- a/src/lib/affair-matching/persistence.ts
+++ b/src/lib/affair-matching/persistence.ts
@@ -4,7 +4,7 @@ import { type Prisma } from "@/generated/prisma";
 import type { AffairCandidateRecord, AffairScoringInput } from "./signals/types";
 import type { CombinerDecision } from "./combiner";
 import { RESOLVER_VERSION } from "./signals/constants";
-import { normalizeText } from "./candidate-prefilter";
+import { CandidatePrefilter, normalizeText } from "./candidate-prefilter";
 import { buildSurnameVocabulary, type SurnameVocabulary } from "./surname-ambiguity";
 
 /** SHA256 hex digest of a text input, used as the idempotency key. */
@@ -148,6 +148,29 @@ export async function loadSurnameVocabulary(): Promise<SurnameVocabulary> {
     politicianNames,
     corpus: decisions.map((d) => d.candidateText),
   });
+}
+
+export interface AffairResolverContext {
+  candidatePool: AffairCandidateRecord[];
+  vocabulary: SurnameVocabulary;
+  prefilter: CandidatePrefilter;
+}
+
+/**
+ * Loads the immutable scoring context for one bounded resolver execution.
+ * Callers processing a batch must keep this value in that execution only.
+ */
+export async function loadAffairResolverContext(): Promise<AffairResolverContext> {
+  const [candidatePool, vocabulary] = await Promise.all([
+    loadCandidatePool(),
+    loadSurnameVocabulary(),
+  ]);
+
+  return {
+    candidatePool,
+    vocabulary,
+    prefilter: new CandidatePrefilter(candidatePool),
+  };
 }
 
 export interface PersistInput {

--- a/src/lib/affair-matching/resolver.ts
+++ b/src/lib/affair-matching/resolver.ts
@@ -6,13 +6,12 @@ import type {
 } from "./signals/types";
 import {
   computeTextHash,
-  loadCandidatePool,
+  loadAffairResolverContext,
   loadBlocklist,
-  loadSurnameVocabulary,
   persistDecision,
 } from "./persistence";
+import type { AffairResolverContext } from "./persistence";
 import type { SurnameVocabulary } from "./surname-ambiguity";
-import { CandidatePrefilter } from "./candidate-prefilter";
 import { RESOLVER_VERSION } from "./signals/constants";
 import { ExternalIdSignal } from "./signals/external-id";
 import { NameQualitySignal } from "./signals/name-quality";
@@ -76,21 +75,23 @@ export type ResolvePreviewResult = Omit<ResolveResult, "decisionId"> & { decisio
  */
 async function resolveAffairPoliticianInternal(
   input: AffairScoringInput,
-  persist: boolean
+  persist: boolean,
+  context?: AffairResolverContext
 ): Promise<ResolveResult | ResolvePreviewResult> {
   if (input.text.length > 100_000) {
     throw new Error("Affair text exceeds 100KB limit");
   }
 
-  const [pool, vocabulary] = await Promise.all([loadCandidatePool(), loadSurnameVocabulary()]);
-  const prefilter = new CandidatePrefilter(pool);
-  const prefiltered = prefilter.filter(input.text);
+  // The optional context is deliberately supplied by the batch boundary. When
+  // absent, this remains the safe one-shot entry point used by administration.
+  const resolverContext = context ?? (await loadAffairResolverContext());
+  const prefiltered = resolverContext.prefilter.filter(input.text);
 
   const textHash = computeTextHash(input.text);
   const blocklist = await loadBlocklist(textHash);
   const candidates = prefiltered.filter((p) => !blocklist.has(p.id));
 
-  const decision = scoreAffairAgainstCandidates(input, candidates, vocabulary);
+  const decision = scoreAffairAgainstCandidates(input, candidates, resolverContext.vocabulary);
 
   const decisionId = persist
     ? (
@@ -112,13 +113,17 @@ async function resolveAffairPoliticianInternal(
   };
 }
 
-export async function resolveAffairPolitician(input: AffairScoringInput): Promise<ResolveResult> {
-  return resolveAffairPoliticianInternal(input, true) as Promise<ResolveResult>;
+export async function resolveAffairPolitician(
+  input: AffairScoringInput,
+  context?: AffairResolverContext
+): Promise<ResolveResult> {
+  return resolveAffairPoliticianInternal(input, true, context) as Promise<ResolveResult>;
 }
 
 /** Runs the same resolver without creating an audit row, for strict dry-runs. */
 export async function previewAffairPolitician(
-  input: AffairScoringInput
+  input: AffairScoringInput,
+  context?: AffairResolverContext
 ): Promise<ResolvePreviewResult> {
-  return resolveAffairPoliticianInternal(input, false) as Promise<ResolvePreviewResult>;
+  return resolveAffairPoliticianInternal(input, false, context) as Promise<ResolvePreviewResult>;
 }

--- a/src/services/sync/__tests__/discover-affairs-web.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-web.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   resolve: vi.fn(),
   preview: vi.fn(),
   findMatching: vi.fn(),
+  loadResolverContext: vi.fn(),
 }));
 
 vi.mock("@/lib/api/brave-search", () => ({
@@ -40,6 +41,12 @@ vi.mock("@/services/affairs/create-draft", () => ({
 vi.mock("@/lib/affair-matching/resolver", () => ({
   resolveAffairPolitician: h.resolve,
   previewAffairPolitician: h.preview,
+}));
+vi.mock("@/lib/affair-matching/persistence", () => ({
+  createAffairResolverContextLoader: () => {
+    let contextPromise: Promise<unknown> | undefined;
+    return () => (contextPromise ??= h.loadResolverContext());
+  },
 }));
 // Mock partiel : seul l'accès base est simulé. Le regroupement par procédure
 // s'appuie sur la vraie comparaison de vocabulaire du matcher, sinon le test
@@ -91,6 +98,7 @@ beforeEach(() => {
   h.preview.mockResolvedValue({ judgment: "SAME", topCandidateId: "p1" });
   h.findMatching.mockResolvedValue([]);
   h.callAnthropic.mockResolvedValue({ content: [] });
+  h.loadResolverContext.mockResolvedValue({ marker: "shared-resolver-context" });
 });
 
 describe("discoverAffairsWeb", () => {
@@ -109,6 +117,26 @@ describe("discoverAffairsWeb", () => {
     expect(stats.resultsReturned).toBe(2);
     expect(stats.resultsScreenedOut).toBe(1);
     expect(h.callAnthropic).toHaveBeenCalledTimes(1);
+    expect(h.loadResolverContext).not.toHaveBeenCalled();
+  });
+
+  it("transmet le même contexte à plusieurs résolutions", async () => {
+    h.searchBrave.mockResolvedValue([hit, { ...hit, url: "https://www.lemonde.fr/b" }]);
+    h.extractToolUse.mockReturnValue({
+      is_subject: true,
+      judicial_status: "MISE_EN_EXAMEN",
+      status_evidence: "mis en examen pour détournement",
+      confidence: 85,
+      reasoning: "x",
+      suggested_title: "Mise en examen de Joseph Afribo",
+    });
+
+    await discoverAffairsWeb({ limit: 1 });
+
+    expect(h.loadResolverContext).toHaveBeenCalledOnce();
+    expect(h.resolve).toHaveBeenCalledTimes(2);
+    expect(h.resolve.mock.calls[0]![1]).toBe(h.resolve.mock.calls[1]![1]);
+    expect(h.resolve.mock.calls[0]![1]).toBeTruthy();
   });
 
   it("ne crée rien quand l'IA dit que la personne n'est pas le sujet", async () => {

--- a/src/services/sync/__tests__/discover-affairs-web.test.ts
+++ b/src/services/sync/__tests__/discover-affairs-web.test.ts
@@ -41,6 +41,9 @@ vi.mock("@/lib/affair-matching/resolver", () => ({
   resolveAffairPolitician: h.resolve,
   previewAffairPolitician: h.preview,
 }));
+vi.mock("@/lib/affair-matching/persistence", () => ({
+  loadAffairResolverContext: vi.fn().mockResolvedValue(undefined),
+}));
 // Mock partiel : seul l'accès base est simulé. Le regroupement par procédure
 // s'appuie sur la vraie comparaison de vocabulaire du matcher, sinon le test
 // validerait un seuil imaginaire.

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -27,6 +27,7 @@ import { selectSearchTargets, type SearchTarget } from "@/lib/affair-discovery/s
 import { screenWebResult } from "@/lib/affair-discovery/web-lead-filter";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { resolveAffairPolitician, previewAffairPolitician } from "@/lib/affair-matching/resolver";
+import { loadAffairResolverContext } from "@/lib/affair-matching/persistence";
 import {
   findMatchingAffairs,
   normalizeAffairTitle,
@@ -445,6 +446,7 @@ export async function discoverAffairsWeb(options: {
   };
 
   const targets = await selectSearchTargets(limit, onlyTier);
+  const resolverContext = targets.length > 0 ? await loadAffairResolverContext() : undefined;
 
   for (const target of targets) {
     const query = `"${target.fullName}" condamné OR "mis en examen" OR procès OR détournement`;
@@ -556,16 +558,19 @@ export async function discoverAffairsWeb(options: {
       // écrit une ligne d'audit AffairPoliticianDecision, si bien qu'une passe
       // de mesure annoncée sans écriture en laissait quand même en production.
       const resolve = dryRun ? previewAffairPolitician : resolveAffairPolitician;
-      const resolved = await resolve({
-        text: `${result.title}\n${result.description}`,
-        candidateNames: [target.fullName],
-        metadata: {
-          source: "PRESSE",
-          sourceRef: result.url,
-          factsDate: null,
-          court: null,
+      const resolved = await resolve(
+        {
+          text: `${result.title}\n${result.description}`,
+          candidateNames: [target.fullName],
+          metadata: {
+            source: "PRESSE",
+            sourceRef: result.url,
+            factsDate: null,
+            court: null,
+          },
         },
-      });
+        resolverContext
+      );
       if (resolved.judgment !== "SAME" || resolved.topCandidateId !== target.id) {
         stats.identityRejected++;
         // The resolver contradicting the judge is either a homonym caught or a

--- a/src/services/sync/discover-affairs-web.ts
+++ b/src/services/sync/discover-affairs-web.ts
@@ -27,6 +27,7 @@ import { selectSearchTargets, type SearchTarget } from "@/lib/affair-discovery/s
 import { screenWebResult } from "@/lib/affair-discovery/web-lead-filter";
 import { createDraftAffairFromDiscovery } from "@/services/affairs/create-draft";
 import { resolveAffairPolitician, previewAffairPolitician } from "@/lib/affair-matching/resolver";
+import { createAffairResolverContextLoader } from "@/lib/affair-matching/persistence";
 import {
   findMatchingAffairs,
   normalizeAffairTitle,
@@ -445,6 +446,7 @@ export async function discoverAffairsWeb(options: {
   };
 
   const targets = await selectSearchTargets(limit, onlyTier);
+  const getResolverContext = createAffairResolverContextLoader();
 
   for (const target of targets) {
     const query = `"${target.fullName}" condamné OR "mis en examen" OR procès OR détournement`;
@@ -556,16 +558,19 @@ export async function discoverAffairsWeb(options: {
       // écrit une ligne d'audit AffairPoliticianDecision, si bien qu'une passe
       // de mesure annoncée sans écriture en laissait quand même en production.
       const resolve = dryRun ? previewAffairPolitician : resolveAffairPolitician;
-      const resolved = await resolve({
-        text: `${result.title}\n${result.description}`,
-        candidateNames: [target.fullName],
-        metadata: {
-          source: "PRESSE",
-          sourceRef: result.url,
-          factsDate: null,
-          court: null,
+      const resolved = await resolve(
+        {
+          text: `${result.title}\n${result.description}`,
+          candidateNames: [target.fullName],
+          metadata: {
+            source: "PRESSE",
+            sourceRef: result.url,
+            factsDate: null,
+            court: null,
+          },
         },
-      });
+        await getResolverContext()
+      );
       if (resolved.judgment !== "SAME" || resolved.topCandidateId !== target.id) {
         stats.identityRejected++;
         // The resolver contradicting the judge is either a homonym caught or a

--- a/src/services/sync/discover-affairs.ts
+++ b/src/services/sync/discover-affairs.ts
@@ -28,9 +28,10 @@ import { classifyAffairMatches, findMatchingAffairs } from "@/services/affairs/m
 import { clampConfidenceScore } from "@/services/affairs/confidence";
 import type { AffairCategory, AffairStatus, SourceType } from "@/generated/prisma";
 import { scoreAffairAgainstCandidates, resolveAffairPolitician } from "@/lib/affair-matching";
-import { loadCandidatePool, loadSurnameVocabulary } from "@/lib/affair-matching/persistence";
-import type { SurnameVocabulary } from "@/lib/affair-matching/surname-ambiguity";
-import type { AffairCandidateRecord } from "@/lib/affair-matching";
+import {
+  loadAffairResolverContext,
+  type AffairResolverContext,
+} from "@/lib/affair-matching/persistence";
 import {
   hashSourceContent,
   previewAffairEventProposal,
@@ -319,29 +320,22 @@ export async function discoverAffairs(options?: {
     return stats;
   }
 
+  // One bounded context for both resolver phases. Blocklists remain loaded per
+  // affair inside the resolver, so a human exclusion is visible immediately.
+  const resolverContext = await loadAffairResolverContext();
+
   // Phase 1: Wikidata
   let phase1Affairs: DiscoveredAffair[] = [];
   if (!wikipediaOnly) {
-    phase1Affairs = await runPhase1Wikidata(politicians, stats, dryRun);
+    phase1Affairs = await runPhase1Wikidata(politicians, stats, dryRun, resolverContext);
   }
 
   // Phase 2: Wikipedia
   let phase2Affairs: DiscoveredAffair[] = [];
   if (!wikidataOnly) {
-    // Load the candidate pool once for the entire Wikipedia pass.
-    // Building a Map avoids repeated array scans during per-politician lookups.
-    const [candidatePool, vocabulary] = await Promise.all([
-      loadCandidatePool(),
-      loadSurnameVocabulary(),
-    ]);
-    const poolById = new Map<string, AffairCandidateRecord>(candidatePool.map((c) => [c.id, c]));
-    phase2Affairs = await runPhase2Wikipedia(
-      politicians,
-      phase1Affairs,
-      stats,
-      poolById,
-      vocabulary
-    );
+    // Reuse the bounded context for the entire Wikipedia pass. Building a Map
+    // avoids repeated array scans during per-politician lookups.
+    phase2Affairs = await runPhase2Wikipedia(politicians, phase1Affairs, stats, resolverContext);
   }
 
   // Phase 3: Reconciliation
@@ -380,7 +374,8 @@ async function runPhase1Wikidata(
     externalIds: Array<{ externalId: string }>;
   }>,
   stats: DiscoverAffairsResult,
-  dryRun: boolean
+  dryRun: boolean,
+  resolverContext: AffairResolverContext
 ): Promise<DiscoveredAffair[]> {
   const discovered: DiscoveredAffair[] = [];
   const wikidataService = new WikidataService();
@@ -432,8 +427,8 @@ async function runPhase1Wikidata(
               },
             };
             const resolveResult = dryRun
-              ? await previewAffairPolitician(resolverInput)
-              : await resolveAffairPolitician(resolverInput);
+              ? await previewAffairPolitician(resolverInput, resolverContext)
+              : await resolveAffairPolitician(resolverInput, resolverContext);
             decisionId = resolveResult.decisionId;
           } catch (resolveErr) {
             console.warn(
@@ -489,11 +484,13 @@ async function runPhase2Wikipedia(
   }>,
   phase1Affairs: DiscoveredAffair[],
   stats: DiscoverAffairsResult,
-  poolById: Map<string, AffairCandidateRecord>,
-  vocabulary: SurnameVocabulary
+  resolverContext: AffairResolverContext
 ): Promise<DiscoveredAffair[]> {
   const discovered: DiscoveredAffair[] = [];
   const phase1Keys = new Set(phase1Affairs.map((a) => `${a.politicianId}:${a.category}`));
+  const poolById = new Map(
+    resolverContext.candidatePool.map((candidate) => [candidate.id, candidate])
+  );
 
   console.log(`Phase 2: Wikipedia - ${politicians.length} politicians`);
 
@@ -545,7 +542,7 @@ async function runPhase2Wikipedia(
               },
             },
             [candidate],
-            vocabulary
+            resolverContext.vocabulary
           );
 
           if (sanityCheck.judgment !== "SAME") {

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -604,11 +604,68 @@ describe("syncPressAnalysis : panne du contexte", () => {
     });
     mocks.getResolverContext.mockRejectedValue(new Error("database unavailable"));
 
-    const stats = await syncPressAnalysis({ force: true });
+    await expect(syncPressAnalysis({ force: true })).rejects.toThrow(
+      "Impossible de charger le contexte du resolver"
+    );
 
-    expect(stats.articlesProcessed).toBe(1);
-    expect(stats.analysisErrors).toBe(1);
     expect(mocks.analyzeArticle).toHaveBeenCalledOnce();
     expect(mocks.pressArticleUpdate).not.toHaveBeenCalled();
+    expect(mocks.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it("rejette le lot après un article réussi et laisse le suivant reprenable", async () => {
+    const first = {
+      id: "article-ok",
+      url: "https://www.lemonde.fr/ok",
+      title: "Une information politique",
+      description: "Aucune procédure n’est évoquée.",
+      feedSource: "lemonde",
+      publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+      mentions: [],
+    };
+    const second = {
+      ...first,
+      id: "article-failed",
+      url: "https://www.lemonde.fr/failed",
+      title: "Une enquête vise Jeanne Martin",
+      description: "Jeanne Martin fait l’objet d’une enquête préliminaire.",
+      mentions: [{ politician: { id: "pol-1", fullName: "Jeanne Martin", slug: "jeanne-martin" } }],
+    };
+    mocks.pressArticleFindMany.mockResolvedValue([first, second]);
+    mocks.analyzeArticle
+      .mockResolvedValueOnce({ isAffairRelated: false, summary: "résumé", affairs: [] })
+      .mockResolvedValueOnce({
+        isAffairRelated: true,
+        summary: "résumé",
+        affairs: [
+          {
+            politicianName: "Jeanne Martin",
+            involvement: "DIRECT",
+            category: "DETOURNEMENT_FONDS_PUBLICS",
+            status: "ENQUETE_PRELIMINAIRE",
+            title: "Enquête sur Jeanne Martin",
+            description: "Une enquête préliminaire est ouverte.",
+            factsDate: null,
+            court: null,
+            charges: [],
+            excerpts: [],
+            isNewRevelation: false,
+            confidenceScore: 95,
+            mentionedNames: ["Jeanne Martin"],
+          },
+        ],
+      });
+    mocks.getResolverContext.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(syncPressAnalysis({ force: true })).rejects.toThrow(
+      "Impossible de charger le contexte du resolver"
+    );
+
+    expect(mocks.analyzeArticle).toHaveBeenCalledTimes(2);
+    expect(mocks.pressArticleUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.pressArticleUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "article-ok" } })
+    );
+    expect(mocks.markCompleted).not.toHaveBeenCalled();
   });
 });

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   createDraftAffairFromDiscovery: vi.fn(),
   proposeAffairEvent: vi.fn(),
   previewAffairEventProposal: vi.fn(),
+  getResolverContext: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -34,6 +35,9 @@ vi.mock("@/lib/affair-matching", async (importOriginal) => ({
 
 vi.mock("@/lib/affair-matching/resolver", () => ({
   previewAffairPolitician: mocks.previewAffairPolitician,
+}));
+vi.mock("@/lib/affair-matching/persistence", () => ({
+  createAffairResolverContextLoader: () => mocks.getResolverContext,
 }));
 
 // pickConfidentMatch is pure and stays real; only the DB lookup is replaced.
@@ -78,6 +82,7 @@ beforeEach(() => {
     pendingProposalId: null,
     deduped: false,
   });
+  mocks.getResolverContext.mockResolvedValue({ marker: "shared-resolver-context" });
 });
 
 function zeroStats() {
@@ -176,6 +181,7 @@ describe("processAnalyzedArticle", () => {
     );
     expect(stats.articlesAnalyzed).toBe(1);
     expect(stats.articlesAffairRelated).toBe(0);
+    expect(mocks.getResolverContext).not.toHaveBeenCalled();
     expect(stats.affairsCreated).toBe(0);
     expect(stats.affairsEnriched).toBe(0);
   });
@@ -380,6 +386,33 @@ describe("processAnalyzedArticle : proposition d’évolution", () => {
     );
     expect(mocks.createDraftAffairFromDiscovery).not.toHaveBeenCalled();
     expect(stats.proposalsPending).toBe(1);
+  });
+
+  it("charge une fois et transmet le même contexte à plusieurs affaires", async () => {
+    const stats = zeroStats();
+    const secondDetected = { ...detected, title: "Deuxième évolution" };
+    let contextPromise: Promise<unknown> | undefined;
+    const getResolverContext = () => (contextPromise ??= mocks.getResolverContext());
+
+    await processAnalyzedArticle(
+      article,
+      `Introduction. ${excerpt} Suite de l’article.`,
+      { isAffairRelated: true, summary: "résumé", affairs: [detected, secondDetected] },
+      stats,
+      {
+        dryRun: false,
+        verbose: false,
+        importRunId: "run-press",
+        getResolverContext,
+      }
+    );
+
+    expect(mocks.getResolverContext).toHaveBeenCalledOnce();
+    expect(mocks.resolveAffairPolitician).toHaveBeenCalledTimes(2);
+    expect(mocks.resolveAffairPolitician.mock.calls[0]![1]).toBe(
+      mocks.resolveAffairPolitician.mock.calls[1]![1]
+    );
+    expect(mocks.resolveAffairPolitician.mock.calls[0]![1]).toBeTruthy();
   });
 
   it("ne choisit rien lorsqu’un autre candidat POSSIBLE existe", async () => {

--- a/src/services/sync/press-analysis.test.ts
+++ b/src/services/sync/press-analysis.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AffairResolverContext } from "@/lib/affair-matching/persistence";
+import { CandidatePrefilter } from "@/lib/affair-matching/candidate-prefilter";
+import { EMPTY_SURNAME_VOCABULARY } from "@/lib/affair-matching/surname-ambiguity";
 
 // Only the DB-backed collaborators are mocked. assessProcedureEvidence and
 // assessPressAttribution stay real: they are pure, and mocking them would empty
@@ -11,11 +14,20 @@ const mocks = vi.hoisted(() => ({
   proposeAffairEvent: vi.fn(),
   previewAffairEventProposal: vi.fn(),
   getResolverContext: vi.fn(),
+  analyzeArticle: vi.fn(),
+  getArticleScraper: vi.fn(),
+  shouldSync: vi.fn(),
+  markCompleted: vi.fn(),
+  pressArticleFindMany: vi.fn(),
+  pressArticleUpdate: vi.fn(async () => ({})),
 }));
 
 vi.mock("@/lib/db", () => ({
   db: {
-    pressArticle: { update: vi.fn(async () => ({})) },
+    pressArticle: {
+      findMany: mocks.pressArticleFindMany,
+      update: mocks.pressArticleUpdate,
+    },
     politician: {
       findUnique: vi.fn(async () => ({
         firstName: "Jeanne",
@@ -26,6 +38,7 @@ vi.mock("@/lib/db", () => ({
     pressArticleAffair: { upsert: vi.fn(async () => ({})) },
     affairPoliticianDecision: { update: vi.fn(async () => ({})) },
   },
+  withAdvisoryLock: vi.fn(async (_key: string, callback: () => unknown) => callback()),
 }));
 
 vi.mock("@/lib/affair-matching", async (importOriginal) => ({
@@ -37,7 +50,30 @@ vi.mock("@/lib/affair-matching/resolver", () => ({
   previewAffairPolitician: mocks.previewAffairPolitician,
 }));
 vi.mock("@/lib/affair-matching/persistence", () => ({
-  createAffairResolverContextLoader: () => mocks.getResolverContext,
+  createAffairResolverContextLoader: () => {
+    let contextPromise: Promise<unknown> | undefined;
+    return () => (contextPromise ??= mocks.getResolverContext());
+  },
+}));
+
+vi.mock("@/services/press-analysis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/press-analysis")>()),
+  analyzeArticle: mocks.analyzeArticle,
+  getAIRateLimitMs: () => 0,
+}));
+vi.mock("@/lib/api/article-scraper", () => ({
+  getArticleScraper: mocks.getArticleScraper,
+}));
+vi.mock("@/lib/sync", () => ({
+  syncMetadata: {
+    shouldSync: mocks.shouldSync,
+    markCompleted: mocks.markCompleted,
+  },
+}));
+vi.mock("@/services/affairs/import-run", () => ({
+  IMPORTER_PRESS_ANALYSIS: "press-analysis",
+  withImportRun: async (_importer: string, callback: (args: unknown) => unknown) =>
+    callback({ importRunId: "run-press", setStats: vi.fn() }),
 }));
 
 // pickConfidentMatch is pure and stays real; only the DB lookup is replaced.
@@ -56,7 +92,11 @@ vi.mock("@/services/affairs/proposals", async (importOriginal) => ({
   previewAffairEventProposal: mocks.previewAffairEventProposal,
 }));
 
-import { isPressAnalysisSuccessful, processAnalyzedArticle } from "./press-analysis";
+import {
+  isPressAnalysisSuccessful,
+  processAnalyzedArticle,
+  syncPressAnalysis,
+} from "./press-analysis";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,7 +122,15 @@ beforeEach(() => {
     pendingProposalId: null,
     deduped: false,
   });
-  mocks.getResolverContext.mockResolvedValue({ marker: "shared-resolver-context" });
+  const resolverContext: AffairResolverContext = {
+    candidatePool: [],
+    vocabulary: EMPTY_SURNAME_VOCABULARY,
+    prefilter: new CandidatePrefilter([]),
+  };
+  mocks.getResolverContext.mockResolvedValue(resolverContext);
+  mocks.shouldSync.mockResolvedValue(true);
+  mocks.pressArticleFindMany.mockResolvedValue([]);
+  mocks.getArticleScraper.mockReturnValue({ canScrape: () => false });
 });
 
 function zeroStats() {
@@ -391,8 +439,9 @@ describe("processAnalyzedArticle : proposition d’évolution", () => {
   it("charge une fois et transmet le même contexte à plusieurs affaires", async () => {
     const stats = zeroStats();
     const secondDetected = { ...detected, title: "Deuxième évolution" };
-    let contextPromise: Promise<unknown> | undefined;
-    const getResolverContext = () => (contextPromise ??= mocks.getResolverContext());
+    let contextPromise: Promise<AffairResolverContext> | undefined;
+    const getResolverContext = (): Promise<AffairResolverContext> =>
+      (contextPromise ??= mocks.getResolverContext());
 
     await processAnalyzedArticle(
       article,
@@ -516,5 +565,50 @@ describe("processAnalyzedArticle : proposition d’évolution", () => {
 
     expect(mocks.proposeAffairEvent).not.toHaveBeenCalled();
     expect(mocks.createDraftAffairFromDiscovery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("syncPressAnalysis : panne du contexte", () => {
+  it("arrête les articles suivants et ne marque pas le premier comme analysé", async () => {
+    const first = {
+      id: "article-1",
+      url: "https://www.lemonde.fr/1",
+      title: "Une enquête vise Jeanne Martin",
+      description: "Jeanne Martin fait l’objet d’une enquête préliminaire.",
+      feedSource: "lemonde",
+      publishedAt: new Date("2026-08-27T08:00:00.000Z"),
+      mentions: [{ politician: { id: "pol-1", fullName: "Jeanne Martin", slug: "jeanne-martin" } }],
+    };
+    const second = { ...first, id: "article-2", url: "https://www.lemonde.fr/2" };
+    mocks.pressArticleFindMany.mockResolvedValue([first, second]);
+    mocks.analyzeArticle.mockResolvedValue({
+      isAffairRelated: true,
+      summary: "résumé",
+      affairs: [
+        {
+          politicianName: "Jeanne Martin",
+          involvement: "DIRECT",
+          category: "DETOURNEMENT_FONDS_PUBLICS",
+          status: "ENQUETE_PRELIMINAIRE",
+          title: "Enquête sur Jeanne Martin",
+          description: "Une enquête préliminaire est ouverte.",
+          factsDate: null,
+          court: null,
+          charges: [],
+          excerpts: [],
+          isNewRevelation: false,
+          confidenceScore: 95,
+          mentionedNames: ["Jeanne Martin"],
+        },
+      ],
+    });
+    mocks.getResolverContext.mockRejectedValue(new Error("database unavailable"));
+
+    const stats = await syncPressAnalysis({ force: true });
+
+    expect(stats.articlesProcessed).toBe(1);
+    expect(stats.analysisErrors).toBe(1);
+    expect(mocks.analyzeArticle).toHaveBeenCalledOnce();
+    expect(mocks.pressArticleUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -49,6 +49,13 @@ import {
   type AffairResolverContext,
 } from "@/lib/affair-matching/persistence";
 
+export class ResolverContextLoadError extends Error {
+  constructor(cause: unknown) {
+    super("Impossible de charger le contexte du resolver", { cause });
+    this.name = "ResolverContextLoadError";
+  }
+}
+
 // ============================================
 // TYPES
 // ============================================
@@ -281,6 +288,10 @@ async function runPressAnalysis(
         });
       } catch (error) {
         stats.analysisErrors++;
+        if (error instanceof ResolverContextLoadError) {
+          console.error(`  ✗ Contexte du resolver indisponible, arrêt du lot: ${error.message}`);
+          break;
+        }
         const errorMsg = error instanceof Error ? error.message : String(error);
 
         // Detect quota/rate limit errors to avoid marking articles and to stop early
@@ -391,8 +402,9 @@ export async function processAnalyzedArticle(
 
   stats.articlesAnalyzed++;
 
-  // Step 3: Update article with analysis results
-  if (!dryRun) {
+  let articleMarkedAnalyzed = false;
+  const markArticleAnalyzed = async () => {
+    if (dryRun || articleMarkedAnalyzed) return;
     await db.pressArticle.update({
       where: { id: article.id },
       data: {
@@ -402,7 +414,8 @@ export async function processAnalyzedArticle(
         aiAnalysisError: null,
       },
     });
-  }
+    articleMarkedAnalyzed = true;
+  };
 
   if (verbose) {
     console.log(`  Résumé: ${result.summary.slice(0, 100)}...`);
@@ -410,6 +423,7 @@ export async function processAnalyzedArticle(
   }
 
   if (!result.isAffairRelated || result.affairs.length === 0) {
+    await markArticleAnalyzed();
     return;
   }
 
@@ -458,8 +472,14 @@ export async function processAnalyzedArticle(
         court: detected.court ?? null,
       },
     };
-    const sharedContext =
-      resolverContext ?? (getResolverContext ? await getResolverContext() : undefined);
+    let sharedContext: AffairResolverContext | undefined;
+    try {
+      sharedContext =
+        resolverContext ?? (getResolverContext ? await getResolverContext() : undefined);
+    } catch (error) {
+      throw new ResolverContextLoadError(error);
+    }
+    await markArticleAnalyzed();
     const resolveResult = dryRun
       ? await previewAffairPolitician(resolverInput, sharedContext)
       : await resolveAffairPolitician(resolverInput, sharedContext);
@@ -629,6 +649,8 @@ export async function processAnalyzedArticle(
       }
     }
   }
+
+  await markArticleAnalyzed();
 }
 
 function recordEventProposalOutcome(

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -44,6 +44,10 @@ import {
 } from "@/services/affairs/proposals";
 import { IMPORTER_PRESS_ANALYSIS, withImportRun } from "@/services/affairs/import-run";
 import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
+import {
+  loadAffairResolverContext,
+  type AffairResolverContext,
+} from "@/lib/affair-matching/persistence";
 
 // ============================================
 // TYPES
@@ -194,6 +198,10 @@ async function runPressAnalysis(
 
   console.log(`${articles.length} article(s) à analyser`);
 
+  // The context is scoped to this execution. Each affair still performs its
+  // own blocklist read and persistence operation in the resolver.
+  const resolverContext = await loadAffairResolverContext();
+
   // Classify articles into tiers and sort by priority
   const classifiedArticles = articles.map((article) => ({
     ...article,
@@ -268,6 +276,7 @@ async function runPressAnalysis(
           dryRun,
           verbose,
           importRunId,
+          resolverContext,
         });
       } catch (error) {
         stats.analysisErrors++;
@@ -369,9 +378,14 @@ export async function processAnalyzedArticle(
   analysisContent: string,
   result: ArticleAnalysisResult,
   stats: PressAnalysisStats,
-  options: { dryRun: boolean; verbose: boolean; importRunId?: string | null }
+  options: {
+    dryRun: boolean;
+    verbose: boolean;
+    importRunId?: string | null;
+    resolverContext?: AffairResolverContext;
+  }
 ): Promise<void> {
-  const { dryRun, verbose, importRunId = null } = options;
+  const { dryRun, verbose, importRunId = null, resolverContext } = options;
 
   stats.articlesAnalyzed++;
 
@@ -443,8 +457,8 @@ export async function processAnalyzedArticle(
       },
     };
     const resolveResult = dryRun
-      ? await previewAffairPolitician(resolverInput)
-      : await resolveAffairPolitician(resolverInput);
+      ? await previewAffairPolitician(resolverInput, resolverContext)
+      : await resolveAffairPolitician(resolverInput, resolverContext);
 
     if (resolveResult.judgment !== "SAME" || !resolveResult.topCandidateId) {
       if (verbose) {

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -44,6 +44,10 @@ import {
 } from "@/services/affairs/proposals";
 import { IMPORTER_PRESS_ANALYSIS, withImportRun } from "@/services/affairs/import-run";
 import { isVerifiedAffairPressUrl } from "@/config/affair-sources";
+import {
+  createAffairResolverContextLoader,
+  type AffairResolverContext,
+} from "@/lib/affair-matching/persistence";
 
 // ============================================
 // TYPES
@@ -194,6 +198,11 @@ async function runPressAnalysis(
 
   console.log(`${articles.length} article(s) à analyser`);
 
+  // The context is scoped to this execution and loaded only if an affair gets
+  // as far as identity resolution. Each affair still performs its own
+  // blocklist read and persistence operation in the resolver.
+  const getResolverContext = createAffairResolverContextLoader();
+
   // Classify articles into tiers and sort by priority
   const classifiedArticles = articles.map((article) => ({
     ...article,
@@ -268,6 +277,7 @@ async function runPressAnalysis(
           dryRun,
           verbose,
           importRunId,
+          getResolverContext,
         });
       } catch (error) {
         stats.analysisErrors++;
@@ -369,9 +379,15 @@ export async function processAnalyzedArticle(
   analysisContent: string,
   result: ArticleAnalysisResult,
   stats: PressAnalysisStats,
-  options: { dryRun: boolean; verbose: boolean; importRunId?: string | null }
+  options: {
+    dryRun: boolean;
+    verbose: boolean;
+    importRunId?: string | null;
+    resolverContext?: AffairResolverContext;
+    getResolverContext?: () => Promise<AffairResolverContext>;
+  }
 ): Promise<void> {
-  const { dryRun, verbose, importRunId = null } = options;
+  const { dryRun, verbose, importRunId = null, resolverContext, getResolverContext } = options;
 
   stats.articlesAnalyzed++;
 
@@ -442,9 +458,11 @@ export async function processAnalyzedArticle(
         court: detected.court ?? null,
       },
     };
+    const sharedContext =
+      resolverContext ?? (getResolverContext ? await getResolverContext() : undefined);
     const resolveResult = dryRun
-      ? await previewAffairPolitician(resolverInput)
-      : await resolveAffairPolitician(resolverInput);
+      ? await previewAffairPolitician(resolverInput, sharedContext)
+      : await resolveAffairPolitician(resolverInput, sharedContext);
 
     if (resolveResult.judgment !== "SAME" || !resolveResult.topCandidateId) {
       if (verbose) {

--- a/src/services/sync/press-analysis.ts
+++ b/src/services/sync/press-analysis.ts
@@ -290,7 +290,7 @@ async function runPressAnalysis(
         stats.analysisErrors++;
         if (error instanceof ResolverContextLoadError) {
           console.error(`  ✗ Contexte du resolver indisponible, arrêt du lot: ${error.message}`);
-          break;
+          throw error;
         }
         const errorMsg = error instanceof Error ? error.message : String(error);
 


### PR DESCRIPTION
## Résumé

- Ajoute un contexte borné du resolver avec pool, vocabulaire et préfiltre mutualisés.
- Propage ce contexte aux lots `discover-affairs`, `discover-affairs-web` et `press-analysis`.
- Conserve une lecture de blocklist et la persistance propres à chaque affaire.
- Préserve le scoring, les décisions, le dry-run et les reprises Inngest.

## Preuve avant / après

- Avant : pool et vocabulaire rechargés à chaque résolution.
- Après : chargement paresseux au premier besoin, une promesse partagée par exécution, avec 100 lectures de blocklist conservées.
- Sans résolution : zéro chargement du contexte, notamment pour les recherches vides, résultats rejetés et quotas interrompus.
- En cas d’échec du contexte : le lot presse est rejeté, `markCompleted()` n’est pas appelé, aucun article suivant n’est traité et les articles affectés restent reprenables, y compris après un article réussi.
- Aucun gain d’egress Supabase revendiqué, les mesures sont locales et synthétiques.

## Vérifications

- Prettier, ESLint et TypeScript passés dans Docker.
- 6 fichiers de tests, 95 tests passés.
- PostgreSQL 17 jetable exécuté dans Docker, 14 tests passés.
- Aucun accès ou écriture en production.
