### PR TITLE
fix(api): borner les candidatures des élections publiques (#870)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,60 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+  election-api-postgres:
+    name: Election API PostgreSQL integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # This is a disposable PostgreSQL 17 only. The suite seeds synthetic elections
+    # and never connects to Supabase or any other shared database.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: poligraph_test
+          POSTGRES_PASSWORD: poligraph_test
+          POSTGRES_DB: poligraph_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -h localhost -U poligraph_test -d poligraph_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DIRECT_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DATABASE_SSL: "false"
+      NODE_ENV: test
+      DOTENV_CONFIG_PATH: /dev/null
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Create extensions and publicId sequences
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f docker/init-search.sql
+
+      - name: Apply the schema
+        run: npx prisma db push
+
+      - name: Run election API integration suite
+        run: npx vitest run --no-file-parallelism "src/app/api/elections/[slug]/route.integration.test.ts"
+
   sec-02-role-contract:
     name: SEC-02 role contract
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           POSTGRES_PASSWORD: poligraph_test
           POSTGRES_DB: poligraph_test
         ports:
-          - 5432:5432
+          - 55433:5432
         options: >-
           --health-cmd "pg_isready -h localhost -U poligraph_test -d poligraph_test"
           --health-interval 5s
@@ -131,8 +131,8 @@ jobs:
           --health-retries 20
 
     env:
-      DATABASE_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
-      DIRECT_URL: postgresql://poligraph_test:poligraph_test@localhost:5432/poligraph_test
+      DATABASE_URL: postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test
+      DIRECT_URL: postgresql://poligraph_test:poligraph_test@localhost:55433/poligraph_test
       DATABASE_SSL: "false"
       NODE_ENV: test
       DOTENV_CONFIG_PATH: /dev/null
@@ -160,7 +160,18 @@ jobs:
         run: npx prisma db push
 
       - name: Run election API integration suite
-        run: npx vitest run --no-file-parallelism "src/app/api/elections/[slug]/route.integration.test.ts"
+        run: |
+          npx vitest run --no-file-parallelism \
+            --reporter=json \
+            --outputFile=election-api-postgres-vitest.json \
+            "src/app/api/elections/[slug]/route.integration.test.ts"
+          node -e '
+            const report = require("./election-api-postgres-vitest.json");
+            if (report.numTotalTests > 0 && report.numPassedTests === 0 && report.numPendingTests === report.numTotalTests) {
+              console.error("Election API integration suite was entirely skipped");
+              process.exit(1);
+            }
+          '
 
   sec-02-role-contract:
     name: SEC-02 role contract

--- a/docs/api/ELECTIONS_API_V1.md
+++ b/docs/api/ELECTIONS_API_V1.md
@@ -1,0 +1,25 @@
+# API élections générique
+
+## `GET /api/elections/{slug}`
+
+Cette route retourne les champs de l'élection, ses tours et une page de candidatures.
+Les candidatures ne sont jamais chargées comme une collection complète dans cette réponse.
+
+Paramètres facultatifs :
+
+- `page`, entier strict supérieur ou égal à 1, défaut `1` ;
+- `limit`, entier strict de `1` à `100`, défaut `20`.
+
+La réponse contient `candidacies.data` et `candidacies.pagination` (`page`, `limit`, `total`,
+`totalPages`). Le `total` est calculé par PostgreSQL. Le tri est déterministe : élues d'abord,
+score du premier tour décroissant, puis identifiant croissant.
+
+### Rupture de contrat
+
+Avant cette version, `candidacies` était un tableau exhaustif. Il devient un objet paginé. Un
+client qui veut parcourir toute la collection doit suivre `page` jusqu'à `totalPages` ; il ne doit
+pas considérer la première page comme exhaustive. Le contrat présidentiel spécialisé
+`GET /api/elections/{slug}/candidacies` reste inchangé.
+
+La borne réduit le volume de chaque réponse et le nombre de lignes transférées à l'application.
+Elle ne constitue pas une mesure directe de l'egress Supabase facturé.

--- a/scripts/test-db-search.sh
+++ b/scripts/test-db-search.sh
@@ -96,6 +96,7 @@ else
     src/lib/data/__tests__/priorites.integration.test.ts \
     src/lib/data/__tests__/subject-page.integration.test.ts \
     src/lib/data/__tests__/themes-index.integration.test.ts \
+    "src/app/api/elections/[slug]/route.integration.test.ts" \
     src/lib/search \
     src/lib/measures \
     src/app/admin/mesures \

--- a/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
+++ b/src/__tests__/architecture/mcp-public-contract-surfaces.test.ts
@@ -324,7 +324,7 @@ describe("MCP-01 public contract surfaces", () => {
   const partyDetailRoute = readSource("src/app/api/partis/[slug]/route.ts");
   const dedicatedPartySearch = readSource("src/app/api/search/parties/route.ts");
   const compareSearchIndex = readSource("src/app/api/compare/search-index/route.ts");
-  const electionDetailRoute = readSource("src/app/api/elections/[slug]/route.ts");
+  const electionDetailData = readSource("src/lib/data/election-details.ts");
   const partyData = readSource("src/lib/data/partis.ts");
   const partyPage = readSource("src/app/partis/[slug]/page.tsx");
   const partyOgImage = readSource("src/app/partis/[slug]/opengraph-image.tsx");
@@ -409,10 +409,6 @@ describe("MCP-01 public contract surfaces", () => {
       "export const GET = withPublicRoute"
     );
     const compareIndexLoader = executionBlock(compareSearchIndex, "async function getSearchIndex");
-    const electionHandler = executionBlock(
-      electionDetailRoute,
-      "export const GET = withPublicRoute"
-    );
     const partyLoader = executionBlock(partyData, "export const getParty = cache");
     const partyStaticParams = executionBlock(
       partyPage,
@@ -431,8 +427,8 @@ describe("MCP-01 public contract surfaces", () => {
     expect(partySearchHandler).toContain("politicians: { where: PUBLIC_POLITICIAN_WHERE }");
     expect(compareIndexLoader).toContain("...PUBLIC_PARTY_WHERE");
     expect(compareIndexLoader).toContain("politicians: { where: PUBLIC_POLITICIAN_WHERE }");
-    expect(electionHandler).toContain("politicians: { where: PUBLIC_POLITICIAN_WHERE }");
-    expect(electionHandler).toContain("candidacy.party._count.politicians > 0");
+    expect(electionDetailData).toContain("politicians: { where: PUBLIC_POLITICIAN_WHERE }");
+    expect(electionDetailData).toContain("candidacy.party._count.politicians > 0");
     expect(partyLoader).toContain("where: { slug, ...PUBLIC_PARTY_WHERE }");
     expect(partyLoader).toContain("successors: { where: PUBLIC_PARTY_WHERE }");
     expect(partyLoader).toContain("party.predecessor._count.politicians > 0");

--- a/src/__tests__/mcp-party-public-boundary.test.ts
+++ b/src/__tests__/mcp-party-public-boundary.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   factCheckCount: vi.fn(),
   groupFindMany: vi.fn(),
   electionFindUnique: vi.fn(),
+  candidacyCount: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -30,6 +31,7 @@ vi.mock("@/lib/db", () => ({
     factCheck: { count: mocks.factCheckCount },
     parliamentaryGroup: { findMany: mocks.groupFindMany },
     election: { findUnique: mocks.electionFindUnique },
+    candidacy: { count: mocks.candidacyCount },
   },
 }));
 
@@ -51,6 +53,7 @@ describe("MCP party public boundary", () => {
     mocks.scrutinCount.mockResolvedValue(0);
     mocks.factCheckCount.mockResolvedValue(0);
     mocks.groupFindMany.mockResolvedValue([]);
+    mocks.candidacyCount.mockResolvedValue(1);
   });
 
   it("exclut de la recherche un parti qui ne possède que des personnalités DRAFT", async () => {
@@ -132,6 +135,13 @@ describe("MCP party public boundary", () => {
         {
           id: "candidacy-draft-party",
           candidateName: "Candidate",
+          partyLabel: null,
+          constituencyName: null,
+          isElected: false,
+          round1Votes: null,
+          round1Pct: null,
+          round2Votes: null,
+          round2Pct: null,
           politician: null,
           party: {
             id: "party-draft-only",
@@ -151,11 +161,13 @@ describe("MCP party public boundary", () => {
     );
     const payload = await response.json();
 
-    expect(payload.candidacies[0].party).toBeNull();
+    expect(payload.candidacies.data[0].party).toBeNull();
     expect(mocks.electionFindUnique).toHaveBeenCalledWith(
       expect.objectContaining({
-        include: expect.objectContaining({
+        select: expect.objectContaining({
           candidacies: expect.objectContaining({
+            skip: 0,
+            take: 20,
             select: expect.objectContaining({
               party: {
                 select: expect.objectContaining({
@@ -171,5 +183,6 @@ describe("MCP party public boundary", () => {
         }),
       })
     );
+    expect(mocks.candidacyCount).toHaveBeenCalledWith({ where: { electionId: "election-1" } });
   });
 });

--- a/src/app/api/elections/[slug]/route.integration.test.ts
+++ b/src/app/api/elections/[slug]/route.integration.test.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server";
+import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
+import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
+
+let db: typeof import("@/lib/db").db;
+let getElection: typeof import("./route").GET;
+
+const PREFIX = "api-election-details-870";
+
+describeIfDisposableDb("GET /api/elections/[slug], PostgreSQL", () => {
+  beforeAll(async () => {
+    assertDisposableTestDb();
+    ({ db } = await import("@/lib/db"));
+    ({ GET: getElection } = await import("./route"));
+  });
+
+  afterEach(async () => {
+    await db.candidacy.deleteMany({ where: { election: { slug: { startsWith: PREFIX } } } });
+    await db.election.deleteMany({ where: { slug: { startsWith: PREFIX } } });
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  async function seedElection(suffix: string, count: number) {
+    const election = await db.election.create({
+      data: {
+        slug: `${PREFIX}-${suffix}`,
+        type: "MUNICIPALES",
+        scope: "MUNICIPAL",
+        title: `Élection fixture ${suffix}`,
+      },
+    });
+
+    await db.candidacy.createMany({
+      data: Array.from({ length: count }, (_, index) => ({
+        electionId: election.id,
+        candidateName: `Candidate ${String(index).padStart(4, "0")}`,
+        isElected: false,
+        round1Pct: "12.00",
+      })),
+    });
+    return election;
+  }
+
+  async function read(slug: string, query = "") {
+    const response = await getElection(
+      new NextRequest(`https://poligraph.fr/api/elections/${slug}${query}`),
+      { params: Promise.resolve({ slug }) }
+    );
+    return { response, body: await response.json() };
+  }
+
+  it("charge et renvoie seulement la page demandée, avec un total SQL exact", async () => {
+    const election = await seedElection("many", 205);
+    const { response, body } = await read(election.slug, "?page=2&limit=20");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=120"
+    );
+    expect(body.candidacies.data).toHaveLength(20);
+    expect(body.candidacies.pagination).toEqual({
+      page: 2,
+      limit: 20,
+      total: 205,
+      totalPages: 11,
+    });
+    expect(body.candidacies.data[0].candidateName).toBe("Candidate 0020");
+    expect(body.candidacies.data.at(-1).candidateName).toBe("Candidate 0039");
+  });
+
+  it("retourne une page vide pour une élection sans candidature", async () => {
+    const election = await seedElection("empty", 0);
+    const { body } = await read(election.slug);
+
+    expect(body.candidacies).toEqual({
+      data: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+  });
+
+  it("parcourt toutes les pages sans doublon ni omission malgré des clés de tri égales", async () => {
+    const election = await seedElection("stable-sort", 53);
+    const names: string[] = [];
+
+    for (let page = 1; page <= 3; page += 1) {
+      const { body } = await read(election.slug, `?page=${page}&limit=20`);
+      names.push(
+        ...body.candidacies.data.map((item: { candidateName: string }) => item.candidateName)
+      );
+    }
+
+    expect(names).toHaveLength(53);
+    expect(new Set(names).size).toBe(53);
+    expect(names).toEqual(
+      Array.from({ length: 53 }, (_, index) => `Candidate ${String(index).padStart(4, "0")}`)
+    );
+  });
+
+  it("ne fait pas croître la page avec le volume total", async () => {
+    const small = await seedElection("small", 5);
+    const large = await seedElection("large", 500);
+    const smallResult = await read(small.slug, "?limit=20");
+    const largeResult = await read(large.slug, "?limit=20");
+
+    expect(smallResult.body.candidacies.data).toHaveLength(5);
+    expect(largeResult.body.candidacies.data).toHaveLength(20);
+    expect(JSON.stringify(largeResult.body.candidacies.data).length).toBeLessThan(
+      JSON.stringify(smallResult.body.candidacies.data).length * 5
+    );
+  });
+
+  it.each(["?page=0", "?page=1.5", "?limit=101"])(
+    "rejette une pagination invalide: %s",
+    async (query) => {
+      const election = await seedElection("invalid", 1);
+      const { response } = await read(election.slug, query);
+      expect(response.status).toBe(400);
+    }
+  );
+});

--- a/src/app/api/elections/[slug]/route.integration.test.ts
+++ b/src/app/api/elections/[slug]/route.integration.test.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import pg from "pg";
 import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
 import { assertDisposableTestDb, describeIfDisposableDb } from "@/test/db-guard";
 
@@ -7,9 +8,47 @@ let getElection: typeof import("./route").GET;
 
 const PREFIX = "api-election-details-870";
 
+type DriverResult = { rows: unknown[]; rowCount: number | null };
+type DriverQuery = { result: DriverResult };
+
+const originalClientQuery = pg.Client.prototype.query as unknown as (
+  this: pg.Client,
+  ...args: unknown[]
+) => Promise<DriverResult>;
+let driverQueries: DriverQuery[] = [];
+
+function installDriverObserver() {
+  pg.Client.prototype.query = function observedQuery(this: pg.Client, ...args: unknown[]) {
+    const callback = args.at(-1);
+    if (typeof callback === "function") {
+      args[args.length - 1] = (error: unknown, result: DriverResult) => {
+        if (!error) driverQueries.push({ result });
+        callback(error, result);
+      };
+      return originalClientQuery.call(this, ...args);
+    }
+
+    return originalClientQuery.call(this, ...args).then((result) => {
+      driverQueries.push({ result });
+      return result;
+    });
+  } as unknown as typeof pg.Client.prototype.query;
+}
+
+function getReturnedCandidacyRows() {
+  return driverQueries
+    .flatMap(({ result }) => result.rows)
+    .filter(
+      (row) =>
+        Array.isArray(row) &&
+        row.some((value) => typeof value === "string" && /^Candidate \d{4}$/.test(value))
+    );
+}
+
 describeIfDisposableDb("GET /api/elections/[slug], PostgreSQL", () => {
   beforeAll(async () => {
     assertDisposableTestDb();
+    installDriverObserver();
     ({ db } = await import("@/lib/db"));
     ({ GET: getElection } = await import("./route"));
   });
@@ -20,6 +59,7 @@ describeIfDisposableDb("GET /api/elections/[slug], PostgreSQL", () => {
   });
 
   afterAll(async () => {
+    pg.Client.prototype.query = originalClientQuery as unknown as typeof pg.Client.prototype.query;
     await db.$disconnect();
   });
 
@@ -45,6 +85,7 @@ describeIfDisposableDb("GET /api/elections/[slug], PostgreSQL", () => {
   }
 
   async function read(slug: string, query = "") {
+    driverQueries = [];
     const response = await getElection(
       new NextRequest(`https://poligraph.fr/api/elections/${slug}${query}`),
       { params: Promise.resolve({ slug }) }
@@ -110,6 +151,23 @@ describeIfDisposableDb("GET /api/elections/[slug], PostgreSQL", () => {
     expect(JSON.stringify(largeResult.body.candidacies.data).length).toBeLessThan(
       JSON.stringify(smallResult.body.candidacies.data).length * 5
     );
+  });
+
+  it("borne les candidatures retournées par le driver PostgreSQL", async () => {
+    const small = await seedElection("driver-small", 5);
+    const smallResult = await read(small.slug, "?limit=20");
+    const smallRows = getReturnedCandidacyRows();
+
+    const large = await seedElection("driver-large", 500);
+    const largeResult = await read(large.slug, "?limit=20");
+    const largeRows = getReturnedCandidacyRows();
+
+    expect(smallResult.response.status).toBe(200);
+    expect(largeResult.response.status).toBe(200);
+    expect(driverQueries.length).toBeGreaterThan(0);
+    expect(smallRows).toHaveLength(5);
+    expect(largeRows).toHaveLength(20);
+    expect(largeRows.length).toBeLessThanOrEqual(100);
   });
 
   it.each(["?page=0", "?page=1.5", "?limit=101"])(

--- a/src/app/api/elections/[slug]/route.test.ts
+++ b/src/app/api/elections/[slug]/route.test.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPublicElectionDetails: vi.fn(),
+}));
+
+vi.mock("@/lib/data/election-details", () => ({
+  ELECTION_CANDIDACIES_DEFAULT_LIMIT: 20,
+  ELECTION_CANDIDACIES_MAX_LIMIT: 100,
+  getPublicElectionDetails: mocks.getPublicElectionDetails,
+}));
+vi.mock("@/lib/cache", () => ({
+  withCache: (response: Response) => response,
+}));
+vi.mock("@/lib/api/with-public-route", () => ({
+  withPublicRoute: <T extends (...args: never[]) => unknown>(handler: T) => handler,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ slug: "municipales-2020" }) };
+
+describe("GET /api/elections/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPublicElectionDetails.mockResolvedValue({
+      id: "election-1",
+      candidacies: {
+        data: [{ id: "candidacy-1" }],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      },
+      rounds: [],
+    });
+  });
+
+  it("demande la page par défaut au lecteur de données", async () => {
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/elections/municipales-2020"),
+      context
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPublicElectionDetails).toHaveBeenCalledWith("municipales-2020", {
+      page: 1,
+      limit: 20,
+      skip: 0,
+    });
+    expect((await response.json()).candidacies.pagination).toBeDefined();
+  });
+
+  it.each([
+    "page=0",
+    "page=1.5",
+    "page=abc",
+    "page=9007199254740992",
+    "limit=0",
+    "limit=101",
+    "limit=999999",
+    "limit=1.0",
+  ])("refuse un paramètre de pagination invalide: %s", async (query) => {
+    const response = await GET(
+      new NextRequest(`https://poligraph.fr/api/elections/municipales-2020?${query}`),
+      context
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Pagination invalide" });
+    expect(mocks.getPublicElectionDetails).not.toHaveBeenCalled();
+  });
+
+  it("retourne 404 sans lire les candidatures d'une élection absente", async () => {
+    mocks.getPublicElectionDetails.mockResolvedValueOnce(null);
+
+    const response = await GET(
+      new NextRequest("https://poligraph.fr/api/elections/inconnue?limit=100"),
+      { params: Promise.resolve({ slug: "inconnue" }) }
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/elections/[slug]/route.ts
+++ b/src/app/api/elections/[slug]/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/db";
+import { parseStrictPagination } from "@/lib/api/pagination";
 import { withCache } from "@/lib/cache";
 import { withPublicRoute } from "@/lib/api/with-public-route";
 import {
-  PUBLIC_POLITICIAN_PUBLICATION_STATUS,
-  PUBLIC_POLITICIAN_WHERE,
-} from "@/lib/api/public-contract";
+  ELECTION_CANDIDACIES_DEFAULT_LIMIT,
+  ELECTION_CANDIDACIES_MAX_LIMIT,
+  getPublicElectionDetails,
+} from "@/lib/data/election-details";
 
 /**
  * @openapi
  * /api/elections/{slug}:
  *   get:
  *     summary: Détail d'une élection
- *     description: Retourne les informations détaillées d'une élection avec ses candidatures et tours. Les liens vers une fiche politique ne sont exposés que si cette fiche est publiée.
+ *     description: Retourne les informations détaillées d'une élection, une page bornée de candidatures et ses tours. Les liens vers une fiche politique ne sont exposés que si cette fiche est publiée.
  *     tags: [Élections]
  *     parameters:
  *       - in: path
@@ -21,6 +22,21 @@ import {
  *         schema:
  *           type: string
  *         description: Slug de l'élection (ex. "municipales-2026")
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page de candidatures
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Nombre de candidatures par page
  *     responses:
  *       200:
  *         description: Détail de l'élection
@@ -43,88 +59,23 @@ import {
  */
 export const GET = withPublicRoute(async (_request, context) => {
   const { slug } = await context.params;
-
-  const election = await db.election.findUnique({
-    where: { slug },
-    include: {
-      candidacies: {
-        select: {
-          id: true,
-          candidateName: true,
-          partyLabel: true,
-          constituencyName: true,
-          isElected: true,
-          round1Votes: true,
-          round1Pct: true,
-          round2Votes: true,
-          round2Pct: true,
-          politician: {
-            select: {
-              id: true,
-              slug: true,
-              fullName: true,
-              photoUrl: true,
-              publicationStatus: true,
-            },
-          },
-          party: {
-            select: {
-              id: true,
-              slug: true,
-              shortName: true,
-              color: true,
-              _count: {
-                select: { politicians: { where: PUBLIC_POLITICIAN_WHERE } },
-              },
-            },
-          },
-        },
-        orderBy: [{ isElected: "desc" }, { round1Pct: "desc" }],
-      },
-      rounds: {
-        select: {
-          round: true,
-          date: true,
-          registeredVoters: true,
-          actualVoters: true,
-          participationRate: true,
-          blankVotes: true,
-          nullVotes: true,
-        },
-        orderBy: { round: "asc" },
-      },
-    },
+  if (!slug) {
+    return NextResponse.json({ error: "Slug d'élection invalide" }, { status: 400 });
+  }
+  const pagination = parseStrictPagination(_request.nextUrl.searchParams, {
+    defaultLimit: ELECTION_CANDIDACIES_DEFAULT_LIMIT,
+    maxLimit: ELECTION_CANDIDACIES_MAX_LIMIT,
   });
+
+  if (pagination === null) {
+    return NextResponse.json({ error: "Pagination invalide" }, { status: 400 });
+  }
+
+  const election = await getPublicElectionDetails(slug, pagination);
 
   if (!election) {
     return NextResponse.json({ error: "Élection non trouvée" }, { status: 404 });
   }
 
-  return withCache(
-    NextResponse.json({
-      ...election,
-      candidacies: election.candidacies.map((candidacy) => ({
-        ...candidacy,
-        politician:
-          candidacy.politician?.publicationStatus === PUBLIC_POLITICIAN_PUBLICATION_STATUS
-            ? {
-                id: candidacy.politician.id,
-                slug: candidacy.politician.slug,
-                fullName: candidacy.politician.fullName,
-                photoUrl: candidacy.politician.photoUrl,
-              }
-            : null,
-        party:
-          candidacy.party && candidacy.party._count.politicians > 0
-            ? {
-                id: candidacy.party.id,
-                slug: candidacy.party.slug,
-                shortName: candidacy.party.shortName,
-                color: candidacy.party.color,
-              }
-            : null,
-      })),
-    }),
-    "daily"
-  );
+  return withCache(NextResponse.json(election), "daily");
 });

--- a/src/lib/data/election-details.ts
+++ b/src/lib/data/election-details.ts
@@ -1,0 +1,140 @@
+import "server-only";
+
+import {
+  PUBLIC_POLITICIAN_PUBLICATION_STATUS,
+  PUBLIC_POLITICIAN_WHERE,
+} from "@/lib/api/public-contract";
+import { buildPaginationMeta, type PaginationResult } from "@/lib/api/pagination";
+import type { Prisma } from "@/generated/prisma";
+import { db } from "@/lib/db";
+
+const ELECTION_DETAILS_SELECT = {
+  id: true,
+  publicId: true,
+  slug: true,
+  type: true,
+  title: true,
+  shortTitle: true,
+  description: true,
+  round1Date: true,
+  round2Date: true,
+  dateConfirmed: true,
+  registrationDeadline: true,
+  candidacyOpenDate: true,
+  candidacyDeadline: true,
+  campaignStartDate: true,
+  decreeUrl: true,
+  sourceUrl: true,
+  scope: true,
+  totalSeats: true,
+  suffrage: true,
+  status: true,
+  featured: true,
+  createdAt: true,
+  updatedAt: true,
+  rounds: {
+    select: {
+      round: true,
+      date: true,
+      registeredVoters: true,
+      actualVoters: true,
+      participationRate: true,
+      blankVotes: true,
+      nullVotes: true,
+    },
+    orderBy: { round: "asc" as const },
+  },
+  candidacies: {
+    select: {
+      id: true,
+      candidateName: true,
+      partyLabel: true,
+      constituencyName: true,
+      isElected: true,
+      round1Votes: true,
+      round1Pct: true,
+      round2Votes: true,
+      round2Pct: true,
+      politician: {
+        select: {
+          id: true,
+          slug: true,
+          fullName: true,
+          photoUrl: true,
+          publicationStatus: true,
+        },
+      },
+      party: {
+        select: {
+          id: true,
+          slug: true,
+          shortName: true,
+          color: true,
+          _count: {
+            select: { politicians: { where: PUBLIC_POLITICIAN_WHERE } },
+          },
+        },
+      },
+    },
+    orderBy: [
+      { isElected: "desc" as const },
+      { round1Pct: "desc" as const },
+      { id: "asc" as const },
+    ],
+  },
+} satisfies Prisma.ElectionSelect;
+
+export const ELECTION_CANDIDACIES_DEFAULT_LIMIT = 20;
+export const ELECTION_CANDIDACIES_MAX_LIMIT = 100;
+
+/**
+ * Public election details. Candidacies are deliberately a page, never an implicit full relation.
+ * The count is computed by PostgreSQL and no candidacy row outside the requested page crosses the
+ * database boundary.
+ */
+export async function getPublicElectionDetails(slug: string, pagination: PaginationResult) {
+  const election = await db.election.findUnique({
+    where: { slug },
+    select: {
+      ...ELECTION_DETAILS_SELECT,
+      candidacies: {
+        ...ELECTION_DETAILS_SELECT.candidacies,
+        skip: pagination.skip,
+        take: pagination.limit,
+      },
+    },
+  });
+
+  if (!election) return null;
+
+  const total = await db.candidacy.count({ where: { electionId: election.id } });
+  const { candidacies, ...electionDetails } = election;
+
+  return {
+    ...electionDetails,
+    candidacies: {
+      data: candidacies.map((candidacy) => ({
+        ...candidacy,
+        politician:
+          candidacy.politician?.publicationStatus === PUBLIC_POLITICIAN_PUBLICATION_STATUS
+            ? {
+                id: candidacy.politician.id,
+                slug: candidacy.politician.slug,
+                fullName: candidacy.politician.fullName,
+                photoUrl: candidacy.politician.photoUrl,
+              }
+            : null,
+        party:
+          candidacy.party && candidacy.party._count.politicians > 0
+            ? {
+                id: candidacy.party.id,
+                slug: candidacy.party.slug,
+                shortName: candidacy.party.shortName,
+                color: candidacy.party.color,
+              }
+            : null,
+      })),
+      pagination: buildPaginationMeta(pagination.page, pagination.limit, total),
+    },
+  };
+}

--- a/src/lib/openapi/schemas.ts
+++ b/src/lib/openapi/schemas.ts
@@ -725,60 +725,67 @@
  *           type: string
  *           nullable: true
  *         candidacies:
- *           type: array
- *           items:
- *             type: object
- *             properties:
- *               id:
- *                 type: string
- *               candidateName:
- *                 type: string
- *               partyLabel:
- *                 type: string
- *                 nullable: true
- *               constituencyName:
- *                 type: string
- *                 nullable: true
- *               isElected:
- *                 type: boolean
- *               round1Votes:
- *                 type: integer
- *                 nullable: true
- *               round1Pct:
- *                 type: number
- *                 nullable: true
- *               round2Votes:
- *                 type: integer
- *                 nullable: true
- *               round2Pct:
- *                 type: number
- *                 nullable: true
- *               politician:
+ *           type: object
+ *           required: [data, pagination]
+ *           description: Page de candidatures. La collection complète se parcourt avec page et limit.
+ *           properties:
+ *             data:
+ *               type: array
+ *               items:
  *                 type: object
- *                 nullable: true
  *                 properties:
  *                   id:
  *                     type: string
- *                   slug:
+ *                   candidateName:
  *                     type: string
- *                   fullName:
- *                     type: string
- *                   photoUrl:
+ *                   partyLabel:
  *                     type: string
  *                     nullable: true
- *               party:
- *                 type: object
- *                 nullable: true
- *                 properties:
- *                   id:
- *                     type: string
- *                   slug:
- *                     type: string
- *                   shortName:
- *                     type: string
- *                   color:
+ *                   constituencyName:
  *                     type: string
  *                     nullable: true
+ *                   isElected:
+ *                     type: boolean
+ *                   round1Votes:
+ *                     type: integer
+ *                     nullable: true
+ *                   round1Pct:
+ *                     type: number
+ *                     nullable: true
+ *                   round2Votes:
+ *                     type: integer
+ *                     nullable: true
+ *                   round2Pct:
+ *                     type: number
+ *                     nullable: true
+ *                   politician:
+ *                     type: object
+ *                     nullable: true
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       slug:
+ *                         type: string
+ *                       fullName:
+ *                         type: string
+ *                       photoUrl:
+ *                         type: string
+ *                         nullable: true
+ *                   party:
+ *                     type: object
+ *                     nullable: true
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       slug:
+ *                         type: string
+ *                       shortName:
+ *                         type: string
+ *                       color:
+ *                         type: string
+ *                         nullable: true
+ *             pagination:
+ *               $ref: '#/components/schemas/Pagination'
  *         rounds:
  *           type: array
  *           items:


### PR DESCRIPTION
## Problème

`GET /api/elections/{slug}` chargeait la relation `candidacies` sans borne. Le cas
`municipales-2020` représente 375 371 lignes et pouvait produire une réponse d'environ 19 Mo.
La PR #873, déjà fusionnée, concerne uniquement le contexte du resolver des affaires et n'est pas
incluse ici.

## Contrat avant / après

Avant, `candidacies` était un tableau présenté comme exhaustif. Après, `candidacies` est un objet
paginé : `data` et `pagination` (`page`, `limit`, `total`, `totalPages`).

- défaut : 20 candidatures ; maximum : 100 ;
- paramètres stricts `page` et `limit`, sans option de désactivation ;
- pagination et tri exécutés en PostgreSQL ;
- tri déterministe : `isElected` décroissant, `round1Pct` décroissant, `id` croissant ;
- total exact calculé par `COUNT` côté base ;
- champs et relations explicitement sélectionnés ;
- prédicats de visibilité inchangés ;
- contrat présidentiel spécialisé `/api/elections/{slug}/candidacies` inchangé.

## Compatibilité

Il s'agit d'une rupture de forme documentée. Les consommateurs doivent lire `candidacies.data` et
parcourir les pages jusqu'à `totalPages`. Les consommateurs trouvés dans le dépôt sont les tests
de frontière/MCP et la documentation OpenAPI ; aucun appel applicatif direct n'a été trouvé. Les
usages externes ne sont pas inventoriables depuis le dépôt.

## Vérifications locales

- 8 tests d'intégration du chemin HTTP réel réussis sur PostgreSQL 17 jetable ;
- l'instrumentation du driver `pg`, avant transformation Prisma et sérialisation, mesure 5 lignes
  pour une élection de 5 candidatures et 20 lignes pour une élection de 500 candidatures avec
  `limit=20` ;
- fixtures : élection absente, élection vide, plusieurs pages, clés de tri identiques, parcours
  sans doublon ni omission, bornes et erreurs de paramètres ;
- le test est inclus dans `scripts/test-db-search.sh` et dans le job CI dédié PostgreSQL 17 ;
- ESLint, Prettier et TypeScript réussis ;
- suite complète précédente : 6 061 tests réussis ; un test avait d'abord échoué uniquement parce
  que Git refusait le répertoire monté dans Docker, puis il a réussi avec `safe.directory`.

Les octets JSON mesurés localement sont un indicateur de taille de payload, pas une mesure de
l'egress Supabase facturé. Aucune économie mensuelle n'est estimée.

## Après déploiement

Validation en lecture seule recommandée : vérifier la borne réelle de la route, les erreurs et
l'évolution de la consommation. Aucun test de charge production n'est prévu.

Closes #870
